### PR TITLE
install: Fix up version/pullPolicy for multiple values files

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -8,15 +8,15 @@ MANAGED_ETCD_VERSION := "v2.0.7"
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
 EXPERIMENTAL_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/experimental-install.yaml"
 MANAGED_ETCD_PATH := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/charts/managed-etcd/values.yaml"
-CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/"
-CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml"
+CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium"
+CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml" "$(CILIUM_CHARTS)/charts/hubble-relay/values.yaml"
 
 VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+.*'
 LATEST_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
 DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
-CILIUM_PULLPOLICY_REGEX := '\(pullPolicy:\) .*'
+CILIUM_PULLPOLICY_REGEX := '\([pP]ullPolicy:\) .*'
 EXPERIMENTAL_OPTIONS := \
     --set global.hubble.enabled=true \
     --set global.hubble.listenAddress=":4244" \
@@ -35,20 +35,21 @@ $(EXPERIMENTAL_INSTALL): $(shell find cilium/ -type f)
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"
 	@# Update chart versions to point to the current version.
-	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS) | \
+	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS)/ | \
 		xargs -0 -l sed -i -e 's/'$(CILIUM_CHART_REGEX)'/\1 $(VERSION)/g'
 	@# Fix up the cilium tag
-	$(QUIET)if echo $(VERSION) | grep -q $(LATEST_VERSION_REGEX); then				\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $(CILIUM_VALUES);			\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
+	$(QUIET)for chart in $(CILIUM_VALUES); do							\
+		if echo $(VERSION) | grep -q $(LATEST_VERSION_REGEX); then				\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $$chart;				\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $$chart;			\
 		elif echo $(VERSION) | grep -q $(DEV_VERSION_REGEX); then				\
 			DEV_BRANCH=$$(echo $(VERSION) | sed 's/-dev//')					\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 $(DEV_BRANCH)/' $(CILIUM_VALUES);		\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 $(DEV_BRANCH)/' $$chart;			\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $$chart;			\
 		else											\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $(CILIUM_VALUES);		\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $(CILIUM_VALUES);	\
-		fi
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $$chart;			\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $$chart;		\
+		fi; done
 	@# Fix up the managed etcd version, as that has its own scheme
 	$(QUIET)sed -i 's/'$(VERSION)'/'$(MANAGED_ETCD_VERSION)'/' $(MANAGED_ETCD_PATH)
 


### PR DESCRIPTION
In particular, add the new hubble-relay values file to the list of files
that we fix these values up for in the make target.