### PR TITLE
operator: Make CRD availability timeout configurable

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -28,6 +28,7 @@ cilium-operator-aws [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -28,6 +28,7 @@ cilium-operator-azure [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -26,6 +26,7 @@ cilium-operator-generic [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -30,6 +30,7 @@ cilium-operator [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -10,6 +10,7 @@
 {{- $defaultBpfCtAnyMax := 262144 -}}
 {{- $enableIdentityMark := "true" -}}
 {{- $fragmentTracking := "true" -}}
+{{- $crdWaitTimeout := "5m" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -585,4 +586,10 @@ data:
 {{- if hasKey .Values "blacklistConflictingRoutes" }}
   # Configure blacklisting of local routes not owned by Cilium.
   blacklist-conflicting-routes: {{ .Values.blacklistConflictingRoutes | quote }}
+{{- end }}
+
+{{- if hasKey .Values "crdWaitTimeout" }}
+  crd-wait-timeout: {{ .Values.crdWaitTimeout | quote }}
+{{- else if ( ne $crdWaitTimeout "5m" ) }}
+  crd-wait-timeout: {{ $crdWaitTimeout | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/config/values.yaml
+++ b/install/kubernetes/cilium/charts/config/values.yaml
@@ -50,3 +50,7 @@
 # enables passing identity on local routes by using the mark fields. However,
 # in cases where this conflicts with a chained CNI plugin it may be disabled.
 #enableIdentityMark: true
+
+# Operator will exit if CRDs are not available within this duration upon
+# startup.
+#crdWaitTimeout: 5m

--- a/operator/crd.go
+++ b/operator/crd.go
@@ -18,7 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -28,10 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	toolswatch "k8s.io/client-go/tools/watch"
-)
-
-const (
-	defaultTimeout = 5 * time.Minute
 )
 
 // waitForCRD waits for the given CRD to be available with the given context.
@@ -78,7 +75,7 @@ func waitForCRD(ctx context.Context, client clientset.Interface, name string) er
 // after which cilium-agent should be ready. Returns an error when timeout
 // is exceeded.
 func WaitForCRD(client clientset.Interface, name string) error {
-	ctx, cancelFunc := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), operatorOption.Config.CRDWaitTimeout)
 	defer cancelFunc()
 	return waitForCRD(ctx, client, name)
 }

--- a/operator/crd_test.go
+++ b/operator/crd_test.go
@@ -67,7 +67,7 @@ func (s *crdTestSuite) TestGetCRD(c *C) {
 	c.Assert(err, IsNil)
 
 	// Try to get existing CRD
-	err = WaitForCRD(client, "foo")
+	err = waitForCRD(context.TODO(), client, "foo")
 	c.Assert(err, IsNil)
 
 	// Try to get non-existing CRD

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -285,5 +285,8 @@ func init() {
 	flags.Duration(option.K8sHeartbeatTimeout, 30*time.Second, "Configures the timeout for api-server heartbeat, set to 0 to disable")
 	option.BindEnv(option.K8sHeartbeatTimeout)
 
+	flags.Duration(operatorOption.CRDWaitTimeout, 5*time.Minute, "Operator will exit if CRDs are not available within this duration upon startup")
+	option.BindEnv(operatorOption.CRDWaitTimeout)
+
 	viper.BindPFlags(flags)
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -155,6 +155,9 @@ const (
 
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup = "azure-resource-group"
+
+	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
+	CRDWaitTimeout = "crd-wait-timeout"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -273,6 +276,9 @@ type OperatorConfig struct {
 
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup string
+
+	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
+	CRDWaitTimeout time.Duration
 }
 
 func (c *OperatorConfig) Populate() {
@@ -296,6 +302,7 @@ func (c *OperatorConfig) Populate() {
 	c.IPAMOperatorV4CIDR = viper.GetStringSlice(IPAMOperatorV4CIDR)
 	c.IPAMOperatorV6CIDR = viper.GetStringSlice(IPAMOperatorV6CIDR)
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
+	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
 
 	// AWS options
 


### PR DESCRIPTION
This change allows to override the default 5m timeout with the
--crd-wait-timeout option.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

Follow up to #10899
