### PR TITLE
daemon: cancel daemon context on TearDownTest

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -150,6 +150,7 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	identitymanager.RemoveAll()
 
 	ds.d.Close()
+	ds.d.cancel()
 }
 
 type DaemonEtcdSuite struct {


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Fixes:

```
WARNING: DATA RACE
Read at 0x00c000e98510 by goroutine 167:
  github.com/cilium/cilium/daemon/cmd.(*Daemon).bootstrapFQDN.func1()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/daemon/cmd/fqdn.go:191 +0x23a
  github.com/cilium/cilium/pkg/controller.(*Controller).runController()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/pkg/controller/controller.go:205 +0x994
Previous write at 0x00c000e98510 by goroutine 65:
  github.com/cilium/cilium/daemon/cmd.(*DaemonSuite).SetUpTest()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:126 +0x479
  github.com/cilium/cilium/daemon/cmd.(*DaemonEtcdSuite).SetUpTest()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:167 +0x44
  runtime.call32()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:730 +0x1c3
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
Goroutine 167 (running) created at:
  github.com/cilium/cilium/pkg/controller.(*Manager).updateController()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/pkg/controller/manager.go:120 +0xae0
  github.com/cilium/cilium/pkg/controller.(*Manager).UpdateController()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/pkg/controller/manager.go:59 +0xe4
  github.com/cilium/cilium/daemon/cmd.(*Daemon).bootstrapFQDN()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/daemon/cmd/fqdn.go:172 +0x815
  github.com/cilium/cilium/daemon/cmd.NewDaemon()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/daemon/cmd/daemon.go:544 +0x2fcd
  github.com/cilium/cilium/daemon/cmd.(*DaemonSuite).SetUpTest()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:115 +0x115
  github.com/cilium/cilium/daemon/cmd.(*DaemonEtcdSuite).SetUpTest()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:167 +0x44
  runtime.call32()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:730 +0x1c3
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
Goroutine 65 (finished) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:672 +0x44d
  gopkg.in/check%2ev1.(*suiteRunner).runFunc()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:682 +0x83
  gopkg.in/check%2ev1.(*suiteRunner).runFixture()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:726 +0x3d
  gopkg.in/check%2ev1.(*suiteRunner).runFixtureWithPanic()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:744 +0x82
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:769 +0x28c
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/aanm/git-repos/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9a
      
      WARNING: DATA RACE
Read at 0x00c000ec82b0 by goroutine 167:
  github.com/cilium/cilium/pkg/endpointmanager.(*EndpointManager).GetEndpoints()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/endpointmanager/manager.go:428 +0x87
  github.com/cilium/cilium/daemon/cmd.(*Daemon).bootstrapFQDN.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/daemon/cmd/fqdn.go:191 +0x252
  github.com/cilium/cilium/pkg/controller.(*Controller).runController()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/controller/controller.go:205 +0x994
Previous write at 0x00c000ec82b0 by goroutine 65:
  github.com/cilium/cilium/pkg/endpointmanager.NewEndpointManager()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/endpointmanager/manager.go:75 +0xd9
  github.com/cilium/cilium/daemon/cmd.(*DaemonSuite).SetUpTest()
      /home/travis/gopath/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:126 +0x42e
  github.com/cilium/cilium/daemon/cmd.(*DaemonEtcdSuite).SetUpTest()
      /home/travis/gopath/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:167 +0x44
  runtime.call32()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:730 +0x1c3
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
Goroutine 167 (running) created at:
  github.com/cilium/cilium/pkg/controller.(*Manager).updateController()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/controller/manager.go:120 +0xae0
  github.com/cilium/cilium/pkg/controller.(*Manager).UpdateController()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/controller/manager.go:59 +0xe4
  github.com/cilium/cilium/daemon/cmd.(*Daemon).bootstrapFQDN()
      /home/travis/gopath/src/github.com/cilium/cilium/daemon/cmd/fqdn.go:172 +0x815
  github.com/cilium/cilium/daemon/cmd.NewDaemon()
      /home/travis/gopath/src/github.com/cilium/cilium/daemon/cmd/daemon.go:544 +0x2fcd
  github.com/cilium/cilium/daemon/cmd.(*DaemonSuite).SetUpTest()
      /home/travis/gopath/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:115 +0x115
  github.com/cilium/cilium/daemon/cmd.(*DaemonEtcdSuite).SetUpTest()
      /home/travis/gopath/src/github.com/cilium/cilium/daemon/cmd/daemon_test.go:167 +0x44
  runtime.call32()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:730 +0x1c3
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
Goroutine 65 (finished) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:672 +0x44d
  gopkg.in/check%2ev1.(*suiteRunner).runFunc()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:682 +0x83
  gopkg.in/check%2ev1.(*suiteRunner).runFixture()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:726 +0x3d
  gopkg.in/check%2ev1.(*suiteRunner).runFixtureWithPanic()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:744 +0x82
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:769 +0x28c
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
==================
```