### PR TITLE
datapath,daemon: Fix initialization panics when IPv6 is enabled

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -438,12 +438,8 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	// and the k8s service watcher depends on option.Config.EnableNodePort flag
 	// which can be modified after the device detection.
 	detectDevicesForNodePortAndHostFirewall(isKubeProxyReplacementStrict)
-	finishKubeProxyReplacementInit()
-	if option.Config.EnableNodePort {
-		if err := node.InitNodePortAddrs(option.Config.Devices); err != nil {
-			log.WithError(err).Fatal("Failed to initialize NodePort addrs")
-		}
-	}
+	finishKubeProxyReplacementInit(isKubeProxyReplacementStrict)
+
 	// BPF masquerade depends on BPF NodePort, so the following checks should
 	// happen after invoking initKubeProxyReplacementOptions().
 	if option.Config.Masquerade && option.Config.EnableBPFMasquerade &&

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -264,7 +264,19 @@ func detectDevicesForNodePortAndHostFirewall(strict bool) {
 
 // finishKubeProxyReplacementInit finishes initialization of kube-proxy
 // replacement after all devices are known.
-func finishKubeProxyReplacementInit() {
+func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) {
+	if option.Config.EnableNodePort {
+		if err := node.InitNodePortAddrs(option.Config.Devices); err != nil {
+			msg := "Failed to initialize NodePort addrs."
+			if isKubeProxyReplacementStrict {
+				log.WithError(err).Fatal(msg)
+			} else {
+				disableNodePort()
+				log.WithError(err).Warn(msg + " Disabling BPF NodePort.")
+			}
+		}
+	}
+
 	if !option.Config.EnableNodePort {
 		// Make sure that NodePort dependencies are disabled
 		disableNodePort()

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -332,7 +332,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			cDefinesMap["SNAT_MAPPING_IPV6_SIZE"] = fmt.Sprintf("%d", option.Config.NATMapEntriesGlobal)
 		}
 
-		if option.Config.EnableBPFMasquerade {
+		if option.Config.EnableBPFMasquerade && option.Config.EnableIPv4 {
 			cDefinesMap["ENABLE_MASQUERADE"] = "1"
 			var cidr *cidr.CIDR
 			if c := option.Config.IPv4NativeRoutingCIDR(); c != nil {
@@ -344,11 +344,12 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				fmt.Sprintf("%#x", byteorder.HostSliceToNetwork(cidr.IP, reflect.Uint32).(uint32))
 			ones, _ := cidr.Mask.Size()
 			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR_LEN"] = fmt.Sprintf("%d", ones)
-		}
 
-		if option.Config.EnableIPMasqAgent {
-			cDefinesMap["ENABLE_IP_MASQ_AGENT"] = "1"
-			cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapName
+			// ip-masq-agent depends on bpf-masq
+			if option.Config.EnableIPMasqAgent {
+				cDefinesMap["ENABLE_IP_MASQ_AGENT"] = "1"
+				cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapName
+			}
 		}
 
 		ctmap.WriteBPFMacros(fw, nil)


### PR DESCRIPTION
This PR fixes two panics mentioned in #12188 (see commit msgs).

Fix #12188 