### PR TITLE
loader: Fix tunneling when device is set without NodePort

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -113,7 +113,6 @@ func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy, r datapath.RouteReserver) error {
 	var (
 		args []string
-		mode string
 		ret  error
 	)
 
@@ -231,17 +230,14 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 			}
 		}
 
-		if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
-			mode = "ipvlan"
+		if option.Config.Tunnel != option.TunnelDisabled {
+			args[initArgMode] = option.Config.Tunnel
+		} else if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
+			args[initArgMode] = "ipvlan"
 		} else {
-			mode = "direct"
+			args[initArgMode] = "direct"
 		}
 
-		args[initArgMode] = mode
-		if option.Config.EnableNodePort &&
-			strings.ToLower(option.Config.Tunnel) != "disabled" {
-			args[initArgMode] = option.Config.Tunnel
-		}
 		args[initArgDevices] = strings.Join(option.Config.Devices, ";")
 	} else {
 		args[initArgMode] = option.Config.Tunnel


### PR DESCRIPTION
Many tests are failing when configuring a device while BPF-based NodePort is disabled (cf. #11972). A bug in the loader causes it to call `init.sh` with the mode set to direct instead of e.g., vxlan. The `cilium_vxlan` is then not created (or even removed if it existed) which causes connectivity disruptions in multiple scenarios (mostly multi-node).

This commit fixes the wrong assumption that multiple devices are only set when NodePort is enabled. That assumption might have been correct when that code was introduced (in 3a83623).

Fixes: #11972
Fixes: 3a83623 ("bpf: add support for local NodePort via tunnel")
/cc @brb @borkmann 