### PR TITLE
cilium, test: Only run sockops tests on 4.19 and bpf-next kernels

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -221,6 +221,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		It("Check connectivity with sockops and VXLAN encapsulation", func() {
 			// Note if run on kernel without sockops feature is ignored
+			if !helpers.RunsOnNetNextOr419Kernel() {
+				Skip("Skipping sockops testing before 4.19 kernel")
+				return
+			}
+
 			deploymentManager.DeployCilium(map[string]string{
 				"global.sockops.enabled": "true",
 			}, DeployCiliumOptionsAndDNS)
@@ -327,6 +332,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		It("Check connectivity with sockops and direct routing", func() {
 			// Note if run on kernel without sockops feature is ignored
+			if !helpers.RunsOnNetNextOr419Kernel() {
+				Skip("Skipping sockops testing before 4.19 kernel")
+				return
+			}
+
 			deploymentManager.DeployCilium(map[string]string{
 				"global.sockops.enabled": "true",
 			}, DeployCiliumOptionsAndDNS)


### PR DESCRIPTION
Lets avoid pointless runs of sockops tests where the feature is disabled due
to kernel limitations. Should save us a couple runs in CI.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>