### PR TITLE
Set 'kubernetes' IPAM in kube-proxy free guide

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -98,6 +98,7 @@ configuration.
 
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
+        --set config.ipam=kubernetes \\
         --set global.kubeProxyReplacement=strict \\
         --set global.k8sServiceHost=API_SERVER_IP \\
         --set global.k8sServicePort=API_SERVER_PORT
@@ -312,6 +313,7 @@ enabled would look as follows:
 
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
+        --set config.ipam=kubernetes \\
         --set global.tunnel=disabled \\
         --set global.autoDirectNodeRoutes=true \\
         --set global.kubeProxyReplacement=strict \\
@@ -339,6 +341,7 @@ mode would look as follows:
 
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
+        --set config.ipam=kubernetes \\
         --set global.tunnel=disabled \\
         --set global.autoDirectNodeRoutes=true \\
         --set global.kubeProxyReplacement=strict \\
@@ -703,6 +706,7 @@ as in the earlier getting started deployment:
 
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
+        --set config.ipam=kubernetes \\
         --set global.kubeProxyReplacement=strict \\
         --set global.k8sServiceHost=API_SERVER_IP \\
         --set global.k8sServicePort=API_SERVER_PORT
@@ -846,6 +850,7 @@ This section therefore elaborates on the various ``global.kubeProxyReplacement``
 
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
+        --set config.ipam=kubernetes \\
         --set global.kubeProxyReplacement=partial \\
         --set global.hostServices.enabled=true \\
         --set global.nodePort.enabled=true \\


### PR DESCRIPTION
The pod cidr should match 10.217.0.0/16 mentioned previously, 
not the default value 10.0.0.0/16 set by default via helm in this tutorial.
Appended '--set global.ipam.operator.clusterPoolIPv4PodCIDR=10.217.0.0/16' to the end of the helm command line.
 
Tested with
Kubernetes v1.17.5
cri-o v1.17

I know none about ipam,  and may be blinded

Is this difference ( not match cidr assigned by kube-controller-manager) OK?
