### PR TITLE
helm/operator: fix IPv6 liveness probe address for operator

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
 {{- if .Values.global.ipv4.enabled }}
             host: '127.0.0.1'
 {{- else }}
-            host: '[::1]'
+            host: '::1'
 {{- end }}
             path: /healthz
             port: 9234


### PR DESCRIPTION
In an IPv6 only cluster, the operator host was set to `[::1]` in the Helm chart.
This is a problem as it is "bracketed" when concatenated with the port to form an invalid address: `[[::1]]:9234`.

In turn, this prevented the liveness probe from working:

    Warning  Unhealthy         10m (x11 over 14m)   kubelet, kind-worker2  Liveness probe failed: Get http://[[::1]]:9234/healthz: dial tcp: address [[::1]]:9234: missing port in address

This commit fixes this issue by removing the extraneous brackets in the Helm chart of the Cilium operator.