### PR TITLE
v1.7 backports for 11884

### DIFF
--- a/api/v1/models/endpoint_state.go
+++ b/api/v1/models/endpoint_state.go
@@ -46,6 +46,9 @@ const (
 
 	// EndpointStateDisconnected captures enum value "disconnected"
 	EndpointStateDisconnected EndpointState = "disconnected"
+
+	// EndpointStateInvalid captures enum value "invalid"
+	EndpointStateInvalid EndpointState = "invalid"
 )
 
 // for schema
@@ -53,7 +56,7 @@ var endpointStateEnum []interface{}
 
 func init() {
 	var res []EndpointState
-	if err := json.Unmarshal([]byte(`["creating","waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["creating","waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected","invalid"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1134,6 +1134,7 @@ definitions:
       - ready
       - disconnecting
       - disconnected
+      - invalid
   EndpointHealth:
     description: Health of the endpoint
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2110,7 +2110,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {
@@ -5571,7 +5572,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	fakedatapath "github.com/cilium/cilium/pkg/datapath/fake"
@@ -35,10 +36,12 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 
+	"github.com/prometheus/client_golang/prometheus"
 	. "gopkg.in/check.v1"
 )
 
@@ -59,6 +62,9 @@ type DaemonSuite struct {
 	OnQueueEndpointBuild  func(ctx context.Context, epID uint64) (func(), error)
 	OnGetCompilationLock  func() *lock.RWMutex
 	OnSendNotification    func(typ monitorAPI.AgentNotification, text string) error
+
+	// Metrics
+	collectors []prometheus.Collector
 }
 
 func setupTestDirectories() {
@@ -106,6 +112,19 @@ type dummyEpSyncher struct{}
 func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 }
 
+func (ds *DaemonSuite) SetUpSuite(c *C) {
+	// Register metrics once before running the suite
+	_, ds.collectors = metrics.CreateConfiguration([]string{"cilium_endpoint_state"})
+	metrics.MustRegister(ds.collectors...)
+}
+
+func (ds *DaemonSuite) TearDownSuite(c *C) {
+	// Unregister the metrics after the suite has finished
+	for _, c := range ds.collectors {
+		metrics.Unregister(c)
+	}
+}
+
 func (ds *DaemonSuite) SetUpTest(c *C) {
 
 	setupTestDirectories()
@@ -125,6 +144,14 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.OnGetCompilationLock = nil
 	ds.OnSendNotification = nil
 	ds.d.endpointManager = endpointmanager.NewEndpointManager(&dummyEpSyncher{})
+
+	// Reset the most common endpoint states before each test.
+	for _, s := range []string{
+		string(models.EndpointStateReady),
+		string(models.EndpointStateWaitingForIdentity),
+		string(models.EndpointStateWaitingToRegenerate)} {
+		metrics.EndpointStateCount.WithLabelValues(s).Set(0.0)
+	}
 }
 
 func (ds *DaemonSuite) TearDownTest(c *C) {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -172,6 +172,7 @@ func (d *Daemon) fetchK8sLabelsAndAnnotations(nsName, podName string) (labels.La
 
 func invalidDataError(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
 	ep.Logger(daemonSubsys).WithError(err).Warning("Creation of endpoint failed due to invalid data")
+	ep.SetState(endpoint.StateInvalid, "Invalid endpoint")
 	return nil, PutEndpointIDInvalidCode, err
 }
 

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"net"
+	"runtime"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -27,6 +28,8 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/metrics"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -47,26 +50,58 @@ func getEPTemplate(c *C, d *Daemon) *models.EndpointChangeRequest {
 }
 
 func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:world"}
 	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
+
+	// Endpoint is created with inital label as well as disallowed
+	// reserved:world label.
+	epTemplate.Labels = append(epTemplate.Labels, "reserved:init")
+	_, code, err = ds.d.createEndpoint(context.TODO(), epTemplate)
+	c.Assert(err, ErrorMatches, "not allowed to add reserved labels:.+")
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
 }
 
 func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:foo"}
 	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
 }
 
 func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	// Create the endpoint without any labels.
 	epTemplate := getEPTemplate(c, ds.d)
 	_, _, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, IsNil)
+
+	// Endpoint enters WaitingToRegenerate as it has its labels updated during
+	// creation.
+	assertOnMetric(c, string(models.EndpointStateWaitingToRegenerate), 1)
 
 	expectedLabels := labels.Labels{
 		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
@@ -79,6 +114,10 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	secID := ep.WaitForIdentity(3 * time.Second)
 	c.Assert(secID, Not(IsNil))
 	c.Assert(secID.ID, Equals, identity.ReservedIdentityInit)
+
+	// Endpoint should transition from WaitingToRegenerate -> Ready.
+	assertOnMetric(c, string(models.EndpointStateWaitingToRegenerate), 0)
+	assertOnMetric(c, string(models.EndpointStateReady), 1)
 }
 
 func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
@@ -86,4 +125,29 @@ func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
 	code, err := ds.d.modifyEndpointIdentityLabelsFromAPI("1", lbls, nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PatchEndpointIDLabelsUpdateFailedCode)
+}
+
+func (ds *DaemonSuite) TestUpdateLabelsFailed(c *C) {
+	cancelledContext, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	cancelFunc() // Cancel immediatly to trigger the codepath to test.
+
+	// Create the endpoint without any labels.
+	epTemplate := getEPTemplate(c, ds.d)
+	_, _, err := ds.d.createEndpoint(cancelledContext, epTemplate)
+	c.Assert(err, ErrorMatches, "request cancelled while resolving identity")
+
+	assertOnMetric(c, string(models.EndpointStateReady), 0)
+}
+
+func getMetricValue(state string) int64 {
+	return int64(metrics.GetGaugeValue(metrics.EndpointStateCount.WithLabelValues(state)))
+}
+
+func assertOnMetric(c *C, state string, expected int64) {
+	obtained := getMetricValue(state)
+	if obtained != expected {
+		_, _, line, _ := runtime.Caller(1)
+		c.Errorf("Metrics assertion failed on line %d for Endpoint state %s: obtained %d, expected %d",
+			line, state, obtained, expected)
+	}
 }

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	pkgLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils/allocator"
+
+	"github.com/prometheus/client_golang/prometheus"
 	. "gopkg.in/check.v1"
 )
 
@@ -65,6 +68,9 @@ type EndpointSuite struct {
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnGetCompilationLock      func() *lock.RWMutex
 	OnSendNotification        func(typ monitorAPI.AgentNotification, text string) error
+
+	// Metrics
+	collectors []prometheus.Collector
 }
 
 // suite can be used by testing.T benchmarks or tests as a mock regeneration.Owner
@@ -77,6 +83,17 @@ func (s *EndpointSuite) SetUpSuite(c *C) {
 	err := labels.ParseLabelPrefixCfg(nil, "")
 	if err != nil {
 		panic("ParseLabelPrefixCfg() failed")
+	}
+
+	// Register metrics once before running the suite
+	_, s.collectors = metrics.CreateConfiguration([]string{"cilium_endpoint_state"})
+	metrics.MustRegister(s.collectors...)
+}
+
+func (s *EndpointSuite) TearDownSuite(c *C) {
+	// Unregister the metrics after the suite has finished
+	for _, c := range s.collectors {
+		metrics.Unregister(c)
 	}
 }
 
@@ -243,132 +260,175 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	e.unconditionalLock()
 	defer e.unlock()
 
-	e.state = StateCreating
-	c.Assert(e.setState(StateCreating, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateCreating
-	c.Assert(e.setState(StateReady, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
-	e.state = StateCreating
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
+	assertStateTransition(c, e, e.setState, StateCreating, StateCreating, false)
+	assertStateTransition(c, e, e.setState, StateCreating, StateWaitingForIdentity, true)
+	assertStateTransition(c, e, e.setState, StateCreating, StateReady, false)
+	assertStateTransition(c, e, e.setState, StateCreating, StateWaitingToRegenerate, false)
+	assertStateTransition(c, e, e.setState, StateCreating, StateRegenerating, false)
+	assertStateTransition(c, e, e.setState, StateCreating, StateDisconnecting, true)
+	assertStateTransition(c, e, e.setState, StateCreating, StateDisconnected, false)
 
-	e.state = StateWaitingForIdentity
-	c.Assert(e.setState(StateCreating, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.setState(StateReady, "test"), Equals, true)
-	e.state = StateWaitingForIdentity
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
-	e.state = StateWaitingForIdentity
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
+	assertStateTransition(c, e, e.setState, StateWaitingForIdentity, StateCreating, false)
+	assertStateTransition(c, e, e.setState, StateWaitingForIdentity, StateWaitingForIdentity, false)
 
-	e.state = StateReady
-	c.Assert(e.setState(StateCreating, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateReady
-	c.Assert(e.setState(StateReady, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
-	e.state = StateReady
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
-	e.state = StateReady
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
+	assertStateTransition(c, e, e.setState, StateWaitingForIdentity, StateReady, true)
 
-	e.state = StateWaitingToRegenerate
-	c.Assert(e.setState(StateCreating, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateWaitingToRegenerate
-	c.Assert(e.setState(StateReady, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
-	e.state = StateWaitingToRegenerate
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
+	assertStateTransition(c, e, e.setState, StateWaitingForIdentity, StateWaitingToRegenerate, false)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateRegenerating, false)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateDisconnecting, true)
 
-	e.state = StateRegenerating
-	c.Assert(e.setState(StateCreating, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateRegenerating
-	c.Assert(e.setState(StateReady, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
-	e.state = StateRegenerating
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
-	e.state = StateRegenerating
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
+	assertStateTransition(c, e, e.setState, StateWaitingForIdentity, StateDisconnected, false)
 
-	e.state = StateDisconnecting
-	c.Assert(e.setState(StateCreating, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.setState(StateReady, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateReady, StateCreating, false)
+	assertStateTransition(c, e, e.setState, StateReady, StateWaitingForIdentity, true)
+	assertStateTransition(c, e, e.setState, StateReady, StateReady, false)
+	assertStateTransition(c, e, e.setState, StateReady, StateWaitingToRegenerate, true)
+	assertStateTransition(c, e, e.setState, StateReady, StateRegenerating, false)
+	assertStateTransition(c, e, e.setState, StateReady, StateDisconnecting, true)
+	assertStateTransition(c, e, e.setState, StateReady, StateDisconnected, false)
 
-	e.state = StateDisconnected
-	c.Assert(e.setState(StateCreating, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.setState(StateReady, "test"), Equals, false)
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateCreating, false)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingForIdentity, true)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateReady, false)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingToRegenerate, false)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateRegenerating, false)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateDisconnecting, true)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateDisconnected, false)
+
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateCreating, false)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateWaitingForIdentity, true)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateReady, false)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateWaitingToRegenerate, true)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateRegenerating, false)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateDisconnecting, true)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateDisconnected, false)
+
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateCreating, false)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateWaitingForIdentity, false)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateReady, false)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateWaitingToRegenerate, false)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateRegenerating, false)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateDisconnecting, false)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateDisconnected, true)
+
+	assertStateTransition(c, e, e.setState, StateDisconnected, StateCreating, false)
+	assertStateTransition(c, e, e.setState, StateDisconnected, StateWaitingForIdentity, false)
+	assertStateTransition(c, e, e.setState, StateDisconnected, StateReady, false)
+	assertStateTransition(c, e, e.setState, StateDisconnected, StateWaitingToRegenerate, false)
+	assertStateTransition(c, e, e.setState, StateDisconnected, StateRegenerating, false)
+	assertStateTransition(c, e, e.setState, StateDisconnected, StateDisconnecting, false)
+	assertStateTransition(c, e, e.setState, StateDisconnected, StateDisconnected, false)
+
+	// State transitions involving the "Invalid" state
+	assertStateTransition(c, e, e.setState, "", StateInvalid, false)
+	assertStateTransition(c, e, e.setState, StateWaitingForIdentity, StateInvalid, true)
+	assertStateTransition(c, e, e.setState, StateInvalid, StateInvalid, false)
 
 	// Builder-specific transitions
-	e.state = StateWaitingToRegenerate
+
 	// Builder can't transition to ready from waiting-to-regenerate
 	// as (another) build is pending
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingToRegenerate, StateReady, false)
 	// Only builder knows when bpf regeneration starts
-	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateRegenerating, false)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingToRegenerate, StateRegenerating, true)
+
 	// Builder does not trigger the need for regeneration
-	c.Assert(e.BuilderSetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateRegenerating, StateWaitingToRegenerate, false)
 	// Builder transitions to ready state after build is done
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, true)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateRegenerating, StateReady, true)
 
 	// Check that direct transition from restoring --> regenerating is valid.
-	e.state = StateRestoring
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateRestoring, StateRegenerating, true)
 
 	// Typical lifecycle
-	e.state = StateCreating
-	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateCreating, StateWaitingForIdentity, true)
+	assertStateTransition(c, e, e.setState, "", StateWaitingForIdentity, true)
 	// Initial build does not change the state
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingForIdentity, StateRegenerating, false)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingForIdentity, StateReady, false)
 	// identity arrives
-	c.Assert(e.setState(StateReady, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateWaitingForIdentity, StateReady, true)
 	// a build is triggered after the identity is set
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateReady, StateWaitingToRegenerate, true)
 	// build starts
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingToRegenerate, StateRegenerating, true)
 	// another change arrives while building
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateRegenerating, StateWaitingToRegenerate, true)
 	// Builder's transition to ready fails due to the queued build
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingToRegenerate, StateReady, false)
 	// second build starts
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingToRegenerate, StateRegenerating, true)
 	// second build finishes
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, true)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateRegenerating, StateReady, true)
 	// endpoint is being deleted
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateReady, StateDisconnecting, true)
 	// parallel disconnect fails
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnected, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateDisconnecting, false)
+	assertStateTransition(c, e, e.setState, StateDisconnecting, StateDisconnected, true)
 
 	// Restoring state
-	e.state = StateRestoring
-	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateRestoring, StateWaitingToRegenerate, false)
+	assertStateTransition(c, e, e.setState, StateRestoring, StateDisconnecting, true)
 
-	e.state = StateRestoring
-	c.Assert(e.setState(StateRestoring, "test"), Equals, true)
+	assertStateTransition(c, e, e.setState, StateRestoring, StateRestoring, true)
 
+	// Invalid state
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateInvalid, StateReady, false)
+	assertStateTransition(c, e, e.BuilderSetStateLocked, StateWaitingToRegenerate, StateInvalid, false)
+}
+
+func assertStateTransition(c *C,
+	e *Endpoint, stateSetter func(string, string) bool,
+	from, to string,
+	success bool) {
+
+	e.state = from
+
+	currStateOldMetric := getMetricValue(e.state)
+	newStateOldMetric := getMetricValue(to)
+	got := stateSetter(to, "test")
+	currStateNewMetric := getMetricValue(from)
+	newStateNewMetric := getMetricValue(e.state)
+
+	c.Assert(got, Equals, success)
+
+	// Do not assert on metrics if the endpoint is not expected to transition.
+	if !success {
+		return
+	}
+
+	// If the state transition moves from itself to itself, we expect the
+	// metrics to be unchanged.
+	if from == to {
+		c.Assert(currStateOldMetric, Equals, currStateNewMetric)
+		c.Assert(newStateOldMetric, Equals, newStateNewMetric)
+	} else {
+		// Blank states don't have metrics so we skip over that; metric should
+		// be unchanged.
+		if from != "" {
+			c.Assert(currStateOldMetric-1, Equals, currStateNewMetric)
+		} else {
+			c.Assert(currStateOldMetric, Equals, currStateNewMetric)
+		}
+
+		// Don't assert on state transition that ends up in a final state, as
+		// the metric is not incremented in this case; metric should be
+		// unchanged.
+		if !isFinalState(to) {
+			c.Assert(newStateOldMetric+1, Equals, newStateNewMetric)
+		} else {
+			c.Assert(newStateOldMetric, Equals, newStateNewMetric)
+		}
+	}
+}
+
+func isFinalState(state string) bool {
+	return (state == StateDisconnected || state == StateInvalid)
+}
+
+func getMetricValue(state string) int64 {
+	return int64(metrics.GetGaugeValue(metrics.EndpointStateCount.WithLabelValues(state)))
 }
 
 func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1141,6 +1141,17 @@ func GetCounterValue(m prometheus.Counter) float64 {
 	return 0
 }
 
+// GetGaugeValue returns the current value stored for the gauge. This function
+// is useful in tests.
+func GetGaugeValue(m prometheus.Gauge) float64 {
+	var pm dto.Metric
+	err := m.Write(&pm)
+	if err == nil {
+		return *pm.Gauge.Value
+	}
+	return 0
+}
+
 // DumpMetrics gets the current Cilium metrics and dumps all into a
 // models.Metrics structure.If metrics cannot be retrieved, returns an error
 func DumpMetrics() ([]*models.Metric, error) {


### PR DESCRIPTION
* #11884 -- endpoint: Implement new Invalid endpoint state (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11884; do contrib/backporting/set-labels.py $pr done 1.7; done
```