### PR TITLE
helm: Clean up the hubble-relay DNS name in the UI chart

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: HUBBLE
               value: "true"
             - name: HUBBLE_SERVICE
-              value: "hubble-relay.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "hubble-relay"
             - name: HUBBLE_PORT
               value: "80"
           ports:

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -8,7 +8,6 @@ image:
   tag: v0.6.0
   # pullPolicy is the container image pull policy
   pullPolicy: IfNotPresent
-clusterDomain: cluster.local
 replicas: 1
 # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
 #

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -802,7 +802,7 @@ spec:
             - name: HUBBLE
               value: "true"
             - name: HUBBLE_SERVICE
-              value: "hubble-relay.kube-system.svc.cluster.local"
+              value: "hubble-relay"
             - name: HUBBLE_PORT
               value: "80"
           ports:


### PR DESCRIPTION
Specifying the service name by itself as the DNS is sufficient since
hubble-relay and hubble-ui get deployed to the same namespace.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>