### PR TITLE
docs: Include directions to restart pods in the k3s install guide

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -64,6 +64,7 @@ Install Cilium
 
     kubectl create -f \ |SCM_WEB|\/install/kubernetes/quick-install.yaml
 
+.. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-validate.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst


### PR DESCRIPTION
Adds directions to restart pods to the k3s install guide

Fixes: #11821

Signed-off-by: Sean Winn <sean@isovalent.com>

