### PR TITLE
release: Improve documentation around release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -9,10 +9,23 @@ assignees: ''
 
 ## Pre-release
 
+- [ ] Create a [new project] for the next release version
+- [ ] Add build targets for the new release on [Docker Hub]
+  - All versions:
+    - [cilium](https://hub.docker.com/repository/docker/cilium/cilium/builds/edit)
+    - [operator](https://hub.docker.com/repository/docker/cilium/operator/builds/edit)
+    - [docker-plugin](https://hub.docker.com/repository/docker/cilium/docker-plugin/builds/edit)
+  - Cilium v1.8 or later:
+    - [operator-generic](https://hub.docker.com/repository/docker/cilium/operator-generic/builds/edit)
+    - [operator-aws](https://hub.docker.com/repository/docker/cilium/operator-aws/builds/edit)
+    - [operator-azure](https://hub.docker.com/repository/docker/cilium/operator-azure/builds/edit)
+    - [hubble-relay](https://hub.docker.com/repository/docker/cilium/hubble-relay/builds/edit)
 - [ ] Check that there are no [release blockers] for the targeted release version
 - [ ] Ensure that outstanding [backport PRs] are merged
-- [ ] Create a [new project] for the next release version
-  - [ ] Move any unresolved issues/PRs into the newly created release project
+- [ ] Consider building new [cilium-runtime images] and bumping the base image
+      versions on this branch
+- [ ] Move any unresolved issues/PRs from old release project into the newly
+      created release project
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Update the VERSION file to represent X.Y.Z
   - [ ] Update helm charts via `make -C install/kubernetes`
@@ -22,18 +35,16 @@ assignees: ''
   - [ ] Use [Cilium release-notes tool] to generate `CHANGELOG.md`
   - [ ] Point `.github/cilium-actions.yml` to the newly created project
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
-- [ ] Run CI
 - [ ] Merge PR
-- [ ] Add build targets for the new release on [Docker Hub]
-  - [cilium](https://hub.docker.com/repository/docker/cilium/cilium/builds/edit)
-  - [operator](https://hub.docker.com/repository/docker/cilium/operator/builds/edit)
-  - [docker-plugin](https://hub.docker.com/repository/docker/cilium/docker-plugin/builds/edit)
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
 - [ ] Wait for docker builds to complete
   - [cilium](https://hub.docker.com/repository/docker/cilium/cilium/builds)
   - [operator](https://hub.docker.com/repository/docker/cilium/operator/builds)
   - [docker-plugin](https://hub.docker.com/repository/docker/cilium/docker-plugin/builds)
-- [ ] Create helm charts artifacts in [Cilium charts] repository
+- [ ] Create helm charts artifacts in [Cilium charts] repository using
+      [cilium helm release tool] & push to repository
+- [ ] Run sanity check of Helm install using connectivity-check script.
+      Suggested approach: Follow the full [GKE getting started guide].
 - [ ] [Create a release] for the new tag `vX.Y.Z`, using the release notes
       from above
 - [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
@@ -57,3 +68,6 @@ assignees: ''
 [Stable releases]: https://github.com/cilium/cilium#stable-releases
 [kops]: https://github.com/kubernetes/kops/
 [kubespray]: https://github.com/kubernetes-sigs/kubespray/
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
+[GKE getting started guide]: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-gke/
+[cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -115,3 +115,19 @@ For the final release
 
 #. Follow the :ref:`generic_release_process` to create the final replace and replace
    ``X.Y.0-rcX`` with ``X.Y.0``.
+
+#. Announce to Slack with a more thorough release text. Sample text:
+
+   ::
+
+      @channel :cilium-new: **Announcement:** Cilium 1.7.0 is out! :tada:
+
+      <Short summary of major features pulled from Blog, eg:>
+      *Amazing Technology*: Just some of the great work the community has
+      been working on over the past few months.
+
+      For more information, see the blog post:
+      https://cilium.io/blog/2020/02/18/cilium-17
+
+#. Update ``SECURITY.md`` to represent the security support for the most recent
+   three release series.

--- a/Documentation/contributing/release/rc.rst
+++ b/Documentation/contributing/release/rc.rst
@@ -134,4 +134,14 @@ If you intent to release a new feature release, see the
 
    #. Preview the description and then publish the release
 
-#. Announce the release in the ``#general`` channel on Slack
+#. Announce the release in the ``#general`` channel on Slack. Sample text:
+
+   ::
+
+      :cilium-new: Cilium release candidate vX.Y.Z-rcN has been released:
+      https://github.com/cilium/cilium/releases/tag/vX.Y.Z-rcN
+
+      This release is not recommended for use in production clusters, but if
+      you're in a position to pull it and try it out in staging / testing
+      environments and report issues that you find, this will help us to put
+      out a high-quality, stable final release :)

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -129,23 +129,6 @@ If you intent to release a new feature release, see the
 
        git push --tags
 
-#. Build the binaries and push it to the release bucket:
-
-   ::
-
-       DOMAIN=releases.cilium.io ./contrib/release/uploadrev v1.0.3
-
-
-   This step will print a markdown snippet which you will need when crafting
-   the GitHub release so make sure to keep it handy.
-
-   .. note:
-
-       This step requires valid AWS credentials to be available via the
-       environment variables ``AWS_ACCESS_KEY_ID`` and
-       ``AWS_SECRET_ACCESS_KEY``. Ping in the ``#development`` channel on Slack
-       if you have no access. It also requires the aws-cli tools to be installed.
-
 #. `Create a GitHub release <https://github.com/cilium/cilium/releases/new>`_:
 
    #. Choose the correct target branch, e.g. ``v1.0``
@@ -157,12 +140,32 @@ If you intent to release a new feature release, see the
 
    #. Preview the description and then publish the release
 
-#. Announce the release in the ``#general`` channel on Slack
+#. Prepare Helm changes using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
+   and push the changes into that repository (not the main cilium repository):
 
-#. Update the ``README.rst#stable-releases`` section from the Cilium master branch
+   ::
 
-#. Update the ``.github/cilium-actions.yml`` with the project created for the
-   upcoming release.
+      ./prepare_artifacts.sh /path/to/cilium/repository/checked/out/to/release/commit
+      git push
+
+#. Announce the release in the ``#general`` channel on Slack. Sample text:
+
+   ::
+
+      :cilium-new: **Announcement:** Cilium vX.Y.Z has been released :tada:
+
+      <If security release or major bugfix, short summary of fix here>
+
+      For more details, see the release notes:
+      https://github.com/cilium/cilium/releases/tag/vX.Y.Z
+
+#. Create a new git branch based on the master branch to update ``README.rst``:
+
+   ::
+
+      git checkout -b pr/bump-readme-vX.Y.Z origin/master
+      contrib/release/bump-readme.sh
+      # (Commit changes & submit PR)
 
 #. Bump the version of Cilium used in the Cilium upgrade tests to use the new release
 


### PR DESCRIPTION
Improve the GH issue templates and release docs to clarify a few points
and streamline the release process to make it more consistent with the
process we actually use.