### PR TITLE
Add Hubble store getter to gain access to k8s data store.

### DIFF
--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
+	k8scache "k8s.io/client-go/tools/cache"
 )
 
 func (d *Daemon) getHubbleStatus(ctx context.Context) *models.HubbleStatus {
@@ -266,4 +267,13 @@ func (d *Daemon) LookupSecIDByIP(ip net.IP) (id ipcache.Identity, ok bool) {
 		}
 	}
 	return id, false
+}
+
+// GetK8sStore returns the k8s watcher cache store for the given resource name.
+// It implements hubble parser's StoreGetter.GetK8sStore
+// WARNING: the objects returned by these stores can't be used to create
+// update objects into k8s as well as the objects returned by these stores
+// should only be used for reading.
+func (d *Daemon) GetK8sStore(name string) k8scache.Store {
+	return d.k8sWatcher.GetStore(name)
 }

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"k8s.io/client-go/tools/cache"
 )
 
 // DNSGetter ...
@@ -54,4 +55,14 @@ type IPGetter interface {
 // ServiceGetter fetches service metadata.
 type ServiceGetter interface {
 	GetServiceByAddr(ip net.IP, port uint16) (service flowpb.Service, ok bool)
+}
+
+// StoreGetter ...
+type StoreGetter interface {
+	// GetK8sStore return the k8s watcher cache store for the given resource name.
+	// Currently only resource networkpolicy and namespace are supported.
+	// WARNING: the objects returned by these stores can't be used to create
+	// update objects into k8s as well as the objects returned by these stores
+	// should only be used for reading.
+	GetK8sStore(name string) cache.Store
 }

--- a/pkg/k8s/watchers/network_policy.go
+++ b/pkg/k8s/watchers/network_policy.go
@@ -33,7 +33,7 @@ import (
 
 func (k *K8sWatcher) networkPoliciesInit(k8sClient kubernetes.Interface, swgKNPs *lock.StoppableWaitGroup) {
 
-	_, policyController := informer.NewInformer(
+	store, policyController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8sClient.NetworkingV1().RESTClient(),
 			"networkpolicies", v1.NamespaceAll, fields.Everything()),
 		&slim_networkingv1.NetworkPolicy{},
@@ -79,6 +79,7 @@ func (k *K8sWatcher) networkPoliciesInit(k8sClient kubernetes.Interface, swgKNPs
 		},
 		nil,
 	)
+	k.networkpolicyStore = store
 	k.blockWaitGroupToSyncResources(wait.NeverStop, swgKNPs, policyController, k8sAPIGroupNetworkingV1Core)
 	go policyController.Run(wait.NeverStop)
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -175,6 +175,8 @@ type K8sWatcher struct {
 
 	namespaceStore cache.Store
 	datapath       datapath.Datapath
+
+	networkpolicyStore cache.Store
 }
 
 func NewK8sWatcher(
@@ -775,4 +777,16 @@ func (k *K8sWatcher) K8sEventReceived(scope string, action string, valid, equal 
 	k8smetrics.LastInteraction.Reset()
 
 	metrics.KubernetesEventReceived.WithLabelValues(scope, action, strconv.FormatBool(valid), strconv.FormatBool(equal)).Inc()
+}
+
+// GetStore returns the k8s cache store for the given resource name.
+func (k *K8sWatcher) GetStore(name string) cache.Store {
+	switch name {
+	case "networkpolicy":
+		return k.networkpolicyStore
+	case "namespace":
+		return k.namespaceStore
+	default:
+		return nil
+	}
 }


### PR DESCRIPTION
Signed-off-by: Zang Li <zangli@google.com>

Add the StoreGetter function to Hubble to get access to k8s cache store for network policy and namespace.

