### PR TITLE
docs: Rework live-preview to use docker container

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -16,12 +16,12 @@ builder-image: Dockerfile requirements.txt
 	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
 
 READTHEDOCS_VERSION:=$(READTHEDOCS_VERSION)
-DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
+DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
 		--workdir /src/Documentation \
 		--volume $(CURDIR)/..:/src \
 		--env SKIP_LINT=$(SKIP_LINT) \
-		--user "$(shell id -u):$(shell id -g)" \
-			cilium/docs-builder
+		--user "$(shell id -u):$(shell id -g)"
+DOCKER_RUN := $(DOCKER_CTR) cilium/docs-builder
 
 update-cmdref: builder-image
 	@$(ECHO_GEN)cmdref
@@ -67,14 +67,11 @@ run-server: stop-server
 	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 
 stop-server:
-	-$(QUIET)$(CONTAINER_ENGINE) container rm --force --volumes docs-cilium
+	-$(QUIET)$(CONTAINER_ENGINE) container rm --force --volumes docs-cilium 2>/dev/null
 
-pipenv:
-	@which pipenv > /dev/null || (echo "Please install pipenv: https://pipenv.pypa.io/en/latest/#install-pipenv-today"; exit 1)
-
-pipenv-install: pipenv
-	pipenv --rm || true
-	pipenv install --three -r requirements.txt
-
-live-preview: pipenv
-	pipenv run sphinx-autobuild -B $(SPHINX_OPTS) -i *.swp -Q . _preview
+live-preview: stop-server
+	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
+	$(QUIET)$(DOCKER_CTR) \
+		--publish $(DOCS_PORT):8000 \
+			cilium/docs-builder \
+		sphinx-autobuild -B -H 0.0.0.0 $(SPHINX_OPTS) -i *.swp -Q . _preview

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -8,14 +8,13 @@ Documentation
 =============
 
 First, start a local document server that automatically refreshes when you save files for
-real-time preview. After installing `pipenv <https://pipenv.pypa.io/en/latest/#install-pipenv-today>`_,
-run:
+real-time preview. It relies on the ``cilium/docs-builder`` Docker container.
 
 ::
 
     $ make render-docs-live-preview
 
-and preview the documentation at http://localhost:8000/ as you make changes. After making changes to
+and preview the documentation at http://localhost:9081/ as you make changes. After making changes to
 Cilium documentation you should check that you did not introduce any new warnings or errors, and also
 check that your changes look as you intended one last time before opening a pull request. To do this
 you can build the docs:

--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,7 @@ render-docs:
 	$(MAKE) -C Documentation html run-server
 
 render-docs-live-preview:
-	$(MAKE) -C Documentation pipenv-install live-preview
+	$(MAKE) -C Documentation live-preview
 
 manpages:
 	-rm -r man


### PR DESCRIPTION
This way, we can rely upon the dependencies provided by the container
rather than forcing folks to install various dependencies (even if
mainly managed by pipenv).