### PR TITLE
test/Vagrantfile: disable unattended-upgrades

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -67,6 +67,12 @@ Vagrant.configure("2") do |config|
         # Provision section
         server.vm.provision :shell,
             :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
+        # Disable unattended-upgrades to prevent it from holding the dpkg frontend lock
+        # To be removed once this has been added through packer-ci-build
+        server.vm.provision :shell,
+            :inline => "sudo systemctl disable unattended-upgrades.service"
+        server.vm.provision :shell,
+            :inline => "sudo systemctl stop unattended-upgrades.service"
         server.vm.provision "file", source: "provision/", destination: "/tmp/"
         server.vm.provision "shell" do |sh|
             sh.path = "./provision/runtime_install.sh"
@@ -127,6 +133,12 @@ Vagrant.configure("2") do |config|
                 :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=1"
             server.vm.provision :shell,
                 :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
+            # Disable unattended-upgrades to prevent it from holding the dpkg frontend lock
+            # To be removed once this has been added through packer-ci-build
+            server.vm.provision :shell,
+                :inline => "sudo systemctl disable unattended-upgrades.service"
+            server.vm.provision :shell,
+                :inline => "sudo systemctl stop unattended-upgrades.service"
             server.vm.provision "file", source: "provision/", destination: "/tmp/"
             server.vm.provision "shell" do |sh|
                 sh.path = "./provision/k8s_install.sh"


### PR DESCRIPTION
CI runs occasionally fail with errors similar to:

```
    Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource
        temporarily unavailable)
    Unable to acquire the dpkg frontend lock
        (/var/lib/dpkg/lock-frontend), is another process using it?
```

This lock is typically held by `dpkg` or `apt` when they check for or proceed to updates. The two main suspects are usually:

- An aborted run of `dpkg` or `apt`, that would not have released the lock   on exit, or
- Automatic updates running in the background, for example with the `unattended-upgrades` package.

The logs did not raise any previous apt failure. Automatic updates may well be responsible for the lock being held. We do not want them running on test machines anyway, so let's disable `unattended-updates` altogether.
    
This should be moved directly to the CI images in the future; the current patch is a quick fix so we can stop the CI failures as soon as possible. See [related issue in packer-ci-build](https://github.com/cilium/packer-ci-build/pull/221).

Quick-Fixes: #8056