### PR TITLE
operator: fix nodes informer

### DIFF
--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -29,7 +29,6 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
@@ -60,7 +59,7 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 	k8sNodeStore, nodeController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.CiliumClient().CiliumV2().RESTClient(),
 			"ciliumnodes", v1.NamespaceAll, fields.Everything()),
-		&slim_corev1.Node{},
+		&cilium_v2.CiliumNode{},
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {


### PR DESCRIPTION
Commit 6d44f4cd replaced the informer feeding nodes to kvstore
from using `corev1.Nodes` to `CiliumNodes`. But the object type
passed to informer isn't updated accordingly, which prevents the
controller from collecting nodes:
```
cilium-operator level=error msg=k8sError
  error="github.com/cilium/cilium/operator/k8s_node.go:96:
  expected type *v1.Node, but watch event object had type *v2.CiliumNode"
  subsys=k8s
```

Note for the longer term: the operator already has a
v2.CiliumNode informer (in operator/cilium_node.go)
hooked in: maybe k8s_node should use that too.

```release-note
operator: provide a proper type to node informer
```
