### PR TITLE
Fix EndpointSlice support

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1223,7 +1223,11 @@ func (d *Daemon) initKVStore() {
 		// up etcd so we can perform the name resolution for etcd-operator
 		// to the service IP as well perform the service -> backend IPs for
 		// that service IP.
-		d.k8sWatcher.WaitForCacheSync(watchers.K8sAPIGroupServiceV1Core, watchers.K8sAPIGroupEndpointV1Core)
+		d.k8sWatcher.WaitForCacheSync(
+			watchers.K8sAPIGroupServiceV1Core,
+			watchers.K8sAPIGroupEndpointV1Core,
+			watchers.K8sAPIGroupEndpointSliceV1Beta1Discovery,
+		)
 		log := log.WithField(logfields.LogSubsys, "etcd")
 		goopts.DialOption = []grpc.DialOption{
 			grpc.WithDialer(k8s.CreateCustomDialer(&d.k8sWatcher.K8sSvcCache, log)),

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -242,10 +242,13 @@ func PreprocessRules(r api.Rules, cache *ServiceCache) error {
 		for ns, ep := range cache.endpoints {
 			svc, ok := cache.services[ns]
 			if ok && svc.IsExternal() {
-				t := NewK8sTranslator(ns, *ep, false, svc.Labels, false)
-				err := t.Translate(rule, &policy.TranslationResult{})
-				if err != nil {
-					return err
+				eps := ep.GetEndpoints()
+				if eps != nil {
+					t := NewK8sTranslator(ns, *eps, false, svc.Labels, false)
+					err := t.Translate(rule, &policy.TranslationResult{})
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -310,8 +310,12 @@ func (s *K8sSuite) TestPreprocessRules(c *C) {
 		Labels: tag1,
 	}
 
-	cache.endpoints = map[ServiceID]*Endpoints{
-		serviceInfo: &endpointInfo,
+	cache.endpoints = map[ServiceID]*endpointSlices{
+		serviceInfo: {
+			epSlices: map[string]*Endpoints{
+				"": &endpointInfo,
+			},
+		},
 	}
 
 	cache.services = map[ServiceID]*Service{

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -167,7 +167,7 @@ func ParseService(svc *slim_corev1.Service, nodeAddressing datapath.NodeAddressi
 	return svcID, svcInfo
 }
 
-// ServiceID identities the Kubernetes service
+// ServiceID identifies the Kubernetes service
 type ServiceID struct {
 	Name      string `json:"serviceName,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
@@ -176,6 +176,13 @@ type ServiceID struct {
 // String returns the string representation of a service ID
 func (s ServiceID) String() string {
 	return fmt.Sprintf("%s/%s", s.Namespace, s.Name)
+}
+
+// EndpointSliceID identifies a Kubernetes EndpointSlice as well as the legacy
+// v1.Endpoints.
+type EndpointSliceID struct {
+	ServiceID
+	EndpointSliceName string
 }
 
 // ParseServiceIDFrom returns a ServiceID derived from the given kubernetes

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -77,9 +77,17 @@ func (s *K8sSuite) TestGetUniqueServiceFrontends(c *check.C) {
 			},
 		},
 	}
-	cache.endpoints = map[ServiceID]*Endpoints{
-		svcID1: &endpoints,
-		svcID2: &endpoints,
+	cache.endpoints = map[ServiceID]*endpointSlices{
+		svcID1: {
+			epSlices: map[string]*Endpoints{
+				"": &endpoints,
+			},
+		},
+		svcID2: {
+			epSlices: map[string]*Endpoints{
+				"": &endpoints,
+			},
+		},
 	}
 
 	frontends := cache.UniqueServiceFrontends()
@@ -626,6 +634,249 @@ func (s *K8sSuite) TestNonSharedServie(c *check.C) {
 	swgSvcs.Stop()
 	c.Assert(testutils.WaitUntil(func() bool {
 		swgSvcs.Wait()
+		return true
+	}, 2*time.Second), IsNil)
+}
+
+func (s *K8sSuite) TestServiceCacheWith2EndpointSlice(c *check.C) {
+	k8sEndpointSlice1 := &slim_discovery_v1beta1.EndpointSlice{
+		AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-yyyyy",
+			Namespace: "bar",
+			Labels: map[string]string{
+				slim_discovery_v1beta1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1beta1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.2",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1beta1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	}
+
+	k8sEndpointSlice2 := &slim_discovery_v1beta1.EndpointSlice{
+		AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-xxxxx",
+			Namespace: "bar",
+			Labels: map[string]string{
+				slim_discovery_v1beta1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1beta1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.3",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1beta1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	}
+
+	k8sEndpointSlice3 := &slim_discovery_v1beta1.EndpointSlice{
+		AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-xxxxx",
+			Namespace: "baz",
+			Labels: map[string]string{
+				slim_discovery_v1beta1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1beta1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.4",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1beta1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	}
+
+	svcCache := NewServiceCache(fakeDatapath.NewNodeAddressing())
+
+	k8sSvc := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+			Type: slim_corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	swgSvcs := lock.NewStoppableWaitGroup()
+	svcID := svcCache.UpdateService(k8sSvc, swgSvcs)
+
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-svcCache.Events:
+		c.Error("Unexpected service event received before endpoints have been imported")
+	default:
+	}
+
+	swgEps := lock.NewStoppableWaitGroup()
+	svcCache.UpdateEndpointSlices(k8sEndpointSlice1, swgEps)
+	svcCache.UpdateEndpointSlices(k8sEndpointSlice2, swgEps)
+	svcCache.UpdateEndpointSlices(k8sEndpointSlice3, swgEps)
+
+	// The service should be ready as both service and endpoints have been
+	// imported for k8sEndpointSlice1
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// The service should be ready as both service and endpoints have been
+	// imported for k8sEndpointSlice2
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	select {
+	case <-svcCache.Events:
+		c.Error("Unexpected service event received when endpoints not selected by a service have been imported")
+	default:
+	}
+	endpoints, ready := svcCache.correlateEndpoints(svcID)
+	c.Assert(ready, check.Equals, true)
+	c.Assert(endpoints.String(), check.Equals, "2.2.2.2:8080/TCP,2.2.2.3:8080/TCP")
+
+	// Updating the service without changing it should not result in an event
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.Events:
+		c.Error("Unexpected service event received for unchanged service object")
+	default:
+	}
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, DeleteService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// Reinserting the service should re-match with the still existing endpoints
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// Deleting the k8sEndpointSlice2 will result in a service update event
+	svcCache.DeleteEndpointSlices(k8sEndpointSlice2, swgEps)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	endpoints, ready = svcCache.correlateEndpoints(svcID)
+	c.Assert(ready, check.Equals, true)
+	c.Assert(endpoints.String(), check.Equals, "2.2.2.2:8080/TCP")
+
+	svcCache.DeleteEndpointSlices(k8sEndpointSlice1, swgEps)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	endpoints, serviceReady := svcCache.correlateEndpoints(svcID)
+	c.Assert(serviceReady, check.Equals, false)
+	c.Assert(endpoints.String(), check.Equals, "")
+
+	// Reinserting the endpoints should re-match with the still existing service
+	svcCache.UpdateEndpointSlices(k8sEndpointSlice1, swgEps)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	endpoints, serviceReady = svcCache.correlateEndpoints(svcID)
+	c.Assert(serviceReady, check.Equals, true)
+	c.Assert(endpoints.String(), check.Equals, "2.2.2.2:8080/TCP")
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		defer event.SWG.Done()
+		c.Assert(event.Action, check.Equals, DeleteService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// Deleting the endpoints will not emit an event as the notification
+	// was sent out when the service was deleted.
+	svcCache.DeleteEndpointSlices(k8sEndpointSlice1, swgEps)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.Events:
+		c.Error("Unexpected service delete event received")
+	default:
+	}
+
+	swgSvcs.Stop()
+	c.Assert(testutils.WaitUntil(func() bool {
+		swgSvcs.Wait()
+		return true
+	}, 2*time.Second), IsNil)
+
+	swgEps.Stop()
+	c.Assert(testutils.WaitUntil(func() bool {
+		swgEps.Wait()
 		return true
 	}, 2*time.Second), IsNil)
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -370,6 +370,7 @@ func (k *K8sWatcher) InitK8sSubsystem() <-chan struct{} {
 			// To perform the service translation and have the BPF LB datapath
 			// with the right service -> backend (k8s endpoints) translation.
 			K8sAPIGroupEndpointV1Core,
+			K8sAPIGroupEndpointSliceV1Beta1Discovery,
 			// We need all network policies in place before restoring to make sure
 			// we are enforcing the correct policies for each endpoint before
 			// restarting.


### PR DESCRIPTION
The endpoint slice implementation did not account that a service could
map to multiple endpoint slices. Wrongly assuming that only a single
endpoint slice existed for a single service can cause Cilium to fail
the translation of a service to a backend in case 2 or more endpoint
slices existed. In some rare occurrences where a single endpoint slice
was deleted and another one was recreated, for the same service, it
could cause Cilium stop doing service translation entirely.

The unit test added easily replicates the issue as we can see the test
fails in the current master where the 2nd endpoint slice added overwrote
the 1st endpoint slice:

```
c.Assert(endpoints.String(), check.Equals, "2.2.2.2:8080/TCP,2.2.2.3:8080/TCP")
Expected :string = "2.2.2.2:8080/TCP,2.2.2.3:8080/TCP"
Actual   :string = "2.2.2.3:8080/TCP"
```

pkg/k8s: wait for EndpointSlice to be ready before initializing Cilium

Similar to the v1.Endpoints, in case Cilium is running with
EndpointSlice enabled, it should wait for the k8s watchers watching
those resources before it starts.

Fixes: c3b5ca6fdc40 ("add support for k8s endpoint slice")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix issue when Cilium randomly stops doing service translation in k8s 1.18
```

Fixes https://github.com/cilium/cilium/issues/11587
Fixes https://github.com/cilium/cilium/issues/11921