### PR TITLE
hubble/peer: fix buf.Pop() crash issue

### DIFF
--- a/pkg/hubble/peer/buffer.go
+++ b/pkg/hubble/peer/buffer.go
@@ -89,6 +89,13 @@ func (b *buffer) Pop() (*peerpb.ChangeNotification, error) {
 			return nil, io.EOF
 		}
 	}
+	//While waiting for b.mu.Lock, b.buffer may be closed.
+	select {
+	case <-b.stop:
+		b.mu.Unlock()
+		return nil, io.EOF
+	default:
+	}
 	cn := b.buf[0]
 	b.buf[0] = nil
 	b.buf = b.buf[1:]


### PR DESCRIPTION
While waiting for b.mu.Lock, b.buffer be closed that is
triggered when the maximum buffer size is reached,
So check b.stop channel before access b.buf.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Fixes: #12178

