### PR TITLE
docs/scalability: set right ipam option

### DIFF
--- a/Documentation/scalability/scalability.rst
+++ b/Documentation/scalability/scalability.rst
@@ -24,7 +24,7 @@ Setup
      --namespace kube-system \\
      --set global.endpointHealthChecking.enabled=false \\
      --set global.healthChecking.enabled=false \\
-     --set global.ipam.mode=kubernetes \\
+     --set config.ipam=kubernetes \\
      --set global.k8sServiceHost=<KUBE-APISERVER-LB-IP-ADDRESS> \\
      --set global.k8sServicePort=<KUBE-APISERVER-LB-PORT-NUMBER> \\
      --set global.prometheus.enabled=true \\
@@ -38,7 +38,7 @@ Setup
   initially on a smaller cluster (3-10 nodes) where it can be used to detect
   potential packet loss due to firewall rules or hypervisor settings.
 
-* ``--set global.ipam.mode=kubernetes`` is set to ``"kubernetes"`` since our
+* ``--set config.ipam=kubernetes`` is set to ``"kubernetes"`` since our
   cloud provider has pod CIDR allocation enabled in ``kube-controller-manager``.
 
 * ``--set global.k8sServiceHost`` and ``--set global.k8sServicePort`` were set


### PR DESCRIPTION
The ipam option was moved from global to the ConfigMap so the
scalability documentation needs to be updated.

Fixes: c1a0025f75b8 ("doc: Fix require-ipv4-pod-cidr value for ENI and Azure mode")
Signed-off-by: André Martins <andre@cilium.io>