### PR TITLE
test/K8sServices: disable fragment tracking test for kernel 4.19

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1412,7 +1412,9 @@ var _ = Describe("K8sServicesTest", func() {
 			})
 
 		// Net-next and not old versions, because of LRU requirement.
-		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Supports IPv4 fragments", func() {
+		// Should also run on 4.19, but it flakes a lot, see #10929.
+		// TODO: Re-enable on 4.19 after GH#11915.
+		SkipItIf(helpers.DoesNotRunOnNetNextKernel, "Supports IPv4 fragments", func() {
 			DeployCiliumAndDNS(kubectl, ciliumFilename)
 			testIPv4FragmentSupport()
 		})


### PR DESCRIPTION
We are currently seeing flakes on the tests for fragment tracking on 4.19 (tracked in #10929), let's temporarily disable the test for that kernel version.
