### PR TITLE
endpoint: Implement new Invalid endpoint state

### DIFF
--- a/api/v1/models/endpoint_state.go
+++ b/api/v1/models/endpoint_state.go
@@ -43,6 +43,9 @@ const (
 
 	// EndpointStateDisconnected captures enum value "disconnected"
 	EndpointStateDisconnected EndpointState = "disconnected"
+
+	// EndpointStateInvalid captures enum value "invalid"
+	EndpointStateInvalid EndpointState = "invalid"
 )
 
 // for schema
@@ -50,7 +53,7 @@ var endpointStateEnum []interface{}
 
 func init() {
 	var res []EndpointState
-	if err := json.Unmarshal([]byte(`["waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected","invalid"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1136,6 +1136,7 @@ definitions:
       - ready
       - disconnecting
       - disconnected
+      - invalid
   EndpointHealth:
     description: Health of the endpoint
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2117,7 +2117,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {
@@ -5687,7 +5688,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -176,6 +176,7 @@ func (d *Daemon) fetchK8sLabelsAndAnnotations(nsName, podName string) (*slim_cor
 
 func invalidDataError(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
 	ep.Logger(daemonSubsys).WithError(err).Warning("Creation of endpoint failed due to invalid data")
+	ep.SetState(endpoint.StateInvalid, "Invalid endpoint")
 	return nil, PutEndpointIDInvalidCode, err
 }
 

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"net"
+	"runtime"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -27,6 +28,8 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/metrics"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -47,26 +50,58 @@ func getEPTemplate(c *C, d *Daemon) *models.EndpointChangeRequest {
 }
 
 func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:world"}
 	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
+
+	// Endpoint is created with inital label as well as disallowed
+	// reserved:world label.
+	epTemplate.Labels = append(epTemplate.Labels, "reserved:init")
+	_, code, err = ds.d.createEndpoint(context.TODO(), epTemplate)
+	c.Assert(err, ErrorMatches, "not allowed to add reserved labels:.+")
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
 }
 
 func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:foo"}
 	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
 }
 
 func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	// Create the endpoint without any labels.
 	epTemplate := getEPTemplate(c, ds.d)
 	_, _, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, IsNil)
+
+	// Endpoint enters WaitingToRegenerate as it has its labels updated during
+	// creation.
+	assertOnMetric(c, string(models.EndpointStateWaitingToRegenerate), 1)
 
 	expectedLabels := labels.Labels{
 		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
@@ -79,6 +114,10 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	secID := ep.WaitForIdentity(3 * time.Second)
 	c.Assert(secID, Not(IsNil))
 	c.Assert(secID.ID, Equals, identity.ReservedIdentityInit)
+
+	// Endpoint should transition from WaitingToRegenerate -> Ready.
+	assertOnMetric(c, string(models.EndpointStateWaitingToRegenerate), 0)
+	assertOnMetric(c, string(models.EndpointStateReady), 1)
 }
 
 func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
@@ -86,4 +125,29 @@ func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
 	code, err := ds.d.modifyEndpointIdentityLabelsFromAPI("1", lbls, nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PatchEndpointIDLabelsUpdateFailedCode)
+}
+
+func (ds *DaemonSuite) TestUpdateLabelsFailed(c *C) {
+	cancelledContext, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	cancelFunc() // Cancel immediatly to trigger the codepath to test.
+
+	// Create the endpoint without any labels.
+	epTemplate := getEPTemplate(c, ds.d)
+	_, _, err := ds.d.createEndpoint(cancelledContext, epTemplate)
+	c.Assert(err, ErrorMatches, "request cancelled while resolving identity")
+
+	assertOnMetric(c, string(models.EndpointStateReady), 0)
+}
+
+func getMetricValue(state string) int64 {
+	return int64(metrics.GetGaugeValue(metrics.EndpointStateCount.WithLabelValues(state)))
+}
+
+func assertOnMetric(c *C, state string, expected int64) {
+	obtained := getMetricValue(state)
+	if obtained != expected {
+		_, _, line, _ := runtime.Caller(1)
+		c.Errorf("Metrics assertion failed on line %d for Endpoint state %s: obtained %d, expected %d",
+			line, state, obtained, expected)
+	}
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -96,6 +96,10 @@ const (
 	// StateRestoring is used to set the endpoint is being restored.
 	StateRestoring = string(models.EndpointStateRestoring)
 
+	// StateInvalid is used when an endpoint failed during creation due to
+	// invalid data.
+	StateInvalid = string(models.EndpointStateInvalid)
+
 	// IpvlanMapName specifies the tail call map for EP on egress used with ipvlan.
 	IpvlanMapName = "cilium_lxc_ipve_"
 )
@@ -1319,7 +1323,7 @@ func (e *Endpoint) setState(toState, reason string) bool {
 		}
 	case StateWaitingForIdentity:
 		switch toState {
-		case StateReady, StateDisconnecting:
+		case StateReady, StateDisconnecting, StateInvalid:
 			goto OKState
 		}
 	case StateReady:
@@ -1332,8 +1336,9 @@ func (e *Endpoint) setState(toState, reason string) bool {
 		case StateDisconnected:
 			goto OKState
 		}
-	case StateDisconnected:
-		// No valid transitions, as disconnected is a terminal state for the endpoint.
+	case StateDisconnected, StateInvalid:
+		// No valid transitions, as disconnected and invalid are terminal
+		// states for the endpoint.
 	case StateWaitingToRegenerate:
 		switch toState {
 		// Note that transitions to StateWaitingToRegenerate are not allowed,
@@ -1387,9 +1392,10 @@ OKState:
 			WithLabelValues(fromState).Dec()
 	}
 
-	// Since StateDisconnected is the final state, after which the
-	// endpoint is gone, we should not increment metrics for this state.
-	if toState != "" && toState != StateDisconnected {
+	// Since StateDisconnected and StateInvalid are final states, after which
+	// the endpoint is gone or doesn't exist, we should not increment metrics
+	// for these states.
+	if toState != "" && toState != StateDisconnected && toState != StateInvalid {
 		metrics.EndpointStateCount.
 			WithLabelValues(toState).Inc()
 	}
@@ -1403,7 +1409,7 @@ func (e *Endpoint) BuilderSetStateLocked(toState, reason string) bool {
 	// Validate the state transition.
 	fromState := e.state
 	switch fromState { // From state
-	case StateWaitingForIdentity, StateReady, StateDisconnecting, StateDisconnected:
+	case StateWaitingForIdentity, StateReady, StateDisconnecting, StateDisconnected, StateInvalid:
 		// No valid transitions for the builder
 	case StateWaitingToRegenerate, StateRestoring:
 		switch toState {
@@ -1454,9 +1460,10 @@ OKState:
 			WithLabelValues(fromState).Dec()
 	}
 
-	// Since StateDisconnected is the final state, after which the
-	// endpoint is gone, we should not increment metrics for this state.
-	if toState != "" && toState != StateDisconnected {
+	// Since StateDisconnected and StateInvalid are final states, after which
+	// the endpoint is gone or doesn't exist, we should not increment metrics
+	// for these states.
+	if toState != "" && toState != StateDisconnected && toState != StateInvalid {
 		metrics.EndpointStateCount.
 			WithLabelValues(toState).Inc()
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1147,6 +1147,17 @@ func GetCounterValue(m prometheus.Counter) float64 {
 	return 0
 }
 
+// GetGaugeValue returns the current value stored for the gauge. This function
+// is useful in tests.
+func GetGaugeValue(m prometheus.Gauge) float64 {
+	var pm dto.Metric
+	err := m.Write(&pm)
+	if err == nil {
+		return *pm.Gauge.Value
+	}
+	return 0
+}
+
 // DumpMetrics gets the current Cilium metrics and dumps all into a
 // models.Metrics structure.If metrics cannot be retrieved, returns an error
 func DumpMetrics() ([]*models.Metric, error) {


### PR DESCRIPTION
See commit msgs.

Endpoint (EP) creation can fail for many reasons due to invalid data, such as IP conflict or if it's created with reserved labels. When EP creation failed, EPs can be stuck in the "waiting-for-identity" state, and left to be garbage collected. However, even though the object would be garbage collected, the metric representing which state the EP is in, is never decremented, thus a leak. 

This PR fixes this by introducing a new EP state representing an "invalid" EP. When EP creations fails, the EP will transition from its current state to "invalid", thus decrementing the current state metric.

```release-note
Fix leaking endpoint state metric
```