### PR TITLE
policy: Fix rule translation test flake

### DIFF
--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -17,6 +17,9 @@
 package k8s
 
 import (
+	"sort"
+
+	"github.com/cilium/cilium/pkg/checker"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -224,17 +227,25 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs := rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	// second run, to make sure there are no duplicates added
 	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs = rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
@@ -244,9 +255,13 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs = rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	// and one final delete
 	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"net"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
@@ -61,6 +62,15 @@ type CIDRRule struct {
 	Generated bool `json:"-"`
 }
 
+// String converts the CIDRRule into a human-readable string.
+func (r CIDRRule) String() string {
+	exceptCIDRs := ""
+	if len(r.ExceptCIDRs) > 0 {
+		exceptCIDRs = "-" + CIDRSlice(r.ExceptCIDRs).String()
+	}
+	return string(r.Cidr) + exceptCIDRs
+}
+
 // CIDRSlice is a slice of CIDRs. It allows receiver methods to be defined for
 // transforming the slice into other convenient forms such as
 // EndpointSelectorSlice.
@@ -98,6 +108,14 @@ func (s CIDRSlice) StringSlice() []string {
 	return result
 }
 
+// String converts the CIDRSlice into a human-readable string.
+func (s CIDRSlice) String() string {
+	if len(s) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(s.StringSlice(), ",") + "]"
+}
+
 // CIDRRuleSlice is a slice of CIDRRules. It allows receiver methods to be
 // defined for transforming the slice into other convenient forms such as
 // EndpointSelectorSlice.
@@ -108,6 +126,15 @@ type CIDRRuleSlice []CIDRRule
 func (s CIDRRuleSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
 	cidrs := ComputeResultantCIDRSet(s)
 	return cidrs.GetAsEndpointSelectors()
+}
+
+// StringSlice returns the CIDRRuleSlice as a slice of strings.
+func (s CIDRRuleSlice) StringSlice() []string {
+	result := make([]string, 0, len(s))
+	for _, c := range s {
+		result = append(result, c.String())
+	}
+	return result
 }
 
 // ComputeResultantCIDRSet converts a slice of CIDRRules into a slice of


### PR DESCRIPTION
The rule_translate_test.go was checking the output of an unsorted slice,
which could occasionally fail with:

    FAIL: rule_translate_test.go:197: K8sSuite.TestGenerateToCIDRFromEndpoint
    rule_translate_test.go:228:
        c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
    ... obtained string = "10.1.1.2/32"
    ... expected string = "10.1.1.1/32"

Fix it by implementing some basic sorting functions in the policy api
package and using these in the offending tests.

Fixes: #11901 

This failure was observed on Travis, so only Travis should be necessary to validate the fix.