### PR TITLE
add missing hook in misc unit tests

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register_test.go
@@ -18,11 +18,15 @@ package client
 
 import (
 	"regexp"
+	"testing"
 
 	. "gopkg.in/check.v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
 
 type CiliumV2RegisterSuite struct{}
 

--- a/pkg/service/store/store_test.go
+++ b/pkg/service/store/store_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,11 +17,16 @@
 package store
 
 import (
+	"testing"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 
 	"gopkg.in/check.v1"
 )
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
 
 type ServiceGenericSuite struct{}
 


### PR DESCRIPTION
All test packages need to have a hook for check.v1

This commit adds the missing checks on those unit tests.

Signed-off-by: André Martins <andre@cilium.io>