### PR TITLE
Update helm chart for cilium-operator to implement per-provider opera…

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Build docker images
         run: |
           make docker-image-no-clean
-          make docker-operator-image
+          make docker-operator-generic-image
 
       - name: Prevent K8s from pulling images
         run: |
@@ -58,7 +58,7 @@ jobs:
       - name: Load local images into kind cluster
         run: |
           kind load docker-image --name chart-testing cilium/cilium:latest
-          kind load docker-image --name chart-testing cilium/operator:latest
+          kind load docker-image --name chart-testing cilium/operator-generic:latest
 
       # This test is just to make sure the helm chart can be installed. It will not replace existing integration tests
       - name: Run chart-testing (install)
@@ -77,4 +77,4 @@ jobs:
         run: |
           cd test
           export PATH=$PATH:$HOME/go/bin
-          ginkgo -v --focus="K8sConformance Portmap Chaining Check one node.*" -- -cilium.provision=false -test.v --cilium.kubeconfig=${HOME}/.kube/config -cilium.image=cilium/cilium:latest -cilium.operator-image=cilium/operator:latest
+          ginkgo -v --focus="K8sConformance Portmap Chaining Check one node.*" -- -cilium.provision=false -test.v --cilium.kubeconfig=${HOME}/.kube/config -cilium.image=cilium/cilium:latest -cilium.operator-image=cilium/operator-generic:latest

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -473,7 +473,7 @@ An example invocation is
 
 ::
 
-  CNI_INTEGRATION=eks K8S_VERSION=1.13 ginkgo --focus="K8s*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=eks K8S_VERSION=1.13 ginkgo --focus="K8s*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator-generic:latest" -cilium.passCLIEnvironment=true
 
 GKE (experimental)
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -495,7 +495,7 @@ cluster.
 
 ::
 
-  CNI_INTEGRATION=gke K8S_VERSION=1.13 ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=gke K8S_VERSION=1.13 ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator-generic:latest" -cilium.passCLIEnvironment=true
 
 .. note:: The kubernetes version defaults to 1.13 but can be configured with
           versions between 1.13 and 1.15. Check with ``kubectl version`` 
@@ -513,7 +513,7 @@ cluster.
 
 ::
 
-  CNI_INTEGRATION=eks K8S_VERSION=1.14 ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=eks K8S_VERSION=1.14 ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator-generic:latest" -cilium.passCLIEnvironment=true
 
 Be sure to pass ``--cilium.passCLIEnvironment=true`` to allow kubectl to invoke ``aws-iam-authenticator``
 

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -8,15 +8,15 @@ MANAGED_ETCD_VERSION := "v2.0.7"
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
 EXPERIMENTAL_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/experimental-install.yaml"
 MANAGED_ETCD_PATH := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/charts/managed-etcd/values.yaml"
-CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/"
-CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml"
+CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium"
+CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml" "$(CILIUM_CHARTS)/charts/operator/values.yaml"
 
 VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+.*'
 LATEST_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
 DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
-CILIUM_PULLPOLICY_REGEX := '\(pullPolicy:\) .*'
+CILIUM_PULLPOLICY_REGEX := '\([pP]ullPolicy:\) .*'
 EXPERIMENTAL_OPTIONS := \
     --set global.hubble.enabled=true \
     --set global.hubble.listenAddress=":4244" \
@@ -35,20 +35,21 @@ $(EXPERIMENTAL_INSTALL): $(shell find cilium/ -type f)
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"
 	@# Update chart versions to point to the current version.
-	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS) | \
+	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS)/ | \
 		xargs -0 -l sed -i -e 's/'$(CILIUM_CHART_REGEX)'/\1 $(VERSION)/g'
 	@# Fix up the cilium tag
-	$(QUIET)if echo $(VERSION) | grep -q $(LATEST_VERSION_REGEX); then				\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $(CILIUM_VALUES);			\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
+	$(QUIET)for chart in $(CILIUM_VALUES); do							\
+		if echo $(VERSION) | grep -q $(LATEST_VERSION_REGEX); then				\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $$chart;				\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $$chart;			\
 		elif echo $(VERSION) | grep -q $(DEV_VERSION_REGEX); then				\
 			DEV_BRANCH=$$(echo $(VERSION) | sed 's/-dev//')					\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 $(DEV_BRANCH)/' $(CILIUM_VALUES);		\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 $(DEV_BRANCH)/' $$chart;			\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $$chart;			\
 		else											\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $(CILIUM_VALUES);		\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $(CILIUM_VALUES);	\
-		fi
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $$chart;			\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $$chart;		\
+		fi; done
 	@# Fix up the managed etcd version, as that has its own scheme
 	$(QUIET)sed -i 's/'$(VERSION)'/'$(MANAGED_ETCD_VERSION)'/' $(MANAGED_ETCD_PATH)
 

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -109,19 +109,19 @@ spec:
 {{- end }}
 {{- if .Values.global.eni }}
 {{- if contains "/" .Values.image.repository }}
-        image: "{{ .Values.image.repository }}-aws"
+        image: "{{ .Values.image.repository }}"
 {{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}-aws:{{ .Values.image.tag }}"
 {{- end }}
 {{- else if .Values.global.azure.enabled }}
 {{- if contains "/" .Values.image.repository }}
-        image: "{{ .Values.image.repository }}-azure"
+        image: "{{ .Values.image.repository }}"
 {{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}-azure:{{ .Values.image.tag }}"
 {{- end }}
 {{- else }}
 {{- if contains "/" .Values.image.repository }}
-        image: "{{ .Values.image.repository }}-generic"
+        image: "{{ .Values.image.repository }}"
 {{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}-generic:{{ .Values.image.tag }}"
 {{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -33,7 +33,13 @@ spec:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
         command:
-        - cilium-operator
+{{- if .Values.global.eni }}
+        - cilium-operator-aws
+{{- else if .Values.global.azure.enabled }}
+        - cilium-operator-azure
+{{- else }}
+        - cilium-operator-generic
+{{- end }}
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -101,12 +107,30 @@ spec:
         - name: AZURE_CLIENT_SECRET
           value: {{ .Values.global.azure.clientSecret }}
 {{- end }}
-{{- if contains "/" .Values.image }}
-        image: "{{ .Values.image }}"
+{{- if .Values.global.eni }}
+{{- if contains "/" .Values.image.repository }}
+        image: "{{ .Values.image.repository }}-aws"
 {{- else }}
-        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+        image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}-aws:{{ .Values.image.tag }}"
 {{- end }}
+{{- else if .Values.global.azure.enabled }}
+{{- if contains "/" .Values.image.repository }}
+        image: "{{ .Values.image.repository }}-azure"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}-azure:{{ .Values.image.tag }}"
+{{- end }}
+{{- else }}
+{{- if contains "/" .Values.image.repository }}
+        image: "{{ .Values.image.repository }}-generic"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}-generic:{{ .Values.image.tag }}"
+{{- end }}
+{{- end }}
+{{- if .Values.global.pullPolicy }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
+{{- else }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- end }}
         name: cilium-operator
 {{- if .Values.global.prometheus.enabled }}
         ports:

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -1,4 +1,8 @@
-image: operator
+image:
+  repository: operator
+  tag: latest
+  pullPolicy: Always
+
 # Deprecated: please use synchronizeK8sNodes in install/kubernetes/cilium/values.yaml
 synchronizeK8sNodes: true
 

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -841,7 +841,7 @@ spec:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
         command:
-        - cilium-operator
+        - cilium-operator-generic
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -877,7 +877,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator:latest"
+        image: "docker.io/cilium/operator-generic:latest"
         imagePullPolicy: Always
         name: cilium-operator
         livenessProbe:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -620,7 +620,7 @@ spec:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
         command:
-        - cilium-operator
+        - cilium-operator-generic
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -656,7 +656,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator:latest"
+        image: "docker.io/cilium/operator-generic:latest"
         imagePullPolicy: Always
         name: cilium-operator
         livenessProbe:

--- a/jenkinsfiles/ginkgo-eks.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-eks.Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
             }
             steps {
                 dir("${TESTDIR}"){
-                    sh 'CILIUM_IMAGE=$(./print-node-ip.sh)/cilium/cilium:latest CILIUM_OPERATOR_IMAGE=$(./print-node-ip.sh)/cilium/operator:latest ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s*/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/eks/eks-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'
+                    sh 'CILIUM_IMAGE=$(./print-node-ip.sh)/cilium/cilium:latest CILIUM_OPERATOR_IMAGE=$(./print-node-ip.sh)/cilium/operator-generic:latest ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s*/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/eks/eks-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'
                 }
             }
             post {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -91,7 +91,7 @@ var (
 		"agent.image":                         "cilium-dev",
 		"preflight.image":                     "cilium-dev", // Set again in init to match agent.image!
 		"global.tag":                          "latest",
-		"operator.image":                      "operator",
+		"operator.image.repository":           "operator",
 		"global.debug.enabled":                "true",
 		"global.k8s.requireIPv4PodCIDR":       "true",
 		"global.pprof.enabled":                "true",
@@ -239,7 +239,7 @@ func Init() {
 		"CILIUM_REGISTRY":       "global.registry",
 		"CILIUM_TAG":            "global.tag",
 		"CILIUM_IMAGE":          "agent.image",
-		"CILIUM_OPERATOR_IMAGE": "operator.image",
+		"CILIUM_OPERATOR_IMAGE": "operator.image.repository",
 		"HUBBLE_RELAY_IMAGE":    "hubble-relay.image",
 	} {
 		if v := os.Getenv(envVar); v != "" {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -240,10 +240,10 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		By("Deploying Cilium %s", oldHelmChartVersion)
 
 		opts := map[string]string{
-			"global.tag":      oldImageVersion,
-			"global.registry": "docker.io/cilium",
-			"agent.image":     "cilium",
-			"operator.image":  "operator",
+			"global.tag":                oldImageVersion,
+			"global.registry":           "docker.io/cilium",
+			"agent.image":               "cilium",
+			"operator.image.repository": "operator",
 		}
 		if helpers.RunsWithoutKubeProxy() {
 			opts["global.nodePort.device"] = privateIface

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -11,7 +11,7 @@ helm template install/kubernetes/cilium \
   --set global.registry=k8s1:5000/cilium \
   --set global.tag=latest \
   --set agent.image=cilium-dev \
-  --set operator.image=operator \
+  --set operator.image.repository=operator \
   --set global.debug.enabled=true \
   --set global.k8s.requireIPv4PodCIDR=true \
   --set global.pprof.enabled=true \


### PR DESCRIPTION
…tor deployment for generic, aws and azure

Fixes: #11800

Signed-off-by: Sean Winn <sean@isovalent.com>


```release-note
cilium-operator now packages a separate container for generic use cases, as well as additional container images for Microsoft Azure and Amazon Web Services. The default configuration will deploy the cilium-operator-generic image. For AWS, configure `.Values.global.eni=true` to deploy the cilium-operator-aws image. For Azure configure `.Values.global.azure.enabled=true` to deploy the cilium-operator-azure image. Only one cloud provider is supported in a Cilium deployment.
```