### PR TITLE
doc: Specify CILIUM_NAMESPACE for Hubble installation instruction

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -65,6 +65,7 @@ Deploy Cilium release via Helm:
 
 .. include:: aws-create-nodegroup.rst
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 
 .. _eni_limitations:

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -60,5 +60,6 @@ If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
 in the respective namespace and see if the pod is listed.
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -36,5 +36,6 @@ If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
 in the respective namespace and see if the pod is listed.
 
 .. include:: k8s-install-azure-cni-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -91,5 +91,6 @@ Deploy Cilium release via Helm:
    them.
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -81,6 +81,7 @@ Deploy Cilium release via Helm:
    them.
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 
 

--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -6,19 +6,6 @@ for cloud native workloads. It is built on top of Cilium and eBPF to enable
 deep visibility into the communication and behavior of services as well as the
 networking infrastructure in a completely transparent manner.
 
-* Specify the namespace in which Cilium is installed as ``CILIUM_NAMESPACE``
-  environment variable. Subsequent commands reference this environment variable.
-
-  .. parsed-literal::
-
-      export CILIUM_NAMESPACE=kube-system
-
-  .. note::
-
-      Cilium is typically installed in the ``kube-system`` namespace, but there are
-      a few exceptions such as GKE which install Cilium in a dedicated ``cilium``
-      namespace.
-
 * Hubble can be configured to be in **local mode** or **distributed mode (beta)**.
 
   .. tabs::

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -86,5 +86,6 @@ To verify, you should see AKS in the name of the nodes when you run:
 .. include:: k8s-install-azure-cni-steps.rst
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/k8s-install-azure.rst
+++ b/Documentation/gettingstarted/k8s-install-azure.rst
@@ -94,6 +94,7 @@ Deploy Cilium release via Helm:
      --set global.nodeinit.enabled=true
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 
 .. _azure_limitations:

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -110,4 +110,5 @@ Deploy Cilium release via Helm:
 
 .. include:: aws-create-nodegroup.rst
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -102,5 +102,6 @@ to the cluster. The NodeInit DaemonSet will perform the following actions:
 
 .. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-gke-validate.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -94,6 +94,7 @@ Install Cilium release via Helm:
       --set global.pullPolicy=IfNotPresent
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 
 Next steps

--- a/Documentation/gettingstarted/namespace-cilium.rst
+++ b/Documentation/gettingstarted/namespace-cilium.rst
@@ -1,0 +1,9 @@
+Specify Environment Variables
+=============================
+
+Specify the namespace in which Cilium is installed as ``CILIUM_NAMESPACE``
+environment variable. Subsequent commands reference this environment variable.
+
+.. parsed-literal::
+
+   export CILIUM_NAMESPACE=cilium

--- a/Documentation/gettingstarted/namespace-kube-system.rst
+++ b/Documentation/gettingstarted/namespace-kube-system.rst
@@ -1,0 +1,9 @@
+Specify Environment Variables
+=============================
+
+Specify the namespace in which Cilium is installed as ``CILIUM_NAMESPACE``
+environment variable. Subsequent commands reference this environment variable.
+
+.. parsed-literal::
+
+   export CILIUM_NAMESPACE=kube-system


### PR DESCRIPTION
This makes it easier to follow the instructions, especially for GKE which
uses cilium namespace instead of kube-system.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>