### PR TITLE
Enable host firewall in kube-proxy-free CI

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1121,6 +1121,11 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, bool from_host)
 	}
 
 	switch (proto) {
+# if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER
+	case bpf_htons(ETH_P_ARP):
+		ret = CTX_ACT_OK;
+		break;
+# endif
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
 		identity = resolve_srcid_ipv6(ctx, identity, from_host);

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -223,7 +223,7 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 srcID, __u32 dstID,
 	int ret;
 
 #ifdef ENCAP_IFINDEX
-	if (is_encap(dport, proto))
+	if (srcID != HOST_ID && is_encap(dport, proto))
 		return DROP_ENCAP_PROHIBITED;
 #endif
 	ret = __policy_can_access(&POLICY_MAP, ctx, srcID, dstID, dport, proto,

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -338,6 +338,10 @@ data:
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
 {{- end }}
 
+{{- if .Values.global.hostFirewall }}
+  enable-host-firewall: {{ .Values.global.hostFirewall | quote }}
+{{- end}}
+
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
 {{- end}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -292,6 +292,9 @@ global:
     # interface is the interface to use for encryption
     # interface: eth0
 
+  # hostFirewall enables the enforcement of host policies in the BPF datapath
+  hostFirewall: false
+
   # kubeProxyReplacement enables kube-proxy replacement in Cilium BPF datapath
   kubeProxyReplacement: "probe"
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2139,6 +2139,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		devices := privateIface
 
 		opts := map[string]string{
+			"global.hostFirewall":         "true",
 			"global.kubeProxyReplacement": "strict",
 			"global.k8sServiceHost":       nodeIP,
 			"global.k8sServicePort":       "6443",


### PR DESCRIPTION
This first commit adds a new Helm option to enable the host firewall, which then allows the second commit to enable it in our kube-proxy-free CI builds (K8s 1.11 Linux net-next). The third and last commits fix two issues found this way: (1) a missing case for ARP resolution on `from-{netdev,host}` paths, and (2) packet drops when tunneling is enabled. I'm not sure how I missed the second before since I had already ran the CI build (although not with the Helm option).

Enabling host firewall on 4.19 is currently blocked by #10567.

Updates: #11799
Fixes: #11507

```release-note
Fix tunneling and ARP resolution when host firewall is enabled.
```