### PR TITLE
Revise doc building to enable it on arm64

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -155,7 +155,11 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme_cilium"
+if os.uname()[4] == "aarch64":
+  html_theme = "sphinx_rtd_theme"
+else:
+  html_theme = "sphinx_rtd_theme_cilium"
+
 html_context = {
     'release': release
 }

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,7 +20,7 @@ snowballstemmer==1.2.1
 Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
-git+git://github.com/cilium/sphinx_rtd_theme.git@v0.6
+git+git://github.com/cilium/sphinx_rtd_theme.git@v0.6; platform_machine != "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1


### PR DESCRIPTION
The current building for the default (x86_64) platform
doesn't support arm64 platform due to the use of
sphinx_rtd_theme_cilium which is not currently available
for arm64 platform since the used node-sass binary release
is still not available for arm64 platform.

So we revise the building to use the default sphinx_rtd_theme
package when meeting the arm64(aarch64) platform which is
tested to be feasible for building on arm64 platform.

Signed-off-by: trevor tao <trevor.tao@arm.com>