### PR TITLE
datapath: Accept proxy traffic if enable-endpoint-routes are enabled

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1046,9 +1046,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 		SkipContextIf(
 			func() bool {
-				return helpers.IsIntegration(helpers.CIIntegrationEKS) ||
-					helpers.IsIntegration(helpers.CIIntegrationGKE) || // Re-enable when GH-11235 is fixed
-					helpers.RunsWithoutKubeProxy()
+				return helpers.RunsWithoutKubeProxy()
 			},
 			"with L7 policy", func() {
 				var (
@@ -1065,7 +1063,7 @@ var _ = Describe("K8sServicesTest", func() {
 					_ = kubectl.Delete(demoPolicy)
 				})
 
-				PIt("Tests NodePort with L7 Policy", func() {
+				It("Tests NodePort with L7 Policy", func() {
 					applyPolicy(demoPolicy)
 					testNodePort(false, false, false)
 				})


### PR DESCRIPTION
The forward chain rules have been depended on the local delivery
interface which depending on the setting of enable-endpoint-routes is
either `cilium_host` or `lxc+`. This is sufficient for all regular
traffic. For proxy redirection traffic, all traffic still passes through
cilium_host regardless of the value of enable-endpoint-routes.

Eample of existing rules:
```
 -A CILIUM_FORWARD -o lxc+ -m comment --comment "cilium: any->cluster on lxc+ forward accept" -j ACCEPT
 -A CILIUM_FORWARD -i lxc+ -m comment --comment "cilium: cluster->any on lxc+ forward accept (nodeport)" -j ACCEPT
 -A CILIUM_FORWARD -i lxc+ -m comment --comment "cilium: cluster->any on lxc+ forward accept" -j ACCEPT
```

This problem was masked because Kubernetes would install these
wide-reaching rules:
```
-A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack pod source rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack pod destination rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
```

However, more recent versions of Kubernetes would install more
fine-grained rules when the PodCIDR is known too the host:
```
 -A KUBE-FORWARD -s 10.10.0.0/16 -m comment --comment "kubernetes forwarding conntrack pod source rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
```

This will still mask the problem if Cilium uses the PodCIDR for IP
allocation. However, in case Cilium does not use the announced PodCIDR
then these rules would no longer allow the proxy redirection traffic
causes proxy redirection to break.

Fixes: #11235
Fixes: #11807
