### PR TITLE
cilium/charts: set system-{node,cluster}-critical priorityClass for k8s >= 1.17

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -346,7 +346,7 @@ spec:
           {{- toYaml .Values.initResources | trim | nindent 10 }}
 {{- end }}
       restartPolicy: Always
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-node-critical
 {{- end }}
       serviceAccount: cilium

--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-cluster-critical
 {{- end }}
       restartPolicy: Always

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -18,7 +18,7 @@ spec:
       - operator: Exists
       hostPID: true
       hostNetwork: true
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-node-critical
 {{- end }}
       containers:

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -174,7 +174,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       restartPolicy: Always
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-cluster-critical
 {{- end }}
       serviceAccount: cilium-operator


### PR DESCRIPTION
Performing a "greater than 16" causes the logic to be true when the
cluster is running with a minor version set to "16+" which is incorrect.
With this commit, the priorityClass will only be set when the clusters
are "greater or equal than 17".

Fixes: ce99a99a17fa ("Set priorityClassName outside kube-system in k8s 1.17+")
Signed-off-by: André Martins <andre@cilium.io>