### PR TITLE
test: Wait for IPCache entries in testSessionAffinity

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -861,7 +861,7 @@ var _ = Describe("K8sServicesTest", func() {
 			// in the vxlan mode (the tailcall IPV4_NODEPORT_NAT body won't pass
 			// the request to the encap routines, and instead it will be dropped
 			// due to failing fib_lookup).
-			if fromOutside && vxlan {
+			if vxlan {
 				podIPs, err := kubectl.GetPodsIPs(helpers.DefaultNamespace, testDS)
 				ExpectWithOffset(1, err).Should(BeNil(), "Cannot get pod IP addrs for -l %s pods", testDS)
 				for _, ipAddr := range podIPs {


### PR DESCRIPTION
We need to wait for an IPCache entry of the restarted pod. Otherwise, a next testSessionAffinity test invokation (with fromOutside = true) might fail, as it could take up to 10s for the entry to appear. See `[1]` for more details.

This is a temporary fix to get rid of the session affinity flakes.

`[1]`: https://github.com/cilium/cilium/issues/11751

Fix #11698