### PR TITLE
loader: Refactor initArgMode assignments

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -229,28 +229,24 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 				return err
 			}
 		}
-
-		if option.Config.Tunnel != option.TunnelDisabled {
-			args[initArgMode] = option.Config.Tunnel
-		} else if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
-			args[initArgMode] = "ipvlan"
-		} else {
-			args[initArgMode] = "direct"
-		}
-
 		args[initArgDevices] = strings.Join(option.Config.Devices, ";")
+	} else if option.Config.IsFlannelMasterDeviceSet() {
+		args[initArgDevices] = option.Config.FlannelMasterDevice
 	} else {
-		args[initArgMode] = option.Config.Tunnel
 		args[initArgDevices] = "<nil>"
-
-		if option.Config.IsFlannelMasterDeviceSet() {
-			args[initArgMode] = "flannel"
-			args[initArgDevices] = option.Config.FlannelMasterDevice
-		}
 	}
 
-	if option.Config.EnableEndpointRoutes == true {
+	switch {
+	case option.Config.EnableEndpointRoutes:
 		args[initArgMode] = "routed"
+	case option.Config.IsFlannelMasterDeviceSet():
+		args[initArgMode] = "flannel"
+	case option.Config.Tunnel != option.TunnelDisabled:
+		args[initArgMode] = option.Config.Tunnel
+	case option.Config.DatapathMode == datapathOption.DatapathModeIpvlan:
+		args[initArgMode] = "ipvlan"
+	default:
+		args[initArgMode] = "direct"
 	}
 
 	if option.Config.EnableNodePort {


### PR DESCRIPTION
Refactor assignments of `args[initArgMode]` to separate the setting of `initArgMode` and `initArgDevices` and simplify the code.

Related: https://github.com/cilium/cilium/pull/11980#discussion_r437361237