### PR TITLE
.travis: disable Documentation building on ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,7 +512,11 @@ install-manpages:
 	mandb
 
 postcheck: build
+ifeq ("$(GOARCH)","amd64")
 	$(QUIET)$(MAKE) $(SUBMAKEOPTS) -C Documentation update-cmdref check
+else
+	@echo "Skip Documentation building on $(GOARCH)"
+endif
 
 minikube:
 	$(QUIET) contrib/scripts/minikube.sh


### PR DESCRIPTION
Disable Documentation building on ARM64
Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Fixes: #12012
Fixes: #12038