### PR TITLE
daemon: Enable device auto detection for host-fw when BPF NodePort is disabled

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -429,7 +429,9 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	// retrieving Node object for self is needed by BPF NodePort device selection,
 	// and the k8s watcher depends on option.Config.EnableNodePort flag which
 	// can be modified by the initialization routine.
-	initKubeProxyReplacementOptions()
+	strict := initKubeProxyReplacementOptions()
+	detectDevicesForNodePortAndHostFirewall(strict)
+	finishKubeProxyReplacementInit()
 	if option.Config.EnableNodePort {
 		if err := node.InitNodePortAddrs(option.Config.Devices); err != nil {
 			log.WithError(err).Fatal("Failed to initialize NodePort addrs")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1749,7 +1749,8 @@ func initKubeProxyReplacementOptions() (strict bool) {
 // detectDevicesForNodePortAndHostFirewall tries to detect bpf_host devices
 // (if needed).
 func detectDevicesForNodePortAndHostFirewall(strict bool) {
-	detectNodePortDevs := option.Config.EnableNodePort && len(option.Config.Devices) == 0
+	detectNodePortDevs := len(option.Config.Devices) == 0 &&
+		(option.Config.EnableNodePort || option.Config.EnableHostFirewall)
 	detectDirectRoutingDev := option.Config.EnableNodePort &&
 		option.Config.DirectRoutingDevice == ""
 	if detectNodePortDevs || detectDirectRoutingDev {
@@ -1901,7 +1902,9 @@ func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 			}
 		}
 	}
-	devSet[option.Config.DirectRoutingDevice] = struct{}{}
+	if option.Config.DirectRoutingDevice != "" {
+		devSet[option.Config.DirectRoutingDevice] = struct{}{}
+	}
 
 	option.Config.Devices = make([]string, 0, len(devSet))
 	for dev := range devSet {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1817,7 +1817,7 @@ func initKubeProxyReplacementOptions() {
 			// and the client IP is reachable via other device than the direct
 			// routing one.
 
-			iface := option.Config.Devices[0] // direct routing interface
+			iface := option.Config.DirectRoutingDevice
 			if val, err := sysctl.Read(fmt.Sprintf("net.ipv4.conf.%s.rp_filter", iface)); err != nil {
 				log.Warnf("Unable to read net.ipv4.conf.%s.rp_filter: %s. Ignoring the check",
 					iface, err)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2914,6 +2914,7 @@ func EndpointStatusValuesMap() (values map[string]struct{}) {
 // MightAutoDetectDevices returns true if the device auto-detection might take
 // place.
 func MightAutoDetectDevices() bool {
-	return Config.KubeProxyReplacement != KubeProxyReplacementDisabled &&
-		(len(Config.Devices) == 0 || Config.DirectRoutingDevice == "")
+	return (Config.EnableHostFirewall && len(Config.Devices) == 0) ||
+		(Config.KubeProxyReplacement != KubeProxyReplacementDisabled &&
+			(len(Config.Devices) == 0 || Config.DirectRoutingDevice == ""))
 }


### PR DESCRIPTION
This PR:

- Restructures `initKubeProxyReplacementOptions()`, and splits it into two helpers.
- Enables device auto detection for host-fw.
- Fixes direct routing iface in the DSR check.

Reviewable per commit.