### PR TITLE
doc: Use Hubble version specified in stable.txt

### DIFF
--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -77,7 +77,7 @@ networking infrastructure in a completely transparent manner.
       kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-relay 4245:80
       hubble observe --server localhost:4245
 
-  For convenience, you may set and export the ``HUBBLE_DEFAULT_SOCKET_PATH``
+  (**For Linux / MacOS**) For convenience, you may set and export the ``HUBBLE_DEFAULT_SOCKET_PATH``
   environment variable:
 
   .. code:: bash

--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -6,8 +6,9 @@
 
       .. parsed-literal::
 
-         curl -LO https://github.com/cilium/hubble/releases/latest/download/hubble-linux-amd64.tar.gz
-         curl -LO https://github.com/cilium/hubble/releases/latest/download/hubble-linux-amd64.tar.gz.sha256sum
+         export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         curl -LO "https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-amd64.tar.gz"
+         curl -LO "https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-amd64.tar.gz.sha256sum"
          sha256sum --check hubble-linux-amd64.tar.gz.sha256sum
          tar zxf hubble-linux-amd64.tar.gz
 
@@ -23,8 +24,9 @@
 
       .. parsed-literal::
 
-         curl -LO https://github.com/cilium/hubble/releases/latest/download/hubble-darwin-amd64.tar.gz
-         curl -LO https://github.com/cilium/hubble/releases/latest/download/hubble-darwin-amd64.tar.gz.sha256sum
+         export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         curl -LO "https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-amd64.tar.gz"
+         curl -LO "https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-amd64.tar.gz.sha256sum"
          shasum -a 256 -c hubble-darwin-amd64.tar.gz.sha256sum
          tar zxf hubble-darwin-amd64.tar.gz
 
@@ -40,11 +42,13 @@
 
       .. parsed-literal::
 
-         curl -LO https://github.com/cilium/hubble/releases/latest/download/hubble-windows-amd64.tar.gz
-         curl -LO https://github.com/cilium/hubble/releases/latest/download/hubble-windows-amd64.tar.gz.sha256sum
+         curl -LO "https://raw.githubusercontent.com/cilium/hubble/master/stable.txt"
+         set /p HUBBLE_VERSION=<stable.txt
+         curl -LO "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz"
+         curl -LO "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz.sha256sum"
          certutil -hashfile hubble-windows-amd64.tar.gz SHA256
          type hubble-windows-amd64.tar.gz.sha256sum
-         # verify that the checksum from the two commands above match
+         :: verify that the checksum from the two commands above match
          tar zxf hubble-windows-amd64.tar.gz
 
       and move the ``hubble.exe`` CLI to a directory listed in the ``%PATH%`` environment variable after


### PR DESCRIPTION
Ref: https://github.com/cilium/hubble/issues/298

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>