### PR TITLE
k8s/watchers: fix missing missing CNP/CCNP updates

### DIFF
--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -288,27 +288,24 @@ func (k *K8sWatcher) updateCiliumNetworkPolicyV2(ciliumNPClient clientset.Interf
 
 	// Do not add rule into policy repository if the spec remains unchanged.
 	if !option.Config.DisableCNPStatusUpdates {
-		if oldRuleCpy.Spec.DeepEqual(newRuleCpy.CiliumNetworkPolicy.Spec) {
-			if !oldRuleCpy.AnnotationsEquals(newRuleCpy.CiliumNetworkPolicy) {
+		if !oldRuleCpy.AnnotationsEquals(newRuleCpy.CiliumNetworkPolicy) {
 
-				// Update annotations within a controller so the status of the update
-				// is trackable from the list of running controllers, and so we do
-				// not block subsequent policy lifecycle operations from Kubernetes
-				// until the update is complete.
-				oldCtrlName := oldRuleCpy.GetControllerName()
-				newCtrlName := newRuleCpy.GetControllerName()
+			// Update annotations within a controller so the status of the update
+			// is trackable from the list of running controllers, and so we do
+			// not block subsequent policy lifecycle operations from Kubernetes
+			// until the update is complete.
+			oldCtrlName := oldRuleCpy.GetControllerName()
+			newCtrlName := newRuleCpy.GetControllerName()
 
-				// In case the controller name changes between copies of rules,
-				// remove old controller so we do not leak goroutines.
-				if oldCtrlName != newCtrlName {
-					err := k8sCM.RemoveController(oldCtrlName)
-					if err != nil {
-						log.Debugf("Unable to remove controller %s: %s", oldCtrlName, err)
-					}
+			// In case the controller name changes between copies of rules,
+			// remove old controller so we do not leak goroutines.
+			if oldCtrlName != newCtrlName {
+				err := k8sCM.RemoveController(oldCtrlName)
+				if err != nil {
+					log.Debugf("Unable to remove controller %s: %s", oldCtrlName, err)
 				}
-				k.updateCiliumNetworkPolicyV2AnnotationsOnly(ciliumNPClient, ciliumV2Store, newRuleCpy)
 			}
-			return nil
+			k.updateCiliumNetworkPolicyV2AnnotationsOnly(ciliumNPClient, ciliumV2Store, newRuleCpy)
 		}
 	}
 


### PR DESCRIPTION
Since we were only comparing the spec of a CNP / CCNP, whenever the
cilium-agent received a CNP or CCNP containing a 'specs', any following
updates to that policy wouldn't be enforced in Cilium since the network
policy would be considered equal as the one already being enforced.

As Cilium is already comparing the network policies, before processing
any policy update, we can remove this Spec.Equals.

Fixes: 2d34336206d5 ("use deepequal generated code")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
do not ignore Kubernetes event updates for CCNP and CNP with 'specs' field after being created
```
