### PR TITLE
test/helpers: allow passing custom number of requests to helpers.Ping()

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -151,7 +151,8 @@ const (
 	StateTerminating = "Terminating"
 	StateRunning     = "Running"
 
-	PingCount = 5
+	PingCount   = 5
+	PingTimeout = 5
 
 	// CurlConnectTimeout is the timeout for the connect() call that curl
 	// invokes

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -40,10 +40,16 @@ const (
 	UDP_RR = PerfTest("UDP_RR")
 )
 
+// PingWithCount returns the string representing the ping command to ping the
+// specified endpoint, and takes a custom number of requests to send.
+func PingWithCount(endpoint string, count uint) string {
+	return fmt.Sprintf("ping -W %d -c %d %s", PingTimeout, count, endpoint)
+}
+
 // Ping returns the string representing the ping command to ping the specified
 // endpoint.
 func Ping(endpoint string) string {
-	return fmt.Sprintf("ping -W 5 -c %d %s", PingCount, endpoint)
+	return PingWithCount(endpoint, PingCount)
 }
 
 // Ping6 returns the string representing the ping6 command to ping6 the

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -616,7 +616,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Testing egress connnectivity works correctly")
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.Ping("8.8.8.8"))
+				helpers.PingWithCount("8.8.8.8", 25))
 			res.ExpectSuccess("Egress ping connectivity should work")
 		})
 


### PR DESCRIPTION
Let's increase the interval between ICMP requests for the cases where the setup might not be ready to process them just yet. Introduce a new `PingWithInterval()` helper that takes an integer passed to ping's `-i` option.

[Edit: switched to interval between requests (`-i`) to number of requests (`-c`)]

Fixes: #11741 (hopefully)