### PR TITLE
helm: Use port 80 for service/hubble-ui

### DIFF
--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -100,6 +100,6 @@ networking infrastructure in a completely transparent manner.
 
   .. parsed-literal::
 
-      kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-ui 12000
+      kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-ui 12000:80
 
   and then open http://localhost:12000/.

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/svc.yaml
@@ -8,6 +8,6 @@ spec:
     k8s-app: hubble-ui
   ports:
     - name: http
-      port: 12000
+      port: 80
       targetPort: 12000
   type: ClusterIP

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -482,7 +482,7 @@ spec:
     k8s-app: hubble-ui
   ports:
     - name: http
-      port: 12000
+      port: 80
       targetPort: 12000
   type: ClusterIP
 ---


### PR DESCRIPTION
Port 12000 is used for historical reasons. Considering it is an HTTP
frontend, we should use port 80 for the ClusterIP service.

Note: This does not change the port exposed by hubble-ui internally,
which remains 12000 for now.

Fixes: #11250

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
