### PR TITLE
v1.6 backports 2020-06-03

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -90,6 +90,7 @@ cilium-agent [flags]
       --ip-allocation-timeout duration                        Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
       --ipam string                                           Backend to use for IPAM
       --ipsec-key-file string                                 Path to IPSec key file
+      --iptables-lock-timeout duration                        Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --ipv4-cluster-cidr-mask-size int                       Mask size for the cluster wide CIDR (default 8)
       --ipv4-node string                                      IPv4 address of node (default "auto")
       --ipv4-pod-subnets strings                              List of IPv4 pod subnets to preconfigure for encryption

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1910,6 +1910,7 @@
     "github.com/optiopay/kafka",
     "github.com/optiopay/kafka/proto",
     "github.com/pborman/uuid",
+    "github.com/pkg/errors",
     "github.com/pmezard/go-difflib/difflib",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ check-microk8s:
 	@$(ECHO_CHECK) microk8s is ready...
 	$(QUIET)microk8s.status >/dev/null \
 		|| (echo "Error: Microk8s is not running" && exit 1)
-	$(QUIET)microk8s.status -o yaml | grep -q "registry.*enabled" \
+	$(QUIET)microk8s.status --yaml | grep -q "registry.*enabled" \
 		|| (echo "Error: Microk8s registry must be enabled" && exit 1)
 
 LOCAL_IMAGE_TAG=local

--- a/daemon/cleanup.go
+++ b/daemon/cleanup.go
@@ -23,6 +23,8 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
+
+	gops "github.com/google/gops/agent"
 )
 
 var (
@@ -56,6 +58,7 @@ func registerSigHandler() <-chan struct{} {
 
 // Clean cleans up everything created by this package.
 func Clean() {
+	gops.Close()
 	close(cleanUPSig)
 	cleanUPWg.Wait()
 }

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -686,6 +686,9 @@ func init() {
 	flags.Bool(option.InstallIptRules, true, "Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading)")
 	option.BindEnv(option.InstallIptRules)
 
+	flags.Duration(option.IPTablesLockTimeout, 5*time.Second, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
+	option.BindEnv(option.IPTablesLockTimeout)
+
 	flags.Int(option.MaxCtrlIntervalName, 0, "Maximum interval (in seconds) between controller runs. Zero is no limit.")
 	flags.MarkHidden(option.MaxCtrlIntervalName)
 	option.BindEnv(option.MaxCtrlIntervalName)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -275,6 +275,9 @@ data:
 
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
+{{- if .Values.global.iptablesLockTimeout }}
+  iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
+{{- end }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nodePort }}
   enable-node-port: {{ .Values.global.nodePort.enabled | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -96,7 +96,10 @@ global:
   # disabled.
   installIptablesRules: true
 
-  # masquerade enables masquerading of traffic leaving the ndoe for
+  # iptablesLockTimeout defines the iptables "--wait" option when invoked from Cilium.
+  # iptablesLockTimeout: "5s"
+
+  # masquerade enables masquerading of traffic leaving the node for
   # destinations outside of the cluster.
   masquerade: true
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -82,6 +82,7 @@ func main() {
 
 	go func() {
 		<-signals
+		gops.Close()
 		close(shutdownSignal)
 	}()
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/command/exec"
@@ -60,8 +61,7 @@ var (
 )
 
 const (
-	waitString       = "-w"
-	waitSecondsValue = "5"
+	waitString = "-w"
 )
 
 type customChain struct {
@@ -400,7 +400,7 @@ func (m *IptablesManager) Init() {
 	if err == nil {
 		switch {
 		case waitSecondsMinVersion.Check(v):
-			m.waitArgs = []string{waitString, waitSecondsValue}
+			m.waitArgs = []string{waitString, fmt.Sprintf("%d", option.Config.IPTablesLockTimeout/time.Second)}
 		case waitMinVersion.Check(v):
 			m.waitArgs = []string{waitString}
 		}

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -147,6 +147,9 @@ func (m *AckingResourceMutatorWrapper) addVersionCompletion(typeURL string, vers
 
 // DeleteNode frees resources held for the named nodes
 func (m *AckingResourceMutatorWrapper) DeleteNode(nodeID string) {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
 	delete(m.ackedVersions, nodeID)
 }
 

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -57,7 +57,7 @@ func ToRegexp(pattern string) string {
 
 	// handle the * match-all case. This will filter down to the end.
 	if pattern == "*" {
-		pattern = "(" + allowedDNSCharsREGroup + "+.)+"
+		return "(^(" + allowedDNSCharsREGroup + "+[.])+$)|(^[.]$)"
 	}
 
 	// base case. * becomes .*, but only for DNS valid characters

--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -42,7 +42,8 @@ func (ts *MatchPatternTestSuite) TestMatchPatternREConversion(c *C) {
 	for source, target := range map[string]string{
 		"cilium.io.":   "^cilium[.]io[.]$",
 		"*.cilium.io.": "^" + allowedDNSCharsREGroup + "*[.]cilium[.]io[.]$",
-		"*":            "^(" + allowedDNSCharsREGroup + "+[.])+$",
+		"*":            "(^(" + allowedDNSCharsREGroup + "+[.])+$)|(^[.]$)",
+		".":            "^[.]$",
 	} {
 		reStr := ToRegexp(source)
 		_, err := regexp.Compile(reStr)
@@ -79,8 +80,13 @@ func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
 		},
 		{
 			pattern: "*",
-			accept:  []string{"io.", "cilium.io.", "svc.cluster.local.", "service.namesace.svc.cluster.local.", "_foobar._tcp.cilium.io."}, // the last is for SRV RFC-2782 and DNS-SD RFC6763
-			reject:  []string{"", ".", ".io.", ".cilium.io.", ".svc.cluster.local.", "cilium.io"},                                          // note no final . on this last one
+			accept:  []string{".", "io.", "cilium.io.", "svc.cluster.local.", "service.namesace.svc.cluster.local.", "_foobar._tcp.cilium.io."}, // the last is for SRV RFC-2782 and DNS-SD RFC6763
+			reject:  []string{"", ".io.", ".cilium.io.", ".svc.cluster.local.", "cilium.io"},                                                    // note no final . on this last one
+		},
+		{
+			pattern: ".",
+			accept:  []string{"."},
+			reject:  []string{"", ".io.", ".cilium.io"},
 		},
 
 		// These are more explicit tests for SRV RFC-2782 and DNS-SD RFC6763

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -41,6 +41,12 @@ type Identity struct {
 
 	// Source is the source of the identity in the cache
 	Source source.Source
+
+	// shadowed determines if another entry overlaps with this one.
+	// Shadowed identities are not propagated to listeners by default.
+	// Most commonly set for Identity with Source = source.Generated when
+	// a pod IP (other source) has the same IP.
+	shadowed bool
 }
 
 // IPKeyPair is the (IP, key) pair used of the identity
@@ -266,7 +272,7 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, newIdentity 
 				scopedLog.Debug("Ignoring CIDR to identity mapping as it is shadowed by an endpoint IP")
 				// Skip calling back the listeners, since the endpoint IP has
 				// precedence over the new CIDR.
-				callbackListeners = false
+				newIdentity.shadowed = true
 			}
 		}
 	} else if endpointIP := net.ParseIP(ip); endpointIP != nil { // Endpoint IP.
@@ -280,6 +286,8 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, newIdentity 
 				oldHostIP, _ = ipc.getHostIPCache(cidrStr)
 				if cidrIdentity.ID != newIdentity.ID || !oldHostIP.Equal(hostIP) {
 					scopedLog.Debug("New endpoint IP started shadowing existing CIDR to identity mapping")
+					cidrIdentity.shadowed = true
+					ipc.ipToIdentityCache[cidrStr] = cidrIdentity
 					oldIdentity = &cidrIdentity.ID
 				} else {
 					// The endpoint IP and the CIDR are associated with the
@@ -320,7 +328,7 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, newIdentity 
 		ipc.ipToHostIPCache[ip] = IPKeyPair{IP: hostIP, Key: hostKey}
 	}
 
-	if callbackListeners {
+	if callbackListeners && !newIdentity.shadowed {
 		for _, listener := range ipc.listeners {
 			listener.OnIPIdentityCacheChange(Upsert, *cidr, oldHostIP, hostIP, oldIdentity, newIdentity.ID, hostKey)
 		}
@@ -333,6 +341,9 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, newIdentity 
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
 func (ipc *IPCache) DumpToListenerLocked(listener IPIdentityMappingListener) {
 	for ip, identity := range ipc.ipToIdentityCache {
+		if identity.shadowed {
+			continue
+		}
 		hostIP, encryptKey := ipc.getHostIPCache(ip)
 		_, cidr, err := net.ParseCIDR(ip)
 		if err != nil {
@@ -407,6 +418,8 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) {
 			if cidrIdentity.ID != cachedIdentity.ID || !oldHostIP.Equal(newHostIP) {
 				scopedLog.Debug("Removal of endpoint IP revives shadowed CIDR to identity mapping")
 				cacheModification = Upsert
+				cidrIdentity.shadowed = false
+				ipc.ipToIdentityCache[cidrStr] = cidrIdentity
 				oldIdentity = &cachedIdentity.ID
 				newIdentity = cidrIdentity
 			} else {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -244,3 +244,87 @@ func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
 	c.Assert(err, Not(IsNil))
 	c.Assert(isHost, Equals, false)
 }
+
+type dummyListener struct {
+	entries map[string]identityPkg.NumericIdentity
+	ipc     *IPCache
+}
+
+func newDummyListener(ipc *IPCache) *dummyListener {
+	return &dummyListener{
+		ipc: ipc,
+	}
+}
+
+func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
+	cidr net.IPNet, oldHostIP, newHostIP net.IP, oldID *identityPkg.NumericIdentity,
+	newID identityPkg.NumericIdentity, encryptKey uint8) {
+
+	switch modType {
+	case Upsert:
+		dl.entries[cidr.String()] = newID
+	default:
+		// Ignore, for simplicity we just clear the cache every time
+	}
+}
+
+func (dl *dummyListener) OnIPIdentityCacheGC() {}
+
+func (dl *dummyListener) ExpectMapping(c *C, targetIP string, targetIdentity identityPkg.NumericIdentity) {
+	// Identity lookup directly shows the expected mapping
+	identity, exists := dl.ipc.LookupByPrefix(targetIP)
+	c.Assert(exists, Equals, true)
+	c.Assert(identity.ID, Equals, targetIdentity)
+
+	// Dump reliably supplies the IP once and only the pod identity.
+	dl.entries = make(map[string]identityPkg.NumericIdentity)
+	dl.ipc.DumpToListenerLocked(dl)
+	c.Assert(dl.entries, checker.DeepEquals,
+		map[string]identityPkg.NumericIdentity{
+			targetIP: targetIdentity,
+		})
+}
+
+func (s *IPCacheTestSuite) TestIPCacheShadowing(c *C) {
+	endpointIP := "10.0.0.15"
+	cidrOverlap := "10.0.0.15/32"
+	epIdentity := (identityPkg.NumericIdentity(68))
+	cidrIdentity := (identityPkg.NumericIdentity(202))
+	ipc := NewIPCache()
+
+	// Assure sane state at start.
+	c.Assert(ipc.ipToIdentityCache, checker.DeepEquals, map[string]Identity{})
+	c.Assert(ipc.identityToIPCache, checker.DeepEquals, map[identityPkg.NumericIdentity]map[string]struct{}{})
+
+	// Upsert overlapping identities for the IP. Pod identity takes precedence.
+	ipc.Upsert(endpointIP, nil, 0, Identity{
+		ID:     epIdentity,
+		Source: source.KVStore,
+	})
+	ipc.Upsert(cidrOverlap, nil, 0, Identity{
+		ID:     cidrIdentity,
+		Source: source.Generated,
+	})
+	ipcache := newDummyListener(ipc)
+	ipcache.ExpectMapping(c, cidrOverlap, epIdentity)
+
+	// Deleting pod identity shows that cidr identity is now used.
+	ipc.Delete(endpointIP, source.KVStore)
+	ipcache.ExpectMapping(c, cidrOverlap, cidrIdentity)
+
+	// Reinsert of pod IP should shadow the CIDR identity again.
+	ipc.Upsert(endpointIP, nil, 0, Identity{
+		ID:     epIdentity,
+		Source: source.KVStore,
+	})
+	ipcache.ExpectMapping(c, cidrOverlap, epIdentity)
+
+	// Deletion of the shadowed identity should not change the output.
+	ipc.Delete(cidrOverlap, source.Generated)
+	ipcache.ExpectMapping(c, cidrOverlap, epIdentity)
+
+	// Clean up
+	ipc.Delete(endpointIP, source.KVStore)
+	_, exists := ipc.LookupByPrefix(cidrOverlap)
+	c.Assert(exists, Equals, false)
+}

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -134,7 +134,7 @@ func (c *crdBackend) AcquireReference(ctx context.Context, id idpool.ID, key all
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("identity does not exist")
+		return allocator.ErrIdentityNonExistent
 	}
 
 	capabilities := k8sversion.Capabilities()

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -81,7 +81,7 @@ var (
 
 	// statusCheckTimeout is the timeout when performing status checks with
 	// all etcd endpoints
-	statusCheckTimeout = 5 * time.Second
+	statusCheckTimeout = 10 * time.Second
 
 	// initialConnectionTimeout  is the timeout for the initial connection to
 	// the etcd server
@@ -211,6 +211,13 @@ func (e *etcdModule) newClient(opts *ExtraOptions) (BackendOperations, chan erro
 func init() {
 	// register etcd module for use
 	registerBackend(EtcdBackendName, etcdInstance)
+
+	if duration := os.Getenv("CILIUM_ETCD_STATUS_CHECK_INTERVAL"); duration != "" {
+		timeout, err := time.ParseDuration(duration)
+		if err == nil {
+			statusCheckTimeout = timeout
+		}
+	}
 }
 
 // Hint tries to improve the error message displayed to te user.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -250,6 +250,8 @@ const (
 	// InstallIptRules sets whether Cilium should install any iptables in general
 	InstallIptRules = "install-iptables-rules"
 
+	IPTablesLockTimeout = "iptables-lock-timeout"
+
 	// IPv6NodeAddr is the IPv6 address of node
 	IPv6NodeAddr = "ipv6-node"
 
@@ -952,6 +954,10 @@ type DaemonConfig struct {
 	// iptables chains instead of appending
 	PrependIptablesChains bool
 
+	// IPTablesLockTimeout defines the "-w" iptables option when the
+	// iptables CLI is directly invoked from the Cilium agent.
+	IPTablesLockTimeout time.Duration
+
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
 	K8sNamespace string
@@ -1644,6 +1650,7 @@ func (c *DaemonConfig) Populate() {
 	c.LoopbackIPv4 = viper.GetString(LoopbackIPv4)
 	c.Masquerade = viper.GetBool(Masquerade)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
+	c.IPTablesLockTimeout = viper.GetDuration(IPTablesLockTimeout)
 	c.IPSecKeyFile = viper.GetString(IPSecKeyFileName)
 	c.ModePreFilter = viper.GetString(PrefilterMode)
 	c.MonitorAggregation = viper.GetString(MonitorAggregationName)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -430,6 +430,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 			var implUpdateRevertFunc revert.RevertFunc
 			implUpdateRevertFunc, err = redir.implementation.UpdateRules(wg, l4)
 			if err != nil {
+				redir.mutex.Unlock()
 				err = fmt.Errorf("unable to update existing redirect: %s", err)
 				return 0, err, nil, nil
 			}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -563,7 +563,8 @@ func (p *Proxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, reve
 }
 
 // removeRedirect removes an existing redirect. p.mutex must be held
-// p.mutex must NOT be held when the returned finalize and revert functions are called!
+// p.mutex must NOT be held when the returned revert function is called!
+// proxyPortsMutex must NOT be held when the returned finalize function is called!
 func (p *Proxy) removeRedirect(id string, wg *completion.WaitGroup) (err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	log.WithField(fieldProxyRedirectID, id).
 		Debug("Removing proxy redirect")

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -48,7 +48,7 @@ var (
 func init() {
 
 	// Open socket for using gops to get stacktraces in case the tests deadlock.
-	if err := gops.Listen(gops.Options{}); err != nil {
+	if err := gops.Listen(gops.Options{ShutdownCleanup: true}); err != nil {
 		errorString := fmt.Sprintf("unable to start gops: %s", err)
 		fmt.Println(errorString)
 		os.Exit(-1)


### PR DESCRIPTION
* #10839 -- Makefile: Fix --yaml arg for microk8s (@joestringer)
 * #11471 -- Properly tear down gops agent on shutdown (@tklauser)
   * Minor conflict due to `daemon/cmd/` refactor
 * #11541 -- envoy: Take xds mutator lock for map access (@jrajahalme)
 * #11633 -- Support DNS matchPattern="*" to match "." (@joestringer)
 * #11580 -- pkg/allocator: Do not log `identity does not exist` if the attempt is not at max (@djboris9)
   * Had to backport from v1.7 branch directly, but only minor dependency fixup needed
* #11666 -- proxy: release redir.mutex on early exit, update a comment on mutex use (@qmonnet)
 * #11701 -- Add "--iptables-lock-timeout" to configure iptables --wait parameter (@joestringer)
   * Minor conflicts, manually validated the change still works correctly
 * #11764 -- Fix issue where traffic from a pod could be dropped despite allow policy when DNS L7 rules are used (@joestringer)
   * Minor conflicts due to extra code from named ports in latest code
 * #11750 -- etcd: Increase status check timeout to 10 seconds (@tgraf)
 * #11753 -- proxy: Do not decrement proxy port reference count when reverting. (@jrajahalme)
   * Minor conflict in function signature for `CreateOrUpdateRedirect()`

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10839 11471 11541 11633 11580 11666 11701 11764 11750 11753; do contrib/backporting/set-labels.py $pr done 1.6; done
```

Skipped due to non-trivial conflicts:
 * #10984 -- datapath: Fix wrong rev-NAT xlation due to stale conntrack entry (@brb)
 * #11673 -- Retry on ciliumnode update/create (@ashrayjain)