### PR TITLE
Make podSubnet consistent across install guide

### DIFF
--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -99,8 +99,8 @@ Example ``kind-cluster1.yaml``:
     - role: worker
     networking:
       disableDefaultCNI: true
-      podSubnet: 10.0.0.0/16
-      serviceSubnet: 10.1.0.0/16
+      podSubnet: "10.0.0.0/16"
+      serviceSubnet: "10.1.0.0/16"
 
 Example ``kind-cluster2.yaml``:
 
@@ -115,8 +115,8 @@ Example ``kind-cluster2.yaml``:
     - role: worker
     networking:
       disableDefaultCNI: true
-      podSubnet: 10.2.0.0/16
-      serviceSubnet: 10.3.0.0/16
+      podSubnet: "10.2.0.0/16"
+      serviceSubnet: "10.3.0.0/16"
 
 Create Kind Clusters
 --------------------


### PR DESCRIPTION
In the [Kind Getting Started page](https://docs.cilium.io/en/v1.8/gettingstarted/kind/), we properly quote `podSubnet` as according to
the kind [kind config page](https://kind.sigs.k8s.io/docs/user/configuration/). However, later in the guide, we don't quote `podSubnet`,
leaving a user with inconsistent configurations. Making quotes standard.