### PR TITLE
eventsmap: Use `present` cpuset instead of `possible` for max_entries

### DIFF
--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -49,4 +49,7 @@ const (
 
 	// PossibleCPUSysfsPath is used to retrieve the number of CPUs for per-CPU maps.
 	PossibleCPUSysfsPath = "/sys/devices/system/cpu/possible"
+
+	// PresentCPUSysfsPath is used to retrieve the number of CPUs for per-CPU maps.
+	PresentCPUSysfsPath = "/sys/devices/system/cpu/present"
 )

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -175,10 +175,27 @@ func GetNumPossibleCPUs(log *logrus.Entry) int {
 	}
 	defer f.Close()
 
-	return getNumPossibleCPUsFromReader(log, f)
+	return getNumCPUsFromReader(log, f)
 }
 
-func getNumPossibleCPUsFromReader(log *logrus.Entry, r io.Reader) int {
+// GetNumPresentCPUs returns a total number of present CPUS, i.e. CPUs that
+// are currently plugged in.
+// The number is retrieved by parsing /sys/device/system/cpu/present.
+//
+// See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/cpumask.h?h=v4.19#n50
+// for more details.
+func GetNumPresentCPUs(log *logrus.Entry) int {
+	f, err := os.Open(PresentCPUSysfsPath)
+	if err != nil {
+		log.WithError(err).Errorf("unable to open %q", PresentCPUSysfsPath)
+		return 0
+	}
+	defer f.Close()
+
+	return getNumCPUsFromReader(log, f)
+}
+
+func getNumCPUsFromReader(log *logrus.Entry, r io.Reader) int {
 	out, err := ioutil.ReadAll(r)
 	if err != nil {
 		log.WithError(err).Errorf("unable to read %q to get CPU count", PossibleCPUSysfsPath)

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -144,7 +144,7 @@ func (s *CommonSuite) TestMoveNewFilesTo(c *check.C) {
 	}
 }
 
-func (s *CommonSuite) TestGetNumPossibleCPUsFromReader(c *check.C) {
+func (s *CommonSuite) TestGetNumCPUsFromReader(c *check.C) {
 	log := logging.DefaultLogger.WithField(logfields.LogSubsys, "utils-test")
 	tests := []struct {
 		in       string
@@ -158,7 +158,7 @@ func (s *CommonSuite) TestGetNumPossibleCPUsFromReader(c *check.C) {
 	}
 
 	for _, t := range tests {
-		possibleCpus := getNumPossibleCPUsFromReader(log, strings.NewReader(t.in))
+		possibleCpus := getNumCPUsFromReader(log, strings.NewReader(t.in))
 		c.Assert(possibleCpus, check.Equals, t.expected)
 	}
 

--- a/pkg/maps/eventsmap/eventsmap.go
+++ b/pkg/maps/eventsmap/eventsmap.go
@@ -71,7 +71,7 @@ func InitMap() error {
 		int(unsafe.Sizeof(Key{})),
 		&Value{},
 		int(unsafe.Sizeof(Value{})),
-		common.GetNumPossibleCPUs(log),
+		common.GetNumPresentCPUs(log),
 		0,
 		0,
 		bpf.ConvertKeyValue,


### PR DESCRIPTION
This fixes an issue where `cilium monitor` fails to report any events
on AKS, due to the `perf_event_array` duplicates being created
with `max_entries=2` and `max_entries=128`, presumably causing the datapath
to write to the first one, while the agent is reading from the second
one.

This bug occurs for example on AKS due to the present/possible cpuset on
the VMs. The default `Standard_D2s_v3` node size has 2 present CPUs, but
128 possible CPUs in `/sys/devices/system/cpu.`

Fixes #12070.
