### PR TITLE
etcd: propagate Context from higher-level calls

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -193,7 +193,7 @@ func (e *etcdModule) newClient(ctx context.Context, opts *ExtraOptions) (Backend
 	for {
 		// connectEtcdClient will close errChan when the connection attempt has
 		// been successful
-		backend, err := connectEtcdClient(e.config, configPath, errChan, rateLimit, opts)
+		backend, err := connectEtcdClient(ctx, e.config, configPath, errChan, rateLimit, opts)
 		switch {
 		case os.IsNotExist(err):
 			log.WithError(err).Info("Waiting for all etcd configuration files to be available")
@@ -455,7 +455,7 @@ func (e *etcdClient) renewSession() error {
 
 	e.getLogger().WithField(fieldSession, newSession).Debug("Renewing etcd session")
 
-	if err := e.checkMinVersion(); err != nil {
+	if err := e.checkMinVersion(context.TODO()); err != nil {
 		return err
 	}
 
@@ -486,7 +486,7 @@ func (e *etcdClient) renewLockSession() error {
 	return nil
 }
 
-func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error, rateLimit int, opts *ExtraOptions) (BackendOperations, error) {
+func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath string, errChan chan error, rateLimit int, opts *ExtraOptions) (BackendOperations, error) {
 	if cfgPath != "" {
 		cfg, err := newConfig(cfgPath)
 		if err != nil {
@@ -574,12 +574,12 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 		ec.getLogger().Debugf("Session received")
 		close(ec.firstSession)
 
-		if err := ec.checkMinVersion(); err != nil {
+		if err := ec.checkMinVersion(ctx); err != nil {
 			errChan <- fmt.Errorf("unable to validate etcd version: %s", err)
 		}
 	}()
 
-	go ec.statusChecker(context.TODO())
+	go ec.statusChecker()
 
 	ec.controllers.UpdateController("kvstore-etcd-session-renew",
 		controller.ControllerParams{
@@ -602,8 +602,8 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 	return ec, nil
 }
 
-func getEPVersion(c client.Maintenance, etcdEP string, timeout time.Duration) (go_version.Version, error) {
-	ctxTimeout, cancel := context.WithTimeout(context.TODO(), timeout)
+func getEPVersion(ctx context.Context, c client.Maintenance, etcdEP string, timeout time.Duration) (go_version.Version, error) {
+	ctxTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	sr, err := c.Status(ctxTimeout, etcdEP)
 	if err != nil {
@@ -619,11 +619,11 @@ func getEPVersion(c client.Maintenance, etcdEP string, timeout time.Duration) (g
 // checkMinVersion checks the minimal version running on etcd cluster.  This
 // function should be run whenever the etcd client is connected for the first
 // time and whenever the session is renewed.
-func (e *etcdClient) checkMinVersion() error {
+func (e *etcdClient) checkMinVersion(ctx context.Context) error {
 	eps := e.client.Endpoints()
 
 	for _, ep := range eps {
-		v, err := getEPVersion(e.client.Maintenance, ep, versionCheckTimeout)
+		v, err := getEPVersion(ctx, e.client.Maintenance, ep, versionCheckTimeout)
 		if err != nil {
 			e.getLogger().WithError(Hint(err)).WithField(fieldEtcdEndpoint, ep).
 				Warn("Unable to verify version of etcd endpoint")
@@ -841,7 +841,9 @@ func (e *etcdClient) determineEndpointStatus(ctx context.Context, endpointAddres
 	return str, nil
 }
 
-func (e *etcdClient) statusChecker(ctx context.Context) {
+func (e *etcdClient) statusChecker() {
+	ctx := context.Background()
+
 	for {
 		newStatus := []string{}
 		ok := 0

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -146,12 +146,12 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 		},
 	}
 	// Check a good version
-	v, err := getEPVersion(mm, "http://127.0.0.1:4003", time.Second)
+	v, err := getEPVersion(context.TODO(), mm, "http://127.0.0.1:4003", time.Second)
 	c.Assert(err, IsNil)
 	c.Assert(v.String(), Equals, goodVersion)
 
 	// Check a bad version
-	v, err = getEPVersion(mm, "http://127.0.0.1:4004", time.Second)
+	v, err = getEPVersion(context.TODO(), mm, "http://127.0.0.1:4004", time.Second)
 	c.Assert(err, IsNil)
 	c.Assert(v.String(), Equals, badVersionStr)
 
@@ -168,7 +168,7 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 	// short timeout for tests
 	versionCheckTimeout = time.Second
 
-	c.Assert(client.checkMinVersion(), IsNil)
+	c.Assert(client.checkMinVersion(context.TODO()), IsNil)
 
 	// One endpoint has a bad version and should fail
 	cfg.Endpoints = []string{"http://127.0.0.1:4003", "http://127.0.0.1:4004", "http://127.0.0.1:4005"}
@@ -179,7 +179,7 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 		client: cli,
 	}
 
-	c.Assert(client.checkMinVersion(), Not(IsNil))
+	c.Assert(client.checkMinVersion(context.TODO()), Not(IsNil))
 }
 
 type EtcdHelpersSuite struct{}


### PR DESCRIPTION
This makes sure that cancelation signals or timeouts are propagated
properly.
