### PR TITLE
contrib: Fix submit-backport PR set-labels detection

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -49,20 +49,14 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push origin "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH,requires-janitor-review -F $SUMMARY
 
-prs=$(sed -e 's/^.*#\([0-9]\+\) .*$/\1/g' -e '/^[^0-9]\+/d' $SUMMARY | tr '\n' ' ')
+prs=$(grep "set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
 echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels
-for pr in $prs; do
-    if [ "$set_all_labels" = "y" ]; then
+if [ "$set_all_labels" = "y" ]; then
+    for pr in $prs; do
         echo -n "Setting labels for PR $pr... "
         $DIR/set-labels.py $pr pending $BRANCH;
-    else
-        echo -n "Set labels for $pr? [y/N] "
-        read setlabels
-        if [ "$setlabels" = "y" ]; then
-            $DIR/set-labels.py $pr pending $BRANCH;
-        fi
-    fi
-    echo "✓"
-done
+        echo "✓"
+    done
+fi


### PR DESCRIPTION
Previously if you manually edited the command in the backport summary
file and referenced PRs elsewhere in the summary file, then the script
would still ask if you wanted to update the labels for *all* PRs
mentioned in the summary.

This commit changes it to only ask whether you want to set the labels
for the set of PRs that are listed in the *command* that's provided in
the summary file.

Used to create #11909 .