### PR TITLE
cni: Only require ipam.Cidrs when masquerade is enabled

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -370,6 +370,7 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 	var err error
 	d.healthEndpointRouting, err = linuxrouting.NewRoutingInfo(result.GatewayIP,
 		result.CIDRs,
-		result.Master)
+		result.Master,
+		option.Config.Masquerade)
 	return err
 }

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -44,19 +44,21 @@ type RoutingInfo struct {
 }
 
 // NewRoutingInfo creates a new RoutingInfo struct, from data that will be
-// parsed and validated. Note, this code assumes IPv4 values because ENI + IPv4
-// is the only supported path currently.
-func NewRoutingInfo(gateway string, cidrs []string, mac string) (*RoutingInfo, error) {
-	return parse(gateway, cidrs, mac)
+// parsed and validated. Note, this code assumes IPv4 values because IPv4
+// (on either ENI or Azure interface) is the only supported path currently.
+// Azure does not support masquerade yet (subnets CIDRs aren't provided):
+// untill it does, we forward a masquerade bool to opt out ipam.Cidrs use.
+func NewRoutingInfo(gateway string, cidrs []string, mac string, masquerade bool) (*RoutingInfo, error) {
+	return parse(gateway, cidrs, mac, masquerade)
 }
 
-func parse(gateway string, cidrs []string, macAddr string) (*RoutingInfo, error) {
+func parse(gateway string, cidrs []string, macAddr string, masquerade bool) (*RoutingInfo, error) {
 	ip := net.ParseIP(gateway)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid ip: %s", gateway)
 	}
 
-	if len(cidrs) == 0 {
+	if len(cidrs) == 0 && masquerade {
 		return nil, errors.New("empty cidrs")
 	}
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -262,7 +262,8 @@ func getFakes(c *C) (net.IP, RoutingInfo) {
 
 	fakeRoutingInfo, err := parse(fakeGateway.String(),
 		[]string{fakeCIDR.String()},
-		fakeMAC.String())
+		fakeMAC.String(),
+		true)
 	c.Assert(err, IsNil)
 	c.Assert(fakeRoutingInfo, NotNil)
 

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -41,7 +41,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		cidrs = append(cidrs, cidr.String())
 	}
 
-	routingInfo, err := linuxrouting.NewRoutingInfo(ipam.Gateway, cidrs, ipam.MasterMac)
+	routingInfo, err := linuxrouting.NewRoutingInfo(ipam.Gateway, cidrs, ipam.MasterMac, conf.Masquerade)
 	if err != nil {
 		return fmt.Errorf("unable to parse routing info: %v", err)
 	}


### PR DESCRIPTION
Since recently, allocations results returned without CIDRs became fatal
for CNI (CNI cmdAdd() would fail due to interfaceAdd() failing, due to
RoutingInfo.parse() bailing out on `len(cidrs) == 0`).

That (now mandatory) `IPv4CIDRs` is used when masquerading is enabled,
to source-route traffic from the pods to its attached VPC CIDRs through
a dedicated local table (that I assume is exempt from masquerade).

But on Azure we don't collect and dont't propagate subnets CIDRs, and
that bit of information is missing from ciliumnodes azure crd/ipam.

Adding masquerade support to Azure CNI (therefore, collecting and bubbling
down per-address CIDRs) would be a nice feature to have in the longer term.
But we might be late in the feature freeze to implement that on time to
unbreak Azure CNI before 1.8 release; and there's no reason to insist on
having CIDRs when masquerade is disabled anyway.

Please ensure your pull request adheres to the following guidelines:

```release-note
Don't require (not supported on Azure) ipam.Cidrs when masquerade is disabled
```
