### PR TITLE
test: Track iptables drops during tests.

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -651,7 +651,7 @@ func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 	}()
 
 	blacklist := GetBadLogMessages()
-	failIfContainsBadLogMsg(logs, blacklist)
+	failIfContainsBadLogMsg("Cilium", "", logs, blacklist, false)
 
 	fmt.Fprintf(CheckLogs, logutils.LogErrorsSummary(logs))
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -236,6 +236,9 @@ const (
 	uninitializedRegen = "Uninitialized regeneration level"           // from https://github.com/cilium/cilium/pull/10949
 	unstableStat       = "BUG: stat() has unstable behavior"          // from https://github.com/cilium/cilium/pull/11028
 
+	// dmesg messages that should not be seen
+	forwardDrop = "FORWARD DROP established:"
+
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
 
@@ -290,6 +293,12 @@ var badLogMessages = map[string][]string{
 	unstableStat:       nil,
 }
 
+// badDmesgMessages is a map which key is a part of a dmesg message which indicates
+// a failure if the message does not contain any part from value list.
+var badDmesgMessages = map[string][]string{
+	forwardDrop: nil,
+}
+
 var ciliumCLICommands = map[string]string{
 	"cilium endpoint list -o json":          "endpoint_list.txt",
 	"cilium service list -o json":           "service_list.txt",
@@ -338,6 +347,18 @@ func K8s2VMName() string {
 func GetBadLogMessages() map[string][]string {
 	mapCopy := make(map[string][]string, len(badLogMessages))
 	for badMsg, exceptions := range badLogMessages {
+		exceptionsCopy := make([]string, len(exceptions))
+		copy(exceptionsCopy, exceptions)
+		mapCopy[badMsg] = exceptionsCopy
+	}
+	return mapCopy
+}
+
+// GetBadDmesgMessages returns a deep copy of badDmesgMessages to allow removing
+// messages for specific tests.
+func GetBadDmesgMessages() map[string][]string {
+	mapCopy := make(map[string][]string, len(badDmesgMessages))
+	for badMsg, exceptions := range badDmesgMessages {
 		exceptionsCopy := make([]string, len(exceptions))
 		copy(exceptionsCopy, exceptions)
 		mapCopy[badMsg] = exceptionsCopy

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2985,11 +2985,37 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 	}
 }
 
+// ValidateNoErrorsInDmesg checks that dmesg output (since the last check)
+// do not contain any of the known-bad messages (e.g., dropped packets).
+// In case of any of these messages, it'll mark the test as failed.
+func (kub *Kubectl) ValidateNoErrorsInDmesg() {
+	blacklist := GetBadDmesgMessages()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	pods, err := kub.GetCiliumPods(GetCiliumNamespace(GetCurrentIntegration()))
+	if err != nil {
+		fmt.Fprintf(CheckLogs, "Could not get Cilium PODs: %s", err)
+		return
+	}
+	for _, pod := range pods {
+		res := kub.CiliumExecContext(ctx, pod,
+			"dmesg --read-clear --level debug --nopager --color=never --time-format iso")
+		if !res.WasSuccessful() {
+			fmt.Fprintf(CheckLogs, "dmesg failed: %s", res.CombineOutput())
+			continue
+		}
+		failIfContainsBadLogMsg("dmesg", pod, res.Output().String(), blacklist, true)
+	}
+
+}
+
 // ValidateNoErrorsInLogs checks that cilium logs since the given duration (By
 // default `CurrentGinkgoTestDescription().Duration`) do not contain any of the
 // known-bad messages (e.g., `deadlocks` or `segmentation faults`). In case of
 // any of these messages, it'll mark the test as failed.
 func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
+	kub.ValidateNoErrorsInDmesg()
 	blacklist := GetBadLogMessages()
 	kub.ValidateListOfErrorsInLogs(duration, blacklist)
 }
@@ -3028,7 +3054,7 @@ func (kub *Kubectl) ValidateListOfErrorsInLogs(duration time.Duration, blacklist
 		}
 	}()
 
-	failIfContainsBadLogMsg(logs, blacklist)
+	failIfContainsBadLogMsg("Cilium", "", logs, blacklist, false)
 
 	fmt.Fprintf(CheckLogs, logutils.LogErrorsSummary(logs))
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -460,8 +460,11 @@ func CanRunK8sVersion(ciliumVersion, k8sVersionStr string) (bool, error) {
 // failIfContainsBadLogMsg makes a test case to fail if any message from
 // given log messages contains an entry from the blacklist (map key) AND
 // does not contain ignore messages (map value).
-func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
+func failIfContainsBadLogMsg(kind, pod string, logs string, blacklist map[string][]string, print bool) {
 	nFailures := 0
+	if pod != "" {
+		pod = " of " + pod
+	}
 	for _, msg := range strings.Split(logs, "\n") {
 		for fail, ignoreMessages := range blacklist {
 			if strings.Contains(msg, fail) {
@@ -473,14 +476,18 @@ func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 					}
 				}
 				if !ok {
-					fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs\n", fail)
+					line := ""
+					if print {
+						line = ": " + msg
+					}
+					fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs%s%s\n", fail, pod, line)
 					nFailures++
 				}
 			}
 		}
 	}
 	if nFailures > 0 {
-		Fail(fmt.Sprintf("Found %d Cilium logs matching list of errors that must be investigated", nFailures))
+		Fail(fmt.Sprintf("Found %d %s logs%s matching list of errors that must be investigated", nFailures, kind, pod))
 	}
 }
 

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -408,6 +408,10 @@ else
     sudo systemctl stop etcd
 fi
 
+# Add iptables LOG rule to catch forward drops
+sudo iptables -t filter -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "Logging established traffic that is being dropped (see dmesg)" -j LOG --log-prefix "FORWARD DROP established: " --log-level debug
+sudo dmesg --clear
+
 # Add aliases and bash completion for kubectl
 cat <<EOF >> /home/vagrant/.bashrc
 


### PR DESCRIPTION
Log packets dropped in iptables forward chain and warn about them in
CI test output. If any packets reach the end of the iptables forward
chain without being accepted they are logged to the kernel message
buffer from where they are fetched after each test for filtering.

If there are any drops the test output will contain lines like:

FAIL: Found 10 dmesg logs of cilium-mmxcb matching list of errors that must be investigated

and:

Found a "FORWARD DROP established:" in logs of cilium-mmxcb: 2020-06-02T23:31:59,055028+00:00 FORWARD DROP established: IN=cilium_net OUT=enp0s8 MAC=ba:a0:e8:df:3f:56:9e:21:27:73:1d:e6:08:00 SRC=10.0.0.182 DST=192.168.36.12 LEN=60 TOS=0x00 PREC=0x00 TTL=63 ID=0 DF PROTO=TCP SPT=80 DPT=60916 WINDOW=28960 RES=0x00 ACK SYN URGP=0

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
