### PR TITLE
test: Fix ginkgo -cilium help output

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -188,15 +188,17 @@ framework in the ``test/`` directory and interact with ginkgo directly:
 ::
 
     $ cd test/
-    $ ginkgo . -- --help | grep -A 1 cilium
+    $ ginkgo . -- -cilium.help
       -cilium.SSHConfig string
             Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')
       -cilium.benchmarks
             Specifies benchmark tests should be run which may increase test time
+      -cilium.help
+            Display this help message.
       -cilium.holdEnvironment
             On failure, hold the environment in its current state
       -cilium.hubble-relay-image string
-            Specifies which image of Hubble Relay to use during tests
+            Specifies which image of hubble-relay to use during tests
       -cilium.image string
             Specifies which image of cilium to use during tests
       -cilium.kubeconfig string
@@ -214,7 +216,7 @@ framework in the ``test/`` directory and interact with ginkgo directly:
       -cilium.registry string
             docker registry hostname for Cilium image
       -cilium.runQuarantined
-        Run tests that are under quarantine.
+            Run tests that are under quarantine.
       -cilium.showCommands
             Output which commands are ran to stdout
       -cilium.skipLogs
@@ -223,6 +225,9 @@ framework in the ``test/`` directory and interact with ginkgo directly:
             Specifies scope of test to be ran (k8s, Nightly, runtime)
       -cilium.timeout duration
             Specifies timeout for test run (default 24h0m0s)
+
+    Ginkgo ran 1 suite in 5.04417992s
+    Test Suite Failed
 
 For more information about other built-in options to Ginkgo, consult the
 `Ginkgo documentation`_.

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -46,6 +46,7 @@ type CiliumTestConfigType struct {
 	// node. If false, some tests will silently skip multinode checks.
 	Multinode      bool
 	RunQuarantined bool
+	Help           bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -54,7 +55,7 @@ var CiliumTestConfig = CiliumTestConfigType{}
 
 // ParseFlags parses commandline flags relevant to testing.
 func (c *CiliumTestConfigType) ParseFlags() {
-	flagset := flag.NewFlagSet("cilium", flag.PanicOnError)
+	flagset := flag.NewFlagSet("cilium", flag.ExitOnError)
 	flagset.BoolVar(&c.Reprovision, "cilium.provision", true,
 		"Provision Vagrant boxes and Cilium before running test")
 	flagset.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
@@ -88,10 +89,14 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Enable tests across multiple nodes. If disabled, such tests may silently pass")
 	flagset.BoolVar(&c.RunQuarantined, "cilium.runQuarantined", false,
 		"Run tests that are under quarantine.")
+	flagset.BoolVar(&c.Help, "cilium.help", false, "Display this help message.")
 
 	args := make([]string, 0, len(os.Args))
 	for index, flag := range os.Args {
-		if strings.Contains(flag, "-cilium") {
+		if flag == "-cilium.help" {
+			flagset.PrintDefaults()
+			os.Exit(1)
+		} else if strings.Contains(flag, "-cilium") {
 			args = append(args, flag)
 			os.Args[index] = ""
 		}


### PR DESCRIPTION
This commit (1) re-introduces the `-cilium` flags in the ginkgo help by adding an explicit `-cilium.help` flag and (2) updates the documentation accordingly.

Given it only impacts contributors, I don't know if we would usually backport this to v1.8?

Fixes: #12099