### PR TITLE
pkg/option: disable K8sEventHandover if Cilium is running without KVStore

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2477,6 +2477,10 @@ func (c *DaemonConfig) Populate() {
 			log.Warningf("Running Cilium with %q=%q requires endpoint CRDs. Changing %s to %t", KVStore, c.KVStore, DisableCiliumEndpointCRDName, false)
 			c.DisableCiliumEndpointCRD = false
 		}
+		if c.K8sEventHandover {
+			log.Warningf("Running Cilium with %q=%q requires KVStore capability. Changing %s to %t", KVStore, c.KVStore, K8sEventHandover, false)
+			c.K8sEventHandover = false
+		}
 	}
 
 	switch c.IPAM {


### PR DESCRIPTION
Running Cilium with K8sEventHandover and without a KVStore configured
causes it on not being able to delete any CNP after being created.

Fixes: e4e83e80128a ("daemon: Allow kvstore to be unconfigured")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
stop Cilium from hanging on CNP or CCNP events from Kubernetes if running with 'k8s-event-handover=true' and 'kvstore=""'
```
