### PR TITLE
cilium: rename --node-port-acceleration=none to =disabled

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -154,7 +154,7 @@ cilium-agent [flags]
       --monitor-queue-size int                        Size of the event queue when reading monitor events
       --mtu int                                       Overwrite auto-detected MTU of underlying network
       --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --node-port-acceleration string                 BPF NodePort acceleration via XDP ("native", "none") (default "none")
+      --node-port-acceleration string                 BPF NodePort acceleration via XDP ("native", "disabled") (default "disabled")
       --node-port-bind-protection                     Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")
       --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -326,7 +326,7 @@ load balancer can be handled by Cilium at the XDP (eXpress Data Path) layer wher
 is operating directly in the networking driver instead of a higher layer.
 
 The mode setting ``global.nodePort.acceleration`` allows to enable this acceleration
-through the option ``native``. The option ``none`` is the default and disables the
+through the option ``native``. The option ``disabled`` is the default and disables the
 acceleration. The majority of drivers supporting 10G or higher rates also support
 ``native`` XDP on a recent kernel. For cloud based deployments most of these drivers
 have SR-IOV variants that support native XDP as well.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -520,7 +520,9 @@ func init() {
 	flags.Bool(option.NodePortBindProtection, true, "Reject application bind(2) requests to service ports in the NodePort range")
 	option.BindEnv(option.NodePortBindProtection)
 
-	flags.String(option.NodePortAcceleration, option.NodePortAccelerationNone, "BPF NodePort acceleration via XDP (\"native\", \"none\")")
+	flags.String(option.NodePortAcceleration, option.NodePortAccelerationDisabled, fmt.Sprintf(
+		"BPF NodePort acceleration via XDP (\"%s\", \"%s\")",
+		option.NodePortAccelerationNative, option.NodePortAccelerationDisabled))
 	option.BindEnv(option.NodePortAcceleration)
 
 	flags.Bool(option.EnableSessionAffinity, false, "Enable support for service session affinity")
@@ -1676,7 +1678,7 @@ func initKubeProxyReplacementOptions() {
 			log.Fatalf("Invalid value for --%s: %s", option.NodePortMode, option.Config.NodePortMode)
 		}
 
-		if option.Config.NodePortAcceleration != option.NodePortAccelerationNone &&
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
 			option.Config.NodePortAcceleration != option.NodePortAccelerationGeneric &&
 			option.Config.NodePortAcceleration != option.NodePortAccelerationNative {
 			log.Fatalf("Invalid value for --%s: %s", option.NodePortAcceleration, option.Config.NodePortAcceleration)
@@ -1738,10 +1740,10 @@ func initKubeProxyReplacementOptions() {
 	}
 
 	if option.Config.EnableNodePort &&
-		option.Config.NodePortAcceleration != option.NodePortAccelerationNone {
+		option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 		if option.Config.Tunnel != option.TunnelDisabled {
 			log.Fatalf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
-				option.NodePortAcceleration, option.NodePortAccelerationNone, option.TunnelName, option.TunnelDisabled)
+				option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
 		}
 
 		if option.Config.XDPDevice != "undefined" &&

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -252,7 +252,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENABLE_DSR_HYBRID"] = "1"
 			}
 		}
-		if option.Config.NodePortAcceleration != option.NodePortAccelerationNone {
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			cDefinesMap["ENABLE_NODEPORT_ACCELERATION"] = "1"
 		}
 		if option.Config.EnableExternalIPs {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -598,7 +598,7 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 		neighborLog("insertNeighbor NeighSet", ifaceName, err, &ciliumIPv4, &hwAddr, link)
 		if err == nil {
 			n.neighByNode[newNode.Identity()] = &neigh
-			if option.Config.NodePortAcceleration != option.NodePortAccelerationNone {
+			if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 				neighborsmap.NeighRetire(ciliumIPv4)
 			}
 		}
@@ -620,7 +620,7 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 			"LinkIndex":      neigh.LinkIndex,
 		}).WithError(err).Warn("Failed to remove neighbor entry")
 	} else {
-		if option.Config.NodePortAcceleration != option.NodePortAccelerationNone {
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			neighborsmap.NeighRetire(neigh.IP)
 		}
 	}

--- a/pkg/datapath/loader/link.go
+++ b/pkg/datapath/loader/link.go
@@ -38,7 +38,7 @@ func SetXDPMode(mode string) error {
 			return fmt.Errorf("XDP Mode conflict: current mode is %s, trying to set conflicting %s",
 				option.Config.XDPMode, option.XDPModeLinkGeneric)
 		}
-	case option.XDPModeNone:
+	case option.XDPModeDisabled:
 		break
 	}
 	return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -651,8 +651,8 @@ const (
 	// XDPModeGeneric for loading progs with XDPModeLinkGeneric
 	XDPModeGeneric = "testing-only"
 
-	// XDPModeNone for not having XDP enabled
-	XDPModeNone = "none"
+	// XDPModeDisabled for not having XDP enabled
+	XDPModeDisabled = "disabled"
 
 	// XDPModeLinkDriver is the tc selector for native XDP
 	XDPModeLinkDriver = "xdpdrv"
@@ -661,7 +661,7 @@ const (
 	XDPModeLinkGeneric = "xdpgeneric"
 
 	// XDPModeLinkNone for not having XDP enabled
-	XDPModeLinkNone = XDPModeNone
+	XDPModeLinkNone = XDPModeDisabled
 
 	// K8sClientQPSLimit is the queries per second limit for the K8s client. Defaults to k8s client defaults.
 	K8sClientQPSLimit = "k8s-client-qps"
@@ -1088,8 +1088,8 @@ const (
 	// NodePortModeHybrid is a dual mode of the above, that is, DSR for TCP and SNAT for UDP
 	NodePortModeHybrid = "hybrid"
 
-	// NodePortAccelerationNone means we do not accelerate NodePort via XDP
-	NodePortAccelerationNone = XDPModeNone
+	// NodePortAccelerationDisabled means we do not accelerate NodePort via XDP
+	NodePortAccelerationDisabled = XDPModeDisabled
 
 	// NodePortAccelerationGeneric means we accelerate NodePort via generic XDP
 	NodePortAccelerationGeneric = XDPModeGeneric


### PR DESCRIPTION
Be more consistent and rename to "disable" since this is common for
various other flags already.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
