### PR TITLE
ci: Change vagrant timeout mechanism

### DIFF
--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -126,10 +126,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 30, unit: 'MINUTES'){
-                                sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
-                                sh 'cd ${TESTDIR}; vagrant up runtime --provision'
-                            }
+                            sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
+                            sh 'cd ${TESTDIR}; timeout 30m vagrant up runtime --provision'
                         }
                     }
                     post {
@@ -158,10 +156,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 45, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
                             }
                         }
                     }
@@ -187,10 +183,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 45, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
                             }
                         }
                     }

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -78,17 +78,14 @@ pipeline {
         }
         stage('Boot VMs'){
             options {
-                timeout(time: 60, unit: 'MINUTES')
+                timeout(time: 70, unit: 'MINUTES')
             }
 
             steps {
                 retry(3){
-                    timeout(time: 20, unit: 'MINUTES'){
-                        sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
-                        sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
-                        sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
-                        sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
-                    }
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; timeout 20m vagrant up k8s1-${K8S_VERSION} k8s2-${K8S_VERSION}'
                 }
             }
         }


### PR DESCRIPTION
Due to bug in jenkins, nesting timeout in retry block causes build to
abort. Work around by using shell-based timeout