### PR TITLE
test: Set devices and enable host firewall in kube-proxy CI

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1122,6 +1122,10 @@ func initEnv(cmd *cobra.Command) {
 	initClockSourceOption()
 	initSockmapOption()
 
+	if option.Config.EnableHostFirewall && option.Config.EnableIPSec {
+		log.Fatal("IPSec cannot be used with the host firewall.")
+	}
+
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
 	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -115,6 +115,8 @@ var (
 
 		// We need CNP node status to know when a policy is being enforced
 		"global.cnpStatusUpdates.enabled": "true",
+
+		"global.hostFirewall": "true",
 	}
 
 	flannelHelmOverrides = map[string]string{
@@ -140,6 +142,7 @@ var (
 		"global.nodePort.mode":        "snat",
 		"global.gke.enabled":          "true",
 		"global.nativeRoutingCIDR":    "10.0.0.0/8",
+		"global.hostFirewall":         "false",
 	}
 
 	microk8sHelmOverrides = map[string]string{
@@ -2162,7 +2165,6 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 
 		opts := map[string]string{
-			"global.hostFirewall":         "true",
 			"global.kubeProxyReplacement": "strict",
 			"global.k8sServiceHost":       nodeIP,
 			"global.k8sServicePort":       "6443",

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -308,10 +308,15 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 
 		It("Check connectivity with automatic direct nodes routes", func() {
-			deploymentManager.DeployCilium(map[string]string{
+			options := map[string]string{
 				"global.tunnel":               "disabled",
 				"global.autoDirectNodeRoutes": "true",
-			}, DeployCiliumOptionsAndDNS)
+			}
+			// Needed to bypass bug with masquerading when devices are set. See #12141.
+			if helpers.RunsWithKubeProxy() {
+				options["global.masquerade"] = "false"
+			}
+			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 			if helpers.RunsOnNetNextOr419Kernel() {
@@ -322,12 +327,17 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 
 		It("Check direct connectivity with per endpoint routes", func() {
-			deploymentManager.DeployCilium(map[string]string{
+			options := map[string]string{
 				"global.tunnel":                 "disabled",
 				"global.autoDirectNodeRoutes":   "true",
 				"global.endpointRoutes.enabled": "true",
 				"global.ipv6.enabled":           "false",
-			}, DeployCiliumOptionsAndDNS)
+			}
+			// Needed to bypass bug with masquerading when devices are set. See #12141.
+			if helpers.RunsWithKubeProxy() {
+				options["global.masquerade"] = "false"
+			}
+			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -554,6 +554,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"global.encryption.enabled":   "true",
 				"global.encryption.interface": privateIface,
 				"global.devices":              "",
+				"global.hostFirewall":         "false",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -553,6 +553,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"global.autoDirectNodeRoutes": "true",
 				"global.encryption.enabled":   "true",
 				"global.encryption.interface": privateIface,
+				"global.devices":              "",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})


### PR DESCRIPTION
This pull request sets devices and enables the host firewall in kube-proxy CIs.
See commit messages for details.

Fixes: #11972
