### PR TITLE
policy/api: Add reserved:health entity

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -308,6 +308,10 @@ init
     security identity has not been resolved yet. This is typically only
     observed in non-Kubernetes environments. See section
     :ref:`endpoint_lifecycle` for details.
+health
+    The health entity represents the health endpoints, used to check cluster
+    connectivity health. Each node managed by Cilium hosts a health endpoint.
+    See `cluster_connectivity_health` for details on health checks.
 world
     The world entity corresponds to all endpoints outside of the cluster.
     Allowing to world is identical to allowing to CIDR 0/0. An alternative

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -383,6 +383,8 @@ pod
       Warning  Unhealthy  6s (x6 over 56s)   kubelet, agent1    Readiness probe failed: curl: (7) Failed to connect to echo-b-host-headless port 40000: Connection refused
       Warning  Unhealthy  2s (x3 over 52s)   kubelet, agent1    Liveness probe failed: curl: (7) Failed to connect to echo-b-host-headless port 40000: Connection refused
 
+.. _cluster_connectivity_health:
+
 Checking cluster connectivity health
 ------------------------------------
 

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,9 @@ const (
 	// EntityRemoteNode is an entity that represents all remote nodes
 	EntityRemoteNode Entity = "remote-node"
 
+	// EntityHealth is an entity that represents all health endpoints.
+	EntityHealth Entity = "health"
+
 	// EntityNone is an entity that can be selected but never exist
 	EntityNone Entity = "none"
 )
@@ -58,6 +61,8 @@ var (
 
 	endpointSelectorRemoteNode = NewESFromLabels(labels.NewLabel(labels.IDNameRemoteNode, "", labels.LabelSourceReserved))
 
+	endpointSelectorHealth = NewESFromLabels(labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved))
+
 	EndpointSelectorNone = NewESFromLabels(labels.NewLabel(labels.IDNameNone, "", labels.LabelSourceReserved))
 
 	endpointSelectorUnmanaged = NewESFromLabels(labels.NewLabel(labels.IDNameUnmanaged, "", labels.LabelSourceReserved))
@@ -70,6 +75,7 @@ var (
 		EntityHost:       {endpointSelectorHost},
 		EntityInit:       {endpointSelectorInit},
 		EntityRemoteNode: {endpointSelectorRemoteNode},
+		EntityHealth:     {endpointSelectorHealth},
 		EntityNone:       {EndpointSelectorNone},
 
 		// EntityCluster is populated with an empty entry to allow the
@@ -106,6 +112,7 @@ func InitEntities(clusterName string, treatRemoteNodeAsHost bool) {
 		endpointSelectorHost,
 		endpointSelectorRemoteNode,
 		endpointSelectorInit,
+		endpointSelectorHealth,
 		endpointSelectorUnmanaged,
 		NewESFromLabels(labels.NewLabel(k8sapi.PolicyLabelCluster, clusterName, labels.LabelSourceK8s)),
 	}

--- a/pkg/policy/api/entity_test.go
+++ b/pkg/policy/api/entity_test.go
@@ -41,18 +41,21 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:none")), Equals, true) // in a white-list model, All trumps None
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("id=foo")), Equals, true)
 
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:init")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
@@ -64,6 +67,7 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("id=foo")), Equals, false)
@@ -71,6 +75,7 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:init")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("id=foo")), Equals, false)
@@ -84,6 +89,15 @@ func (s *PolicyAPITestSuite) TestEntitySliceMatches(c *C) {
 	slice := EntitySlice{EntityHost, EntityWorld}
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("id=foo")), Equals, false)
+
+	slice = EntitySlice{EntityHost, EntityHealth}
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(slice.matches(labels.ParseLabelArray("id=foo")), Equals, false)


### PR DESCRIPTION
With the introduction of CiliumClusterwideNetworkPolicies a policy has
the ability to select the 'reserved:health' endpoints. If a user applies
a policy such as [0], it will block all connectivity for the health
endpoints. As this does not seem expected, since Cilium will report that
the connectivity across Cilium pods is not working, the user will need to
deploy a CCNP that allows connectivity between health endpoints. This
can be done with [1].

This commit introduces 'reserved:health' as an entity that can be
selected by CNP and / or CCNP.

[0]
```
---
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: ingress-deny-all
spec:
  endpointSelector:
    matchLabels: {}
  ingress:
  - {}
---
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: egress-deny-all
spec:
  endpointSelector:
    matchLabels: {}
  egress:
  - {}
```

[1]
```
apiVersion: "cilium.io/v2"
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: "allow-reserved-health"
spec:
  endpointSelector:
    matchLabels:
      'reserved:health': ""
  ingress:
    - fromEntities:
      - health
```

Related: #11099 (which I couldn't reopen)
Signed-off-by: André Martins <andre@cilium.io>