### PR TITLE
 ci/helpers: Collect Hubble flow logs upon failure

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -303,6 +303,8 @@ var ciliumCLICommands = map[string]string{
 	"cilium policy get":                     "policy_get.txt",
 	"cilium status --all-controllers":       "status.txt",
 	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
+
+	"hubble observe --since 4h -o json": "hubble_observe.txt",
 }
 
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
@@ -316,6 +318,8 @@ var ciliumKubCLICommands = map[string]string{
 	"cilium bpf tunnel list":          "bpf_tunnel_list.txt",
 	"cilium policy get":               "policy_get.txt",
 	"cilium status --all-controllers": "status.txt",
+
+	"hubble observe --since 4h -o json": "hubble_observe.txt",
 }
 
 // ciliumKubCLICommandsKVStore contains commands related to querying the kvstore.


### PR DESCRIPTION
This extends the commands executed by `CiliumReport` with calls to `hubble observe`. Hubble is enabled by default, therefore we can dump all recent flows when a test fails.