### PR TITLE
daemon: Fix fallback to iptables-based masquerading

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -438,20 +438,24 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	// BPF masquerade depends on BPF NodePort, so the following checks should
 	// happen after invoking initKubeProxyReplacementOptions().
 	if option.Config.Masquerade && option.Config.EnableBPFMasquerade &&
-		!option.Config.EnableNodePort {
+		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "") {
+		var msg string
+		if !option.Config.EnableNodePort {
+			msg = fmt.Sprintf("BPF masquerade requires NodePort (--%s=\"true\").",
+				option.EnableNodePort)
+		} else if option.Config.EgressMasqueradeInterfaces != "" {
+			msg = fmt.Sprintf("BPF masquerade does not allow to specify devices via --%s (use --%s instead).",
+				option.EgressMasqueradeInterfaces, option.Devices)
+		}
 		// ipt.InstallRules() (called by Reinitialize()) happens later than
 		// this  statement, so it's OK to fallback to iptables-based MASQ.
-		log.Warnf("BPF masquerade requires NodePort (--%s=\"true\"). "+
-			"Falling back to iptables-based masquerading.", option.EnableNodePort)
 		option.Config.EnableBPFMasquerade = false
+		log.Warn(msg + " Falling back to iptables-based masquerading.")
 	}
 	if option.Config.Masquerade && option.Config.EnableBPFMasquerade {
 		// TODO(brb) nodeport + ipvlan constraints will be lifted once the SNAT BPF code has been refactored
 		if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
 			log.Fatalf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)
-		}
-		if option.Config.EgressMasqueradeInterfaces != "" {
-			log.Fatalf("BPF masquerade does not allow to specify devices via --%s. Use --%s instead.", option.EgressMasqueradeInterfaces, option.Devices)
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		log.Fatalf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.Masquerade, option.EnableBPFMasquerade)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -437,14 +437,15 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	}
 	// BPF masquerade depends on BPF NodePort, so the following checks should
 	// happen after invoking initKubeProxyReplacementOptions().
+	if option.Config.Masquerade && option.Config.EnableBPFMasquerade &&
+		!option.Config.EnableNodePort {
+		// ipt.InstallRules() (called by Reinitialize()) happens later than
+		// this  statement, so it's OK to fallback to iptables-based MASQ.
+		log.Warnf("BPF masquerade requires NodePort (--%s=\"true\"). "+
+			"Falling back to iptables-based masquerading.", option.EnableNodePort)
+		option.Config.EnableBPFMasquerade = false
+	}
 	if option.Config.Masquerade && option.Config.EnableBPFMasquerade {
-		if !option.Config.EnableNodePort {
-			// ipt.InstallRules() (called by Reinitialize()) happens later than
-			// this  statement, so it's OK to fallback to iptables-based MASQ.
-			log.Warnf("BPF masquerade requires NodePort (--%s=\"true\"). "+
-				"Falling back to iptables-based masquerading.", option.EnableNodePort)
-			option.Config.EnableBPFMasquerade = false
-		}
 		// TODO(brb) nodeport + ipvlan constraints will be lifted once the SNAT BPF code has been refactored
 		if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
 			log.Fatalf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -103,6 +103,7 @@ var (
 		"global.ipv6.enabled":                 "true",
 		"global.psp.enabled":                  "true",
 		"global.ci.kubeCacheMutationDetector": "true",
+		"global.bpfMasquerade":                "true",
 		// Disable by default, so that 4.9 CI build does not panic due to
 		// missing LRU support. On 4.19 and net-next we enable it with
 		// kubeProxyReplacement=strict.
@@ -2176,7 +2177,6 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 				return err
 			}
 			devices = fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface)
-			opts["global.bpfMasquerade"] = "true"
 		}
 
 		opts["global.devices"] = devices


### PR DESCRIPTION
Previously, when falling back to iptables-based masquerading, if a user
had specified `--egress-masquerade-interface`, the agent considered it
as part of BPF masquerading options. This made it obviously to fail.

Fix: b7b962ba0 ("daemon: Fallback to iptables if BPF masq cannot be enabled")
Reported-by: Tobias Klauser <tklauser@distanz.ch>

Fix #12081

/cc @tklauser 