### PR TITLE
v1.7 backports 2020-06-04

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -64,6 +64,7 @@ Install Cilium
 
     kubectl create -f \ |SCM_WEB|\/install/kubernetes/quick-install.yaml
 
+.. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-validate.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -112,10 +112,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 30, unit: 'MINUTES'){
-                                sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
-                                sh 'cd ${TESTDIR}; vagrant up runtime --provision'
-                            }
+                            sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
+                            sh 'cd ${TESTDIR}; timeout 30m vagrant up runtime --provision'
                         }
                     }
                     post {
@@ -144,10 +142,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 45, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
                             }
                         }
                     }
@@ -173,10 +169,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 45, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
                             }
                         }
                     }

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -68,17 +68,14 @@ pipeline {
         }
         stage('Boot VMs'){
             options {
-                timeout(time: 60, unit: 'MINUTES')
+                timeout(time: 70, unit: 'MINUTES')
             }
 
             steps {
                 retry(3){
-                    timeout(time: 20, unit: 'MINUTES'){
-                        sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
-                        sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
-                        sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
-                        sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
-                    }
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; timeout 20m vagrant up k8s1-${K8S_VERSION} k8s2-${K8S_VERSION}'
                 }
             }
         }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -234,9 +234,13 @@ func (s *Service) UpsertService(
 		return false, lb.ID(0), err
 	}
 
-	localBackendCount := len(backendsCopy)
-	s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
-		localBackendCount, svc.svcHealthCheckNodePort)
+	// Only add a HealthCheckNodePort server if this is a service which may
+	// only contain local backends.
+	if onlyLocalBackends {
+		localBackendCount := len(backendsCopy)
+		s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
+			localBackendCount, svc.svcHealthCheckNodePort)
+	}
 
 	if new {
 		addMetric.Inc()


### PR DESCRIPTION
* #11858 -- ci: Change vagrant timeout mechanism (@nebril)
 * #11879 -- docs: Include directions to restart pods in the k3s install guide (@seanmwinn)
 * #11863 -- service: Fix wrong localEndpoints count in HealthCheckNodePort (@gandro)
   * Note: Kept most of the PR intact except for dropping changes in tests, see [here](https://github.com/cilium/cilium/pull/11863#issuecomment-639210442).
 * #11762 -- test: Add simple retries for flaky Helm operations (@christarazi)


Skipped due to non-trivial conflicts:
 * #11617 -- bpf: getpeername hook implementation for socket lb (@borkmann)
 * #11231 -- Protect ENI and Azure IPAM from misbehaving cloud APIs (@tgraf)
   * Note: seems to depend on changes from https://github.com/cilium/cilium/pull/10691


~~Skipped as it depends on #11766:~~
 ~~* #11804 -- fix(datarace): Fix possible nil pointer dereference (@sayboras)~~
*The above PR doesn't need to be backported, see [here](https://github.com/cilium/cilium/pull/11804#issuecomment-639200020). Removing.*

Skipped as it will be handled by original author:
 * #11830 -- Add anti-affinity for Cilium pods (@nebril)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11858 11879 11863 11762; do contrib/backporting/set-labels.py $pr done 1.7; done
```