### PR TITLE
operator: make: Add install target

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -26,3 +26,7 @@ clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -f $(TARGETS)
 	$(GO) clean $(GOCLEAN)
+
+install: $(TARGETS)
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(foreach target,$(TARGETS), $(QUIET)$(INSTALL) -m 0755 $(target) $(DESTDIR)$(BINDIR);)


### PR DESCRIPTION
Add `install` make target which installs cilium-operator binaries.

Fixes: #12184
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>