### PR TITLE
docs: k3s command missing `sh -`

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -42,7 +42,7 @@ replace the variables with values from your environment:
 
 .. parsed-literal::
 
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--no-flannel' K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN}
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--no-flannel' K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
 
 Should you encounter any issues during the installation, please refer to the
 :ref:`troubleshooting_k8s` section and / or seek help on the `Slack channel`.


### PR DESCRIPTION
Spent a long time trying to figure out what went wrong, turns out the command to join nodes was just missing `sh -` to actually run it :|

Signed-off-by: Glib Smaga <code@gsmaga.com>