### PR TITLE
ci: retry docker build in jenkins

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -98,7 +98,9 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; ./make-images-push-to-local-registry.sh $(./print-node-ip.sh) latest'
+                retry(3){
+                    sh 'cd ${TESTDIR}; ./make-images-push-to-local-registry.sh $(./print-node-ip.sh) latest'
+                }
             }
             post {
                 unsuccessful {


### PR DESCRIPTION
We are sometimes hitting errors while updating alpine packages when
building an image. This
change adds 3 retries to image building step.