### PR TITLE
operator: sync CiliumNodes into etcd instead of k8s nodes

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -25,10 +25,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to automatically read from k8s and import the node's pod CIDR to cilium's
-  # etcd so all nodes know how to reach another pod running in in a different
-  # node.
-  - nodes
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -318,10 +318,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to automatically read from k8s and import the node's pod CIDR to cilium's
-  # etcd so all nodes know how to reach another pod running in in a different
-  # node.
-  - nodes
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -247,10 +247,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to automatically read from k8s and import the node's pod CIDR to cilium's
-  # etcd so all nodes know how to reach another pod running in in a different
-  # node.
-  - nodes
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -163,7 +164,10 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.Manager.NodeUpdated(n.LocalNode)
 
 	go func() {
-		log.Info("Adding local node to cluster")
+		log.WithFields(
+			logrus.Fields{
+				logfields.Node: n.LocalNode,
+			}).Info("Adding local node to cluster")
 		for {
 			if err := n.Registrar.RegisterNode(&n.LocalNode, n.Manager); err != nil {
 				log.WithError(err).Error("Unable to initialize local node. Retrying...")


### PR DESCRIPTION
operator: sync cilium nodes to kvstore instead of k8s nodes

As Cilium is more dependent on the CiliumNodes information to be more up
to date, the Cilium Operator should sync those nodes into the KVStore
instead of the k8s nodes. Using k8s nodes is not reliable as some of the
fields set in these structures are not up to date with the fields set in
the Cilium Nodes.

Signed-off-by: André Martins <andre@cilium.io>
