### PR TITLE
.gitignore: Ignore test/cilium.conf.ginkgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ test/cilium-istioctl
 
 # generated test file
 test/k8sT/manifests/cnp-second-namespaces.yaml
+test/cilium.conf.ginkgo
 
 # Emacs backup files
 *~


### PR DESCRIPTION
test/cilium.conf.ginkgo is generated when running Runtime tests.

Fixes: #10578