### PR TITLE
test/K8sServices: re-enable IPv4 fragment tests on kernel 4.19

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -558,6 +558,24 @@ func DoesNotSupportMetalLB() bool {
 	return true
 }
 
+func (kub *Kubectl) HasHostReachableServices(pod string, checkTCP, checkUDP bool) bool {
+	status := kub.CiliumExecContext(context.TODO(), pod,
+		"cilium status -o jsonpath='{.kube-proxy-replacement.features.hostReachableServices}'")
+	status.ExpectSuccess("Failed to get status: %s", status.OutputPrettyPrint())
+	lines := status.ByLines()
+	Expect(len(lines)).ShouldNot(Equal(0), "Failed to get hostReachableServices status")
+
+	// One-line result is e.g. "{true [TCP UDP]}" if host-reachable
+	// services are activated for both protocols.
+	if checkUDP && !strings.Contains(lines[0], "UDP") {
+		return false
+	}
+	if checkTCP && !strings.Contains(lines[0], "TCP") {
+		return false
+	}
+	return true
+}
+
 // GetNodeWithoutCilium returns a name of a node which does not run cilium.
 func GetNodeWithoutCilium() string {
 	return os.Getenv("NO_CILIUM_ON_NODE")


### PR DESCRIPTION
The test for fragment tracking support got a fix with commit 0e772e7a1e73 ("test: Fix fragment tracking test under KUBEPROXY=1"), where the pattern for searching entries in the Conntrack table accounts for DNAT not happening if kube-proxy is present.

Following recent changes in the datapath and tests for the Linux 4.19 kernel, DNAT is now used even with kube-proxy, provided bpf_sock is in use. This led to CI failures, and the test was disabled for 4.19 kernels with commit 1120aed4144c ("test/K8sServices: disable fragment tracking test for kernel 4.19").

Now that complexity issues are fixed (see #11977 and #12045), let's enable the test on 4.19 again. Ignore DNAT only if kube-proxy is present and bpf_sock (host-reachable services) is not in use. This is also the case for net-next kernels (this didn't fail in CI before because we do not test with kube-proxy on net-next).

Note that (as far as I know) both 4.19 and net-next always use bpf_sock in CI runs, so the check on hostReachableServices is currently superfluous. Let's have it all the same, in case something changes in the future, to avoid unexpected breakage.
