### PR TITLE
test: Download correct cilium-istioctl for the executing OS.

### DIFF
--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -37,6 +37,7 @@ var (
 
 // Executor executes commands
 type Executor interface {
+	IsLocal() bool
 	CloseSSHClient()
 	Exec(cmd string, options ...ExecOptions) *CmdRes
 	ExecContext(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes
@@ -64,6 +65,11 @@ type LocalExecutor struct {
 // CreateLocalExecutor returns a local executor
 func CreateLocalExecutor(env []string) *LocalExecutor {
 	return &LocalExecutor{env: env}
+}
+
+// IsLocal returns true if commands are executed on the Ginkgo host
+func (s *LocalExecutor) IsLocal() bool {
+	return true
 }
 
 // Logger returns logger for executor

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -54,6 +54,11 @@ func CreateSSHMeta(host string, port int, user string) *SSHMeta {
 	}
 }
 
+// IsLocal returns true if commands are executed on the Ginkgo host
+func (s *SSHMeta) IsLocal() bool {
+	return false
+}
+
 // Logger returns logger for SSHMeta
 func (s *SSHMeta) Logger() *logrus.Entry {
 	return s.logger

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -58,7 +58,6 @@ var _ = Describe("K8sIstioTest", func() {
 			"linux":  "linux",
 		}
 
-		ciliumIstioctlURL = "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-" + ciliumIstioctlOSes[runtime.GOOS] + ".tar.gz"
 		// istioServiceNames is the set of Istio services needed for the tests
 		istioServiceNames = []string{
 			"istio-ingressgateway",
@@ -87,6 +86,12 @@ var _ = Describe("K8sIstioTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		By("Downloading cilium-istioctl")
+		os := "linux"
+		if kubectl.IsLocal() {
+			// Use Ginkgo runtime OS instead when commands are executed in the local Ginkgo host
+			os = ciliumIstioctlOSes[runtime.GOOS]
+		}
+		ciliumIstioctlURL := "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-" + os + ".tar.gz"
 		res := kubectl.Exec(fmt.Sprintf("curl --retry 5 -L %s | tar xz", ciliumIstioctlURL))
 		res.ExpectSuccess("unable to download %s", ciliumIstioctlURL)
 		res = kubectl.ExecShort("./cilium-istioctl version")


### PR DESCRIPTION
Only use the Ginkgo runtime OS for determining which cilium-istioctl
binary to download is the command executor is local, otherwise default
to "linux". This supports Ginkgo running in OSX both with local and
SSH Executors.

Fixes: #11905
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
