### PR TITLE
helm: added global.logOptions parameter

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -388,6 +388,9 @@ data:
 {{- if .Values.global.logSystemLoad }}
   log-system-load: {{ .Values.global.logSystemLoad | quote }}
 {{- end }}
+{{- if .Values.global.logOptions }}
+  log-opt: {{ toYaml .Values.global.logOptions | nindent 4 }}
+{{- end }}
 {{- if and .Values.global.sockops .Values.global.sockops.enabled }}
   sockops-enable: {{ .Values.global.sockops.enabled | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -371,6 +371,10 @@ global:
   # logSytemLoad enables logging of system load
   logSystemLoad: false
 
+  # logOptions allows you to define logging options. eg:
+  # logOptions:
+  #   format: json
+
   # sockops is the BPF socket operations configuration
   sockops:
     # enabled enables installation of socket level functionality.


### PR DESCRIPTION
Following up onto #11133, this PR adds a new `global.logOptions` parameter in order to be able to configure log configuration through the helm chart.
