### PR TITLE
helm: Set dnsPolicy for Cilium pod to ClusterFirstWithHostNet

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -254,11 +254,7 @@ spec:
           {{- toYaml .Values.monitor.resources | trim | nindent 10 }}
 {{- end }}
 {{- end }}
-{{- if .Values.global.etcd.managed }}
-      # In managed etcd mode, Cilium must be able to resolve the DNS name of
-      # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
-{{- end }}
       hostNetwork: true
       initContainers:
 {{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -495,6 +495,7 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - command:


### PR DESCRIPTION
Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>