### PR TITLE
helm: Remove affinity from cilium-etcd-operator

### DIFF
--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         io.cilium/app: etcd-operator
         name: cilium-etcd-operator
     spec:
-{{- if .Values.global.affinity }}
-      affinity:
-{{ toYaml .Values.global.affinity | indent 8 }}
-{{- end }}
       containers:
       - args:
         #- --etcd-node-selector=disktype=ssd,cputype=high


### PR DESCRIPTION
The affinity section in the operator spec was introduced to avoid
scheduling an instance of the operator on the node which is not managed
by Cilium (`NO_CILIUM_ON_NODE`; used by the CI net-next).

We are no longer using the operator in the K8sDatapathSuite's Etcd
test case. Therefore we can remove the affinity section.

Fix #12124.