### PR TITLE
install/kubernetes: Helm option for fragment tracking

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -9,6 +9,7 @@
 {{- $defaultBpfCtTcpMax := 524288 -}}
 {{- $defaultBpfCtAnyMax := 262144 -}}
 {{- $enableIdentityMark := "true" -}}
+{{- $fragmentTracking := "true" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -401,6 +402,12 @@ data:
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nativeRoutingCIDR }}
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
+{{- end }}
+
+{{- if hasKey .Values "fragmentTracking" }}
+  enable-ipv4-fragment-tracking: {{ .Values.fragmentTracking | quote }}
+{{- else if (ne $fragmentTracking "true") }}
+  enable-ipv4-fragment-tracking: "false"
 {{- end }}
 
 {{- if .Values.global.hostFirewall }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -321,6 +321,9 @@ global:
     # interface is the interface to use for encryption
     # interface: eth0
 
+  # fragmentTracking enables IPv4 fragment tracking support in the datapath.
+  fragmentTracking: true
+
   # hostFirewall enables the enforcement of host policies in the BPF datapath
   hostFirewall: false
 


### PR DESCRIPTION
This pull request adds a Helm option to allow users to disable IPv4 fragment tracking.