### PR TITLE
bpf: Reply NA when recv ND for local IPv6 endpoints

### DIFF
--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -10,14 +10,20 @@
 #include "maps.h"
 
 static __always_inline __maybe_unused struct endpoint_info *
-lookup_ip6_endpoint(struct ipv6hdr *ip6)
+lookup_ip6_endpoint_from_daddr(const union v6addr *ip6)
 {
 	struct endpoint_key key = {};
 
-	key.ip6 = *((union v6addr *) &ip6->daddr);
+	key.ip6 = *ip6;
 	key.family = ENDPOINT_KEY_IPV6;
 
 	return map_lookup_elem(&ENDPOINTS_MAP, &key);
+}
+
+static __always_inline __maybe_unused struct endpoint_info *
+lookup_ip6_endpoint(struct ipv6hdr *ip6)
+{
+	return lookup_ip6_endpoint_from_daddr((union v6addr *)&ip6->daddr);
 }
 
 static __always_inline __maybe_unused struct endpoint_info *


### PR DESCRIPTION
When receiving ICMPv6 ND message from native NIC, lookup local endpoints
for target IPv6 address. If local endpoint was found, reply NA message
via the same NIC.

This enables pod's IPv6 address discoverable on the subnet to which the
node is connected to.

Torwards #10935
Signed-off-by: Yongkun Gui <ygui@google.com>

Please ensure your pull request adheres to the following guidelines:

- [ x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #10935

```release-note
Add ND responder on native NIC to make endpoint IPv6 address discoverable on node network.
```

TODO: test still to be added.