### PR TITLE
iptables: carry on and log on failure to set up transient rules

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -50,7 +50,7 @@ const (
 	ciliumPreMangleChain        = "CILIUM_PRE_mangle"
 	ciliumPreRawChain           = "CILIUM_PRE_raw"
 	ciliumForwardChain          = "CILIUM_FORWARD"
-	ciliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
+	CiliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
 	feederDescription           = "cilium-feeder:"
 	xfrmDescription             = "cilium-xfrm-notrack:"
 )
@@ -165,7 +165,7 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 	for scanner.Scan() {
 		rule := scanner.Text()
 		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering removing %s rule", prog)
-		if match != ciliumTransientForwardChain && strings.Contains(rule, ciliumTransientForwardChain) {
+		if match != CiliumTransientForwardChain && strings.Contains(rule, CiliumTransientForwardChain) {
 			continue
 		}
 
@@ -179,8 +179,8 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 			// disabled chains
 			skipFeeder := false
 			for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-				// we skip if the match is ciliumTransientForwardChain since we don't want to touch it
-				if match != ciliumTransientForwardChain && strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
+				// we skip if the match is CiliumTransientForwardChain since we don't want to touch it
+				if match != CiliumTransientForwardChain && strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
 					log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
 					skipFeeder = true
 					break
@@ -217,11 +217,11 @@ func (c *customChain) remove(waitArgs []string, quiet bool) {
 			// present, log the error.
 			// This is to help debug #11276.
 			msgChainNotFound := ": No chain/target/match by that name.\n"
-			debugTransientRules := c.name == ciliumTransientForwardChain &&
+			debugTransientRules := c.name == CiliumTransientForwardChain &&
 				string(combinedOutput) != prog+msgChainNotFound
 			if !quiet || debugTransientRules {
 				log.Warnf(string(combinedOutput))
-				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s Cilium %s chain", operation, prog)
+				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to process chain %s with %s (%s)", c.name, prog, operation)
 			}
 		}
 	}
@@ -339,7 +339,7 @@ var ciliumChains = []customChain{
 }
 
 var transientChain = customChain{
-	name:       ciliumTransientForwardChain,
+	name:       CiliumTransientForwardChain,
 	table:      "filter",
 	hook:       "FORWARD",
 	feederArgs: []string{""},
@@ -717,7 +717,7 @@ func getDeliveryInterface(ifName string) string {
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
 	transient := ""
-	if forwardChain == ciliumTransientForwardChain {
+	if forwardChain == CiliumTransientForwardChain {
 		transient = " (transient)"
 	}
 
@@ -829,7 +829,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 // TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
 func (m *IptablesManager) TransientRulesEnd(quiet bool) {
 	if option.Config.EnableIPv4 {
-		m.removeCiliumRules("filter", "iptables", ciliumTransientForwardChain)
+		m.removeCiliumRules("filter", "iptables", CiliumTransientForwardChain)
 		transientChain.remove(m.waitArgs, quiet)
 	}
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -342,7 +342,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.InstallIptRules {
 		if err := iptMgr.TransientRulesStart(option.Config.HostDevice); err != nil {
-			return err
+			log.WithError(err).Warning("failed to install transient iptables rules")
 		}
 	}
 	// The iptables rules are only removed on the first initialization to

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cilium/cilium/test/ginkgo-ext"
@@ -222,20 +223,22 @@ const (
 	SecondaryIface = "enp0s9"
 
 	// Logs messages that should not be in the cilium logs.
-	panicMessage       = "panic:"
-	deadLockHeader     = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault  = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived       = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed      = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
-	sizeMismatch       = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
-	emptyBPFInitArg    = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
-	RemovingMapMsg     = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
-	logBufferMessage   = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
-	ClangErrorsMsg     = " errors generated."                         // from https://github.com/cilium/cilium/issues/10857
-	ClangErrorMsg      = "1 error generated."                         // from https://github.com/cilium/cilium/issues/10857
-	symbolSubstitution = "Skipping symbol substitution"               //
-	uninitializedRegen = "Uninitialized regeneration level"           // from https://github.com/cilium/cilium/pull/10949
-	unstableStat       = "BUG: stat() has unstable behavior"          // from https://github.com/cilium/cilium/pull/11028
+	panicMessage        = "panic:"
+	deadLockHeader      = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault   = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived        = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed       = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch        = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
+	emptyBPFInitArg     = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
+	RemovingMapMsg      = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
+	logBufferMessage    = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
+	ClangErrorsMsg      = " errors generated."                         // from https://github.com/cilium/cilium/issues/10857
+	ClangErrorMsg       = "1 error generated."                         // from https://github.com/cilium/cilium/issues/10857
+	symbolSubstitution  = "Skipping symbol substitution"               //
+	uninitializedRegen  = "Uninitialized regeneration level"           // from https://github.com/cilium/cilium/pull/10949
+	unstableStat        = "BUG: stat() has unstable behavior"          // from https://github.com/cilium/cilium/pull/11028
+	removeTransientRule = "Unable to process chain " +
+		iptables.CiliumTransientForwardChain + " with ip" // from https://github.com/cilium/cilium/issues/11276
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -275,20 +278,21 @@ var (
 // badLogMessages is a map which key is a part of a log message which indicates
 // a failure if the message does not contain any part from value list.
 var badLogMessages = map[string][]string{
-	panicMessage:       nil,
-	deadLockHeader:     nil,
-	segmentationFault:  nil,
-	NACKreceived:       nil,
-	RunInitFailed:      {"signal: terminated", "signal: killed"},
-	sizeMismatch:       nil,
-	emptyBPFInitArg:    nil,
-	RemovingMapMsg:     nil,
-	logBufferMessage:   nil,
-	ClangErrorsMsg:     nil,
-	ClangErrorMsg:      nil,
-	symbolSubstitution: nil,
-	uninitializedRegen: nil,
-	unstableStat:       nil,
+	panicMessage:        nil,
+	deadLockHeader:      nil,
+	segmentationFault:   nil,
+	NACKreceived:        nil,
+	RunInitFailed:       {"signal: terminated", "signal: killed"},
+	sizeMismatch:        nil,
+	emptyBPFInitArg:     nil,
+	RemovingMapMsg:      nil,
+	logBufferMessage:    nil,
+	ClangErrorsMsg:      nil,
+	ClangErrorMsg:       nil,
+	symbolSubstitution:  nil,
+	uninitializedRegen:  nil,
+	unstableStat:        nil,
+	removeTransientRule: nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
As reported in #11276, we have occasionally observed unexpected failures when trying to set up iptables transient rules (used to avoid dropping packets while reinitialising the daemon).

This set brings two changes:

- Do not abort reinitialisation if transient rules set up fails (we risk dropping a few packets until Cilium's rules are up again, this is better than failing to restart the agent).

- Log iptables messages on failures to flush or delete leftover transient rules, as we suspect this is the cause for the error messages observed, so we can understand what happens if the issue reoccurs.

Please refer to individual commit logs for details.