### PR TITLE
test: Fix nativeRoutingCIDR in CI

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -117,7 +117,7 @@ var (
 		"config.enableCnpStatusUpdates": "true",
 
 		"global.hostFirewall":      "true",
-		"global.nativeRoutingCIDR": "10.0.0.0/16",
+		"global.nativeRoutingCIDR": "10.0.0.0/8",
 	}
 
 	flannelHelmOverrides = map[string]string{


### PR DESCRIPTION
CI is allocating addresses from 10.10.0.0/16, which falls in a
different CIDR to the currently configured native routing CIDR. Fix up
the native routing CIDR to also include the CIDR range of the cluster pool.

This should fix a recently-seen flake in CI in the "bookinfo" tests.