### PR TITLE
chore(helm): To default PullPolicy as IfNotPresent

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -27,8 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check quick-install.yaml
         run: |
-          cd install/kubernetes
-          make all
+          make -C install/kubernetes all
           git diff --exit-code
 
   lint-test:

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -90,8 +90,7 @@ Install Cilium release via Helm:
       --set global.hostServices.enabled=false \\
       --set global.externalIPs.enabled=true \\
       --set global.nodePort.enabled=true \\
-      --set global.hostPort.enabled=true \\
-      --set global.pullPolicy=IfNotPresent
+      --set global.hostPort.enabled=true
 
 .. include:: k8s-install-validate.rst
 .. include:: hubble-install.rst

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -36,7 +36,7 @@ global:
   tag: latest
 
   # pullPolicy is the container image pull policy
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
   # etcd is the etcd configuration
   etcd:


### PR DESCRIPTION
The current PullPolicy in for cilium is Always. This will cause some
leap time if there is re-create/restart cilium pods. Even this can be
overridden in helm, but most likely is overlooked.

This will make default value consistent to hubble related pull policies
as well.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Please ensure your pull request adheres to the following guidelines:

```release-note
helm: Default PullPolicy to IfNotPresent
```
