### PR TITLE
Fix GKE Helm options for CI and docs.

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -482,8 +482,6 @@ An example invocation is
 GKE (experimental)
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Not all tests can succeed on GKE. Many do, however and may be useful.
-
 1- Setup a cluster as in :ref:`k8s_install_gke` or utilize an existing
 cluster.
 
@@ -497,12 +495,18 @@ cluster.
 2- Invoke the tests from ``cilium/test`` with options set as explained in
 `Running End-To-End Tests In Other Environments via kubeconfig`_
 
+.. note:: GKE clusters may have namespaces stuck at the ``Terminating`` state,
+          causing Ginkgo tests to fail. If so, you'll see them in ``kubectl get ns``,
+          and can get rid of them by running
+          ``cilium/test/gke/delete-terminating-namespaces.sh``.
+
 ::
 
-  CNI_INTEGRATION=gke K8S_VERSION=1.14 ginkgo -v --focus="K8sDemo" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator-generic:latest" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=gke K8S_VERSION=1.14 ginkgo -v --focus="K8sDemo" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator-generic:latest" -cilium.hubble-relay-image="docker.io/cilium/hubble-relay:latest" -cilium.passCLIEnvironment=true
 
-.. note:: The kubernetes version defaults to 1.13 but can be configured with
-          versions between 1.13 and 1.15. Check with ``kubectl version`` 
+.. note:: The kubernetes version defaults to 1.18 but can be configured with
+          versions between 1.13 and 1.18. Version should match the server
+          version reported by ``kubectl version``.
 
 AWS EKS (experimental)
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -92,7 +92,7 @@ below. This will ensure all pods are managed by Cilium.
       --set global.cni.binPath=/home/kubernetes/bin \\
       --set global.gke.enabled=true \\
       --set config.ipam=kubernetes \\
-      --set global.native-routing-cidr=$NATIVE_CIDR
+      --set global.nativeRoutingCIDR=$NATIVE_CIDR
 
 The NodeInit DaemonSet is required to prepare the GKE nodes as nodes are added
 to the cluster. The NodeInit DaemonSet will perform the following actions:

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -139,6 +139,10 @@ pipeline {
                         returnStdout: true,
                         script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator-generic:${TAG}'
                         )}"""
+                HUBBLE_RELAY_IMAGE= """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/hubble-relay:${TAG}'
+                        )}"""
                 K8S_VERSION= """${sh(
                         returnStdout: true,
                         script: 'cat ${TESTDIR}/gke/cluster-version'
@@ -151,7 +155,7 @@ pipeline {
             steps {
                 dir("${TESTDIR}"){
                     sh 'env'
-                    sh 'ginkgo --focus="${FOCUS}" -v -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh) -cilium.image=${CILIUM_IMAGE} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.holdEnvironment=false'
+                    sh 'ginkgo --focus="${FOCUS}" -v -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh) -cilium.image=${CILIUM_IMAGE} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.holdEnvironment=false'
                 }
             }
             post {

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -137,7 +137,7 @@ pipeline {
                         )}"""
                 CILIUM_OPERATOR_IMAGE= """${sh(
                         returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator:${TAG}'
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator-generic:${TAG}'
                         )}"""
                 K8S_VERSION= """${sh(
                         returnStdout: true,

--- a/test/gke/delete-terminating-namespaces.sh
+++ b/test/gke/delete-terminating-namespaces.sh
@@ -2,9 +2,10 @@
 
 # because of https://github.com/kubernetes/kubernetes/issues/60807 , we may end up with garbage terminating
 # namespaces leftovers after tests. This is a hacky workaround
+# '\[[^]]*\]' below matches a pair of square brackets with anything in between, not containing a closing square bracket
 kubectl get ns | \
 	awk '/Terminating/ {print $1}' | \
-   	xargs -n 1 bash -c 'if [ "$#" -ne 1 ]; then exit 0; fi; kubectl get ns -o json $1 | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/$1/finalize -f -' -
+   	xargs -n 1 bash -c 'if [ "$#" -ne 1 ]; then exit 0; fi; kubectl get ns -o json $1 | tr -d "\n" | sed "s/\"finalizers\": \[[^]]*\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/$1/finalize -f -' -
 
 # Note: This can be removed once GKE stops having the issue with namespaces no
 # deleting.

--- a/test/gke/lock.yaml
+++ b/test/gke/lock.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lock
+  namespace: cilium-ci-lock
 spec:
   replicas: 0
   selector:

--- a/test/gke/release-cluster.sh
+++ b/test/gke/release-cluster.sh
@@ -17,7 +17,7 @@ cluster_uri="$(cat "${script_dir}/cluster-uri")"
 # for example.
 unlock() {    
     echo "releasing cluster lock from ${cluster_uri}"
-    kubectl annotate deployment lock lock-
+    kubectl annotate deployment -n cilium-ci-lock lock lock-
 }
 trap unlock EXIT
 

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -23,15 +23,16 @@ while [ $locked -ne 0 ]; do
     echo "getting kubeconfig for ${cluster_uri} (will store in ${KUBECONFIG})"
     gcloud container clusters get-credentials --project "${project}" --region "${region}" "${cluster_uri}"
 
-    echo "aquiring cluster lock"
+    echo "acquiring cluster lock"
     set +e
+    kubectl create namespace cilium-ci-lock
     kubectl create -f "${script_dir}/lock.yaml"
 
-    kubectl annotate deployment lock lock=1
+    kubectl annotate deployment -n cilium-ci-lock lock lock=1
     locked=$?
     echo $locked
     if [ -n "${BUILD_URL+x}" ] && [ $locked -eq 0 ] ; then
-      kubectl annotate deployment lock --overwrite "jenkins-build-url=${BUILD_URL}"
+      kubectl annotate deployment -n cilium-ci-lock lock --overwrite "jenkins-build-url=${BUILD_URL}"
     fi
     set -e
 done

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -144,6 +144,7 @@ var (
 		"global.nativeRoutingCIDR":    "10.0.0.0/8",
 		"global.hostFirewall":         "false",
 		"config.ipam":                 "kubernetes",
+		"global.devices":              "", // Override "eth0 eth0\neth0"
 	}
 
 	microk8sHelmOverrides = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1403,7 +1403,10 @@ func (kub *Kubectl) Apply(options ApplyOptions) *CmdRes {
 	if len(options.Piped) > 0 {
 		cmd = options.Piped + " | " + cmd
 	}
-	return kub.ExecMiddle(cmd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout*2)
+	defer cancel()
+	return kub.ExecContext(ctx, cmd)
 }
 
 // ApplyDefault applies give filepath with other options set to default

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -143,6 +143,7 @@ var (
 		"global.gke.enabled":          "true",
 		"global.nativeRoutingCIDR":    "10.0.0.0/8",
 		"global.hostFirewall":         "false",
+		"config.ipam":                 "kubernetes",
 	}
 
 	microk8sHelmOverrides = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1880,6 +1880,9 @@ func (kub *Kubectl) RedeployKubernetesDnsIfNecessary() {
 		return err == nil
 	})
 	if err != nil {
+		desc := kub.ExecShort(fmt.Sprintf("%s describe pods -n %s -l %s", KubectlCmd, KubeSystemNamespace, kubeDNSLabel))
+		ginkgoext.By(desc.GetDebugMessage())
+
 		ginkgoext.Fail("Kubernetes DNS did not become ready in time")
 	}
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -557,6 +557,7 @@ func (kub *Kubectl) PrepareCluster() {
 		"kube-node-lease",
 		"kube-public",
 		"container-registry",
+		"cilium-ci-lock",
 	})
 	if err != nil {
 		ginkgoext.Failf("Unable to delete non-essential namespaces: %s", err)


### PR DESCRIPTION
GKE install guide specifies the "ipam.config=kubernetes" option while
CI gkeHelmOverrides do not. Adding this option to CI gkeHelmOverrides
allowed Ginkgo runs in GKE to succeed.

Helm name for the native routing CIDR is
"global.nativeRoutingCIDR". Cilium agent command line option name is
"native-routing-cidr".

Fixes: #12053