### PR TITLE
test: Fix and re-enable test reliant on managed etcd

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -551,7 +551,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	Context("Etcd", func() {
 		// Flaky on pipelines other than K8s 1.11/Linux net-next.
-		SkipItIf(helpers.DoesNotRunOnNetNextKernel, "Check connectivity", func() {
+		It("Check connectivity", func() {
 			deploymentManager.Deploy(helpers.CiliumNamespace, StatelessEtcd)
 			deploymentManager.WaitUntilReady()
 
@@ -560,8 +560,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			etcdService := fmt.Sprintf("http://%s:%d", host, port)
 			opts := map[string]string{
-				"global.etcd.enabled":      "true",
-				"global.etcd.endpoints[0]": etcdService,
+				"global.etcd.enabled":           "true",
+				"global.etcd.endpoints[0]":      etcdService,
+				"global.identityAllocationMode": "kvstore",
 			}
 			if helpers.ExistNodeWithoutCilium() {
 				opts["global.synchronizeK8sNodes"] = "false"


### PR DESCRIPTION
- ensure `global.identityAllocationMode=kvstore` is set; the default
  is `crd` which is not what etcd test was meant to be testing
- it looks like there is still a deadlock occuring when default `crd`
  modes is used

Fixes: #11690