### PR TITLE
docs: NodePort XDP on Azure

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -29,6 +29,7 @@ Cloudflare
 Clusterwide
 Committer
 Committers
+ConnectX
 DDoS
 DMA'ed
 DNS
@@ -87,6 +88,7 @@ Loadbalancing
 Login
 Lookup
 Lund
+Lx
 Majkowski
 Marek
 Meetup
@@ -452,6 +454,7 @@ logout
 lookup
 lookups
 loopback
+lspci
 luke
 lwt
 macOS


### PR DESCRIPTION
This adds a basic section with details on how to run NodePort XDP on
Azure. There are two things needed to get native XDP on a Azure VM:

  - The VM needs to be have "Accelerated Networking", which attaches
    an native XDP capable `mlx4`/`mlx5` NIC.
  - Because the above VF card acts as a slave to the Hyper-V NIC on
    Azure, the running kernel must in addition also have native XDP
    for the `hv_netvsc` driver. This is available in Linux >= 5.6 [1].

Unfortunately, this means that running NodePort XDP on e.g. AKS is not
straightforward, as none of the provided VM images right now offer
native XDP for `hv_netsvc`. There is an open issue to add backport this
to Ubuntu, which is likely to land in the next few weeks [2].

Beacuse we cannot use the stock images for now, I have therefore
validated the setup on a self-managed Kubernetes cluster set up
with `kubeadm` on Flatcar Container Linux Edge. This one of few
Azure supporting distributions with kernel 5.6+. It runs NodePort XDP
and passes the `connectivity-check.yaml` with the `helm install`
command provided in the section. I used Azure IPAM, as I was not able
to convince the underlying vnet forward the pod-to-pod traffic
otherwise.

Because my setup is rather ad-hoc and therefore not recommended for
production use, we abstain from a step-by-step guide until native XDP
for `hv_netsvc` is available in official Azure images.

[1] https://lore.kernel.org/netdev/1579816355-6933-2-git-send-email-haiyangz@microsoft.com/
[2] https://bugs.launchpad.net/ubuntu/+source/linux-azure/+bug/1877654
