### PR TITLE
docs: quote helm flags with brackets

### DIFF
--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -57,8 +57,8 @@ Deploy Cilium release via Helm:
     helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
       --set global.etcd.enabled=true \\
-      --set global.etcd.endpoints[0]=http://etcd-endpoint1:2379 \\
-      --set global.etcd.endpoints[1]=http://etcd-endpoint2:2379
+      --set "global.etcd.endpoints[0]=http://etcd-endpoint1:2379" \\
+      --set "global.etcd.endpoints[1]=http://etcd-endpoint2:2379"
 
 
 Optional: Configure the SSL certificates
@@ -83,8 +83,8 @@ of http for the etcd endpoint URLs:
       --namespace kube-system \\
       --set global.etcd.enabled=true \\
       --set global.etcd.ssl=true \\
-      --set global.etcd.endpoints[0]=https://etcd-endpoint1:2379 \\
-      --set global.etcd.endpoints[1]=https://etcd-endpoint2:2379
+      --set "global.etcd.endpoints[0]=https://etcd-endpoint1:2379" \\
+      --set "global.etcd.endpoints[1]=https://etcd-endpoint2:2379"
 
 Validate the Installation
 =========================


### PR DESCRIPTION
Due to zsh using square brackets for globbing/pattern matching, our etcd
endpoints examples failed with
`zsh: no matches found: global.etcd.endpoints[0]=url`.

Grepping through the docs didn't find any other commands using brackets,
so only etcd-endpoint related ones are in quotes.