### PR TITLE
pkg/k8s: use node name from pkg/node instead of env variable

### DIFF
--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"os"
 	"path"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
-	k8sConst "github.com/cilium/cilium/pkg/k8s/constants"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -201,7 +199,7 @@ func initK8s(ctx context.Context) (crdBackend allocator.Backend, crdAllocator *a
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 
-	if err := k8s.GetNodeSpec(os.Getenv(k8sConst.EnvNodeNameSpec)); err != nil {
+	if err := k8s.GetNodeSpec(); err != nil {
 		log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -47,7 +47,6 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
-	k8sConst "github.com/cilium/cilium/pkg/k8s/constants"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -416,7 +415,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 			d.nodeDiscovery.UpdateCiliumNodeResource()
 		}
 
-		if err := k8s.GetNodeSpec(os.Getenv(k8sConst.EnvNodeNameSpec)); err != nil {
+		if err := k8s.GetNodeSpec(); err != nil {
 			log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 		}
 

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -188,17 +188,16 @@ func Init(conf k8sconfig.Configuration) error {
 
 // GetNodeSpec retrieves this node spec from kubernetes. This node information
 // can either be derived from a CiliumNode or a Kubernetes node.
-func GetNodeSpec(nodeName string) error {
+func GetNodeSpec() error {
+	// Use of the environment variable overwrites the node-name
+	// automatically derived
+	nodeName := nodeTypes.GetName()
 	if nodeName == "" {
 		if option.Config.K8sRequireIPv4PodCIDR || option.Config.K8sRequireIPv6PodCIDR {
 			return fmt.Errorf("node name must be specified via environment variable '%s' to retrieve Kubernetes PodCIDR range", k8sConst.EnvNodeNameSpec)
 		}
 		return nil
 	}
-
-	// Use of the environment variable overwrites the node-name
-	// automatically derived
-	nodeTypes.SetName(nodeName)
 
 	if n := waitForNodeInformation(context.TODO(), nodeName); n != nil {
 		nodeIP4 := n.GetNodeIP(false)


### PR DESCRIPTION
The node name in the pkg/node is set at `init()` time so there is not
point on setting this package variable all over the code.

Fixes: 3533fd357925 ("pkg/node: give priority to nodeName from K8S_NODE_NAME env variable")
Signed-off-by: André Martins <andre@cilium.io>

EDIT: Actually I think it's another occurrence caused by https://github.com/cilium/cilium/issues/11836

Fixes:

```
2020-06-02T16:10:15.813451601Z WARNING: DATA RACE
2020-06-02T16:10:15.813457516Z Read at 0x000004e9b100 by goroutine 165:
2020-06-02T16:10:15.813461237Z   github.com/cilium/cilium/pkg/node/types.(*Node).IsLocal()
2020-06-02T16:10:15.813464571Z       /go/src/github.com/cilium/cilium/pkg/node/types/node.go:360 +0x1ae
2020-06-02T16:10:15.81346792Z   github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumNodeInit.func2()
2020-06-02T16:10:15.813471331Z       /go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_node.go:70 +0x20b
2020-06-02T16:10:15.813487405Z   k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate()
2020-06-02T16:10:15.813500515Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:225 +0xa5
2020-06-02T16:10:15.81350407Z   k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnUpdate()
2020-06-02T16:10:15.813524008Z       <autogenerated>:1 +0x2e
2020-06-02T16:10:15.813527837Z   github.com/cilium/cilium/pkg/k8s/informer.NewInformerWithStore.func1()
2020-06-02T16:10:15.813531055Z       /go/src/github.com/cilium/cilium/pkg/k8s/informer/informer.go:113 +0x372
2020-06-02T16:10:15.813534135Z   k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop()
2020-06-02T16:10:15.813537208Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:492 +0x396
2020-06-02T16:10:15.813540559Z   k8s.io/client-go/tools/cache.(*controller).processLoop()
2020-06-02T16:10:15.813543639Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:173 +0x83
2020-06-02T16:10:15.813546932Z   k8s.io/client-go/tools/cache.(*controller).processLoop-fm()
2020-06-02T16:10:15.813550216Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:171 +0x41
2020-06-02T16:10:15.813553842Z   k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
2020-06-02T16:10:15.813556947Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x75
2020-06-02T16:10:15.813560246Z   k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
2020-06-02T16:10:15.813563444Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb3
2020-06-02T16:10:15.813566656Z   k8s.io/apimachinery/pkg/util/wait.JitterUntil()
2020-06-02T16:10:15.813569765Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x10d
2020-06-02T16:10:15.81357308Z   k8s.io/apimachinery/pkg/util/wait.Until()
2020-06-02T16:10:15.813576346Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x4a1
2020-06-02T16:10:15.813579629Z   k8s.io/client-go/tools/cache.(*controller).Run()
2020-06-02T16:10:15.813582834Z       /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:145 +0x443
2020-06-02T16:10:15.813586265Z 
2020-06-02T16:10:15.813590406Z Previous write at 0x000004e9b100 by main goroutine:
2020-06-02T16:10:15.813609438Z   github.com/cilium/cilium/pkg/node/types.SetName()
2020-06-02T16:10:15.81361309Z       /go/src/github.com/cilium/cilium/pkg/node/types/nodename.go:35 +0x1c6
2020-06-02T16:10:15.813616464Z   github.com/cilium/cilium/pkg/k8s.GetNodeSpec()
2020-06-02T16:10:15.813619663Z       /go/src/github.com/cilium/cilium/pkg/k8s/init.go:201 +0x1b6
2020-06-02T16:10:15.813622905Z   github.com/cilium/cilium/daemon/cmd.NewDaemon()
2020-06-02T16:10:15.813630836Z       /go/src/github.com/cilium/cilium/daemon/cmd/daemon.go:403 +0x446d
2020-06-02T16:10:15.813634623Z   github.com/cilium/cilium/daemon/cmd.runDaemon()
2020-06-02T16:10:15.81363783Z       /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1281 +0x354
2020-06-02T16:10:15.813641171Z   github.com/cilium/cilium/daemon/cmd.glob..func1()
2020-06-02T16:10:15.813644397Z       /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:116 +0xab
2020-06-02T16:10:15.813736725Z   github.com/cilium/cilium/daemon/cmd.glob..func1()
2020-06-02T16:10:15.813744571Z       /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:114 +0x91
2020-06-02T16:10:15.813748239Z   github.com/spf13/cobra.(*Command).execute()
2020-06-02T16:10:15.81375152Z       /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:846 +0x8e0
2020-06-02T16:10:15.813754971Z   github.com/spf13/cobra.(*Command).ExecuteC()
2020-06-02T16:10:15.813758158Z       /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:950 +0x499
2020-06-02T16:10:15.81376151Z   github.com/spf13/cobra.(*Command).Execute()
2020-06-02T16:10:15.813764727Z       /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:887 +0x1eb
2020-06-02T16:10:15.813768122Z   github.com/cilium/cilium/daemon/cmd.Execute()
2020-06-02T16:10:15.813771486Z       /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:147 +0x1cc
2020-06-02T16:10:15.813774756Z   main.main()
2020-06-02T16:10:15.813777984Z       /go/src/github.com/cilium/cilium/daemon/main.go:22 +0x2f
2020-06-02T16:10:15.813868057Z 
2020-06-02T16:10:15.813875324Z Goroutine 165 (running) created at:
2020-06-02T16:10:15.813878847Z   github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumNodeInit()
2020-06-02T16:10:15.813882164Z       /go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_node.go:103 +0x24e
```
