### PR TITLE
daemon: Clarify log msg how to use only TCP socket-lb

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1826,7 +1826,7 @@ func initKubeProxyReplacementOptions() {
 		if option.Config.EnableHostServicesUDP &&
 			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_RECVMSG) != nil ||
 				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_RECVMSG) != nil) {
-			msg := "BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp"
+			msg := fmt.Sprintf("BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --%s=tcp and --%s=%s", option.HostReachableServicesProtos, option.KubeProxyReplacement, option.KubeProxyReplacementPartial)
 			if strict {
 				log.Fatal(msg)
 			} else {


### PR DESCRIPTION
Fix: https://github.com/cilium/cilium/issues/11055

No need to update docs, as it already has an example:
```
The following helm setup below would optimize Cilium’s ClusterIP handling for TCP in a kube-proxy environment (global.hostServices.protocols default is tcp,udp):

helm install cilium ./cilium \
    --namespace kube-system \
    --set global.kubeProxyReplacement=partial \
    --set global.hostServices.enabled=true \
    --set global.hostServices.protocols=tcp
```

Also, no need to run tests due to trivial change (except for Travis).