### PR TITLE
test,daemon: Fix repeated devices

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2533,6 +2533,19 @@ func (c *DaemonConfig) populateDevices() {
 	if device != "" {
 		c.Devices = []string{device}
 	}
+
+	// Make sure that devices are unique
+	if len(c.Devices) <= 1 {
+		return
+	}
+	devSet := map[string]struct{}{}
+	for _, dev := range c.Devices {
+		devSet[dev] = struct{}{}
+	}
+	c.Devices = make([]string, 0, len(devSet))
+	for dev := range devSet {
+		c.Devices = append(c.Devices, dev)
+	}
 }
 
 func (c *DaemonConfig) populateNodePortRange() error {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2261,7 +2261,7 @@ func (kub *Kubectl) waitToDelete(name, label string) error {
 // GetDefaultIface returns an interface name which is used by a default route.
 // Assumes that all nodes have identical interfaces.
 func (kub *Kubectl) GetDefaultIface() (string, error) {
-	cmd := `ip -o r | grep default | grep -o 'dev [a-zA-Z0-9]*' | cut -d' ' -f2`
+	cmd := `ip -o r | grep default | grep -o 'dev [a-zA-Z0-9]*' | cut -d' ' -f2 | head -n1`
 	iface, err := kub.ExecInHostNetNSByLabel(context.TODO(), K8s1, cmd)
 	if err != nil {
 		return "", fmt.Errorf("Failed to retrieve default iface: %s", err)


### PR DESCRIPTION
This PR:

- Ensures that the `GetDefaultIface()` test helper will return a single device.
- Omits repeated devices passed via `--devices` by a user.

/cc @pchaigno @jrajahalme 

Reviewable per commit.