### PR TITLE
test/packet: extend add_vagrant_box.sh script to load dev/CI images

### DIFF
--- a/test/packet/scripts/install.sh
+++ b/test/packet/scripts/install.sh
@@ -43,7 +43,7 @@ cp /provision/add_vagrant_box.sh /usr/local/bin/
 chmod 755 /usr/local/bin/add_vagrant_box.sh
 
 curl -s https://raw.githubusercontent.com/cilium/cilium/master/vagrant_box_defaults.rb > defaults.rb
-/usr/local/bin/add_vagrant_box defaults.rb
+/usr/local/bin/add_vagrant_box.sh defaults.rb
 
 wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
 unzip packer_${PACKER_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Extend the script used to preload Ubuntu images for the CI with packet, so it can be used to preload images for tests and dev in general.

Changes include:

- Make `vagrant_box_defaults.rb` path optional (defaults to `./vagrant_box_defaults.rb`).
- Add a `-b` option to pass the names of the boxes to download.
- Add a `-l` option to download latest available versions for the images instead of version numbers from `vagrant_box_defaults.rb`.
- Add a `-a` option to download with `aria2c` instead of `curl`.
- Add a `-t` option to download the images under `/tmp/` instead of using the current directory.
- Extend help message to reflect these changes and provide a couple of example invocations.
  <details><summary>New help message</summary>

  ```
  usage: add-vagrant-boxes.sh [options] [vagrant_box_defaults.rb path]
          path to vagrant_box_defaults.rb defaults to ./vagrant_box_defaults.rb
  
  options:
          -a              use aria2c instead of curl
          -b <box>        download selected box (defaults: ubuntu ubuntu-next)
          -l              download latest versions instead of using vagrant_box_defaults
          -t              download to /tmp/ instead of current directory
          -h              display this help
  
  examples:
          download boxes ubuntu and ubuntu-next from vagrant_box_defaults.rb:
          $ add-vagrant-boxes.sh $HOME/go/src/github.com/cilium/cilium/vagrant_box_defaults.rb
          download latest version for ubuntu-dev and ubuntu-next:
          $ add-vagrant-boxes.sh -l -b ubuntu-dev -b ubuntu-next
          same as above, downloading into /tmp/ and using aria2c:
          $ add-vagrant-boxes.sh -alt -b ubuntu-dev -b ubuntu-next
  ```
  </details>

The behaviour of the script is unchanged if invoked with none of those new options.

Currently marking as a RFC because I don't know if there is any interest for extending that script, and I can keep a local version if I'm the only one finding it useful. If others were to find it helpful, a follow-up could be to move that script under `contrib/` and to mention it in the docs.