### PR TITLE
v1.8 backports 2020-06-24

### DIFF
--- a/Documentation/cmdref/cilium_service_update.md
+++ b/Documentation/cmdref/cilium_service_update.md
@@ -21,6 +21,7 @@ cilium service update [flags]
       --id uint                     Identifier
       --k8s-external                Set service as a k8s ExternalIPs
       --k8s-host-port               Set service as a k8s HostPort
+      --k8s-load-balancer           Set service as a k8s LoadBalancer
       --k8s-node-port               Set service as a k8s NodePort
       --k8s-traffic-policy string   Set service with k8s externalTrafficPolicy as {Local,Cluster} (default "Cluster")
 ```

--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -65,7 +65,7 @@ toFQDNs rules and events relating to those rules are also relevant.
     -> endpoint 3459 flow 0xe6866e21 identity 15194->323 state reply ifindex lxc84b58cbdabfe orig-ip 10.60.1.115: 10.63.240.10:53 -> 10.60.0.182:42132 udp
     -> Response dns to 3459 ([k8s:org=alliance k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.cilium.k8s.policy.cluster=default k8s:class=xwing]) from 0 ([k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=kube-dns k8s:io.kubernetes.pod.namespace=kube-system k8s:k8s-app=kube-dns]), identity 323->15194, verdict Forwarded DNS Query: cilium.io. A TTL: 486 Answer: '104.198.14.52'
     -> endpoint 3459 flow 0xe6866e21 identity 15194->323 state reply ifindex lxc84b58cbdabfe orig-ip 10.60.1.115: 10.63.240.10:53 -> 10.60.0.182:42132 udp
-    Policy verdict log: flow 0x614e9723 local EP ID 3459, remote ID 16777217, dst port 80, proto 6, ingress false, action allow, match L3-Only, 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN
+    Policy verdict log: flow 0x614e9723 local EP ID 3459, remote ID 16777217, proto 6, egress, action allow, match L3-Only, 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN
 
     -> stack flow 0x614e9723 identity 323->16777217 state new ifindex 0 orig-ip 0.0.0.0: 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN
     -> 0: 10.60.0.182:41510 -> 104.198.14.52:80 tcp SYN

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -99,8 +99,8 @@ Example ``kind-cluster1.yaml``:
     - role: worker
     networking:
       disableDefaultCNI: true
-      podSubnet: 10.0.0.0/16
-      serviceSubnet: 10.1.0.0/16
+      podSubnet: "10.0.0.0/16"
+      serviceSubnet: "10.1.0.0/16"
 
 Example ``kind-cluster2.yaml``:
 
@@ -115,8 +115,8 @@ Example ``kind-cluster2.yaml``:
     - role: worker
     networking:
       disableDefaultCNI: true
-      podSubnet: 10.2.0.0/16
-      serviceSubnet: 10.3.0.0/16
+      podSubnet: "10.2.0.0/16"
+      serviceSubnet: "10.3.0.0/16"
 
 Create Kind Clusters
 --------------------

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -348,22 +348,25 @@ mode would look as follows:
 
 .. _XDP acceleration:
 
-NodePort XDP Acceleration
-*************************
+LoadBalancer & NodePort XDP Acceleration
+****************************************
 
 Cilium has built-in support for accelerating NodePort, LoadBalancer services and
 services with externalIPs for the case where the arriving request needs to be
 pushed back out of the node when the backend is located on a remote node. This
 ability to act as a "one-legged" / hairpin load balancer can be handled by Cilium
-at the XDP (eXpress Data Path) layer where BPF is operating directly in the networking
+starting from version `1.8 <https://cilium.io/blog/2020/06/22/cilium-18/#kube-proxy-replacement-at-the-xdp-layer>`_ at
+the XDP (eXpress Data Path) layer where BPF is operating directly in the networking
 driver instead of a higher layer.
 
 The mode setting ``global.nodePort.acceleration`` allows to enable this acceleration
 through the option ``native``. The option ``disabled`` is the default and disables the
 acceleration. The majority of drivers supporting 10G or higher rates also support
 ``native`` XDP on a recent kernel. For cloud based deployments most of these drivers
-have SR-IOV variants that support native XDP as well. The acceleration can be
-enabled only on a single device which is used for direct routing.
+have SR-IOV variants that support native XDP as well. For on-prem deployments the
+Cilium XDP acceleration can be used in combination with LoadBalancer service
+implementations for Kubernetes such as `MetalLB <https://metallb.universe.tf/>`_. The
+acceleration can be enabled only on a single device which is used for direct routing.
 
 For high-scale environments, also consider tweaking the default map sizes to a larger
 number of entries e.g. through setting a higher ``global.bpf.mapDynamicSizeRatio``.

--- a/Documentation/gettingstarted/policy-creation.rst
+++ b/Documentation/gettingstarted/policy-creation.rst
@@ -98,7 +98,7 @@ output:
 
    # cilium monitor -t policy-verdict
    ...
-   Policy verdict log: flow 0x63113709 local EP ID 232, remote ID 31028, dst port 80, proto 6, ingress true, action audit, match none, 10.0.0.112 :54134 -> 10.29.50.40:80 tcp SYN
+   Policy verdict log: flow 0x63113709 local EP ID 232, remote ID 31028, proto 6, ingress, action audit, match none, 10.0.0.112 :54134 -> 10.29.50.40:80 tcp SYN
 
 In the above example, we can see that endpoint ``232`` has received traffic
 (``ingress true``) which doesn't match the policy (``action audit match
@@ -156,7 +156,7 @@ Executed from the cilium pod:
 .. code-block:: shell-session
 
    # cilium monitor -t policy-verdict
-   Policy verdict log: flow 0xabf3bda6 local EP ID 232, remote ID 31028, dst port 80, proto 6, ingress true, action allow, match L3-L4, 10.0.0.112 :59824 -> 10.0.0.147:80 tcp SYN
+   Policy verdict log: flow 0xabf3bda6 local EP ID 232, remote ID 31028, proto 6, ingress, action allow, match L3-L4, 10.0.0.112 :59824 -> 10.0.0.147:80 tcp SYN
 
 Now the policy verdict states that the traffic would be allowed: ``action
 allow``. Success!

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -542,6 +542,7 @@ pre
 prebuild
 prefilter
 preflight
+prem
 prepend
 priori
 productpage

--- a/api/v1/models/service_spec.go
+++ b/api/v1/models/service_spec.go
@@ -153,7 +153,7 @@ type ServiceSpecFlags struct {
 	TrafficPolicy string `json:"trafficPolicy,omitempty"`
 
 	// Service type
-	// Enum: [ClusterIP NodePort ExternalIPs HostPort]
+	// Enum: [ClusterIP NodePort ExternalIPs HostPort LoadBalancer]
 	Type string `json:"type,omitempty"`
 }
 
@@ -222,7 +222,7 @@ var serviceSpecFlagsTypeTypePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["ClusterIP","NodePort","ExternalIPs","HostPort"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["ClusterIP","NodePort","ExternalIPs","HostPort","LoadBalancer"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -243,6 +243,9 @@ const (
 
 	// ServiceSpecFlagsTypeHostPort captures enum value "HostPort"
 	ServiceSpecFlagsTypeHostPort string = "HostPort"
+
+	// ServiceSpecFlagsTypeLoadBalancer captures enum value "LoadBalancer"
+	ServiceSpecFlagsTypeLoadBalancer string = "LoadBalancer"
 )
 
 // prop value enum

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2169,6 +2169,7 @@ definitions:
             - NodePort
             - ExternalIPs
             - HostPort
+            - LoadBalancer
           trafficPolicy:
             description: Service traffic policy
             type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3177,7 +3177,8 @@ func init() {
                 "ClusterIP",
                 "NodePort",
                 "ExternalIPs",
-                "HostPort"
+                "HostPort",
+                "LoadBalancer"
               ]
             }
           }
@@ -6788,7 +6789,8 @@ func init() {
                 "ClusterIP",
                 "NodePort",
                 "ExternalIPs",
-                "HostPort"
+                "HostPort",
+                "LoadBalancer"
               ]
             }
           }

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -185,8 +185,7 @@ int sock4_update_revnat(struct bpf_sock_addr *ctx __maybe_unused,
 #endif /* ENABLE_HOST_SERVICES_UDP || ENABLE_HOST_SERVICES_PEER */
 
 static __always_inline bool
-sock4_skip_xlate(struct lb4_service *svc, const bool in_hostns,
-		 __be32 address)
+sock4_skip_xlate(struct lb4_service *svc, __be32 address)
 {
 	if (is_v4_loopback(address))
 		return false;
@@ -195,14 +194,8 @@ sock4_skip_xlate(struct lb4_service *svc, const bool in_hostns,
 
 		info = ipcache_lookup4(&IPCACHE_MAP, address,
 				       V4_CACHE_KEY_LEN);
-		if (info == NULL ||
-		    (svc->local_scope && info->sec_label != HOST_ID))
+		if (info == NULL || info->sec_label != HOST_ID)
 			return true;
-		if (lb4_svc_is_external_ip(svc)) {
-			if (info->sec_label != HOST_ID &&
-			    info->sec_label != REMOTE_NODE_ID)
-				return in_hostns;
-		}
 	}
 
 	return false;
@@ -283,7 +276,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * IP address. But do the service translation if the IP
 	 * is from the host.
 	 */
-	if (sock4_skip_xlate(svc, in_hostns, orig_key.address))
+	if (sock4_skip_xlate(svc, orig_key.address))
 		return -EPERM;
 
 	if (svc->affinity) {
@@ -537,8 +530,7 @@ static __always_inline void ctx_set_v6_address(struct bpf_sock_addr *ctx,
 }
 
 static __always_inline __maybe_unused bool
-sock6_skip_xlate(struct lb6_service *svc, const bool in_hostns,
-		 union v6addr *address)
+sock6_skip_xlate(struct lb6_service *svc, union v6addr *address)
 {
 	if (is_v6_loopback(address))
 		return false;
@@ -547,14 +539,8 @@ sock6_skip_xlate(struct lb6_service *svc, const bool in_hostns,
 
 		info = ipcache_lookup6(&IPCACHE_MAP, address,
 				       V6_CACHE_KEY_LEN);
-		if (info == NULL ||
-		    (svc->local_scope && info->sec_label != HOST_ID))
+		if (info == NULL || info->sec_label != HOST_ID)
 			return true;
-		if (lb6_svc_is_external_ip(svc)) {
-			if (info->sec_label != HOST_ID &&
-			    info->sec_label != REMOTE_NODE_ID)
-				return in_hostns;
-		}
 	}
 
 	return false;
@@ -718,7 +704,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (!svc)
 		return -ENXIO;
 
-	if (sock6_skip_xlate(svc, in_hostns, &orig_key.address))
+	if (sock6_skip_xlate(svc, &orig_key.address))
 		return -EPERM;
 
 	if (svc->affinity) {

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -368,11 +368,13 @@ static __always_inline int __sock4_bind(struct bpf_sock *ctx,
 		svc = sock4_nodeport_wildcard_lookup(&key, false, true);
 	}
 
-	/* If the sockaddr of this socket overlaps with a NodePort
-	 * or ExternalIP service. We must reject this bind() call
-	 * to avoid accidentally hijacking its traffic.
+	/* If the sockaddr of this socket overlaps with a NodePort,
+	 * LoadBalancer or ExternalIP service. We must reject this
+	 * bind() call to avoid accidentally hijacking its traffic.
 	 */
-	if (svc && (lb4_svc_is_nodeport(svc) || lb4_svc_is_external_ip(svc)))
+	if (svc && (lb4_svc_is_nodeport(svc) ||
+		    lb4_svc_is_external_ip(svc) ||
+		    lb4_svc_is_loadbalancer(svc)))
 		return -EADDRINUSE;
 
 	return 0;
@@ -655,7 +657,9 @@ static __always_inline int __sock6_bind(struct bpf_sock *ctx)
 			return sock6_bind_v4_in_v6(ctx);
 	}
 
-	if (svc && (lb6_svc_is_nodeport(svc) || lb6_svc_is_external_ip(svc)))
+	if (svc && (lb6_svc_is_nodeport(svc) ||
+		    lb6_svc_is_external_ip(svc) ||
+		    lb6_svc_is_loadbalancer(svc)))
 		return -EADDRINUSE;
 
 	return 0;

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -180,7 +180,7 @@ int sock4_update_revnat(struct bpf_sock_addr *ctx __maybe_unused,
 			struct lb4_key *orig_key __maybe_unused,
 			__u16 rev_nat_id __maybe_unused)
 {
-	return -1;
+	return 0;
 }
 #endif /* ENABLE_HOST_SERVICES_UDP || ENABLE_HOST_SERVICES_PEER */
 
@@ -502,7 +502,7 @@ int sock6_update_revnat(struct bpf_sock_addr *ctx __maybe_unused,
 			struct lb6_key *orig_key __maybe_unused,
 			__u16 rev_nat_index __maybe_unused)
 {
-	return -1;
+	return 0;
 }
 #endif /* ENABLE_HOST_SERVICES_UDP || ENABLE_HOST_SERVICES_PEER */
 #endif /* ENABLE_IPV6 */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -590,7 +590,8 @@ struct lb6_service {
 	     local_scope:1,	/* K8s externalTrafficPolicy=Local */
 	     hostport:1,	/* K8s hostPort forwarding */
 	     affinity:1,	/* K8s sessionAffinity=clientIP */
-	     reserved:3;
+	     loadbalancer:1,	/* K8s LoadBalancer service */
+	     reserved:2;
 	__u8 pad[3];
 };
 
@@ -643,7 +644,8 @@ struct lb4_service {
 	     local_scope:1,	/* K8s externalTrafficPolicy=Local */
 	     hostport:1,	/* K8s hostPort forwarding */
 	     affinity:1,	/* K8s sessionAffinity=clientIP */
-	     reserved:3;
+	     loadbalancer:1,	/* K8s LoadBalancer service */
+	     reserved:2;
 	__u8 pad[3];
 };
 

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -158,26 +158,6 @@ bool lb6_svc_is_external_ip(const struct lb6_service *svc __maybe_unused)
 }
 
 static __always_inline
-bool lb4_svc_needs_lxc_xlation(const struct lb4_service *svc __maybe_unused)
-{
-#if defined(ENABLE_HOST_SERVICES_FULL) && defined(ENABLE_EXTERNAL_IP)
-	return lb4_svc_is_external_ip(svc);
-#else
-	return true;
-#endif
-}
-
-static __always_inline
-bool lb6_svc_needs_lxc_xlation(const struct lb6_service *svc __maybe_unused)
-{
-#if defined(ENABLE_HOST_SERVICES_FULL) && defined(ENABLE_EXTERNAL_IP)
-	return lb6_svc_is_external_ip(svc);
-#else
-	return true;
-#endif
-}
-
-static __always_inline
 bool lb4_svc_is_hostport(const struct lb4_service *svc __maybe_unused)
 {
 #ifdef ENABLE_HOSTPORT

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -583,7 +583,6 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 	struct lb6_service *slave_svc;
 	int slave;
 	__u32 backend_id = 0;
-	bool backend_from_affinity = false;
 	int ret;
 #ifdef ENABLE_SESSION_AFFINITY
 	union lb6_affinity_client_id client_id;
@@ -598,8 +597,6 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		if (svc->affinity) {
 			backend_id = lb6_affinity_backend_id_by_addr(svc, &client_id);
 			if (backend_id != 0) {
-				backend_from_affinity = true;
-
 				backend = lb6_lookup_backend(ctx, backend_id);
 				if (backend == NULL)
 					backend_id = 0;
@@ -607,8 +604,6 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		}
 #endif
 		if (backend_id == 0) {
-			backend_from_affinity = false;
-
 			slave = lb6_select_slave(svc->count);
 			if ((slave_svc = lb6_lookup_slave(ctx, key, slave)) == NULL)
 				goto drop_no_service;
@@ -647,11 +642,9 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 	// See lb4_local comment
 	if (state->rev_nat_index != svc->rev_nat_index) {
 #ifdef ENABLE_SESSION_AFFINITY
-		if (svc->affinity) {
+		if (svc->affinity)
 			backend_id = lb6_affinity_backend_id_by_addr(svc,
 								     &client_id);
-			backend_from_affinity = true;
-		}
 #endif
 		if (backend_id == 0) {
 			slave = lb6_select_slave(svc->count);
@@ -1088,7 +1081,6 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	struct lb4_service *slave_svc;
 	int slave;
 	__u32 backend_id = 0;
-	bool backend_from_affinity = false;
 	int ret;
 #ifdef ENABLE_SESSION_AFFINITY
 	union lb4_affinity_client_id client_id = {
@@ -1102,8 +1094,6 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		if (svc->affinity) {
 			backend_id = lb4_affinity_backend_id_by_addr(svc, &client_id);
 			if (backend_id != 0) {
-				backend_from_affinity = true;
-
 				backend = lb4_lookup_backend(ctx, backend_id);
 				if (backend == NULL)
 					backend_id = 0;
@@ -1111,8 +1101,6 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		}
 #endif
 		if (backend_id == 0) {
-			backend_from_affinity = false;
-
 			/* No CT entry has been found, so select a svc endpoint */
 			slave = lb4_select_slave(svc->count);
 			if ((slave_svc = lb4_lookup_slave(ctx, key, slave)) == NULL)
@@ -1160,11 +1148,9 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	// select a new backend.
 	if (state->rev_nat_index != svc->rev_nat_index) {
 #ifdef ENABLE_SESSION_AFFINITY
-		if (svc->affinity) {
+		if (svc->affinity)
 			backend_id = lb4_affinity_backend_id_by_addr(svc,
 								     &client_id);
-			backend_from_affinity = true;
-		}
 #endif
 		if (backend_id == 0) {
 			slave = lb4_select_slave(svc->count);

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -118,6 +118,26 @@ struct bpf_elf_map __section_maps LB_AFFINITY_MATCH_MAP = {
 #endif
 
 static __always_inline
+bool lb4_svc_is_loadbalancer(const struct lb4_service *svc __maybe_unused)
+{
+#ifdef ENABLE_LOADBALANCER
+	return svc->loadbalancer;
+#else
+	return false;
+#endif /* ENABLE_LOADBALANCER */
+}
+
+static __always_inline
+bool lb6_svc_is_loadbalancer(const struct lb6_service *svc __maybe_unused)
+{
+#ifdef ENABLE_LOADBALANCER
+	return svc->loadbalancer;
+#else
+	return false;
+#endif /* ENABLE_LOADBALANCER */
+}
+
+static __always_inline
 bool lb4_svc_is_nodeport(const struct lb4_service *svc __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -548,7 +548,8 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if (!svc || (!lb6_svc_is_nodeport(svc) &&
+	if (!svc || (!lb6_svc_is_loadbalancer(svc) &&
+		     !lb6_svc_is_nodeport(svc) &&
 		     !lb6_svc_is_external_ip(svc) &&
 		     !lb6_svc_is_hostport(svc))) {
 		if (svc)
@@ -1224,7 +1225,8 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if (!svc || (!lb4_svc_is_nodeport(svc) &&
+	if (!svc || (!lb4_svc_is_loadbalancer(svc) &&
+		     !lb4_svc_is_nodeport(svc) &&
 		     !lb4_svc_is_external_ip(svc) &&
 		     !lb4_svc_is_hostport(svc))) {
 		if (svc)

--- a/cilium/cmd/service_update.go
+++ b/cilium/cmd/service_update.go
@@ -32,6 +32,7 @@ var (
 	k8sExternalIPs   bool
 	k8sNodePort      bool
 	k8sHostPort      bool
+	k8sLoadBalancer  bool
 	k8sTrafficPolicy string
 	idU              uint64
 	frontend         string
@@ -52,6 +53,7 @@ func init() {
 	serviceUpdateCmd.Flags().Uint64VarP(&idU, "id", "", 0, "Identifier")
 	serviceUpdateCmd.Flags().BoolVarP(&k8sExternalIPs, "k8s-external", "", false, "Set service as a k8s ExternalIPs")
 	serviceUpdateCmd.Flags().BoolVarP(&k8sNodePort, "k8s-node-port", "", false, "Set service as a k8s NodePort")
+	serviceUpdateCmd.Flags().BoolVarP(&k8sLoadBalancer, "k8s-load-balancer", "", false, "Set service as a k8s LoadBalancer")
 	serviceUpdateCmd.Flags().BoolVarP(&k8sHostPort, "k8s-host-port", "", false, "Set service as a k8s HostPort")
 	serviceUpdateCmd.Flags().StringVarP(&k8sTrafficPolicy, "k8s-traffic-policy", "", "Cluster", "Set service with k8s externalTrafficPolicy as {Local,Cluster}")
 	serviceUpdateCmd.Flags().BoolVarP(&deprecatedAddRev, "rev", "", false, "Add reverse translation")
@@ -106,12 +108,14 @@ func updateService(cmd *cobra.Command, args []string) {
 		spec.Flags = &models.ServiceSpecFlags{}
 	}
 
-	if boolToInt(k8sExternalIPs)+boolToInt(k8sNodePort)+boolToInt(k8sHostPort) > 1 {
-		Fatalf("Can only set one of --k8s-external, --k8s-node-port, --k8s-host-port for a service")
+	if boolToInt(k8sExternalIPs)+boolToInt(k8sNodePort)+boolToInt(k8sHostPort)+boolToInt(k8sLoadBalancer) > 1 {
+		Fatalf("Can only set one of --k8s-external, --k8s-node-port, --k8s-load-balancer, --k8s-host-port for a service")
 	} else if k8sExternalIPs {
 		spec.Flags = &models.ServiceSpecFlags{Type: models.ServiceSpecFlagsTypeExternalIPs}
 	} else if k8sNodePort {
 		spec.Flags = &models.ServiceSpecFlags{Type: models.ServiceSpecFlagsTypeNodePort}
+	} else if k8sLoadBalancer {
+		spec.Flags = &models.ServiceSpecFlags{Type: models.ServiceSpecFlagsTypeLoadBalancer}
 	} else if k8sHostPort {
 		spec.Flags = &models.ServiceSpecFlags{Type: models.ServiceSpecFlagsTypeHostPort}
 	} else {

--- a/daemon/cmd/loadbalancer.go
+++ b/daemon/cmd/loadbalancer.go
@@ -66,6 +66,8 @@ func (h *putServiceID) Handle(params PutServiceIDParams) middleware.Responder {
 		svcType = loadbalancer.SVCTypeExternalIPs
 	case models.ServiceSpecFlagsTypeNodePort:
 		svcType = loadbalancer.SVCTypeNodePort
+	case models.ServiceSpecFlagsTypeLoadBalancer:
+		svcType = loadbalancer.SVCTypeLoadBalancer
 	case models.ServiceSpecFlagsTypeHostPort:
 		svcType = loadbalancer.SVCTypeHostPort
 	default:

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -117,7 +117,9 @@ func (d *Daemon) getMasqueradingStatus() *models.Masquerading {
 		return s
 	}
 
-	s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDR().String()
+	if option.Config.EnableIPv4 {
+		s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDR().String()
+	}
 
 	if option.Config.EnableBPFMasquerade {
 		s.Mode = models.MasqueradingModeBPF

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
 {{- if .Values.global.ipv4.enabled }}
             host: '127.0.0.1'
 {{- else }}
-            host: '[::1]'
+            host: '::1'
 {{- end }}
             path: /healthz
             port: 9234

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -29,7 +29,6 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
@@ -60,7 +59,7 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 	k8sNodeStore, nodeController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.CiliumClient().CiliumV2().RESTClient(),
 			"ciliumnodes", v1.NamespaceAll, fields.Everything()),
-		&slim_corev1.Node{},
+		&cilium_v2.CiliumNode{},
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -235,6 +235,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	if option.Config.EnableNodePort {
 		cDefinesMap["ENABLE_NODEPORT"] = "1"
+		cDefinesMap["ENABLE_LOADBALANCER"] = "1"
 
 		if option.Config.EnableIPv4 {
 			cDefinesMap["NODEPORT_NEIGH4"] = neighborsmap.Map4Name

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -831,7 +831,9 @@ func (zombies *DNSZombieMappings) MarkAlive(now time.Time, ip net.IP) {
 // no longer alive. Thus, this call acts as a gating function for what data is
 // returned by GC.
 func (zombies *DNSZombieMappings) SetCTGCTime(now time.Time) {
+	zombies.Lock()
 	zombies.lastCTGCUpdate = now
+	zombies.Unlock()
 }
 
 // ForceExpire is used to clear zombies irrespective of their alive status.
@@ -937,6 +939,9 @@ func (zombies *DNSZombieMappings) DumpAlive() (alive []*DNSZombieMapping) {
 // MarshalJSON encodes DNSZombieMappings into JSON. Only the DNSZombieMapping
 // entries are encoded.
 func (zombies *DNSZombieMappings) MarshalJSON() ([]byte, error) {
+	zombies.Lock()
+	defer zombies.Unlock()
+
 	// This hackery avoids exposing DNSZombieMappings.deletes as a public field.
 	// The JSON package cannot serialize private fields so we have to make a
 	// proxy type here.

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -62,6 +62,7 @@ const (
 	serviceFlagLocalScope      = 4
 	serviceFlagHostPort        = 8
 	serviceFlagSessionAffinity = 16
+	serviceFlagLoadBalancer    = 32
 )
 
 // CreateSvcFlag returns the ServiceFlags for all given SVCTypes.
@@ -71,10 +72,12 @@ func CreateSvcFlag(svcLocal, sessionAffinity bool, svcTypes ...SVCType) ServiceF
 		switch svcType {
 		case SVCTypeExternalIPs:
 			flags |= serviceFlagExternalIPs
-		case SVCTypeHostPort:
-			flags |= serviceFlagHostPort
 		case SVCTypeNodePort:
 			flags |= serviceFlagNodePort
+		case SVCTypeLoadBalancer:
+			flags |= serviceFlagLoadBalancer
+		case SVCTypeHostPort:
+			flags |= serviceFlagHostPort
 		}
 	}
 	if svcLocal {
@@ -97,10 +100,12 @@ func (s ServiceFlags) SVCType() SVCType {
 	switch {
 	case s&serviceFlagExternalIPs != 0:
 		return SVCTypeExternalIPs
-	case s&serviceFlagHostPort != 0:
-		return SVCTypeHostPort
 	case s&serviceFlagNodePort != 0:
 		return SVCTypeNodePort
+	case s&serviceFlagLoadBalancer != 0:
+		return SVCTypeLoadBalancer
+	case s&serviceFlagHostPort != 0:
+		return SVCTypeHostPort
 	default:
 		return SVCTypeClusterIP
 	}
@@ -120,8 +125,8 @@ func (s ServiceFlags) SVCTrafficPolicy() SVCTrafficPolicy {
 func (s ServiceFlags) String() string {
 	var strTypes []string
 	typeSet := false
-	sType := s & (serviceFlagExternalIPs | serviceFlagHostPort | serviceFlagNodePort)
-	for _, svcType := range []SVCType{SVCTypeExternalIPs, SVCTypeHostPort, SVCTypeNodePort} {
+	sType := s & (serviceFlagExternalIPs | serviceFlagHostPort | serviceFlagNodePort | serviceFlagLoadBalancer)
+	for _, svcType := range []SVCType{SVCTypeExternalIPs, SVCTypeHostPort, SVCTypeNodePort, SVCTypeLoadBalancer} {
 		if sType.IsSvcType(false, false, svcType) {
 			strTypes = append(strTypes, string(svcType))
 			typeSet = true

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -330,6 +330,14 @@ func TestServiceFlags_IsSvcType(t *testing.T) {
 			s:    serviceFlagExternalIPs | serviceFlagLocalScope,
 			want: false,
 		},
+		{
+			args: args{
+				svcType:  SVCTypeLoadBalancer,
+				svcLocal: false,
+			},
+			s:    serviceFlagLoadBalancer,
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -365,6 +373,11 @@ func TestServiceFlags_String(t *testing.T) {
 			name: "Test-4",
 			s:    serviceFlagExternalIPs | serviceFlagLocalScope,
 			want: "ExternalIPs, Local",
+		},
+		{
+			name: "Test-5",
+			s:    serviceFlagLoadBalancer,
+			want: "LoadBalancer",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -593,19 +593,11 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, prevBackendCount int,
 		backendIDs[i] = uint16(b.ID)
 	}
 
-	svcType := svc.svcType
-	// SVC of LoadBalancer type is identical to ExternalIP. However, currently
-	// datapath does not support the LoadBalancer type, only ExternalIP. So,
-	// for now set the ExternalIP type.
-	if svcType == lb.SVCTypeLoadBalancer {
-		svcType = lb.SVCTypeExternalIPs
-	}
-
 	err := s.lbmap.UpsertService(
 		uint16(svc.frontend.ID), svc.frontend.L3n4Addr.IP,
 		svc.frontend.L3n4Addr.L4Addr.Port,
 		backendIDs, prevBackendCount,
-		ipv6, svcType, svc.requireNodeLocalBackends(),
+		ipv6, svc.svcType, svc.requireNodeLocalBackends(),
 		svc.sessionAffinity, svc.sessionAffinityTimeoutSec)
 	if err != nil {
 		return err

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -303,6 +303,8 @@ var ciliumCLICommands = map[string]string{
 	"cilium policy get":                     "policy_get.txt",
 	"cilium status --all-controllers":       "status.txt",
 	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
+
+	"hubble observe --since 4h -o json": "hubble_observe.txt",
 }
 
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
@@ -316,6 +318,8 @@ var ciliumKubCLICommands = map[string]string{
 	"cilium bpf tunnel list":          "bpf_tunnel_list.txt",
 	"cilium policy get":               "policy_get.txt",
 	"cilium status --all-controllers": "status.txt",
+
+	"hubble observe --since 4h -o json": "hubble_observe.txt",
 }
 
 // ciliumKubCLICommandsKVStore contains commands related to querying the kvstore.

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -785,10 +785,9 @@ var _ = Describe("K8sServicesTest", func() {
 			// Should work from outside via the external IP
 			testCurlFromOutside(httpURL, count, false)
 			testCurlFromOutside(tftpURL, count, false)
-			// Same from inside a pod
-			testCurlFromPods(testDSClient, httpURL, 10, 0)
-			testCurlFromPods(testDSClient, tftpURL, 10, 0)
-			// But not from the host netns (to prevent MITM)
+			// Should fail from inside a pod & hostns
+			testCurlFromPodsFail(testDSClient, httpURL)
+			testCurlFromPodsFail(testDSClient, tftpURL)
 			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s1NodeName)
 			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s1NodeName)
 			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s2NodeName)

--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -24,7 +24,9 @@ docker push "$1/cilium/hubble-relay:$2"
 cilium_git_version="$(cat GIT_VERSION)"
 
 counter=0
-until [ $counter -eq 10 ] || docker image prune -f --all --filter "label=cilium-sha=${cilium_git_version%% *}"; do
-	((counter++))
+exitCode=1
+until [ $exitCode -eq 0 ] || [ $counter -eq 10 ]; do
+	docker image prune -f --all --filter "label=cilium-sha=${cilium_git_version%% *}" && exitCode=$? || exitCode=$?
+	counter=$((counter+1))
 	sleep 6
 done


### PR DESCRIPTION
* #11824 -- ci/helpers: Collect Hubble flow logs upon failure (@gandro)
 * #12218 -- fqdn: Fix panic on MarshalJSON() (@pchaigno)
 * #12221 -- daemon: fix panic for cilium status in IPv6 only cluster (@Rolinh)
 * #12222 -- bpf: support host to TCP services when host to UDP services is disabled (@bpineau)
 * #12220 -- bpf: skip in-cluster xlation for non-local ips (@borkmann)
 * #12223 -- helm/operator: fix IPv6 liveness probe address for operator (@Rolinh)
 * #12226 -- ci: fix gke prune script (@nebril)
 * #12235 -- operator: fix nodes informer (@bpineau)
 * #12237 -- bpf: remove write-only bool backend_from_affinity from lb{4,6}local (@tklauser)
 * #12243 -- Make podSubnet consistent across install guide (@jedsalazar)
 * #12256 -- docs: adjust policy verdict log output examples to new format (@tklauser)
 * #12234 -- cilium: split off handling of lb svc type in datapath (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11824 12218 12221 12222 12220 12223 12226 12235 12237 12243 12256 12234; do contrib/backporting/set-labels.py $pr done 1.8; done
```