### PR TITLE
v1.8 backports 2020-06-09

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Check quick-install.yaml
+      - name: Check quick-install.yaml and experimental-install.yaml
         run: |
           cd install/kubernetes
           make all

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-06-02 as builder
+FROM quay.io/cilium/cilium-builder:2020-06-08 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
@@ -50,7 +50,7 @@ RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGI
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-06-02
+FROM quay.io/cilium/cilium-runtime:2020-06-08
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,7 +1,7 @@
 #
 # Cilium build-time base image (image created from this file is used to build Cilium)
 #
-FROM quay.io/cilium/cilium-runtime:2020-06-02
+FROM quay.io/cilium/cilium-runtime:2020-06-08
 LABEL maintainer="maintainer@cilium.io"
 ARG ARCH=amd64
 WORKDIR /go/src/github.com/cilium/cilium

--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -257,6 +257,7 @@ Policy                   endpoint         16k             Max 16k allowed identi
 Proxy Map                node             512k            Max 512k concurrent redirected TCP connections to proxy
 Tunnel                   node             64k             Max 32k nodes (IPv4+IPv6) or 64k nodes (IPv4 or IPv6) across all clusters
 IPv4 Fragmentation       node             8k              Max 8k fragmented datagrams in flight simultaneously on the node
+Session Affinity         node             64k             Max 64k affinities from different clients
 ======================== ================ =============== =====================================================
 
 For some BPF maps, the upper capacity limit can be overridden using command

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -57,8 +57,8 @@ Deploy Cilium release via Helm:
     helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
       --set global.etcd.enabled=true \\
-      --set global.etcd.endpoints[0]=http://etcd-endpoint1:2379 \\
-      --set global.etcd.endpoints[1]=http://etcd-endpoint2:2379
+      --set "global.etcd.endpoints[0]=http://etcd-endpoint1:2379" \\
+      --set "global.etcd.endpoints[1]=http://etcd-endpoint2:2379"
 
 
 Optional: Configure the SSL certificates
@@ -83,8 +83,8 @@ of http for the etcd endpoint URLs:
       --namespace kube-system \\
       --set global.etcd.enabled=true \\
       --set global.etcd.ssl=true \\
-      --set global.etcd.endpoints[0]=https://etcd-endpoint1:2379 \\
-      --set global.etcd.endpoints[1]=https://etcd-endpoint2:2379
+      --set "global.etcd.endpoints[0]=https://etcd-endpoint1:2379" \\
+      --set "global.etcd.endpoints[1]=https://etcd-endpoint2:2379"
 
 Validate the Installation
 =========================

--- a/Documentation/gettingstarted/k8s-install-gke-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-gke-validate.rst
@@ -6,19 +6,23 @@ You can monitor as Cilium and all required components are being installed:
 .. parsed-literal::
 
     kubectl -n cilium get pods --watch
-    NAME                                    READY   STATUS              RESTARTS   AGE
-    cilium-operator-cb4578bc5-q52qk         0/1     Pending             0          8s
-    cilium-s8w5m                            0/1     PodInitializing     0          7s
-    coredns-86c58d9df4-4g7dd                0/1     ContainerCreating   0          8m57s
-    coredns-86c58d9df4-4l6b2                0/1     ContainerCreating   0          8m57s
+    NAME                               READY   STATUS            RESTARTS   AGE
+    cilium-bbpwg                       0/1     PodInitializing   0          27s
+    cilium-node-init-jwtw6             1/1     Running           0          27s
+    cilium-node-init-t5cm9             1/1     Running           0          27s
+    cilium-operator-7967c75f94-ckd5g   0/1     Pending           0          27s
+    cilium-rnrxr                       0/1     Running           0          27s
 
 It may take a couple of minutes for all components to come up:
 
 .. parsed-literal::
 
-    cilium-operator-cb4578bc5-q52qk         1/1     Running   0          4m13s
-    cilium-s8w5m                            1/1     Running   0          4m12s
-    coredns-86c58d9df4-4g7dd                1/1     Running   0          13m
-    coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
+    kubectl -n cilium get pods
+    NAME                               READY   STATUS    RESTARTS   AGE
+    cilium-bbpwg                       1/1     Running   0          70s
+    cilium-node-init-jwtw6             1/1     Running   0          70s
+    cilium-node-init-t5cm9             1/1     Running   0          70s
+    cilium-operator-7967c75f94-ckd5g   1/1     Running   0          70s
+    cilium-rnrxr                       1/1     Running   0          70s
 
 .. include:: k8s-install-connectivity-test.rst

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -36,16 +36,23 @@ Create a GKE Cluster
 You can apply any method to create a GKE cluster. The example given here is
 using the `Google Cloud SDK <https://cloud.google.com/sdk/>`_.
 
+.. note:: Either of the cluster zone or region must be specified in ``gcloud``
+          commands below. The full list of locations is available on
+          `this page <https://cloud.google.com/compute/docs/regions-zones#locations>`_.
+          This guide uses ``--zone`` to specify the zone but you may replace
+          this flag with ``--region`` instead.
+
 .. code:: bash
 
     export CLUSTER_NAME=cluster1
-    gcloud container clusters create $CLUSTER_NAME --image-type COS --num-nodes 2 --machine-type n1-standard-4
+    export CLUSTER_ZONE=us-west2-a
+    gcloud container clusters create $CLUSTER_NAME --image-type COS --num-nodes 2 --machine-type n1-standard-4 --zone $CLUSTER_ZONE
 
 Retrieve the credentials to access the cluster:
 
 .. code:: bash
 
-    gcloud container clusters get-credentials $CLUSTER_NAME
+    gcloud container clusters get-credentials $CLUSTER_NAME --zone $CLUSTER_ZONE
 
 When done, you should be able to access your cluster like this:
 
@@ -53,8 +60,8 @@ When done, you should be able to access your cluster like this:
 
     kubectl get nodes
     NAME                                      STATUS   ROLES    AGE   VERSION
-    gke-cluster1-default-pool-a63a765c-flr2   Ready    <none>   6m    v1.11.7-gke.4
-    gke-cluster1-default-pool-a63a765c-z73c   Ready    <none>   6m    v1.11.7-gke.4
+    gke-cluster1-default-pool-a63a765c-flr2   Ready    <none>   6m    v1.14.10-gke.36
+    gke-cluster1-default-pool-a63a765c-z73c   Ready    <none>   6m    v1.14.10-gke.36
 
 Deploy Cilium
 =============
@@ -63,7 +70,7 @@ Extract the Cluster CIDR to enable native-routing:
 
 .. code:: bash
 
-    NATIVE_CIDR=$(gcloud container clusters describe $CLUSTER_NAME | grep -i clusterIpv4Cidr | awk '{print $2}')
+    NATIVE_CIDR=$(gcloud container clusters describe $CLUSTER_NAME --zone $CLUSTER_ZONE | grep -i clusterIpv4Cidr | awk '{print $2}')
     echo $NATIVE_CIDR
 
 .. include:: k8s-install-download-release.rst
@@ -71,7 +78,7 @@ Extract the Cluster CIDR to enable native-routing:
 Deploy Cilium release via Helm:
 
 If you are ready to restart existing pods when initializing the node, you can
-also pass the ``--set nodeinit.restartPods`` flag to the ``helm`` command
+also pass the ``--set nodeinit.restartPods=true`` flag to the ``helm`` command
 below. This will ensure all pods are managed by Cilium.
 
 .. parsed-literal::

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -611,10 +611,10 @@ if needed.
 The source for the affinity depends on the origin of a request. If a request is
 sent from outside the cluster to the service, the request's source IP address is
 used for determining the endpoint affinity. If a request is sent from inside
-the cluster - a network namespace cookie of a client. The latter was introduced
+the cluster, the client's network namespace cookie is used. The latter was introduced
 in the 5.7 Linux kernel to implement the affinity at the socket layer at which
-:ref:`host-services` operates (a source IP is not available there, as the endpoint
-selection happens before a network packet has been built by kernel).
+:ref:`host-services` operate (a source IP is not available there, as the endpoint
+selection happens before a network packet has been built by the kernel).
 
 The session affinity support is enabled by default for Cilium's kube-proxy
 replacement. For users who run on older kernels which do not support the network

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -346,13 +346,70 @@ modes and can be enabled as follows for ``nodePort.mode=hybrid`` in this example
         --set global.k8sServiceHost=API_SERVER_IP \\
         --set global.k8sServicePort=API_SERVER_PORT
 
+A list of drivers supporting native XDP can be found in the table below. The
+corresponding network driver name of an interface can be determined as follows:
+
+.. parsed-literal::
+
+    # ethtool -i eth0
+    driver: nfp
+    [...]
+
++-------------------+------------+-------------+
+| Vendor            | Driver     | XDP Support |
++===================+============+=============+
+| Amazon            | ena        | >= 5.6      |
++-------------------+------------+-------------+
+| Broadcom          | bnxt_en    | >= 4.11     |
++-------------------+------------+-------------+
+| Cavium            | thunderx   | >= 4.12     |
++-------------------+------------+-------------+
+| Freescale         | dpaa2      | >= 5.0      |
++-------------------+------------+-------------+
+| Intel             | ixgbe      | >= 4.12     |
+|                   +------------+-------------+
+|                   | ixgbevf    | >= 4.17     |
+|                   +------------+-------------+
+|                   | i40e       | >= 4.13     |
+|                   +------------+-------------+
+|                   | ice        | >= 5.5      |
++-------------------+------------+-------------+
+| Marvell           | mvneta     | >= 5.5      |
++-------------------+------------+-------------+
+| Mellanox          | mlx4       | >= 4.8      |
+|                   +------------+-------------+
+|                   | mlx5       | >= 4.9      |
++-------------------+------------+-------------+
+| Microsoft         | hv_netvsc  | >= 5.6      |
++-------------------+------------+-------------+
+| Netronome         | nfp        | >= 4.10     |
++-------------------+------------+-------------+
+| Others            | virtio_net | >= 4.10     |
+|                   +------------+-------------+
+|                   | tun/tap    | >= 4.14     |
++-------------------+------------+-------------+
+| Qlogic            | qede       | >= 4.10     |
++-------------------+------------+-------------+
+| Socionext         | netsec     | >= 5.3      |
++-------------------+------------+-------------+
+| Solarflare        | sfc        | >= 5.5      |
++-------------------+------------+-------------+
+| Texas Instruments | cpsw       | >= 5.3      |
++-------------------+------------+-------------+
+
 The current Cilium kube-proxy XDP acceleration mode can also be introspected through
-the ``cilium status`` CLI command:
+the ``cilium status`` CLI command. If it has been enabled successfully, ``XDP: NATIVE``
+is shown:
 
 .. parsed-literal::
 
     kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep KubeProxyReplacement
     KubeProxyReplacement:   Strict   [NodePort (SNAT, 30000-32767, XDP: NATIVE), HostPort, ExternalIPs, HostReachableServices (TCP, UDP)]
+
+Note that packets which have been pushed back out of the device for NodePort handling
+right at the XDP layer are not visible in tcpdump since packet taps come at a much
+later stage in the networking stack. Cilium's monitor or metric counters can be used
+instead for gaining visibility.
 
 NodePort Device, Port and Bind settings
 ***************************************

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -21,8 +21,8 @@ For installing ``kubeadm`` and for more provisioning options please refer to
 
    Cilium's kube-proxy replacement depends on the :ref:`host-services` feature,
    therefore a v4.19.57, v5.1.16, v5.2.0 or more recent Linux kernel is required.
-   We recommend a v5.3 or even more recent Linux kernel such as v5.7 as Cilium
-   can perform additional optimizations in its kube-proxy replacement implementation.
+   Linux kernels v5.3 and v5.8 add additional features that Cilium can use to
+   further optimize the kube-proxy replacement implementation.
 
    Note that v5.0.y kernels do not have the fix required to run the kube-proxy
    replacement since at this point in time the v5.0.y stable kernel is end-of-life

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -12,12 +12,14 @@ Blog
 Bookinfo
 Borkmann
 Brenden
+Broadcom
 Brouer
 Bugtool
 CIDR
 CIDRs
 CRD
 CRI
+Cavium
 Cheatsheet
 Cheng
 Chewbacca
@@ -41,6 +43,7 @@ FIt
 Facebook
 Fastabend
 Fosdem
+Freescale
 GCE
 Gartrell
 Geneve
@@ -86,6 +89,7 @@ Lund
 Majkowski
 Marek
 Meetup
+Mellanox
 Memcached
 Menlo
 Mesos
@@ -119,6 +123,7 @@ Profiler
 Proxylib
 QCon
 Qemu
+Qlogic
 Rebasing
 Redis
 Refactor
@@ -132,6 +137,8 @@ SR-IOV
 Sep
 Sharma
 Shirokov
+Socionext
+Solarflare
 Spectre
 Stacktrace
 Starovoitov
@@ -240,6 +247,7 @@ containerd
 contrib
 coord
 coredns
+cpsw
 cpumap
 cqlsh
 crd
@@ -275,6 +283,7 @@ distro
 distros
 dns
 dockerhub
+dpaa
 dports
 droid
 dryRun
@@ -284,6 +293,7 @@ eBPF
 eXpress
 ebpf
 elfutils
+ena
 endian
 endianness
 endpointSelector
@@ -346,6 +356,7 @@ https
 hubble
 hubble-relay
 hugepages
+hv
 hypervisor
 hypervisors
 iam
@@ -463,6 +474,7 @@ multinode
 musl
 mutex
 mutexes
+mvneta
 myCA
 myapp
 mysql
@@ -476,6 +488,8 @@ netdevice
 netdevices
 netdevsim
 netfilter
+netsec
+netvsc
 newproto
 newprotoparser
 nfp

--- a/bpf/include/bpf/api.h
+++ b/bpf/include/bpf/api.h
@@ -17,5 +17,6 @@
 #include "tailcall.h"
 #include "errno.h"
 #include "loader.h"
+#include "csum.h"
 
 #endif /* __BPF_API__ */

--- a/bpf/include/bpf/csum.h
+++ b/bpf/include/bpf/csum.h
@@ -30,13 +30,17 @@ static __always_inline __wsum csum_diff(const void *from, __u32 size_from,
 					__u32 seed)
 {
 	if (__builtin_constant_p(size_from) &&
-	    __builtin_constant_p(size_to) &&
-	    __builtin_constant_p(seed) && seed == 0) {
+	    __builtin_constant_p(size_to)) {
 		/* Optimizations for frequent hot-path cases that are tiny to just
 		 * inline into the code instead of calling more expensive helper.
 		 */
-		if (size_from == 4 && size_to == 4)
+		if (size_from == 4 && size_to == 4 &&
+		    __builtin_constant_p(seed) && seed == 0)
 			return csum_add(~(*(__u32*)from), *(__u32*)to);
+		if (size_from == 4 && size_to == 4)
+			return csum_add(seed,
+					csum_add(~(*(__u32*)from),
+						 *(__u32*)to));
 	}
 
 	return csum_diff_external(from, size_from, to, size_to, seed);

--- a/bpf/include/bpf/csum.h
+++ b/bpf/include/bpf/csum.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2020 Authors of Cilium */
+
+#ifndef __BPF_CSUM_H_
+#define __BPF_CSUM_H_
+
+#include "compiler.h"
+#include "helpers.h"
+
+static __always_inline __sum16 csum_fold(__wsum csum)
+{
+	csum = (csum & 0xffff) + (csum >> 16);
+	csum = (csum & 0xffff) + (csum >> 16);
+	return (__sum16)~csum;
+}
+
+static __always_inline __wsum csum_unfold(__sum16 csum)
+{
+	return (__wsum)csum;
+}
+
+static __always_inline __wsum csum_add(__wsum csum, __wsum addend)
+{
+	csum += addend;
+	return csum + (csum < addend);
+}
+
+static __always_inline __wsum csum_diff(const void *from, __u32 size_from,
+					const void *to,   __u32 size_to,
+					__u32 seed)
+{
+	if (__builtin_constant_p(size_from) &&
+	    __builtin_constant_p(size_to) &&
+	    __builtin_constant_p(seed) && seed == 0) {
+		/* Optimizations for frequent hot-path cases that are tiny to just
+		 * inline into the code instead of calling more expensive helper.
+		 */
+		if (size_from == 4 && size_to == 4)
+			return csum_add(~(*(__u32*)from), *(__u32*)to);
+	}
+
+	return csum_diff_external(from, size_from, to, size_to, seed);
+}
+
+#endif /* __BPF_CSUM_H_ */

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -196,7 +196,7 @@ l4_csum_replace(const struct xdp_md *ctx, __u64 off, __u32 from, __u32 to,
 
 static __always_inline __maybe_unused int
 ctx_adjust_room(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
-		const __u64 flags)
+		const __u64 flags __maybe_unused)
 {
 	const __u32 move_len_v4 = 14 + 20;
 	const __u32 move_len_v6 = 14 + 40;
@@ -205,7 +205,6 @@ ctx_adjust_room(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 
 	build_bug_on(len_diff <= 0 || len_diff >= 64);
 	build_bug_on(mode != BPF_ADJ_ROOM_NET);
-	build_bug_on(flags != 0);
 
 	ret = xdp_adjust_head(ctx, -len_diff);
 

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -14,6 +14,7 @@
 #include "../builtins.h"
 #include "../section.h"
 #include "../loader.h"
+#include "../csum.h"
 
 #define CTX_ACT_OK			XDP_PASS
 #define CTX_ACT_DROP			XDP_DROP
@@ -104,27 +105,6 @@ xdp_store_bytes(const struct xdp_md *ctx, __u64 off, const void *from,
 
 #define get_hash(ctx)			({ 0; })
 #define get_hash_recalc(ctx)		get_hash(ctx)
-
-/* Checksum pieces from Linux kernel. */
-static inline __sum16 csum_fold(__wsum csum)
-{
-	__u32 sum = (__u32)csum;
-	sum = (sum & 0xffff) + (sum >> 16);
-	sum = (sum & 0xffff) + (sum >> 16);
-	return (__sum16)~sum;
-}
-
-static inline __wsum csum_unfold(__sum16 n)
-{
-	return (__wsum)n;
-}
-
-static inline __wsum csum_add(__wsum csum, __wsum addend)
-{
-	__u32 res = (__u32)csum;
-	res += (__u32)addend;
-	return (__wsum)(res + (res < (__u32)addend));
-}
 
 static __always_inline __maybe_unused void
 __csum_replace_by_diff(__sum16 *sum, __wsum diff)

--- a/bpf/include/bpf/features.h
+++ b/bpf/include/bpf/features.h
@@ -27,4 +27,8 @@
 # define BPF_HAVE_JIFFIES 1
 #endif
 
+#if HAVE_PROG_TYPE_HELPER(sched_cls, bpf_csum_level)
+# define BPF_HAVE_CSUM_LEVEL 1
+#endif
+
 #endif /* ____BPF_FEATURES____ */

--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -59,8 +59,9 @@ static __printf(1,3) void BPF_FUNC(trace_printk, const char *fmt, int fmt_size, 
 static __u32 BPF_FUNC(get_prandom_u32);
 
 /* Checksumming */
-static int BPF_FUNC(csum_diff, const void *from, __u32 from_size, void *to,
-		    __u32 to_size, __u32 seed);
+static int BPF_FUNC_REMAP(csum_diff_external, const void *from, __u32 size_from,
+			  const void *to, __u32 size_to, __u32 seed) =
+	(void *)BPF_FUNC_csum_diff;
 
 /* Tail calls */
 static void BPF_FUNC(tail_call, void *ctx, const void *map, __u32 index);

--- a/bpf/include/bpf/verifier.h
+++ b/bpf/include/bpf/verifier.h
@@ -4,6 +4,8 @@
 #ifndef __BPF_VERIFIER__
 #define __BPF_VERIFIER__
 
+#include "csum.h"
+
 /* relax_verifier is a dummy helper call to introduce a pruning checkpoint
  * to help relax the verifier to avoid reaching complexity limits on older
  * kernels.

--- a/bpf/include/linux/bpf.h
+++ b/bpf/include/linux/bpf.h
@@ -73,7 +73,7 @@ struct bpf_insn {
 /* Key of an a BPF_MAP_TYPE_LPM_TRIE entry */
 struct bpf_lpm_trie_key {
 	__u32	prefixlen;	/* up to 32 for AF_INET, 128 for AF_INET6 */
-	__u8	data[];	/* Arbitrary size */
+	__u8	data[0];	/* Arbitrary size */
 };
 
 struct bpf_cgroup_storage_key {
@@ -113,6 +113,10 @@ enum bpf_cmd {
 	BPF_MAP_DELETE_BATCH,
 	BPF_LINK_CREATE,
 	BPF_LINK_UPDATE,
+	BPF_LINK_GET_FD_BY_ID,
+	BPF_LINK_GET_NEXT_ID,
+	BPF_ENABLE_STATS,
+	BPF_ITER_CREATE,
 };
 
 enum bpf_map_type {
@@ -143,6 +147,7 @@ enum bpf_map_type {
 	BPF_MAP_TYPE_SK_STORAGE,
 	BPF_MAP_TYPE_DEVMAP_HASH,
 	BPF_MAP_TYPE_STRUCT_OPS,
+	BPF_MAP_TYPE_RINGBUF,
 };
 
 /* Note that tracing related programs such as
@@ -215,10 +220,27 @@ enum bpf_attach_type {
 	BPF_TRACE_FEXIT,
 	BPF_MODIFY_RETURN,
 	BPF_LSM_MAC,
+	BPF_TRACE_ITER,
+	BPF_CGROUP_INET4_GETPEERNAME,
+	BPF_CGROUP_INET6_GETPEERNAME,
+	BPF_CGROUP_INET4_GETSOCKNAME,
+	BPF_CGROUP_INET6_GETSOCKNAME,
+	BPF_XDP_DEVMAP,
 	__MAX_BPF_ATTACH_TYPE
 };
 
 #define MAX_BPF_ATTACH_TYPE __MAX_BPF_ATTACH_TYPE
+
+enum bpf_link_type {
+	BPF_LINK_TYPE_UNSPEC = 0,
+	BPF_LINK_TYPE_RAW_TRACEPOINT = 1,
+	BPF_LINK_TYPE_TRACING = 2,
+	BPF_LINK_TYPE_CGROUP = 3,
+	BPF_LINK_TYPE_ITER = 4,
+	BPF_LINK_TYPE_NETNS = 5,
+
+	MAX_BPF_LINK_TYPE,
+};
 
 /* cgroup-bpf attach flags used in BPF_PROG_ATTACH command
  *
@@ -379,6 +401,12 @@ enum {
  */
 #define BPF_F_QUERY_EFFECTIVE	(1U << 0)
 
+/* type for BPF_ENABLE_STATS */
+enum bpf_stats_type {
+	/* enabled run_time_ns and run_cnt */
+	BPF_STATS_RUN_TIME = 0,
+};
+
 enum bpf_stack_build_id_status {
 	/* user space need an empty entry to identify end of a trace */
 	BPF_STACK_BUILD_ID_EMPTY = 0,
@@ -523,6 +551,7 @@ union bpf_attr {
 			__u32		prog_id;
 			__u32		map_id;
 			__u32		btf_id;
+			__u32		link_id;
 		};
 		__u32		next_id;
 		__u32		open_flags;
@@ -589,6 +618,15 @@ union bpf_attr {
 		__u32		old_prog_fd;
 	} link_update;
 
+	struct { /* struct used by BPF_ENABLE_STATS command */
+		__u32		type;
+	} enable_stats;
+
+	struct { /* struct used by BPF_ITER_CREATE command */
+		__u32		link_fd;
+		__u32		flags;
+	} iter_create;
+
 } __attribute__((aligned(8)));
 
 /* The description below is an attempt at providing documentation to eBPF
@@ -644,14 +682,16 @@ union bpf_attr {
  * 		For tracing programs, safely attempt to read *size* bytes from
  * 		kernel space address *unsafe_ptr* and store the data in *dst*.
  *
- * 		Generally, use bpf_probe_read_user() or bpf_probe_read_kernel()
- * 		instead.
+ * 		Generally, use **bpf_probe_read_user**\ () or
+ * 		**bpf_probe_read_kernel**\ () instead.
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
  * u64 bpf_ktime_get_ns(void)
  * 	Description
  * 		Return the time elapsed since system boot, in nanoseconds.
+ * 		Does not include time the system was suspended.
+ * 		See: **clock_gettime**\ (**CLOCK_MONOTONIC**)
  * 	Return
  * 		Current *ktime*.
  *
@@ -1510,11 +1550,11 @@ union bpf_attr {
  * int bpf_probe_read_str(void *dst, u32 size, const void *unsafe_ptr)
  * 	Description
  * 		Copy a NUL terminated string from an unsafe kernel address
- * 		*unsafe_ptr* to *dst*. See bpf_probe_read_kernel_str() for
+ * 		*unsafe_ptr* to *dst*. See **bpf_probe_read_kernel_str**\ () for
  * 		more details.
  *
- * 		Generally, use bpf_probe_read_user_str() or bpf_probe_read_kernel_str()
- * 		instead.
+ * 		Generally, use **bpf_probe_read_user_str**\ () or
+ * 		**bpf_probe_read_kernel_str**\ () instead.
  * 	Return
  * 		On success, the strictly positive length of the string,
  * 		including the trailing NUL character. On error, a negative
@@ -1542,7 +1582,7 @@ union bpf_attr {
  *
  * u64 bpf_get_socket_cookie(struct bpf_sock_ops *ctx)
  * 	Description
- * 		Equivalent to bpf_get_socket_cookie() helper that accepts
+ * 		Equivalent to **bpf_get_socket_cookie**\ () helper that accepts
  * 		*skb*, but gets socket from **struct bpf_sock_ops** context.
  * 	Return
  * 		A 8-byte long non-decreasing number.
@@ -1562,13 +1602,19 @@ union bpf_attr {
  * 	Return
  * 		0
  *
- * int bpf_setsockopt(struct bpf_sock_ops *bpf_socket, int level, int optname, void *optval, int optlen)
+ * int bpf_setsockopt(void *bpf_socket, int level, int optname, void *optval, int optlen)
  * 	Description
  * 		Emulate a call to **setsockopt()** on the socket associated to
  * 		*bpf_socket*, which must be a full socket. The *level* at
  * 		which the option resides and the name *optname* of the option
  * 		must be specified, see **setsockopt(2)** for more information.
  * 		The option value of length *optlen* is pointed by *optval*.
+ *
+ * 		*bpf_socket* should be one of the following:
+ *
+ * 		* **struct bpf_sock_ops** for **BPF_PROG_TYPE_SOCK_OPS**.
+ * 		* **struct bpf_sock_addr** for **BPF_CGROUP_INET4_CONNECT**
+ * 		  and **BPF_CGROUP_INET6_CONNECT**.
  *
  * 		This helper actually implements a subset of **setsockopt()**.
  * 		It supports the following *level*\ s:
@@ -1588,6 +1634,13 @@ union bpf_attr {
  * 	Description
  * 		Grow or shrink the room for data in the packet associated to
  * 		*skb* by *len_diff*, and according to the selected *mode*.
+ *
+ * 		By default, the helper will reset any offloaded checksum
+ * 		indicator of the skb to CHECKSUM_NONE. This can be avoided
+ * 		by the following flag:
+ *
+ * 		* **BPF_F_ADJ_ROOM_NO_CSUM_RESET**: Do not reset offloaded
+ * 		  checksum data of the skb to CHECKSUM_NONE.
  *
  *		There are two supported modes at this time:
  *
@@ -1634,15 +1687,15 @@ union bpf_attr {
  *
  * 		The lower two bits of *flags* are used as the return code if
  * 		the map lookup fails. This is so that the return value can be
- * 		one of the XDP program return codes up to XDP_TX, as chosen by
- * 		the caller. Any higher bits in the *flags* argument must be
+ * 		one of the XDP program return codes up to **XDP_TX**, as chosen
+ * 		by the caller. Any higher bits in the *flags* argument must be
  * 		unset.
  *
- * 		See also bpf_redirect(), which only supports redirecting to an
- * 		ifindex, but doesn't require a map to do so.
+ * 		See also **bpf_redirect**\ (), which only supports redirecting
+ * 		to an ifindex, but doesn't require a map to do so.
  * 	Return
  * 		**XDP_REDIRECT** on success, or the value of the two lower bits
- * 		of the **flags* argument on error.
+ * 		of the *flags* argument on error.
  *
  * int bpf_sk_redirect_map(struct sk_buff *skb, struct bpf_map *map, u32 key, u64 flags)
  * 	Description
@@ -1747,7 +1800,7 @@ union bpf_attr {
  * 		the time running for event since last normalization. The
  * 		enabled and running times are accumulated since the perf event
  * 		open. To achieve scaling factor between two invocations of an
- * 		eBPF program, users can can use CPU id as the key (which is
+ * 		eBPF program, users can use CPU id as the key (which is
  * 		typical for perf array usage model) to remember the previous
  * 		value and do the calculation inside the eBPF program.
  * 	Return
@@ -1764,7 +1817,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_getsockopt(struct bpf_sock_ops *bpf_socket, int level, int optname, void *optval, int optlen)
+ * int bpf_getsockopt(void *bpf_socket, int level, int optname, void *optval, int optlen)
  * 	Description
  * 		Emulate a call to **getsockopt()** on the socket associated to
  * 		*bpf_socket*, which must be a full socket. The *level* at
@@ -1772,6 +1825,12 @@ union bpf_attr {
  * 		must be specified, see **getsockopt(2)** for more information.
  * 		The retrieved value is stored in the structure pointed by
  * 		*opval* and of length *optlen*.
+ *
+ * 		*bpf_socket* should be one of the following:
+ *
+ * 		* **struct bpf_sock_ops** for **BPF_PROG_TYPE_SOCK_OPS**.
+ * 		* **struct bpf_sock_addr** for **BPF_CGROUP_INET4_CONNECT**
+ * 		  and **BPF_CGROUP_INET6_CONNECT**.
  *
  * 		This helper actually implements a subset of **getsockopt()**.
  * 		It supports the following *level*\ s:
@@ -1790,7 +1849,7 @@ union bpf_attr {
  * 		The first argument is the context *regs* on which the kprobe
  * 		works.
  *
- * 		This helper works by setting setting the PC (program counter)
+ * 		This helper works by setting the PC (program counter)
  * 		to an override function which is run in place of the original
  * 		probed function. This means the probed function is not run at
  * 		all. The replacement function just returns with the required
@@ -1959,18 +2018,19 @@ union bpf_attr {
  *
  * 		This helper works for IPv4 and IPv6, TCP and UDP sockets. The
  * 		domain (*addr*\ **->sa_family**) must be **AF_INET** (or
- * 		**AF_INET6**). Looking for a free port to bind to can be
- * 		expensive, therefore binding to port is not permitted by the
- * 		helper: *addr*\ **->sin_port** (or **sin6_port**, respectively)
- * 		must be set to zero.
+ * 		**AF_INET6**). It's advised to pass zero port (**sin_port**
+ * 		or **sin6_port**) which triggers IP_BIND_ADDRESS_NO_PORT-like
+ * 		behavior and lets the kernel efficiently pick up an unused
+ * 		port as long as 4-tuple is unique. Passing non-zero port might
+ * 		lead to degraded performance.
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
  * int bpf_xdp_adjust_tail(struct xdp_buff *xdp_md, int delta)
  * 	Description
  * 		Adjust (move) *xdp_md*\ **->data_end** by *delta* bytes. It is
- * 		only possible to shrink the packet as of this writing,
- * 		therefore *delta* must be a negative integer.
+ * 		possible to both shrink and grow the packet tail.
+ * 		Shrink done via *delta* being a negative integer.
  *
  * 		A call to this helper is susceptible to change the underlying
  * 		packet buffer. Therefore, at load time, all checks on pointers
@@ -2256,7 +2316,7 @@ union bpf_attr {
  *		**bpf_rc_keydown**\ () again with the same values, or calling
  *		**bpf_rc_repeat**\ ().
  *
- *		Some protocols include a toggle bit, in case the button	was
+ *		Some protocols include a toggle bit, in case the button was
  *		released and pressed again between consecutive scancodes.
  *
  *		The *ctx* should point to the lirc sample as passed into
@@ -2602,7 +2662,6 @@ union bpf_attr {
  *
  * 		*th* points to the start of the TCP header, while *th_len*
  * 		contains **sizeof**\ (**struct tcphdr**).
- *
  * 	Return
  * 		0 if *iph* and *th* are a valid SYN cookie ACK, or a negative
  * 		error otherwise.
@@ -2785,7 +2844,6 @@ union bpf_attr {
  *
  *		*th* points to the start of the TCP header, while *th_len*
  *		contains the length of the TCP header.
- *
  *	Return
  *		On success, lower 32 bits hold the generated SYN cookie in
  *		followed by 16 bits which hold the MSS value for that cookie,
@@ -2868,7 +2926,7 @@ union bpf_attr {
  * 				// size, after checking its boundaries.
  * 			}
  *
- * 		In comparison, using **bpf_probe_read_user()** helper here
+ * 		In comparison, using **bpf_probe_read_user**\ () helper here
  * 		instead to read the string would require to estimate the length
  * 		at compile time, and would often result in copying more memory
  * 		than necessary.
@@ -2886,14 +2944,14 @@ union bpf_attr {
  * int bpf_probe_read_kernel_str(void *dst, u32 size, const void *unsafe_ptr)
  * 	Description
  * 		Copy a NUL terminated string from an unsafe kernel address *unsafe_ptr*
- * 		to *dst*. Same semantics as with bpf_probe_read_user_str() apply.
+ * 		to *dst*. Same semantics as with **bpf_probe_read_user_str**\ () apply.
  * 	Return
- * 		On success, the strictly positive length of the string,	including
+ * 		On success, the strictly positive length of the string, including
  * 		the trailing NUL character. On error, a negative value.
  *
  * int bpf_tcp_send_ack(void *tp, u32 rcv_nxt)
  *	Description
- *		Send out a tcp-ack. *tp* is the in-kernel struct tcp_sock.
+ *		Send out a tcp-ack. *tp* is the in-kernel struct **tcp_sock**.
  *		*rcv_nxt* is the ack_seq to be sent out.
  *	Return
  *		0 on success, or a negative error in case of failure.
@@ -2921,19 +2979,19 @@ union bpf_attr {
  * int bpf_read_branch_records(struct bpf_perf_event_data *ctx, void *buf, u32 size, u64 flags)
  *	Description
  *		For an eBPF program attached to a perf event, retrieve the
- *		branch records (struct perf_branch_entry) associated to *ctx*
- *		and store it in	the buffer pointed by *buf* up to size
+ *		branch records (**struct perf_branch_entry**) associated to *ctx*
+ *		and store it in the buffer pointed by *buf* up to size
  *		*size* bytes.
  *	Return
  *		On success, number of bytes written to *buf*. On error, a
  *		negative value.
  *
  *		The *flags* can be set to **BPF_F_GET_BRANCH_RECORDS_SIZE** to
- *		instead	return the number of bytes required to store all the
+ *		instead return the number of bytes required to store all the
  *		branch entries. If this flag is set, *buf* may be NULL.
  *
  *		**-EINVAL** if arguments invalid or **size** not a multiple
- *		of sizeof(struct perf_branch_entry).
+ *		of **sizeof**\ (**struct perf_branch_entry**\ ).
  *
  *		**-ENOENT** if architecture does not support branch records.
  *
@@ -2941,8 +2999,8 @@ union bpf_attr {
  *	Description
  *		Returns 0 on success, values for *pid* and *tgid* as seen from the current
  *		*namespace* will be returned in *nsdata*.
- *
- *		On failure, the returned value is one of the following:
+ *	Return
+ *		0 on success, or one of the following in case of failure:
  *
  *		**-EINVAL** if dev and inum supplied don't match dev_t and inode number
  *              with nsfs of current task, or if dev conversion to dev_t lost high bits.
@@ -2981,8 +3039,8 @@ union bpf_attr {
  * 		a global identifier that can be assumed unique. If *ctx* is
  * 		NULL, then the helper returns the cookie for the initial
  * 		network namespace. The cookie itself is very similar to that
- * 		of bpf_get_socket_cookie() helper, but for network namespaces
- * 		instead of sockets.
+ * 		of **bpf_get_socket_cookie**\ () helper, but for network
+ * 		namespaces instead of sockets.
  * 	Return
  * 		A 8-byte long opaque number.
  *
@@ -3017,14 +3075,183 @@ union bpf_attr {
  *
  *		The *flags* argument must be zero.
  *	Return
- *		0 on success, or a negative errno in case of failure.
+ *		0 on success, or a negative error in case of failure:
  *
- *		* **-EINVAL**		Unsupported flags specified.
- *		* **-ENOENT**		Socket is unavailable for assignment.
- *		* **-ENETUNREACH**	Socket is unreachable (wrong netns).
- *		* **-EOPNOTSUPP**	Unsupported operation, for example a
- *					call from outside of TC ingress.
- *		* **-ESOCKTNOSUPPORT**	Socket type not supported (reuseport).
+ *		**-EINVAL** if specified *flags* are not supported.
+ *
+ *		**-ENOENT** if the socket is unavailable for assignment.
+ *
+ *		**-ENETUNREACH** if the socket is unreachable (wrong netns).
+ *
+ *		**-EOPNOTSUPP** if the operation is not supported, for example
+ *		a call from outside of TC ingress.
+ *
+ *		**-ESOCKTNOSUPPORT** if the socket type is not supported
+ *		(reuseport).
+ *
+ * u64 bpf_ktime_get_boot_ns(void)
+ * 	Description
+ * 		Return the time elapsed since system boot, in nanoseconds.
+ * 		Does include the time the system was suspended.
+ * 		See: **clock_gettime**\ (**CLOCK_BOOTTIME**)
+ * 	Return
+ * 		Current *ktime*.
+ *
+ * int bpf_seq_printf(struct seq_file *m, const char *fmt, u32 fmt_size, const void *data, u32 data_len)
+ * 	Description
+ * 		**bpf_seq_printf**\ () uses seq_file **seq_printf**\ () to print
+ * 		out the format string.
+ * 		The *m* represents the seq_file. The *fmt* and *fmt_size* are for
+ * 		the format string itself. The *data* and *data_len* are format string
+ * 		arguments. The *data* are a **u64** array and corresponding format string
+ * 		values are stored in the array. For strings and pointers where pointees
+ * 		are accessed, only the pointer values are stored in the *data* array.
+ * 		The *data_len* is the size of *data* in bytes.
+ *
+ *		Formats **%s**, **%p{i,I}{4,6}** requires to read kernel memory.
+ *		Reading kernel memory may fail due to either invalid address or
+ *		valid address but requiring a major memory fault. If reading kernel memory
+ *		fails, the string for **%s** will be an empty string, and the ip
+ *		address for **%p{i,I}{4,6}** will be 0. Not returning error to
+ *		bpf program is consistent with what **bpf_trace_printk**\ () does for now.
+ * 	Return
+ * 		0 on success, or a negative error in case of failure:
+ *
+ *		**-EBUSY** if per-CPU memory copy buffer is busy, can try again
+ *		by returning 1 from bpf program.
+ *
+ *		**-EINVAL** if arguments are invalid, or if *fmt* is invalid/unsupported.
+ *
+ *		**-E2BIG** if *fmt* contains too many format specifiers.
+ *
+ *		**-EOVERFLOW** if an overflow happened: The same object will be tried again.
+ *
+ * int bpf_seq_write(struct seq_file *m, const void *data, u32 len)
+ * 	Description
+ * 		**bpf_seq_write**\ () uses seq_file **seq_write**\ () to write the data.
+ * 		The *m* represents the seq_file. The *data* and *len* represent the
+ * 		data to write in bytes.
+ * 	Return
+ * 		0 on success, or a negative error in case of failure:
+ *
+ *		**-EOVERFLOW** if an overflow happened: The same object will be tried again.
+ *
+ * u64 bpf_sk_cgroup_id(struct bpf_sock *sk)
+ *	Description
+ *		Return the cgroup v2 id of the socket *sk*.
+ *
+ *		*sk* must be a non-**NULL** pointer to a full socket, e.g. one
+ *		returned from **bpf_sk_lookup_xxx**\ (),
+ *		**bpf_sk_fullsock**\ (), etc. The format of returned id is
+ *		same as in **bpf_skb_cgroup_id**\ ().
+ *
+ *		This helper is available only if the kernel was compiled with
+ *		the **CONFIG_SOCK_CGROUP_DATA** configuration option.
+ *	Return
+ *		The id is returned or 0 in case the id could not be retrieved.
+ *
+ * u64 bpf_sk_ancestor_cgroup_id(struct bpf_sock *sk, int ancestor_level)
+ *	Description
+ *		Return id of cgroup v2 that is ancestor of cgroup associated
+ *		with the *sk* at the *ancestor_level*.  The root cgroup is at
+ *		*ancestor_level* zero and each step down the hierarchy
+ *		increments the level. If *ancestor_level* == level of cgroup
+ *		associated with *sk*, then return value will be same as that
+ *		of **bpf_sk_cgroup_id**\ ().
+ *
+ *		The helper is useful to implement policies based on cgroups
+ *		that are upper in hierarchy than immediate cgroup associated
+ *		with *sk*.
+ *
+ *		The format of returned id and helper limitations are same as in
+ *		**bpf_sk_cgroup_id**\ ().
+ *	Return
+ *		The id is returned or 0 in case the id could not be retrieved.
+ *
+ * void *bpf_ringbuf_output(void *ringbuf, void *data, u64 size, u64 flags)
+ * 	Description
+ * 		Copy *size* bytes from *data* into a ring buffer *ringbuf*.
+ * 		If BPF_RB_NO_WAKEUP is specified in *flags*, no notification of
+ * 		new data availability is sent.
+ * 		IF BPF_RB_FORCE_WAKEUP is specified in *flags*, notification of
+ * 		new data availability is sent unconditionally.
+ * 	Return
+ * 		0, on success;
+ * 		< 0, on error.
+ *
+ * void *bpf_ringbuf_reserve(void *ringbuf, u64 size, u64 flags)
+ * 	Description
+ * 		Reserve *size* bytes of payload in a ring buffer *ringbuf*.
+ * 	Return
+ * 		Valid pointer with *size* bytes of memory available; NULL,
+ * 		otherwise.
+ *
+ * void bpf_ringbuf_submit(void *data, u64 flags)
+ * 	Description
+ * 		Submit reserved ring buffer sample, pointed to by *data*.
+ * 		If BPF_RB_NO_WAKEUP is specified in *flags*, no notification of
+ * 		new data availability is sent.
+ * 		IF BPF_RB_FORCE_WAKEUP is specified in *flags*, notification of
+ * 		new data availability is sent unconditionally.
+ * 	Return
+ * 		Nothing. Always succeeds.
+ *
+ * void bpf_ringbuf_discard(void *data, u64 flags)
+ * 	Description
+ * 		Discard reserved ring buffer sample, pointed to by *data*.
+ * 		If BPF_RB_NO_WAKEUP is specified in *flags*, no notification of
+ * 		new data availability is sent.
+ * 		IF BPF_RB_FORCE_WAKEUP is specified in *flags*, notification of
+ * 		new data availability is sent unconditionally.
+ * 	Return
+ * 		Nothing. Always succeeds.
+ *
+ * u64 bpf_ringbuf_query(void *ringbuf, u64 flags)
+ *	Description
+ *		Query various characteristics of provided ring buffer. What
+ *		exactly is queries is determined by *flags*:
+ *		  - BPF_RB_AVAIL_DATA - amount of data not yet consumed;
+ *		  - BPF_RB_RING_SIZE - the size of ring buffer;
+ *		  - BPF_RB_CONS_POS - consumer position (can wrap around);
+ *		  - BPF_RB_PROD_POS - producer(s) position (can wrap around);
+ *		Data returned is just a momentary snapshots of actual values
+ *		and could be inaccurate, so this facility should be used to
+ *		power heuristics and for reporting, not to make 100% correct
+ *		calculation.
+ *	Return
+ *		Requested value, or 0, if flags are not recognized.
+ *
+ * int bpf_csum_level(struct sk_buff *skb, u64 level)
+ * 	Description
+ * 		Change the skbs checksum level by one layer up or down, or
+ * 		reset it entirely to none in order to have the stack perform
+ * 		checksum validation. The level is applicable to the following
+ * 		protocols: TCP, UDP, GRE, SCTP, FCOE. For example, a decap of
+ * 		| ETH | IP | UDP | GUE | IP | TCP | into | ETH | IP | TCP |
+ * 		through **bpf_skb_adjust_room**\ () helper with passing in
+ * 		**BPF_F_ADJ_ROOM_NO_CSUM_RESET** flag would require one	call
+ * 		to **bpf_csum_level**\ () with **BPF_CSUM_LEVEL_DEC** since
+ * 		the UDP header is removed. Similarly, an encap of the latter
+ * 		into the former could be accompanied by a helper call to
+ * 		**bpf_csum_level**\ () with **BPF_CSUM_LEVEL_INC** if the
+ * 		skb is still intended to be processed in higher layers of the
+ * 		stack instead of just egressing at tc.
+ *
+ * 		There are three supported level settings at this time:
+ *
+ * 		* **BPF_CSUM_LEVEL_INC**: Increases skb->csum_level for skbs
+ * 		  with CHECKSUM_UNNECESSARY.
+ * 		* **BPF_CSUM_LEVEL_DEC**: Decreases skb->csum_level for skbs
+ * 		  with CHECKSUM_UNNECESSARY.
+ * 		* **BPF_CSUM_LEVEL_RESET**: Resets skb->csum_level to 0 and
+ * 		  sets CHECKSUM_NONE to force checksum validation by the stack.
+ * 		* **BPF_CSUM_LEVEL_QUERY**: No-op, returns the current
+ * 		  skb->csum_level.
+ * 	Return
+ * 		0 on success, or a negative error in case of failure. In the
+ * 		case of **BPF_CSUM_LEVEL_QUERY**, the current skb->csum_level
+ * 		is returned or the error code -EACCES in case the skb is not
+ * 		subject to CHECKSUM_UNNECESSARY.
  */
 #define __BPF_FUNC_MAPPER(FN)		\
 	FN(unspec),			\
@@ -3151,7 +3378,18 @@ union bpf_attr {
 	FN(xdp_output),			\
 	FN(get_netns_cookie),		\
 	FN(get_current_ancestor_cgroup_id),	\
-	FN(sk_assign),
+	FN(sk_assign),			\
+	FN(ktime_get_boot_ns),		\
+	FN(seq_printf),			\
+	FN(seq_write),			\
+	FN(sk_cgroup_id),		\
+	FN(sk_ancestor_cgroup_id),	\
+	FN(ringbuf_output),		\
+	FN(ringbuf_reserve),		\
+	FN(ringbuf_submit),		\
+	FN(ringbuf_discard),		\
+	FN(ringbuf_query),		\
+	FN(csum_level),
 
 /* integer value in 'imm' field of BPF_CALL instruction selects which helper
  * function eBPF program intends to call
@@ -3228,6 +3466,14 @@ enum {
 	BPF_F_CURRENT_NETNS		= (-1L),
 };
 
+/* BPF_FUNC_csum_level level values. */
+enum {
+	BPF_CSUM_LEVEL_QUERY,
+	BPF_CSUM_LEVEL_INC,
+	BPF_CSUM_LEVEL_DEC,
+	BPF_CSUM_LEVEL_RESET,
+};
+
 /* BPF_FUNC_skb_adjust_room flags. */
 enum {
 	BPF_F_ADJ_ROOM_FIXED_GSO	= (1ULL << 0),
@@ -3235,6 +3481,7 @@ enum {
 	BPF_F_ADJ_ROOM_ENCAP_L3_IPV6	= (1ULL << 2),
 	BPF_F_ADJ_ROOM_ENCAP_L4_GRE	= (1ULL << 3),
 	BPF_F_ADJ_ROOM_ENCAP_L4_UDP	= (1ULL << 4),
+	BPF_F_ADJ_ROOM_NO_CSUM_RESET	= (1ULL << 5),
 };
 
 enum {
@@ -3259,6 +3506,29 @@ enum {
 /* BPF_FUNC_read_branch_records flags. */
 enum {
 	BPF_F_GET_BRANCH_RECORDS_SIZE	= (1ULL << 0),
+};
+
+/* BPF_FUNC_bpf_ringbuf_commit, BPF_FUNC_bpf_ringbuf_discard, and
+ * BPF_FUNC_bpf_ringbuf_output flags.
+ */
+enum {
+	BPF_RB_NO_WAKEUP		= (1ULL << 0),
+	BPF_RB_FORCE_WAKEUP		= (1ULL << 1),
+};
+
+/* BPF_FUNC_bpf_ringbuf_query flags */
+enum {
+	BPF_RB_AVAIL_DATA = 0,
+	BPF_RB_RING_SIZE = 1,
+	BPF_RB_CONS_POS = 2,
+	BPF_RB_PROD_POS = 3,
+};
+
+/* BPF ring buffer constants */
+enum {
+	BPF_RINGBUF_BUSY_BIT		= (1U << 31),
+	BPF_RINGBUF_DISCARD_BIT		= (1U << 30),
+	BPF_RINGBUF_HDR_SZ		= 8,
 };
 
 /* Mode for BPF_FUNC_skb_adjust_room helper. */
@@ -3400,6 +3670,7 @@ struct bpf_sock {
 	__u32 dst_ip4;
 	__u32 dst_ip6[4];
 	__u32 state;
+	__s32 rx_queue_mapping;
 };
 
 struct bpf_tcp_sock {
@@ -3493,6 +3764,8 @@ struct xdp_md {
 	/* Below access go through struct xdp_rxq_info */
 	__u32 ingress_ifindex; /* rxq->dev->ifindex */
 	__u32 rx_queue_index;  /* rxq->queue_index  */
+
+	__u32 egress_ifindex;  /* txq->dev->ifindex */
 };
 
 enum sk_action {
@@ -3515,6 +3788,8 @@ struct sk_msg_md {
 	__u32 remote_port;	/* Stored in network byte order */
 	__u32 local_port;	/* stored in host byte order */
 	__u32 size;		/* Total size of sk_msg */
+
+	__bpf_md_ptr(struct bpf_sock *, sk); /* current socket */
 };
 
 struct sk_reuseport_md {
@@ -3605,6 +3880,29 @@ struct bpf_btf_info {
 	__u32 id;
 } __attribute__((aligned(8)));
 
+struct bpf_link_info {
+	__u32 type;
+	__u32 id;
+	__u32 prog_id;
+	union {
+		struct {
+			__aligned_u64 tp_name; /* in/out: tp_name buffer ptr */
+			__u32 tp_name_len;     /* in/out: tp_name buffer len */
+		} raw_tracepoint;
+		struct {
+			__u32 attach_type;
+		} tracing;
+		struct {
+			__u64 cgroup_id;
+			__u32 attach_type;
+		} cgroup;
+		struct  {
+			__u32 netns_ino;
+			__u32 attach_type;
+		} netns;
+	};
+} __attribute__((aligned(8)));
+
 /* User bpf_sock_addr struct to access socket fields and sockaddr struct passed
  * by user and intended to be used by socket (e.g. to bind to, depends on
  * attach attach type).
@@ -3617,7 +3915,7 @@ struct bpf_sock_addr {
 	__u32 user_ip6[4];	/* Allows 1,2,4,8-byte read and 4,8-byte write.
 				 * Stored in network byte order.
 				 */
-	__u32 user_port;	/* Allows 4-byte read and write.
+	__u32 user_port;	/* Allows 1,2,4-byte read and 4-byte write.
 				 * Stored in network byte order
 				 */
 	__u32 family;		/* Allows 4-byte read, but no write */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -550,8 +550,8 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if (!svc || (!lb6_svc_is_external_ip(svc) &&
-		     !lb6_svc_is_nodeport(svc) &&
+	if (!svc || (!lb6_svc_is_nodeport(svc) &&
+		     !lb6_svc_is_external_ip(svc) &&
 		     !lb6_svc_is_hostport(svc))) {
 		if (svc)
 			return DROP_IS_CLUSTER_IP;
@@ -888,11 +888,12 @@ static __always_inline int set_dsr_opt4(struct __ctx_buff *ctx,
 					struct iphdr *ip4,
 					__be32 svc_addr, __be32 svc_port)
 {
-	union tcp_flags tcp_flags = { .value = 0 };
 	__u32 iph_old, iph_new, opt[2];
 	__be32 sum;
 
 	if (ip4->protocol == IPPROTO_TCP) {
+		union tcp_flags tcp_flags = { .value = 0 };
+
 		if (ctx_load_bytes(ctx, ETH_HLEN + sizeof(*ip4) + 12,
 				   &tcp_flags, 2) < 0)
 			return DROP_CT_INVALID_HDR;
@@ -1214,8 +1215,8 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if (!svc || (!lb4_svc_is_external_ip(svc) &&
-		     !lb4_svc_is_nodeport(svc) &&
+	if (!svc || (!lb4_svc_is_nodeport(svc) &&
+		     !lb4_svc_is_external_ip(svc) &&
 		     !lb4_svc_is_hostport(svc))) {
 		if (svc)
 			return DROP_IS_CLUSTER_IP;

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -3,7 +3,7 @@
 # development environmennt
 FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
-FROM quay.io/cilium/cilium-runtime:2020-06-02
+FROM quay.io/cilium/cilium-runtime:2020-06-08
 LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -50,7 +50,7 @@ RUN apt-get update && \
     curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${ARCH}-v0.7.5.tgz -o cni.tar.gz && \
     tar -xvf cni.tar.gz ./loopback && \
     strip -s ./loopback
-COPY --from=docker.io/cilium/cilium-llvm:629310350b8cf33a1e426e167e1caadb6848f6c5 /bin/clang /bin/llc /bin/
+COPY --from=docker.io/cilium/cilium-llvm:178583d8925906270379830fb44641c38f7cc062 /bin/clang /bin/llc /bin/
 COPY --from=docker.io/cilium/cilium-bpftool:f0bbd0cb389ce92b33ff29f0489c17c8e33f9da7 /bin/bpftool /bin/
 COPY --from=docker.io/cilium/cilium-iproute2:044e7a6a43d5a42a8ce696535b3dbf773f82dbec /bin/tc /bin/ip /bin/ss /bin/
 COPY --from=gops /go/bin/gops /bin/

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
 )
@@ -144,10 +145,19 @@ func getMetricValue(state string) int64 {
 }
 
 func assertOnMetric(c *C, state string, expected int64) {
-	obtained := getMetricValue(state)
-	if obtained != expected {
-		_, _, line, _ := runtime.Caller(1)
-		c.Errorf("Metrics assertion failed on line %d for Endpoint state %s: obtained %d, expected %d",
-			line, state, obtained, expected)
+	_, _, line, _ := runtime.Caller(1)
+
+	obtainedValues := make(map[int64]struct{}, 0)
+	err := testutils.WaitUntil(func() bool {
+		obtained := getMetricValue(state)
+		obtainedValues[obtained] = struct{}{}
+		return obtained == expected
+	}, 10*time.Second)
+	if err != nil {
+		// We are printing the map here to show every unique obtained metrics
+		// value because these values change rapidly and it may be misleading
+		// to only show the last obtained value.
+		c.Errorf("Metrics assertion failed on line %d for Endpoint state %s: obtained %v, expected %d",
+			line, state, obtainedValues, expected)
 	}
 }

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -6,6 +6,7 @@ include ../../Makefile.defs
 MANAGED_ETCD_VERSION := "v2.0.7"
 
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
+EXPERIMENTAL_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/experimental-install.yaml"
 MANAGED_ETCD_PATH := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/charts/managed-etcd/values.yaml"
 CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/"
 CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml"
@@ -16,11 +17,20 @@ DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
 CILIUM_PULLPOLICY_REGEX := '\(pullPolicy:\) .*'
+EXPERIMENTAL_OPTIONS := \
+    --set global.hubble.enabled=true \
+    --set global.hubble.listenAddress=":4244" \
+    --set global.hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}" \
+    --set global.hubble.relay.enabled=true \
+    --set global.hubble.ui.enabled=true
 
-all: update-versions $(QUICK_INSTALL)
+all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL)
 
 $(QUICK_INSTALL): $(shell find cilium/ -type f)
 	$(QUIET)helm template cilium --namespace=kube-system $(OPTS) > $(QUICK_INSTALL)
+
+$(EXPERIMENTAL_INSTALL): $(shell find cilium/ -type f)
+	$(QUIET)helm template cilium --namespace=kube-system $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
 
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"
@@ -43,6 +53,6 @@ update-versions:
 	$(QUIET)sed -i 's/'$(VERSION)'/'$(MANAGED_ETCD_VERSION)'/' $(MANAGED_ETCD_PATH)
 
 clean:
-	$(RM) $(QUICK_INSTALL)
+	$(RM) $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL)
 
 .phony: all clean update-versions

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace }}
   name: hubble-ui
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -1,0 +1,905 @@
+---
+# Source: cilium/charts/agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system
+---
+# Source: cilium/charts/hubble-ui/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+---
+# Source: cilium/charts/operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+# Source: cilium/charts/config/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+
+  # Identity allocation mode selects how identities are shared between cilium
+  # nodes by setting how they are stored. The options are "crd" or "kvstore".
+  # - "crd" stores identities in kubernetes as CRDs (custom resource definition).
+  #   These can be queried with:
+  #     kubectl get ciliumid
+  # - "kvstore" stores identities in a kvstore, etcd or consul, that is
+  #   configured below. Cilium versions before 1.6 supported only the kvstore
+  #   backend. Upgrades from these older cilium versions should continue using
+  #   the kvstore by commenting out the identity-allocation-mode below, or
+  #   setting it to "kvstore".
+  identity-allocation-mode: crd
+
+  # identity-change-grace-period is the grace period that needs to pass
+  # before an endpoint that has changed its identity will start using
+  # that new identity. During the grace period, the new identity has
+  # already been allocated and other nodes in the cluster have a chance
+  # to whitelist the new upcoming identity of the endpoint.
+  identity-change-grace-period: "5s"
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  # Set the TCP port for the agent health status API. This is not the port used
+  # for cilium-health.
+  agent-health-port: "9876"
+
+  # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
+  # address.
+  enable-ipv4: "true"
+
+  # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
+  # address.
+  enable-ipv6: "false"
+
+  enable-bpf-clock-probe: "true"
+
+  # If you want cilium monitor to aggregate tracing for packets, set this level
+  # to "low", "medium", or "maximum". The higher the level, the less packets
+  # that will be seen in monitor output.
+  monitor-aggregation: medium
+
+  # The monitor aggregation interval governs the typical time between monitor
+  # notification events for each allowed connection.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-interval: 5s
+
+  # The monitor aggregation flags determine which TCP flags which, upon the
+  # first observation, cause monitor notifications to be generated.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-flags: all
+
+  # bpf-ct-global-*-max specifies the maximum number of connections
+  # supported across all endpoints, split by protocol: tcp or other. One pair
+  # of maps uses these values for IPv4 connections, and another pair of maps
+  # use these values for IPv6 connections.
+  #
+  # If these values are modified, then during the next Cilium startup the
+  # tracking of ongoing connections may be disrupted. This may lead to brief
+  # policy drops or a change in loadbalancing decisions for a connection.
+  #
+  # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
+  # during the upgrade process, set bpf-ct-global-tcp-max to 1000000.
+  bpf-ct-global-tcp-max: "524288"
+  bpf-ct-global-any-max: "262144"
+
+  # bpf-nat-global-max specified the maximum number of entries in the
+  # BPF NAT table.
+  bpf-nat-global-max: "524288"
+
+  # bpf-neigh-global-max specified the maximum number of entries in the
+  # BPF neighbor table.
+  bpf-neigh-global-max: "524288"
+
+  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "16384"
+
+  # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
+  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
+  bpf-map-dynamic-size-ratio: "0.03"
+
+  # Pre-allocation of map entries allows per-packet latency to be reduced, at
+  # the expense of up-front memory allocation for the entries in the maps. The
+  # default value below will minimize memory usage in the default installation;
+  # users who are sensitive to latency may consider setting this to "true".
+  #
+  # This option was introduced in Cilium 1.4. Cilium 1.3 and earlier ignore
+  # this option and behave as though it is set to "true".
+  #
+  # If this value is modified, then during the next Cilium startup the restore
+  # of existing endpoints and tracking of ongoing connections may be disrupted.
+  # This may lead to policy drops or a change in loadbalancing decisions for a
+  # connection for some time. Endpoints may need to be recreated to restore
+  # connectivity.
+  #
+  # If this option is set to "false" during an upgrade from 1.3 or earlier to
+  # 1.4 or later, then it may cause one-time disruptions during the upgrade.
+  preallocate-bpf-maps: "false"
+
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
+  tunnel: vxlan
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # DNS Polling periodically issues a DNS lookup for each `matchName` from
+  # cilium-agent. The result is used to regenerate endpoint policy.
+  # DNS lookups are repeated with an interval of 5 seconds, and are made for
+  # A(IPv4) and AAAA(IPv6) addresses. Should a lookup fail, the most recent IP
+  # data is used instead. An IP change will trigger a regeneration of the Cilium
+  # policy for each endpoint and increment the per cilium-agent policy
+  # repository revision.
+  #
+  # This option is disabled by default starting from version 1.4.x in favor
+  # of a more powerful DNS proxy-based implementation, see [0] for details.
+  # Enable this option if you want to use FQDN policies but do not want to use
+  # the DNS proxy.
+  #
+  # To ease upgrade, users may opt to set this option to "true".
+  # Otherwise please refer to the Upgrade Guide [1] which explains how to
+  # prepare policy rules for upgrade.
+  #
+  # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
+  # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
+  tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
+
+  masquerade: "true"
+  enable-bpf-masquerade: "false"
+  enable-xt-socket-fallback: "true"
+  install-iptables-rules: "true"
+  auto-direct-node-routes: "false"
+  kube-proxy-replacement:  "probe"
+  node-port-bind-protection: "true"
+  enable-auto-protect-node-port-range: "true"
+  enable-session-affinity: "true"
+  k8s-require-ipv4-pod-cidr: "true"
+  k8s-require-ipv6-pod-cidr: "false"
+  enable-endpoint-health-checking: "true"
+  enable-health-checking: "true"
+  enable-well-known-identities: "false"
+  enable-remote-node-identity: "true"
+
+  synchronize-k8s-nodes: "true"
+  policy-audit-mode: "false"
+  operator-api-serve-addr: '127.0.0.1:9234'
+
+  # Enable Hubble gRPC service.
+  enable-hubble: "true"
+  # UNIX domain socket for Hubble server to listen to.
+  hubble-socket-path:  "/var/run/cilium/hubble.sock"
+  # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this
+  # field is not set.
+  hubble-metrics-server: ":9091"
+  # A space separated list of metrics to enable. See [0] for available metrics.
+  #
+  # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md
+  hubble-metrics:
+    dns
+    drop
+    tcp
+    flow
+    port-distribution
+    icmp
+    http
+  # An additional address for Hubble server to listen to (e.g. ":4244").
+  hubble-listen-address: ":4244"
+
+  # A space separated list of iptables chains to disable when installing feeder rules.
+  disable-iptables-feeder-rules: ""
+  ipam: "cluster-pool"
+  cluster-pool-ipv4-cidr: "10.0.0.0/8"
+  cluster-pool-ipv4-mask-size: "24"
+  disable-cnp-status-updates: "true"
+---
+# Source: cilium/charts/agent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  - ciliumnodes
+  - ciliumnodes/status
+  - ciliumidentities
+  verbs:
+  - '*'
+---
+# Source: cilium/charts/hubble-ui/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hubble-ui 
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - endpoints
+      - namespaces
+      - nodes
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: cilium/charts/operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
+  - services
+  - endpoints
+  # to check apiserver connectivity
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  - ciliumnodes
+  - ciliumnodes/status
+  - ciliumidentities
+  - ciliumidentities/status
+  verbs:
+  - '*'
+---
+# Source: cilium/charts/agent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+---
+# Source: cilium/charts/hubble-ui/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hubble-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble-ui 
+subjects:
+  - kind: ServiceAccount
+    namespace: kube-system
+    name: hubble-ui
+---
+# Source: cilium/charts/operator/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
+# Source: cilium/charts/hubble-relay/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-relay
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: hubble-relay
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 4245
+---
+# Source: cilium/charts/hubble-ui/templates/svc.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: kube-system
+  name: hubble-ui
+spec:
+  selector:
+    k8s-app: hubble-ui
+  ports:
+    - name: http
+      port: 12000
+      targetPort: 12000
+  type: ClusterIP
+---
+# Source: cilium/charts/agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: cilium
+  name: cilium
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  template:
+    metadata:
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: cilium
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values:
+                - cilium
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - --config-dir=/tmp/cilium/config-map
+        command:
+        - cilium-agent
+        livenessProbe:
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: 9876
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: 9876
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_FLANNEL_MASTER_DEVICE
+          valueFrom:
+            configMapKeyRef:
+              key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
+          valueFrom:
+            configMapKeyRef:
+              key: flannel-uninstall-on-exit
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
+        image: "docker.io/cilium/cilium:v1.8.0-rc2"
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "/cni-install.sh"
+              - "--enable-debug=false"
+          preStop:
+            exec:
+              command:
+              - /cni-uninstall.sh
+        name: cilium-agent
+        ports:
+        - containerPort: 9091
+          hostPort: 9091
+          name: hubble-metrics
+          protocol: TCP
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_MODULE
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+        - mountPath: /tmp/cilium/config-map
+          name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+      hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CILIUM_ALL_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
+        image: "docker.io/cilium/cilium:v1.8.0-rc2"
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+          mountPropagation: HostToContainer
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 1
+      tolerations:
+      - operator: Exists
+      volumes:
+        # To keep state between restarts / upgrades
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
+        # To keep state between restarts / upgrades for bpf maps
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
+      # To install cilium cni plugin in the host
+      - hostPath:
+          path:  /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
+        # To install cilium cni configuration in the host
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+        # To read the clustermesh configuration
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+        # To read the configuration from the config map
+      - configMap:
+          name: cilium-config
+        name: cilium-config-path
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
+---
+# Source: cilium/charts/hubble-relay/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-relay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-relay
+  template:
+    metadata:
+      labels:
+        k8s-app: hubble-relay
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: "k8s-app"
+                  operator: In
+                  values:
+                    - cilium
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: hubble-relay
+          image: "docker.io/cilium/hubble-relay:v1.8.0-rc2"
+          imagePullPolicy: IfNotPresent
+          command:
+            - "hubble-relay"
+          args:
+            - "serve"
+            - "--peer-service=unix:///var/run/cilium/hubble.sock"
+            - "--listen-address=:4245"
+          ports:
+            - name: grpc
+              containerPort: 4245
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+          livenessProbe:
+            tcpSocket:
+              port: grpc
+          volumeMounts:
+          - mountPath: /var/run/cilium
+            name: hubble-sock-dir
+            readOnly: true
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/run/cilium
+          type: Directory
+        name: hubble-sock-dir
+---
+# Source: cilium/charts/hubble-ui/templates/deployment.yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  namespace: kube-system
+  name: hubble-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-ui
+  template:
+    metadata:
+      labels:
+        k8s-app: hubble-ui
+    spec:
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: hubble-ui
+      containers:
+        - name: hubble-ui
+          image: "quay.io/cilium/hubble-ui:v0.6.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: HUBBLE
+              value: "true"
+            - name: HUBBLE_SERVICE
+              value: "hubble-relay.kube-system.svc.cluster.local"
+            - name: HUBBLE_PORT
+              value: "80"
+          ports:
+            - containerPort: 12000
+              name: http
+          resources:
+            {}
+---
+# Source: cilium/charts/operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        io.cilium/app: operator
+        name: cilium-operator
+    spec:
+      containers:
+      - args:
+        - --config-dir=/tmp/cilium/config-map
+        - --debug=$(CILIUM_DEBUG)
+        command:
+        - cilium-operator
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
+        image: "docker.io/cilium/operator:v1.8.0-rc2"
+        imagePullPolicy: IfNotPresent
+        name: cilium-operator
+        livenessProbe:
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
+        volumeMounts:
+        - mountPath: /tmp/cilium/config-map
+          name: cilium-config-path
+          readOnly: true
+      hostNetwork: true
+      restartPolicy: Always
+      priorityClassName: system-cluster-critical
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
+      volumes:
+        # To read the configuration from the config map
+      - configMap:
+          name: cilium-config
+        name: cilium-config-path

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -47,6 +47,11 @@ type LoadTimeConfiguration interface {
 	// GetIdentity returns a globally-significant numeric security identity.
 	GetIdentity() identity.NumericIdentity
 
+	// GetIdentityLocked returns a globally-significant numeric security
+	// identity while assuming that the backing data structure is locked.
+	// This function should be removed in favour of GetIdentity()
+	GetIdentityLocked() identity.NumericIdentity
+
 	IPv4Address() addressing.CiliumIPv4
 	IPv6Address() addressing.CiliumIPv6
 	GetNodeMAC() mac.MAC

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -482,7 +482,7 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 
 	fmt.Fprint(fw, defineMAC("NODE_MAC", e.GetNodeMAC()))
 
-	secID := e.GetIdentity().Uint32()
+	secID := e.GetIdentityLocked().Uint32()
 	fmt.Fprintf(fw, defineUint32("SECLABEL", secID))
 	fmt.Fprintf(fw, defineUint32("SECLABEL_NB", byteorder.HostToNetwork(secID).(uint32)))
 	fmt.Fprintf(fw, defineUint32("POLICY_VERDICT_LOG_FILTER", e.GetPolicyVerdictLogFilter()))
@@ -558,7 +558,7 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 	return fw.Flush()
 }
 
-// WriteEndpointConfig writes the BPF configuration for the template to a writer.
+// WriteTemplateConfig writes the BPF configuration for the template to a writer.
 func (h *HeaderfileWriter) WriteTemplateConfig(w io.Writer, e datapath.EndpointConfiguration) error {
 	fw := bufio.NewWriter(w)
 	return h.writeTemplateConfig(fw, e)

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -101,6 +101,13 @@ func (t *templateCfg) GetIdentity() identity.NumericIdentity {
 	return templateSecurityID
 }
 
+// GetIdentityLocked is identical to GetIdentity(). This is a temporary
+// function until WriteEndpointConfig() no longer assumes that the endpoint is
+// locked.
+func (t *templateCfg) GetIdentityLocked() identity.NumericIdentity {
+	return templateSecurityID
+}
+
 // GetNodeMAC returns a well-known dummy MAC address which may be later
 // substituted in the ELF.
 func (t *templateCfg) GetNodeMAC() mac.MAC {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -72,6 +72,8 @@ func (e *Endpoint) BPFIpvlanMapPath() string {
 // strings describing the configuration of the datapath.
 //
 // For configuration of actual datapath behavior, see WriteEndpointConfig().
+//
+// e.Mutex must be held
 func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	fw := bufio.NewWriter(w)
 
@@ -107,7 +109,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		" * NodeMAC: %s\n"+
 		" */\n\n",
 		e.IPv4.String(),
-		e.GetIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
+		e.getIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
 		e.nodeMAC)
 
 	fw.WriteString("/*\n")
@@ -126,6 +128,9 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	return fw.Flush()
 }
 
+// writeHeaderfile writes the lxc_config.h header file of an endpoint
+//
+// e.Mutex must be held.
 func (e *Endpoint) writeHeaderfile(prefix string) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
 	e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -76,7 +76,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		id:                     e.GetID(),
 		ifName:                 e.ifName,
 		ipvlan:                 e.HasIpvlanDataPath(),
-		identity:               e.GetIdentity(),
+		identity:               e.getIdentity(),
 		mac:                    e.GetNodeMAC(),
 		ipv4:                   e.IPv4Address(),
 		ipv6:                   e.IPv6Address(),
@@ -128,6 +128,11 @@ func (ep *epInfoCache) StringID() string {
 
 // GetIdentity returns the security identity of the endpoint.
 func (ep *epInfoCache) GetIdentity() identity.NumericIdentity {
+	return ep.identity
+}
+
+// GetIdentityLocked returns the security identity of the endpoint.
+func (ep *epInfoCache) GetIdentityLocked() identity.NumericIdentity {
 	return ep.identity
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -613,7 +613,21 @@ func (e *Endpoint) StringID() string {
 	return strconv.Itoa(int(e.ID))
 }
 
+// GetIdentityLocked is identical to GetIdentity() but assumes that a.mutex is
+// already held. This function is obsolete and should no longer be used.
+func (e *Endpoint) GetIdentityLocked() identity.NumericIdentity {
+	return e.getIdentity()
+}
+
+// GetIdentity returns the numeric security identity of the endpoint
 func (e *Endpoint) GetIdentity() identity.NumericIdentity {
+	e.unconditionalRLock()
+	defer e.runlock()
+
+	return e.getIdentity()
+}
+
+func (e *Endpoint) getIdentity() identity.NumericIdentity {
 	if e.SecurityIdentity != nil {
 		return e.SecurityIdentity.ID
 	}
@@ -2234,7 +2248,7 @@ func (e *Endpoint) GetProxyInfoByFields() (uint64, string, string, []string, str
 	if e.IsDisconnecting() {
 		err = fmt.Errorf("endpoint is in the process of being deleted")
 	}
-	return e.GetID(), e.GetIPv4Address(), e.GetIPv6Address(), e.GetLabels(), e.GetLabelsSHA(), uint64(e.GetIdentity()), err
+	return e.GetID(), e.GetIPv4Address(), e.GetIPv6Address(), e.GetLabels(), e.GetLabelsSHA(), uint64(e.getIdentity()), err
 }
 
 // WaitForFirstRegeneration waits for specific conditions before returning:

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1054,7 +1054,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 		if ip == "" {
 			continue
 		}
-		networkPolicy := getNetworkPolicy(ip, ep.GetIdentity(), ep.ConntrackNameLocked(), policy, npMap,
+		networkPolicy := getNetworkPolicy(ip, ep.GetIdentityLocked(), ep.ConntrackNameLocked(), policy, npMap,
 			ingressPolicyEnforced, egressPolicyEnforced)
 		err := networkPolicy.Validate()
 		if err != nil {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -325,12 +325,14 @@ func (s *DNSProxyTestSuite) TestRejectNonMatchingRefusedResponse(c *C) {
 
 	// reject a query with NXDomain
 	s.proxy.SetRejectReply(option.FQDNProxyDenyWithNameError)
-	response, _, _ := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+	response, _, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed"))
 	c.Assert(response.Rcode, Equals, dns.RcodeNameError, Commentf("DNS request from test client was not rejected when it should be blocked"))
 
 	// reject a query with Refused
 	s.proxy.SetRejectReply(option.FQDNProxyDenyWithRefused)
-	response, _, _ = s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+	response, _, err = s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed"))
 	c.Assert(response.Rcode, Equals, dns.RcodeRefused, Commentf("DNS request from test client was not rejected when it should be blocked"))
 
 }

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -28,7 +28,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetIdentity() identity.NumericIdentity
+	GetIdentityLocked() identity.NumericIdentity
 	GetLabels() []string
 	GetLabelsSHA() string
 	HasSidecarProxy() bool

--- a/pkg/proxy/mock_test.go
+++ b/pkg/proxy/mock_test.go
@@ -35,19 +35,19 @@ type proxyUpdaterMock struct {
 }
 
 func (m *proxyUpdaterMock) GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error) {
-	return m.GetID(), m.GetIPv4Address(), m.GetIPv6Address(), m.GetLabels(), m.GetLabelsSHA(), uint64(m.GetIdentity()), nil
+	return m.GetID(), m.GetIPv4Address(), m.GetIPv6Address(), m.GetLabels(), m.GetLabelsSHA(), uint64(m.GetIdentityLocked()), nil
 }
 
 func (m *proxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
 func (m *proxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 
-func (m *proxyUpdaterMock) GetID() uint64                         { return m.id }
-func (m *proxyUpdaterMock) GetIPv4Address() string                { return m.ipv4 }
-func (m *proxyUpdaterMock) GetIPv6Address() string                { return m.ipv6 }
-func (m *proxyUpdaterMock) GetLabels() []string                   { return m.labels }
-func (m *proxyUpdaterMock) GetEgressPolicyEnabledLocked() bool    { return true }
-func (m *proxyUpdaterMock) GetIngressPolicyEnabledLocked() bool   { return true }
-func (m *proxyUpdaterMock) GetIdentity() identity.NumericIdentity { return m.identity }
+func (m *proxyUpdaterMock) GetID() uint64                               { return m.id }
+func (m *proxyUpdaterMock) GetIPv4Address() string                      { return m.ipv4 }
+func (m *proxyUpdaterMock) GetIPv6Address() string                      { return m.ipv6 }
+func (m *proxyUpdaterMock) GetLabels() []string                         { return m.labels }
+func (m *proxyUpdaterMock) GetEgressPolicyEnabledLocked() bool          { return true }
+func (m *proxyUpdaterMock) GetIngressPolicyEnabledLocked() bool         { return true }
+func (m *proxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.identity }
 func (m *proxyUpdaterMock) ProxyID(npMap policy.NamedPortsMap, l4 *policy.L4Filter) (string, error) {
 	return "", nil
 }

--- a/pkg/service/healthserver/healthserver.go
+++ b/pkg/service/healthserver/healthserver.go
@@ -130,7 +130,6 @@ func (s *ServiceHealthServer) UpsertService(svcID lb.ID, ns, name string, localE
 	// endpoints. We reference count the listeners to make sure we only have
 	// a single listener per port.
 
-	var srv healthHTTPServer
 	svc := NewService(ns, name, localEndpoints)
 	if !foundSvc {
 		// We only bump the reference count if this is a service ID we have

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -262,11 +262,16 @@ func (s *Service) UpsertService(
 	}
 
 	// Only add a HealthCheckNodePort server if this is a service which may
-	// only contain local backends.
+	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
 	if onlyLocalBackends {
 		localBackendCount := len(backendsCopy)
 		s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
 			localBackendCount, svc.svcHealthCheckNodePort)
+	} else if svc.svcHealthCheckNodePort == 0 {
+		// Remove the health check server in case this service used to have
+		// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
+		// version, but not anymore.
+		s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 	}
 
 	if new {

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -61,21 +61,22 @@ func NewTestHostEndpoint() TestEndpoint {
 	}
 }
 
-func (e *TestEndpoint) HasIpvlanDataPath() bool                 { return false }
-func (e *TestEndpoint) ConntrackLocalLocked() bool              { return false }
-func (e *TestEndpoint) RequireARPPassthrough() bool             { return false }
-func (e *TestEndpoint) RequireEgressProg() bool                 { return false }
-func (e *TestEndpoint) RequireRouting() bool                    { return false }
-func (e *TestEndpoint) RequireEndpointRoute() bool              { return false }
-func (e *TestEndpoint) GetPolicyVerdictLogFilter() uint32       { return 0xffff }
-func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)    { return nil, nil }
-func (e *TestEndpoint) GetID() uint64                           { return e.Id }
-func (e *TestEndpoint) StringID() string                        { return "42" }
-func (e *TestEndpoint) GetIdentity() identity.NumericIdentity   { return e.Identity.ID }
-func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity { return e.Identity }
-func (e *TestEndpoint) GetNodeMAC() mac.MAC                     { return e.MAC }
-func (e *TestEndpoint) GetOptions() *option.IntOptions          { return e.Opts }
-func (e *TestEndpoint) IsHost() bool                            { return e.isHost }
+func (e *TestEndpoint) HasIpvlanDataPath() bool                     { return false }
+func (e *TestEndpoint) ConntrackLocalLocked() bool                  { return false }
+func (e *TestEndpoint) RequireARPPassthrough() bool                 { return false }
+func (e *TestEndpoint) RequireEgressProg() bool                     { return false }
+func (e *TestEndpoint) RequireRouting() bool                        { return false }
+func (e *TestEndpoint) RequireEndpointRoute() bool                  { return false }
+func (e *TestEndpoint) GetPolicyVerdictLogFilter() uint32           { return 0xffff }
+func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)        { return nil, nil }
+func (e *TestEndpoint) GetID() uint64                               { return e.Id }
+func (e *TestEndpoint) StringID() string                            { return "42" }
+func (e *TestEndpoint) GetIdentity() identity.NumericIdentity       { return e.Identity.ID }
+func (e *TestEndpoint) GetIdentityLocked() identity.NumericIdentity { return e.Identity.ID }
+func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity     { return e.Identity }
+func (e *TestEndpoint) GetNodeMAC() mac.MAC                         { return e.MAC }
+func (e *TestEndpoint) GetOptions() *option.IntOptions              { return e.Opts }
+func (e *TestEndpoint) IsHost() bool                                { return e.isHost }
 
 func (e *TestEndpoint) IPv4Address() addressing.CiliumIPv4 {
 	addr, _ := addressing.NewCiliumIPv4("192.0.2.3")

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2020-06-02"
+    image: "quay.io/cilium/cilium-builder:2020-06-08"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("RuntimeKVStoreTest", func() {
+var _ = PDescribe("RuntimeKVStoreTest", func() {
 
 	var vm *helpers.SSHMeta
 


### PR DESCRIPTION
* #11922 -- docs: quote helm flags with brackets (@nebril)
 * #11945 -- test: Disable flaky RuntimeKVStoreTest tests (@pchaigno)
 * #11941 -- endpoint: Fix data races while accessing GetIdentity() (@tgraf)
 * #11957 -- docs: Add session affinity to kubeproxy-free guide (@brb)
 * #11953 -- fqdn: Fix missing IsNil checks in unit tests (@pchaigno)
 * #11950 -- ipcache: Fix deadlock when ipcache GC results in datapath reload (@tgraf)
 * #11924 -- bpf: various datapath follow-up optimisations and fixes (@borkmann)
 * #11958 -- docs: Improve session affinity section in kube-proxy free guide (@brb)
 * #11952 -- service: Clean up HealthCheckNodePort server when traffic policy changes  (@gandro)
 * #11966 -- daemon: Fix waiting on metrics in endpoint_test.go (@christarazi)
 * #11968 -- runtime: Update LLVM image (@errordeveloper)
 * #11970 -- bpf, docs: add list of XDP supported drivers (@borkmann)
 * #11960 -- doc: fix up GKE install guide (@Rolinh)
 * #11907 -- helm: Generate experimental-install.yaml (@michi-covalent)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11922 11945 11941 11957 11953 11950 11924 11958 11952 11966 11968 11970 11960 11907; do contrib/backporting/set-labels.py $pr done 1.8; done
```