### PR TITLE
docs: point cilium docs into a stable version of sphinx theme

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,7 +20,7 @@ snowballstemmer==1.2.1
 Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
-git+git://github.com/cilium/sphinx_rtd_theme.git@37b2f4031ecfdc1aa0f79caa3600530fc43ff939
+git+git://github.com/cilium/sphinx_rtd_theme.git@v0.6
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1


### PR DESCRIPTION
- point to v0.6 version of the sphinx theme

Signed-off-by: Sergey Generalov <sergey@genbit.ru>
