### PR TITLE
bpf: Use `nproc --all` for __NR_CPUS__

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -1,7 +1,7 @@
 # Copyright 2017-2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-FLAGS := -I$(ROOT_DIR)/bpf/include -I$(ROOT_DIR)/bpf -D__NR_CPUS__=$(shell nproc) -O2 -g
+FLAGS := -I$(ROOT_DIR)/bpf/include -I$(ROOT_DIR)/bpf -D__NR_CPUS__=$(shell nproc --all) -O2 -g
 
 CLANG_FLAGS := ${FLAGS} -target bpf -std=gnu89 -nostdinc -emit-llvm
 # eBPF verifier enforces unaligned access checks where necessary, so don't

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -278,7 +278,7 @@ function bpf_compile()
 	      -Wno-gnu-variable-sized-type-not-at-end			\
 	      -Wdeclaration-after-statement				\
 	      -I. -I$DIR -I$LIB -I$LIB/include				\
-	      -D__NR_CPUS__=$(nproc)					\
+	      -D__NR_CPUS__=$(nproc --all)					\
 	      -DENABLE_ARP_RESPONDER=1					\
 	      -DHANDLE_NS=1						\
 	      $EXTRA_OPTS						\

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -23,10 +23,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -90,7 +90,7 @@ type directoryInfo struct {
 
 var (
 	standardCFlags = []string{"-O2", "-target", "bpf", "-std=gnu89",
-		"-nostdinc", fmt.Sprintf("-D__NR_CPUS__=%d", runtime.NumCPU()),
+		"-nostdinc", fmt.Sprintf("-D__NR_CPUS__=%d", common.GetNumPossibleCPUs(log)),
 		"-Wall", "-Wextra", "-Werror", "-Wshadow",
 		"-Wno-address-of-packed-member",
 		"-Wno-unknown-warning-option",

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -3,7 +3,7 @@
 
 include ../../Makefile.defs
 
-FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc) -O2
+FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc --all) -O2
 FLAGS_CLANG := -Wall -Wextra -Werror -Wshadow -Wno-unused-parameter
 FLAGS_CLANG += -Wno-address-of-packed-member
 FLAGS_CLANG += -Wno-unknown-warning-option


### PR DESCRIPTION
This uses `-D__NR_CPUS__=$(nproc --all)` (or `GetNumPossibleCPUs` when
invoked from Go) to compile the datapath.

This fixes an issue where `cilium monitor` fails to report any events
on AKS, due to the `perf_event_array` map duplicates being created
with different `max_entries` sizes, presumably causing the datapath
to write to the first one, while the agent is reading from the second
one.

This bug occurs for example on AKS due to the present/possible cpuset on
the VMs. The default Standard_D2s_v3 node size has 2 present CPUs, but
128 possible CPUs in `/sys/devices/system/cpu`.

Fixes: #12070
