### PR TITLE
v1.7 backports 2020-06-11

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -47,7 +47,7 @@ cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push origin "$PR_BRANCH"
-hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH,requires-janitor-review -F $SUMMARY
+hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(sed -e 's/^.*#\([0-9]\+\) .*$/\1/g' -e '/^[^0-9]\+/d' $SUMMARY | tr '\n' ' ')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -187,33 +187,25 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 }
 
 func (c *customChain) remove(waitArgs []string, quiet bool) {
-	if option.Config.EnableIPv4 {
-		prog := "iptables"
-		args := append(waitArgs, "-t", c.table, "-F", c.name)
+	doProcess := func(c *customChain, prog string, args []string, operation string, quiet bool) {
 		err := runProg(prog, args, true)
 		if err != nil && !quiet {
-			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to flush Cilium %s chain", prog)
-		}
-
-		args = append(waitArgs, "-t", c.table, "-X", c.name)
-		err = runProg(prog, args, true)
-		if err != nil && !quiet {
-			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to delete Cilium %s chain", prog)
+			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s Cilium %s chain", operation, prog)
 		}
 	}
-	if option.Config.EnableIPv6 && c.ipv6 == true {
-		prog := "ip6tables"
+	doRemove := func(c *customChain, prog string, waitArgs []string, quiet bool) {
 		args := append(waitArgs, "-t", c.table, "-F", c.name)
-		err := runProg(prog, args, true)
-		if err != nil && !quiet {
-			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to flush Cilium %s chain", prog)
-		}
-
+		doProcess(c, prog, args, "flush", quiet)
 		args = append(waitArgs, "-t", c.table, "-X", c.name)
-		err = runProg(prog, args, true)
-		if err != nil && !quiet {
-			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to delete Cilium %s chain", prog)
-		}
+		doProcess(c, prog, args, "delete", quiet)
+	}
+	if option.Config.EnableIPv4 {
+		prog := "iptables"
+		doRemove(c, prog, waitArgs, quiet)
+	}
+	if option.Config.EnableIPv6 && c.ipv6 {
+		prog := "ip6tables"
+		doRemove(c, prog, waitArgs, quiet)
 	}
 }
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -49,7 +49,7 @@ const (
 	ciliumPreMangleChain        = "CILIUM_PRE_mangle"
 	ciliumPreRawChain           = "CILIUM_PRE_raw"
 	ciliumForwardChain          = "CILIUM_FORWARD"
-	ciliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
+	CiliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
 	feederDescription           = "cilium-feeder:"
 	xfrmDescription             = "cilium-xfrm-notrack:"
 )
@@ -164,7 +164,7 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 	for scanner.Scan() {
 		rule := scanner.Text()
 		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering removing %s rule", prog)
-		if match != ciliumTransientForwardChain && strings.Contains(rule, ciliumTransientForwardChain) {
+		if match != CiliumTransientForwardChain && strings.Contains(rule, CiliumTransientForwardChain) {
 			continue
 		}
 
@@ -200,11 +200,11 @@ func (c *customChain) remove(waitArgs []string, quiet bool) {
 			// present, log the error.
 			// This is to help debug #11276.
 			msgChainNotFound := ": No chain/target/match by that name.\n"
-			debugTransientRules := c.name == ciliumTransientForwardChain &&
+			debugTransientRules := c.name == CiliumTransientForwardChain &&
 				string(combinedOutput) != prog+msgChainNotFound
 			if !quiet || debugTransientRules {
 				log.Warnf(string(combinedOutput))
-				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s Cilium %s chain", operation, prog)
+				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to process chain %s with %s (%s)", c.name, prog, operation)
 			}
 		}
 	}
@@ -322,7 +322,7 @@ var ciliumChains = []customChain{
 }
 
 var transientChain = customChain{
-	name:       ciliumTransientForwardChain,
+	name:       CiliumTransientForwardChain,
 	table:      "filter",
 	hook:       "FORWARD",
 	feederArgs: []string{""},
@@ -721,7 +721,7 @@ func getDeliveryInterface(ifName string) string {
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
 	transient := ""
-	if forwardChain == ciliumTransientForwardChain {
+	if forwardChain == CiliumTransientForwardChain {
 		transient = " (transient)"
 	}
 
@@ -833,7 +833,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 // TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
 func (m *IptablesManager) TransientRulesEnd(quiet bool) {
 	if option.Config.EnableIPv4 {
-		m.removeCiliumRules("filter", "iptables", ciliumTransientForwardChain)
+		m.removeCiliumRules("filter", "iptables", CiliumTransientForwardChain)
 		transientChain.remove(m.waitArgs, quiet)
 	}
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -85,8 +85,13 @@ func getVersion(prog string) (go_version.Version, error) {
 	return versioncheck.Version(vString[1])
 }
 
+func runProgCombinedOutput(prog string, args []string, quiet bool) ([]byte, error) {
+	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, !quiet)
+	return out, err
+}
+
 func runProg(prog string, args []string, quiet bool) error {
-	_, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, !quiet)
+	_, err := runProgCombinedOutput(prog, args, quiet)
 	return err
 }
 
@@ -188,9 +193,19 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 
 func (c *customChain) remove(waitArgs []string, quiet bool) {
 	doProcess := func(c *customChain, prog string, args []string, operation string, quiet bool) {
-		err := runProg(prog, args, true)
-		if err != nil && !quiet {
-			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s Cilium %s chain", operation, prog)
+		combinedOutput, err := runProgCombinedOutput(prog, args, true)
+		if err != nil {
+			// If the chain is for transient rules and deletion
+			// fails for a reason other than the chain not being
+			// present, log the error.
+			// This is to help debug #11276.
+			msgChainNotFound := ": No chain/target/match by that name.\n"
+			debugTransientRules := c.name == ciliumTransientForwardChain &&
+				string(combinedOutput) != prog+msgChainNotFound
+			if !quiet || debugTransientRules {
+				log.Warnf(string(combinedOutput))
+				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s Cilium %s chain", operation, prog)
+			}
 		}
 	}
 	doRemove := func(c *customChain, prog string, waitArgs []string, quiet bool) {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -308,7 +308,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.InstallIptRules {
 		if err := iptMgr.TransientRulesStart(option.Config.HostDevice); err != nil {
-			return err
+			log.WithError(err).Warning("failed to install transient iptables rules")
 		}
 	}
 	// Always remove masquerade rule and then re-add it if required

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -342,7 +342,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				}
 				if versionInfo < nonce {
 					// versions after VersionInfo, upto and including ResponseNonce are NACKed
-					requestLog.Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
+					requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
 					// Watcher will behave as if the sent version was acked.
 					// Otherwise we will just be sending the same failing
 					// version over and over filling logs.

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -316,6 +316,9 @@ const (
 	// XDSResource is an xDS resource message.
 	XDSResource = "xdsResource"
 
+	// XDSDetail is detail string included in XDS NACKs.
+	XDSDetail = "xdsDetail"
+
 	// K8s-specific
 
 	// K8sNodeID is the k8s ID of a K8sNode

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cilium/cilium/test/ginkgo-ext"
@@ -210,15 +211,17 @@ const (
 	PrivateIface = "enp0s8"
 
 	// Logs messages that should not be in the cilium logs.
-	panicMessage      = "panic:"
-	deadLockHeader    = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived      = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed     = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
-	sizeMismatch      = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
-	emptyBPFInitArg   = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
-	RemovingMapMsg    = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
-	logBufferMessage  = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
+	panicMessage        = "panic:"
+	deadLockHeader      = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault   = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived        = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed       = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch        = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
+	emptyBPFInitArg     = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
+	RemovingMapMsg      = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
+	logBufferMessage    = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
+	removeTransientRule = "Unable to process chain " +
+		iptables.CiliumTransientForwardChain + " with ip" // from https://github.com/cilium/cilium/issues/11276
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -265,15 +268,16 @@ const CiliumConfigMapPatchKvstoreAllocator = "cilium-cm-kvstore-allocator-patch.
 // badLogMessages is a map which key is a part of a log message which indicates
 // a failure if the message does not contain any part from value list.
 var badLogMessages = map[string][]string{
-	panicMessage:      nil,
-	deadLockHeader:    nil,
-	segmentationFault: nil,
-	NACKreceived:      nil,
-	RunInitFailed:     {"signal: terminated", "signal: killed"},
-	sizeMismatch:      nil,
-	emptyBPFInitArg:   nil,
-	RemovingMapMsg:    nil,
-	logBufferMessage:  nil,
+	panicMessage:        nil,
+	deadLockHeader:      nil,
+	segmentationFault:   nil,
+	NACKreceived:        nil,
+	RunInitFailed:       {"signal: terminated", "signal: killed"},
+	sizeMismatch:        nil,
+	emptyBPFInitArg:     nil,
+	RemovingMapMsg:      nil,
+	logBufferMessage:    nil,
+	removeTransientRule: nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
* #12016 -- envoy: Include detail in NACK warning (@jrajahalme)
 * #12006 -- iptables: carry on and log on failure to set up transient rules (@qmonnet)
   * Minor conflicts because PR #10639 was not present on v1.7 branch.
   * Also conflict in the messages we fail out the CI on. I only added the
     specific message that the PR adds, not all of the others in latest branch.
 * #11986 -- contrib/backporting: remove requires-janitor-review label (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12016 12006 11986; do contrib/backporting/set-labels.py $pr done 1.7; done
```