### PR TITLE
bpf: enable hairpin optimizations to avoid fib lookup also for tc

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -119,7 +119,7 @@ static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 
 static __always_inline bool nodeport_lb_hairpin(void)
 {
-	return is_defined(ENABLE_NODEPORT_ACCELERATION);
+	return is_defined(ENABLE_NODEPORT_HAIRPIN);
 }
 
 static __always_inline void

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1855,6 +1855,10 @@ func initKubeProxyReplacementOptions() {
 				option.Config.NodePortMode)
 			option.Config.NodePortMode = option.NodePortModeSNAT
 		}
+
+		option.Config.NodePortHairpin =
+			option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled ||
+				len(option.Config.Devices) == 1
 	}
 
 	if option.Config.EnableSessionAffinity {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -255,6 +255,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			cDefinesMap["ENABLE_NODEPORT_ACCELERATION"] = "1"
 		}
+		if option.Config.NodePortHairpin {
+			cDefinesMap["ENABLE_NODEPORT_HAIRPIN"] = "1"
+		}
 		if option.Config.EnableExternalIPs {
 			cDefinesMap["ENABLE_EXTERNAL_IP"] = "1"
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -598,7 +598,7 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 		neighborLog("insertNeighbor NeighSet", ifaceName, err, &ciliumIPv4, &hwAddr, link)
 		if err == nil {
 			n.neighByNode[newNode.Identity()] = &neigh
-			if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
+			if option.Config.NodePortHairpin {
 				neighborsmap.NeighRetire(ciliumIPv4)
 			}
 		}
@@ -620,7 +620,7 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 			"LinkIndex":      neigh.LinkIndex,
 		}).WithError(err).Warn("Failed to remove neighbor entry")
 	} else {
-		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
+		if option.Config.NodePortHairpin {
 			neighborsmap.NeighRetire(neigh.IP)
 		}
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1631,6 +1631,9 @@ type DaemonConfig struct {
 	// via XDP ("none", "generic" or "native")
 	NodePortAcceleration string
 
+	// NodePortHairpin indicates whether the setup is a one-legged LB
+	NodePortHairpin bool
+
 	// NodePortBindProtection rejects bind requests to NodePort service ports
 	NodePortBindProtection bool
 


### PR DESCRIPTION
Make 0532f887eb8e ("bpf: avoid using fib lookup in nodeport for dsr v4/v6
hairpin case") generic such that also the tc BPF case can benefit from it
when only a single external device was specified or detected on the node.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>