### PR TITLE
daemon: Fix detection of BPF/XDP NodePort, BPF masq and host-fw devices

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -49,7 +49,7 @@ cilium-agent [flags]
       --datapath-mode string                          Datapath mode name (default "veth")
   -D, --debug                                         Enable debugging mode
       --debug-verbose strings                         List of enabled verbose debug groups
-  -d, --device strings                                List of devices facing cluster/external network for attaching bpf_host
+      --devices strings                               List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
       --direct-routing-device string                  Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
       --disable-conntrack                             Disable connection tracking

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -49,7 +49,8 @@ cilium-agent [flags]
       --datapath-mode string                          Datapath mode name (default "veth")
   -D, --debug                                         Enable debugging mode
       --debug-verbose strings                         List of enabled verbose debug groups
-  -d, --device strings                                List of devices facing cluster/external network for attaching bpf_netdev (first device should be one used for direct routing if tunneling is disabled)
+  -d, --device strings                                List of devices facing cluster/external network for attaching bpf_host
+      --direct-routing-device string                  Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
       --disable-conntrack                             Disable connection tracking
       --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -417,7 +417,7 @@ NodePort Device, Port and Bind settings
 When running Cilium's BPF kube-proxy replacement, by default, a NodePort or
 ExternalIPs service will be accessible through the IP address of a native device
 which has the default route on the host. To change the device, set its name in
-the ``global.nodePort.device`` helm option.
+the ``global.devices`` helm option.
 
 In addition, thanks to the :ref:`host-services` feature, the NodePort service can
 be accessed by default from a host or a pod within a cluster via its public, any

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -91,19 +91,6 @@ struct dsr_opt_v6 {
 };
 #endif /* ENABLE_IPV6 */
 
-static __always_inline bool nodeport_must_drop_remote(void)
-{
-#if defined(ENABLE_NODEPORT_ACCELERATION) && !defined(FROM_ENCAP_DEV) && \
-    __ctx_is == __ctx_skb
-	/* We already handled remote backends on XDP layer. Anything
-	 * landing here that is remote is a bug.
-	 */
-	return true;
-#else
-	return false;
-#endif
-}
-
 static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 {
 # if defined(ENABLE_DSR) && !defined(ENABLE_DSR_HYBRID)
@@ -586,8 +573,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 		return DROP_INVALID;
 
 	backend_local = lookup_ip6_endpoint(ip6);
-	if (!backend_local && (lb6_svc_is_hostport(svc) ||
-			       nodeport_must_drop_remote()))
+	if (!backend_local && lb6_svc_is_hostport(svc))
 		return DROP_INVALID;
 
 	switch (ret) {
@@ -1253,8 +1239,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		return DROP_INVALID;
 
 	backend_local = lookup_ip4_endpoint(ip4);
-	if (!backend_local && (lb4_svc_is_hostport(svc) ||
-			       nodeport_must_drop_remote()))
+	if (!backend_local && lb4_svc_is_hostport(svc))
 		return DROP_INVALID;
 
 	switch (ret) {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -444,7 +444,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 			log.Fatalf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)
 		}
 		if option.Config.EgressMasqueradeInterfaces != "" {
-			log.Fatalf("BPF masquerade does not allow to specify devices via --%s. Use --%s instead.", option.EgressMasqueradeInterfaces, option.Device)
+			log.Fatalf("BPF masquerade does not allow to specify devices via --%s. Use --%s instead.", option.EgressMasqueradeInterfaces, option.Devices)
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		log.Fatalf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.Masquerade, option.EnableBPFMasquerade)
@@ -461,7 +461,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		device, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {
 			msg := "Host firewall's external facing device could not be determined. Use --%s to specify."
-			log.WithError(err).Fatalf(msg, option.Device)
+			log.WithError(err).Fatalf(msg, option.Devices)
 		}
 		log.WithField(logfields.Interface, device).
 			Info("Using auto-derived device for host firewall")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1659,9 +1659,10 @@ func initKubeProxyReplacementOptions() {
 	}
 
 	if option.Config.EnableNodePort && len(option.Config.Devices) == 0 {
-		device, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
-		if err != nil {
-			msg := "BPF NodePort's external facing device could not be determined. Use --device to specify."
+		var err error
+
+		if option.Config.Devices, err = detectDevices(); err != nil {
+			msg := "BPF NodePort's external facing devices could not be determined. Use --device to specify."
 			if strict {
 				log.WithError(err).Fatal(msg)
 			} else {
@@ -1671,9 +1672,8 @@ func initKubeProxyReplacementOptions() {
 				option.Config.EnableExternalIPs = false
 			}
 		} else {
-			log.WithField(logfields.Interface, device).
-				Info("Using auto-derived device for BPF node port")
-			option.Config.Devices = []string{device}
+			log.WithField(logfields.Interface, option.Config.Devices).
+				Info("Using auto-derived devices for BPF node port")
 		}
 	}
 
@@ -1826,6 +1826,14 @@ func initKubeProxyReplacementOptions() {
 				"will be selected from all network namespaces on the host.")
 		}
 	}
+}
+
+func detectDevices() ([]string, error) {
+	device, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
+	if err != nil {
+		return nil, err
+	}
+	return []string{device}, nil
 }
 
 // checkNodePortAndEphemeralPortRanges checks whether the ephemeral port range

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1558,8 +1558,6 @@ func initKubeProxyReplacementOptions() {
 		log.Fatalf("Invalid value for --%s: %s", option.KubeProxyReplacement, option.Config.KubeProxyReplacement)
 	}
 
-	probesManager := probes.NewProbeManager()
-
 	if option.Config.DisableK8sServices {
 		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled {
 			log.Warnf("Service handling disabled. Auto-disabling --%s from \"%s\" to \"%s\"",
@@ -1584,6 +1582,8 @@ func initKubeProxyReplacementOptions() {
 
 		return
 	}
+
+	probesManager := probes.NewProbeManager()
 
 	// strict denotes to panic if any to-be enabled feature cannot be enabled
 	strict := option.Config.KubeProxyReplacement != option.KubeProxyReplacementProbe

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -253,8 +253,13 @@ func init() {
 	flags.StringSlice(option.DebugVerbose, []string{}, "List of enabled verbose debug groups")
 	option.BindEnv(option.DebugVerbose)
 
-	flags.StringSliceP(option.Device, "d", []string{}, "List of devices facing cluster/external network for attaching bpf_host")
+	flags.StringP(option.Device, "d", "",
+		fmt.Sprintf("Device facing cluster/external network for attaching bpf_host. Deprecated in favor of --%s", option.Devices))
+	flags.MarkDeprecated(option.Device, "This option will be removed in v1.10")
 	option.BindEnv(option.Device)
+
+	flags.StringSlice(option.Devices, []string{}, "List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)")
+	option.BindEnv(option.Devices)
 
 	flags.String(option.DirectRoutingDevice, "", "Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)")
 	option.BindEnv(option.DirectRoutingDevice)
@@ -1857,7 +1862,7 @@ func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 	if detectNodePortDevs {
 		if devSet, err = detectNodePortDevices(ifidxByAddr); err != nil {
 			return fmt.Errorf("Unable to determine BPF NodePort devices: %s. Use --%s to specify them",
-				err, option.Device)
+				err, option.Devices)
 		}
 	} else {
 		for _, dev := range option.Config.Devices {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -253,8 +253,11 @@ func init() {
 	flags.StringSlice(option.DebugVerbose, []string{}, "List of enabled verbose debug groups")
 	option.BindEnv(option.DebugVerbose)
 
-	flags.StringSliceP(option.Device, "d", []string{}, "List of devices facing cluster/external network for attaching bpf_netdev (first device should be one used for direct routing if tunneling is disabled)")
+	flags.StringSliceP(option.Device, "d", []string{}, "List of devices facing cluster/external network for attaching bpf_host")
 	option.BindEnv(option.Device)
+
+	flags.String(option.DirectRoutingDevice, "", "Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)")
+	option.BindEnv(option.DirectRoutingDevice)
 
 	flags.String(option.DatapathMode, defaults.DatapathMode, "Datapath mode name")
 	option.BindEnv(option.DatapathMode)
@@ -1115,7 +1118,7 @@ func initEnv(cmd *cobra.Command) {
 
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
-	node.InitDefaultPrefix(option.Config.Devices)
+	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)
 
 	if option.Config.IPv6NodeAddr != "auto" {
 		if ip := net.ParseIP(option.Config.IPv6NodeAddr); ip == nil {
@@ -1658,11 +1661,12 @@ func initKubeProxyReplacementOptions() {
 		}
 	}
 
-	if option.Config.EnableNodePort && len(option.Config.Devices) == 0 {
-		var err error
-
-		if option.Config.Devices, err = detectDevices(); err != nil {
-			msg := "BPF NodePort's external facing devices could not be determined. Use --device to specify."
+	detectNodePortDevs := option.Config.EnableNodePort && len(option.Config.Devices) == 0
+	detectDirectRoutingDev := option.Config.EnableNodePort &&
+		option.Config.DirectRoutingDevice == ""
+	if detectNodePortDevs || detectDirectRoutingDev {
+		if err := detectDevices(detectNodePortDevs, detectDirectRoutingDev); err != nil {
+			msg := "Unable to detect devices for BPF NodePort"
 			if strict {
 				log.WithError(err).Fatal(msg)
 			} else {
@@ -1828,9 +1832,15 @@ func initKubeProxyReplacementOptions() {
 	}
 }
 
-func detectDevices() ([]string, error) {
+// detectDevices tries to detect device names which are going to be used for
+// (a) NodePort BPF, (b) direct routing in NodePort BPF.
+//
+// (a) is determined from a default route and the k8s node IP addr.
+// (b) is derived either from NodePort BPF devices (if only one is set) or
+//     from the k8s node IP addr.
+func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 	var err error
-	var devSet map[string]struct{}  // iface name
+	devSet := map[string]struct{}{} // iface name
 	ifidxByAddr := map[string]int{} // str(ip addr) => ifindex
 
 	if addrs, err := netlink.AddrList(nil, netlink.FAMILY_ALL); err != nil {
@@ -1844,16 +1854,38 @@ func detectDevices() ([]string, error) {
 		}
 	}
 
-	if devSet, err = detectNodePortDevices(ifidxByAddr); err != nil {
-		return nil, fmt.Errorf("Unable to determine BPF NodePort devices. Use --%s to specify them",
-			option.Device)
+	if detectNodePortDevs {
+		if devSet, err = detectNodePortDevices(ifidxByAddr); err != nil {
+			return fmt.Errorf("Unable to determine BPF NodePort devices: %s. Use --%s to specify them",
+				err, option.Device)
+		}
+	} else {
+		for _, dev := range option.Config.Devices {
+			devSet[dev] = struct{}{}
+		}
 	}
 
-	devList := make([]string, 0, len(devSet))
-	for dev := range devSet {
-		devList = append(devList, dev)
+	if detectDirectRoutingDev {
+		// If only single device was previously found, use it for direct routing.
+		// Otherwise, use k8s Node IP addr to determine the device.
+		if len(devSet) == 1 {
+			for dev := range devSet {
+				option.Config.DirectRoutingDevice = dev
+			}
+		} else {
+			if option.Config.DirectRoutingDevice, err = detectNodeDevice(ifidxByAddr); err != nil {
+				return fmt.Errorf("Unable to determine BPF NodePort direct routing device: %s. "+
+					"Use --%s to specify it", err, option.DirectRoutingDevice)
+			}
+		}
 	}
-	return devList, nil
+	devSet[option.Config.DirectRoutingDevice] = struct{}{}
+
+	option.Config.Devices = make([]string, 0, len(devSet))
+	for dev := range devSet {
+		option.Config.Devices = append(option.Config.Devices, dev)
+	}
+	return nil
 }
 
 func detectNodePortDevices(ifidxByAddr map[string]int) (map[string]struct{}, error) {
@@ -1863,24 +1895,17 @@ func detectNodePortDevices(ifidxByAddr map[string]int) (map[string]struct{}, err
 	defaultRouteDevice, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 	if err != nil {
 		log.WithError(err).Warn(
-			"Device with a default route cannot be found for NodePort BPF device detection")
+			"Device with a default route cannot be found for BPF NodePort device detection")
 	} else {
 		devSet[defaultRouteDevice] = struct{}{}
 	}
 
 	// Derive a device from k8s Node IP
-	nodeIP := node.GetK8sNodeIP()
-	if nodeIP != nil {
-		ifindex, found := ifidxByAddr[nodeIP.String()]
-		if !found {
-			return nil, fmt.Errorf("Cannot find device with %s addr", nodeIP)
-		}
-		link, err := netlink.LinkByIndex(ifindex)
-		if err != nil {
-			return nil, fmt.Errorf("Cannot find device with %s addr by %d ifindex",
-				nodeIP, ifindex)
-		}
-		devSet[link.Attrs().Name] = struct{}{}
+	if dev, err := detectNodeDevice(ifidxByAddr); err != nil {
+		log.WithError(err).Warn(
+			"Cannot determine a device from k8s Node IP addr for BPF NodePort device detection")
+	} else {
+		devSet[dev] = struct{}{}
 	}
 
 	if len(devSet) == 0 {
@@ -1888,6 +1913,26 @@ func detectNodePortDevices(ifidxByAddr map[string]int) (map[string]struct{}, err
 	}
 
 	return devSet, nil
+}
+
+func detectNodeDevice(ifidxByAddr map[string]int) (string, error) {
+	nodeIP := node.GetK8sNodeIP()
+	if nodeIP == nil {
+		return "", fmt.Errorf("K8s Node IP is not set")
+	}
+
+	ifindex, found := ifidxByAddr[nodeIP.String()]
+	if !found {
+		return "", fmt.Errorf("Cannot find device with %s addr", nodeIP)
+	}
+
+	link, err := netlink.LinkByIndex(ifindex)
+	if err != nil {
+		return "", fmt.Errorf("Cannot find device with %s addr by %d ifindex",
+			nodeIP, ifindex)
+	}
+
+	return link.Attrs().Name, nil
 }
 
 // checkNodePortAndEphemeralPortRanges checks whether the ephemeral port range

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1110,49 +1110,8 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EncryptInterface = link
 	}
 
-	initKubeProxyReplacementOptions()
-	if option.Config.EnableNodePort {
-		if err := node.InitNodePortAddrs(option.Config.Devices); err != nil {
-			log.WithError(err).Fatal("Failed to initialize NodePort addrs")
-		}
-	}
 	initClockSourceOption()
 	initSockmapOption()
-
-	if option.Config.Masquerade && option.Config.EnableBPFMasquerade {
-		// TODO(brb) nodeport + ipvlan constraints will be lifted once the SNAT BPF code has been refactored
-		if !option.Config.EnableNodePort {
-			log.Fatalf("BPF masquerade requires NodePort (--%s=\"true\")", option.EnableNodePort)
-		}
-		if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
-			log.Fatalf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)
-		}
-		if option.Config.EgressMasqueradeInterfaces != "" {
-			log.Fatalf("BPF masquerade does not allow to specify devices via --%s. Use --%s instead.", option.EgressMasqueradeInterfaces, option.Device)
-		}
-	} else if option.Config.EnableIPMasqAgent {
-		log.Fatalf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.Masquerade, option.EnableBPFMasquerade)
-	}
-
-	if option.Config.EnableIPMasqAgent {
-		if !option.Config.EnableIPv4 {
-			log.Fatalf("BPF ip-masq-agent requires IPv4 support (--%s=\"true\")", option.EnableIPv4Name)
-		}
-		if !probe.HaveFullLPM() {
-			log.Fatal("BPF ip-masq-agent needs kernel 4.16 or newer")
-		}
-	}
-
-	if option.Config.EnableHostFirewall && len(option.Config.Devices) == 0 {
-		device, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
-		if err != nil {
-			msg := "Host firewall's external facing device could not be determined. Use --%s to specify."
-			log.WithError(err).Fatalf(msg, option.Device)
-		}
-		log.WithField(logfields.Interface, device).
-			Info("Using auto-derived device for host firewall")
-		option.Config.Devices = []string{device}
-	}
 
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1681,8 +1681,14 @@ func initKubeProxyReplacementOptions() {
 				option.Config.EnableExternalIPs = false
 			}
 		} else {
-			log.WithField(logfields.Interface, option.Config.Devices).
-				Info("Using auto-derived devices for BPF node port")
+			l := log
+			if detectNodePortDevs {
+				l = l.WithField(logfields.Devices, option.Config.Devices)
+			}
+			if detectDirectRoutingDev {
+				l = l.WithField(logfields.DirectRoutingDevice, option.Config.DirectRoutingDevice)
+			}
+			l.Info("Using auto-derived devices for BPF node port")
 		}
 	}
 
@@ -1694,13 +1700,12 @@ func initKubeProxyReplacementOptions() {
 		}
 
 		if option.Config.XDPDevice != "undefined" &&
-			(len(option.Config.Devices) == 0 ||
-				option.Config.XDPDevice != option.Config.Devices[0]) {
+			(option.Config.DirectRoutingDevice == "" ||
+				option.Config.XDPDevice != option.Config.DirectRoutingDevice) {
 			log.Fatalf("Cannot set NodePort acceleration device: mismatch between Prefilter device %s and NodePort device %s",
-				option.Config.XDPDevice, option.Config.Devices[0])
+				option.Config.XDPDevice, option.Config.DirectRoutingDevice)
 		}
-		// TODO(brb) support multi-dev for XDP
-		option.Config.XDPDevice = option.Config.Devices[0]
+		option.Config.XDPDevice = option.Config.DirectRoutingDevice
 		if err := loader.SetXDPMode(option.Config.NodePortAcceleration); err != nil {
 			log.WithError(err).Fatal("Cannot set NodePort acceleration")
 		}

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -102,6 +102,11 @@ func TestMain(m *testing.M) {
 	// state left on disk.
 	option.Config.EnableHostIPRestore = false
 
+	// Disable the replacement, as its initialization function execs bpftool
+	// which requires root privileges. This would require marking the test suite
+	// as privileged.
+	option.Config.KubeProxyReplacement = option.KubeProxyReplacementDisabled
+
 	time.Local = time.UTC
 	os.Exit(m.Run())
 }

--- a/daemon/cmd/kubeproxy_replacement_test.go
+++ b/daemon/cmd/kubeproxy_replacement_test.go
@@ -1,0 +1,165 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package cmd
+
+import (
+	"net"
+	"runtime"
+	"sort"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	. "gopkg.in/check.v1"
+)
+
+type KubeProxySuite struct {
+	currentNetNS                  netns.NsHandle
+	testNetNS                     netns.NsHandle
+	prevConfigDevices             []string
+	prevConfigDirectRoutingDevice string
+	prevConfigEnableIPv4          bool
+	prevConfigEnableIPv6          bool
+	prevK8sNodeIP                 net.IP
+}
+
+var _ = Suite(&KubeProxySuite{})
+
+func (s *KubeProxySuite) SetUpSuite(c *C) {
+	var err error
+
+	s.prevConfigDevices = option.Config.Devices
+	s.prevConfigDirectRoutingDevice = option.Config.DirectRoutingDevice
+	s.prevConfigEnableIPv4 = option.Config.EnableIPv4
+	s.prevConfigEnableIPv6 = option.Config.EnableIPv6
+	s.prevK8sNodeIP = node.GetK8sNodeIP()
+
+	s.currentNetNS, err = netns.Get()
+	c.Assert(err, IsNil)
+	s.testNetNS, err = netns.New()
+	c.Assert(err, IsNil)
+}
+
+func (s *KubeProxySuite) TearDownTest(c *C) {
+	option.Config.Devices = s.prevConfigDevices
+	option.Config.DirectRoutingDevice = s.prevConfigDirectRoutingDevice
+	option.Config.EnableIPv4 = s.prevConfigEnableIPv4
+	option.Config.EnableIPv6 = s.prevConfigEnableIPv6
+	node.SetK8sNodeIP(s.prevK8sNodeIP)
+
+	c.Assert(s.testNetNS.Close(), IsNil)
+}
+
+func (s *KubeProxySuite) TestDetectDevices(c *C) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	c.Assert(netns.Set(s.testNetNS), IsNil)
+	defer func() { c.Assert(netns.Set(s.currentNetNS), IsNil) }()
+
+	// 1. No devices = impossible to detect
+	c.Assert(detectDevices(true, true), NotNil)
+
+	// 2. No devices, but no detection is required
+	c.Assert(detectDevices(false, false), IsNil)
+
+	// 3. Direct routing mode, should find dummy0 for both opts
+	c.Assert(createDummy("dummy0", "192.168.0.1/24"), IsNil)
+	c.Assert(createDummy("dummy1", "192.168.1.2/24"), IsNil)
+	c.Assert(createDummy("dummy2", "192.168.2.3/24"), IsNil)
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = false
+	option.Config.Tunnel = option.TunnelDisabled
+	node.SetK8sNodeIP(net.ParseIP("192.168.0.1"))
+	c.Assert(detectDevices(true, true), IsNil)
+	c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy0"})
+	c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
+
+	// 4. dummy1 should be detected too
+	c.Assert(addDefaultRoute("dummy1", "192.168.1.1"), IsNil)
+	c.Assert(detectDevices(true, true), IsNil)
+	sort.Strings(option.Config.Devices)
+	c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy0", "dummy1"})
+	c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
+
+	// 5. Enable IPv6, dummy1 should not be detected, as no default route for
+	// ipv6 is found
+	option.Config.EnableIPv6 = true
+	c.Assert(detectDevices(true, true), IsNil)
+	c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy0"})
+	c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
+
+	// 6. Set random NodeIP, only dummy1 should be detected
+	option.Config.EnableIPv6 = false
+	node.SetK8sNodeIP(net.ParseIP("192.168.34.1"))
+	c.Assert(detectDevices(true, true), IsNil)
+	c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy1"})
+	c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy1")
+}
+
+func createDummy(iface, ipAddr string) error {
+	dummy := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: iface,
+		},
+	}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		return err
+	}
+
+	link, err := netlink.LinkByName(iface)
+	if err != nil {
+		return err
+	}
+
+	ip, ipnet, err := net.ParseCIDR(ipAddr)
+	if err != nil {
+		return err
+	}
+	ipnet.IP = ip
+
+	if err := netlink.AddrAdd(link, &netlink.Addr{IPNet: ipnet}); err != nil {
+		return err
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addDefaultRoute(iface string, ipAddr string) error {
+	link, err := netlink.LinkByName(iface)
+	if err != nil {
+		return err
+	}
+
+	route := &netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Dst:       nil,
+		Gw:        net.ParseIP(ipAddr),
+	}
+	if err := netlink.RouteAdd(route); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
-	github.com/vishvananda/netlink v1.1.1-0.20200210222539-bfba8e4149db
+	github.com/vishvananda/netlink v1.1.1-0.20200603190939-5a869a71f0cb
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 	go.uber.org/goleak v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
-github.com/vishvananda/netlink v1.1.1-0.20200210222539-bfba8e4149db h1:hnvngmmfj2NuQomCEsi9fp86Pn51ij6lwRJOk9Bb++Y=
-github.com/vishvananda/netlink v1.1.1-0.20200210222539-bfba8e4149db/go.mod h1:FSQhuTO7eHT34mPzX+B04SUAjiqLxtXs1et0S6l9k4k=
+github.com/vishvananda/netlink v1.1.1-0.20200603190939-5a869a71f0cb h1:MY3XXjEi7+I9L6iwK4x0KWNL9OaWMQ5CntP06o+8zZc=
+github.com/vishvananda/netlink v1.1.1-0.20200603190939-5a869a71f0cb/go.mod h1:FSQhuTO7eHT34mPzX+B04SUAjiqLxtXs1et0S6l9k4k=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -373,6 +373,9 @@ data:
 {{- if .Values.global.nodePort.device }}
   device: {{ join " " .Values.global.nodePort.device | quote }}
 {{- end }}
+{{- if .Values.global.nodePort.directRoutingDevice }}
+  direct-routing-device: {{ .Values.global.nodePort.directRoutingDevice | quote }}
+{{- end }}
 {{- if .Values.global.nodePort.mode }}
   node-port-mode: {{ .Values.global.nodePort.mode | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -342,6 +342,12 @@ data:
   enable-host-firewall: {{ .Values.global.hostFirewall | quote }}
 {{- end}}
 
+{{- if .Values.global.devices }}
+  # List of devices used to attach bpf_host.o (implements BPF NodePort,
+  # host-firewall and BPF masquerading)
+  devices: {{ join " " .Values.global.devices | quote }}
+{{- end }}
+
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
 {{- end}}
@@ -371,7 +377,7 @@ data:
   node-port-range: {{ .Values.global.nodePort.range | quote }}
 {{- end }}
 {{- if .Values.global.nodePort.device }}
-  device: {{ join " " .Values.global.nodePort.device | quote }}
+  device: {{ .Values.global.nodePort.device | quote }}
 {{- end }}
 {{- if .Values.global.nodePort.directRoutingDevice }}
   direct-routing-device: {{ .Values.global.nodePort.directRoutingDevice | quote }}

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
             )}"""
         TESTED_SUITE="k8s-${K8S_VERSION}"
         GINKGO_TIMEOUT="300m"
-        DEFAULT_KERNEL="""${sh(
+        KERNEL="""${sh(
             returnStdout: true,
             script: 'echo -n "${JobKernelVersion}"'
             )}"""
@@ -143,7 +143,7 @@ pipeline {
                 sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                 retry(3) {
                     dir("${TESTDIR}") {
-                        sh 'KERNEL=$(python get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=version | sed "s/^$/${DEFAULT_KERNEL}/") CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
+                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
                     }
                 }
             }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -271,9 +271,8 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["NODEPORT_PORT_MAX_NAT"] = "65535"
 	}
 
-	if len(option.Config.Devices) > 0 && option.Config.EnableNodePort {
-		// First device from the list is used for direct routing between nodes
-		directRoutingIface := option.Config.Devices[0]
+	if option.Config.EnableNodePort {
+		directRoutingIface := option.Config.DirectRoutingDevice
 		directRoutingIfIndex, err := link.GetIfIndex(directRoutingIface)
 		if err != nil {
 			return err

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -52,7 +52,7 @@ var (
 func (s *ConfigSuite) SetUpTest(c *C) {
 	err := bpf.ConfigureResourceLimits()
 	c.Assert(err, IsNil)
-	node.InitDefaultPrefix(nil)
+	node.InitDefaultPrefix("")
 	node.SetInternalIPv4(ipv4DummyAddr)
 	node.SetIPv4Loopback(ipv4DummyAddr)
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -708,7 +708,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 	if n.enableNeighDiscovery {
 		var ifaceName string
 		if option.Config.EnableNodePort {
-			ifaceName = option.Config.Devices[0]
+			ifaceName = option.Config.DirectRoutingDevice
 		} else {
 			ifaceName = option.Config.EncryptInterface
 		}

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -34,7 +34,7 @@ func Test(t *testing.T) {
 }
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
-	node.InitDefaultPrefix(nil)
+	node.InitDefaultPrefix("")
 	node.SetInternalIPv4(templateIPv4)
 	node.SetIPv4Loopback(templateIPv4)
 }

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -197,7 +197,7 @@ func GetNodeSpec() error {
 			return fmt.Errorf("node name must be specified via environment variable '%s' to retrieve Kubernetes PodCIDR range", k8sConst.EnvNodeNameSpec)
 		}
 		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled &&
-			len(option.Config.Devices) == 0 {
+			(len(option.Config.Devices) == 0 || option.Config.DirectRoutingDevice == "") {
 			log.Info("K8s node name is empty. BPF NodePort might not be able to auto detect all devices")
 		}
 		return nil

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -262,6 +262,9 @@ const (
 	// Devices is the devices name
 	Devices = "devices"
 
+	//DirectRoutingDevice is the name of the direct routing device
+	DirectRoutingDevice = "directRoutingDevice"
+
 	// IpvlanMasterDevice is the ipvlan master device name
 	IpvlanMasterDevice = "ipvlanMasterDevice"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -376,6 +376,9 @@ const (
 	// K8sAPIVersion is the version of the k8s API an object has
 	K8sAPIVersion = "k8sApiVersion"
 
+	// K8sNodeIP is the k8s Node IP (either InternalIP or ExternalIP)
+	K8sNodeIP = "k8sNodeIP"
+
 	// Attempt is the attempt number if an operation is attempted multiple times
 	Attempt = "attempt"
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -61,17 +61,10 @@ func makeIPv6HostIP() net.IP {
 }
 
 // InitDefaultPrefix initializes the node address and allocation prefixes with
-// default values derived from the system.
-// If specified, the first device from the given devices can be used for
-// the derivation. Its first address with global scope will be regarded as
-// the system's node address.
-func InitDefaultPrefix(devices []string) {
-	device := ""
-	// Use first device to determine the node address and allocation prefixes
-	if len(devices) > 0 {
-		device = devices[0]
-	}
-
+// default values derived from the system. device can be set to the primary
+// network device of the system in which case the first address with global
+// scope will be regarded as the system's node address.
+func InitDefaultPrefix(device string) {
 	if option.Config.EnableIPv4 {
 		ip, err := firstGlobalV4Addr(device, GetInternalIPv4())
 		if err != nil {
@@ -279,7 +272,7 @@ func AutoComplete() error {
 		}
 	}
 
-	InitDefaultPrefix(option.Config.Devices)
+	InitDefaultPrefix(option.Config.DirectRoutingDevice)
 
 	if option.Config.EnableIPv6 && ipv6AllocRange == nil {
 		return fmt.Errorf("IPv6 allocation CIDR is not configured. Please specificy --ipv6-range")

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ var (
 	ipv6NodePortAddrs   map[string]net.IP // iface name => ip addr
 	ipv4AllocRange      *cidr.CIDR
 	ipv6AllocRange      *cidr.CIDR
+
+	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is prefered)
+	k8sNodeIP net.IP
 
 	ipsecKeyIdentity uint8
 )
@@ -454,4 +457,14 @@ func SetIPsecKeyIdentity(id uint8) {
 // GetIPsecKeyIdentity returns the IPsec key identity of the node
 func GetIPsecKeyIdentity() uint8 {
 	return ipsecKeyIdentity
+}
+
+// GetK8sNodeIPs returns k8s Node IP addr.
+func GetK8sNodeIP() net.IP {
+	return k8sNodeIP
+}
+
+// SetK8sNodeIP sets k8s Node IP addr.
+func SetK8sNodeIP(ip net.IP) {
+	k8sNodeIP = ip
 }

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -40,7 +40,7 @@ type NodeSuite struct{}
 var _ = Suite(&NodeSuite{})
 
 func (s *NodeSuite) TestMaskCheck(c *C) {
-	InitDefaultPrefix(nil)
+	InitDefaultPrefix("")
 
 	allocCIDR := cidr.MustParseCIDR("1.1.1.1/16")
 	SetIPv4AllocRange(allocCIDR)

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -223,6 +223,22 @@ func (n *Node) getNodeIP(ipv6 bool) (net.IP, addressing.AddressType) {
 	return backupIP, ipType
 }
 
+// GetK8sNodeIPs returns k8s Node IP (either InternalIP or ExternalIP or nil;
+// the former is prefered).
+func (n *Node) GetK8sNodeIP() net.IP {
+	var externalIP net.IP
+
+	for _, addr := range n.IPAddresses {
+		if addr.Type == addressing.NodeInternalIP {
+			return addr.IP
+		} else if addr.Type == addressing.NodeExternalIP {
+			externalIP = addr.IP
+		}
+	}
+
+	return externalIP
+}
+
 // GetNodeIP returns one of the node's IP addresses available with the
 // following priority:
 // - NodeInternalIP

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -114,8 +114,12 @@ const (
 	// DebugVerbose is the argument enables verbose log message for particular subsystems
 	DebugVerbose = "debug-verbose"
 
-	// List of devices facing cluster/external network for attaching bpf_netdev
+	// List of devices facing cluster/external network for attaching bpf_host
 	Device = "device"
+
+	// DirectRoutingDevice is the name of a device used to connect nodes in
+	// direct routing mode (only required by BPF NodePort)
+	DirectRoutingDevice = "direct-routing-device"
 
 	// DisableConntrack disables connection tracking
 	DisableConntrack = "disable-conntrack"
@@ -1182,19 +1186,20 @@ type IpvlanConfig struct {
 
 // DaemonConfig is the configuration used by Daemon.
 type DaemonConfig struct {
-	BpfDir           string     // BPF template files directory
-	LibDir           string     // Cilium library files directory
-	RunDir           string     // Cilium runtime directory
-	NAT46Prefix      *net.IPNet // NAT46 IPv6 Prefix
-	Devices          []string   // bpf_netdev device
-	DevicePreFilter  string     // Prefilter device
-	ModePreFilter    string     // Prefilter mode
-	XDPDevice        string     // XDP device
-	XDPMode          string     // XDP mode, values: { xdpdrv | xdpgeneric | none }
-	HostV4Addr       net.IP     // Host v4 address of the snooping device
-	HostV6Addr       net.IP     // Host v6 address of the snooping device
-	EncryptInterface string     // Set with name of network facing interface to encrypt
-	EncryptNode      bool       // Set to true for encrypting node IP traffic
+	BpfDir              string     // BPF template files directory
+	LibDir              string     // Cilium library files directory
+	RunDir              string     // Cilium runtime directory
+	NAT46Prefix         *net.IPNet // NAT46 IPv6 Prefix
+	Devices             []string   // bpf_host device
+	DirectRoutingDevice string     // Direct routing device (used only by NodePort BPF)
+	DevicePreFilter     string     // Prefilter device
+	ModePreFilter       string     // Prefilter mode
+	XDPDevice           string     // XDP device
+	XDPMode             string     // XDP mode, values: { xdpdrv | xdpgeneric | none }
+	HostV4Addr          net.IP     // Host v4 address of the snooping device
+	HostV6Addr          net.IP     // Host v6 address of the snooping device
+	EncryptInterface    string     // Set with name of network facing interface to encrypt
+	EncryptNode         bool       // Set to true for encrypting node IP traffic
 
 	Ipvlan IpvlanConfig // Ipvlan related configuration
 
@@ -2150,6 +2155,7 @@ func (c *DaemonConfig) Populate() {
 	c.Debug = viper.GetBool(DebugArg)
 	c.DebugVerbose = viper.GetStringSlice(DebugVerbose)
 	c.Devices = viper.GetStringSlice(Device)
+	c.DirectRoutingDevice = viper.GetString(DirectRoutingDevice)
 	c.DisableConntrack = viper.GetBool(DisableConntrack)
 	c.EnableIPv4 = getIPv4Enabled()
 	c.EnableIPv6 = viper.GetBool(EnableIPv6Name)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2836,3 +2836,10 @@ func EndpointStatusValuesMap() (values map[string]struct{}) {
 	}
 	return
 }
+
+// MightAutoDetectDevices returns true if the device auto-detection might take
+// place.
+func MightAutoDetectDevices() bool {
+	return Config.KubeProxyReplacement != KubeProxyReplacementDisabled &&
+		(len(Config.Devices) == 0 || Config.DirectRoutingDevice == "")
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -114,8 +114,11 @@ const (
 	// DebugVerbose is the argument enables verbose log message for particular subsystems
 	DebugVerbose = "debug-verbose"
 
-	// List of devices facing cluster/external network for attaching bpf_host
+	// Device facing cluster/external network for attaching bpf_host
 	Device = "device"
+
+	// Devices facing cluster/external network for attaching bpf_host
+	Devices = "devices"
 
 	// DirectRoutingDevice is the name of a device used to connect nodes in
 	// direct routing mode (only required by BPF NodePort)
@@ -2154,7 +2157,6 @@ func (c *DaemonConfig) Populate() {
 	c.DatapathMode = viper.GetString(DatapathMode)
 	c.Debug = viper.GetBool(DebugArg)
 	c.DebugVerbose = viper.GetStringSlice(DebugVerbose)
-	c.Devices = viper.GetStringSlice(Device)
 	c.DirectRoutingDevice = viper.GetString(DirectRoutingDevice)
 	c.DisableConntrack = viper.GetBool(DisableConntrack)
 	c.EnableIPv4 = getIPv4Enabled()
@@ -2277,6 +2279,8 @@ func (c *DaemonConfig) Populate() {
 	c.PolicyAuditMode = viper.GetBool(PolicyAuditModeArg)
 	c.EnableIPv4FragmentsTracking = viper.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = viper.GetInt(FragmentsMapEntriesName)
+
+	c.populateDevices()
 
 	if nativeCIDR := viper.GetString(IPv4NativeRoutingCIDR); nativeCIDR != "" {
 		c.ipv4NativeRoutingCIDR = cidr.MustParseCIDR(nativeCIDR)
@@ -2457,6 +2461,21 @@ func (c *DaemonConfig) Populate() {
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
+}
+
+func (c *DaemonConfig) populateDevices() {
+	c.Devices = viper.GetStringSlice(Devices)
+	device := viper.GetString(Device)
+
+	if len(c.Devices) != 0 && device != "" {
+		log.Fatalf("--%s and --%s (deprecated) are mutually exclusive",
+			Devices, Device)
+	}
+
+	// For backward compatibility until the flag is completely deprecated
+	if device != "" {
+		c.Devices = []string{device}
+	}
 }
 
 func (c *DaemonConfig) populateNodePortRange() error {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2140,6 +2140,14 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 	}
 
+	// Temporary workaround until https://github.com/cilium/cilium/pull/11915
+	// has been merged. Otherwise, the BPF verifier rejects some programs on
+	// the 4.19 kernel
+	if os.Getenv("KERNEL") == "419" {
+		options = addIfNotOverwritten(options, "global.kubeProxyReplacement", "partial")
+		options = addIfNotOverwritten(options, "global.hostServices.enabled", "true")
+	}
+
 	if !RunsWithKubeProxy() {
 		nodeIP, err := kub.GetNodeIPByLabel(K8s1, false)
 		if err != nil {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2169,7 +2169,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 			opts["global.bpfMasquerade"] = "true"
 		}
 
-		opts["global.nodePort.device"] = devices
+		opts["global.devices"] = devices
 
 		for key, value := range opts {
 			options = addIfNotOverwritten(options, key, value)

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -205,8 +205,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}
 
 		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
-			if !helpers.RunsOnNetNextOr419Kernel() {
-				Skip("Skipping test because it is not running with the net-next kernel or 4.19 kernel")
+			// FIXME(brb) Currently, the test is broken with CI 4.19 setup. Run it on 4.19
+			//			  once we have kube-proxy disabled there.
+			if !helpers.RunsOnNetNextKernel() {
+				Skip("Skipping test because it is not running with the net-next kernel")
 				return
 			}
 			SkipItIfNoKubeProxy()

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1223,7 +1223,7 @@ var _ = Describe("K8sServicesTest", func() {
 					SkipItIf(func() bool { return helpers.GetCurrentIntegration() != "" },
 						"Tests with secondary NodePort device", func() {
 							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-								"global.nodePort.device": fmt.Sprintf(`'{%s,%s}'`, privateIface, helpers.SecondaryIface),
+								"global.devices": fmt.Sprintf(`'{%s,%s}'`, privateIface, helpers.SecondaryIface),
 							})
 
 							testNodePort(true, true, helpers.ExistNodeWithoutCilium(), 0)
@@ -1276,7 +1276,7 @@ var _ = Describe("K8sServicesTest", func() {
 								"global.tunnel":               "disabled",
 								"global.autoDirectNodeRoutes": "true",
 								"global.nodePort.mode":        "snat",
-								"global.nodePort.device":      fmt.Sprintf(`'{%s,%s}'`, privateIface, helpers.SecondaryIface),
+								"global.devices":              fmt.Sprintf(`'{%s,%s}'`, privateIface, helpers.SecondaryIface),
 							})
 
 							testNodePort(true, true, helpers.ExistNodeWithoutCilium(), 0)

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -244,7 +244,7 @@ var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 				deployCilium(map[string]string{
 					"global.tunnel":               "disabled",
 					"global.autoDirectNodeRoutes": "true",
-					"global.nodePort.device":      external_ips.PublicInterfaceName,
+					"global.devices":              external_ips.PublicInterfaceName,
 					"global.nodePort.enabled":     "true",
 					"global.bpfMasquerade":        "false",
 				})
@@ -289,7 +289,7 @@ var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 			BeforeAll(func() {
 				deployCilium(map[string]string{
 					"global.tunnel":           "vxlan",
-					"global.nodePort.device":  external_ips.PublicInterfaceName,
+					"global.devices":          external_ips.PublicInterfaceName,
 					"global.nodePort.enabled": "true",
 					"global.bpfMasquerade":    "false",
 				})

--- a/vendor/github.com/vishvananda/netlink/addr.go
+++ b/vendor/github.com/vishvananda/netlink/addr.go
@@ -17,6 +17,7 @@ type Addr struct {
 	Broadcast   net.IP
 	PreferedLft int
 	ValidLft    int
+	LinkIndex   int
 }
 
 // String returns $ip/$netmask $label

--- a/vendor/github.com/vishvananda/netlink/addr_linux.go
+++ b/vendor/github.com/vishvananda/netlink/addr_linux.go
@@ -193,12 +193,12 @@ func (h *Handle) AddrList(link Link, family int) ([]Addr, error) {
 
 	var res []Addr
 	for _, m := range msgs {
-		addr, msgFamily, ifindex, err := parseAddr(m)
+		addr, msgFamily, err := parseAddr(m)
 		if err != nil {
 			return res, err
 		}
 
-		if link != nil && ifindex != indexFilter {
+		if link != nil && addr.LinkIndex != indexFilter {
 			// Ignore messages from other interfaces
 			continue
 		}
@@ -213,11 +213,11 @@ func (h *Handle) AddrList(link Link, family int) ([]Addr, error) {
 	return res, nil
 }
 
-func parseAddr(m []byte) (addr Addr, family, index int, err error) {
+func parseAddr(m []byte) (addr Addr, family int, err error) {
 	msg := nl.DeserializeIfAddrmsg(m)
 
 	family = -1
-	index = -1
+	addr.LinkIndex = -1
 
 	attrs, err1 := nl.ParseRouteAttr(m[msg.Len():])
 	if err1 != nil {
@@ -226,7 +226,7 @@ func parseAddr(m []byte) (addr Addr, family, index int, err error) {
 	}
 
 	family = int(msg.Family)
-	index = int(msg.Index)
+	addr.LinkIndex = int(msg.Index)
 
 	var local, dst *net.IPNet
 	for _, attr := range attrs {
@@ -391,7 +391,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 					continue
 				}
 
-				addr, _, ifindex, err := parseAddr(m.Data)
+				addr, _, err := parseAddr(m.Data)
 				if err != nil {
 					if cberr != nil {
 						cberr(fmt.Errorf("could not parse address: %v", err))
@@ -400,7 +400,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 				}
 
 				ch <- AddrUpdate{LinkAddress: *addr.IPNet,
-					LinkIndex:   ifindex,
+					LinkIndex:   addr.LinkIndex,
 					NewAddr:     msgType == unix.RTM_NEWADDR,
 					Flags:       addr.Flags,
 					Scope:       addr.Scope,

--- a/vendor/github.com/vishvananda/netlink/rdma_link_linux.go
+++ b/vendor/github.com/vishvananda/netlink/rdma_link_linux.go
@@ -77,28 +77,39 @@ func executeOneGetRdmaLink(data []byte) (*RdmaLink, error) {
 	return &link, nil
 }
 
-func execRdmaGetLink(req *nl.NetlinkRequest, name string) (*RdmaLink, error) {
+func execRdmaSetLink(req *nl.NetlinkRequest) error {
+
+	_, err := req.Execute(unix.NETLINK_RDMA, 0)
+	return err
+}
+
+// RdmaLinkList gets a list of RDMA link devices.
+// Equivalent to: `rdma dev show`
+func RdmaLinkList() ([]*RdmaLink, error) {
+	return pkgHandle.RdmaLinkList()
+}
+
+// RdmaLinkList gets a list of RDMA link devices.
+// Equivalent to: `rdma dev show`
+func (h *Handle) RdmaLinkList() ([]*RdmaLink, error) {
+	proto := getProtoField(nl.RDMA_NL_NLDEV, nl.RDMA_NLDEV_CMD_GET)
+	req := h.newNetlinkRequest(proto, unix.NLM_F_ACK|unix.NLM_F_DUMP)
 
 	msgs, err := req.Execute(unix.NETLINK_RDMA, 0)
 	if err != nil {
 		return nil, err
 	}
+
+	var res []*RdmaLink
 	for _, m := range msgs {
 		link, err := executeOneGetRdmaLink(m)
 		if err != nil {
 			return nil, err
 		}
-		if link.Attrs.Name == name {
-			return link, nil
-		}
+		res = append(res, link)
 	}
-	return nil, fmt.Errorf("Rdma device %v not found", name)
-}
 
-func execRdmaSetLink(req *nl.NetlinkRequest) error {
-
-	_, err := req.Execute(unix.NETLINK_RDMA, 0)
-	return err
+	return res, nil
 }
 
 // RdmaLinkByName finds a link by name and returns a pointer to the object if
@@ -110,11 +121,16 @@ func RdmaLinkByName(name string) (*RdmaLink, error) {
 // RdmaLinkByName finds a link by name and returns a pointer to the object if
 // found and nil error, otherwise returns error code.
 func (h *Handle) RdmaLinkByName(name string) (*RdmaLink, error) {
-
-	proto := getProtoField(nl.RDMA_NL_NLDEV, nl.RDMA_NLDEV_CMD_GET)
-	req := h.newNetlinkRequest(proto, unix.NLM_F_ACK|unix.NLM_F_DUMP)
-
-	return execRdmaGetLink(req, name)
+	links, err := h.RdmaLinkList()
+	if err != nil {
+		return nil, err
+	}
+	for _, link := range links {
+		if link.Attrs.Name == name {
+			return link, nil
+		}
+	}
+	return nil, fmt.Errorf("Rdma device %v not found", name)
 }
 
 // RdmaLinkSetName sets the name of the rdma link device. Return nil on success

--- a/vendor/github.com/vishvananda/netlink/rule_linux.go
+++ b/vendor/github.com/vishvananda/netlink/rule_linux.go
@@ -177,6 +177,19 @@ func RuleList(family int) ([]Rule, error) {
 // RuleList lists rules in the system.
 // Equivalent to: ip rule list
 func (h *Handle) RuleList(family int) ([]Rule, error) {
+	return h.RuleListFiltered(family, nil, 0)
+}
+
+// RuleListFiltered gets a list of rules in the system filtered by the
+// specified rule template `filter`.
+// Equivalent to: ip rule list
+func RuleListFiltered(family int, filter *Rule, filterMask uint64) ([]Rule, error) {
+	return pkgHandle.RuleListFiltered(family, filter, filterMask)
+}
+
+// RuleListFiltered lists rules in the system.
+// Equivalent to: ip rule list
+func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) ([]Rule, error) {
 	req := h.newNetlinkRequest(unix.RTM_GETRULE, unix.NLM_F_DUMP|unix.NLM_F_REQUEST)
 	msg := nl.NewIfInfomsg(family)
 	req.AddData(msg)
@@ -246,6 +259,29 @@ func (h *Handle) RuleList(family int) ([]Rule, error) {
 				rule.Sport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
 			}
 		}
+
+		if filter != nil {
+			switch {
+			case filterMask&RT_FILTER_SRC != 0 &&
+				(rule.Src == nil || rule.Src.String() != filter.Src.String()):
+				continue
+			case filterMask&RT_FILTER_DST != 0 &&
+				(rule.Dst == nil || rule.Dst.String() != filter.Dst.String()):
+				continue
+			case filterMask&RT_FILTER_TABLE != 0 &&
+				filter.Table != unix.RT_TABLE_UNSPEC && rule.Table != filter.Table:
+				continue
+			case filterMask&RT_FILTER_TOS != 0 && rule.Tos != filter.Tos:
+				continue
+			case filterMask&RT_FILTER_PRIORITY != 0 && rule.Priority != filter.Priority:
+				continue
+			case filterMask&RT_FILTER_MARK != 0 && rule.Mark != filter.Mark:
+				continue
+			case filterMask&RT_FILTER_MASK != 0 && rule.Mask != filter.Mask:
+				continue
+			}
+		}
+
 		res = append(res, *rule)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -547,7 +547,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
-# github.com/vishvananda/netlink v1.1.1-0.20200210222539-bfba8e4149db
+# github.com/vishvananda/netlink v1.1.1-0.20200603190939-5a869a71f0cb
 ## explicit
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl


### PR DESCRIPTION
First, this PR extends the BPF NodePort device auto-detection mechanism by:

1. In addition to a device with a default route, it considers a device with k8s Node IP addr. The k8s Node IP addr is derived from the self Node object, and it's either `InternalIP` or `ExternalIP` or `nil` (the former is preferred).
2. BPF NodePort direct routing device can be automatically detected (previously, it was the first device among all BPF NodePort devices). If there is only one BPF NodePort device is set, then that device is used for the direct routing. Otherwise, the k8s Node IP device is used. Users can specify the device via `--direct-routing-device` (`global.nodePort.directRoutingDevice`).
3. Enables XDP on the direct routing device (see reasoning in the commit msg).

The detected devices by 1. are used for BPF masquerading and host-fw too.

Second, this PR introduces `--devices` flag and deprecated `--device`. If the latter is specified, its value is appended to the former.

Reviewable per commit.

One limitation which hasn't been resolved in this PR, is that if in the k8s dualstack mode InternalIPv4 and InternalIPv6 are assigned to two different devices, then only one will be considered. I'm going to address it in a separate PR (not a release blocker).

Once this PR is merged, I will move `initKubeProxyReplacement()` to `daemon/cmd/kube_proxy.go` (I didn't want to move in this PR to avoid complicating the reviewing).

Fix: https://github.com/cilium/cilium/issues/11789