### PR TITLE
test: Add generated files to .gitignore, avoid pulling stale images.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ outgoing
 man/
 
 tests/cilium-files
-test/test_results
+test/test_results*
 test/.vagrant
 test/tmp.yaml
 test/*_manifest.yaml
@@ -62,6 +62,10 @@ test/*.log
 test/bpf/_results
 test/cilium-[0-9a-f]*.yaml
 test/*tmp
+test/cilium-istioctl
+
+# generated test file
+test/k8sT/manifests/cnp-second-namespaces.yaml
 
 # Emacs backup files
 *~

--- a/test/provision/container-images.sh
+++ b/test/provision/container-images.sh
@@ -26,8 +26,10 @@ function test_images {
   # sed's -n does not print non-matching lines and the `#p` prints only
   # matching groups. `#` is used as the sed delimiter to avoid escaping `/` in
   # the regex.
-  DOCKER_IMAGES=$(grep -rI --no-filename "docker.io" test/ | sed -nEe 's#.*(docker.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p' | sort | uniq)
-  QUAY_IMAGES=$(grep -rI --no-filename "quay.io" test/     | sed -nEe 's#.*(quay.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p'   | sort | uniq)
+  # Narrow down the directories to avoid pulling images from random yamls or test_result logs.
+  TEST_DIRS="test/helpers test/k8sT test/provision"
+  DOCKER_IMAGES=$(grep -rI --no-filename "docker.io" $TEST_DIRS | sed -nEe 's#.*(docker.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p' | sort | uniq)
+  QUAY_IMAGES=$(grep -rI --no-filename "quay.io" $TEST_DIRS     | sed -nEe   's#.*(quay.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p' | sort | uniq)
 
   check_img_list $DOCKER_IMAGES
   check_img_list $QUAY_IMAGES


### PR DESCRIPTION
Add generated or downloaded files to .gitignore and avoid pulling
images mentioned in generated logs or yamls.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
