### PR TITLE
Fix setting monitorAggregationLevel to max reflects via CLI

### DIFF
--- a/pkg/option/monitor.go
+++ b/pkg/option/monitor.go
@@ -52,7 +52,7 @@ const (
 
 	// MonitorAggregationLevelMax is the maximum level of aggregation
 	// currently supported.
-	MonitorAggregationLevelMax = MonitorAggregationLevelMedium
+	MonitorAggregationLevelMax OptionSetting = 4
 )
 
 // monitorAggregationOption maps a user-specified string to a monitor
@@ -81,6 +81,7 @@ var monitorAggregationFormat = map[OptionSetting]string{
 	MonitorAggregationLevelLowest: "Lowest",
 	MonitorAggregationLevelLow:    "Low",
 	MonitorAggregationLevelMedium: "Medium",
+	MonitorAggregationLevelMax:    "Max",
 }
 
 // VerifyMonitorAggregationLevel validates the specified key/value for a


### PR DESCRIPTION
This PR fixes setting MonitorAggregationLevel to max to correctly
reflect through CLI.

Fixes: #12000
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>