### PR TITLE
helm: fixed hubble servicemonitor matchLabels parameter

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: cilium
+      k8s-app: hubble
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}


### PR DESCRIPTION
The `k8s-app` label of the **hubble-metrics** service is equal to `hubble` and not `cilium`

https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/charts/agent/templates/svc.yaml#L28
