### PR TITLE
v1.7 backports 2020-06-08

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1601,7 +1601,7 @@ func initKubeProxyReplacementOptions() {
 		if option.Config.EnableHostServicesUDP &&
 			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_RECVMSG) != nil ||
 				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_RECVMSG) != nil) {
-			msg := "BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp"
+			msg := fmt.Sprintf("BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --%s=tcp and --%s=%s", option.HostReachableServicesProtos, option.KubeProxyReplacement, option.KubeProxyReplacementPartial)
 			if strict {
 				log.Fatal(msg)
 			} else {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
@@ -31,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -187,6 +189,93 @@ func (d *Daemon) errorDuringCreation(ep *endpoint.Endpoint, err error) (*endpoin
 	return nil, PutEndpointIDFailedCode, err
 }
 
+type endpointCreationRequest struct {
+	// cancel is the cancellation function that can be called to cancel
+	// this endpoint create request
+	cancel context.CancelFunc
+
+	// endpoint is the endpoint being added in the request
+	endpoint *endpoint.Endpoint
+
+	// started is the timestamp on when the processing has started
+	started time.Time
+}
+
+type endpointCreationManager struct {
+	mutex    lock.Mutex
+	requests map[string]*endpointCreationRequest
+}
+
+func newEndpointCreationManager() *endpointCreationManager {
+	return &endpointCreationManager{
+		requests: map[string]*endpointCreationRequest{},
+	}
+}
+
+func (m *endpointCreationManager) NewCreateRequest(ep *endpoint.Endpoint, cancel context.CancelFunc) {
+	// Tracking is only performed if Kubernetes pod names are available.
+	// The endpoint create logic already ensures that IPs and containerID
+	// are unique and thus tracking is not required outside of the
+	// Kubernetes context
+	if !ep.K8sNamespaceAndPodNameIsSet() || !k8s.IsEnabled() {
+		return
+	}
+
+	podName := ep.GetK8sNamespaceAndPodName()
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if req, ok := m.requests[podName]; ok {
+		ep.Logger(daemonSubsys).Warning("Cancelling obsolete endpoint creating due to new create for same pod")
+		req.cancel()
+	}
+
+	ep.Logger(daemonSubsys).Debug("New create request")
+	m.requests[podName] = &endpointCreationRequest{
+		cancel:   cancel,
+		endpoint: ep,
+		started:  time.Now(),
+	}
+}
+
+func (m *endpointCreationManager) EndCreateRequest(ep *endpoint.Endpoint) bool {
+	if !ep.K8sNamespaceAndPodNameIsSet() || !k8s.IsEnabled() {
+		return false
+	}
+
+	podName := ep.GetK8sNamespaceAndPodName()
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if req, ok := m.requests[podName]; ok {
+		if req.endpoint == ep {
+			ep.Logger(daemonSubsys).Debug("End of create request")
+			delete(m.requests, podName)
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *endpointCreationManager) CancelCreateRequest(ep *endpoint.Endpoint) {
+	if m.EndCreateRequest(ep) {
+		ep.Logger(daemonSubsys).Warning("Cancelled endpoint create request due to receiving endpoint delete request")
+	}
+}
+
+func (m *endpointCreationManager) DebugStatus() (output string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for _, req := range m.requests {
+		output += fmt.Sprintf("- %s: %s\n", req.started.String(), req.endpoint.String())
+	}
+	return
+}
+
 // createEndpoint attempts to create the endpoint corresponding to the change
 // request that was specified.
 func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.EndpointChangeRequest) (*endpoint.Endpoint, int, error) {
@@ -271,6 +360,11 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 			return invalidDataError(ep, fmt.Errorf("no valid labels provided"))
 		}
 	}
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	d.endpointCreations.NewCreateRequest(ep, cancel)
+	defer d.endpointCreations.EndCreateRequest(ep)
 
 	if ep.K8sNamespaceAndPodNameIsSet() && k8s.IsEnabled() {
 		identityLabels, info, _, err := d.fetchK8sLabelsAndAnnotations(ep.K8sNamespace, ep.K8sPodName)
@@ -496,6 +590,9 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 }
 
 func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
+	// Cancel any ongoing endpoint creation
+	d.endpointCreations.CancelCreateRequest(ep)
+
 	scopedLog := log.WithField(logfields.EndpointID, ep.ID)
 	errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
 		// If the IP is managed by an external IPAM, it does not need to be released

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/sirupsen/logrus"
 )
 
 type getEndpoint struct {
@@ -208,6 +209,16 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		disabled := false
 		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	}
+
+	log.WithFields(logrus.Fields{
+		"addressing":            epTemplate.Addressing,
+		logfields.ContainerID:   epTemplate.ContainerID,
+		"datapathConfiguration": epTemplate.DatapathConfiguration,
+		logfields.Interface:     epTemplate.InterfaceName,
+		logfields.K8sPodName:    epTemplate.K8sNamespace + "/" + epTemplate.K8sPodName,
+		logfields.Labels:        epTemplate.Labels,
+		"sync-build":            epTemplate.SyncBuildEndpoint,
+	}).Info("Create endpoint request")
 
 	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, d, d.l7Proxy, d.identityAllocator, epTemplate)
 	if err != nil {
@@ -419,6 +430,16 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	epTemplate := params.Endpoint
 
+	log.WithFields(logrus.Fields{
+		logfields.EndpointID:    params.ID,
+		"addressing":            epTemplate.Addressing,
+		logfields.ContainerID:   epTemplate.ContainerID,
+		"datapathConfiguration": epTemplate.DatapathConfiguration,
+		logfields.Interface:     epTemplate.InterfaceName,
+		logfields.K8sPodName:    epTemplate.K8sNamespace + "/" + epTemplate.K8sPodName,
+		logfields.Labels:        epTemplate.Labels,
+	}).Info("Patch endpoint request")
+
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
 	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d.ctx, h.d, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
@@ -507,6 +528,9 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.Delete
 }
 
 func (d *Daemon) DeleteEndpoint(id string) (int, error) {
+	// id can be an endpoint iD or an IP so not using logfields.EndpointID
+	log.WithField("id", id).Info("Delete endpoint request")
+
 	if ep, err := d.endpointManager.Lookup(id); err != nil {
 		return 0, api.Error(DeleteEndpointIDInvalidCode, err)
 	} else if ep == nil {

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
 )
@@ -144,10 +145,19 @@ func getMetricValue(state string) int64 {
 }
 
 func assertOnMetric(c *C, state string, expected int64) {
-	obtained := getMetricValue(state)
-	if obtained != expected {
-		_, _, line, _ := runtime.Caller(1)
-		c.Errorf("Metrics assertion failed on line %d for Endpoint state %s: obtained %d, expected %d",
-			line, state, obtained, expected)
+	_, _, line, _ := runtime.Caller(1)
+
+	obtainedValues := make(map[int64]struct{}, 0)
+	err := testutils.WaitUntil(func() bool {
+		obtained := getMetricValue(state)
+		obtainedValues[obtained] = struct{}{}
+		return obtained == expected
+	}, 10*time.Second)
+	if err != nil {
+		// We are printing the map here to show every unique obtained metrics
+		// value because these values change rapidly and it may be misleading
+		// to only show the last obtained value.
+		c.Errorf("Metrics assertion failed on line %d for Endpoint state %s: obtained %v, expected %d",
+			line, state, obtainedValues, expected)
 	}
 }

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -49,6 +49,11 @@ type EndpointConfiguration interface {
 	// GetIdentity returns a globally-significant numeric security identity.
 	GetIdentity() identity.NumericIdentity
 
+	// GetIdentityLocked returns a globally-significant numeric security
+	// identity while assuming that the backing data structure is locked.
+	// This function should be removed in favour of GetIdentity()
+	GetIdentityLocked() identity.NumericIdentity
+
 	IPv4Address() addressing.CiliumIPv4
 	IPv6Address() addressing.CiliumIPv6
 	GetNodeMAC() mac.MAC

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -349,7 +349,7 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 	fmt.Fprint(fw, defineMAC("NODE_MAC", e.GetNodeMAC()))
 	fmt.Fprint(fw, defineUint32("LXC_ID", uint32(e.GetID())))
 
-	secID := e.GetIdentity().Uint32()
+	secID := e.GetIdentityLocked().Uint32()
 	fmt.Fprintf(fw, defineUint32("SECLABEL", secID))
 	fmt.Fprintf(fw, defineUint32("SECLABEL_NB", byteorder.HostToNetwork(secID).(uint32)))
 
@@ -412,7 +412,7 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 	return fw.Flush()
 }
 
-// WriteEndpointConfig writes the BPF configuration for the template to a writer.
+// WriteTemplateConfig writes the BPF configuration for the template to a writer.
 func (h *HeaderfileWriter) WriteTemplateConfig(w io.Writer, e datapath.EndpointConfiguration) error {
 	fw := bufio.NewWriter(w)
 	return h.writeTemplateConfig(fw, e)

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -92,6 +92,13 @@ func (t *templateCfg) GetIdentity() identity.NumericIdentity {
 	return TemplateSecurityID
 }
 
+// GetIdentityLocked is identical to GetIdentity(). This is a temporary
+// function until WriteEndpointConfig() no longer assumes that the endpoint is
+// locked.
+func (t *templateCfg) GetIdentityLocked() identity.NumericIdentity {
+	return TemplateSecurityID
+}
+
 // GetNodeMAC returns a well-known dummy MAC address which may be later
 // substituted in the ELF.
 func (t *templateCfg) GetNodeMAC() mac.MAC {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -356,7 +356,7 @@ const (
 
 	// IPAMExpiration is the timeout after which an IP subject to expiratio
 	// is being released again if no endpoint is being created in time.
-	IPAMExpiration = 3 * time.Minute
+	IPAMExpiration = 10 * time.Minute
 
 	// K8sEnableAPIDiscovery defines whether Kuberntes API groups and
 	// resources should be probed using the discovery API

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -71,6 +71,8 @@ func (e *Endpoint) BPFIpvlanMapPath() string {
 // strings describing the configuration of the datapath.
 //
 // For configuration of actual datapath behavior, see WriteEndpointConfig().
+//
+// e.Mutex must be held
 func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	fw := bufio.NewWriter(w)
 
@@ -104,7 +106,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		" * NodeMAC: %s\n"+
 		" */\n\n",
 		e.IPv6.String(), e.IPv4.String(),
-		e.GetIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
+		e.getIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
 		e.nodeMAC)
 
 	fw.WriteString("/*\n")
@@ -123,6 +125,9 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	return fw.Flush()
 }
 
+// writeHeaderfile writes the lxc_config.h header file of an endpoint
+//
+// e.Mutex must be held.
 func (e *Endpoint) writeHeaderfile(prefix string) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
 	e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -75,7 +75,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		id:                    e.GetID(),
 		ifName:                e.ifName,
 		ipvlan:                e.HasIpvlanDataPath(),
-		identity:              e.GetIdentity(),
+		identity:              e.getIdentity(),
 		mac:                   e.GetNodeMAC(),
 		ipv4:                  e.IPv4Address(),
 		ipv6:                  e.IPv6Address(),
@@ -126,6 +126,11 @@ func (ep *epInfoCache) StringID() string {
 
 // GetIdentity returns the security identity of the endpoint.
 func (ep *epInfoCache) GetIdentity() identity.NumericIdentity {
+	return ep.identity
+}
+
+// GetIdentityLocked returns the security identity of the endpoint.
+func (ep *epInfoCache) GetIdentityLocked() identity.NumericIdentity {
 	return ep.identity
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -567,7 +567,21 @@ func (e *Endpoint) StringID() string {
 	return strconv.Itoa(int(e.ID))
 }
 
+// GetIdentityLocked is identical to GetIdentity() but assumes that a.mutex is
+// already held. This function is obsolete and should no longer be used.
+func (e *Endpoint) GetIdentityLocked() identity.NumericIdentity {
+	return e.getIdentity()
+}
+
+// GetIdentity returns the numeric security identity of the endpoint
 func (e *Endpoint) GetIdentity() identity.NumericIdentity {
+	e.unconditionalRLock()
+	defer e.runlock()
+
+	return e.getIdentity()
+}
+
+func (e *Endpoint) getIdentity() identity.NumericIdentity {
 	if e.SecurityIdentity != nil {
 		return e.SecurityIdentity.ID
 	}
@@ -2151,7 +2165,7 @@ func (e *Endpoint) GetProxyInfoByFields() (uint64, string, string, []string, str
 	if e.IsDisconnecting() {
 		err = fmt.Errorf("endpoint is in the process of being deleted")
 	}
-	return e.GetID(), e.GetIPv4Address(), e.GetIPv6Address(), e.GetLabels(), e.GetLabelsSHA(), uint64(e.GetIdentity()), err
+	return e.GetID(), e.GetIPv4Address(), e.GetIPv6Address(), e.GetLabels(), e.GetLabelsSHA(), uint64(e.getIdentity()), err
 }
 
 // WaitForFirstRegeneration waits for specific conditions before returning:

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1033,7 +1033,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 		if ip == "" {
 			continue
 		}
-		networkPolicy := getNetworkPolicy(ip, ep.GetIdentity(), ep.ConntrackNameLocked(), policy,
+		networkPolicy := getNetworkPolicy(ip, ep.GetIdentityLocked(), ep.ConntrackNameLocked(), policy,
 			ingressPolicyEnforced, egressPolicyEnforced)
 		err := networkPolicy.Validate()
 		if err != nil {

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -175,8 +175,7 @@ func deleteToCidrFromEndpoint(
 	endpoint Endpoints,
 	releasePrefixes bool) error {
 
-	newToCIDR := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
-	deleted := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
+	delCIDRRules := make(map[int]*api.CIDRRule, len(egress.ToCIDRSet))
 
 	for ip := range endpoint.Backends {
 		epIP := net.ParseIP(ip)
@@ -184,26 +183,52 @@ func deleteToCidrFromEndpoint(
 			return fmt.Errorf("unable to parse ip: %s", ip)
 		}
 
-		for _, c := range egress.ToCIDRSet {
+		for i, c := range egress.ToCIDRSet {
+			if _, ok := delCIDRRules[i]; ok {
+				// it's already going to be deleted so we can continue
+				continue
+			}
 			_, cidr, err := net.ParseCIDR(string(c.Cidr))
 			if err != nil {
 				return err
 			}
-			// if endpoint is not in CIDR or it's not
-			// generated it's ok to retain it
-			if !cidr.Contains(epIP) || !c.Generated {
-				newToCIDR = append(newToCIDR, c)
-			} else {
-				deleted = append(deleted, c)
+			// delete all generated CIDRs for a CIDR that match the given
+			// endpoint
+			if c.Generated && cidr.Contains(epIP) {
+				delCIDRRules[i] = &egress.ToCIDRSet[i]
 			}
+		}
+		if len(delCIDRRules) == len(egress.ToCIDRSet) {
+			break
 		}
 	}
 
-	egress.ToCIDRSet = newToCIDR
+	// If no rules were deleted we can do an early return here and avoid doing
+	// the useless operations below.
+	if len(delCIDRRules) == 0 {
+		return nil
+	}
+
 	if releasePrefixes {
-		prefixes := policy.GetPrefixesFromCIDRSet(deleted)
+		delSlice := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
+		for _, delCIDRRule := range delCIDRRules {
+			delSlice = append(delSlice, *delCIDRRule)
+		}
+		prefixes := policy.GetPrefixesFromCIDRSet(delSlice)
 		ipcache.ReleaseCIDRs(prefixes)
 	}
+
+	// if endpoint is not in CIDR or it's not generated it's ok to retain it
+	newCIDRRules := make([]api.CIDRRule, 0, len(egress.ToCIDRSet)-len(delCIDRRules))
+	for i, c := range egress.ToCIDRSet {
+		// If the rule was deleted then it shouldn't be re-added
+		if _, ok := delCIDRRules[i]; ok {
+			continue
+		}
+		newCIDRRules = append(newCIDRRules, c)
+	}
+
+	egress.ToCIDRSet = newCIDRRules
 
 	return nil
 }

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -17,6 +17,9 @@
 package k8s
 
 import (
+	"sort"
+
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
@@ -223,17 +226,25 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs := rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	// second run, to make sure there are no duplicates added
 	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs = rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
@@ -243,9 +254,13 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 2)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
-	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+	cidrs = rule.ToCIDRSet.StringSlice()
+	sort.Strings(cidrs)
+	c.Assert(len(cidrs), Equals, 2)
+	c.Assert(cidrs, checker.DeepEquals, []string{
+		epIP1 + "/32",
+		epIP2 + "/32",
+	})
 
 	// and one final delete
 	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -196,11 +196,20 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	rule := &api.EgressRule{}
 
-	epIP := "10.1.1.1"
+	epIP1 := "10.1.1.1"
+	epIP2 := "10.1.1.2"
 
 	endpointInfo := Endpoints{
 		Backends: map[string]*Backend{
-			epIP: {
+			epIP1: {
+				Ports: map[string]*loadbalancer.L4Addr{
+					"port": {
+						Protocol: loadbalancer.TCP,
+						Port:     80,
+					},
+				},
+			},
+			epIP2: {
 				Ports: map[string]*loadbalancer.L4Addr{
 					"port": {
 						Protocol: loadbalancer.TCP,
@@ -214,16 +223,31 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 1)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
+	c.Assert(len(rule.ToCIDRSet), Equals, 2)
+	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
+	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
 
 	// second run, to make sure there are no duplicates added
 	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
-	c.Assert(len(rule.ToCIDRSet), Equals, 1)
-	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
+	c.Assert(len(rule.ToCIDRSet), Equals, 2)
+	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
+	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
 
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	c.Assert(err, IsNil)
+	c.Assert(len(rule.ToCIDRSet), Equals, 0)
+
+	// third run, to make sure there are no duplicates added
+	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
+	c.Assert(err, IsNil)
+
+	c.Assert(len(rule.ToCIDRSet), Equals, 2)
+	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP1+"/32")
+	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP2+"/32")
+
+	// and one final delete
 	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"net"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
@@ -61,6 +62,15 @@ type CIDRRule struct {
 	Generated bool `json:"-"`
 }
 
+// String converts the CIDRRule into a human-readable string.
+func (r CIDRRule) String() string {
+	exceptCIDRs := ""
+	if len(r.ExceptCIDRs) > 0 {
+		exceptCIDRs = "-" + CIDRSlice(r.ExceptCIDRs).String()
+	}
+	return string(r.Cidr) + exceptCIDRs
+}
+
 // CIDRSlice is a slice of CIDRs. It allows receiver methods to be defined for
 // transforming the slice into other convenient forms such as
 // EndpointSelectorSlice.
@@ -98,6 +108,14 @@ func (s CIDRSlice) StringSlice() []string {
 	return result
 }
 
+// String converts the CIDRSlice into a human-readable string.
+func (s CIDRSlice) String() string {
+	if len(s) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(s.StringSlice(), ",") + "]"
+}
+
 // CIDRRuleSlice is a slice of CIDRRules. It allows receiver methods to be
 // defined for transforming the slice into other convenient forms such as
 // EndpointSelectorSlice.
@@ -108,6 +126,15 @@ type CIDRRuleSlice []CIDRRule
 func (s CIDRRuleSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
 	cidrs := ComputeResultantCIDRSet(s)
 	return cidrs.GetAsEndpointSelectors()
+}
+
+// StringSlice returns the CIDRRuleSlice as a slice of strings.
+func (s CIDRRuleSlice) StringSlice() []string {
+	result := make([]string, 0, len(s))
+	for _, c := range s {
+		result = append(result, c.String())
+	}
+	return result
 }
 
 // ComputeResultantCIDRSet converts a slice of CIDRRules into a slice of

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -28,7 +28,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetIdentity() identity.NumericIdentity
+	GetIdentityLocked() identity.NumericIdentity
 	GetLabels() []string
 	GetLabelsSHA() string
 	HasSidecarProxy() bool

--- a/pkg/proxy/mock_test.go
+++ b/pkg/proxy/mock_test.go
@@ -35,20 +35,20 @@ type proxyUpdaterMock struct {
 }
 
 func (m *proxyUpdaterMock) GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error) {
-	return m.GetID(), m.GetIPv4Address(), m.GetIPv6Address(), m.GetLabels(), m.GetLabelsSHA(), uint64(m.GetIdentity()), nil
+	return m.GetID(), m.GetIPv4Address(), m.GetIPv6Address(), m.GetLabels(), m.GetLabelsSHA(), uint64(m.GetIdentityLocked()), nil
 }
 
 func (m *proxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
 func (m *proxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 
-func (m *proxyUpdaterMock) GetID() uint64                         { return m.id }
-func (m *proxyUpdaterMock) GetIPv4Address() string                { return m.ipv4 }
-func (m *proxyUpdaterMock) GetIPv6Address() string                { return m.ipv6 }
-func (m *proxyUpdaterMock) GetLabels() []string                   { return m.labels }
-func (m *proxyUpdaterMock) GetEgressPolicyEnabledLocked() bool    { return true }
-func (m *proxyUpdaterMock) GetIngressPolicyEnabledLocked() bool   { return true }
-func (m *proxyUpdaterMock) GetIdentity() identity.NumericIdentity { return m.identity }
-func (m *proxyUpdaterMock) ProxyID(l4 *policy.L4Filter) string    { return "" }
+func (m *proxyUpdaterMock) GetID() uint64                               { return m.id }
+func (m *proxyUpdaterMock) GetIPv4Address() string                      { return m.ipv4 }
+func (m *proxyUpdaterMock) GetIPv6Address() string                      { return m.ipv6 }
+func (m *proxyUpdaterMock) GetLabels() []string                         { return m.labels }
+func (m *proxyUpdaterMock) GetEgressPolicyEnabledLocked() bool          { return true }
+func (m *proxyUpdaterMock) GetIngressPolicyEnabledLocked() bool         { return true }
+func (m *proxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.identity }
+func (m *proxyUpdaterMock) ProxyID(l4 *policy.L4Filter) string          { return "" }
 func (m *proxyUpdaterMock) GetLabelsSHA() string {
 	return labels.NewLabelsFromModel(m.labels).SHA256Sum()
 }

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -49,19 +49,20 @@ func NewTestEndpoint() TestEndpoint {
 	}
 }
 
-func (e *TestEndpoint) HasIpvlanDataPath() bool                 { return false }
-func (e *TestEndpoint) ConntrackLocalLocked() bool              { return false }
-func (e *TestEndpoint) RequireARPPassthrough() bool             { return false }
-func (e *TestEndpoint) RequireEgressProg() bool                 { return false }
-func (e *TestEndpoint) RequireRouting() bool                    { return false }
-func (e *TestEndpoint) RequireEndpointRoute() bool              { return false }
-func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)    { return nil, nil }
-func (e *TestEndpoint) GetID() uint64                           { return e.Id }
-func (e *TestEndpoint) StringID() string                        { return "42" }
-func (e *TestEndpoint) GetIdentity() identity.NumericIdentity   { return e.Identity.ID }
-func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity { return e.Identity }
-func (e *TestEndpoint) GetNodeMAC() mac.MAC                     { return e.MAC }
-func (e *TestEndpoint) GetOptions() *option.IntOptions          { return e.Opts }
+func (e *TestEndpoint) HasIpvlanDataPath() bool                     { return false }
+func (e *TestEndpoint) ConntrackLocalLocked() bool                  { return false }
+func (e *TestEndpoint) RequireARPPassthrough() bool                 { return false }
+func (e *TestEndpoint) RequireEgressProg() bool                     { return false }
+func (e *TestEndpoint) RequireRouting() bool                        { return false }
+func (e *TestEndpoint) RequireEndpointRoute() bool                  { return false }
+func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)        { return nil, nil }
+func (e *TestEndpoint) GetID() uint64                               { return e.Id }
+func (e *TestEndpoint) StringID() string                            { return "42" }
+func (e *TestEndpoint) GetIdentity() identity.NumericIdentity       { return e.Identity.ID }
+func (e *TestEndpoint) GetIdentityLocked() identity.NumericIdentity { return e.Identity.ID }
+func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity     { return e.Identity }
+func (e *TestEndpoint) GetNodeMAC() mac.MAC                         { return e.MAC }
+func (e *TestEndpoint) GetOptions() *option.IntOptions              { return e.Opts }
 
 func (e *TestEndpoint) IPv4Address() addressing.CiliumIPv4 {
 	addr, _ := addressing.NewCiliumIPv4("192.0.2.3")


### PR DESCRIPTION
Backported here:

 * #11901 -- pkg/k8s: delete toCIDRSets for more than 2 endpoints (@aanm)
 * #11913 -- policy: Fix rule translation test flake (@joestringer)
   * Minor conflict, easily resolved
 * #11918 -- daemon: Clarify log msg how to use only TCP socket-lb (@brb)
 * #11899 -- datapath: Only NOTRACK proxy return traffic going to Cilium datapath (@jrajahalme)
   * @jrajahalme PTAL. v1.7 had an extra match here on the source IP address which
     I folded into this commit.
 * #11920 -- Properly cancel endpoint creations as they become obsolete (@tgraf)
 * #11941 -- endpoint: Fix data races while accessing GetIdentity() (@tgraf)
   * Minor conflicts in various places because of replacing `GetIdentity()`
     with `getIdentity()` and `GetIdentityLocked()`.
 * #11950 -- ipcache: Fix deadlock when ipcache GC results in datapath reload (@tgraf)
 * #11966 -- daemon: Fix waiting on metrics in endpoint_test.go (@christarazi)

*NOT* backported:
 * #11617 -- bpf: getpeername hook implementation for socket lb (@borkmann)
 * #11231 -- Protect ENI and Azure IPAM from misbehaving cloud APIs (@tgraf)
 * #11952 -- service: Clean up HealthCheckNodePort server when traffic policy changes  (@gandro)
   * Seems to depend on a PR that's being merged in #11906. Skipping for now.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11901 11913 11918 11899 11920 11941 11950 11966; do contrib/backporting/set-labels.py $pr done 1.7; done
```