### PR TITLE
[v1.6] k8s: update k8s libraries to v1.16.11

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1558,7 +1558,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
 [[projects]]
   digest = "1:3a3169935f116c03f1b538e5ea55a2978b13511035136b345d427761ec8063ee"
@@ -1574,10 +1574,10 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
 [[projects]]
-  digest = "1:de0dae006fbbc5512f2e59a2c50fae2890ca7b3b959e6d08f13d8460e737dad5"
+  digest = "1:ad8ce875829241250e2c4d455f9a42b09e0a7d1ed5ef9ebd8a42400f804f6e6b"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1626,7 +1626,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
 [[projects]]
   digest = "1:421721461ab2987bb721dd8ecb397b7ab1aafb3ed2bbcda185af0db2f8b1099e"
@@ -1741,7 +1741,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "0481265146a5db11d297ba153a6772809c800887"
+  revision = "4e53353d513604b5f88d2f1e68d3ee03ea9def4f"
   source = "https://github.com/cilium/client-go"
 
 [[projects]]
@@ -1760,14 +1760,14 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
 [[projects]]
   digest = "1:5e496d711fa03e4aaf3cab0d7de079634a9465ebf940613b69b34f5cc6513db8"
   name = "k8s.io/cri-api"
   packages = ["pkg/apis/runtime/v1alpha2"]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
 [[projects]]
   digest = "1:d233b263f74608ab5528c04453935d899a2b9fb0bf02b03d38a4a11f91442a5c"
@@ -1812,7 +1812,7 @@
     "pkg/registry/core/service/ipallocator",
   ]
   pruneopts = "NUT"
-  revision = "v1.16.10"
+  revision = "v1.16.11"
 
 [[projects]]
   digest = "1:99dbf7ef753ca02399778c93a4ed4b689b28668317134ecd1fabeb07be70f354"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -514,28 +514,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -543,10 +543,10 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   source = "https://github.com/cilium/client-go"
-  revision = "0481265146a5db11d297ba153a6772809c800887"
+  revision = "4e53353d513604b5f88d2f1e68d3ee03ea9def4f"
 
   # main-usage = "pkg/k8s"
-  # on-revision = "TODO @aanm is on 0481265146a5db11d297ba153a6772809c800887 as it contains the hotfix for the metrics path"
+  # on-revision = "TODO @aanm is on 4e53353d513604b5f88d2f1e68d3ee03ea9def4f as it contains the hotfix for the metrics path"
 
 [[override]]
   name = "k8s.io/utils"
@@ -557,7 +557,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -571,14 +571,14 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.16.10"
+  revision = "v1.16.11"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/cri-api"
-  revision = "kubernetes-1.16.10"
+  revision = "kubernetes-1.16.11"
 
   # main-usage = "pkg/workloads"
   # on-revision = ""

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -17,7 +17,7 @@ CONTAINER_RUNTIME=$5
 CNI_INTEGRATION=$6
 # Pinned to the last version of k8s 1.16 branch so we can do
 # kubectl apply on older k8s test frameworks
-K8S_KUBECTL_APPLY_FORCE="1.16.10"
+K8S_KUBECTL_APPLY_FORCE="1.16.11"
 
 # Kubeadm default parameters
 export KUBEADM_ADDR='192.168.36.11'
@@ -224,7 +224,7 @@ case $K8S_VERSION in
         KUBEADM_CONFIG="${KUBEADM_CONFIG_ALPHA3}"
         ;;
     "1.16")
-        KUBERNETES_CNI_VERSION="0.7.5"
+        KUBERNETES_CNI_VERSION="0.8.6"
         K8S_FULL_VERSION="${K8S_KUBECTL_APPLY_FORCE}"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -178,7 +178,7 @@ func ValidateManagedFields(fieldsList []metav1.ManagedFieldsEntry, fldPath *fiel
 		default:
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("operation"), fields.Operation, "must be `Apply` or `Update`"))
 		}
-		if fields.FieldsType != "FieldsV1" {
+		if len(fields.FieldsType) > 0 && fields.FieldsType != "FieldsV1" {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("fieldsType"), fields.FieldsType, "must be `FieldsV1`"))
 		}
 	}


### PR DESCRIPTION
Also update k8s test versions to v1.16.11

Signed-off-by: André Martins <andre@cilium.io>