### PR TITLE
doc: ensure to use --set config.ipam=kubernetes with kind

### DIFF
--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -31,8 +31,8 @@ Deploy Cilium and Hubble
 
 .. include:: k8s-install-download-release.rst
 
-Pre-load images into the kind cluster so each node does not have to pull
-them:
+**(optional, but recommended)** Pre-load Cilium images into the kind cluster so
+each worker doesn't have to pull them.
 
 .. parsed-literal::
 
@@ -52,10 +52,23 @@ Install Cilium release via Helm:
       --set global.nodePort.enabled=true \\
       --set global.hostPort.enabled=true \\
       --set global.pullPolicy=IfNotPresent \\
+      --set config.ipam=kubernetes \\
       --set global.hubble.enabled=true \\
       --set global.hubble.listenAddress=":4244" \\
       --set global.hubble.relay.enabled=true \\
       --set global.hubble.ui.enabled=true
+
+.. tip::
+   If your local network subnet conflicts with the one picked up by kind,
+   update the ``networking`` section of the kind configuration file to specify
+   different subnets (pick a network range that does not conflict with yours)
+   and re-create the cluster.
+
+   .. parsed-literal::
+        networking:
+          disableDefaultCNI: true
+          podSubnet: "10.244.0.0/16"
+          serviceSubnet: "10.245.0.0/16"
 
 Validate the Installation
 =========================

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -25,7 +25,8 @@ Install Cilium
 .. include:: k8s-install-download-release.rst
 
 
-**(optional, but recommended)** Pre-load Cilium images into the kind cluster so each worker doesn't have to pull them.
+**(optional, but recommended)** Pre-load Cilium images into the kind cluster so
+each worker doesn't have to pull them.
 
 .. parsed-literal::
 
@@ -44,7 +45,20 @@ Install Cilium release via Helm:
       --set global.externalIPs.enabled=true \\
       --set global.nodePort.enabled=true \\
       --set global.hostPort.enabled=true \\
-      --set global.pullPolicy=IfNotPresent
+      --set global.pullPolicy=IfNotPresent \\
+      --set config.ipam=kubernetes
+
+.. tip::
+   If your local network subnet conflicts with the one picked up by kind,
+   update the ``networking`` section of the kind configuration file to specify
+   different subnets (pick a network range that does not conflict with yours)
+   and re-create the cluster.
+
+   .. parsed-literal::
+        networking:
+          disableDefaultCNI: true
+          podSubnet: "10.244.0.0/16"
+          serviceSubnet: "10.245.0.0/16"
 
 .. include:: k8s-install-validate.rst
 .. include:: namespace-kube-system.rst


### PR DESCRIPTION
Local clusters that I created with Kind lost connectivity as soon as
Cilium was deployed. It took me a while to figure out that the subnet
conflicted with the subnet on my local network.

This commit the option `--set config.ipam=kubernetes` to guides that
deploy Cilium on Kind clusters and adds a note about the possibility of
defining specific subnets for use by Kind.
