### PR TITLE
ci: run lscpu at end of build

### DIFF
--- a/jenkinsfiles/Jenkinsfile.nightly
+++ b/jenkinsfiles/Jenkinsfile.nightly
@@ -133,6 +133,7 @@ pipeline {
     }
     post {
         always {
+            sh 'lscpu'
             sh "cd ${TESTDIR}; K8S_VERSION=1.12 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; vagrant destroy -f || true"
             sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -193,6 +193,7 @@ pipeline {
 
     post {
         always {
+            sh 'lscpu'
             cleanWs()
             sh '/usr/local/bin/cleanup || true'
         }

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -498,6 +498,7 @@ pipeline {
     }
     post {
         always {
+            sh 'lscpu'
             archiveArtifacts artifacts: '*.zip'
             junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
             cleanWs()

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
             }
 
             environment {
-				CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
+                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
                 GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                 TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                 KUBECONFIG="vagrant-kubeconfig"
@@ -157,6 +157,7 @@ pipeline {
 
     post {
         always {
+            sh 'lscpu'
             cleanWs()
             sh '/usr/local/bin/cleanup || true'
         }

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -313,6 +313,7 @@ pipeline {
 
     post {
         always {
+            sh 'lscpu'
             cleanWs()
             sh '/usr/local/bin/cleanup || true'
         }

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -129,6 +129,7 @@ pipeline {
     }
     post {
         always {
+            sh 'lscpu'
             sh 'cd ${TESTDIR}; K8S_VERSION=${K8S_VERSION} vagrant destroy -f || true'
             cleanWs()
             sh '/usr/local/bin/cleanup || true'


### PR DESCRIPTION
We have been running into cpu frequency issues in our ci, this change
will allow us to check whether the build was affected by the problem.