### PR TITLE
operator: re-add install target to Makefile

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -26,3 +26,7 @@ clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -f $(TARGETS)
 	$(GO) clean $(GOCLEAN)
+
+install:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGETS) $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
This was removed in #10972, re-add so binaries can easily be installed
e.g. to a temporary location during development.

Fixes: 053fc866ab53 ("operator: Build 3 new slimmer binaries")