### PR TITLE
v1.6 backports 2020-06-05

### DIFF
--- a/api/v1/models/endpoint_state.go
+++ b/api/v1/models/endpoint_state.go
@@ -46,6 +46,9 @@ const (
 
 	// EndpointStateDisconnected captures enum value "disconnected"
 	EndpointStateDisconnected EndpointState = "disconnected"
+
+	// EndpointStateInvalid captures enum value "invalid"
+	EndpointStateInvalid EndpointState = "invalid"
 )
 
 // for schema
@@ -53,7 +56,7 @@ var endpointStateEnum []interface{}
 
 func init() {
 	var res []EndpointState
-	if err := json.Unmarshal([]byte(`["creating","waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["creating","waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected","invalid"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1094,6 +1094,7 @@ definitions:
       - ready
       - disconnecting
       - disconnected
+      - invalid
   EndpointHealth:
     description: Health of the endpoint
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2034,7 +2034,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {
@@ -5183,7 +5184,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -149,6 +149,7 @@ func fetchK8sLabels(ep *endpoint.Endpoint) (labels.Labels, labels.Labels, error)
 
 func invalidDataError(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
 	ep.Logger(daemonSubsys).WithError(err).Warning("Creation of endpoint failed due to invalid data")
+	ep.SetState(endpoint.StateInvalid, "Invalid endpoint")
 	return nil, PutEndpointIDInvalidCode, err
 }
 

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -47,7 +47,7 @@ func (e *Endpoint) RUnlock() {
 }
 
 // UnconditionalLock should be used only for locking endpoint for
-// - setting its state to StateDisconnected
+// - setting its state to StateDisconnected or StateInvalid
 // - handling regular Lock errors
 // - reporting endpoint status (like in LogStatus method)
 // Use Lock in all other cases

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -17,6 +17,9 @@
 package k8s
 
 import (
+	"sort"
+
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
@@ -214,17 +217,41 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	err := generateToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs := rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	// second run, to make sure there are no duplicates added
 	err = generateToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs = rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
+
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, nil)
+	c.Assert(err, IsNil)
+	c.Assert(len(rule.ToCIDRSet), Equals, 0)
+
+	// third run, to make sure there are no duplicates added
+	err = generateToCidrFromEndpoint(rule, endpointInfo, nil)
+	c.Assert(err, IsNil)
+
+	cidrs = rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	err = deleteToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1120,6 +1120,17 @@ func GetCounterValue(m prometheus.Counter) float64 {
 	return 0
 }
 
+// GetGaugeValue returns the current value stored for the gauge. This function
+// is useful in tests.
+func GetGaugeValue(m prometheus.Gauge) float64 {
+	var pm dto.Metric
+	err := m.Write(&pm)
+	if err == nil {
+		return *pm.Gauge.Value
+	}
+	return 0
+}
+
 // DumpMetrics gets the current Cilium metrics and dumps all into a
 // models.Metrics structure.If metrics cannot be retrieved, returns an error
 func DumpMetrics() ([]*models.Metric, error) {

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"net"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
@@ -61,6 +62,15 @@ type CIDRRule struct {
 	Generated bool `json:"-"`
 }
 
+// String converts the CIDRRule into a human-readable string.
+func (r CIDRRule) String() string {
+	exceptCIDRs := ""
+	if len(r.ExceptCIDRs) > 0 {
+		exceptCIDRs = "-" + CIDRSlice(r.ExceptCIDRs).String()
+	}
+	return string(r.Cidr) + exceptCIDRs
+}
+
 // CIDRSlice is a slice of CIDRs. It allows receiver methods to be defined for
 // transforming the slice into other convenient forms such as
 // EndpointSelectorSlice.
@@ -98,6 +108,14 @@ func (s CIDRSlice) StringSlice() []string {
 	return result
 }
 
+// String converts the CIDRSlice into a human-readable string.
+func (s CIDRSlice) String() string {
+	if len(s) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(s.StringSlice(), ",") + "]"
+}
+
 // CIDRRuleSlice is a slice of CIDRRules. It allows receiver methods to be
 // defined for transforming the slice into other convenient forms such as
 // EndpointSelectorSlice.
@@ -108,6 +126,15 @@ type CIDRRuleSlice []CIDRRule
 func (s CIDRRuleSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
 	cidrs := ComputeResultantCIDRSet(s)
 	return cidrs.GetAsEndpointSelectors()
+}
+
+// StringSlice returns the CIDRRuleSlice as a slice of strings.
+func (s CIDRRuleSlice) StringSlice() []string {
+	result := make([]string, 0, len(s))
+	for _, c := range s {
+		result = append(result, c.String())
+	}
+	return result
 }
 
 // ComputeResultantCIDRSet converts a slice of CIDRRules into a slice of


### PR DESCRIPTION
* #11913 -- policy: Fix rule translation test flake (@joestringer)
   * Note: resolved conflict regarding fixed differing function signature in `pkg/k8s/rule_translate.go::{delete,generate}ToCidrFromEndpoint()`
 * #11884 -- endpoint: Implement new Invalid endpoint state (@christarazi)
    * Note: 
         1) Resolved conflicts with endpoint state `StateCreating` that was removed in 1.8
         2) Resolved conflict with the rename of `daemon/cmd/endpoint_test.go -> daemon/endpoint_test.go`; also added `Endpoint::SetState()`

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11913 11884; do contrib/backporting/set-labels.py $pr done 1.6; done
```