### PR TITLE
datapath: Silent iptables removal on first init

### DIFF
--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -80,7 +80,7 @@ func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *fakeDatapath) RemoveRules() {}
+func (f *fakeDatapath) RemoveRules(quiet bool) {}
 
 func (f *fakeDatapath) InstallRules(ifName string) error {
 	return nil

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -434,7 +434,7 @@ func (m *IptablesManager) SupportsOriginalSourceAddr() bool {
 }
 
 // RemoveRules removes iptables rules installed by Cilium.
-func (m *IptablesManager) RemoveRules() {
+func (m *IptablesManager) RemoveRules(quiet bool) {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
@@ -450,7 +450,7 @@ func (m *IptablesManager) RemoveRules() {
 	}
 
 	for _, c := range ciliumChains {
-		c.remove(m.waitArgs, false)
+		c.remove(m.waitArgs, quiet)
 	}
 }
 

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -77,7 +77,7 @@ type IptablesManager interface {
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	RemoveRules()
+	RemoveRules(quiet bool)
 	InstallRules(ifName string) error
 	TransientRulesStart(ifName string) error
 	TransientRulesEnd(quiet bool)


### PR DESCRIPTION
On the first initialization, the iptables rules may not exist. Remove
the silently and warn on any attempt to remove rules once they are known
to exist.

Also, don't remove iptables rules on additional calls to Reinitialize()
unless iptables is enabled.

Fixes: #11809