### PR TITLE
test: Disable flaky RuntimeKVStoreTest tests

### DIFF
--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("RuntimeKVStoreTest", func() {
+var _ = PDescribe("RuntimeKVStoreTest", func() {
 
 	var vm *helpers.SSHMeta
 


### PR DESCRIPTION
Related: #11895

Marked as needing backport to v1.8 because we have the same flake there, although less frequently:
https://jenkins.cilium.io/view/Cilium-v1.8/job/cilium-v1.8-runtime-4.9/53/testReport/(root)/Suite-runtime/RuntimeKVStoreTest_Consul_KVStore/
https://jenkins.cilium.io/view/Cilium-v1.8/job/cilium-v1.8-runtime-4.9/63/testReport/(root)/Suite-runtime/RuntimeKVStoreTest_Consul_KVStore/
https://jenkins.cilium.io/view/Cilium-v1.8/job/cilium-v1.8-runtime-4.9/62/testReport/(root)/Suite-runtime/RuntimeKVStoreTest_Consul_KVStore/
https://jenkins.cilium.io/view/Cilium-v1.8/job/cilium-v1.8-runtime-4.9/66/testReport/(root)/Suite-runtime/RuntimeKVStoreTest_Consul_KVStore/