### PR TITLE
mountinfo improvements

### DIFF
--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -72,7 +72,7 @@ func mapPathFromMountInfo(name string) string {
 		}
 
 		for _, mountInfo := range mountInfos {
-			if mountInfo.FilesystemType == mountinfo.FilesystemTypeBPFFS {
+			if mountInfo.FilesystemType == "bpf" {
 				mountInfoPrefix = filepath.Join(mountInfo.MountPoint, mapPrefix)
 				return
 			}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -62,7 +62,7 @@ func mountCgroup() error {
 		return fmt.Errorf("%s is a file which is not a directory", cgroupRoot)
 	}
 
-	if err := unix.Mount("none", cgroupRoot, mountinfo.FilesystemTypeCgroup2, 0, ""); err != nil {
+	if err := unix.Mount("none", cgroupRoot, "cgroup2", 0, ""); err != nil {
 		return fmt.Errorf("failed to mount %s: %s", cgroupRoot, err)
 	}
 

--- a/pkg/mountinfo/mountinfo.go
+++ b/pkg/mountinfo/mountinfo.go
@@ -67,8 +67,8 @@ func parseMountInfoFile(r io.Reader) ([]*MountInfo, error) {
 		}
 
 		// Extract fields from both sides of mountinfo
-		mountInfoLeft := strings.Split(strings.TrimSpace(mountInfoSeparated[0]), " ")
-		mountInfoRight := strings.Split(strings.TrimSpace(mountInfoSeparated[1]), " ")
+		mountInfoLeft := strings.Split(mountInfoSeparated[0], " ")
+		mountInfoRight := strings.Split(mountInfoSeparated[1], " ")
 
 		// Before '-' separator there should be 6 fields and unknown
 		// number of optional fields

--- a/pkg/mountinfo/mountinfo_privileged_test.go
+++ b/pkg/mountinfo/mountinfo_privileged_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build privileged_tests
+
+package mountinfo
+
+import (
+	"io/ioutil"
+	"os"
+
+	"golang.org/x/sys/unix"
+
+	. "gopkg.in/check.v1"
+)
+
+type MountInfoPrivilegedTestSuite struct{}
+
+var _ = Suite(&MountInfoPrivilegedTestSuite{})
+
+// TestIsMountFSbyMount tests the public function IsMountFS by performing
+// an actual mount.
+func (s *MountInfoPrivilegedTestSuite) TestIsMountFSbyMount(c *C) {
+	tmpDir, err := ioutil.TempDir("", "IsMountFS_")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmpDir)
+
+	mounted, matched, err := IsMountFS(unix.TMPFS_MAGIC, tmpDir)
+	c.Assert(err, IsNil)
+	c.Assert(mounted, Equals, false)
+	c.Assert(matched, Equals, false)
+
+	err = unix.Mount("tmpfs", tmpDir, "tmpfs", 0, "")
+	c.Assert(err, IsNil)
+	defer unix.Unmount(tmpDir, unix.MNT_DETACH)
+
+	// deliberately check with wrong fstype
+	mounted, matched, err = IsMountFS(unix.PROC_SUPER_MAGIC, tmpDir)
+	c.Assert(err, IsNil)
+	c.Assert(mounted, Equals, true)
+	c.Assert(matched, Equals, false)
+
+	// now check with proper fstype
+	mounted, matched, err = IsMountFS(unix.TMPFS_MAGIC, tmpDir)
+	c.Assert(err, IsNil)
+	c.Assert(mounted, Equals, true)
+	c.Assert(matched, Equals, true)
+}


### PR DESCRIPTION
Two unrelated improvements to mountinfo package.

### 1. mountinfo/IsMountFS: avoid parsing mountinfo

Instead of parsing /proc/self/mountinfo (which is slow and prone to
errors), we can check if a given directory is a mount point having
a specific fs type with just a 3 simple syscalls.

NOTE the implementation provided here is not working for bind mounts (for that, to the best of my knowledge, parsing mountinfo is unavoidable), and therefore is not working for bind-mounted files.

### 2. mountinfo: remove useless TrimSpace
    
The /proc/self/mountinfo format is well-defined and it should not contain
any extra whitespace, so strings.TrimSpace() is a useless no-op here.

```release-note
mountinfo speedups
```
