### PR TITLE
vagrant: Don't use the NFS device's IP as node IP

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -177,7 +177,6 @@ Vagrant.configure(2) do |config|
                 type: "shell",
                 run: "always",
                 inline: "ip -6 a a #{$master_ipv6}/16 dev enp0s9"
-            node_ip = "#{$nfs_ipv4_master_addr}"
             if ENV["IPV6_EXT"] then
                 node_ip = "#{$master_ipv6}"
             end
@@ -225,7 +224,6 @@ Vagrant.configure(2) do |config|
                 :libvirt__dhcp_enabled => false
             if ENV["NFS"] || ENV["IPV6_EXT"] then
                 nfs_ipv4_addr = $workers_ipv4_addrs_nfs[n]
-                node_ip = "#{nfs_ipv4_addr}"
                 ipv6_addr = $workers_ipv6_addrs[n]
                 node.vm.network "private_network", ip: "#{nfs_ipv4_addr}", bridge: "enp0s9"
                 # Add IPv6 address this way or we get hit by a virtualbox bug


### PR DESCRIPTION
The K8s node IP is the IP address propagated to other nodes and mapped to the `REMOTE_NODE_ID` in the ipcache. We therefore don't want to use the IP address of the NFS interface (`enp0s9`) for that. When we use that IP address, any policy using the remote-node identity (or host in case the two aren't dissociated) will fail to resolve properly.

In general, I don't think K8s even needs to know about the NFS interface or its IP addresses.

Fixes: #1770
/cc @aanm 