### PR TITLE
docs: add word to misspelled list

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -311,6 +311,7 @@ fromEndpoints
 fromEntities
 frontend
 fs
+functionalities
 fwmark
 gRPC
 gcc


### PR DESCRIPTION
Fixes: a24ba16ca353 ("docs: add scalability guide")
Signed-off-by: André Martins <andre@cilium.io>