### PR TITLE
Add anti-affinity for Cilium pods

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -517,3 +517,14 @@ global:
 
   cnpStatusUpdates:
     enabled: false
+
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: k8s-app
+            operator: In
+            values:
+            - cilium
+        topologyKey: "kubernetes.io/hostname"

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -372,6 +372,16 @@ spec:
       labels:
         k8s-app: cilium
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values:
+                - cilium
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map


### PR DESCRIPTION
This change makes sure that two Cilium pods cannot be running on the
same node in parallel. Which can happen in case an daemonset is deleted and immediately created.

Fixes: #11828

```release-note
Add anti-affinity for Cilium pods to prevent 2 pods being executed on the same node at the same time
```