### PR TITLE
helm: updated default values.yml to advise about config.ipam=eni

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -12,6 +12,14 @@ agent:
 config:
   enabled: true
 
+  # Configure IPAM type (default: "cluster-pool"). Possible values:
+  # - cluster-pool
+  # - kubernetes
+  # - eni
+  # - azure
+  # - crd
+  # ipam: cluster-pool
+
 # Include the cilium-operator Deployment
 operator:
   enabled: true
@@ -383,6 +391,7 @@ global:
     requireIPv4PodCIDR: false
 
   # ENI mode configures the options required to run with ENI
+  # You will also need to set `config.ipam: eni`
   eni: false
 
   # Google Kubernetes Engine


### PR DESCRIPTION
Following the upgrade from `1.7.4` to `1.8.0-rc1`, I experienced a small issue regarding the existing IPAM configuration:

<img width="715" alt="image" src="https://user-images.githubusercontent.com/1761583/83636753-c797f400-a5a6-11ea-9516-e81014a76496.png">

We now have to set : `config.ipam: eni` in order to keep an existing/working configuration in place. I added a few indications in the default values of the chart to make it more obvious.