### PR TITLE
v1.8 backports 2020-06-05 (2)

### DIFF
--- a/Documentation/contributing/development/codeoverview.rst
+++ b/Documentation/contributing/development/codeoverview.rst
@@ -40,7 +40,7 @@ examples
   before usage is possible.
 
 hubble-relay
-  Hubble relay server
+  Hubble Relay server
 
 install
   Helm deployment manifests for all components
@@ -98,7 +98,7 @@ api/v1/external, api/v1/flow, api/v1/observer, api/v1/peer, api/v1/relay
   API specifications of the Hubble APIs.
 
 hubble-relay
-  Hubble relay agent
+  Hubble Relay agent
 
 pkg/hubble
   All Hubble specific code
@@ -123,7 +123,7 @@ pkg/hubble/peer
   Peer service implementation
 
 pkg/hubble/relay
-  Relay service implementation
+  Hubble Relay service implementation
 
 pkg/hubble/server
   The server providing the API for the Hubble client and UI

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -196,7 +196,7 @@ framework in the ``test/`` directory and interact with ginkgo directly:
       -cilium.holdEnvironment
             On failure, hold the environment in its current state
       -cilium.hubble-relay-image string
-            Specifies which image of hubble-relay to use during tests
+            Specifies which image of Hubble Relay to use during tests
       -cilium.image string
             Specifies which image of cilium to use during tests
       -cilium.kubeconfig string

--- a/Documentation/hubble.rst
+++ b/Documentation/hubble.rst
@@ -7,7 +7,7 @@ Hubble internals
           Hubble internals.
 
 .. note:: This documentation covers the Hubble server (sometimes referred as
-          "Hubble embedded") and Hubble-relay components but does not cover the
+          "Hubble embedded") and Hubble Relay components but does not cover the
           Hubble UI and CLI.
 
 Hubble builds on top of Cilium and eBPF to enable deep visibility into the
@@ -18,10 +18,10 @@ achieve all of this at large scale.
 Hubble's server component is embedded into the Cilium agent in order to achieve
 high performance with low-overhead. The gRPC services offered by Hubble server
 may be consumed locally via a Unix domain socket or, more typically, through
-Hubble-relay. Hubble-relay is a standalone component which is aware of all
+Hubble Relay. Hubble-relay is a standalone component which is aware of all
 running Hubble instances and offers full cluster visibility by connecting to
 their respective gRPC APIs. This capability is usually referred to as
-multi-node. Hubble-relay's main goal is to offer a rich API that can be safely
+multi-node. Hubble Relay's main goal is to offer a rich API that can be safely
 exposed and consumed by the Hubble UI and CLI.
 
 .. note:: This guide does not cover Hubble in standalone mode, which is
@@ -86,21 +86,21 @@ updated, added or removed from the cluster. Thus , it allows the caller to
 keep track of all Hubble instances and query their respective gRPC services.
 
 This service is typically only exposed on a local Unix domain socket and is
-primarily used by Hubble-relay in order to have a cluster-wide view of all
+primarily used by Hubble Relay in order to have a cluster-wide view of all
 Hubble instances.
 
 The Peer service obtains peer change notifications by subscribing to Cilium's
 node manager. To this end, it internally defines a handler that implements
 Cilium's datapath node handler interface.
 
-Hubble-relay
+Hubble Relay
 ------------
 
-.. note:: At the time of this writing, the hubble-relay component is still
+.. note:: At the time of this writing, Hubble Relay component is still
           work in progress and may undergo major changes. For this reason,
-          internal documentation about Hubble-relay is limited.
+          internal documentation about Hubble Relay is limited.
 
-Hubble-relay is a component that was introduced in the context of multi-node
+Hubble Relay is a component that was introduced in the context of multi-node
 support. It leverages the Peer service to obtain information about Hubble
 instances and consume their gRPC API in order to provide a more rich API that
 covers events from across the entire cluster.

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -296,8 +296,8 @@ The following ports should also be available on each node:
 Port Range / Protocol    Description
 ======================== ==========================================
 4240/tcp                 cluster health checks (``cilium-health``)
-4244/tcp                 hubble server
-4245/tcp                 hubble relay
+4244/tcp                 Hubble server
+4245/tcp                 Hubble Relay
 6942/tcp                 operator Prometheus metrics
 9090/tcp                 cilium-agent Prometheus metrics
 9876/tcp                 cilium-agent health status API

--- a/api/v1/models/endpoint_state.go
+++ b/api/v1/models/endpoint_state.go
@@ -43,6 +43,9 @@ const (
 
 	// EndpointStateDisconnected captures enum value "disconnected"
 	EndpointStateDisconnected EndpointState = "disconnected"
+
+	// EndpointStateInvalid captures enum value "invalid"
+	EndpointStateInvalid EndpointState = "invalid"
 )
 
 // for schema
@@ -50,7 +53,7 @@ var endpointStateEnum []interface{}
 
 func init() {
 	var res []EndpointState
-	if err := json.Unmarshal([]byte(`["waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected","invalid"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1136,6 +1136,7 @@ definitions:
       - ready
       - disconnecting
       - disconnected
+      - invalid
   EndpointHealth:
     description: Health of the endpoint
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2117,7 +2117,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {
@@ -5687,7 +5688,8 @@ func init() {
         "restoring",
         "ready",
         "disconnecting",
-        "disconnected"
+        "disconnected",
+        "invalid"
       ]
     },
     "EndpointStatus": {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -176,6 +176,7 @@ func (d *Daemon) fetchK8sLabelsAndAnnotations(nsName, podName string) (*slim_cor
 
 func invalidDataError(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
 	ep.Logger(daemonSubsys).WithError(err).Warning("Creation of endpoint failed due to invalid data")
+	ep.SetState(endpoint.StateInvalid, "Invalid endpoint")
 	return nil, PutEndpointIDInvalidCode, err
 }
 

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"net"
+	"runtime"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -27,6 +28,8 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/metrics"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -47,26 +50,58 @@ func getEPTemplate(c *C, d *Daemon) *models.EndpointChangeRequest {
 }
 
 func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:world"}
 	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
+
+	// Endpoint is created with inital label as well as disallowed
+	// reserved:world label.
+	epTemplate.Labels = append(epTemplate.Labels, "reserved:init")
+	_, code, err = ds.d.createEndpoint(context.TODO(), epTemplate)
+	c.Assert(err, ErrorMatches, "not allowed to add reserved labels:.+")
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
 }
 
 func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:foo"}
 	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	// Endpoint was created with invalid data; should transition from
+	// WaitForIdentity -> Invalid.
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
 }
 
 func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
+	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
+
 	// Create the endpoint without any labels.
 	epTemplate := getEPTemplate(c, ds.d)
 	_, _, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, IsNil)
+
+	// Endpoint enters WaitingToRegenerate as it has its labels updated during
+	// creation.
+	assertOnMetric(c, string(models.EndpointStateWaitingToRegenerate), 1)
 
 	expectedLabels := labels.Labels{
 		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
@@ -79,6 +114,10 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	secID := ep.WaitForIdentity(3 * time.Second)
 	c.Assert(secID, Not(IsNil))
 	c.Assert(secID.ID, Equals, identity.ReservedIdentityInit)
+
+	// Endpoint should transition from WaitingToRegenerate -> Ready.
+	assertOnMetric(c, string(models.EndpointStateWaitingToRegenerate), 0)
+	assertOnMetric(c, string(models.EndpointStateReady), 1)
 }
 
 func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
@@ -86,4 +125,29 @@ func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
 	code, err := ds.d.modifyEndpointIdentityLabelsFromAPI("1", lbls, nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PatchEndpointIDLabelsUpdateFailedCode)
+}
+
+func (ds *DaemonSuite) TestUpdateLabelsFailed(c *C) {
+	cancelledContext, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	cancelFunc() // Cancel immediatly to trigger the codepath to test.
+
+	// Create the endpoint without any labels.
+	epTemplate := getEPTemplate(c, ds.d)
+	_, _, err := ds.d.createEndpoint(cancelledContext, epTemplate)
+	c.Assert(err, ErrorMatches, "request cancelled while resolving identity")
+
+	assertOnMetric(c, string(models.EndpointStateReady), 0)
+}
+
+func getMetricValue(state string) int64 {
+	return int64(metrics.GetGaugeValue(metrics.EndpointStateCount.WithLabelValues(state)))
+}
+
+func assertOnMetric(c *C, state string, expected int64) {
+	obtained := getMetricValue(state)
+	if obtained != expected {
+		_, _, line, _ := runtime.Caller(1)
+		c.Errorf("Metrics assertion failed on line %d for Endpoint state %s: obtained %d, expected %d",
+			line, state, obtained, expected)
+	}
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -574,11 +574,23 @@ func (m *IptablesManager) installStaticProxyRules() error {
 				"-j", "ACCEPT"), false)
 		}
 		if err == nil {
-			// No conntrack for proxy return traffic
+			// No conntrack for proxy return traffic that is heading to lxc+
 			err = runProg("iptables", append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
+				"-o", "lxc+",
+				"-m", "mark", "--mark", matchProxyReply,
+				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
+				"-j", "NOTRACK"), false)
+		}
+		if err == nil {
+			// No conntrack for proxy return traffic that is heading to cilium_host
+			err = runProg("iptables", append(
+				m.waitArgs,
+				"-t", "raw",
+				"-A", ciliumOutputRawChain,
+				"-o", "cilium_host",
 				"-m", "mark", "--mark", matchProxyReply,
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 				"-j", "NOTRACK"), false)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -96,6 +96,10 @@ const (
 	// StateRestoring is used to set the endpoint is being restored.
 	StateRestoring = string(models.EndpointStateRestoring)
 
+	// StateInvalid is used when an endpoint failed during creation due to
+	// invalid data.
+	StateInvalid = string(models.EndpointStateInvalid)
+
 	// IpvlanMapName specifies the tail call map for EP on egress used with ipvlan.
 	IpvlanMapName = "cilium_lxc_ipve_"
 )
@@ -1319,7 +1323,7 @@ func (e *Endpoint) setState(toState, reason string) bool {
 		}
 	case StateWaitingForIdentity:
 		switch toState {
-		case StateReady, StateDisconnecting:
+		case StateReady, StateDisconnecting, StateInvalid:
 			goto OKState
 		}
 	case StateReady:
@@ -1332,8 +1336,9 @@ func (e *Endpoint) setState(toState, reason string) bool {
 		case StateDisconnected:
 			goto OKState
 		}
-	case StateDisconnected:
-		// No valid transitions, as disconnected is a terminal state for the endpoint.
+	case StateDisconnected, StateInvalid:
+		// No valid transitions, as disconnected and invalid are terminal
+		// states for the endpoint.
 	case StateWaitingToRegenerate:
 		switch toState {
 		// Note that transitions to StateWaitingToRegenerate are not allowed,
@@ -1387,9 +1392,10 @@ OKState:
 			WithLabelValues(fromState).Dec()
 	}
 
-	// Since StateDisconnected is the final state, after which the
-	// endpoint is gone, we should not increment metrics for this state.
-	if toState != "" && toState != StateDisconnected {
+	// Since StateDisconnected and StateInvalid are final states, after which
+	// the endpoint is gone or doesn't exist, we should not increment metrics
+	// for these states.
+	if toState != "" && toState != StateDisconnected && toState != StateInvalid {
 		metrics.EndpointStateCount.
 			WithLabelValues(toState).Inc()
 	}
@@ -1403,7 +1409,7 @@ func (e *Endpoint) BuilderSetStateLocked(toState, reason string) bool {
 	// Validate the state transition.
 	fromState := e.state
 	switch fromState { // From state
-	case StateWaitingForIdentity, StateReady, StateDisconnecting, StateDisconnected:
+	case StateWaitingForIdentity, StateReady, StateDisconnecting, StateDisconnected, StateInvalid:
 		// No valid transitions for the builder
 	case StateWaitingToRegenerate, StateRestoring:
 		switch toState {
@@ -1454,9 +1460,10 @@ OKState:
 			WithLabelValues(fromState).Dec()
 	}
 
-	// Since StateDisconnected is the final state, after which the
-	// endpoint is gone, we should not increment metrics for this state.
-	if toState != "" && toState != StateDisconnected {
+	// Since StateDisconnected and StateInvalid are final states, after which
+	// the endpoint is gone or doesn't exist, we should not increment metrics
+	// for these states.
+	if toState != "" && toState != StateDisconnected && toState != StateInvalid {
 		metrics.EndpointStateCount.
 			WithLabelValues(toState).Inc()
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1147,6 +1147,17 @@ func GetCounterValue(m prometheus.Counter) float64 {
 	return 0
 }
 
+// GetGaugeValue returns the current value stored for the gauge. This function
+// is useful in tests.
+func GetGaugeValue(m prometheus.Gauge) float64 {
+	var pm dto.Metric
+	err := m.Write(&pm)
+	if err == nil {
+		return *pm.Gauge.Value
+	}
+	return 0
+}
+
 // DumpMetrics gets the current Cilium metrics and dumps all into a
 // models.Metrics structure.If metrics cannot be retrieved, returns an error
 func DumpMetrics() ([]*models.Metric, error) {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -151,7 +151,8 @@ const (
 	StateTerminating = "Terminating"
 	StateRunning     = "Running"
 
-	PingCount = 5
+	PingCount   = 5
+	PingTimeout = 5
 
 	// CurlConnectTimeout is the timeout for the connect() call that curl
 	// invokes

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3188,14 +3188,14 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 			}
 
 			archiveName := filepath.Join(logsPath, fmt.Sprintf("bugtool-%s", pod))
-			res = kub.ExecContext(ctx, fmt.Sprintf("mkdir -p %s", archiveName))
+			res = kub.ExecContext(ctx, fmt.Sprintf("mkdir -p %q", archiveName))
 			if !res.WasSuccessful() {
 				logger.WithField("cmd", res.GetCmd()).Errorf(
 					"cannot create bugtool archive folder: %s", res.CombineOutput())
 				continue
 			}
 
-			cmd := fmt.Sprintf("tar -xf /tmp/%s -C %s --strip-components=1", line, archiveName)
+			cmd := fmt.Sprintf("tar -xf /tmp/%s -C %q --strip-components=1", line, archiveName)
 			res = kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 			if !res.WasSuccessful() {
 				logger.WithField("cmd", cmd).Errorf(

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -40,10 +40,16 @@ const (
 	UDP_RR = PerfTest("UDP_RR")
 )
 
+// PingWithCount returns the string representing the ping command to ping the
+// specified endpoint, and takes a custom number of requests to send.
+func PingWithCount(endpoint string, count uint) string {
+	return fmt.Sprintf("ping -W %d -c %d %s", PingTimeout, count, endpoint)
+}
+
 // Ping returns the string representing the ping command to ping the specified
 // endpoint.
 func Ping(endpoint string) string {
-	return fmt.Sprintf("ping -W 5 -c %d %s", PingCount, endpoint)
+	return PingWithCount(endpoint, PingCount)
 }
 
 // Ping6 returns the string representing the ping6 command to ping6 the

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -65,8 +65,8 @@ func Wrk(endpoint string) string {
 
 // CurlFail returns the string representing the curl command with `-s` and
 // `--fail` options enabled to curl the specified endpoint.  It takes a
-// variadic optinalValues argument. This is passed on to fmt.Sprintf() and uses
-// into the curl message
+// variadic optionalValues argument. This is passed on to fmt.Sprintf() and
+// used into the curl message.
 func CurlFail(endpoint string, optionalValues ...interface{}) string {
 	statsInfo := `time-> DNS: '%{time_namelookup}(%{remote_ip})', Connect: '%{time_connect}',` +
 		`Transfer '%{time_starttransfer}', total '%{time_total}'`
@@ -75,7 +75,7 @@ func CurlFail(endpoint string, optionalValues ...interface{}) string {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
 	return fmt.Sprintf(
-		`curl --path-as-is -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[2]d %[3]s -w "%[4]s"`,
+		`curl --path-as-is -s -D /dev/stderr --fail --connect-timeout %d --max-time %d %s -w "%s"`,
 		CurlConnectTimeout, CurlMaxTimeout, endpoint, statsInfo)
 }
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -616,7 +616,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Testing egress connnectivity works correctly")
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.Ping("8.8.8.8"))
+				helpers.PingWithCount("8.8.8.8", 25))
 			res.ExpectSuccess("Egress ping connectivity should work")
 		})
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -383,7 +383,7 @@ var _ = Describe("K8sServicesTest", func() {
 		testCurlFailFromPodInHostNetNS := func(url string, count int, fromPod string) {
 			By("Making %d curl requests from %s to %q", count, fromPod, url)
 			for i := 1; i <= count; i++ {
-				res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod, helpers.CurlFail(url, "--max-time 3"))
+				res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod, helpers.CurlFail(url))
 				ExpectWithOffset(1, err).To(BeNil(), "Cannot run curl in host netns")
 				ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
 					"%s host unexpectedly connected to service %q, it should fail", fromPod, url)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -927,8 +927,14 @@ var _ = Describe("K8sServicesTest", func() {
 			httpURL = getHTTPLink(k8s1IP, data.Spec.Ports[0].NodePort)
 			tftpURL = getTFTPLink(k8s1IP, data.Spec.Ports[1].NodePort)
 			// Local requests should be load-balanced
-			testCurlFromPodInHostNetNS(httpURL, count, k8s1NodeName)
-			testCurlFromPodInHostNetNS(tftpURL, count, k8s1NodeName)
+			if helpers.RunsWithKubeProxy() {
+				// FIXME: The Nodeport BPF implementation for
+				// externalTrafficPolicy=Local is not compliant
+				// here, and the following checks fail. Let's
+				// disable them for now. See #11746.
+				testCurlFromPodInHostNetNS(httpURL, count, k8s1NodeName)
+				testCurlFromPodInHostNetNS(tftpURL, count, k8s1NodeName)
+			}
 			// Requests from another node are not
 			testCurlFailFromPodInHostNetNS(httpURL, count, k8s2NodeName)
 			testCurlFailFromPodInHostNetNS(tftpURL, count, k8s2NodeName)


### PR DESCRIPTION
* #11884 -- endpoint: Implement new Invalid endpoint state (@christarazi)
 * #11923 -- doc: uniformize name when referring to Hubble Relay (@Rolinh)
 * #11919 -- doc: add "observing flows with Hubble Relay" to troubleshooting section (@Rolinh)
 * #11897 -- test/helpers: allow passing custom number of requests to helpers.Ping() (@qmonnet)
 * #11307 -- CI: fix bash complaining about "unexpected tokens" (parenthesis) (@qmonnet)
 * #11899 -- datapath: Only NOTRACK proxy return traffic going to Cilium datapath (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11884 11923 11919 11897 11307 11899; do contrib/backporting/set-labels.py $pr done 1.8; done
```