### PR TITLE
contrib: extend checkpr.sh to watch for Smoke Tests completion

### DIFF
--- a/contrib/scripts/checkpr.sh
+++ b/contrib/scripts/checkpr.sh
@@ -13,6 +13,24 @@ then
 	exit
 fi
 
+BARK_PATH="${BARK_PATH:-/usr/share/sounds/freedesktop/stereo/bell.oga}"
+name=$(uname)
+notify() {
+	set +e
+	notify-send "$1" "$2"
+	set -e
+
+	for run in {1..5}
+	do
+		if [ "$name" == "Linux" ]; then
+			paplay ${BARK_PATH}
+		else
+			# for osx
+			afplay /System/Library/Sounds/Ping.aiff
+		fi
+	done
+}
+
 PR_ID=$1
 
 statuses=$(curl -s https://api.github.com/repos/cilium/cilium/pulls/${PR_ID} | jq -r '._links.statuses.href')
@@ -33,15 +51,4 @@ for base_url in "${jenkins_urls[@]}"; do
 	echo "See $base_url for more details."
 done
 
-BARK_PATH="${BARK_PATH:-/usr/share/sounds/freedesktop/stereo/bell.oga}"
-
-name=$(uname)
-for run in {1..5}
-do
-	if [ "$name" == "Linux" ]; then
-		paplay ${BARK_PATH}
-	else
-		# for osx
-		afplay /System/Library/Sounds/Ping.aiff
-	fi
-done
+notify "PR $PR_ID checks terminated" "Result: $result\nSee $base_url for more details."

--- a/contrib/scripts/checkpr.sh
+++ b/contrib/scripts/checkpr.sh
@@ -13,12 +13,14 @@ usage() {
 	echo -e "\t-h\tdisplay this help"
 	echo -e "\t-m\tdisable audio notifications"
 	echo -e "\t-q\tdisable textual notifications"
+	echo -e "\t-s\twatch Smoke Tests instead of Jenkins"
 }
 
 notif_audio=1
 notif_desktop=1
+smoke_tests=0
 OPTIND=1
-while getopts "hmq" opt; do
+while getopts "hmqs" opt; do
 	case "$opt" in
 		h)
 			usage
@@ -29,6 +31,9 @@ while getopts "hmq" opt; do
 			;;
 		q)
 			notif_desktop=0
+			;;
+		s)
+			smoke_tests=1
 			;;
 	esac
 done
@@ -65,24 +70,69 @@ notify() {
 	done
 }
 
-PR_ID=$1
+is_true() {
+	if [ $1 == "true" ]; then
+		return 0
+	else
+		return 1
+	fi
+}
 
-statuses=$(curl -s https://api.github.com/repos/cilium/cilium/pulls/${PR_ID} | jq -r '._links.statuses.href')
-jenkins_urls=($(curl -s $statuses | jq -r '.[] | select(.target_url != null) | select(.target_url | contains("jenkins")) | .target_url' | sort | uniq))
+check_smoke_test() {
+	PR_ID=$1
 
-for base_url in "${jenkins_urls[@]}"; do
-	result="null"
-	first=true
-	until [ "$result" != "null" ]; do
-		if [ $first = true ]; then
-			first=false
-		else
-			sleep 60
+	# Get branch (HEAD) for PR
+	BRANCH=$(curl -s "https://api.github.com/repos/cilium/cilium/pulls/$PR_ID" | jq -r '.head.ref')
+
+	# Get workflow ID for latest Smoke tests run for that branch
+	ID=$(curl -s "https://api.github.com/repos/cilium/cilium/actions/workflows/helm-check.yaml/runs?branch=$BRANCH&per_page=1" | jq '.workflow_runs[].id');
+
+	while true; do
+		# Get info for jobs in the Smoke tests workflow run
+		OVERVIEW=$(curl -s "https://api.github.com/repos/cilium/cilium/actions/runs/$ID/jobs" | jq '[.jobs[]|{name: .name, status: .status, conclusion: .conclusion}]')
+		date
+		echo $OVERVIEW | jq
+
+		STATUS=$(echo $OVERVIEW | jq '[.[]|.status == "completed"]|all')
+		if $(is_true $STATUS); then
+			CONCLUSION=$(echo $OVERVIEW | jq '[.[]|.conclusion == "success"]|all')
+			if $(is_true $CONCLUSION); then
+				RESULT="PASS ✔️"
+			else
+				RESULT="FAIL ❌"
+			fi
+			notify "Smoke tests for #$PR_ID finished" "Result: $RESULT\nhttps://github.com/cilium/cilium/pull/$PR_ID"
+			break
 		fi
-		result=$(curl -s ${base_url}/api/json | jq ".result")
+		sleep 60
 	done
-	echo "PR $PR_ID result: $result"
-	echo "See $base_url for more details."
-done
+}
 
-notify "PR $PR_ID checks terminated" "Result: $result\nSee $base_url for more details."
+check_jenkins() {
+	PR_ID=$1
+	statuses=$(curl -s https://api.github.com/repos/cilium/cilium/pulls/${PR_ID} | jq -r '._links.statuses.href')
+	jenkins_urls=($(curl -s $statuses | jq -r '.[] | select(.target_url != null) | select(.target_url | contains("jenkins")) | .target_url' | sort | uniq))
+
+	for base_url in "${jenkins_urls[@]}"; do
+		result="null"
+		first=true
+		until [ "$result" != "null" ]; do
+			if [ $first = true ]; then
+				first=false
+			else
+				sleep 60
+			fi
+			result=$(curl -s ${base_url}/api/json | jq ".result")
+		done
+		echo "PR $PR_ID result: $result"
+		echo "See $base_url for more details."
+	done
+
+	notify "PR $PR_ID checks terminated" "Result: $result\nSee $base_url for more details."
+}
+
+if [ $smoke_tests -eq 1 ]; then
+	check_smoke_test $1
+else
+	check_jenkins $1
+fi


### PR DESCRIPTION
Extend `contrib/scripts/checkpr.sh` with options, including a `-s` option to watch for the completion of Smoke Tests (from GitHub actions) instead of the Jenkins job for the given PR. This is so we can launch the Jenkins CI tests once the Smoke Tests are finished.

Usage: Check for Jenkins status as before:
```
./contrib/scripts/checkpr.sh <PR_ID>
```
Check for Smoke Tests instead with the `-s` option:
```
./contrib/scripts/checkpr.sh -s <PR_ID>
```