### PR TITLE
Envoy: Update to Envoy 1.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:a3385205ad620550b35d3b0b651e40898386e6e3 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776 as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 


### PR DESCRIPTION
Update proxy image to build with Envoy 1.13.2. This fixes
CVE-2020-11080 by rejecting HTTP/2 SETTINGS frames with too many
parameters.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy is updated to release 1.13.2.
```
