### PR TITLE
Add quarantine mechanism to test suite

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -213,6 +213,8 @@ framework in the ``test/`` directory and interact with ginkgo directly:
             Specifies whether Kubernetes should be deployed and installed via kubeadm or not (default true)
       -cilium.registry string
             docker registry hostname for Cilium image
+      -cilium.runQuarantined
+        Run tests that are under quarantine.
       -cilium.showCommands
             Output which commands are ran to stdout
       -cilium.skipLogs

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -37,6 +37,10 @@ pipeline {
             returnStdout: true,
             script: 'if [ "${JobKernelVersion}" = "net-next" ]; then echo -n "0"; else echo -n ""; fi'
             )}"""
+        RUN_QUARANTINED="""${sh(
+				returnStdout: true,
+				script: 'if [ "${RunQuarantined}" = "" ]; then echo -n "false"; else echo -n "${RunQuarantined}"; fi'
+            )}"""
     }
 
     options {
@@ -170,7 +174,7 @@ pipeline {
             }
             steps {
                 sh 'env'
-                sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/K8s*/" | sed "s/Runtime.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'
+                sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/K8s*/" | sed "s/Runtime.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh) -cilium.runQuarantined=${RUN_QUARANTINED}'
             }
             post {
                 always {

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -20,6 +20,10 @@ pipeline {
             )}"""
         TESTED_SUITE="runtime"
         FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
+        RUN_QUARANTINED="""${sh(
+				returnStdout: true,
+				script: 'if [ "${RunQuarantined}" = "" ]; then echo -n "false"; else echo -n "${RunQuarantined}"; fi'
+            )}"""
     }
 
     options {
@@ -132,7 +136,7 @@ pipeline {
                 TESTDIR="${GOPATH}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime.*/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'
+                sh 'cd ${TESTDIR}; ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime.*/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED}'
             }
             post {
                 always {

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -42,7 +42,8 @@ type CiliumTestConfigType struct {
 	Benchmarks          bool
 	// Multinode enables the running of tests that involve more than one
 	// node. If false, some tests will silently skip multinode checks.
-	Multinode bool
+	Multinode      bool
+	RunQuarantined bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -82,4 +83,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies benchmark tests should be run which may increase test time")
 	flag.BoolVar(&c.Multinode, "cilium.multinode", true,
 		"Enable tests across multiple nodes. If disabled, such tests may silently pass")
+	flag.BoolVar(&c.RunQuarantined, "cilium.runQuarantined", false,
+		"Run tests that are under quarantine.")
 }

--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -653,14 +653,14 @@ func SkipContextIf(condition func() bool, text string, body func()) bool {
 }
 
 // SkipItIf executes the given body if the given condition is NOT met.
-func SkipItIf(condition func() bool, text string, body func()) bool {
+func SkipItIf(condition func() bool, text string, body func(), timeout ...float64) bool {
 	if condition() {
 		return It(text, func() {
 			Skip("skipping due to unmet condition")
 		})
 	}
 
-	return It(text, body)
+	return It(text, body, timeout...)
 }
 
 // Failf calls Fail with a formatted string

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -603,3 +603,8 @@ func GetLatestImageVersion() string {
 	}
 	return "latest"
 }
+
+// SkipQuarantined returns whether test under quarantine should be skipped
+func SkipQuarantined() bool {
+	return !config.CiliumTestConfig.RunQuarantined
+}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -375,7 +375,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				appPods[helpers.App3], clusterIP)
 		}, 500)
 
-		PIt("TLS policy", func() {
+		SkipItIf(helpers.SkipQuarantined, "TLS policy", func() {
 			By("Testing L7 Policy with TLS")
 
 			res := kubectl.CreateSecret("generic", "user-agent", "default", "--from-literal=user-agent=CURRL")

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -108,7 +108,7 @@ var _ = Describe("K8sFQDNTest", func() {
 		_ = kubectl.Exec(fmt.Sprintf("%s delete --all cnp", helpers.KubectlCmd))
 	})
 
-	It("Restart Cilium validate that FQDN is still working", func() {
+	SkipItIf(helpers.SkipQuarantined, "Restart Cilium validate that FQDN is still working", func() {
 		// Test functionality:
 		// - When Cilium is running) Connectivity from App2 application can
 		// connect to DNS because dns-proxy filter the DNS request. If the

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = PDescribe("RuntimeKVStoreTest", func() {
+var _ = Describe("RuntimeKVStoreTest", func() {
 
 	var vm *helpers.SSHMeta
 
@@ -68,45 +68,48 @@ var _ = PDescribe("RuntimeKVStoreTest", func() {
 		vm.CloseSSHClient()
 	})
 
-	It("Consul KVStore", func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		By("Starting Cilium with consul as kvstore")
-		vm.ExecInBackground(
-			ctx,
-			"sudo cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug")
-		err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
-		Expect(err).Should(BeNil())
+	SkipContextIf(helpers.SkipQuarantined, "KVStore tests under quarantine", func() {
 
-		By("Restarting cilium-docker service")
-		vm.Exec("sudo systemctl restart cilium-docker")
-		helpers.Sleep(2)
-		containers(helpers.Create)
-		vm.WaitEndpointsReady()
-		eps, err := vm.GetEndpointsNames()
-		Expect(err).Should(BeNil(), "Error getting names of endpoints from cilium")
-		Expect(len(eps)).To(Equal(1), "Number of endpoints in Cilium differs from what is expected")
-	})
+		It("Consul KVStore", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			By("Starting Cilium with consul as kvstore")
+			vm.ExecInBackground(
+				ctx,
+				"sudo cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug")
+			err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
+			Expect(err).Should(BeNil())
 
-	It("Etcd KVStore", func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		By("Starting Cilium with etcd as kvstore")
-		vm.ExecInBackground(
-			ctx,
-			"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001 2>&1 | logger -t cilium")
-		err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
-		Expect(err).Should(BeNil(), "Timed out waiting for VM to be ready after restarting Cilium")
+			By("Restarting cilium-docker service")
+			vm.Exec("sudo systemctl restart cilium-docker")
+			helpers.Sleep(2)
+			containers(helpers.Create)
+			vm.WaitEndpointsReady()
+			eps, err := vm.GetEndpointsNames()
+			Expect(err).Should(BeNil(), "Error getting names of endpoints from cilium")
+			Expect(len(eps)).To(Equal(1), "Number of endpoints in Cilium differs from what is expected")
+		})
 
-		By("Restarting cilium-docker service")
-		vm.Exec("sudo systemctl restart cilium-docker")
-		helpers.Sleep(2)
-		containers(helpers.Create)
+		It("Etcd KVStore", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			By("Starting Cilium with etcd as kvstore")
+			vm.ExecInBackground(
+				ctx,
+				"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001 2>&1 | logger -t cilium")
+			err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
+			Expect(err).Should(BeNil(), "Timed out waiting for VM to be ready after restarting Cilium")
 
-		vm.WaitEndpointsReady()
+			By("Restarting cilium-docker service")
+			vm.Exec("sudo systemctl restart cilium-docker")
+			helpers.Sleep(2)
+			containers(helpers.Create)
 
-		eps, err := vm.GetEndpointsNames()
-		Expect(err).Should(BeNil(), "Error getting names of endpoints from cilium")
-		Expect(len(eps)).To(Equal(1), "Number of endpoints in Cilium differs from what is expected")
+			vm.WaitEndpointsReady()
+
+			eps, err := vm.GetEndpointsNames()
+			Expect(err).Should(BeNil(), "Error getting names of endpoints from cilium")
+			Expect(len(eps)).To(Equal(1), "Number of endpoints in Cilium differs from what is expected")
+		})
 	})
 })


### PR DESCRIPTION
There is a new cli options for our test suite - `cilium.runQuarantined`, which tells ginkgo whether to skip tests which are marked as quarantined.

Test is marked as being under quarantine when its `It(...` call is replaced by `SkipItIf(helpers.SkipQuarantined, ...`