### PR TITLE
service: Clean up HealthCheckNodePort server when traffic policy changes 

### DIFF
--- a/pkg/service/healthserver/healthserver.go
+++ b/pkg/service/healthserver/healthserver.go
@@ -130,7 +130,6 @@ func (s *ServiceHealthServer) UpsertService(svcID lb.ID, ns, name string, localE
 	// endpoints. We reference count the listeners to make sure we only have
 	// a single listener per port.
 
-	var srv healthHTTPServer
 	svc := NewService(ns, name, localEndpoints)
 	if !foundSvc {
 		// We only bump the reference count if this is a service ID we have

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -262,11 +262,16 @@ func (s *Service) UpsertService(
 	}
 
 	// Only add a HealthCheckNodePort server if this is a service which may
-	// only contain local backends.
+	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
 	if onlyLocalBackends {
 		localBackendCount := len(backendsCopy)
 		s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
 			localBackendCount, svc.svcHealthCheckNodePort)
+	} else if svc.svcHealthCheckNodePort == 0 {
+		// Remove the health check server in case this service used to have
+		// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
+		// version, but not anymore.
+		s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 	}
 
 	if new {


### PR DESCRIPTION
This PR fixes a case where the `HealthCheckNodePort` service was not
removed properly anymore when a `LoadBalancer` service defintion was changed from
`externalTrafficPolicy=Local` to `externalTrafficPolicy=Cluster`. The unit
tests are extended to capture this behavior.

Fixes: f7b0378 ("service: Fix wrong localEndpoints count in HealthCheckNodePort")