### PR TITLE
daemon/cli: Add SessionAffinity to cilium status

### DIFF
--- a/api/v1/models/kube_proxy_replacement.go
+++ b/api/v1/models/kube_proxy_replacement.go
@@ -150,6 +150,9 @@ type KubeProxyReplacementFeatures struct {
 
 	// node port
 	NodePort *KubeProxyReplacementFeaturesNodePort `json:"nodePort,omitempty"`
+
+	// session affinity
+	SessionAffinity *KubeProxyReplacementFeaturesSessionAffinity `json:"sessionAffinity,omitempty"`
 }
 
 // Validate validates this kube proxy replacement features
@@ -169,6 +172,10 @@ func (m *KubeProxyReplacementFeatures) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateNodePort(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSessionAffinity(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -242,6 +249,24 @@ func (m *KubeProxyReplacementFeatures) validateNodePort(formats strfmt.Registry)
 		if err := m.NodePort.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features" + "." + "nodePort")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *KubeProxyReplacementFeatures) validateSessionAffinity(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SessionAffinity) { // not required
+		return nil
+	}
+
+	if m.SessionAffinity != nil {
+		if err := m.SessionAffinity.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("features" + "." + "sessionAffinity")
 			}
 			return err
 		}
@@ -511,6 +536,37 @@ func (m *KubeProxyReplacementFeaturesNodePort) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *KubeProxyReplacementFeaturesNodePort) UnmarshalBinary(b []byte) error {
 	var res KubeProxyReplacementFeaturesNodePort
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// KubeProxyReplacementFeaturesSessionAffinity kube proxy replacement features session affinity
+// swagger:model KubeProxyReplacementFeaturesSessionAffinity
+type KubeProxyReplacementFeaturesSessionAffinity struct {
+
+	// enabled
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// Validate validates this kube proxy replacement features session affinity
+func (m *KubeProxyReplacementFeaturesSessionAffinity) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *KubeProxyReplacementFeaturesSessionAffinity) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *KubeProxyReplacementFeaturesSessionAffinity) UnmarshalBinary(b []byte) error {
+	var res KubeProxyReplacementFeaturesSessionAffinity
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/api/v1/models/zz_generated.deepcopy.go
+++ b/api/v1/models/zz_generated.deepcopy.go
@@ -272,6 +272,11 @@ func (in *KubeProxyReplacementFeatures) DeepCopyInto(out *KubeProxyReplacementFe
 		*out = new(KubeProxyReplacementFeaturesNodePort)
 		**out = **in
 	}
+	if in.SessionAffinity != nil {
+		in, out := &in.SessionAffinity, &out.SessionAffinity
+		*out = new(KubeProxyReplacementFeaturesSessionAffinity)
+		**out = **in
+	}
 	return
 }
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1722,6 +1722,11 @@ definitions:
                 type: array
                 items:
                   type: string
+          sessionAffinity:
+            type: object
+            properties:
+              enabled:
+                type: boolean
   AllocationMap:
     description: |
       Map of allocated IPs

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2577,6 +2577,14 @@ func init() {
                   "type": "integer"
                 }
               }
+            },
+            "sessionAffinity": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         },
@@ -6145,6 +6153,14 @@ func init() {
                 },
                 "portMin": {
                   "type": "integer"
+                }
+              }
+            },
+            "sessionAffinity": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
                 }
               }
             }

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -135,6 +135,7 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 		HostPort:              &models.KubeProxyReplacementFeaturesHostPort{},
 		ExternalIPs:           &models.KubeProxyReplacementFeaturesExternalIPs{},
 		HostReachableServices: &models.KubeProxyReplacementFeaturesHostReachableServices{},
+		SessionAffinity:       &models.KubeProxyReplacementFeaturesSessionAffinity{},
 	}
 	if option.Config.EnableNodePort {
 		features.NodePort.Enabled = true
@@ -163,6 +164,9 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 			protocols = append(protocols, "UDP")
 		}
 		features.HostReachableServices.Protocols = protocols
+	}
+	if option.Config.EnableSessionAffinity {
+		features.SessionAffinity.Enabled = true
 	}
 
 	return &models.KubeProxyReplacement{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -286,6 +286,10 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 					strings.Join(hs.Protocols, ", ")))
 			}
 
+			if sr.KubeProxyReplacement.Features.SessionAffinity.Enabled {
+				features = append(features, "SessionAffinity")
+			}
+
 			devices := strings.Join(sr.KubeProxyReplacement.Devices, ", ")
 
 			fmt.Fprintf(w, "KubeProxyReplacement:\t%s\t(%s)\t[%s]\n",


### PR DESCRIPTION
The example output:

```
    [..]
    KubeProxyReplacement:   Strict   (wlp3s0)   [NodePort (SNAT, 30000-32767,
                            XDP: NONE), HostPort, ExternalIPs,
                            HostReachableServices (TCP, UDP), SessionAffinity]
```