### PR TITLE
helm: add agent and operator hostPorts to PodSecurityPolicy

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/podsecuritypolicy.yaml
@@ -34,6 +34,15 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+  hostPorts:
+{{- if .Values.global.prometheus.enabled }}
+    - min: {{ .Values.global.prometheus.port }}
+      max: {{ .Values.global.prometheus.port }}
+{{- end }}
+{{- if .Values.global.hubble.metrics.enabled }}
+    - min: {{ .Values.global.hubble.metrics.port }}
+      max: {{ .Values.global.hubble.metrics.port }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/install/kubernetes/cilium/charts/operator/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/podsecuritypolicy.yaml
@@ -32,6 +32,11 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+  hostPorts:
+{{- if .Values.global.prometheus.enabled }}
+    - min: {{ .Values.global.operatorPrometheus.port }}
+      max: {{ .Values.global.operatorPrometheus.port }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
When config options that open hostPorts are enabled the PodeSecurityPolicy needs to reflect this or it will not be selected.

Fixes https://github.com/cilium/cilium/issues/12324