### PR TITLE
docs: Add note about `--node-ip` kubelet option

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -70,6 +70,16 @@ the token returned by ``kubeadm init``:
 
    kubeadm join <..>
 
+.. note::
+
+    Please ensure that
+    `kubelet <https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/>`_'s
+    ``--node-ip`` is set correctly on each worker if you have multiple interfaces.
+    Cilium's kube-proxy replacement may not work correctly otherwise.
+    You can validate this by running ``kubectl get nodes -o wide`` to see whether
+    each node has an ``InternalIP`` which is assigned to a device with the same
+    name on each node.
+
 .. include:: k8s-install-download-release.rst
 
 Next, generate the required YAML files and deploy them. **Important:** Replace


### PR DESCRIPTION
This adds a note about setting the `--node-ip` correctly in kube-proxy
free deployments with kubeadm. Without `--node-ip` set correctly,
Cilium's multi-device detection will not pick up all needed interfaces.
