### PR TITLE
[RFC] install/kubernetes: provide way to keep ConfigMap for upgrades

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -211,8 +211,11 @@ configuration options for each minor version.
 
   .. group-tab:: Helm
 
-    Keeping an existing `ConfigMap` with ``helm upgrade`` is currently not
-    supported.
+    .. parsed-literal::
+
+      helm upgrade |CHART_RELEASE| \\
+        --namespace kube-system cilium \\
+        --set global.configMap="$(kubectl get -n kube-system cm cilium-config -o yaml)"
 
 .. note::
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -1,3 +1,6 @@
+{{- if .Values.global.configMap }}
+{{ .Values.global.configMap }}
+{{- else }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -516,4 +519,5 @@ data:
 
 {{- if .Values.global.cnpStatusUpdates }}
   disable-cnp-status-updates: {{ not .Values.global.cnpStatusUpdates.enabled | quote }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Keeping the existing ConfigMap can be possible if the user passes the
current ConfigMap as a flag in the upgrade step.

Signed-off-by: André Martins <andre@cilium.io>

fixes https://github.com/cilium/cilium/issues/12079