### PR TITLE
Properly cancel endpoint creations as they become obsolete

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -149,6 +149,10 @@ type Daemon struct {
 	// k8sCachesSynced is closed when all essential Kubernetes caches have
 	// been fully synchronized
 	k8sCachesSynced <-chan struct{}
+
+	// endpointCreations is a map of all currently ongoing endpoint
+	// creation events
+	endpointCreations *endpointCreationManager
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
@@ -297,15 +301,16 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	nd := nodediscovery.NewNodeDiscovery(nodeMngr, mtuConfig, netConf)
 
 	d := Daemon{
-		ctx:              dCtx,
-		cancel:           cancel,
-		prefixLengths:    createPrefixLengthCounter(),
-		buildEndpointSem: semaphore.NewWeighted(int64(numWorkerThreads())),
-		compilationMutex: new(lock.RWMutex),
-		netConf:          netConf,
-		mtuConfig:        mtuConfig,
-		datapath:         dp,
-		nodeDiscovery:    nd,
+		ctx:               dCtx,
+		cancel:            cancel,
+		prefixLengths:     createPrefixLengthCounter(),
+		buildEndpointSem:  semaphore.NewWeighted(int64(numWorkerThreads())),
+		compilationMutex:  new(lock.RWMutex),
+		netConf:           netConf,
+		mtuConfig:         mtuConfig,
+		datapath:          dp,
+		nodeDiscovery:     nd,
+		endpointCreations: newEndpointCreationManager(),
 	}
 
 	d.svc = service.NewService(&d)
@@ -380,6 +385,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 
 	debug.RegisterStatusObject("k8s-service-cache", &d.k8sWatcher.K8sSvcCache)
 	debug.RegisterStatusObject("ipam", d.ipam)
+	debug.RegisterStatusObject("ongoing-endpoint-creations", d.endpointCreations)
 
 	d.k8sWatcher.RunK8sServiceHandler()
 	treatRemoteNodeAsHost := option.Config.AlwaysAllowLocalhost() && !option.Config.EnableRemoteNodeIdentity

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -364,7 +364,7 @@ const (
 
 	// IPAMExpiration is the timeout after which an IP subject to expiratio
 	// is being released again if no endpoint is being created in time.
-	IPAMExpiration = 3 * time.Minute
+	IPAMExpiration = 10 * time.Minute
 
 	// EnableIPv4FragmentsTracking enables IPv4 fragments tracking for
 	// L4-based lookups


### PR DESCRIPTION
So far, the endpoint create request has relied on timing out eventually
and checking liveness of the endpoint in various spots to then abort the
creation.

This has the disadvantage that if a blocking operation such as etcd
interactions are delayed for a long time, kubelet may schedule a new pod
creation attempt while the old endpoint is still being created, leading
to parallel endpoint create events for the same pod.

Establish a new map which keeps track of all endpoint create requests
and:
* Cancel any endpoint create request if an endpoint delete request for
the same endpoint is being received.
* Cancel any endpoint create request if a new endpoint create request
for the same pod is being received. The new request will continue.

In order to assist in troubleshooting of create endpoint related issues,
the list of ongoing endpoint creations is printed in the debuginfo
output.