### PR TITLE
docs: fix set flag in upgrade guide

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -165,7 +165,7 @@ the initial deployment:
 
       helm template |CHART_RELEASE| \\
         --set config.upgradeCompatibility=1.7 \\
-        --agent.keepDeprecatedProbes=true \\
+        --set agent.keepDeprecatedProbes=true \\
         --namespace kube-system \\
         > cilium.yaml
       kubectl apply -f cilium.yaml
@@ -179,7 +179,7 @@ the initial deployment:
       helm upgrade cilium |CHART_RELEASE| \\
         --namespace=kube-system \\
         --set config.upgradeCompatibility=1.7 \\
-        --agent.keepDeprecatedProbes=true
+        --set agent.keepDeprecatedProbes=true
 
 .. note::
 


### PR DESCRIPTION
Fixes: 8ec15e20c6a9 ("doc: Ensure ConfigMap remains compatible across 1.7 -> 1.8 upgrade")
Signed-off-by: André Martins <andre@cilium.io>