### PR TITLE
tools: Remove absolute paths from shims

### DIFF
--- a/tools/protoc-gen-go
+++ b/tools/protoc-gen-go
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
-GO111MODULE=off go run ${SCRIPTPATH}/../vendor/github.com/golang/protobuf/protoc-gen-go $@
+go run github.com/golang/protobuf/protoc-gen-go $@

--- a/tools/protoc-gen-go-json
+++ b/tools/protoc-gen-go-json
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
-GO111MODULE=off go run ${SCRIPTPATH}/../vendor/github.com/mitchellh/protoc-gen-go-json $@
+go run github.com/mitchellh/protoc-gen-go-json $@

--- a/tools/protoc-gen-gogo
+++ b/tools/protoc-gen-gogo
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
-GO111MODULE=off go run ${SCRIPTPATH}/../vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo $@
+go run k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo $@

--- a/tools/protoc-gen-validate
+++ b/tools/protoc-gen-validate
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
-GO111MODULE=off go run ${SCRIPTPATH}/../vendor/github.com/envoyproxy/protoc-gen-validate $@
+go run github.com/envoyproxy/protoc-gen-validate $@


### PR DESCRIPTION
Absolute paths can only work in GOPATH mode, which is not
require for cilium development as it uses `go mod`. Anybody
who has their cilium dir outside their GOPATH, or if they
have GOPATH undefined, won't be able to run these.

```
❯ make
libprotoc 3.11.4
...
: cannot import absolute path
```

Signed-off-by: Glib Smaga <code@gsmaga.com>