### PR TITLE
docs: Improve consistency in Azure docs

### DIFF
--- a/Documentation/concepts/networking/ipam/azure.rst
+++ b/Documentation/concepts/networking/ipam/azure.rst
@@ -6,9 +6,9 @@
 
 .. _ipam_azure:
 
-##########
-Azure IPAM
-##########
+#################
+Azure IPAM (beta)
+#################
 
 The Azure IPAM allocator is specific to Cilium deployments running in the Azure
 cloud and performs IP allocation based on `Azure Private IP addresses
@@ -19,6 +19,11 @@ Azure API to avoid rate-limiting issues in large clusters. A pre-allocation
 watermark allows to maintain a number of IP addresses to be available for use
 on nodes at all time without requiring to contact the Azure API when a new pod
 is scheduled in the cluster.
+
+.. note::
+
+    This is a beta feature. Please provide feedback and file a GitHub issue if
+    you experience any problems.
 
 ************
 Architecture

--- a/Documentation/gettingstarted/k8s-install-aks-create-cluster.rst
+++ b/Documentation/gettingstarted/k8s-install-aks-create-cluster.rst
@@ -1,0 +1,19 @@
+.. note:: **Do NOT specify the '--network-policy' flag** when creating the cluster,
+    as this will cause the Azure CNI plugin to push down unwanted iptables rules:
+
+.. code:: bash
+
+   export RESOURCE_GROUP_NAME=aks-test
+   export CLUSTER_NAME=aks-test
+   export LOCATION=westeurope
+
+   az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
+   az aks create \
+      --resource-group $RESOURCE_GROUP_NAME \
+      --name $CLUSTER_NAME \
+      --location $LOCATION \
+      --node-count 2 \
+      --network-plugin azure
+
+.. note:: When setting up AKS, it is important to use the flag
+          ``--network-plugin azure`` to ensure that CNI mode is enabled.

--- a/Documentation/gettingstarted/k8s-install-aks-get-credentials.rst
+++ b/Documentation/gettingstarted/k8s-install-aks-get-credentials.rst
@@ -1,0 +1,4 @@
+
+.. code:: bash
+
+    az aks get-credentials --name $CLUSTER_NAME --resource-group $RESOURCE_GROUP_NAME

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -53,8 +53,8 @@ the cluster is ready.
 
 .. code:: bash
 
-        export RESOURCE_GROUP_NAME=group1
-        export CLUSTER_NAME=aks-test1
+        export RESOURCE_GROUP_NAME=aks-test
+        export CLUSTER_NAME=aks-test
         export LOCATION=westus
 
         az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
@@ -62,7 +62,6 @@ the cluster is ready.
             --resource-group $RESOURCE_GROUP_NAME \
             --name $CLUSTER_NAME \
             --node-count 2 \
-            --generate-ssh-keys \
             --network-plugin azure
 
 Configure kubectl to Point to Newly Created Cluster
@@ -71,9 +70,7 @@ Configure kubectl to Point to Newly Created Cluster
 Run the following commands to configure kubectl to connect to this
 AKS cluster:
 
-.. code:: bash
-
-    az aks get-credentials --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME
+.. include:: k8s-install-aks-get-credentials.rst
 
 To verify, you should see AKS in the name of the nodes when you run:
 

--- a/Documentation/gettingstarted/k8s-install-azure.rst
+++ b/Documentation/gettingstarted/k8s-install-azure.rst
@@ -6,9 +6,16 @@
 
 .. _k8s_azure:
 
-*************************************
-Installation on Microsoft Azure Cloud
-*************************************
+********************************************
+Installation on Microsoft Azure Cloud (beta)
+********************************************
+
+This guide explains how to configure Cilium in Azure Cloud to use :ref:`ipam_azure`.
+
+.. note::
+
+    This is a beta feature. Please provide feedback and file a GitHub issue if
+    you experience any problems.
 
 Create an Azure Kubernetes cluster
 ==================================


### PR DESCRIPTION
- move `az aks create` to a separate file
- remove `--generate-ssh-keys`
- ensure each version creates 2-node clusters
- ensure each version calls `az group create`
- avoid asking user copy-paste API credentials,
  utilise exsiting dependency on `jq`
- ensure beta marking is present