### PR TITLE
test: Fix hubble-relay tag pull for release branches

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -92,6 +92,7 @@ var (
 		"preflight.image":                     "cilium-dev", // Set again in init to match agent.image!
 		"global.tag":                          "latest",
 		"operator.image":                      "operator",
+		"hubble-relay.image.tag":              "latest",
 		"global.debug.enabled":                "true",
 		"global.k8s.requireIPv4PodCIDR":       "true",
 		"global.pprof.enabled":                "true",


### PR DESCRIPTION
(The following was written from the perspective of the v1.8 branch)

In the CI framework we build images from the current tree and tag them
as `latest`, even if the current tree is for instance `v1.8` (with
version `v1.8.0-rc2`).

At the same time, the Helm charts in the tree specify in the files that
they will pull the current tag from `VERSION`, for instance right now
on v1.8 branch, `v1.8.0-rc2`.

For `cilium` and `operator` images, we *override* the helm chart
defaults with `latest` to pick up the build/cached images from the first
step above. So `latest` contains the version built from `v1.8`.

However we weren't doing this for Hubble Relay, which meant that it
tried to pull the image with the tag `v1.8.0-rc2` but this image didn't
exist in the local registry.

To fix this and get the v1.8 tree to properly build with a version of
hubble-relay from v1.8 branch, we must tag, cache and deploy images that
represent the latest v1.8 development with `latest`, and pull that image
from the CI framework, and explicitly *not* pull the v1.8 version which
is specified in the helm charts.

:exploding_head: