### PR TITLE
doc: fix up GKE install guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-gke-validate.rst
@@ -6,19 +6,23 @@ You can monitor as Cilium and all required components are being installed:
 .. parsed-literal::
 
     kubectl -n cilium get pods --watch
-    NAME                                    READY   STATUS              RESTARTS   AGE
-    cilium-operator-cb4578bc5-q52qk         0/1     Pending             0          8s
-    cilium-s8w5m                            0/1     PodInitializing     0          7s
-    coredns-86c58d9df4-4g7dd                0/1     ContainerCreating   0          8m57s
-    coredns-86c58d9df4-4l6b2                0/1     ContainerCreating   0          8m57s
+    NAME                               READY   STATUS            RESTARTS   AGE
+    cilium-bbpwg                       0/1     PodInitializing   0          27s
+    cilium-node-init-jwtw6             1/1     Running           0          27s
+    cilium-node-init-t5cm9             1/1     Running           0          27s
+    cilium-operator-7967c75f94-ckd5g   0/1     Pending           0          27s
+    cilium-rnrxr                       0/1     Running           0          27s
 
 It may take a couple of minutes for all components to come up:
 
 .. parsed-literal::
 
-    cilium-operator-cb4578bc5-q52qk         1/1     Running   0          4m13s
-    cilium-s8w5m                            1/1     Running   0          4m12s
-    coredns-86c58d9df4-4g7dd                1/1     Running   0          13m
-    coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
+    kubectl -n cilium get pods
+    NAME                               READY   STATUS    RESTARTS   AGE
+    cilium-bbpwg                       1/1     Running   0          70s
+    cilium-node-init-jwtw6             1/1     Running   0          70s
+    cilium-node-init-t5cm9             1/1     Running   0          70s
+    cilium-operator-7967c75f94-ckd5g   1/1     Running   0          70s
+    cilium-rnrxr                       1/1     Running   0          70s
 
 .. include:: k8s-install-connectivity-test.rst

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -36,16 +36,23 @@ Create a GKE Cluster
 You can apply any method to create a GKE cluster. The example given here is
 using the `Google Cloud SDK <https://cloud.google.com/sdk/>`_.
 
+.. note:: Either of the cluster zone or region must be specified in ``gcloud``
+          commands below. The full list of locations is available on
+          `this page <https://cloud.google.com/compute/docs/regions-zones#locations>`_.
+          This guide uses ``--zone`` to specify the zone but you may replace
+          this flag with ``--region`` instead.
+
 .. code:: bash
 
     export CLUSTER_NAME=cluster1
-    gcloud container clusters create $CLUSTER_NAME --image-type COS --num-nodes 2 --machine-type n1-standard-4
+    export CLUSTER_ZONE=us-west2-a
+    gcloud container clusters create $CLUSTER_NAME --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone $CLUSTER_ZONE
 
 Retrieve the credentials to access the cluster:
 
 .. code:: bash
 
-    gcloud container clusters get-credentials $CLUSTER_NAME
+    gcloud container clusters get-credentials $CLUSTER_NAME --zone $CLUSTER_ZONE
 
 When done, you should be able to access your cluster like this:
 
@@ -53,8 +60,8 @@ When done, you should be able to access your cluster like this:
 
     kubectl get nodes
     NAME                                      STATUS   ROLES    AGE   VERSION
-    gke-cluster1-default-pool-a63a765c-flr2   Ready    <none>   6m    v1.11.7-gke.4
-    gke-cluster1-default-pool-a63a765c-z73c   Ready    <none>   6m    v1.11.7-gke.4
+    gke-cluster1-default-pool-a63a765c-flr2   Ready    <none>   6m    v1.14.10-gke.36
+    gke-cluster1-default-pool-a63a765c-z73c   Ready    <none>   6m    v1.14.10-gke.36
 
 Deploy Cilium
 =============
@@ -63,7 +70,7 @@ Extract the Cluster CIDR to enable native-routing:
 
 .. code:: bash
 
-    NATIVE_CIDR=$(gcloud container clusters describe $CLUSTER_NAME | grep -i clusterIpv4Cidr | awk '{print $2}')
+    NATIVE_CIDR=$(gcloud container clusters describe $CLUSTER_NAME --zone $CLUSTER_ZONE | grep -i clusterIpv4Cidr | awk '{print $2}')
     echo $NATIVE_CIDR
 
 .. include:: k8s-install-download-release.rst
@@ -71,7 +78,7 @@ Extract the Cluster CIDR to enable native-routing:
 Deploy Cilium release via Helm:
 
 If you are ready to restart existing pods when initializing the node, you can
-also pass the ``--set nodeinit.restartPods`` flag to the ``helm`` command
+also pass the ``--set nodeinit.restartPods=true`` flag to the ``helm`` command
 below. This will ensure all pods are managed by Cilium.
 
 .. parsed-literal::


### PR DESCRIPTION
This commit fixes the GKE install guide:

- `gcloud` now requires to pass `--zone` or `--region` or fails. Update
  the guide to use `--zone` to all `gcloud` commands that require it.
- The set of pods in the `cilium` namespace is different now. Update the
  sample list so that the reader does not get confused.
- Add `=true` to `--set nodeinit.restartPods` as without specifying
  `=true`, the Helm command fails.
