### PR TITLE
vagrant: Fix make in net-next dev. VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Can be removed once PR #11528 with the golangci-lint replacement is merged.
+go get -u github.com/gordonklaus/ineffassign
+
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 #{$makeclean}
 ~/go/src/github.com/cilium/cilium/contrib/vagrant/build.sh


### PR DESCRIPTION
The ineffassign dependency was removed from the VM image in cilium/packer-ci-build#211, in preparation for the switch to golangci-lint implemented by #11528. However, (1) the VM image update was merged before the golangci-lint PR was, and (2) the golangci-lint PR won't be backported to v1.8, whereas the VM image update has already been.

We therefore need to reinstall the ineffassign dependency in the dev. VM until #11528 is merged and in order to backport this fix to v1.8.

I tested this PR by running `NETNEXT=1 NFS=1 K8S=1 ./contrib/vagrant/start.sh` (broken in master).

/cc @sayboras 
Fixes: cilium/packer-ci-build#211
Fixes: #11917