### PR TITLE
v1.7 backports 2020-06-10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!


### PR DESCRIPTION
 * #11973 -- Envoy: Update to Envoy 1.13.2 (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11973; do contrib/backporting/set-labels.py $pr done 1.7; done
```
