### PR TITLE
test: Fix hubble-relay image helm path

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -241,7 +241,7 @@ func Init() {
 		"CILIUM_TAG":            "global.tag",
 		"CILIUM_IMAGE":          "agent.image",
 		"CILIUM_OPERATOR_IMAGE": "operator.image",
-		"HUBBLE_RELAY_IMAGE":    "hubble-relay.image",
+		"HUBBLE_RELAY_IMAGE":    "hubble-relay.image.repository",
 	} {
 		if v := os.Getenv(envVar); v != "" {
 			defaultHelmOptions[helmVar] = v


### PR DESCRIPTION
'hubble-relay.image' was changed from a string to a map of strings by
commit commit bbf53770a ("Fix values scoping for newly implemented
sub-chart hubble-relay"). Fix the test helpers accordingly.

Without this helm would panic when ginkgo option
'-cilium.hubble-relay-image="docker.io/cilium/hubble-relay:latest"' is
passed as the helm command line included both 'hubble-relay.image' and
'hubble-relay.image.tag' like so:

$ helm template install/kubernetes/cilium --namespace=cilium  --set hubble-relay.image=docker.io/cilium/hubble-relay:latest  --set hubble-relay.image.tag=latest
panic: interface conversion: interface {} is string, not map[string]interface {}

goroutine 1 [running]:
helm.sh/helm/v3/pkg/strvals.(*parser).key(0xc0004c5ac0, 0xc00031a3c0, 0xc00067f800, 0xc)
	/private/tmp/helm-20200608-50972-gq0j1j/src/helm.sh/helm/pkg/strvals/parser.go:211 +0xdea

Fixes: #11757
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
