### PR TITLE
doc: Handle READTHEDOCS_VERSION in preview

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -19,6 +19,7 @@ READTHEDOCS_VERSION:=$(READTHEDOCS_VERSION)
 DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
 		--workdir /src/Documentation \
 		--volume $(CURDIR)/..:/src \
+		--env READTHEDOCS_VERSION=$(READTHEDOCS_VERSION) \
 		--env SKIP_LINT=$(SKIP_LINT) \
 		--user "$(shell id -u):$(shell id -g)"
 DOCKER_RUN := $(DOCKER_CTR) cilium/docs-builder

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -81,7 +81,7 @@ image_tag = 'v' + release
 # Map latest -> master.
 # Map stable -> current version number.
 branch = os.environ.get('READTHEDOCS_VERSION')
-if branch is None or branch == 'latest':
+if not branch or branch == 'latest':
     branch = 'HEAD'
     archive_name = 'master'
     chart_release = './cilium'

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -26,3 +26,13 @@ you can build the docs:
 This generates documentation files and starts a web server using a Docker container. You can
 view the updated documentation by opening either ``Documentation/_build/html/index.html`` or
 http://localhost:9081 in a browser.
+
+.. note::
+
+   By default, ``render-docs-live-preview`` generates a preview with instructions to install
+   Cilium from the latest version on GitHub (i.e. from the HEAD of the master branch that has
+   not been released) regardless of which Cilium branch you are in. You can target a specific
+   branch by specifying ``READTHEDOCS_VERSION`` environment variable:
+
+   .. parsed-literal::
+      READTHEDOCS_VERSION=v1.7 make render-docs-live-preview


### PR DESCRIPTION
- Document the use of READTHEDOCS_VERSION environment variable.
- Allow users to override READTHEDOCS_VERSION during preview.
- Fix conf.py to check READTHEDOCS_VERSION using its truth value instead
  of checking against None. READTHEDOCS_VERSION is set to an empty string
  by default in https://github.com/cilium/cilium/blob/f949c1b1c5d8cc6582c8f0354c4cc242792d4126/Documentation/Dockerfile#L23

      % docker run cilium/docs-builder env | grep READTHEDOCS_VERSION
      READTHEDOCS_VERSION=

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>