### PR TITLE
install/kubernetes: remove mapDynamicSizeRatio leftover

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -369,7 +369,7 @@ implementations for Kubernetes such as `MetalLB <https://metallb.universe.tf/>`_
 acceleration can be enabled only on a single device which is used for direct routing.
 
 For high-scale environments, also consider tweaking the default map sizes to a larger
-number of entries e.g. through setting a higher ``global.bpf.mapDynamicSizeRatio``.
+number of entries e.g. through setting a higher ``config.bpfMapDynamicSizeRatio``.
 See :ref:`bpf_map_limitations` for further details.
 
 The ``global.nodePort.acceleration`` setting is supported for DSR, SNAT and hybrid

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -281,13 +281,6 @@ global:
     # policyMapMax is the maximum number of entries in endpoint policy map (per endpoint)
     policyMapMax: 16384
 
-    # mapDynamicSizeRatio is the ratio (0.0-1.0) of total system memory to use
-    # for dynamic sizing of CT, NAT, neighbor and SockRevNAT BPF maps. If set to
-    # 0.0, dynamic sizing of BPF maps is disabled. The default value of 0.0025
-    # (0.25%) leads to approximately the default CT size kube-proxy sets on a
-    # node with 16 GiB of total system memory.
-    mapDynamicSizeRatio: 0.0025
-
     # monitorAggregation is the level of aggregation for datapath trace events
     monitorAggregation: medium
 


### PR DESCRIPTION
This option should have been removed as it was replaced by
`bpfMapDynamicSizeRatio` set in
install/kubernetes/cilium/charts/config/values.yaml

Fixes: 8ec15e20c6a9 ("doc: Ensure ConfigMap remains compatible across 1.7 -> 1.8 upgrade")
Signed-off-by: André Martins <andre@cilium.io>