### PR TITLE
daemon, option: remove deprecated flannel-manage-existing-containers flag

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -575,8 +575,8 @@ Removed options
 
 * ``enable-legacy-services``: This option was deprecated in Cilium 1.6 and is
   now removed.
-* The options ``container-runtime`` and ``container-runtime-endpoint`` were
-  deprecated in Cilium 1.7 and are now removed.
+* The options ``container-runtime``, ``container-runtime-endpoint`` and
+  ``flannel-manage-existing-containers`` were deprecated in Cilium 1.7 and are now removed.
 * The ``conntrack-garbage-collector-interval`` option deprecated in Cilium 1.6
   is now removed. Please use ``conntrack-gc-interval`` instead.
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -633,12 +633,6 @@ func init() {
 		"flag, it cleans up all BPF programs installed when Cilium agent is terminated.", option.FlannelMasterDevice))
 	option.BindEnv(option.FlannelUninstallOnExit)
 
-	flags.Bool(option.FlannelManageExistingContainers, false,
-		fmt.Sprintf("Installs a BPF program to allow for policy enforcement in already running containers managed by Flannel."+
-			" Require Cilium to be running in the hostPID."))
-	option.BindEnv(option.FlannelManageExistingContainers)
-	flags.MarkDeprecated(option.FlannelManageExistingContainers, "This option is no longer supported and will be removed in v1.8")
-
 	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
 	option.BindEnv(option.PProf)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -325,13 +325,6 @@ const (
 	// it cleans up all BPF programs installed when Cilium agent is terminated.
 	FlannelUninstallOnExit = "flannel-uninstall-on-exit"
 
-	// FlannelManageExistingContainers sets if Cilium should install the BPF
-	// programs on already running interfaces created by flannel. Require
-	// Cilium to be running in the hostPID.
-	// Deprecated: This option is no longer available since cilium-daemon does
-	//             not have any direct interaction with container runtimes.
-	FlannelManageExistingContainers = "flannel-manage-existing-containers"
-
 	// PProf enables serving the pprof debugging API
 	PProf = "pprof"
 


### PR DESCRIPTION
The flag no longer has any effect and is scheduled for removal in
Cilium 1.8.

```release-note
Remove deprecated --flannel-manage-existing-containers option
```