### PR TITLE
Helm: Make nodeinit image, tag and registry configurable using helm values

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -23,7 +23,11 @@ spec:
 {{- end }}
       containers:
         - name: node-init
-          image: docker.io/cilium/startup-script:af2a99046eca96c0138551393b21a5c044c7fe79
+{{- if contains "/" .Values.image }}
+          image: "{{ .Values.image }}:{{ .Values.tag }}"
+{{- else }}
+          image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.tag }}"
+{{- end }}
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -1,3 +1,6 @@
+image: startup-script
+tag: af2a99046eca96c0138551393b21a5c044c7fe79
+
 # Restart existing pods when initializing the node to force all pods being
 # managed by Cilium (GKE, EKS)
 restartPods: false


### PR DESCRIPTION
Helm: Make nodeinit image, tag and registry configurable using helm values to enable running in air-gapped environments or ones with private registries

Fixes: #12273

Signed-off-by: Sean Winn <sean@isovalent.com>

