### PR TITLE
docs: Parameterize READTHEDOCS_VERSION

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -18,6 +18,7 @@ ADD ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
+ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION
 
 ## Workaround odd behaviour of sphinx versionwarning extension. It wants to
 ## write runtime data inside a system directory.

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -15,6 +15,7 @@ builder-image: Dockerfile requirements.txt
 	$(QUIET)tar c requirements.txt Dockerfile \
 	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
 
+READTHEDOCS_VERSION:=$(READTHEDOCS_VERSION)
 DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 		--workdir /src/Documentation \
 		--volume $(CURDIR)/..:/src \


### PR DESCRIPTION
This way you can specify it on the commandline to generate docs in the
way that RTD would by passing the environment variable, eg:

    $ READTHEDOCS_VERSION="v1.8.0-rc2" make render-docs