### PR TITLE
fqdn: Fix panic on MarshalJSON()

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -831,7 +831,9 @@ func (zombies *DNSZombieMappings) MarkAlive(now time.Time, ip net.IP) {
 // no longer alive. Thus, this call acts as a gating function for what data is
 // returned by GC.
 func (zombies *DNSZombieMappings) SetCTGCTime(now time.Time) {
+	zombies.Lock()
 	zombies.lastCTGCUpdate = now
+	zombies.Unlock()
 }
 
 // ForceExpire is used to clear zombies irrespective of their alive status.
@@ -937,6 +939,9 @@ func (zombies *DNSZombieMappings) DumpAlive() (alive []*DNSZombieMapping) {
 // MarshalJSON encodes DNSZombieMappings into JSON. Only the DNSZombieMapping
 // entries are encoded.
 func (zombies *DNSZombieMappings) MarshalJSON() ([]byte, error) {
+	zombies.Lock()
+	defer zombies.Unlock()
+
 	// This hackery avoids exposing DNSZombieMappings.deletes as a public field.
 	// The JSON package cannot serialize private fields so we have to make a
 	// proxy type here.


### PR DESCRIPTION
We need to hold a lock on `DNSZombieMappings` when calling `json.Marshal()`, otherwise we risk hitting panics on concurrent writes.
```
  panic: reflect: call of reflect.Value.IsNil on zero Value [recovered]
   goroutine 2807 [running]:
   ...
   panic(...)
   	/usr/local/go/src/runtime/panic.go:679 +0x1b2
   reflect.Value.IsNil(...)
   	/usr/local/go/src/reflect/value.go:1073
   ...
   github.com/cilium/cilium/pkg/fqdn.(*DNSZombieMappings).MarshalJSON(...)
   	/go/src/github.com/cilium/cilium/pkg/fqdn/cache.go:949 +0x3b
```
Fixes: f629372 ("fqdn: Add and use DNSZombieMappings in Endpoint")