### PR TITLE
Add audit action to the policy verdict log

### DIFF
--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -30,7 +30,8 @@ struct policy_verdict_notify {
 	__u8	dir:2,
 		ipv6:1,
 		match_type:3,
-		pad0:2;
+		audited:1,
+		pad0:1;
 	__u32	pad1; /* align with 64 bits */
 };
 
@@ -46,7 +47,7 @@ static __always_inline bool policy_verdict_filter_allow(__u32 filter, __u8 dir)
 static __always_inline void
 send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst_port,
 			   __u8 proto, __u8 dir, __u8 is_ipv6, int verdict,
-			   __u8 match_type)
+			   __u8 match_type, __u8 is_audited)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
@@ -65,6 +66,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 		.proto		= proto,
 		.dir		= dir,
 		.ipv6		= is_ipv6,
+		.audited	= is_audited,
 	};
 
 	ctx_event_output(ctx, &EVENTS_MAP,

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1540,6 +1540,9 @@ var _ = Describe("RuntimePolicies", func() {
 				hubbleRes := vm.HubbleObserveFollow(ctx, "--type", "policy-verdict", "--type", "trace:to-endpoint", "--protocol", "ICMPv4")
 				defer cancel()
 
+				By("Starting cilium monitor in background")
+				monitorRes := vm.ExecInBackground(ctx, "cilium monitor --type policy-verdict")
+
 				By("Creating an endpoint")
 				endpointID, endpointIP := createEndpoint()
 
@@ -1559,6 +1562,12 @@ var _ = Describe("RuntimePolicies", func() {
 					fmt.Sprintf("[reserved:host] -> %s [container:somelabel] %s : FORWARDED 4", endpointID, endpointIP.IPV4),
 					"No ingress traffic to endpoint")
 
+				By("Testing cilium monitor output")
+				monitorRes.ExpectContains(
+					fmt.Sprintf("local EP ID %s, remote ID 1, dst port 0, proto 1, ingress true, action audit", endpointID),
+					"No ingress policy log record",
+				)
+
 				By("Testing cilium endpoint list output")
 				res = vm.Exec("cilium endpoint list")
 				res.ExpectMatchesRegexp(endpointID+"\\s*Disabled \\(Audit\\)\\s*Disabled \\(Audit\\)", "Endpoint is not in audit mode")
@@ -1571,6 +1580,9 @@ var _ = Describe("RuntimePolicies", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				hubbleRes := vm.HubbleObserveFollow(ctx, "--type", "policy-verdict", "--type", "trace:to-endpoint", "--protocol", "ICMPv4")
 				defer cancel()
+
+				By("Starting cilium monitor in background")
+				monitorRes := vm.ExecInBackground(ctx, "cilium monitor --type policy-verdict")
 
 				By("Creating an endpoint")
 				endpointID, _ := createEndpoint("ping", hostIP)
@@ -1590,6 +1602,12 @@ var _ = Describe("RuntimePolicies", func() {
 					`{.source.ID} -> {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
 					fmt.Sprintf("%s -> [reserved:host] %s : FORWARDED 5", endpointID, hostIP),
 					"Default policy verdict on egress failed")
+
+				By("Testing cilium monitor output")
+				monitorRes.ExpectContains(
+					fmt.Sprintf("ID %s, remote ID 1, dst port 0, proto 1, ingress false, action audit", endpointID),
+					"No egress policy log record",
+				)
 
 				By("Testing cilium endpoint list output")
 				res := vm.Exec("cilium endpoint list")


### PR DESCRIPTION
The audit mode may overwrite policy related verdict and in this
situation it's unclear from the policy verdict log that this
happened. This commit adds a new audit bit to the policy log's struct
and adds a new policy log action 'audit' based on that flag. Related
policy log calls were updated to contain audit flag.

fixes #11778 