### PR TITLE
helm: Simplify Hubble metrics values

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -158,7 +158,7 @@ spec:
           {{- toYaml .Values.resources | trim | nindent 10 }}
 {{- end }}
         name: cilium-agent
-{{- if or .Values.global.prometheus.enabled .Values.global.hubble.metricsServer }}
+{{- if or .Values.global.prometheus.enabled .Values.global.hubble.metrics.enabled }}
         ports:
 {{- if .Values.global.prometheus.enabled }}                
         - containerPort: {{ .Values.global.prometheus.port }}
@@ -166,9 +166,9 @@ spec:
           name: prometheus
           protocol: TCP
 {{- end }}
-{{- if .Values.global.hubble.metricsServer }}
-        - containerPort: {{ regexReplaceAll ":([0-9]+)$" .Values.global.hubble.metricsServer "${1}" }}
-          hostPort: {{ regexReplaceAll ":([0-9]+)$" .Values.global.hubble.metricsServer "${1}" }} 
+{{- if .Values.global.hubble.metrics.enabled }}
+        - containerPort: {{ .Values.global.hubble.metrics.port }}
+          hostPort: {{ .Values.global.hubble.metrics.port }}
           name: hubble-metrics
           protocol: TCP
 {{- end }}

--- a/install/kubernetes/cilium/charts/agent/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/svc.yaml
@@ -31,7 +31,7 @@ spec:
   type: ClusterIP
   ports:
   - name: hubble-metrics
-    port: {{ regexReplaceAll ":([0-9]+)$" .Values.global.hubble.metricsServer "${1}" }}
+    port: {{ .Values.global.hubble.metrics.port }}
     protocol: TCP
     targetPort: hubble-metrics
   selector:

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -452,10 +452,10 @@ data:
   # Size of the buffer to store recent flows.
   hubble-flow-buffer-size: {{ .Values.global.hubble.flowBufferSize | quote }}
 {{- end }}
-{{- if .Values.global.hubble.metricsServer }}
+{{- if .Values.global.hubble.metrics.enabled }}
   # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this
   # field is not set.
-  hubble-metrics-server: {{ .Values.global.hubble.metricsServer | quote }}
+  hubble-metrics-server: ":{{ .Values.global.hubble.metrics.port }}"
   # A space separated list of metrics to enable. See [0] for available metrics.
   #
   # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -460,29 +460,30 @@ global:
     eventQueueSize: ~
     # Number of recent flows for Hubble to cache. Defaults to 4096.
     flowBufferSize: ~
-    # Specifies the address the metric server listens to (e.g. ":12345"). The metric server is
-    # disabled if this value is empty.
-    metricsServer: ~
-    # List of metrics to collect, for example:
-    #
-    #   metrics:
-    #   - dns:query;ignoreAAAA
-    #   - drop
-    #   - tcp
-    #   - flow
-    #   - port-distribution
-    #   - icmp
-    #   - http
-    #
-    # You can specify the list of metrics from the helm CLI:
-    #
-    #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"
-    #
+    # Hubble metrics configuration.
     # See https://github.com/cilium/hubble/blob/master/Documentation/metrics.md for more comprehensive
     # documentation about Hubble's metric collection.
     metrics:
-      enabled:
-        - drop
+      # List of metrics to collect. If empty or null, metrics are disabled.
+      # Example:
+      #
+      #   enabled:
+      #   - dns:query;ignoreAAAA
+      #   - drop
+      #   - tcp
+      #   - flow
+      #   - port-distribution
+      #   - icmp
+      #   - http
+      #
+      # You can specify the list of metrics from the helm CLI:
+      #
+      #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"
+      #
+      enabled: ~
+      # Specifies the port the metric server listens on (e.g. 9091).
+      port: 9091
+      # Creates ServiceMonitor resources for Prometheus Operator
       serviceMonitor:
         enabled: false
 

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -113,7 +113,6 @@ var _ = Describe("K8sHubbleTest", func() {
 		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-			"global.hubble.metricsServer":   fmt.Sprintf(":%s", prometheusPort),
 			"global.hubble.metrics.enabled": `"{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"`,
 			"global.hubble.relay.enabled":   "true",
 		})


### PR DESCRIPTION
This introduces a standard port for the Hubble metrics: 9091. The port
is chosen after 9090, which is used by the Cilium metrics.

To enable Hubble metrics, a user now only has to specify which metrics
should be enabled, e.g. `global.hubble.metrics.enabled='{drop,icmp}'`
instead of providing both a list of metrics and the server port.

In addition, the Helm values are made more consistent:
`global.hubble.metricsServer` is changed to `global.hubble.metrics.port`.
This mirrors the existing `global.prometheus.port` and simplifies the
chart.