### PR TITLE
docs: Extend BPF-based masquerading section

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -60,7 +60,7 @@ to determine which devices the program is running on:
 ::
 
     kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep Masquerading
-    Masquerading:   BPF (ip-masq-agent)   [eth0, eth1]
+    Masquerading:   BPF (ip-masq-agent)   [eth0, eth1]  10.0.0.0/16
 
 From the output above, the program is running on the ``eth0`` and ``eth1`` devices.
 
@@ -72,7 +72,8 @@ The eBPF-based masquerading can masquerade packets of the following IPv4 L4 prot
 - ICMP (only Echo request and Echo reply)
 
 By default, any packet from a pod destined to an IP address outside of the
-``native-routing-cidr`` range is masqueraded. To allow more fine-grained control,
+``native-routing-cidr`` range is masqueraded. The exclusion CIDR is shown in the above
+output of ``cilium status`` (``10.0.0.0.16``).  To allow more fine-grained control,
 Cilium implements `ip-masq-agent <https://github.com/kubernetes-sigs/ip-masq-agent>`_
 in eBPF which can be enabled with the ``global.ipMasqAgent.enabled=true`` helm option.
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -630,6 +630,8 @@ When running Azure IPAM on a self-managed Kubernetes cluster, each ``v1.Node``
 must have the resource ID of its VM in the ``spec.providerID`` field.
 Refer to the :ref:`ipam_azure` reference for more information.
 
+.. _NodePort Devices:
+
 NodePort Devices, Port and Bind settings
 ****************************************
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -386,7 +386,7 @@ modes and can be enabled as follows for ``nodePort.mode=hybrid`` in this example
 
 In case of a multi-device environment, where Cilium's device auto-detection selects
 more than a single device to expose NodePort, for example, the helm option
-``global.devices={eth0}`` must be additionally specified for the enablement, where
+``global.devices=eth0`` must be additionally specified for the enablement, where
 ``eth0`` is the native XDP supported networking device. In that case, the device
 name ``eth0`` must be the same on all Cilium managed nodes. Similarly, the underlying
 driver for ``eth0`` must have native XDP support on all Cilium managed nodes.
@@ -638,7 +638,7 @@ LoadBalancer service or a service with externalIPs will be accessible through
 the IP addresses of native devices which have the default route on the host or
 have Kubernetes InternalIP or ExternalIP assigned. InternalIP is preferred over
 ExternalIP if both exist. To change the devices, set their names in the
-``global.devices`` helm option, e.g. ``global.devices={eth0,eth1,eth2}``. Each
+``global.devices`` helm option, e.g. ``global.devices='{eth0,eth1,eth2}'``. Each
 listed device has to be named the same on all Cilium managed nodes.
 
 When multiple devices are used, only one device can be used for direct routing
@@ -935,7 +935,7 @@ Limitations
     * Cilium's BPF kube-proxy acceleration in XDP can only be used in a single device setup
       as a "one-legged" / hairpin load-balancer scenario. In case of a multi-device environment,
       where auto-detection selects more than a single device to expose NodePort, the option
-      ``global.devices={eth0}`` must be specified in helm in order to work, where ``eth0``
+      ``global.devices=eth0`` must be specified in helm in order to work, where ``eth0``
       is the native XDP supported networking device.
     * Cilium's DSR NodePort mode currently does not operate well in environments with
       TCP Fast Open (TFO) enabled. It is recommended to switch to ``snat`` mode in this

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -46,6 +46,7 @@ Facebook
 Fastabend
 Fosdem
 Freescale
+Fsnotify
 GCE
 Gartrell
 Geneve
@@ -459,6 +460,7 @@ luke
 lwt
 macOS
 masq
+masqLinkLocal
 matchLabels
 matchPattern
 mc
@@ -508,6 +510,7 @@ nginx
 nodeSelector
 nodeX
 nodegroup
+nonMasqueradeCIDRs
 observability
 offline
 onData
@@ -705,5 +708,6 @@ xml
 xor
 xoring
 xwing
+xxxxx
 yaml
 zsh

--- a/api/v1/models/masquerading.go
+++ b/api/v1/models/masquerading.go
@@ -29,6 +29,9 @@ type Masquerading struct {
 	// mode
 	// Enum: [BPF iptables]
 	Mode string `json:"mode,omitempty"`
+
+	// Any packet sent to IP addr belonging to CIDR will not be SNAT'd
+	SnatExclusionCidr string `json:"snat-exclusion-cidr,omitempty"`
 }
 
 // Validate validates this masquerading

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2286,6 +2286,9 @@ definitions:
       ip-masq-agent:
         description: Is BPF ip-masq-agent enabled
         type: boolean
+      snat-exclusion-cidr:
+        description: Any packet sent to IP addr belonging to CIDR will not be SNAT'd
+        type: string
   ControllerStatuses:
     description: Collection of controller statuses
     type: array

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2694,6 +2694,10 @@ func init() {
             "BPF",
             "iptables"
           ]
+        },
+        "snat-exclusion-cidr": {
+          "description": "Any packet sent to IP addr belonging to CIDR will not be SNAT'd",
+          "type": "string"
         }
       }
     },
@@ -6301,6 +6305,10 @@ func init() {
             "BPF",
             "iptables"
           ]
+        },
+        "snat-exclusion-cidr": {
+          "description": "Any packet sent to IP addr belonging to CIDR will not be SNAT'd",
+          "type": "string"
         }
       }
     },

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -117,6 +117,8 @@ func (d *Daemon) getMasqueradingStatus() *models.Masquerading {
 		return s
 	}
 
+	s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDR().String()
+
 	if option.Config.EnableBPFMasquerade {
 		s.Mode = models.MasqueradingModeBPF
 		s.IPMasqAgent = option.Config.EnableIPMasqAgent

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -382,8 +382,9 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 				status = "BPF"
 			}
 			if sr.KubeProxyReplacement != nil {
-				status += fmt.Sprintf("\t[%s]",
-					strings.Join(sr.KubeProxyReplacement.Devices, ", "))
+				status += fmt.Sprintf("\t[%s]\t%s",
+					strings.Join(sr.KubeProxyReplacement.Devices, ", "),
+					sr.Masquerading.SnatExclusionCidr)
 			}
 
 		} else if sr.Masquerading.Mode == models.MasqueradingModeIptables {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -381,6 +381,11 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 			} else {
 				status = "BPF"
 			}
+			if sr.KubeProxyReplacement != nil {
+				status += fmt.Sprintf("\t[%s]",
+					strings.Join(sr.KubeProxyReplacement.Devices, ", "))
+			}
+
 		} else if sr.Masquerading.Mode == models.MasqueradingModeIptables {
 			status = "IPTables"
 		}

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -18,8 +18,10 @@ import (
 	"io"
 
 	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -119,4 +121,16 @@ type ConfigWriter interface {
 	// WriteEndpointConfig writes the implementation-specific configuration
 	// of configurable options for the endpoint to the specified writer.
 	WriteEndpointConfig(w io.Writer, cfg EndpointConfiguration) error
+}
+
+// RemoteSNATDstAddrExclusionCIDR returns a CIDR for SNAT exclusion. Any
+// packet sent from a local endpoint to an IP address belonging to the CIDR
+// should not be SNAT'd.
+func RemoteSNATDstAddrExclusionCIDR() *cidr.CIDR {
+	if c := option.Config.IPv4NativeRoutingCIDR(); c != nil {
+		// native-routing-cidr is set, so use it
+		return c
+	}
+
+	return node.GetIPv4AllocRange()
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
@@ -334,12 +333,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 		if option.Config.EnableBPFMasquerade {
 			cDefinesMap["ENABLE_MASQUERADE"] = "1"
-			var cidr *cidr.CIDR
-			if c := option.Config.IPv4NativeRoutingCIDR(); c != nil {
-				cidr = c
-			} else {
-				cidr = node.GetIPv4AllocRange()
-			}
+			cidr := datapath.RemoteSNATDstAddrExclusionCIDR()
 			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR"] =
 				fmt.Sprintf("%#x", byteorder.HostSliceToNetwork(cidr.IP, reflect.Uint32).(uint32))
 			ones, _ := cidr.Mask.Size()


### PR DESCRIPTION
This PR:

- Extend the section.
- Extends `cilium status` to show masq devices.
- Improve usage of `global.devices` in the kubeproxy-free gsg.

Reviewable per commit.