### PR TITLE
Fix syslog hook missing in DefaultLogger

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -261,6 +261,7 @@ func setupSyslog(logOpts LogOptions, tag string, debug bool) {
 	}
 	// TODO: switch to a per-logger version when we upgrade to logrus >1.0.3
 	logrus.AddHook(h)
+	DefaultLogger.AddHook(h)
 }
 
 // GetFormatter returns a configured logrus.Formatter with some specific values


### PR DESCRIPTION
When specify cilium-agent to use syslog driver, all logs will still be
output to `stdout`. This is because each module uses the `DefaultLogger`
(cilium's customized logger, not logrus's default logger), while syslog
hook is not added to this logger.

This patch fixes this problem by adding syslog hook to `DefaultLogger`.

Signed-off-by: arthurchiao <arthurchiao@hotmail.com>