### PR TITLE
v1.7 Backport ENI data race fixes

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -374,8 +374,12 @@ func indexExists(enis map[string]v2.ENI, index int64) bool {
 }
 
 // findNextIndex returns the next available index with the provided index being
-// the first candidate
+// the first candidate. When calling this function, ensure that the mutex is
+// not held as this function read-locks the mutex to protect access to
+// `n.enis`.
 func (n *Node) findNextIndex(index int64) int64 {
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
 	for indexExists(n.enis, index) {
 		index++
 	}

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -495,7 +495,7 @@ func (n *Node) allocateENI(ctx context.Context, s *types.Subnet, a *allocatableR
 	}
 
 	// Add the information of the created ENI to the instances manager
-	n.manager.instancesAPI.UpdateENI(n.resource.Spec.ENI.InstanceID, eni)
+	n.manager.instancesAPI.UpdateENI(nodeResource.Spec.ENI.InstanceID, eni)
 
 	n.manager.metricsAPI.IncENIAllocationAttempt("success", s.ID)
 	n.manager.metricsAPI.AddIPAllocation(s.ID, toAllocate)

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -63,6 +63,14 @@ var (
 	eniTags    = map[string]string{}
 )
 
+func (e *ENISuite) SetUpTest(c *check.C) {
+	metricsapi = metricsmock.NewMockMetrics()
+}
+
+func (e *ENISuite) TearDownTest(c *check.C) {
+	metricsapi = nil
+}
+
 func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*types.Subnet{testSubnet}, []*types.Vpc{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api, metricsapi)
@@ -552,7 +560,6 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 	}
 
 	ec2api := ec2mock.NewAPI(subnets, []*types.Vpc{testVpc}, testSecurityGroups)
-	metricsapi := metricsmock.NewMockMetrics()
 	instancesManager := NewInstancesManager(ec2api, metricsapi)
 	mngr, err := NewNodeManager(instancesManager, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
The fixes in this PR do not attempt to fix all data races within the code, as
many of them are not "crucial". These data races come from test code. For
example, the test code may access an internal field within the `Node` struct,
but an equivalent access from within the implementation has a mutex protecting
it.

The fixes landing in this PR are around "crucial" data structures like the
`Node.enis`, a map containing all references to ENIs in a node. These fixes
attempt to mitigate any potential upgrade regression from older versions. Note,
the 1.6 tree contains may of the same data races as the code difference between
this tree (1.7) and 1.6 is not significant. The code difference likely did not
include new data races. This means that these data races have been around
since 1.6, at least.

```
$ git diff origin/v1.6..origin/v1.7 -- $(find pkg/aws/eni -type f -not -path '*/mock/*' -not -path '*test.go')
```

This PR is a partial backport of the two PRs below:

https://github.com/cilium/cilium/pull/11685
https://github.com/cilium/cilium/pull/10587

Commits from https://github.com/cilium/cilium/pull/11685:

- 699a8a515 | Backported; this fixes issues around the main ENI map
- ef77a9844 | Dropped as it doesn't change anything relevant in v1.7 tree
- 20055e47b | Dropped as it doesn't change anything relevant in v1.7 tree
- ab1b7e2a3 | Dropped as it doesn't change anything relevant in v1.7 tree
- 7427e223b | Dropped as it doesn't change anything relevant in v1.7 tree
- 9ded76e2a | Dropped as it doesn't change anything relevant in v1.7 tree
- 916826877 | Backported; included because it could fix flaky v1.7 Travis; amended to remove all other references of `metricsapi`

Commits from https://github.com/cilium/cilium/pull/10587:

- cac8d0d8 | Backported; included to provide protection around ENI limits map

This PR also contains two new commits which are fixes for (potential) data races that only
exists in this 1.7 tree:

- d96e579
- 43253d0 

```upstream-prs
$ for pr in 11685 10587; do contrib/backporting/set-labels.py $pr done 1.7; done
```