### PR TITLE
pkg/k8s: ignore status field in CNP DeepEqual

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -71,9 +71,12 @@ type CiliumNetworkPolicy struct {
 
 	// Status is the status of the Cilium policy rule
 	// +optional
+	// +deepequal-gen=false
 	Status CiliumNetworkPolicyStatus `json:"status"`
 }
 
+// DeepEqual compares 2 CNPs while ignoring the LastAppliedConfigAnnotation and
+// ignoring the Status field of the CNP.
 func (in *CiliumNetworkPolicy) DeepEqual(other *CiliumNetworkPolicy) bool {
 	switch {
 	case (in == nil) != (other == nil):

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -183,10 +183,6 @@ func (in *CiliumNetworkPolicy) deepEqual(other *CiliumNetworkPolicy) bool {
 		}
 	}
 
-	if !in.Status.DeepEqual(&other.Status) {
-		return false
-	}
-
 	return true
 }
 


### PR DESCRIPTION
The status field should be ignored when comparing 2 CNPs as this field
does not matter to the policy enforcement of the CNP.

This fixes a bug introduced by 134fdb5e4ba7 which make Cilium to process
all CNP events from k8s including the ones where a status was the only
field modified. This made a cluster with 2 or more nodes to concurrently
trying the update its own status in the CNP causing the other node to
receive and process the CNP event.

Fixes: 134fdb5e4ba7 ("k8s/watchers: fix missing missing CNP/CCNP updates")
Signed-off-by: André Martins <andre@cilium.io>