### PR TITLE
test: Display error in case command fails

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -195,6 +195,9 @@ func (res *CmdRes) SendToLog(quietMode bool) {
 
 	logformat := "cmd: %q exitCode: %d duration: %s stdout:\n%s\n"
 	log := fmt.Sprintf(logformat, res.cmd, res.GetExitCode(), res.duration, res.stdout.String())
+	if res.err != nil {
+		log = fmt.Sprintf("%serr:\n%s\n", log, res.err)
+	}
 	if res.stderr.Len() > 0 {
 		log = fmt.Sprintf("%sstderr:\n%s\n", log, res.stderr.String())
 	}
@@ -381,9 +384,14 @@ func (res *CmdRes) OutputPrettyPrint() string {
 		return strings.Join(result, "\n")
 
 	}
+	errStr := ""
+	if res.err != nil {
+		errStr = fmt.Sprintf("Err: %s\n", res.err)
+	}
 	return fmt.Sprintf(
-		"Exitcode: %d \nStdout:\n %s\nStderr:\n %s\n",
+		"Exitcode: %d \n%sStdout:\n %s\nStderr:\n %s\n",
 		res.GetExitCode(),
+		errStr,
 		format(res.Stdout()),
 		format(res.Stderr()))
 }


### PR DESCRIPTION
This is a follow up to #11677. We spent too much time debugging a timeout issue in privileged unit tests because no error message was displayed. This pull request fixes it by printing the error from the command execution, which includes timeout error messages, if it errored.

Old output: https://jenkins.cilium.io/view/PR/job/Cilium-PR-Ginkgo-Tests-Validated-Focus/310/testReport/(root)/Suite-runtime/RuntimePrivilegedUnitTests_Run_Tests/
New output: https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated-Focus/314/testReport/(root)/Suite-runtime/RuntimePrivilegedUnitTests_Run_Tests/