### PR TITLE
doc: Fix clustermesh documentation to set the correct identityMode

### DIFF
--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -29,8 +29,11 @@ Prerequisites
 * All nodes must have a unique IP address assigned them. Node IPs of clusters
   being connected together may not conflict with each other.
 
-* Cilium must be configured to use etcd as the kvstore. Consul is not supported
-  by cluster mesh at this point.
+* Cilium must be configured to use etcd as the kvstore, along with the identity
+  allocation mode (``global.identityAllocationMode``). With the identity
+  allocation mode set to ``kvstore``, this allows direct etcd connections,
+  identity propagation across the clusters, and enables cross-cluster policy
+  functionality. Consul is not currently supported with cluster mesh.
 
 * It is highly recommended to use a TLS protected etcd cluster with Cilium. The
   server certificate of etcd must whitelist the host name ``*.mesh.cilium.io``.

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -77,7 +77,11 @@ data:
   #   backend. Upgrades from these older cilium versions should continue using
   #   the kvstore by commenting out the identity-allocation-mode below, or
   #   setting it to "kvstore".
+{{- if .Values.global.etcd.enabled }}
+  identity-allocation-mode: kvstore
+{{- else }}
   identity-allocation-mode: {{ .Values.global.identityAllocationMode }}
+{{- end }}
 {{- if .Values.global.identityHeartbeatTimeout }}
   identity-heartbeat-timeout: "{{ .Values.global.identityHeartbeatTimeout }}"
 {{- end }}


### PR DESCRIPTION
This PR fixes the documentation issues and as well adds in the option
through helm when 'etcd' is enabled.

Fixes: #12125
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
