### PR TITLE
fix misc data races in unit tests

### DIFF
--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -99,6 +99,10 @@ func (e *IdentityAllocatorEtcdSuite) SetUpTest(c *C) {
 	kvstore.SetupDummy("etcd")
 }
 
+func (e *IdentityAllocatorEtcdSuite) TearDownTest(c *C) {
+	kvstore.Client().Close()
+}
+
 type IdentityAllocatorConsulSuite struct {
 	IdentityAllocatorSuite
 }
@@ -107,6 +111,10 @@ var _ = Suite(&IdentityAllocatorConsulSuite{})
 
 func (e *IdentityAllocatorConsulSuite) SetUpTest(c *C) {
 	kvstore.SetupDummy("consul")
+}
+
+func (e *IdentityAllocatorConsulSuite) TearDownTest(c *C) {
+	kvstore.Client().Close()
 }
 
 type dummyOwner struct {


### PR DESCRIPTION
Fixes the following issues:
```
WARNING: DATA RACE
Read at 0x00000374d850 by goroutine 88:
  github.com/cilium/cilium/pkg/kvstore.deleteLegacyPrefixes()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/kvstore/backwards_compat.go:38 +0x97
  github.com/cilium/cilium/pkg/kvstore.initClient.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/kvstore/client.go:51 +0xc9
Previous write at 0x00000374d850 by goroutine 17:
  github.com/cilium/cilium/pkg/kvstore.initClient()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/kvstore/client.go:38 +0x238
  github.com/cilium/cilium/pkg/kvstore.SetupDummy()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/kvstore/dummy.go:28 +0x10a
  github.com/cilium/cilium/pkg/identity/cache.(*IdentityAllocatorEtcdSuite).SetUpTest()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/identity/cache/allocation_test.go:99 +0x43
  runtime.call32()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:730 +0x1c3
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
Goroutine 88 (running) created at:
  github.com/cilium/cilium/pkg/kvstore.initClient()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/kvstore/client.go:46 +0x307
  github.com/cilium/cilium/pkg/kvstore.SetupDummy()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/kvstore/dummy.go:28 +0x10a
  github.com/cilium/cilium/pkg/identity/cache.(*IdentityAllocatorEtcdSuite).SetUpTest()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/identity/cache/allocation_test.go:99 +0x43
  runtime.call32()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.14.4.linux.amd64/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:730 +0x1c3
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
Goroutine 17 (finished) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:672 +0x44d
  gopkg.in/check%2ev1.(*suiteRunner).runFunc()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:682 +0x83
  gopkg.in/check%2ev1.(*suiteRunner).runFixture()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:726 +0x3d
  gopkg.in/check%2ev1.(*suiteRunner).runFixtureWithPanic()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:744 +0x82
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:769 +0x28c
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9
```


```
WARNING: DATA RACE
Write at 0x00c0002ca868 by goroutine 80:
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxy).SetRejectReply()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:508 +0x24f
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxyTestSuite).TestRejectNonMatchingRefusedResponse()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy_test.go:332 +0xaba
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:781 +0xa0a
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9

Previous read at 0x00c0002ca868 by goroutine 85:
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxy).sendRefused()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:493 +0x8e
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxy).ServeDNS()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:427 +0x2e09
  github.com/miekg/dns.(*Server).serveDNS()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/miekg/dns/server.go:597 +0x3de
  github.com/miekg/dns.(*Server).serveTCPConn()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/miekg/dns/server.go:520 +0x3ed
```

```
WARNING: DATA RACE
Write at 0x00c0002ca860 by goroutine 60:
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxyTestSuite).TearDownTest()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy_test.go:220 +0x7a
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:730 +0x1c3
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9

Previous read at 0x00c0002ca860 by goroutine 23:
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxy).CheckAllowed()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:329 +0x148
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxy).ServeDNS()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:415 +0x1815
  github.com/miekg/dns.(*Server).serveDNS()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/miekg/dns/server.go:597 +0x3de
  github.com/miekg/dns.(*Server).serveTCPConn()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/miekg/dns/server.go:520 +0x3ed

Goroutine 60 (running) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:672 +0x44d
  gopkg.in/check%2ev1.(*suiteRunner).runFunc()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:682 +0x83
  gopkg.in/check%2ev1.(*suiteRunner).runFixture()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:726 +0x3d
  gopkg.in/check%2ev1.(*suiteRunner).runFixtureWithPanic()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:744 +0x82
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:782 +0xa0b
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xd9

Goroutine 23 (finished) created at:
  github.com/miekg/dns.(*Server).serveTCP()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/miekg/dns/server.go:432 +0x3ad
  github.com/miekg/dns.(*Server).ActivateAndServe()
      /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/miekg/dns/server.go:335 +0x2f8
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.StartDNSProxy.func1()
      /home/vagrant/go/src/github.com/cilium/cilium/pkg/fqdn/dnsproxy/proxy.go:294 +0x10a
```