### PR TITLE
nodeinit: Disable default ip-masq-agent jumps

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -81,6 +81,19 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
+{{- if .Values.global.gke.enabled }}
+                    # If the IP-MASQ chain exists, add back jump rule
+                    if iptables -w -t nat -L IP-MASQ > /dev/null; then
+                      iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
+                    fi
+{{- end }}
+{{- if .Values.azure }}
+                    # If the IP-MASQ-AGENT chain exists, add back jump rule
+                    if iptables -w -t nat -L IP-MASQ-AGENT > /dev/null; then
+                      iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT
+                    fi
+{{- end }}
+
                     echo "Node de-initialization complete"
 {{- end }}
           env:
@@ -154,6 +167,8 @@ spec:
               if [ -f /var/run/azure-vnet.json ]; then
                 sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
               fi
+              # Disable jumping to ip-masq chain
+              iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT || true
 {{- end }}
 
 {{- if .Values.removeCbrBridge }}
@@ -170,6 +185,11 @@ spec:
               sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.global.cni.binPath }}:g" /etc/default/kubelet
               echo "Restarting kubelet..."
               systemctl restart kubelet
+{{- end }}
+
+{{- if .Values.global.gke.enabled }}
+              # Disable jumping to ip-masq chain
+              iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ || true
 {{- end }}
 
 {{- if not (eq .Values.global.nodeinit.bootstrapFile "") }}

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -82,7 +82,7 @@ spec:
 {{- end }}
 
 {{- if .Values.global.gke.enabled }}
-                    # If the IP-MASQ chain exists, add back jump rule
+                    # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
                     fi
@@ -180,7 +180,12 @@ spec:
 {{- end }}
 
 {{- if .Values.global.gke.enabled }}
-              # Disable jumping to ip-masq chain
+              # If Cilium is installed, it would be expected that it would be solely responsible
+              # for the networking configuration on that node.
+              # In GKE, even if the IP masquerade agent is not enabled, the instance
+              # configure script adds some default masquerade rules anyway.
+              # If we remove the jump to that ip-masq chain, then we ensure masquerade configuration
+              # is managed by Cilium.
               iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ || true
 {{- end }}
 

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -87,12 +87,6 @@ spec:
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
                     fi
 {{- end }}
-{{- if .Values.azure }}
-                    # If the IP-MASQ-AGENT chain exists, add back jump rule
-                    if iptables -w -t nat -L IP-MASQ-AGENT > /dev/null; then
-                      iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT
-                    fi
-{{- end }}
 
                     echo "Node de-initialization complete"
 {{- end }}
@@ -167,8 +161,6 @@ spec:
               if [ -f /var/run/azure-vnet.json ]; then
                 sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
               fi
-              # Disable jumping to ip-masq chain
-              iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT || true
 {{- end }}
 
 {{- if .Values.removeCbrBridge }}


### PR DESCRIPTION
Noticed some surprising behavior where disabling Cilium masquerade does not actually disable masquerade in GKE.

In GKE, even if the [IP masquerade agent](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-masquerade-agent) is not enabled, the instance configure script [adds some default rules](https://github.com/kubernetes/kubernetes/blob/ae1103726f9aea1f9bbad1b215edfa47e0747dce/cluster/gce/gci/configure-helper.sh#L126-L143)

This removes the jump from `POSTROUTING` to the `IP-MASQ` chain