### PR TITLE
CODEOWNERS: remove cilium/api from /api/v1/{flow,observer,peer}

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,9 +28,9 @@
 # is not properly picked up in Github.
 * @cilium/janitors
 /api/ @cilium/api
-/api/v1/flow/ @cilium/api @cilium/hubble
-/api/v1/observer/ @cilium/api @cilium/hubble
-/api/v1/peer/ @cilium/api @cilium/hubble
+/api/v1/flow/ @cilium/hubble
+/api/v1/observer/ @cilium/hubble
+/api/v1/peer/ @cilium/hubble
 /bpf/ @cilium/bpf
 Makefile* @cilium/build
 /bpf/Makefile* @cilium/build @cilium/bpf


### PR DESCRIPTION
This API directly used for hubble so it does not make sense to have
'@cilium/api' as reviewers.

Signed-off-by: André Martins <andre@cilium.io>