### PR TITLE
build: install gops binary in operator images

### DIFF
--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-aws /usr/bin/cilium-operator-aws
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator-aws"]

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-azure /usr/bin/cilium-operator-azure
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator-azure"]

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-generic /usr/bin/cilium-operator-generic
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator-generic"]

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator"]


### PR DESCRIPTION
We embed gops into the operator binaries, so it makes sense to have the
gops binary in the operator images as well in order to simplify
debugging and/or profiling.