### PR TITLE
travis: fix arm64 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
     packages:
       - kernel-package
       - gnupg
+      - libelf-dev
 
 before_install: ./.travis/prepare.sh
 


### PR DESCRIPTION
After PR #11740, a complete build is run on Travis CI. This currently
breaks the ARM64 build which is missing some dependencies.

Fixes: a6ca5d539168 ("travis: run build checks and complete build")
Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>