### PR TITLE
docs: Improve session affinity section in kube-proxy free guide

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -257,6 +257,7 @@ Policy                   endpoint         16k             Max 16k allowed identi
 Proxy Map                node             512k            Max 512k concurrent redirected TCP connections to proxy
 Tunnel                   node             64k             Max 32k nodes (IPv4+IPv6) or 64k nodes (IPv4 or IPv6) across all clusters
 IPv4 Fragmentation       node             8k              Max 8k fragmented datagrams in flight simultaneously on the node
+Session Affinity         node             64k             Max 64k affinities from different clients
 ======================== ================ =============== =====================================================
 
 For some BPF maps, the upper capacity limit can be overridden using command

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -611,10 +611,10 @@ if needed.
 The source for the affinity depends on the origin of a request. If a request is
 sent from outside the cluster to the service, the request's source IP address is
 used for determining the endpoint affinity. If a request is sent from inside
-the cluster - a network namespace cookie of a client. The latter was introduced
+the cluster, the client's network namespace cookie is used. The latter was introduced
 in the 5.7 Linux kernel to implement the affinity at the socket layer at which
-:ref:`host-services` operates (a source IP is not available there, as the endpoint
-selection happens before a network packet has been built by kernel).
+:ref:`host-services` operate (a source IP is not available there, as the endpoint
+selection happens before a network packet has been built by the kernel).
 
 The session affinity support is enabled by default for Cilium's kube-proxy
 replacement. For users who run on older kernels which do not support the network


### PR DESCRIPTION
- Address @pchaigno comments (https://github.com/cilium/cilium/pull/11957/).
- Mention BPF map size scale implications for the affinity map.