### PR TITLE
datapath: Only NOTRACK proxy return traffic going to Cilium datapath

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -574,11 +574,23 @@ func (m *IptablesManager) installStaticProxyRules() error {
 				"-j", "ACCEPT"), false)
 		}
 		if err == nil {
-			// No conntrack for proxy return traffic
+			// No conntrack for proxy return traffic that is heading to lxc+
 			err = runProg("iptables", append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
+				"-o", "lxc+",
+				"-m", "mark", "--mark", matchProxyReply,
+				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
+				"-j", "NOTRACK"), false)
+		}
+		if err == nil {
+			// No conntrack for proxy return traffic that is heading to cilium_host
+			err = runProg("iptables", append(
+				m.waitArgs,
+				"-t", "raw",
+				"-A", ciliumOutputRawChain,
+				"-o", "cilium_host",
 				"-m", "mark", "--mark", matchProxyReply,
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 				"-j", "NOTRACK"), false)


### PR DESCRIPTION
Proxy return traffic accessed via a k8s NodePort will not be routed
back via Cilium bpf datapath, so such traffic needs to have possible
reverse NAT applied. Setting NOTRACK prevented this. Fix this by
setting NOTRACK only on packets heading back to the Cilium datapath
(`-o lxc+` and `-o cilium_host`).

Fixes: #8971
Fixes: #8945
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
