### PR TITLE
test/k8s: keep configmap across upgrade test

### DIFF
--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -36,7 +36,7 @@ cilium-operator-generic [flags]
       --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration           GC interval for security identities (default 15m0s)
       --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ipam string                             Backend to use for IPAM (default "cluster-pool")
+      --ipam string                             Backend to use for IPAM (default "hostscope-legacy")
       --k8s-api-server string                   Kubernetes API server URL
       --k8s-client-burst int                    Burst value allowed for the K8s client
       --k8s-client-qps float32                  Queries per second limit for the K8s client

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -55,6 +55,13 @@ spec:
         command:
         - cilium-agent
         livenessProbe:
+{{- if .Values.keepDeprecatedProbes }}
+          exec:
+            command:
+            - cilium
+            - status
+            - --brief
+{{- else }}
           httpGet:
             host: '127.0.0.1'
             path: /healthz
@@ -63,6 +70,7 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
+{{- end }}
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -72,6 +80,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
+{{- if .Values.keepDeprecatedProbes }}
+          exec:
+            command:
+            - cilium
+            - status
+            - --brief
+{{- else }}
           httpGet:
             host: '127.0.0.1'
             path: /healthz
@@ -80,6 +95,7 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
+{{- end }}
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -37,8 +37,10 @@ spec:
         - cilium-operator-aws
 {{- else if .Values.global.azure.enabled }}
         - cilium-operator-azure
-{{- else }}
+{{- else if .Values.global.ipam.operator }}
         - cilium-operator-generic
+{{- else }}
+        - cilium-operator
 {{- end }}
         env:
         - name: K8S_NODE_NAME
@@ -114,8 +116,10 @@ spec:
         image: "{{ .Values.global.registry }}/{{ .Values.image }}-aws:{{ .Values.global.tag }}"
 {{- else if .Values.global.azure.enabled }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}-azure:{{ .Values.global.tag }}"
-{{- else }}
+{{- else if .Values.global.ipam.operator }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}-generic:{{ .Values.global.tag }}"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
 {{- end }}
 {{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -7,6 +7,8 @@ agent:
   sleepAfterInit: false
   # Keep the deprecated selector labels when deploying Cilium DaemonSet
   keepDeprecatedLabels: false
+  # Keep the deprecated probes when deploying Cilium DaemonSet
+  keepDeprecatedProbes: false
 
 # Include the cilium-config ConfigMap
 config:

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -124,7 +124,9 @@ func init() {
 	case "cilium-operator-azure":
 		defaultIPAM = ipamOption.IPAMAzure
 	case "cilium-operator-generic":
-		defaultIPAM = ipamOption.IPAMOperator
+		// Default to Legacy for upgrade paths; new users should
+		// explicitly override the IPAM flag.
+		defaultIPAM = ipamOption.IPAMHostScopeLegacy
 	}
 
 	flags.String(option.IPAM, defaultIPAM, "Backend to use for IPAM")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2355,6 +2355,24 @@ func (kub *Kubectl) RunHelm(action, repo, helmName, version, namespace string, o
 		"%s", action, helmName, repo, version, namespace, optionsString)), nil
 }
 
+// RunHelmTemplate runs the helm template command for a specific version.
+func (kub *Kubectl) RunHelmTemplateApply(repo, helmName, version, namespace string, options map[string]string) (*CmdRes, error) {
+	err := kub.overwriteHelmOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	optionsString := ""
+
+	for k, v := range options {
+		optionsString += fmt.Sprintf(" --set %s=%s ", k, v)
+	}
+
+	return kub.ExecMiddle(fmt.Sprintf("helm template %s %s "+
+		"--version=%s "+
+		"--namespace=%s "+
+		"%s | %s apply -f -", helmName, repo, version, namespace, optionsString, KubectlCmd)), nil
+}
+
 // CiliumUninstall uninstalls Cilium with the provided Helm options.
 func (kub *Kubectl) CiliumUninstall(filename string, options map[string]string) error {
 	return kub.ciliumUninstallHelm(filename, options)


### PR DESCRIPTION
test/k8s: keep configmap across upgrade test

Since we have new options set for new Cilium installations those
might break the connectivity when doing upgrades.

To ideally test an upgrade, we should keep the existing ConfigMap
from the previous the version.

This also fixes the upgrade guide using helm as using `--set
config.enabled=false` deploys Cilium without its configuration map,
deleting the existing one from the cluster.

Also fixes the Cilium DaemonSet since its upgrade does not work using
kubectl apply given that we have introduced a new liveness and readiness
probes in the DaemonSet. Added upgrade notes to keep the old probes
while users perform the upgrades.

Fixes: d613dea5d524 ("install/kubernetes: use HTTP for agent {liveness,readiness}Probe")
Signed-off-by: André Martins <andre@cilium.io>