### PR TITLE
ci: Fix FilterLine test matchers and related specs

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -136,8 +136,12 @@ func (res *CmdRes) ExpectMatchesRegexp(regexp string, optionalDescription ...int
 func (res *CmdRes) ExpectContainsFilterLine(filter, expected string, optionalDescription ...interface{}) bool {
 	lines, err := res.FilterLines(filter)
 	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), optionalDescription...)
-	return gomega.ExpectWithOffset(1, expected).Should(
-		gomega.BeElementOf(lines), optionalDescription...)
+	sLines := []string{}
+	for _, fLine := range lines {
+		sLines = append(sLines, fLine.ByLines()...)
+	}
+	return gomega.ExpectWithOffset(1, sLines).To(
+		gomega.ContainElement(expected), optionalDescription...)
 }
 
 // ExpectDoesNotContain asserts that a string is not contained in the stdout of
@@ -164,8 +168,12 @@ func (res *CmdRes) ExpectDoesNotMatchRegexp(regexp string, optionalDescription .
 func (res *CmdRes) ExpectDoesNotContainFilterLine(filter, expected string, optionalDescription ...interface{}) bool {
 	lines, err := res.FilterLines(filter)
 	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), optionalDescription...)
-	return gomega.ExpectWithOffset(1, expected).ToNot(
-		gomega.BeElementOf(lines), optionalDescription...)
+	sLines := []string{}
+	for _, fLine := range lines {
+		sLines = append(sLines, fLine.ByLines()...)
+	}
+	return gomega.ExpectWithOffset(1, sLines).ToNot(
+		gomega.ContainElement(expected), optionalDescription...)
 }
 
 // CountLines return the number of lines in the stdout of res.

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1477,7 +1477,7 @@ var _ = Describe("RuntimePolicies", func() {
 		It("tests ingress", func() {
 			By("Starting hubble observe in background")
 			ctx, cancel := context.WithCancel(context.Background())
-			hubbleRes := vm.HubbleObserveFollow(ctx, "--type", "drop", "--type", "trace", "--protocol", "ICMPv4")
+			hubbleRes := vm.HubbleObserveFollow(ctx, "--type", "drop", "--type", "trace:to-endpoint", "--protocol", "ICMPv4")
 			defer cancel()
 
 			By("Creating an endpoint")
@@ -1493,12 +1493,12 @@ var _ = Describe("RuntimePolicies", func() {
 
 			By("Testing hubble observe output")
 			err := hubbleRes.WaitUntilMatchFilterLine(
-				`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict}`,
-				fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : DROPPED", endpointID, endpointIP.IPV4))
+				`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+				fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : DROPPED 1", endpointID, endpointIP.IPV4))
 			Expect(err).To(BeNil(), "Default drop on ingress failed")
 			hubbleRes.ExpectDoesNotContainFilterLine(
-				`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict}`,
-				fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : FORWARDED", endpointID, endpointIP.IPV4),
+				`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+				fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : FORWARDED 4", endpointID, endpointIP.IPV4),
 				"Unexpected ingress traffic to endpoint")
 		})
 
@@ -1507,7 +1507,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 			By("Starting hubble observe in background")
 			ctx, cancel := context.WithCancel(context.Background())
-			hubbleRes := vm.HubbleObserveFollow(ctx, "--type", "drop", "--type", "trace", "--protocol", "ICMPv4")
+			hubbleRes := vm.HubbleObserveFollow(ctx, "--type", "drop", "--type", "trace:to-endpoint", "--protocol", "ICMPv4")
 			defer cancel()
 
 			By("Creating an endpoint")
@@ -1515,13 +1515,13 @@ var _ = Describe("RuntimePolicies", func() {
 
 			By("Testing hubble observe output")
 			err := hubbleRes.WaitUntilMatchFilterLine(
-				`{.source.ID} {.source.labels} -> {.destination.labels} {.IP.destination} : {.verdict}`,
-				fmt.Sprintf("%s [container:somelabel] -> [reserved:host] %s : DROPPED", endpointID, hostIP))
+				`{.source.ID} {.source.labels} -> {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+				fmt.Sprintf("%s [container:somelabel] -> [reserved:host] %s : DROPPED 1", endpointID, hostIP))
 			Expect(err).To(BeNil(), "Default drop on egress failed")
 
 			hubbleRes.ExpectDoesNotContainFilterLine(
-				`{.source.labels} {.IP.source} -> {.destination.ID} : {.verdict} {.reply}`,
-				fmt.Sprintf("[reserved:host] %s -> %s : FORWARDED true", hostIP, endpointID),
+				`{.source.labels} {.IP.source} -> {.destination.ID} : {.verdict} {.reply} {.event_type.type}`,
+				fmt.Sprintf("[reserved:host] %s -> %s : FORWARDED true 4", hostIP, endpointID),
 				"Unexpected reply traffic to endpoint")
 		})
 
@@ -1554,10 +1554,10 @@ var _ = Describe("RuntimePolicies", func() {
 					fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : FORWARDED 5", endpointID, endpointIP.IPV4))
 				Expect(err).To(BeNil(), "Default policy verdict on ingress failed")
 				// Checks for the subsequent trace:to-endpoint event (type 4)
-				err = hubbleRes.WaitUntilMatchFilterLine(
-					`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.event_type.type}`,
-					fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : 4", endpointID, endpointIP.IPV4))
-				Expect(err).To(BeNil(), "No ingress traffic to endpoint")
+				hubbleRes.ExpectContainsFilterLine(
+					`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+					fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : FORWARDED 4", endpointID, endpointIP.IPV4),
+					"No ingress traffic to endpoint")
 
 				By("Testing cilium endpoint list output")
 				res = vm.Exec("cilium endpoint list")
@@ -1579,18 +1579,17 @@ var _ = Describe("RuntimePolicies", func() {
 				// In PolicyAuditMode, this means that the ping will succeed. Therefore we don't
 				// check for the source labels in the output (they can by either [reserved:init]
 				// or [container:somelabel]), only the endpoint ID.
-				// Checks for a ingress policy verdict event (type 5)
 				By("Testing hubble observe output")
+				// Checks for the subsequent trace:to-endpoint event (type 4)
 				err := hubbleRes.WaitUntilMatchFilterLine(
-					`{.source.ID} -> {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
-					fmt.Sprintf("%s -> [reserved:host] %s : FORWARDED 5", endpointID, hostIP))
-				Expect(err).To(BeNil(), "Default policy verdict on egress failed")
-
-				// Checks for the subsequent trace:to-endpoint reply (type 4)
-				err = hubbleRes.WaitUntilMatchFilterLine(
 					`{.source.labels} {.IP.source} -> {.destination.ID} : {.verdict} {.reply} {.event_type.type}`,
 					fmt.Sprintf("[reserved:host] %s -> %s : FORWARDED true 4", hostIP, endpointID))
 				Expect(err).To(BeNil(), "No ingress traffic to endpoint")
+				// Checks for a ingress policy verdict event (type 5)
+				hubbleRes.ExpectContainsFilterLine(
+					`{.source.ID} -> {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+					fmt.Sprintf("%s -> [reserved:host] %s : FORWARDED 5", endpointID, hostIP),
+					"Default policy verdict on egress failed")
 
 				By("Testing cilium endpoint list output")
 				res := vm.Exec("cilium endpoint list")


### PR DESCRIPTION
Current matchers implementation makes policy related specs always pass
even when value is present in the output. This patch updates
ExpectContainsFilterLine and ExpectDoesNotContainFilterLine matchers
to match expected value against string slice rather than slice of
FilterBuffer. This patch also updates policy specs to use
ExpectContainsFilterLine matcher where applicable. Minor consistency
changes were also added to policy specs.