### PR TITLE
fix(datarace): Fix possible nil pointer dereference

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -494,12 +494,16 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 // GetMaximumAllocatableIPv4 returns the maximum amount of IPv4 addresses
 // that can be allocated to the instance
 func (n *Node) GetMaximumAllocatableIPv4() int {
+	if n == nil {
+		log.Warningf("Could not determine first interface index, %s", getMaximumAllocatableIPv4FailureWarningStr)
+		return 0
+	}
+
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
 
 	// Retrieve FirstInterfaceIndex from node spec
-	if n == nil ||
-		n.k8sObj == nil ||
+	if n.k8sObj == nil ||
 		n.k8sObj.Spec.ENI.FirstInterfaceIndex == nil {
 		n.loggerLocked().WithFields(logrus.Fields{
 			"first-interface-index": "unknown",


### PR DESCRIPTION
This commit is to fix the recent changes after rebased. Related PR
is #11685.

Basically, there was a check if Node is nil after calling mutex lock,
which will cause nil pointer dereference. I just refactor the code
to make sure underlying node is not nil before obtaining mutex lock.

Relates to 5259ff7961

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
fix(datarace): Fix possible nil pointer dereference
```
