### PR TITLE
ipv6: Support joining NDP mcast group for pods

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -118,6 +118,7 @@ Jenkinsfile.nightly @cilium/ci
 /pkg/logging/ @cilium/cli
 /pkg/mac @cilium/bpf
 /pkg/maps/ @cilium/bpf
+/pkg/mcastmanager @cilium/bpf
 /pkg/metrics @cilium/metrics
 /pkg/monitor @cilium/monitor
 /pkg/monitor/api @cilium/api
@@ -126,6 +127,7 @@ Jenkinsfile.nightly @cilium/ci
 /pkg/monitor/payload @cilium/api
 /pkg/mountinfo @cilium/bpf
 /pkg/mtu @cilium/bpf
+/pkg/multicast @cilium/bpf
 /pkg/option @cilium/agent @cilium/cli
 /pkg/pidfile @cilium/agent
 /pkg/policy @cilium/policy

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -74,6 +74,7 @@ cilium-agent [flags]
       --enable-ipv4                                   Enable IPv4 support (default true)
       --enable-ipv4-fragment-tracking                 Enable IPv4 fragments tracking for L4-based lookups (default true)
       --enable-ipv6                                   Enable IPv6 support (default true)
+      --enable-ipv6-ndp                               Enable IPv6 NDP support
       --enable-k8s-api-discovery                      Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                     Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                     Enable k8s event handover to kvstore for improved scalability
@@ -124,6 +125,7 @@ cilium-agent [flags]
       --ipv4-service-loopback-address string          IPv4 address for service loopback SNAT (default "169.254.42.1")
       --ipv4-service-range string                     Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
       --ipv6-cluster-alloc-cidr string                IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-mcast-device string                      Device that joins a Solicited-Node multicast group for IPv6
       --ipv6-node string                              IPv6 address of node (default "auto")
       --ipv6-pod-subnets strings                      List of IPv6 pod subnets to preconfigure for encryption
       --ipv6-range string                             Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -315,6 +315,9 @@ function write_cilium_cfg() {
         cilium_options+=" --enable-ipv4=false"
     fi
 
+    cilium_options+=" --enable-ipv6-ndp"
+    cilium_options+=" --ipv6-mcast-device enp0s8"
+
     if [ -n "${K8S}" ]; then
         cilium_options+=" --k8s-kubeconfig-path /var/lib/cilium/cilium.kubeconfig"
         cilium_options+=" --kvstore etcd"

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -298,6 +298,12 @@ func init() {
 	flags.Bool(option.EnableIPv6Name, defaults.EnableIPv6, "Enable IPv6 support")
 	option.BindEnv(option.EnableIPv6Name)
 
+	flags.Bool(option.EnableIPv6NDPName, defaults.EnableIPv6NDP, "Enable IPv6 NDP support")
+	option.BindEnv(option.EnableIPv6NDPName)
+
+	flags.String(option.IPv6MCastDevice, "", "Device that joins a Solicited-Node multicast group for IPv6")
+	option.BindEnv(option.IPv6MCastDevice)
+
 	flags.Bool(option.EnableRemoteNodeIdentity, defaults.EnableRemoteNodeIdentity, "Enable use of remote node identity")
 	option.BindEnv(option.EnableRemoteNodeIdentity)
 

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -826,6 +826,12 @@ func (d *dummyManager) ReleaseID(*endpoint.Endpoint) error {
 	return nil
 }
 
+func (d *dummyManager) AddIPv6Address(addressing.CiliumIPv6) {
+}
+
+func (d *dummyManager) RemoveIPv6Address(addressing.CiliumIPv6) {
+}
+
 func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -144,6 +144,9 @@ const (
 	// EnableIPv6 is the default value for IPv6 enablement
 	EnableIPv6 = true
 
+	// EnableIPv6NDP is the default value for IPv6 NDP support enablement
+	EnableIPv6NDP = false
+
 	// EnableL7Proxy is the default value for L7 proxy enablement
 	EnableL7Proxy = true
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -751,3 +751,9 @@ func (d *dummyManager) RemoveID(uint16) {
 func (d *dummyManager) ReleaseID(*Endpoint) error {
 	return nil
 }
+
+func (d *dummyManager) AddIPv6Address(addressing.CiliumIPv6) {
+}
+
+func (d *dummyManager) RemoveIPv6Address(addressing.CiliumIPv6) {
+}

--- a/pkg/mcastmanager/doc.go
+++ b/pkg/mcastmanager/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mcastmanager manages endpoint's IPv6 addresses and join the node
+// solicitation multicast addresses
+package mcastmanager

--- a/pkg/mcastmanager/mcastmanager.go
+++ b/pkg/mcastmanager/mcastmanager.go
@@ -1,0 +1,125 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcastmanager
+
+import (
+	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/multicast"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "mcast-manager")
+)
+
+// MCastManager manages IPv6 address
+type MCastManager struct {
+	mutex lock.Mutex
+
+	// iface is the interface that mcast addresses are applied to
+	iface string
+
+	// addresses keeps track of all ipv6 addresses by grouping them based on the
+	// last 3 bytes of the address. The last 3 bytes of an IPv6 address determines
+	// the solicited node multicast address: https://tools.ietf.org/html/rfc4291#section-2.7.1
+	addresses map[int32]map[string]struct{}
+
+	// state tracks all the IPv6 multicast addresses created by MCastManager
+	state map[string]struct{}
+}
+
+// New creates a McastManager instance. Create a dummy manager when iface is empty
+// string.
+func New(iface string) *MCastManager {
+	return &MCastManager{
+		addresses: make(map[int32]map[string]struct{}),
+		state:     make(map[string]struct{}),
+		iface:     iface,
+	}
+}
+
+// AddAddress is called when a new endpoint is added
+func (mgr *MCastManager) AddAddress(ipv6 addressing.CiliumIPv6) {
+	if mgr.iface == "" || !ipv6.IsSet() {
+		return
+	}
+
+	key := multicast.Address(ipv6).Key()
+
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+
+	if _, ok := mgr.addresses[key]; !ok {
+		// First IP that has the solicited node maddr
+		mgr.joinGroup(ipv6)
+		mgr.addresses[key] = map[string]struct{}{}
+	}
+
+	mgr.addresses[key][ipv6.String()] = struct{}{}
+}
+
+// RemoveAddress is called when an endpoint is removed
+func (mgr *MCastManager) RemoveAddress(ipv6 addressing.CiliumIPv6) {
+	if mgr.iface == "" || !ipv6.IsSet() {
+		return
+	}
+
+	key := multicast.Address(ipv6).Key()
+
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+
+	if m, ok := mgr.addresses[key]; ok {
+		delete(m, ipv6.String())
+		if len(m) == 0 {
+			// Last IP that has the solicited node maddr
+			mgr.leaveGroup(ipv6)
+			delete(mgr.addresses, key)
+		}
+	}
+}
+
+func (mgr *MCastManager) joinGroup(ipv6 addressing.CiliumIPv6) {
+	maddr := multicast.Address(ipv6).SolicitedNodeMaddr()
+	if err := multicast.JoinGroup(mgr.iface, maddr.String()); err != nil {
+		log.WithError(err).WithField("maddr", maddr).Warn("failed to join multicast group")
+		return
+	}
+
+	log.WithFields(logrus.Fields{
+		"device": mgr.iface,
+		"mcast":  maddr,
+	}).Info("Joined multicast group")
+
+	mgr.state[maddr.String()] = struct{}{}
+}
+
+func (mgr *MCastManager) leaveGroup(ipv6 addressing.CiliumIPv6) {
+	maddr := multicast.Address(ipv6).SolicitedNodeMaddr()
+	if err := multicast.LeaveGroup(mgr.iface, maddr.String()); err != nil {
+		log.WithError(err).WithField("maddr", maddr).Warn("failed to leave multicast group")
+		return
+	}
+
+	log.WithFields(logrus.Fields{
+		"device": mgr.iface,
+		"mcast":  maddr,
+	}).Info("Left multicast group")
+
+	delete(mgr.state, maddr.String())
+}

--- a/pkg/mcastmanager/mcastmanager_test.go
+++ b/pkg/mcastmanager/mcastmanager_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package mcastmanager
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/addressing"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type McastManagerSuite struct {
+}
+
+var _ = Suite(&McastManagerSuite{})
+
+func (m *McastManagerSuite) TestAddRemoveEndpoint(c *C) {
+	ifaces, err := net.Interfaces()
+	c.Assert(err, IsNil)
+
+	if len(ifaces) == 0 {
+		c.Skip("no interfaces to test")
+	}
+
+	var (
+		ok bool
+
+		iface = ifaces[0]
+		mgr   = New(iface.Name)
+	)
+
+	// Add first endpoint
+	mgr.AddAddress(ipv6("f00d::1234"))
+
+	c.Assert(mgr.state, HasLen, 1)
+	_, ok = mgr.state["ff02::1:ff00:1234"]
+	c.Assert(ok, Equals, true)
+
+	// Add another endpoint that shares the same maddr
+	mgr.AddAddress(ipv6("f00d:aabb::1234"))
+
+	c.Assert(mgr.state, HasLen, 1)
+
+	// Remove the first endpoint
+	mgr.RemoveAddress(ipv6("f00d::1234"))
+
+	c.Assert(mgr.state, HasLen, 1)
+	_, ok = mgr.state["ff02::1:ff00:1234"]
+	c.Assert(ok, Equals, true)
+
+	// Remove the second endpoint
+	mgr.RemoveAddress(ipv6("f00d:aabb::1234"))
+
+	c.Assert(mgr.state, HasLen, 0)
+	_, ok = mgr.state["ff02::1:ff00:1234"]
+	c.Assert(ok, Equals, false)
+}
+
+func (m *McastManagerSuite) TestAddRemoveNil(c *C) {
+	ifaces, err := net.Interfaces()
+	c.Assert(err, IsNil)
+
+	if len(ifaces) == 0 {
+		c.Skip("no interfaces to test")
+	}
+
+	var (
+		iface = ifaces[0]
+		mgr   = New(iface.Name)
+	)
+
+	mgr.AddAddress(nil)
+	mgr.RemoveAddress(nil)
+}
+
+func ipv6(addr string) addressing.CiliumIPv6 {
+	ret, _ := addressing.NewCiliumIPv6(addr)
+	return ret
+}

--- a/pkg/multicast/doc.go
+++ b/pkg/multicast/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package multicast contains various utility functions to work with IPv6
+// multicast
+package multicast

--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -1,0 +1,176 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicast
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"golang.org/x/net/ipv6"
+)
+
+var (
+	// v6Socket is the udp socket used to join/leave a multicast group
+	v6Socket net.PacketConn
+
+	mutex lock.Mutex
+
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "multicast")
+)
+
+// Pre-Defined Multicast Addresses
+// as defined in https://tools.ietf.org/html/rfc4291#section-2.7.1
+
+var (
+	// AllNodesIfcLocalMaddr is the multicast address that identifies the group of
+	// all IPv6 nodes, within scope 1 (interface-local)
+	AllNodesIfcLocalMaddr net.IP = net.ParseIP("ff01::1")
+
+	// AllNodesLinkLocalMaddr is the multicast address that identifies the group of
+	// all IPv6 nodes, within scope 2 (link-local)
+	AllNodesLinkLocalMaddr net.IP = net.ParseIP("ff02::1")
+
+	// AllRoutersIfcLocalMaddr is the multicast address that identifies the group of
+	// all IPv6 routers, within scope 1 (interface-local)
+	AllRoutersIfcLocalMaddr net.IP = net.ParseIP("ff01::2")
+
+	// AllRoutersLinkLocalMaddr is the multicast address that identifies the group of
+	// all IPv6 routers, within scope 2 (link-local)
+	AllRoutersLinkLocalMaddr net.IP = net.ParseIP("ff02::2")
+
+	// AllRoutersSiteLocalMaddr is the multicast address that identifies the group of
+	// all IPv6 routers, within scope 5 (site-local)
+	AllRoutersSiteLocalMaddr net.IP = net.ParseIP("ff05::2")
+
+	// SolicitedNodeMaddrPrefix is the prefix of the multicast address that is used
+	// as part of NDP
+	SolicitedNodeMaddrPrefix net.IP = net.ParseIP("ff02::1:ff00:0")
+)
+
+func initSocket() error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if v6Socket != nil {
+		return nil
+	}
+
+	c, err := net.ListenPacket("udp6", "[::]:0")
+	if err != nil {
+		log.WithError(err).Warn("Failed to listen on socket for multicast")
+		return err
+	}
+
+	v6Socket = c
+	return nil
+}
+
+// JoinGroup joins the group address group on the interface ifc
+func JoinGroup(ifc string, ip string) error {
+	if err := initSocket(); err != nil {
+		return err
+	}
+
+	dev, err := net.InterfaceByName(ifc)
+	if err != nil {
+		return err
+	}
+
+	group := net.ParseIP(ip)
+
+	return ipv6.NewPacketConn(v6Socket).JoinGroup(dev, &net.UDPAddr{IP: group})
+}
+
+// LeaveGroup leaves the group address group on the interface ifc
+func LeaveGroup(ifc string, ip string) error {
+	if err := initSocket(); err != nil {
+		return err
+	}
+
+	dev, err := net.InterfaceByName(ifc)
+	if err != nil {
+		return err
+	}
+
+	group := net.ParseIP(ip)
+
+	return ipv6.NewPacketConn(v6Socket).LeaveGroup(dev, &net.UDPAddr{IP: group})
+}
+
+// ListGroup lists multicast addresses on the interface ifc
+func ListGroup(ifc string) ([]net.Addr, error) {
+	dev, err := net.InterfaceByName(ifc)
+	if err != nil {
+		return nil, err
+	}
+
+	return dev.MulticastAddrs()
+}
+
+// IsInGroup tells if interface ifc belongs to group represented by maddr
+func IsInGroup(ifc string, maddr string) (bool, error) {
+	ips, err := ListGroup(ifc)
+	if err != nil {
+		return false, err
+	}
+
+	for _, gip := range ips {
+		if gip.String() == maddr {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Address encapsulates the functionality to generate solicated node multicast address
+type Address addressing.CiliumIPv6
+
+// Key takes the last 3 bytes of endpoint's IPv6 address and compile them in to
+// an int32 value as key of the endpoint. It assumes the input is a valid IPv6 address.
+// Otherwise it returns 0 (https://tools.ietf.org/html/rfc4291#section-2.7.1)
+func (a Address) Key() int32 {
+	ipv6 := addressing.CiliumIPv6(a)
+
+	if !ipv6.IsSet() {
+		return 0
+	}
+
+	var key int32
+	for _, v := range ipv6[13:] {
+		key <<= 8
+		key += int32(v)
+	}
+
+	return key
+}
+
+// SolicitedNodeMaddr returns solicited node multicast address
+func (a Address) SolicitedNodeMaddr() addressing.CiliumIPv6 {
+	ipv6 := addressing.CiliumIPv6(a)
+
+	if !ipv6.IsSet() {
+		return nil
+	}
+
+	maddr := make([]byte, 16)
+	copy(maddr[:13], SolicitedNodeMaddrPrefix[:13])
+	copy(maddr[13:], ipv6[13:])
+
+	return maddr
+}

--- a/pkg/multicast/multicast_test.go
+++ b/pkg/multicast/multicast_test.go
@@ -1,0 +1,130 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package multicast
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/addressing"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type MulticastSuite struct {
+	r *rand.Rand
+}
+
+var _ = Suite(&MulticastSuite{
+	r: rand.New(rand.NewSource(time.Now().Unix())),
+})
+
+func (m *MulticastSuite) TestGroupOps(c *C) {
+	ifs, err := net.Interfaces()
+	c.Assert(err, IsNil)
+
+	if len(ifs) == 0 {
+		c.Skip("no interfaces to test")
+	}
+
+	ifc := ifs[0]
+	maddr := m.randMaddr()
+
+	// Join Group
+	err = JoinGroup(ifc.Name, maddr.String())
+	c.Assert(err, IsNil)
+
+	// maddr in group
+	inGroup, err := IsInGroup(ifc.Name, maddr.String())
+	c.Assert(err, IsNil)
+	c.Assert(inGroup, Equals, true)
+
+	// LeaveGroup
+	err = LeaveGroup(ifc.Name, maddr.String())
+	c.Assert(err, IsNil)
+
+	// maddr not in group
+	inGroup, err = IsInGroup(ifc.Name, maddr.String())
+	c.Assert(err, IsNil)
+	c.Assert(inGroup, Equals, false)
+}
+
+func (m *MulticastSuite) TestSolicitedNodeMaddr(c *C) {
+	tests := []struct {
+		ip       string
+		expected string
+	}{
+		{
+			ip:       "f00d:abcd:ef01::abcd",
+			expected: "ff02::1:ff00:abcd",
+		},
+	}
+
+	for _, test := range tests {
+		ip, _ := addressing.NewCiliumIPv6(test.ip)
+		got := Address(ip).SolicitedNodeMaddr().String()
+		c.Assert(got, Equals, test.expected)
+	}
+
+}
+
+func (m *MulticastSuite) randMaddr() addressing.CiliumIPv6 {
+	maddr := make([]byte, 16)
+	m.r.Read(maddr[13:])
+	return Address(maddr).SolicitedNodeMaddr()
+}
+
+func (m *MulticastSuite) TestMcastKey(c *C) {
+	tests := []struct {
+		ipv6 string
+		key  int32
+	}{
+		{
+			ipv6: "f00d::",
+			key:  0x0,
+		},
+		{
+			ipv6: "f00d::1000",
+			key:  0x1000,
+		},
+		{
+			ipv6: "f00d::11:1000",
+			key:  0x111000,
+		},
+		{
+			ipv6: "f00d::aa:aaaa",
+			key:  0xaaaaaa,
+		},
+		{
+			ipv6: "f00d::ff:ffff",
+			key:  0xffffff,
+		},
+		{
+			ipv6: "f00d::11ff:ffff",
+			key:  0xffffff,
+		},
+	}
+
+	for _, test := range tests {
+		ipv6, err := addressing.NewCiliumIPv6(test.ipv6)
+		c.Assert(err, IsNil)
+		c.Assert(Address(ipv6).Key(), Equals, test.key)
+	}
+}


### PR DESCRIPTION
This commit added --enable-ipv6-ndp to support joining solicited node
multicast address group for pods' IPv6 address. When a pod is created,
it joins the corresponding solicited node multicast address on a
the external network device, specified by --devices. If multiple devices
are specified, it only applies to the first device. When the pod is
deleted, it leaves the group. When cilium-agent exits, it leaves all
multicast groups.

With the node joining the multicast groups, it has the ability to
receive the NDP message (e.g. NS) coming from external source, which
would enable the pod's IPv6 address discoverable in the future.

Towards #10935

Signed-off-by: Yongkun Gui <ygui@google.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Make pods IPv6 address discoverable on node's subnet
```
