### PR TITLE
option: Require native-routing-cidr only if IPv4 is enabled

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2678,9 +2678,13 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 }
 
 func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
-	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled && c.IPAMMode() != ipamOption.IPAMENI {
-		return fmt.Errorf("native routing cidr must be configured with option --%s in combination with --%s --%s=%s --%s=%s",
-			IPv4NativeRoutingCIDR, Masquerade, TunnelName, c.Tunnel, IPAM, c.IPAMMode())
+	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled &&
+		c.IPAMMode() != ipamOption.IPAMENI && c.EnableIPv4 {
+		return fmt.Errorf(
+			"native routing cidr must be configured with option --%s "+
+				"in combination with --%s --%s=%s --%s=%s --%s=true",
+			IPv4NativeRoutingCIDR, Masquerade, TunnelName, c.Tunnel,
+			IPAM, c.IPAMMode(), EnableIPv4Name)
 	}
 
 	return nil

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -494,6 +494,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Tunnel:                TunnelDisabled,
 				IPAM:                  ipamOption.IPAMAzure,
 				ipv4NativeRoutingCIDR: cidr.MustParseCIDR("10.127.64.0/18"),
+				EnableIPv4:            true,
 			},
 			wantErr: false,
 		},
@@ -503,6 +504,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: false,
 				Tunnel:     TunnelDisabled,
 				IPAM:       ipamOption.IPAMAzure,
+				EnableIPv4: true,
 			},
 			wantErr: false,
 		},
@@ -512,6 +514,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: true,
 				Tunnel:     TunnelVXLAN,
 				IPAM:       ipamOption.IPAMAzure,
+				EnableIPv4: true,
 			},
 			wantErr: false,
 		},
@@ -521,6 +524,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: true,
 				Tunnel:     TunnelDisabled,
 				IPAM:       ipamOption.IPAMENI,
+				EnableIPv4: true,
 			},
 			wantErr: false,
 		},
@@ -530,6 +534,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: true,
 				Tunnel:     TunnelDisabled,
 				IPAM:       ipamOption.IPAMAzure,
+				EnableIPv4: true,
 			},
 			wantErr: true,
 		},
@@ -543,6 +548,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 func Test_populateNodePortRange(t *testing.T) {


### PR DESCRIPTION
Otherwise, when running with IPv6-only the agent fails with the
following:

    level=fatal msg="Error while creating daemon" error="invalid daemon
    configuration: native routing cidr must be configured with option
    --native-routing-cidr in combination with --masquerade --tunnel=disabled
    --ipam=hostscope-legacy" subsys=daemon

Also, we currently do not masquerade IPv6.

Fixes: e7d4f5c6af ("daemon: validate IPv4NativeRoutingCIDR value in DaemonConfig")