### PR TITLE
bpf: skip in-cluster xlation for non-local ips

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -185,8 +185,7 @@ int sock4_update_revnat(struct bpf_sock_addr *ctx __maybe_unused,
 #endif /* ENABLE_HOST_SERVICES_UDP || ENABLE_HOST_SERVICES_PEER */
 
 static __always_inline bool
-sock4_skip_xlate(struct lb4_service *svc, const bool in_hostns,
-		 __be32 address)
+sock4_skip_xlate(struct lb4_service *svc, __be32 address)
 {
 	if (is_v4_loopback(address))
 		return false;
@@ -195,14 +194,8 @@ sock4_skip_xlate(struct lb4_service *svc, const bool in_hostns,
 
 		info = ipcache_lookup4(&IPCACHE_MAP, address,
 				       V4_CACHE_KEY_LEN);
-		if (info == NULL ||
-		    (svc->local_scope && info->sec_label != HOST_ID))
+		if (info == NULL || info->sec_label != HOST_ID)
 			return true;
-		if (lb4_svc_is_external_ip(svc)) {
-			if (info->sec_label != HOST_ID &&
-			    info->sec_label != REMOTE_NODE_ID)
-				return in_hostns;
-		}
 	}
 
 	return false;
@@ -283,7 +276,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * IP address. But do the service translation if the IP
 	 * is from the host.
 	 */
-	if (sock4_skip_xlate(svc, in_hostns, orig_key.address))
+	if (sock4_skip_xlate(svc, orig_key.address))
 		return -EPERM;
 
 	if (svc->affinity) {
@@ -537,8 +530,7 @@ static __always_inline void ctx_set_v6_address(struct bpf_sock_addr *ctx,
 }
 
 static __always_inline __maybe_unused bool
-sock6_skip_xlate(struct lb6_service *svc, const bool in_hostns,
-		 union v6addr *address)
+sock6_skip_xlate(struct lb6_service *svc, union v6addr *address)
 {
 	if (is_v6_loopback(address))
 		return false;
@@ -547,14 +539,8 @@ sock6_skip_xlate(struct lb6_service *svc, const bool in_hostns,
 
 		info = ipcache_lookup6(&IPCACHE_MAP, address,
 				       V6_CACHE_KEY_LEN);
-		if (info == NULL ||
-		    (svc->local_scope && info->sec_label != HOST_ID))
+		if (info == NULL || info->sec_label != HOST_ID)
 			return true;
-		if (lb6_svc_is_external_ip(svc)) {
-			if (info->sec_label != HOST_ID &&
-			    info->sec_label != REMOTE_NODE_ID)
-				return in_hostns;
-		}
 	}
 
 	return false;
@@ -718,7 +704,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (!svc)
 		return -ENXIO;
 
-	if (sock6_skip_xlate(svc, in_hostns, &orig_key.address))
+	if (sock6_skip_xlate(svc, &orig_key.address))
 		return -EPERM;
 
 	if (svc->affinity) {

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -158,26 +158,6 @@ bool lb6_svc_is_external_ip(const struct lb6_service *svc __maybe_unused)
 }
 
 static __always_inline
-bool lb4_svc_needs_lxc_xlation(const struct lb4_service *svc __maybe_unused)
-{
-#if defined(ENABLE_HOST_SERVICES_FULL) && defined(ENABLE_EXTERNAL_IP)
-	return lb4_svc_is_external_ip(svc);
-#else
-	return true;
-#endif
-}
-
-static __always_inline
-bool lb6_svc_needs_lxc_xlation(const struct lb6_service *svc __maybe_unused)
-{
-#if defined(ENABLE_HOST_SERVICES_FULL) && defined(ENABLE_EXTERNAL_IP)
-	return lb6_svc_is_external_ip(svc);
-#else
-	return true;
-#endif
-}
-
-static __always_inline
 bool lb4_svc_is_hostport(const struct lb4_service *svc __maybe_unused)
 {
 #ifdef ENABLE_HOSTPORT

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -117,7 +117,9 @@ func (d *Daemon) getMasqueradingStatus() *models.Masquerading {
 		return s
 	}
 
-	s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDR().String()
+	if option.Config.EnableIPv4 {
+		s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDR().String()
+	}
 
 	if option.Config.EnableBPFMasquerade {
 		s.Mode = models.MasqueradingModeBPF

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -785,10 +785,9 @@ var _ = Describe("K8sServicesTest", func() {
 			// Should work from outside via the external IP
 			testCurlFromOutside(httpURL, count, false)
 			testCurlFromOutside(tftpURL, count, false)
-			// Same from inside a pod
-			testCurlFromPods(testDSClient, httpURL, 10, 0)
-			testCurlFromPods(testDSClient, tftpURL, 10, 0)
-			// But not from the host netns (to prevent MITM)
+			// Should fail from inside a pod & hostns
+			testCurlFromPodsFail(testDSClient, httpURL)
+			testCurlFromPodsFail(testDSClient, tftpURL)
 			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s1NodeName)
 			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s1NodeName)
 			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s2NodeName)


### PR DESCRIPTION
See commit msg.
```release-note
Skip in-cluster xlation for non-local ips in socket lb for case of external ips
```