### PR TITLE
test: Disable flaky etcd test

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -484,12 +484,24 @@ func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 	}
 }
 
+// RunsOnNetNextKernel checks whether a test case is running on the net-next
+// kernel (depending on the image, it's the latest kernel either from net-next.git
+// or bpf-next.git tree).
+func RunsOnNetNextKernel() bool {
+	netNext := os.Getenv("NETNEXT")
+	return netNext == "true" || netNext == "1"
+}
+
+// DoesNotRunOnNetNextKernel is the complement function of RunsOnNetNextKernel.
+func DoesNotRunOnNetNextKernel() bool {
+	return !RunsOnNetNextKernel()
+}
+
 // RunsOnNetNextOr419Kernel checks whether a test case is running on the net-next
 // kernel (depending on the image, it's the latest kernel either from net-next.git
 // or bpf-next.git tree), or on the > 4.19.57 kernel.
 func RunsOnNetNextOr419Kernel() bool {
-	netNext := os.Getenv("NETNEXT")
-	return netNext == "true" || netNext == "1" || os.Getenv("KERNEL") == "419"
+	return RunsOnNetNextKernel() || os.Getenv("KERNEL") == "419"
 }
 
 // DoesNotRunOnNetNextOr419Kernel is the complement function of

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -550,7 +550,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("Etcd", func() {
-		It("Check connectivity", func() {
+		// Flaky on pipelines other than K8s 1.11/Linux net-next.
+		SkipItIf(helpers.DoesNotRunOnNetNextKernel, "Check connectivity", func() {
 			deploymentManager.Deploy(helpers.CiliumNamespace, StatelessEtcd)
 			deploymentManager.WaitUntilReady()
 


### PR DESCRIPTION
Disable on all pipelines except for K8s 1.11/Linux net-next, since the test never flaked on that one so far.

Related: https://github.com/cilium/cilium/issues/11690
