### PR TITLE
test: set hubble-relay image in helm defaults if available

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -240,6 +240,7 @@ func Init() {
 		"CILIUM_TAG":            "global.tag",
 		"CILIUM_IMAGE":          "agent.image",
 		"CILIUM_OPERATOR_IMAGE": "operator.image",
+		"HUBBLE_RELAY_IMAGE":    "hubble-relay.image",
 	} {
 		if v := os.Getenv(envVar); v != "" {
 			defaultHelmOptions[helmVar] = v


### PR DESCRIPTION
Hubble-relay image must be set in helm defaults for it to take effect.

Without this the test suite will try to pull bubble-relay with the same 'hub' and 'tag' as the main cilium image (e.g., a dev build etc.). This change allows this behavior to be overridden by passing e.g. `--cilium.hubble-relay-image="docker.io/cilium/hubble-relay:latest"` on `ginkgo` command line.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
