### PR TITLE
test: Scrub GKE cluster more thoroughly when releasing cluster.

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -497,8 +497,7 @@ cluster.
 
 .. note:: GKE clusters may have namespaces stuck at the ``Terminating`` state,
           causing Ginkgo tests to fail. If so, you'll see them in ``kubectl get ns``,
-          and can get rid of them by running
-          ``cilium/test/gke/delete-terminating-namespaces.sh``.
+          and can get rid of them by running ``cilium/test/gke/clean-cluster.sh``.
 
 ::
 

--- a/test/gke/release-cluster.sh
+++ b/test/gke/release-cluster.sh
@@ -3,12 +3,6 @@
 test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-project="cilium-ci"
-# this is only needs to be set as some of gcloud commands requires it,
-# but as this script uses resource URIs clusters in all locations are
-# going to be discovered and used
-region="us-west1"
-
 export KUBECONFIG="${script_dir}/gke-kubeconfig"
 cluster_uri="$(cat "${script_dir}/cluster-uri")"
 
@@ -21,15 +15,8 @@ unlock() {
 }
 trap unlock EXIT
 
-# We leak istio pods for an unknown reason (these tests do cleanup). This may
-# be related to timeouts or other failures. In any case, we delete them here to
-# be sure.
-echo "deleting istio-system namespace and contents"
-kubectl delete all -n istio-system --all
-kubectl delete ns istio-system
-
-echo "deleting terminating namespaces"
-./delete-terminating-namespaces.sh
+echo "cleaning cluster after tests"
+./clean-cluster.sh
 
 set -e
 

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -43,11 +43,11 @@ gcloud container clusters describe --project "${project}" --region "${region}" -
 gcloud container clusters describe --project "${project}" --region "${region}" --format='value(currentMasterVersion)' "${cluster_uri}" \
   | sed -E 's/([0-9]+\.[0-9]+)\..*/\1/' | tr -d '\n' > "${script_dir}/cluster-version"
 
+echo "cleaning cluster before tests"
+${script_dir}/clean-cluster.sh
+
 echo "creating cilium ns"
 kubectl create ns cilium || true
-
-echo "deleting terminating namespaces"
-${script_dir}/delete-terminating-namespaces.sh
 
 echo "scaling ${cluster_uri} to 2"
 ${script_dir}/resize-cluster.sh 2 ${cluster_uri}


### PR DESCRIPTION
Noticed in local testing that an Istio sidecar-injector label can
prevent PODs being deployed in the default namespace if left behind by
a failed Istio test, so deleted this label in the clean-up.

Delete also all other resources left into the default namespace.

Delete cilium-monitoring and cilium namespaces to leave the cluster in
a more predictable condition and remove all CRDs from the cluster.

Move the cleaning to the renamed `gke/clean-cluster.sh` so that it can be reused from the command line in local testing.

These changes allowed the `cilium-ci-12` cluster to successfully pass all the K8s tests, while before it would not pass anything.

Fixes: #11928
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
