### PR TITLE
azure/ipam: Fix nil dereference with logger

### DIFF
--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -158,14 +158,14 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 	n.manager.instances.ForeachAddress(n.node.InstanceID(), func(instanceID, interfaceID, ip, poolID string, addressObj ipamTypes.Address) error {
 		address, ok := addressObj.(types.AzureAddress)
 		if !ok {
-			log.WithField("ip", ip).Warning("Not an Azure address object, ignoring IP")
+			scopedLog.WithField("ip", ip).Warning("Not an Azure address object, ignoring IP")
 			return nil
 		}
 
 		if address.State == types.StateSucceeded {
 			available[address.IP] = ipamTypes.AllocationIP{Resource: interfaceID}
 		} else {
-			log.WithFields(logrus.Fields{
+			scopedLog.WithFields(logrus.Fields{
 				"ip":    address.IP,
 				"state": address.State,
 			}).Warning("Ignoring potentially available IP due to non-successful state")


### PR DESCRIPTION
The code erroneously used `log` which is a global variable, that's
unprotected by a mutex. The correct usage is to use `scopedLog` which is
passed into ResyncInterfacesAndIPs(), which already has been locked by
the caller of ResyncInterfacesAndIPs(). The caller is n.recalculate().

Fixes: https://github.com/cilium/cilium/issues/11785
Fixes: 3dfd638dcf ("ipam: Move iterator logic into generic InstanceMap")
Fixes: 9779b09b6a ("ipam: Support for Azure IPAM")