### PR TITLE
pkg/k8s: decrease CEP status initialization

### DIFF
--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -117,7 +117,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				// Serialize the endpoint into a model. It is compared with the one
 				// from before, only updating on changes.
 				mdl := e.GetCiliumEndpointStatus(conf)
-				if mdl.DeepEqual(lastMdl) {
+				if !needInit && mdl.DeepEqual(lastMdl) {
 					scopedLog.Debug("Skipping CiliumEndpoint update because it has not changed")
 					return nil
 				}
@@ -167,10 +167,10 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 							return err
 						}
 
-						// We have successfully created the CEP and can return. Subsequent
-						// runs will update using localCEP.
 						needInit = false
-						return nil
+
+						// continue the execution so we update the endpoint
+						// status immediately upon endpoint creation
 					case err != nil:
 						scopedLog.WithError(err).Warn("Error getting CEP")
 						return err

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -861,7 +861,7 @@ var _ = Describe("K8sServicesTest", func() {
 			// in the vxlan mode (the tailcall IPV4_NODEPORT_NAT body won't pass
 			// the request to the encap routines, and instead it will be dropped
 			// due to failing fib_lookup).
-			if vxlan {
+			if fromOutside && vxlan {
 				podIPs, err := kubectl.GetPodsIPs(helpers.DefaultNamespace, testDS)
 				ExpectWithOffset(1, err).Should(BeNil(), "Cannot get pod IP addrs for -l %s pods", testDS)
 				for _, ipAddr := range podIPs {


### PR DESCRIPTION
When an endpoint is created, its status is only created 10 seconds
after. This happens because Kubernetes ignores the status field of a CRD
object on its initialization and Cilium has a controller running every
10 seconds.

In order to have a shorter CEP update window, Cilium can create the
status field immediately after the creation of the CEP without waiting
for the next execution of the CEP controller to be executed.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/11751