### PR TITLE
docs: adjust policy verdict log output examples to new format

### DIFF
--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -65,7 +65,7 @@ toFQDNs rules and events relating to those rules are also relevant.
     -> endpoint 3459 flow 0xe6866e21 identity 15194->323 state reply ifindex lxc84b58cbdabfe orig-ip 10.60.1.115: 10.63.240.10:53 -> 10.60.0.182:42132 udp
     -> Response dns to 3459 ([k8s:org=alliance k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.cilium.k8s.policy.cluster=default k8s:class=xwing]) from 0 ([k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=kube-dns k8s:io.kubernetes.pod.namespace=kube-system k8s:k8s-app=kube-dns]), identity 323->15194, verdict Forwarded DNS Query: cilium.io. A TTL: 486 Answer: '104.198.14.52'
     -> endpoint 3459 flow 0xe6866e21 identity 15194->323 state reply ifindex lxc84b58cbdabfe orig-ip 10.60.1.115: 10.63.240.10:53 -> 10.60.0.182:42132 udp
-    Policy verdict log: flow 0x614e9723 local EP ID 3459, remote ID 16777217, dst port 80, proto 6, ingress false, action allow, match L3-Only, 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN
+    Policy verdict log: flow 0x614e9723 local EP ID 3459, remote ID 16777217, proto 6, egress, action allow, match L3-Only, 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN
 
     -> stack flow 0x614e9723 identity 323->16777217 state new ifindex 0 orig-ip 0.0.0.0: 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN
     -> 0: 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN

--- a/Documentation/gettingstarted/policy-creation.rst
+++ b/Documentation/gettingstarted/policy-creation.rst
@@ -98,7 +98,7 @@ output:
 
    # cilium monitor -t policy-verdict
    ...
-   Policy verdict log: flow 0x63113709 local EP ID 232, remote ID 31028, dst port 80, proto 6, ingress true, action audit, match none, 10.0.0.112 :54134 -> 10.29.50.40:80 tcp SYN
+   Policy verdict log: flow 0x63113709 local EP ID 232, remote ID 31028, proto 6, ingress, action audit, match none, 10.0.0.112 :54134 -> 10.29.50.40:80 tcp SYN
 
 In the above example, we can see that endpoint ``232`` has received traffic
 (``ingress true``) which doesn't match the policy (``action audit match
@@ -156,7 +156,7 @@ Executed from the cilium pod:
 .. code-block:: shell-session
 
    # cilium monitor -t policy-verdict
-   Policy verdict log: flow 0xabf3bda6 local EP ID 232, remote ID 31028, dst port 80, proto 6, ingress true, action allow, match L3-L4, 10.0.0.112 :59824 -> 10.0.0.147:80 tcp SYN
+   Policy verdict log: flow 0xabf3bda6 local EP ID 232, remote ID 31028, proto 6, ingress, action allow, match L3-L4, 10.0.0.112 :59824 -> 10.0.0.147:80 tcp SYN
 
 Now the policy verdict states that the traffic would be allowed: ``action
 allow``. Success!


### PR DESCRIPTION
Commit 0ce6480582df ("monitor: Shorten policy-verdict output") changed
the format of the policy verdict log output. Adjust the example output
in the contribution guide and the GSGs to the new format.
