### PR TITLE
bpf: support host to TCP services when host to UDP services is disabled

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -180,7 +180,7 @@ int sock4_update_revnat(struct bpf_sock_addr *ctx __maybe_unused,
 			struct lb4_key *orig_key __maybe_unused,
 			__u16 rev_nat_id __maybe_unused)
 {
-	return -1;
+	return 0;
 }
 #endif /* ENABLE_HOST_SERVICES_UDP || ENABLE_HOST_SERVICES_PEER */
 
@@ -502,7 +502,7 @@ int sock6_update_revnat(struct bpf_sock_addr *ctx __maybe_unused,
 			struct lb6_key *orig_key __maybe_unused,
 			__u16 rev_nat_index __maybe_unused)
 {
-	return -1;
+	return 0;
 }
 #endif /* ENABLE_HOST_SERVICES_UDP || ENABLE_HOST_SERVICES_PEER */
 #endif /* ENABLE_IPV6 */


### PR DESCRIPTION
Commit `f9c2d709` (implementing support for getpeername reverse mapping to
service's frontend HostIP) made reverse NAT tracking mandatory for TCP, but
only implemented (in `sock4_update_revnat()`) when either hostnet to UDP
services is enabled (`host-reachable-services-protos=udp`, which requires
a recent kernel), or when support for `BPF_CGROUP_INET(4|6)_GETPEERNAME`
is present (even more recent kernels - 5.8 isn't GA yet).

So with slightly older kernels (or disabled "hostnetwork -> UDP svc"),
this prevented host network to TCP services.

To reproduce:
```
  --kube-proxy-replacement=partial
  --enable-host-reachable-services=true
  --host-reachable-services-protos=tcp
```

Signed-off-by: Benjamin Pineau <benjamin.pineau@datadoghq.com>

```
Support hostnet->tcp service when hostnet->udp is disabled and kernel < 5.8
```