### PR TITLE
helm: configurable annotations for agent and operator pods

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -27,6 +27,7 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+{{- with .Values.podsAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
       labels:
         k8s-app: cilium
 {{- if .Values.keepDeprecatedLabels }}

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -4,6 +4,9 @@ image: cilium
 # update process.
 maxUnavailable: 2
 
+# Additional annotations for the agent pods
+podsAnnotations:
+
 # Specifies annotation for service accounts
 serviceAccount:
   annotations: {}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         prometheus.io/port: {{ .Values.global.operatorPrometheus.port | quote }}
         prometheus.io/scrape: "true"
 {{- end }}
+{{- with .Values.podsAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
       labels:
         io.cilium/app: operator
         name: cilium-operator

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -6,3 +6,6 @@ serviceAccount:
 
 # Specifies the resources for the operator container
 resources: {}
+
+# Additional annotations for the operator pods
+podsAnnotations:


### PR DESCRIPTION
This change allows the enduser to specify arbitrary annotations for the **agent** and **operator** pods. This is not necessarily Cilium related but is for example a prerequisite to get Datadog autodiscovery configured. Thanks to this change, it gets as "simple" as:

```yaml
---
agent:
  podsAnnotations:
    ad.datadoghq.com/cilium-agent.check_names: '["cilium"]'
    ad.datadoghq.com/cilium-agent.init_configs: '[{}]'
    ad.datadoghq.com/cilium-agent.instances: '[{"agent_endpoint": "http://%%host%%:9090/metrics"}]'

operator:
  podsAnnotations:
    ad.datadoghq.com/cilium-operator.check_names: '["cilium"]'
    ad.datadoghq.com/cilium-operator.init_configs: '[{}]'
    ad.datadoghq.com/cilium-operator.instances: '[{"operator_endpoint": "http://%%host%%:6942/metrics"}]'
```
