### PR TITLE
docs: Support minikube in Hubble getting started guide

### DIFF
--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -10,9 +10,9 @@
 Networking and security observability with Hubble
 *************************************************
 
-This guide provides a walkthrough of setting up a local multi-node Kubernetes
-cluster on Docker using `kind <https://kind.sigs.k8s.io/>`_ in order to
-demonstrate some of Hubble's capabilities.
+This guide provides a walkthrough of setting up a local Kubernetes cluster with
+Hubble and Cilium installed, in order to demonstrate some of Hubble's
+capabilities.
 
 If you haven't read the :ref:`intro` yet, we'd encourage you to do that first.
 
@@ -20,33 +20,99 @@ The best way to get help if you get stuck is to ask a question on the `Cilium
 Slack channel <https://cilium.herokuapp.com>`_.  With Cilium contributors
 across the globe, there is almost always someone available to help.
 
-.. include:: kind-install.rst
+Set up a Kubernetes cluster
+===========================
+
+To run a Kubernetes cluster on your local machine, you have the choice to
+either set up a single-node cluster with
+`minikube <https://kubernetes.io/docs/setup/learning-environment/minikube/>`_,
+or a local multi-node cluster on Docker using
+`kind <https://kind.sigs.k8s.io/>`_:
+
+- ``minikube`` runs a single-node Kubernetes cluster inside a Virtual Machine
+  (VM) and is the easiest way to run a Kubernetes cluster locally.
+- ``kind`` runs a multi-node Kubernetes using Docker container to emulate
+  cluster nodes. It allows you to experiment with the cluster-wide observability
+  features of Hubble Relay.
+
+When unsure about the option to pick, follow the instructions for ``minikube``
+as it is less likely to cause friction.
+
+.. tabs::
+
+    .. group-tab:: Single-node cluster with ``minikube``
+
+        **Install kubectl & minikube**
+
+        .. include:: minikube-install.rst
+        .. include directive in tab requires three newlines to terminate correctly
+
+
+
+    .. group-tab:: Multi-node cluster with ``kind``
+
+        **Install dependencies**
+
+        .. include:: kind-install-deps.rst
+
+        **Configure kind**
+
+        .. include:: kind-configure.rst
+
+        **Create a cluster**
+
+        .. include:: kind-create-cluster.rst
+
+        **Preload images**
+
+        .. include:: kind-preload.rst
+        .. include directive in tab requires three newlines to terminate correctly
+
+
 
 Deploy Cilium and Hubble
 ========================
 
-.. include:: k8s-install-download-release.rst
-.. include:: kind-preload.rst
+This section shows how to install Cilium, enable Hubble and deploy Hubble
+Relay and Hubble's graphical UI.
 
-Install Cilium, enable Hubble and deploy Hubble Relay and Hubble's graphical UI
-in one command using Helm:
+.. tabs::
 
-.. parsed-literal::
+    .. group-tab:: Single-node cluster with ``minikube``
 
-   helm install cilium |CHART_RELEASE| \\
-      --namespace kube-system \\
-      --set global.nodeinit.enabled=true \\
-      --set global.kubeProxyReplacement=partial \\
-      --set global.hostServices.enabled=false \\
-      --set global.externalIPs.enabled=true \\
-      --set global.nodePort.enabled=true \\
-      --set global.hostPort.enabled=true \\
-      --set global.pullPolicy=IfNotPresent \\
-      --set config.ipam=kubernetes \\
-      --set global.hubble.enabled=true \\
-      --set global.hubble.listenAddress=":4244" \\
-      --set global.hubble.relay.enabled=true \\
-      --set global.hubble.ui.enabled=true
+       Deploy Hubble and Cilium with the provided pre-rendered YAML manifest:
+
+       .. parsed-literal::
+
+            kubectl create -f |SCM_WEB|/install/kubernetes/experimental-install.yaml
+
+    .. group-tab:: Multi-node cluster with ``kind``
+
+        .. include:: k8s-install-download-release.rst
+
+        Deploy Hubble and Cilium with the following Helm command:
+
+            .. parsed-literal::
+
+               helm install cilium |CHART_RELEASE| \\
+                  --namespace kube-system \\
+                  --set global.nodeinit.enabled=true \\
+                  --set global.kubeProxyReplacement=partial \\
+                  --set global.hostServices.enabled=false \\
+                  --set global.externalIPs.enabled=true \\
+                  --set global.nodePort.enabled=true \\
+                  --set global.hostPort.enabled=true \\
+                  --set global.pullPolicy=IfNotPresent \\
+                  --set config.ipam=kubernetes \\
+                  --set global.hubble.enabled=true \\
+                  --set global.hubble.listenAddress=":4244" \\
+                  --set global.hubble.relay.enabled=true \\
+                  --set global.hubble.ui.enabled=true
+
+.. note::
+
+    Please note that Hubble Relay and Hubble UI are currently in beta status
+    and are not yet recommended for production use.
 
 Validate the Installation
 =========================
@@ -236,5 +302,14 @@ Cleanup
 Once you are done experimenting with Hubble, you can remove all traces of the
 cluster by running the following command:
 
-.. parsed-literal::
-   kind delete cluster
+.. tabs::
+
+    .. group-tab:: Single-node cluster with ``minikube``
+
+        .. parsed-literal::
+           minikube delete
+
+    .. group-tab:: Multi-node cluster with ``kind``
+
+        .. parsed-literal::
+           kind delete cluster

--- a/Documentation/gettingstarted/kind-configure.rst
+++ b/Documentation/gettingstarted/kind-configure.rst
@@ -1,21 +1,3 @@
-Install Dependencies
-====================
-
-1. Install ``docker`` stable as described in
-   `Install Docker Engine <https://docs.docker.com/engine/install/>`_
-
-2. Install ``kubectl`` version >= v1.14.0 as described in the
-   `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
-
-3. Install ``helm`` >= v3.0.3 per Helm documentation:
-   `Installing Helm <https://helm.sh/docs/intro/install/>`_
-
-4. Install ``kind`` >= v0.7.0 per kind documentation:
-   `Installation and Usage <https://kind.sigs.k8s.io/#installation-and-usage>`_
-
-Configure kind
-==============
-
 Configuring kind cluster creation is done using a YAML configuration file.
 This step is necessary in order to disable the default CNI and replace it with
 Cilium.
@@ -53,26 +35,3 @@ documentation for more information.
            disableDefaultCNI: true
            podSubnet: "10.10.0.0/16"
            serviceSubnet: "10.11.0.0/16"
-
-Create a cluster
-================
-
-To create a cluster with the configuration defined above, pass the
-``kind-config.yaml`` you created with the ``--config`` flag of kind.
-
-.. code:: bash
-
-    kind create cluster --config=kind-config.yaml
-
-After a couple of seconds or minutes, a 4 nodes cluster should be created.
-
-A new ``kubectl`` context (``kind-kind``) should be added to ``KUBECONFIG`` or, if unset,
-to ``${HOME}/.kube/config``:
-
-.. code:: bash
-
-    kubectl cluster-info --context kind-kind
-
-.. note::
-   The cluster nodes will remain in state ``NotReady`` until Cilium is deployed.
-   This behavior is expected.

--- a/Documentation/gettingstarted/kind-create-cluster.rst
+++ b/Documentation/gettingstarted/kind-create-cluster.rst
@@ -1,0 +1,19 @@
+To create a cluster with the configuration defined above, pass the
+``kind-config.yaml`` you created with the ``--config`` flag of kind.
+
+.. code:: bash
+
+    kind create cluster --config=kind-config.yaml
+
+After a couple of seconds or minutes, a 4 nodes cluster should be created.
+
+A new ``kubectl`` context (``kind-kind``) should be added to ``KUBECONFIG`` or, if unset,
+to ``${HOME}/.kube/config``:
+
+.. code:: bash
+
+    kubectl cluster-info --context kind-kind
+
+.. note::
+   The cluster nodes will remain in state ``NotReady`` until Cilium is deployed.
+   This behavior is expected.

--- a/Documentation/gettingstarted/kind-install-deps.rst
+++ b/Documentation/gettingstarted/kind-install-deps.rst
@@ -1,0 +1,11 @@
+1. Install ``docker`` stable as described in
+   `Install Docker Engine <https://docs.docker.com/engine/install/>`_
+
+2. Install ``kubectl`` version >= v1.14.0 as described in the
+   `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
+
+3. Install ``helm`` >= v3.0.3 per Helm documentation:
+   `Installing Helm <https://helm.sh/docs/intro/install/>`_
+
+4. Install ``kind`` >= v0.7.0 per kind documentation:
+   `Installation and Usage <https://kind.sigs.k8s.io/#installation-and-usage>`_

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -14,7 +14,20 @@ This guide uses `kind <https://kind.sigs.k8s.io/>`_ to demonstrate deployment
 and operation of Cilium in a multi-node Kubernetes cluster running locally on
 Docker.
 
-.. include:: kind-install.rst
+Install Dependencies
+====================
+
+.. include:: kind-install-deps.rst
+
+Configure kind
+==============
+
+.. include:: kind-configure.rst
+
+Create a cluster
+================
+
+.. include:: kind-create-cluster.rst
 
 .. _kind_install_cilium:
 

--- a/Documentation/gettingstarted/minikube-install.rst
+++ b/Documentation/gettingstarted/minikube-install.rst
@@ -1,0 +1,36 @@
+1. Install ``kubectl`` version >= v1.10.0 as described in the
+   `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
+
+2. Install ``minikube`` >= v1.3.1 as per minikube documentation:
+   `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
+
+.. note::
+
+   It is important to validate that you have minikube v1.3.1 installed. Older
+   versions of minikube are shipping a kernel configuration that is *not*
+   compatible with the TPROXY requirements of Cilium >= 1.6.0.
+
+::
+
+     minikube version
+     minikube version: v1.3.1
+     commit: ca60a424ce69a4d79f502650199ca2b52f29e631
+
+3. Create a minikube cluster:
+
+::
+
+     minikube start --network-plugin=cni --memory=4096
+
+4. Mount the BPF filesystem
+
+::
+
+     minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf
+
+.. note::
+
+   In case of installing Cilium for a specific Kubernetes version, the
+   ``--kubernetes-version vx.y.z`` parameter can be appended to the ``minikube
+   start`` command for bootstrapping the local cluster. By default, minikube
+   will install the most recent version of Kubernetes.

--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -18,41 +18,7 @@ that run on Linux, macOS, and Windows.
 Install kubectl & minikube
 ==========================
 
-1. Install ``kubectl`` version >= v1.10.0 as described in the `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_.
-
-2. Install ``minikube`` >= v1.3.1 as per minikube documentation: `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
-
-.. note::
-
-   It is important to validate that you have minikube v1.3.1 installed. Older
-   versions of minikube are shipping a kernel configuration that is *not*
-   compatible with the TPROXY requirements of Cilium >= 1.6.0.
-
-::
-
-     minikube version
-     minikube version: v1.3.1
-     commit: ca60a424ce69a4d79f502650199ca2b52f29e631
-
-3. Create a minikube cluster:
-
-::
-
-     minikube start --network-plugin=cni --memory=4096
-
-4. Mount the BPF filesystem
-
-::
-
-     minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf
-
-.. note::
-
-   In case of installing Cilium for a specific Kubernetes version, the
-   ``--kubernetes-version vx.y.z`` parameter can be appended to the ``minikube
-   start`` command for bootstrapping the local cluster. By default, minikube
-   will install the most recent version of Kubernetes.
-
+.. include:: minikube-install.rst
 .. include:: quick-install.rst
 .. include:: k8s-install-validate.rst
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -544,6 +544,7 @@ pre
 prebuild
 prefilter
 preflight
+preload
 prem
 prepend
 priori


### PR DESCRIPTION
The current Hubble getting started guide recommends using `kind` to set
up a test cluster. While `kind` is a great way to experiment with
Hubble's cluster-wide observability, it requires more installation steps
than `minikube`. Minikube is also is generally more widely supported
and is able to run our `experimental-install.yaml`.

This PR updates the guide to include instructions for both `minikube`
and `kind`, with `minikube` being the recommended choice.

In order to include the instructions from a tab, some restructing of
the `kind` and `minikube` files was necessary. RST does not support
section titles inside blocks or tabs, therefore the `kind` guide is
split into one file per section.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
