### PR TITLE
Fix commands in EKS kube-proxy free GSG

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -501,7 +501,7 @@ support on the ena driver. The latter is needed to configure channel parameters 
 
   IPS=$(kubectl get no -o jsonpath='{$.items[*].status.addresses[?(@.type=="ExternalIP")].address }{"\\n"}' | tr ' ' '\\n')
 
-  for ip in $IPS ; do ssh ec2-user@$ip "sudo amazon-linux-extras install -y ethtool kernel-ng && sudo reboot"; done
+  for ip in $IPS ; do ssh ec2-user@$ip "sudo amazon-linux-extras install -y kernel-ng && sudo ethtool install -y ethtool && sudo reboot"; done
 
 Once the nodes come back up their kernel version should say ``5.4.38-17.76.amzn2.x86_64`` or
 similar through ``uname -r``. In order to run XDP on ena, make sure the driver version is at

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -499,7 +499,7 @@ support on the ena driver. The latter is needed to configure channel parameters 
 
 .. parsed-literal::
 
-  IPS=$(kubectl get no -o jsonpath='{$.items[*].status.addresses[?(@.type=="ExternalIP")].address }{"\n"}' | tr ' ' '\n')
+  IPS=$(kubectl get no -o jsonpath='{$.items[*].status.addresses[?(@.type=="ExternalIP")].address }{"\\n"}' | tr ' ' '\\n')
 
   for ip in $IPS ; do ssh ec2-user@$ip "sudo amazon-linux-extras install -y ethtool kernel-ng && sudo reboot"; done
 


### PR DESCRIPTION
Small fixes for the commands used in the EKS kube-proxy free GSG:

* Missing escaping of backslashes
* Installation of `ethtool` using `yum install` instead of `amazon-linux-extras install`