### PR TITLE
pkg/k8s: delete toCIDRSets for more than 2 endpoints

### DIFF
--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -174,8 +174,7 @@ func deleteToCidrFromEndpoint(
 	endpoint Endpoints,
 	releasePrefixes bool) error {
 
-	newToCIDR := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
-	deleted := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
+	delCIDRRules := make(map[int]*api.CIDRRule, len(egress.ToCIDRSet))
 
 	for ip := range endpoint.Backends {
 		epIP := net.ParseIP(ip)
@@ -183,26 +182,52 @@ func deleteToCidrFromEndpoint(
 			return fmt.Errorf("unable to parse ip: %s", ip)
 		}
 
-		for _, c := range egress.ToCIDRSet {
+		for i, c := range egress.ToCIDRSet {
+			if _, ok := delCIDRRules[i]; ok {
+				// it's already going to be deleted so we can continue
+				continue
+			}
 			_, cidr, err := net.ParseCIDR(string(c.Cidr))
 			if err != nil {
 				return err
 			}
-			// if endpoint is not in CIDR or it's not
-			// generated it's ok to retain it
-			if !cidr.Contains(epIP) || !c.Generated {
-				newToCIDR = append(newToCIDR, c)
-			} else {
-				deleted = append(deleted, c)
+			// delete all generated CIDRs for a CIDR that match the given
+			// endpoint
+			if c.Generated && cidr.Contains(epIP) {
+				delCIDRRules[i] = &egress.ToCIDRSet[i]
 			}
+		}
+		if len(delCIDRRules) == len(egress.ToCIDRSet) {
+			break
 		}
 	}
 
-	egress.ToCIDRSet = newToCIDR
+	// If no rules were deleted we can do an early return here and avoid doing
+	// the useless operations below.
+	if len(delCIDRRules) == 0 {
+		return nil
+	}
+
 	if releasePrefixes {
-		prefixes := policy.GetPrefixesFromCIDRSet(deleted)
+		delSlice := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
+		for _, delCIDRRule := range delCIDRRules {
+			delSlice = append(delSlice, *delCIDRRule)
+		}
+		prefixes := policy.GetPrefixesFromCIDRSet(delSlice)
 		ipcache.ReleaseCIDRs(prefixes)
 	}
+
+	// if endpoint is not in CIDR or it's not generated it's ok to retain it
+	newCIDRRules := make([]api.CIDRRule, 0, len(egress.ToCIDRSet)-len(delCIDRRules))
+	for i, c := range egress.ToCIDRSet {
+		// If the rule was deleted then it shouldn't be re-added
+		if _, ok := delCIDRRules[i]; ok {
+			continue
+		}
+		newCIDRRules = append(newCIDRRules, c)
+	}
+
+	egress.ToCIDRSet = newCIDRRules
 
 	return nil
 }

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -197,11 +197,20 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	rule := &api.EgressRule{}
 
-	epIP := "10.1.1.1"
+	epIP1 := "10.1.1.1"
+	epIP2 := "10.1.1.2"
 
 	endpointInfo := Endpoints{
 		Backends: map[string]*Backend{
-			epIP: {
+			epIP1: {
+				Ports: map[string]*loadbalancer.L4Addr{
+					"port": {
+						Protocol: loadbalancer.TCP,
+						Port:     80,
+					},
+				},
+			},
+			epIP2: {
 				Ports: map[string]*loadbalancer.L4Addr{
 					"port": {
 						Protocol: loadbalancer.TCP,
@@ -215,16 +224,31 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 1)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
+	c.Assert(len(rule.ToCIDRSet), Equals, 2)
+	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
+	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
 
 	// second run, to make sure there are no duplicates added
 	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 1)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
+	c.Assert(len(rule.ToCIDRSet), Equals, 2)
+	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
+	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
 
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	c.Assert(err, IsNil)
+	c.Assert(len(rule.ToCIDRSet), Equals, 0)
+
+	// third run, to make sure there are no duplicates added
+	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
+	c.Assert(err, IsNil)
+
+	c.Assert(len(rule.ToCIDRSet), Equals, 2)
+	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
+	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+
+	// and one final delete
 	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)


### PR DESCRIPTION
In case a toServices selected a service that contained more than 1
endpoint, the generated rules could never be deleted. This can easily be
reproducible by adding one more endpoint to the unit test of the
deleteToCidrFromEndpoint function.

Fixes: bae09f7cc960 ("Move ToCIDR gen logic to k8s package")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Avoid duplication of generated toCIDRs when using a toServices based CNP (or CCNP)
```

The PR for the v1.6 branch is made separately since the code is slightly different: https://github.com/cilium/cilium/pull/11900