### PR TITLE
daemon: fix panic for cilium status in IPv6 only cluster

### DIFF
--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -117,7 +117,9 @@ func (d *Daemon) getMasqueradingStatus() *models.Masquerading {
 		return s
 	}
 
-	s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDR().String()
+	if option.Config.EnableIPv4 {
+		s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDR().String()
+	}
 
 	if option.Config.EnableBPFMasquerade {
 		s.Mode = models.MasqueradingModeBPF


### PR DESCRIPTION
This commit fixes a panic that occurs when calling `getMasqueradingStatus()` in IPv6 only clusters. It's a regression that
was introduced in 419702199de67e3051229db82691f85fe01a87a9 as `datapath.RemoteSNATDstAddrExclusionCIDR()` returns `<nil>` on IPv6 only clusters.