### PR TITLE
monitor: Shorten policy-verdict output

### DIFF
--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -104,7 +104,11 @@ func GetPolicyActionString(verdict int32, audit bool) string {
 
 // DumpInfo prints a summary of the policy notify messages.
 func (n *PolicyVerdictNotify) DumpInfo(data []byte) {
-	fmt.Printf("Policy verdict log: flow %#x local EP ID %d, remote ID %d, dst port %d, proto %d, ingress %v, action %s, match %s, %s\n",
-		n.Hash, n.Source, n.RemoteLabel, n.DstPort, n.Proto, n.IsTrafficIngress(), GetPolicyActionString(n.Verdict, n.IsTrafficAudited()),
+	dir := "egress"
+	if n.IsTrafficIngress() {
+		dir = "ingress"
+	}
+	fmt.Printf("Policy verdict log: flow %#x local EP ID %d, remote ID %d, proto %d, %s, action %s, match %s, %s\n",
+		n.Hash, n.Source, n.RemoteLabel, n.Proto, dir, GetPolicyActionString(n.Verdict, n.IsTrafficAudited()),
 		n.GetPolicyMatchType(), GetConnectionSummary(data[PolicyVerdictNotifyLen:]))
 }

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1568,7 +1568,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 				By("Testing cilium monitor output")
 				monitorRes.ExpectContains(
-					fmt.Sprintf("local EP ID %s, remote ID 1, dst port 0, proto 1, ingress true, action audit", endpointID),
+					fmt.Sprintf("local EP ID %s, remote ID 1, proto 1, ingress, action audit", endpointID),
 					"No ingress policy log record",
 				)
 
@@ -1609,7 +1609,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 				By("Testing cilium monitor output")
 				monitorRes.ExpectContains(
-					fmt.Sprintf("ID %s, remote ID 1, dst port 0, proto 1, ingress false, action audit", endpointID),
+					fmt.Sprintf("ID %s, remote ID 1, proto 1, egress, action audit", endpointID),
 					"No egress policy log record",
 				)
 


### PR DESCRIPTION
Current `cilium monitor -t policy-verdict` output is a bit more verbose than necessary:

    Policy verdict log: flow 0x4a9eceac local EP ID 905, remote ID 2, dst port 80, proto 6, ingress false, action deny, match none, 10.0.2.15:53512 -> 1.1.1.1:80 tcp SYN

This commit shortens policy verdict log messages by printing ingress/egress instead of true/false after ingress and removes the `dst port` part as it's already included in the connection summary at the end.

    Policy verdict log: flow 0x4a9eceac local EP ID 905, remote ID 2, proto 6, egress, action deny, match none, 10.0.2.15:53512 -> 1.1.1.1:80 tcp SYN