### PR TITLE
docs: Mark host-policies as tech preview

### DIFF
--- a/Documentation/concepts/ebpf/lifeofapacket.rst
+++ b/Documentation/concepts/ebpf/lifeofapacket.rst
@@ -48,9 +48,7 @@ the normal flow.
 veth-based versus ipvlan-based datapath
 =======================================
 
-.. note:: The ipvlan-based datapath is currently only in technology preview
-          and to be used for experimentation purposes. This restriction will
-          be lifted in future Cilium releases.
+.. include:: ../../tech-preview.rst
 
 By default Cilium CNI operates in veth-based datapath mode which allows for
 more flexibility in that all BPF programs are managed by Cilium out of the host

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1067,6 +1067,8 @@ for instructions.
 Host Policies
 =============
 
+.. include:: ../tech-preview.rst
+
 Host policies take the form of a `CiliumClusterwideNetworkPolicy` with a
 :ref:`NodeSelector` instead of an `EndpointSelector`. Host policies can have
 layer 3 and layer 4 rules on both ingress and egress. They cannot have layer

--- a/Documentation/tech-preview.rst
+++ b/Documentation/tech-preview.rst
@@ -1,0 +1,3 @@
+.. note:: This feature is currently only in technology preview and to be used
+          for experimentation purposes. This restriction will be lifted in
+          future Cilium releases.


### PR DESCRIPTION
The Cilium v1.8 blog describes this feature as tech preview, make sure
the docs are consistent with this.