### PR TITLE
Allow the generic-veth CNI plugin to be used even if the network name is unknown

### DIFF
--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -36,6 +36,9 @@ const (
 	// DefaultConfigName is the name used by default in the standard CNI
 	// configuration
 	DefaultConfigName = "cilium"
+
+	// GenericConfigName is the plugin to use if the network name is unknown
+	GenericConfigName = "generic-veth"
 )
 
 // PluginContext is the context given to chaining plugins
@@ -85,10 +88,18 @@ func Register(name string, p ChainingPlugin) error {
 	return nil
 }
 
-// Lookup searches for a chaining plugin with a given name and returns it
+// Lookup searches for a chaining plugin with a given name and returns it.
+// If no plugin with that name exists, returns the generic veth plugin.
 func Lookup(name string) ChainingPlugin {
 	mutex.RLock()
 	defer mutex.RUnlock()
+	if name == DefaultConfigName {
+		return nil
+	}
 
-	return chainingPlugins[name]
+	if plugin, exists := chainingPlugins[name]; exists {
+		return plugin
+	}
+	return chainingPlugins[GenericConfigName]
+
 }

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -64,3 +64,10 @@ func (a *APISuite) TestRegistration(c *check.C) {
 func (a *APISuite) TestNonChaining(c *check.C) {
 	c.Assert(Lookup("cilium"), check.IsNil)
 }
+
+func (a *APISuite) TestGenericChainingWithAnyName(c *check.C) {
+	err := Register(GenericConfigName, &pluginTest{})
+	c.Assert(err, check.IsNil)
+	c.Assert(Lookup("generic-veth"), check.Not(check.IsNil))
+	c.Assert(Lookup("network123"), check.Not(check.IsNil))
+}

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -202,5 +202,5 @@ func (f *GenericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.P
 }
 
 func init() {
-	chainingapi.Register("generic-veth", &GenericVethChainer{})
+	chainingapi.Register(chainingapi.GenericConfigName, &GenericVethChainer{})
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
When cilium-cni is used in chaining mode, if the network name is not pre-registered, use the generic-veth plugin instead of the full cilium CNI

This is a *breaking change*. Network names that used to default to the
regular "cilium" cni handler will now use the generic-veth plugin instead.

Signed-off-by: Varun Marupadi <varunmar@google.com>

Fixes: #11844

```release-note
When chaining, if the network name is not pre-registered use the generic-veth plugin instead of the full cilium CNI
```
