### PR TITLE
test: Fix NodePort acceleration param

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1319,7 +1319,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with TC, direct routing and Hybrid", func() {
 					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"global.nodePort.acceleration": "none",
+						"global.nodePort.acceleration": "disabled",
 						"global.nodePort.mode":         "hybrid",
 						"global.tunnel":                "disabled",
 						"global.autoDirectNodeRoutes":  "true",


### PR DESCRIPTION
(`K8sServicesTest Checks service across nodes Tests NodePort BPF Tests with TC, direct routing and Hybrid` is currently broken on master).

The node-port-acceleration param "none" has been changed to "disabled".

Fix: eee8b09e14 ("cilium: rename --node-port-acceleration=none to =disabled")