### PR TITLE
iptables: Remove '--nowildcard' from socket match

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -488,7 +488,7 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 	return append(m.waitArgs,
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
-		"-m", "socket", "--transparent", "--nowildcard",
+		"-m", "socket", "--transparent",
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1113,7 +1113,7 @@ var _ = Describe("K8sServicesTest", func() {
 			testExternalTrafficPolicyLocal()
 		})
 
-		SkipContextIf(helpers.RunsWithoutKubeProxy, "with L4 policy", func() {
+		Context("with L4 policy", func() {
 			var (
 				demoPolicy string
 			)


### PR DESCRIPTION
'--no-wildcard' allows the socket match to find zero-bound (listening)
sockets, which we do not want, as this may intercept traffic intended
for other nodes, for example, reply traffic when an ephemeral source
port number allocated in one node happens to be the same as the
allocated proxy port number in the node doing the iptables socket
match changed here.

Note to backporters: The test suite changes need not be backported
to older releases (e.g., 1.6) if these are non-trivial merge conflicts.

Fixes: #12281
Fixes: #12127
Fixes: #8945
Fixes: #10669
Fixes: #11867
Fixes: #10118
Fixes: #11313
Fixes: #12241
Fixes: #10231
Related: #8864
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
