### PR TITLE
v1.6 backports 2020-06-11

### DIFF
--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -47,6 +47,11 @@ type EndpointConfiguration interface {
 	// GetIdentity returns a globally-significant numeric security identity.
 	GetIdentity() identity.NumericIdentity
 
+	// GetIdentityLocked returns a globally-significant numeric security
+	// identity while assuming that the backing data structure is locked.
+	// This function should be removed in favour of GetIdentity()
+	GetIdentityLocked() identity.NumericIdentity
+
 	IPv4Address() addressing.CiliumIPv4
 	IPv6Address() addressing.CiliumIPv6
 	GetNodeMAC() mac.MAC

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -212,13 +212,13 @@ func shuffleMaps(realized, backup, pending string) error {
 func (l *BPFListener) garbageCollect(ctx context.Context) (*sync.WaitGroup, error) {
 	log.Debug("Running garbage collection for BPF IPCache")
 
-	// Since controllers run asynchronously, need to make sure
-	// IPIdentityCache is not being updated concurrently while we do
-	// GC;
-	ipcache.IPIdentityCache.RLock()
-	defer ipcache.IPIdentityCache.RUnlock()
-
 	if ipcacheMap.SupportsDelete() {
+		// Since controllers run asynchronously, need to make sure
+		// IPIdentityCache is not being updated concurrently while we
+		// do GC;
+		ipcache.IPIdentityCache.RLock()
+		defer ipcache.IPIdentityCache.RUnlock()
+
 		keysToRemove := map[string]*ipcacheMap.Key{}
 		if err := l.bpfMap.DumpWithCallback(updateStaleEntriesFunction(keysToRemove)); err != nil {
 			return nil, fmt.Errorf("error dumping ipcache BPF map: %s", err)
@@ -234,10 +234,16 @@ func (l *BPFListener) garbageCollect(ctx context.Context) (*sync.WaitGroup, erro
 			}
 		}
 	} else {
+		// Since controllers run asynchronously, need to make sure
+		// IPIdentityCache is not being updated concurrently while we
+		// do GC;
+		ipcache.IPIdentityCache.RLock()
+
 		// Populate the map at the new path
 		pendingMapName := fmt.Sprintf("%s_pending", ipcacheMap.Name)
 		pendingMap := ipcacheMap.NewMap(pendingMapName)
 		if _, err := pendingMap.OpenOrCreate(); err != nil {
+			ipcache.IPIdentityCache.RUnlock()
 			return nil, fmt.Errorf("Unable to create %s map: %s", pendingMapName, err)
 		}
 		pendingListener := newListener(pendingMap, l.datapath)
@@ -251,24 +257,35 @@ func (l *BPFListener) garbageCollect(ctx context.Context) (*sync.WaitGroup, erro
 		// will pick up the new paths without requiring recompilation.
 		backupMapName := fmt.Sprintf("%s_old", ipcacheMap.Name)
 		if err := shuffleMaps(ipcacheMap.Name, backupMapName, pendingMapName); err != nil {
+			ipcache.IPIdentityCache.RUnlock()
 			return nil, err
 		}
+
+		// Reopen the ipcache map so that new writes and reads will use
+		// the new map
+		if err := ipcacheMap.Reopen(); err != nil {
+			handleMapShuffleFailure(backupMapName, ipcacheMap.Name)
+			ipcache.IPIdentityCache.RUnlock()
+			return nil, err
+		}
+
+		// Unlock the ipcache as in order for
+		// TriggerReloadWithoutCompile() to succeed, other endpoint
+		// regenerations which are blocking on the ipcache lock may
+		// need to succeed first (#11946)
+		ipcache.IPIdentityCache.RUnlock()
 
 		wg, err := l.datapath.TriggerReloadWithoutCompile("datapath ipcache")
 		if err != nil {
-			handleMapShuffleFailure(backupMapName, ipcacheMap.Name)
-			return nil, err
+			// We can't really undo the map rename again as ipcache
+			// operations had already been permitted so the backup
+			// map is potentially outdated. Fail hard to restart
+			// the agent so we reconstruct the ipcache from
+			// scratch.
+			log.WithError(err).Fatal("Endpoint datapath reload triggered by ipcache GC failed. Inconsistent state.")
 		}
 
-		// If the base programs successfully compiled, then the maps
-		// should be OK so let's update all references to the IPCache
-		// so that they point to the new version.
 		_ = os.RemoveAll(bpf.MapPath(backupMapName))
-		if err := ipcacheMap.Reopen(); err != nil {
-			// Very unlikely; base program compilation succeeded.
-			log.WithError(err).Warning("Failed to reopen BPF ipcache map")
-			return nil, err
-		}
 		return wg, nil
 	}
 	return nil, nil

--- a/pkg/datapath/linux/config.go
+++ b/pkg/datapath/linux/config.go
@@ -331,7 +331,7 @@ func (l *linuxDatapath) writeStaticData(fw io.Writer, e datapath.EndpointConfigu
 	fmt.Fprint(fw, defineMAC("NODE_MAC", e.GetNodeMAC()))
 	fmt.Fprint(fw, defineUint32("LXC_ID", uint32(e.GetID())))
 
-	secID := e.GetIdentity().Uint32()
+	secID := e.GetIdentityLocked().Uint32()
 	fmt.Fprintf(fw, defineUint32("SECLABEL", secID))
 	fmt.Fprintf(fw, defineUint32("SECLABEL_NB", byteorder.HostToNetwork(secID).(uint32)))
 
@@ -395,7 +395,7 @@ func (l *linuxDatapath) writeTemplateConfig(fw *bufio.Writer, e datapath.Endpoin
 	return fw.Flush()
 }
 
-// WriteEndpointConfig writes the BPF configuration for the template to a writer.
+// WriteTemplateConfig writes the BPF configuration for the template to a writer.
 func (l *linuxDatapath) WriteTemplateConfig(w io.Writer, e datapath.EndpointConfiguration) error {
 	fw := bufio.NewWriter(w)
 	return l.writeTemplateConfig(fw, e)

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -93,6 +93,13 @@ func (t *templateCfg) GetIdentity() identity.NumericIdentity {
 	return TemplateSecurityID
 }
 
+// GetIdentityLocked is identical to GetIdentity(). This is a temporary
+// function until WriteEndpointConfig() no longer assumes that the endpoint is
+// locked.
+func (t *templateCfg) GetIdentityLocked() identity.NumericIdentity {
+	return TemplateSecurityID
+}
+
 // GetNodeMAC returns a well-known dummy MAC address which may be later
 // substituted in the ELF.
 func (t *templateCfg) GetNodeMAC() mac.MAC {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -77,6 +77,8 @@ func (e *Endpoint) BPFIpvlanMapPath() string {
 // strings describing the configuration of the datapath.
 //
 // For configuration of actual datapath behavior, see WriteEndpointConfig().
+//
+// e.Mutex must be held
 func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	fw := bufio.NewWriter(w)
 
@@ -110,7 +112,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		" * NodeMAC: %s\n"+
 		" */\n\n",
 		e.IPv6.String(), e.IPv4.String(),
-		e.GetIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
+		e.getIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
 		e.NodeMAC)
 
 	fw.WriteString("/*\n")
@@ -129,6 +131,9 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	return fw.Flush()
 }
 
+// writeHeaderfile writes the lxc_config.h header file of an endpoint
+//
+// e.Mutex must be held.
 func (e *Endpoint) writeHeaderfile(prefix string) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
 	e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -81,7 +81,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		ifName: e.IfName,
 		ipvlan: e.HasIpvlanDataPath(),
 
-		identity:              e.GetIdentity(),
+		identity:              e.getIdentity(),
 		mac:                   e.GetNodeMAC(),
 		ipv4:                  e.IPv4Address(),
 		ipv6:                  e.IPv6Address(),
@@ -129,6 +129,11 @@ func (ep *epInfoCache) StringID() string {
 
 // GetIdentity returns the security identity of the endpoint.
 func (ep *epInfoCache) GetIdentity() identity.NumericIdentity {
+	return ep.identity
+}
+
+// GetIdentityLocked returns the security identity of the endpoint.
+func (ep *epInfoCache) GetIdentityLocked() identity.NumericIdentity {
 	return ep.identity
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -928,7 +928,21 @@ func (e *Endpoint) StringID() string {
 	return strconv.Itoa(int(e.ID))
 }
 
+// GetIdentityLocked is identical to GetIdentity() but assumes that a.mutex is
+// already held. This function is obsolete and should no longer be used.
+func (e *Endpoint) GetIdentityLocked() identityPkg.NumericIdentity {
+	return e.getIdentity()
+}
+
+// GetIdentity returns the numeric security identity of the endpoint
 func (e *Endpoint) GetIdentity() identityPkg.NumericIdentity {
+	e.UnconditionalRLock()
+	defer e.RUnlock()
+
+	return e.getIdentity()
+}
+
+func (e *Endpoint) getIdentity() identityPkg.NumericIdentity {
 	if e.SecurityIdentity != nil {
 		return e.SecurityIdentity.ID
 	}

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -80,7 +80,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetIdentity() identity.NumericIdentity
+	GetIdentityLocked() identity.NumericIdentity
 	GetLabels() []string
 	GetLabelsSHA() string
 	HasSidecarProxy() bool

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -797,7 +797,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 		if ip == "" {
 			continue
 		}
-		networkPolicy := getNetworkPolicy(ip, ep.GetIdentity(), ep.ConntrackName(), policy,
+		networkPolicy := getNetworkPolicy(ip, ep.GetIdentityLocked(), ep.ConntrackName(), policy,
 			ingressPolicyEnforced, egressPolicyEnforced)
 		err := networkPolicy.Validate()
 		if err != nil {

--- a/pkg/proxy/epinfo.go
+++ b/pkg/proxy/epinfo.go
@@ -59,7 +59,7 @@ func (r *defaultEndpointInfoRegistry) FillEndpointIdentityByIP(ip net.IP, info *
 	}
 
 	info.ID = uint64(ep.ID)
-	info.Identity = uint64(ep.GetIdentity())
+	info.Identity = uint64(ep.GetIdentityLocked())
 	info.Labels = ep.GetLabels()
 	info.LabelsSHA256 = ep.GetLabelsSHA()
 

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -30,7 +30,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetIdentity() identity.NumericIdentity
+	GetIdentityLocked() identity.NumericIdentity
 	GetLabels() []string
 	GetLabelsSHA() string
 	HasSidecarProxy() bool
@@ -51,7 +51,7 @@ func getEndpointInfo(source EndpointInfoSource) *accesslog.EndpointInfo {
 		IPv6:         source.GetIPv6Address(),
 		Labels:       source.GetLabels(),
 		LabelsSHA256: source.GetLabelsSHA(),
-		Identity:     uint64(source.GetIdentity()),
+		Identity:     uint64(source.GetIdentityLocked()),
 	}
 }
 

--- a/pkg/proxy/mock_test.go
+++ b/pkg/proxy/mock_test.go
@@ -37,14 +37,14 @@ type proxyUpdaterMock struct {
 func (m *proxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
 func (m *proxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 
-func (m *proxyUpdaterMock) GetID() uint64                         { return m.id }
-func (m *proxyUpdaterMock) GetIPv4Address() string                { return m.ipv4 }
-func (m *proxyUpdaterMock) GetIPv6Address() string                { return m.ipv6 }
-func (m *proxyUpdaterMock) GetLabels() []string                   { return m.labels }
-func (m *proxyUpdaterMock) GetEgressPolicyEnabledLocked() bool    { return true }
-func (m *proxyUpdaterMock) GetIngressPolicyEnabledLocked() bool   { return true }
-func (m *proxyUpdaterMock) GetIdentity() identity.NumericIdentity { return m.identity }
-func (m *proxyUpdaterMock) ProxyID(l4 *policy.L4Filter) string    { return "" }
+func (m *proxyUpdaterMock) GetID() uint64                               { return m.id }
+func (m *proxyUpdaterMock) GetIPv4Address() string                      { return m.ipv4 }
+func (m *proxyUpdaterMock) GetIPv6Address() string                      { return m.ipv6 }
+func (m *proxyUpdaterMock) GetLabels() []string                         { return m.labels }
+func (m *proxyUpdaterMock) GetEgressPolicyEnabledLocked() bool          { return true }
+func (m *proxyUpdaterMock) GetIngressPolicyEnabledLocked() bool         { return true }
+func (m *proxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.identity }
+func (m *proxyUpdaterMock) ProxyID(l4 *policy.L4Filter) string          { return "" }
 func (m *proxyUpdaterMock) GetLabelsSHA() string {
 	return labels.NewLabelsFromModel(m.labels).SHA256Sum()
 }

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -49,19 +49,20 @@ func NewTestEndpoint() TestEndpoint {
 	}
 }
 
-func (e *TestEndpoint) HasIpvlanDataPath() bool                 { return false }
-func (e *TestEndpoint) ConntrackLocalLocked() bool              { return false }
-func (e *TestEndpoint) RequireARPPassthrough() bool             { return false }
-func (e *TestEndpoint) RequireEgressProg() bool                 { return false }
-func (e *TestEndpoint) RequireRouting() bool                    { return false }
-func (e *TestEndpoint) RequireEndpointRoute() bool              { return false }
-func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)    { return nil, nil }
-func (e *TestEndpoint) GetID() uint64                           { return e.Id }
-func (e *TestEndpoint) StringID() string                        { return "42" }
-func (e *TestEndpoint) GetIdentity() identity.NumericIdentity   { return e.Identity.ID }
-func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity { return e.Identity }
-func (e *TestEndpoint) GetNodeMAC() mac.MAC                     { return e.MAC }
-func (e *TestEndpoint) GetOptions() *option.IntOptions          { return e.Opts }
+func (e *TestEndpoint) HasIpvlanDataPath() bool                     { return false }
+func (e *TestEndpoint) ConntrackLocalLocked() bool                  { return false }
+func (e *TestEndpoint) RequireARPPassthrough() bool                 { return false }
+func (e *TestEndpoint) RequireEgressProg() bool                     { return false }
+func (e *TestEndpoint) RequireRouting() bool                        { return false }
+func (e *TestEndpoint) RequireEndpointRoute() bool                  { return false }
+func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)        { return nil, nil }
+func (e *TestEndpoint) GetID() uint64                               { return e.Id }
+func (e *TestEndpoint) StringID() string                            { return "42" }
+func (e *TestEndpoint) GetIdentity() identity.NumericIdentity       { return e.Identity.ID }
+func (e *TestEndpoint) GetIdentityLocked() identity.NumericIdentity { return e.Identity.ID }
+func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity     { return e.Identity }
+func (e *TestEndpoint) GetNodeMAC() mac.MAC                         { return e.MAC }
+func (e *TestEndpoint) GetOptions() *option.IntOptions              { return e.Opts }
 
 func (e *TestEndpoint) IPv4Address() addressing.CiliumIPv4 {
 	addr, _ := addressing.NewCiliumIPv4("192.0.2.3")


### PR DESCRIPTION
* #11941 -- endpoint: Fix data races while accessing GetIdentity() (@tgraf)
   * Minor conflicts
 * #11950 -- ipcache: Fix deadlock when ipcache GC results in datapath reload (@tgraf)
 * #11966 -- daemon: Fix waiting on metrics in endpoint_test.go (@christarazi)
   * Minor conflicts

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11941 11950 11966; do contrib/backporting/set-labels.py $pr done 1.6; done
```