### PR TITLE
k8s: Fix data race when setting node address

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -380,16 +380,8 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	treatRemoteNodeAsHost := option.Config.AlwaysAllowLocalhost() && !option.Config.EnableRemoteNodeIdentity
 	policyApi.InitEntities(option.Config.ClusterName, treatRemoteNodeAsHost)
 
-	d.k8sCachesSynced = d.k8sWatcher.InitK8sSubsystem()
-
-	bootstrapStats.cleanup.Start()
-	err = clearCiliumVeths()
-	bootstrapStats.cleanup.EndError(err)
-	if err != nil {
-		log.WithError(err).Warning("Unable to clean stale endpoint interfaces")
-	}
-
 	if k8s.IsEnabled() {
+		bootstrapStats.k8sInit.Start()
 		if err := k8s.RegisterCRDs(); err != nil {
 			log.WithError(err).Fatal("Unable to register CRDs")
 		}
@@ -414,6 +406,15 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		}
 
 		bootstrapStats.k8sInit.End(true)
+	}
+
+	d.k8sCachesSynced = d.k8sWatcher.InitK8sSubsystem()
+
+	bootstrapStats.cleanup.Start()
+	err = clearCiliumVeths()
+	bootstrapStats.cleanup.EndError(err)
+	if err != nil {
+		log.WithError(err).Warning("Unable to clean stale endpoint interfaces")
 	}
 
 	d.bootstrapIPAM()


### PR DESCRIPTION
The k8s cache handlers will depend on node addressing information so the
retrieval of own node information must complete before caches are being
synchronized.

Also re-add a bootstrap start sequence that was removed accidentally by
05163ed608e.

Fixes: 05163ed608e ("endpoint: Ensure restored endpoint is validated before regenerating it")
Fixes: #11836
