### PR TITLE
Fix DOCKER_BUILDKIT builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,13 @@
 
 include Makefile.defs
 
-# Use the main repo as the build-context by default
-DOCKER_BUILD_DIR := .
-CILIUM_DOCKERFILE := Dockerfile
-DOCKER_PLUGIN_DOCKERFILE := cilium-docker-plugin.Dockerfile
-HUBBLE_RELAY_DOCKERFILE := hubble-relay.Dockerfile
-
-BUILD_DIR ?= _build
-
 # This is a no-op unless DOCKER_BUILDKIT is defined
+# Provides buildkit specific defaults BUILD_DIR and DOCKER_BUILD_DIR
 include Makefile.buildkit
+
+# Use the main repo as the build-context by default.
+DOCKER_BUILD_DIR ?= .
+BUILD_DIR ?= .
 
 SUBDIRS_CILIUM_CONTAINER := proxylib envoy bpf cilium daemon cilium-health bugtool
 SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools hubble-relay
@@ -26,7 +23,7 @@ GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(GO_LIST) -e ./...))
 GOFILES ?= $(GOFILES_EVAL)
 TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell echo $(GOFILES) | \
 	sed 's/ /\n/g' | \
-	grep -v '/api/v1\|/vendor\|/contrib\|/$(BUILD_DIR)' | \
+	grep -v '/api/v1\|/vendor\|/contrib\|/$(BUILD_DIR)/' | \
 	grep -v -P 'test(?!/helpers/logutils)'))
 TESTPKGS ?= $(TESTPKGS_EVAL)
 GOLANGVERSION := $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ include Makefile.defs
 # Use the main repo as the build-context by default
 DOCKER_BUILD_DIR := .
 CILIUM_DOCKERFILE := Dockerfile
-OPERATOR_DOCKERFILES := cilium-operator.Dockerfile \
-  cilium-operator-aws.Dockerfile \
-  cilium-operator-azure.Dockerfile \
-  cilium-operator-generic.Dockerfile
 DOCKER_PLUGIN_DOCKERFILE := cilium-docker-plugin.Dockerfile
 HUBBLE_RELAY_DOCKERFILE := hubble-relay.Dockerfile
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Copyright 2017-2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+all: precheck build postcheck
+	@echo "Build finished."
+
 include Makefile.defs
 
 # This is a no-op unless DOCKER_BUILDKIT is defined
@@ -122,9 +125,6 @@ define generate_k8s_protobuf
 		--packages=$(1) \
 	    --go-header-file "$(PWD)/hack/custom-boilerplate.go.txt"
 endef
-
-all: precheck build postcheck
-	@echo "Build finished."
 
 build: $(SUBDIRS)
 

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -16,10 +16,6 @@ veryclean: clean-build
 # Overrides for the main Dockerfile
 DOCKER_BUILD_DIR := $(BUILD_DIR)/context
 CILIUM_DOCKERFILE := $(BUILD_DIR)/cilium.Dockerfile
-OPERATOR_DOCKERFILES := $(BUILD_DIR)/cilium-operator.Dockerfile \
-  $(BUILD_DIR)/cilium-operator-aws.Dockerfile \
-  $(BUILD_DIR)/cilium-operator-azure.Dockerfile \
-  $(BUILD_DIR)/cilium-operator-generic.Dockerfile
 DOCKER_PLUGIN_DOCKERFILE := $(BUILD_DIR)/cilium-docker-plugin.Dockerfile
 HUBBLE_RELAY_DOCKERFILE := $(BUILD_DIR)/hubble-relay.Dockerfile
 

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -8,7 +8,7 @@ export DOCKER_BUILDKIT=1
 
 # Clean the build directory and cache
 clean-build:
-	-$(QUIET) rm -rf $(BUILD_DIR)
+	-$(QUIET) rm -rf _build
 	-$(QUIET) docker builder prune --filter type=exec.cachemount -f
 
 veryclean: clean-build
@@ -22,18 +22,18 @@ HUBBLE_RELAY_DOCKERFILE := $(BUILD_DIR)/hubble-relay.Dockerfile
 BUILDKIT_DOCKERFILE_FILTER := | sed -e "1s|^\#.*|\# syntax = docker/dockerfile:experimental|" -e "s|^RUN\(.*\)make|RUN --mount=type=cache,target=/root/.cache/go-build\1make|"
 
 # _build/.git is a shallow bare clone of the main repo
-$(BUILD_DIR)/.git:
-	-mkdir -p $(dir $@)
-	git clone --bare --no-local --depth 1 . $@
-	@cd $(dir $@) && git remote set-url origin "$(shell realpath --relative-to $(dir $@) $(ROOT_DIR))"
+_build/.git:
+	-mkdir -p _build
+	git clone --bare --no-local --depth 1 . _build/.git
+	@cd _build && git remote set-url origin ..
 
 #
 # Create _build context:
-# $(DOCKER_BUILD_DIR)/.git will be a file (rather than directory) that contains git specific
+# _build/context/.git will be a file (rather than directory) that contains git specific
 # symbolic link to _build/.git (--separate-git-dir)
 #
-$(DOCKER_BUILD_DIR): $(BUILD_DIR)/.git
-	git init --separate-git-dir=$(BUILD_DIR)/.git $@
+_build/context: _build/.git
+	git init --separate-git-dir=$< $@
 
 #
 # Update the docker build context by:
@@ -48,19 +48,19 @@ $(DOCKER_BUILD_DIR): $(BUILD_DIR)/.git
 # - update GIT_VERSION in the build context if needed
 # - update BPF_SRCFILES in the build context if needed
 #
-build-context-update: check-status $(DOCKER_BUILD_DIR) $(DOCKER_BUILD_DIR)/GIT_VERSION $(DOCKER_BUILD_DIR)/BPF_SRCFILES
-	@echo "gitdir: ../.git" > $(DOCKER_BUILD_DIR)/.git
-	cd $(BUILD_DIR) && git fetch --depth=1 --no-tags
-	cd $(DOCKER_BUILD_DIR) && git reset --hard FETCH_HEAD && git clean -fd
-	@rm $(DOCKER_BUILD_DIR)/.git
+build-context-update: check-status _build/context _build/context/GIT_VERSION _build/context/BPF_SRCFILES
+	@echo "gitdir: ../.git" > _build/context/.git
+	cd _build && git fetch --depth=1 --no-tags
+	cd _build/context && git reset --hard FETCH_HEAD && git clean -fd
+	@rm _build/context/.git
 
 #
 # Docker build context does not contain the actual git repo, so we need to pass
 # GIT_VERSION and/or BPF_SRCFILES to the build context separately.
 #
-$(DOCKER_BUILD_DIR)/GIT_VERSION: GIT_VERSION $(DOCKER_BUILD_DIR)
+_build/context/GIT_VERSION: GIT_VERSION _build/context
 	cp $< $@
-$(DOCKER_BUILD_DIR)/BPF_SRCFILES: BPF_SRCFILES $(DOCKER_BUILD_DIR)
+_build/context/BPF_SRCFILES: BPF_SRCFILES _build/context
 	cp $< $@
 
 # Bare 'Dockerfile' needs a special rule

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -64,6 +64,7 @@ _build/context/BPF_SRCFILES: BPF_SRCFILES _build/context
 _build/%ockerfile: %ockerfile force
 	@-mkdir -p $(dir $@)
 	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
+	@-grep "^FROM " $@ | cut -d ' ' -f2 | grep -v "scratch" | xargs -P4 -n1 docker pull
 
 check-status:
 	@if [ -n "`git status --porcelain`" ] ; then git status && echo "These changes will not be included in build, aborting. Define IGNORE_GIT_STATUS to build anyway." && test $(IGNORE_GIT_STATUS); fi

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -3,6 +3,9 @@
 
 ifdef DOCKER_BUILDKIT
 
+BUILD_DIR := _build
+DOCKER_BUILD_DIR := $(BUILD_DIR)/context
+
 # Export with value expected by docker
 export DOCKER_BUILDKIT=1
 
@@ -12,12 +15,6 @@ clean-build:
 	-$(QUIET) docker builder prune --filter type=exec.cachemount -f
 
 veryclean: clean-build
-
-# Overrides for the main Dockerfile
-DOCKER_BUILD_DIR := $(BUILD_DIR)/context
-CILIUM_DOCKERFILE := $(BUILD_DIR)/cilium.Dockerfile
-DOCKER_PLUGIN_DOCKERFILE := $(BUILD_DIR)/cilium-docker-plugin.Dockerfile
-HUBBLE_RELAY_DOCKERFILE := $(BUILD_DIR)/hubble-relay.Dockerfile
 
 BUILDKIT_DOCKERFILE_FILTER := | sed -e "1s|^\#.*|\# syntax = docker/dockerfile:experimental|" -e "s|^RUN\(.*\)make|RUN --mount=type=cache,target=/root/.cache/go-build\1make|"
 
@@ -63,13 +60,8 @@ _build/context/GIT_VERSION: GIT_VERSION _build/context
 _build/context/BPF_SRCFILES: BPF_SRCFILES _build/context
 	cp $< $@
 
-# Bare 'Dockerfile' needs a special rule
-$(CILIUM_DOCKERFILE): Dockerfile force
-	@-mkdir -p $(dir $@)
-	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
-
-# Generic rule for '*.Dockerfile'
-$(BUILD_DIR)/%.Dockerfile: %.Dockerfile force
+# Generic rule for Dockerfiles. For 'Dockerfile' the stem ('%') matches just the 'D'.
+_build/%ockerfile: %ockerfile force
 	@-mkdir -p $(dir $@)
 	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
 

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -19,10 +19,13 @@ veryclean: clean-build
 BUILDKIT_DOCKERFILE_FILTER := | sed -e "1s|^\#.*|\# syntax = docker/dockerfile:experimental|" -e "s|^RUN\(.*\)make|RUN --mount=type=cache,target=/root/.cache/go-build\1make|"
 
 # _build/.git is a shallow bare clone of the main repo
+# - mkdir can fail if the directory exists already
+# - git clone will fail if _build.git already exists.
+#   In this case the following 'build-context-update' will update it
+# If the _build directory gets into bad shape 'make veryclean' will nuke it.
 _build/.git:
 	-mkdir -p _build
-	git clone --bare --no-local --depth 1 . _build/.git
-	@cd _build && git remote set-url origin ..
+	-git clone --bare --no-local --depth 1 . _build/.git && cd _build && git remote set-url origin ..
 
 #
 # Create _build context:

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -85,7 +85,8 @@ else
 	BPF_SRCFILES = $(shell cat $(ROOT_DIR)/BPF_SRCFILES)
 endif
 
-CILIUM_DATAPATH_SHA=$(shell cat $(BPF_FILES) | sha1sum | awk '{print $$1}')
+# Use BPF_SRCFILES as BPF_FILES is not available in the buildkit context
+CILIUM_DATAPATH_SHA=$(shell cd $(ROOT_DIR); cat $(BPF_SRCFILES) | sha1sum | awk '{print $$1}')
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/datapath/loader.DatapathSHA=$(CILIUM_DATAPATH_SHA)"
 
 # Set -mod=vendor if running >= go 1.13 or if GO111MODULE is set.

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -24,8 +24,8 @@ docker-image-unstripped: clean docker-image-no-clean-unstripped docker-plugin-im
 	$(MAKE) docker-operator-azure-image-unstripped
 	$(MAKE) docker-operator-generic-image-unstripped
 
-docker-image-no-clean: GIT_VERSION $(CILIUM_DOCKERFILE) build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build -f $(CILIUM_DOCKERFILE) \
+docker-image-no-clean: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
+	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/Dockerfile \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg V=${V} \
@@ -44,8 +44,8 @@ docker-cilium-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium $(DOCKER_IMAGE_TAG)
 	$(QUIET) contrib/scripts/push_manifest.sh cilium $(DOCKER_IMAGE_TAG)
 
-dev-docker-image: GIT_VERSION $(CILIUM_DOCKERFILE) build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build -f $(CILIUM_DOCKERFILE) \
+dev-docker-image: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
+	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/Dockerfile \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg V=${V} \
@@ -85,12 +85,12 @@ docker-operator-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh operator $(DOCKER_IMAGE_TAG)
 	$(QUIET) contrib/scripts/push_manifest.sh operator $(DOCKER_IMAGE_TAG)
 
-docker-plugin-image: GIT_VERSION $(DOCKER_PLUGIN_DOCKERFILE) build-context-update
+docker-plugin-image: GIT_VERSION $(BUILD_DIR)/cilium-docker-plugin.Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEUBG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f $(DOCKER_PLUGIN_DOCKERFILE) \
+		-f $(BUILD_DIR)/cilium-docker-plugin.Dockerfile \
 		-t cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
 	@echo "Push like this when ready:"
@@ -120,11 +120,11 @@ docker-cilium-builder-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium-builder $(UTC_DATE)
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-builder $(UTC_DATE)
 
-docker-hubble-relay-image: $(HUBBLE_RELAY_DOCKERFILE) build-context-update
+docker-hubble-relay-image: $(BUILD_DIR)/hubble-relay.Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f $(HUBBLE_RELAY_DOCKERFILE) \
+		-f $(BUILD_DIR)/hubble-relay.Dockerfile \
 		-t cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
 	@echo "Push like this when ready:"

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -64,28 +64,22 @@ docker-cilium-dev-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium-dev $(DOCKER_IMAGE_TAG)
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-dev $(DOCKER_IMAGE_TAG)
 
-docker-operator-image: GIT_VERSION cilium-operator$(OPERATOR_FLAVOUR).Dockerfile build-context-update
+# Build cilium-operator images.
+# We eat the ending of "operator" in to the stem ('%') to allow this pattern
+# to build also 'docker-operator-image', where the stem would be empty otherwise
+docker-opera%-image: GIT_VERSION $(BUILD_DIR)/cilium-opera%.Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f cilium-operator$(OPERATOR_FLAVOUR).Dockerfile \
-		-t cilium/operator$(OPERATOR_FLAVOUR)$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
+		-f $(BUILD_DIR)/cilium-opera$*.Dockerfile \
+		-t cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
 	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push cilium/operator$(OPERATOR_FLAVOUR)$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
+	@echo "${CONTAINER_ENGINE} push cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
 docker-operator-image-unstripped: NOSTRIP=1
 docker-operator-image-unstripped: UNSTRIPPED=-unstripped
 docker-operator-image-unstripped: docker-operator-image
-
-docker-operator-aws-image: OPERATOR_FLAVOUR=-aws
-docker-operator-aws-image: docker-operator-image
-
-docker-operator-azure-image: OPERATOR_FLAVOUR=-azure
-docker-operator-azure-image: docker-operator-image
-
-docker-operator-generic-image: OPERATOR_FLAVOUR=-generic
-docker-operator-generic-image: docker-operator-image
 
 docker-operator-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh operator $(DOCKER_IMAGE_TAG)


### PR DESCRIPTION
- Fix operator builds when `DOCKER_BUILDKIT=1`
- Avoid accidental `rm -rf .`
- Address docker bug by pre-pulling `FROM` images with `DOCKER_BUIDKIT=1`
- Fix `CILIUM_DATAPATH_SHA` when building a docker image with `DOCKER_BUIDKIT=1`

Fixes: #10972
Fixes: #11513