### PR TITLE
Update xargs usage in restart-pods documentation

### DIFF
--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -10,7 +10,7 @@ connectivity provided by Cilium and NetworkPolicy applies to them:
 
 ::
 
-    kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs kubectl delete pod
+    kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -L 1 -r kubectl delete pod
     pod "event-exporter-v0.2.3-f9c896d75-cbvcz" deleted
     pod "fluentd-gcp-scaler-69d79984cb-nfwwk" deleted
     pod "heapster-v1.6.0-beta.1-56d5d5d87f-qw8pv" deleted


### PR DESCRIPTION
Restart command in documentation pipes complete output of the awk into
xargs which creates invalid kubectl command. This commit updates
xargs to use per line mode and also makes it omit empty input to not
execute empty "kubectl delete pod" on the last line.

before:

```sh
kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -p kubectl delete pod
kubectl delete pod -n gitlab-managed-apps hubble-27vkw -n gitlab-managed-apps hubble-p2zdg -n gitlab-managed-apps tiller-deploy-7f847cb9d9-cm5gn -n kube-system event-exporter-v0.2.5-599d65f456-sn2r4 -n kube-system fluentd-gcp-scaler-bfd6cf8dd-nrhhz -n kube-system heapster-gke-779b9d8866-w9d5g -n kube-system kube-dns-5995c95f64-dcrdc -n kube-system kube-dns-5995c95f64-zj4wh -n kube-system kube-dns-autoscaler-8687c64fc-lfgtg -n kube-system l7-default-backend-8f479dd9-5twjj -n kube-system metrics-server-v0.3.1-5c6fbf777-pfw2m -n kube-system stackdriver-metadata-agent-cluster-level-87f57d8-m68fj -n policy-mock-19288614-production production-5f4876cc95-g6zmp ?...
```

after:

```sh
kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -L 1 -r -p kubectl delete pod
kubectl delete pod -n gitlab-managed-apps hubble-27vkw ?...n
kubectl delete pod -n gitlab-managed-apps hubble-p2zdg ?...n
kubectl delete pod -n gitlab-managed-apps tiller-deploy-7f847cb9d9-cm5gn ?...n
kubectl delete pod -n kube-system event-exporter-v0.2.5-599d65f456-sn2r4 ?...n
kubectl delete pod -n kube-system fluentd-gcp-scaler-bfd6cf8dd-nrhhz ?...n
kubectl delete pod -n kube-system heapster-gke-779b9d8866-w9d5g ?...n
kubectl delete pod -n kube-system kube-dns-5995c95f64-dcrdc ?...n
kubectl delete pod -n kube-system kube-dns-5995c95f64-zj4wh ?...n
kubectl delete pod -n kube-system kube-dns-autoscaler-8687c64fc-lfgtg ?...n
kubectl delete pod -n kube-system l7-default-backend-8f479dd9-5twjj ?...n
kubectl delete pod -n kube-system metrics-server-v0.3.1-5c6fbf777-pfw2m ?...n
kubectl delete pod -n kube-system stackdriver-metadata-agent-cluster-level-87f57d8-m68fj ?...n
kubectl delete pod -n policy-mock-19288614-production production-5f4876cc95-g6zmp ?...n
```