### PR TITLE
nodeinit: Fix for restarting kubenet managed pods

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -180,7 +180,8 @@ spec:
               echo "Restarting kubenet managed pods"
               if grep -q 'docker' /etc/crictl.yaml; then
                 # Works for COS, ubuntu
-                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f $(cat $f) || true; done
+                # Note the first line is the containerID with a trailing \r
+                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f "$(sed 's/\r//;1q' $f)" || true; done
               elif [ -n "$(docker ps --format '{{ "{{" }}.Image{{ "}}" }}' | grep ^[0-9]*\.dkr\.ecr\.[a-z]*-[a-z]*-[0-9]*\.amazonaws\.com/amazon-k8s-cni)" ]; then
                 timeout=1
                 for i in $(seq 1 7); do


### PR DESCRIPTION
When using restartPods in GKE, it would fail to actually restart kubenet managed pods because bad arguments are being passed to docker.

`/var/lib/cni/networks/kubenet/10.3.1.2` looks like:
```
c937c5a3d5c2282881a86246f772d1b6f6619024e8555c2c205598baf51460e7
eth0
```

Resulting in:
```
Restarting kubenet managed pods
Error: No such container: c937c5a3d5c2282881a86246f772d1b6f6619024e8555c2c205598baf51460e7
Error: No such container: eth0
```