### PR TITLE
pkg/k8s: add validation schema for MatchLabels

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -110,7 +110,7 @@ func createCNPCRD(clientset apiextensionsclient.Interface) error {
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
 			Scope:      apiextensionsv1beta1.NamespaceScoped,
-			Validation: &CNPCRV,
+			Validation: CNPCRV,
 		},
 	}
 	// Kubernetes < 1.12 does not support having the field Type set in the root
@@ -548,7 +548,7 @@ var (
 		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{},
 	}
 
-	CNPCRV = apiextensionsv1beta1.CustomResourceValidation{
+	CNPCRV = &apiextensionsv1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
 			// TODO: remove the following comment when we add checker
 			// to detect if we should install the CNP validation for k8s > 1.11
@@ -988,6 +988,13 @@ var (
 					"whose key field is \"key\", the operator is \"In\", and the values array " +
 					"contains only \"value\". The requirements are ANDed.",
 				Type: "object",
+				AdditionalProperties: &apiextensionsv1beta1.JSONSchemaPropsOrBool{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type:      "string",
+						MaxLength: getInt64(63),
+						Pattern:   `^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`,
+					},
+				},
 			},
 			"matchExpressions": {
 				Description: "matchExpressions is a list of label selector requirements. " +

--- a/pkg/k8s/apis/cilium.io/v2/client/register_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ func (s *CiliumV2RegisterSuite) getTestUpToDateDefinition() *apiextensionsv1beta
 			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Validation: &CNPCRV,
+			Validation: CNPCRV,
 		},
 	}
 }

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -31,7 +31,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.20"
+	CustomResourceDefinitionSchemaVersion = "1.21"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
+
+	"github.com/go-openapi/validate"
+	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// NPValidator is a validator structure used to validate CNP.
+type NPValidator struct {
+	cnpValidator  *validate.SchemaValidator
+	ccnpValidator *validate.SchemaValidator
+}
+
+func NewNPValidator() (*NPValidator, error) {
+	// There are some default variables set by the CustomResourceValidation
+	// Marshaller so we need to marshal and unmarshal the CNPCRV to have those
+	// default values, the same way k8s api-server has it.
+	cnpCRVJSONBytes, err := json.Marshal(client.CNPCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to marshall CNPCRV: %w", err)
+	}
+	var cnpCRV apiextensionsv1beta1.CustomResourceValidation
+	err = json.Unmarshal(cnpCRVJSONBytes, &cnpCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to unmarshall CNPCRV: %w", err)
+	}
+
+	var cnpInternal apiextensionsinternal.CustomResourceValidation
+	err = apiextensionsv1beta1.Convert_v1beta1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(
+		&cnpCRV,
+		&cnpInternal,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cnpValidator, _, err := validation.NewSchemaValidator(&cnpInternal)
+	if err != nil {
+		return nil, err
+	}
+
+	// There are some default variables set by the CustomResourceValidation
+	// Marshaller so we need to marshal and unmarshal the CNPCRV to have those
+	// default values, the same way k8s api-server has it.
+	ccnpCRVJSONBytes, err := json.Marshal(client.CCNPCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to marshall CCNPCRV: %w", err)
+	}
+	var ccnpCRV apiextensionsv1beta1.CustomResourceValidation
+	err = json.Unmarshal(ccnpCRVJSONBytes, &ccnpCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to unmarshall CCNPCRV: %w", err)
+	}
+
+	var ccnpInternal apiextensionsinternal.CustomResourceValidation
+	err = apiextensionsv1beta1.Convert_v1beta1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(
+		&ccnpCRV,
+		&ccnpInternal,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ccnpValidator, _, err := validation.NewSchemaValidator(&ccnpInternal)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NPValidator{
+		cnpValidator:  cnpValidator,
+		ccnpValidator: ccnpValidator,
+	}, nil
+}
+
+// ValidateCNP validates the given CNP accordingly the CNP validation schema.
+func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
+	if errs := validation.ValidateCustomResource(nil, &cnp, n.cnpValidator); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	return nil
+}
+
+// ValidateCCNP validates the given CCNP accordingly the CCNP validation schema.
+func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
+	if errs := validation.ValidateCustomResource(nil, &ccnp, n.ccnpValidator); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	return nil
+}

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -1,0 +1,224 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package validator
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+// Hook up gocheck into the "go test" runner.
+type CNPValidationSuite struct {
+}
+
+var _ = Suite(&CNPValidationSuite{})
+
+func (s *CNPValidationSuite) Test_GH10643(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: exampleapp
+  namespace: examplens
+spec:
+  egress:
+  - toFQDNs:
+    - matchPattern: prefix*.tier.location.example.com
+    toPorts:
+    - ports:
+      - port "8050"
+      - protocl TCP
+      - port "8051"
+      - protocl TCP
+      - port "8052"
+      - protocl TCP
+      - port "8053"
+      - protocl TCP
+      - port "8054"
+      - protocl TCP
+      - port "8055"
+      - protocl TCP
+      - port "8056"
+      - protocl TCP
+      - port "8057"
+      - protocl TCP
+      - port "8058"
+      - protocl TCP
+      - port "8059"
+      - protocl TCP
+  endpointSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - example-app-0-spark-worker
+      - example-app-0-spark-driver
+      - example-app-0-spark-worker-qe3
+      - example-app-0-spark-driver-qe3
+      - example-app-1-spark-worker
+      - example-app-1-spark-driver
+      - example-app-1-spark-worker-qe3
+      - example-app-1-spark-driver-qe3
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	// Err can't be nil since validation should detect the policy is not correct.
+	c.Assert(err, Not(IsNil))
+}
+
+func (s *CNPValidationSuite) Test_BadMatchLabels(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-test-1
+  namespace: ns-2
+spec:
+  egress:
+  - toServices:
+    - k8sService:
+        namespace: default
+        serviceName: kubernetes
+  endpointSelector:
+    matchLabels:
+      key: app
+      operator: In
+      values:
+      - prometheus
+      - kube-state-metrics
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	// Err can't be nil since validation should detect the policy is not correct.
+	c.Assert(err, Not(IsNil))
+}
+
+func (s *CNPValidationSuite) Test_GoodCNP(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-test-1
+  namespace: ns-2
+spec:
+  egress:
+  - toServices:
+    - k8sService:
+        namespace: default
+        serviceName: kubernetes
+  endpointSelector:
+    matchLabels:
+      key: app
+      operator: In
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	c.Assert(err, IsNil)
+}
+
+func (s *CNPValidationSuite) Test_GoodCCNP(c *C) {
+	ccnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: cnp-test-1
+spec:
+  egress:
+  - toServices:
+    - k8sService:
+        namespace: default
+        serviceName: kubernetes
+  endpointSelector:
+    matchLabels:
+      key: app
+      operator: In
+`)
+	jsnByte, err := yaml.YAMLToJSON(ccnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCCNP(&us)
+	c.Assert(err, IsNil)
+}
+
+func (s *CNPValidationSuite) Test_BadCCNP(c *C) {
+	// Bad CCNP with endpointSelector and nodeSelector
+	ccnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: cnp-test-1
+spec:
+  egress:
+  - toServices:
+    - k8sService:
+        namespace: default
+        serviceName: kubernetes
+  endpointSelector:
+    matchLabels:
+      key: app
+      operator: In
+  nodeSelector:
+    matchLabels:
+      key: app
+      operator: In
+`)
+	jsnByte, err := yaml.YAMLToJSON(ccnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCCNP(&us)
+	// Err can't be nil since validation should detect the policy is not correct.
+	c.Assert(err, Not(IsNil))
+}


### PR DESCRIPTION
From now on, the validation schema for MatchLabels will only allow at
maximum of 63 characters with the regex
'^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' similar to what is used
in k8s structures:

"Valid label values must be 63 characters or less and must be empty or
begin and end with an alphanumeric character ([a-z0-9A-Z]) with dashes
(-), underscores (_), dots (.), and alphanumerics between."

Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

This fixes an issue where a user could create a badly defined CNP
which wouldn't have a map[string]string in the matchLabels field. This
CNP would then be accepted by the kube-apiserver and make Cilium error
out and possibly crashing. Unfortunately not all k8s version support
this fix and we can only backport it to Cilium versions that have a
minimum support for k8s >= 1.11.


Signed-off-by: André Martins <andre@cilium.io>

```release-note
Valid CNP and CCNP 'matchLabel' values must be 63 characters or less and must be empty or begin and end with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
```