### PR TITLE
contrib: Add environment variable to script  to control K8s namespace

### DIFF
--- a/contrib/k8s/k8s-cilium-exec.sh
+++ b/contrib/k8s/k8s-cilium-exec.sh
@@ -29,8 +29,10 @@ function cleanup {
 	kill_jobs TERM
 }
 
+K8S_NAMESPACE="${K8S_NAMESPACE:-kube-system}"
+
 while read -r p; do
-	kubectl -n kube-system exec -ti $p -- $*&
-done <<< "$(kubectl -n kube-system get pods -l k8s-app=cilium | awk '{print $1}' | grep cilium)"
+	kubectl -n "${K8S_NAMESPACE}" exec -ti $p -- $*&
+done <<< "$(kubectl -n ${K8S_NAMESPACE} get pods -l k8s-app=cilium | awk '{print $1}' | grep cilium)"
 
 wait


### PR DESCRIPTION
This updates the script to allow the user to specify which namespace Cilium is
deployed in.