### PR TITLE
test/helpers: introduce CmdStreamBuffer to manipulate a command's output 

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -163,7 +163,7 @@ func (s *SSHMeta) WaitEndpointsDeleted() bool {
 	body := func() bool {
 		cmd := `cilium endpoint list -o json | jq '. | length'`
 		res := s.Exec(cmd)
-		numEndpointsRunning := strings.TrimSpace(res.GetStdOut())
+		numEndpointsRunning := strings.TrimSpace(res.Stdout())
 		if numEndpointsRunning == desiredState {
 			return true
 		}
@@ -656,7 +656,7 @@ func (s *SSHMeta) ValidateEndpointsAreCorrect(dockerNetwork string) error {
 func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 	logsCmd := fmt.Sprintf(`sudo journalctl -au %s --since '%v seconds ago'`,
 		DaemonName, duration.Seconds())
-	logs := s.Exec(logsCmd, ExecOptions{SkipLog: true}).Output().String()
+	logs := s.Exec(logsCmd, ExecOptions{SkipLog: true}).Stdout()
 
 	defer func() {
 		// Keep the cilium logs for the given test in a separate file.

--- a/test/helpers/filterBuffer.go
+++ b/test/helpers/filterBuffer.go
@@ -26,7 +26,13 @@ type FilterBuffer struct {
 
 // ByLines returns buf string plit by the newline characters
 func (buf *FilterBuffer) ByLines() []string {
-	return strings.Split(buf.String(), "\n")
+	out := buf.String()
+	sep := "\n"
+	if strings.Contains(out, "\r\n") {
+		sep = "\r\n"
+	}
+	out = strings.TrimRight(out, sep)
+	return strings.Split(out, sep)
 }
 
 // KVOutput returns a map of the buff string split based on

--- a/test/helpers/filterBuffer.go
+++ b/test/helpers/filterBuffer.go
@@ -32,9 +32,9 @@ func (buf *FilterBuffer) ByLines() []string {
 // KVOutput returns a map of the buff string split based on
 // the separator '='.
 // For example, the following strings would be split as follows:
-// 		a=1
-// 		b=2
-// 		c=3
+//		a=1
+//		b=2
+//		c=3
 func (buf *FilterBuffer) KVOutput() map[string]string {
 	result := make(map[string]string)
 	for _, line := range buf.ByLines() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -385,7 +385,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-hostnetns.yaml")
 			res := kubectl.ExecMiddle("mktemp")
 			res.ExpectSuccess()
-			tmpEchoPodPath = strings.Trim(res.GetStdOut(), "\n")
+			tmpEchoPodPath = strings.Trim(res.Stdout(), "\n")
 			kubectl.ExecMiddle(fmt.Sprintf("sed 's/NODE_WITHOUT_CILIUM/%s/' %s > %s",
 				helpers.GetNodeWithoutCilium(), echoPodPath, tmpEchoPodPath)).ExpectSuccess()
 			kubectl.ApplyDefault(tmpEchoPodPath).ExpectSuccess("Cannot install echoserver application")
@@ -395,11 +395,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// Setup ip-masq-agent configmap dir
 			res = kubectl.ExecMiddle("mktemp -d")
 			res.ExpectSuccess()
-			tmpConfigMapDirPath = strings.Trim(res.GetStdOut(), "\n")
+			tmpConfigMapDirPath = strings.Trim(res.Stdout(), "\n")
 			tmpConfigMapPath = filepath.Join(tmpConfigMapDirPath, "config")
 			res = kubectl.ExecMiddle("mktemp")
 			res.ExpectSuccess()
-			tmpConfigYAMLPath = strings.Trim(res.GetStdOut(), "\n")
+			tmpConfigYAMLPath = strings.Trim(res.Stdout(), "\n")
 
 			// Deploy empty ip-masq-agent config to prevent the ipmasq agent from
 			// adding the default nonMasq CIDRs which include the echoserver's
@@ -772,7 +772,7 @@ func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNod
 
 			if expectNodeIP || expectPodIP {
 				// Parse the IPs to avoid issues with 4-in-6 formats
-				sourceIP := net.ParseIP(strings.TrimSpace(strings.Split(res.GetStdOut(), "=")[1]))
+				sourceIP := net.ParseIP(strings.TrimSpace(strings.Split(res.Stdout(), "=")[1]))
 				if expectNodeIP {
 					Expect(sourceIP).To(Equal(hostIP), "Expected node IP")
 				}

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -91,7 +91,7 @@ var _ = Describe("K8sHealthTest", func() {
 		By("checking that `cilium-health --probe` succeeds")
 		healthCmd := "cilium-health status --probe -o json"
 		status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd)
-		Expect(status.Output()).ShouldNot(ContainSubstring("error"))
+		Expect(status.Stdout()).ShouldNot(ContainSubstring("error"))
 
 		apiPaths := []string{
 			"endpoint.icmp",

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -97,7 +97,7 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 		res := vm.Exec(fmt.Sprintf(
 			"%s -n %s get pods -l k8s-app=cilium-pre-flight-check",
 			helpers.KubectlCmd, helpers.CiliumNamespace))
-		warningMessage = res.Output().String()
+		warningMessage = res.Stdout()
 	}
 	Expect(err).To(BeNil(), "cilium pre-flight check is not ready after timeout, pods status:\n %s", warningMessage)
 }

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -117,7 +117,7 @@ var _ = Describe("K8sDemosTest", func() {
 
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlFail("http://%s/v1", deathstarFQDN))
-		res.ExpectSuccess("unable to curl %s/v1: %s", deathstarFQDN, res.Output())
+		res.ExpectSuccess("unable to curl %s/v1: %s", deathstarFQDN, res.Stdout())
 
 		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
 		_, err = kubectl.CiliumPolicyAction(
@@ -131,12 +131,12 @@ var _ = Describe("K8sDemosTest", func() {
 		By("Showing how alliance cannot access %q without force header in API request after importing L7 Policy", exhaustPortPath)
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT http://%s", exhaustPortPath))
-		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.Output())
+		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.Stdout())
 
 		By("Showing how alliance can access %q with force header in API request to attack the deathstar", exhaustPortPath)
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT -H 'X-Has-Force: True' http://%s", exhaustPortPath))
 		By("Expecting 503 to be returned when using force header to attack the deathstar")
-		res.ExpectContains("503", "unable to access %s when policy allows it; %s", exhaustPortPath, res.Output())
+		res.ExpectContains("503", "unable to access %s when policy allows it; %s", exhaustPortPath, res.Stdout())
 	})
 })

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1891,7 +1891,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		By("Verifying that trace says that %q can reach %q", httpd2Label, httpd1Label)
 
 		res := vm.Exec(fmt.Sprintf(`cilium policy trace -s %s -d %s/TCP`, httpd2Label, httpd1Label))
-		Expect(res.Output().String()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
+		Expect(res.Stdout()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
 
 		endpointIDS, err := vm.GetEndpointsIds()
 		Expect(err).To(BeNil(), "Unable to get IDs of endpoints")

--- a/test/runtime/benchmark.go
+++ b/test/runtime/benchmark.go
@@ -132,12 +132,12 @@ var _ = Describe("BenchmarkNetperfPerformance", func() {
 
 	superNetperfRRLog := func(client string, server string, num int) {
 		res := superNetperfRR(vm, client, server, num)
-		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.GetStdOut(), "\n"))
+		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.Stdout(), "\n"))
 	}
 
 	superNetperfStreamLog := func(client string, server string, num int) {
 		res := superNetperfStream(vm, client, server, num)
-		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.GetStdOut(), "\n"))
+		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.Stdout(), "\n"))
 	}
 
 	Context("Benchmark Netperf Tests", func() {

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -102,14 +102,14 @@ var _ = Describe("RuntimeChaos", func() {
 		ips := vm.Exec(`
 		curl -s --unix-socket /var/run/cilium/cilium.sock \
 		http://localhost/v1beta/healthz/ | jq ".ipam.ipv4|length"`)
-		Expect(originalIps.Output().String()).To(Equal(ips.Output().String()))
+		Expect(originalIps.Stdout()).To(Equal(ips.Stdout()))
 
 		EndpointList := vm.Exec(endpointListCmd)
-		By("original: %s", originalEndpointList.Output().String())
-		By("new: %s", EndpointList.Output().String())
-		Expect(EndpointList.Output().String()).To(Equal(originalEndpointList.Output().String()))
-		Expect(hasher.Sum(EndpointList.Output().Bytes())).To(
-			Equal(hasher.Sum(originalEndpointList.Output().Bytes())))
+		By("original: %s", originalEndpointList.Stdout())
+		By("new: %s", EndpointList.Stdout())
+		Expect(EndpointList.Stdout()).To(Equal(originalEndpointList.Stdout()))
+		Expect(hasher.Sum(EndpointList.GetStdOut().Bytes())).To(
+			Equal(hasher.Sum(originalEndpointList.GetStdOut().Bytes())))
 
 	}, 300)
 

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -121,20 +121,20 @@ var _ = Describe("RuntimeCLI", func() {
 
 		It("root command help should print to stdout", func() {
 			res := vm.ExecCilium("help")
-			Expect(res.GetStdErr()).Should(BeEmpty())
-			Expect(res.GetStdOut()).Should(ContainSubstring("Use \"cilium [command] --help\" for more information about a command."))
+			Expect(res.Stderr()).Should(BeEmpty())
+			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium [command] --help\" for more information about a command."))
 		})
 
 		It("subcommand help should print to stdout", func() {
 			res := vm.ExecCilium("help bpf")
-			Expect(res.GetStdErr()).Should(BeEmpty())
-			Expect(res.GetStdOut()).Should(ContainSubstring("Use \"cilium bpf [command] --help\" for more information about a command."))
+			Expect(res.Stderr()).Should(BeEmpty())
+			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium bpf [command] --help\" for more information about a command."))
 		})
 
 		It("failed subcommand should print help to stdout", func() {
 			res := vm.ExecCilium("endpoint confi 173")
-			Expect(res.GetStdErr()).Should(BeEmpty())
-			Expect(res.GetStdOut()).Should(ContainSubstring("Use \"cilium endpoint [command] --help\" for more information about a command."))
+			Expect(res.Stderr()).Should(BeEmpty())
+			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium endpoint [command] --help\" for more information about a command."))
 		})
 
 	})

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -178,7 +178,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		By("Create sample containers in %q docker network", helpers.WorldDockerNetwork)
 		res := vm.Exec(fmt.Sprintf("docker network create %s", helpers.WorldDockerNetwork))
 		if !res.WasSuccessful() {
-			if !strings.Contains(res.GetStdErr(), "network with name world already exists") {
+			if !strings.Contains(res.Stderr(), "network with name world already exists") {
 				res.ExpectSuccess(
 					"%q network cant be created", helpers.WorldDockerNetwork)
 			}
@@ -295,7 +295,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		GinkgoPrint(vm.Exec(
 			`docker ps -q | xargs -n 1 docker inspect --format ` +
 				`'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}} {{ .Name }}'` +
-				`| sed 's/ \// /'`).Output().String())
+				`| sed 's/ \// /'`).Stdout())
 		vm.ReportFailed("cilium policy get")
 	})
 
@@ -304,7 +304,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		jqfilter := fmt.Sprintf(`jq -c '.[] | select(.identities|length >= %d) | select(.users|length > 0) | .selector | match("^MatchName: (\\w+\\.%s|), MatchPattern: ([\\w*]+\\.%s|)$") | length > 0'`, minNumIDs, escapedDomain, escapedDomain)
 		body := func() bool {
 			res := vm.Exec(fmt.Sprintf(`cilium policy selectors -o json | %s`, jqfilter))
-			return strings.HasPrefix(res.GetStdOut(), "true")
+			return strings.HasPrefix(res.Stdout(), "true")
 		}
 		err := helpers.WithTimeout(
 			body,

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -90,7 +90,7 @@ var _ = Describe("RuntimeLB", func() {
 		frontendAddress, err := vm.ServiceGetFrontendAddress(1)
 		Expect(err).Should(BeNil())
 		Expect(frontendAddress).To(ContainSubstring("[::]:80"),
-			"failed to retrieve frontend address: %q", result.Output())
+			"failed to retrieve frontend address: %q", result.GetStdOut())
 
 		//TODO: This need to be with Wait,Timeout
 		helpers.Sleep(5)
@@ -99,8 +99,8 @@ var _ = Describe("RuntimeLB", func() {
 
 		result = vm.ExecCilium("bpf lb list")
 		result.ExpectSuccess("bpf lb map cannot be retrieved correctly")
-		Expect(result.Output()).To(ContainSubstring("[::1]:90"), fmt.Sprintf(
-			"service backends not added to BPF map: %q", result.Output()))
+		Expect(result.Stdout()).To(ContainSubstring("[::1]:90"), fmt.Sprintf(
+			"service backends not added to BPF map: %q", result.GetStdOut()))
 
 		By("Adding services that should not be allowed")
 
@@ -190,7 +190,7 @@ var _ = Describe("RuntimeLB", func() {
 				"Service ids %s do not match old service ids %s", svcIds, oldSvcIds)
 			newSvc := vm.ServiceList()
 			newSvc.ExpectSuccess("Cannot retrieve service list after restart")
-			newSvc.ExpectEqual(oldSvc.Output().String(), "Service list does not match")
+			newSvc.ExpectEqual(oldSvc.Stdout(), "Service list does not match")
 
 			By("Checking that BPF LB maps match the service")
 

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -123,7 +123,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 				vm.ContainerExec(k, helpers.Ping(helpers.Httpd1))
 				Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 					"%q is not in the output after timeout", filter)
-				Expect(res.Output().String()).Should(ContainSubstring(filter))
+				Expect(res.Stdout()).Should(ContainSubstring(filter))
 			}
 		})
 
@@ -155,7 +155,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 				Expect(res.WaitUntilMatch(v)).To(BeNil(),
 					"%q is not in the output after timeout", v)
 				Expect(res.CountLines()).Should(BeNumerically(">", 3))
-				Expect(res.Output().String()).Should(ContainSubstring(v))
+				Expect(res.Stdout()).Should(ContainSubstring(v))
 				cancel()
 			}
 
@@ -180,7 +180,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			for _, v := range eventTypes {
 				Expect(res.WaitUntilMatch(v)).To(BeNil(),
 					"%q is not in the output after timeout", v)
-				Expect(res.Output().String()).Should(ContainSubstring(v))
+				Expect(res.Stdout()).Should(ContainSubstring(v))
 			}
 
 			Expect(res.CountLines()).Should(BeNumerically(">", 3))
@@ -206,10 +206,10 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 				"%q is not in the output after timeout", filter)
 			Expect(res.CountLines()).Should(BeNumerically(">", 3))
-			Expect(res.Output().String()).Should(ContainSubstring(filter))
+			Expect(res.Stdout()).Should(ContainSubstring(filter))
 
 			//MonitorDebug mode shouldn't have DROP lines
-			Expect(res.Output().String()).ShouldNot(ContainSubstring("DROP"))
+			Expect(res.Stdout()).ShouldNot(ContainSubstring("DROP"))
 		})
 
 		It("cilium monitor check --to", func() {
@@ -233,7 +233,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 				"%q is not in the output after timeout", filter)
 			Expect(res.CountLines()).Should(BeNumerically(">=", 3))
-			Expect(res.Output().String()).Should(ContainSubstring(filter))
+			Expect(res.Stdout()).Should(ContainSubstring(filter))
 		})
 
 		It("cilium monitor check --related-to", func() {
@@ -257,7 +257,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 				"%q is not in the output after timeout", filter)
 			Expect(res.CountLines()).Should(BeNumerically(">=", 3))
-			Expect(res.Output().String()).Should(ContainSubstring(filter))
+			Expect(res.Stdout()).Should(ContainSubstring(filter))
 		})
 
 		It("delivers the same information to multiple monitors", func() {


### PR DESCRIPTION
The current implementation of `CmdRes` allows to perform a certain
number of operations on the standard output stream of a command.
However, these operations are not available for the standard error
stream of a command.

This commit adds a new type, `CmdStreamBuffer` which is a superset of
`Buffer`. It has basic operations to process the buffered stream namely
`ByLines()`, `KVOutput()`, `Filter()`, `FilterLineJSONPath()` and
`FilterLines()`. These methods, which were part of `CmdRes`, are still
available to `CmdRes` but they have been updated to call the respective
methods from the standard output stream's corresponding methods.

Two new methods have been added to `CmdRes`: `GetStdOut()` which returns
a `CmdStreamBuffer` for the standard output stream and `GetStdErr()`
which returns a `CmdStreamBuffer` for the standard error stream.
The new methods `Stdout()` and `Stderr()` return the respective buffers
content as string. The method `Output()`, which return the `CmdRes`
stdout has been removed to avoid any confusion.

All Go code in tests has been adapted to these changes.