### PR TITLE
cilium: fixes transparent encryption

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1033,8 +1033,7 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 {
 	int encrypt_iface = 0;
 	int ret = 0;
-
-#if defined(ENCRYPT_NODE) || defined(BPF_HAVE_FIB_LOOKUP)
+#if defined(ENCRYPT_IFACE)
 	encrypt_iface = ENCRYPT_IFACE;
 #endif
 	ret = do_netdev_encrypt_pools(ctx);
@@ -1046,11 +1045,9 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	bpf_clear_meta(ctx);
-#if defined(ENCRYPT_NODE) || defined(BPF_HAVE_FIB_LOOKUP)
-	return redirect(encrypt_iface, 0);
-#else
+	if (encrypt_iface)
+		return redirect(encrypt_iface, 0);
 	return CTX_ACT_OK;
-#endif
 }
 
 #else /* ENCAP_IFINDEX */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -356,15 +356,17 @@ pass_to_stack:
 #ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #endif
+	} else
+#endif
+#endif
+	{
+		/* Always encode the source identity when passing to the stack. If the
+		 * stack hairpins the packet back to a local endpoint the source
+		 * identity can still be derived even if SNAT is performed by a
+		 * component such as portmap */
+		ctx->mark |= MARK_MAGIC_IDENTITY;
+		set_identity_mark(ctx, SECLABEL);
 	}
-#endif
-#endif
-	/* Always encode the source identity when passing to the stack. If the
-	 * stack hairpins the packet back to a local endpoint the source
-	 * identity can still be derived even if SNAT is performed by a
-	 * component such as portmap */
-	ctx->mark |= MARK_MAGIC_IDENTITY;
-	set_identity_mark(ctx, SECLABEL);
 
 	return CTX_ACT_OK;
 }
@@ -708,16 +710,17 @@ pass_to_stack:
 #ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #endif
+	} else
+#endif
+#endif
+	{
+		/* Always encode the source identity when passing to the stack. If the
+		 * stack hairpins the packet back to a local endpoint the source
+		 * identity can still be derived even if SNAT is performed by a
+		 * component such as portmap */
+		ctx->mark |= MARK_MAGIC_IDENTITY;
+		set_identity_mark(ctx, SECLABEL);
 	}
-#endif
-#endif
-
-	/* Always encode the source identity when passing to the stack. If the
-	 * stack hairpins the packet back to a local endpoint the source
-	 * identity can still be derived even if SNAT is performed by a
-	 * component such as portmap */
-	ctx->mark |= MARK_MAGIC_IDENTITY;
-	set_identity_mark(ctx, SECLABEL);
 
 	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, 0);
 	return CTX_ACT_OK;

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -684,7 +684,10 @@ func ConvertToCiliumEndpoint(obj interface{}) interface{} {
 				Labels:      nil,
 				Annotations: nil,
 			},
-			Encryption: &concreteObj.Status.Encryption,
+			Encryption: func() *cilium_v2.EncryptionSpec {
+				enc := concreteObj.Status.Encryption
+				return &enc
+			}(),
 			Identity:   concreteObj.Status.Identity,
 			Networking: concreteObj.Status.Networking,
 			NamedPorts: concreteObj.Status.NamedPorts,
@@ -713,7 +716,10 @@ func ConvertToCiliumEndpoint(obj interface{}) interface{} {
 					Labels:      nil,
 					Annotations: nil,
 				},
-				Encryption: &ciliumEndpoint.Status.Encryption,
+				Encryption: func() *cilium_v2.EncryptionSpec {
+					enc := ciliumEndpoint.Status.Encryption
+					return &enc
+				}(),
 				Identity:   ciliumEndpoint.Status.Identity,
 				Networking: ciliumEndpoint.Status.Networking,
 				NamedPorts: ciliumEndpoint.Status.NamedPorts,

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -19,6 +19,7 @@ package k8s
 import (
 	"time"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
@@ -1224,13 +1225,135 @@ func (s *K8sSuite) Test_ConvertToCiliumEndpoint(c *C) {
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{
 					Key: "foo",
-					Obj: &v2.CiliumEndpoint{},
+					Obj: &v2.CiliumEndpoint{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "CiliumEndpoint",
+							APIVersion: "v2",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "foo",
+							GenerateName:    "generated-Foo",
+							Namespace:       "bar",
+							UID:             "fdadada-dada",
+							ResourceVersion: "5454",
+							Generation:      5,
+							CreationTimestamp: metav1.Time{
+								Time: time.Date(2018, 01, 01, 01, 01, 01, 01, time.UTC),
+							},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+							Annotations: map[string]string{
+								"foo": "bar",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									Kind:               "Pod",
+									APIVersion:         "v1",
+									Name:               "foo",
+									UID:                "65dasd54d45",
+									Controller:         nil,
+									BlockOwnerDeletion: func() *bool { a := true; return &a }(),
+								},
+							},
+							ClusterName: "default",
+						},
+						Status: v2.EndpointStatus{
+							ID:          0,
+							Controllers: nil,
+							ExternalIdentifiers: &models.EndpointIdentifiers{
+								ContainerID:   "3290f4bc32129cb3e2f81074557ad9690240ea8fcce84bcc51a9921034875878",
+								ContainerName: "foo",
+								K8sNamespace:  "foo",
+								K8sPodName:    "bar",
+								PodName:       "foo/bar",
+							},
+							Health: &models.EndpointHealth{
+								Bpf:           "good",
+								Connected:     false,
+								OverallHealth: "excellent",
+								Policy:        "excellent",
+							},
+							Identity: &v2.EndpointIdentity{
+								ID: 9654,
+								Labels: []string{
+									"k8s:io.cilium.namespace=bar",
+								},
+							},
+							Networking: &v2.EndpointNetworking{
+								Addressing: []*v2.AddressPair{
+									{
+										IPV4: "10.0.0.1",
+										IPV6: "fd00::1",
+									},
+								},
+								NodeIP: "192.168.0.1",
+							},
+							Encryption: v2.EncryptionSpec{
+								Key: 250,
+							},
+							Policy: &v2.EndpointPolicy{
+								Ingress: &v2.EndpointPolicyDirection{
+									Enforcing: true,
+								},
+								Egress: &v2.EndpointPolicyDirection{
+									Enforcing: true,
+								},
+							},
+							State: "",
+							NamedPorts: []*models.Port{
+								{
+									Name:     "foo-port",
+									Port:     8181,
+									Protocol: "TCP",
+								},
+							},
+						},
+					},
 				},
 			},
 			want: cache.DeletedFinalStateUnknown{
 				Key: "foo",
 				Obj: &types.CiliumEndpoint{
-					Encryption: &v2.EncryptionSpec{},
+					TypeMeta: slim_metav1.TypeMeta{
+						Kind:       "CiliumEndpoint",
+						APIVersion: "v2",
+					},
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Name:            "foo",
+						Namespace:       "bar",
+						UID:             "fdadada-dada",
+						ResourceVersion: "5454",
+						// We don't need to store labels nor annotations because
+						// they are not used by the CEP handlers.
+						Labels:      nil,
+						Annotations: nil,
+					},
+					Identity: &v2.EndpointIdentity{
+						ID: 9654,
+						Labels: []string{
+							"k8s:io.cilium.namespace=bar",
+						},
+					},
+					Networking: &v2.EndpointNetworking{
+						Addressing: []*v2.AddressPair{
+							{
+								IPV4: "10.0.0.1",
+								IPV6: "fd00::1",
+							},
+						},
+						NodeIP: "192.168.0.1",
+					},
+					Encryption: &v2.EncryptionSpec{
+						Key: 250,
+					},
+					NamedPorts: []*models.Port{
+						{
+							Name:     "foo-port",
+							Port:     8181,
+							Protocol: "TCP",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Fix a couple issues with transparent encryption. First ensure encryption mark field is not replaced with source identity. If packet is being encrypted it is a remote packet and source identity in the mark field is not needed. Next on kernels without FIB support we may still have a encryption interface. By using the interface with redirect encryption will continue to work even when an explicit route has not been configured. With above two fixes GKE using standard configuration from guides will work correctly.

Finally, on GKE systems and a local cluster the endpoint k8s watcher was reporting a zero key. By doing an explicit assignment this is resolved. I'm not entirely clear what is happening here but its clear the event has a correct encryption key identifier and the post translated even drops the encryption key id. By doing the assignment directly the key is now correct. TBD understand golang parts here.

```release-note
fix transparent encryption related bugs
```