### PR TITLE
service: Fix wrong localEndpoints count in HealthCheckNodePort

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -261,9 +261,13 @@ func (s *Service) UpsertService(
 		return false, lb.ID(0), err
 	}
 
-	localBackendCount := len(backendsCopy)
-	s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
-		localBackendCount, svc.svcHealthCheckNodePort)
+	// Only add a HealthCheckNodePort server if this is a service which may
+	// only contain local backends.
+	if onlyLocalBackends {
+		localBackendCount := len(backendsCopy)
+		s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
+			localBackendCount, svc.svcHealthCheckNodePort)
+	}
 
 	if new {
 		addMetric.Inc()


### PR DESCRIPTION
This fixes an issue with the `HealthCheckNodePort` server where it
would non-deterministically sometimes return a non-zero
`localEndpoints` count on nodes which do not have local endpoints.

Because Cilium internally creates a service object per frontend IP, we
end up with multiple services sharing the same name. In the case where
a `LoadBalancer` service has `externalTrafficPolicy=Local` with no
local backends, Cilium will still create a `ClusterIP` sibling service
which retains the non-local backends. In that case, we must take care
to not incooperate the `ClusterIP` backends into the `localEndpoints`
count intended for external traffic. The final count is dependent on
the order in which services are added to the service manager, which
explains why the occurence of this bug was non-deterministic.

This commit fixes this issue by checking that the service may only
contain local backends before its count is added to the
`HealthCheckNodePort` server. The unit tests are adapated as well and
try to emulate the way the K8s watcher upserts services in the service
manager.

Fixes: #11043

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
