### PR TITLE
docs: Add Hubble metrics reference

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -125,6 +125,7 @@ Proxylib
 QCon
 Qemu
 Qlogic
+Quantiles
 Rebasing
 Redis
 Refactor
@@ -556,6 +557,7 @@ regex
 regexes
 relocations
 reparsing
+replicaset
 repo
 repos
 retpoline

--- a/install/kubernetes/cilium/charts/agent/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/svc.yaml
@@ -17,15 +17,18 @@ spec:
   selector:
     k8s-app: cilium
 {{- end }}
-{{- if and .Values.global.hubble.metrics.enabled (.Values.global.hubble.metrics.serviceMonitor.enabled) }}
+{{- if and .Values.global.hubble.metrics.enabled }}
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: hubble-metrics
   namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: {{ .Values.global.hubble.metrics.port | quote }}
   labels:
-    k8s-app: hubble 
+    k8s-app: hubble
 spec:
   clusterIP: None
   type: ClusterIP

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -432,6 +432,28 @@ subjects:
   name: cilium-operator
   namespace: kube-system
 ---
+# Source: cilium/charts/agent/templates/svc.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-metrics
+  namespace: kube-system
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: "9091"
+  labels:
+    k8s-app: hubble
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: hubble-metrics
+    port: 9091
+    protocol: TCP
+    targetPort: hubble-metrics
+  selector:
+    k8s-app: cilium
+---
 # Source: cilium/charts/hubble-relay/templates/service.yaml
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
This PR slightly restructures the "Monitoring & Metrics" section
in the documentation and adds a reference for the available Hubble
metrics.

The document is restructured to explain how to enable the Cilium/
Cilium Operator metrics in Helm separately from the Hubble metrics
provided by embedded Hubble. The rationale for this split
is that Cilium metrics are used to monitor Cilium itself, while Hubble
metrics are used to monitor network traffic of applications in the
cluster.

To simplify the use of Hubble metrics, the `prometheus.io/{scrape,port}`
annotations are also added to the `hubble-metrics` headless service,
which is now enabled whenever Hubble metrics are enabled.

We cannot add this annotation directly on the cilium-agent pod, as it is
already used for the cilium-agent metrics and the Prometheus annotation
only supports a single port.

Still absent from this PR is the Grafana dashboard to display the Hubble metrics.
I will add this in a separate PR, as I'm having some trouble integrating it into the
existing `monitoring-example.yaml`.