### PR TITLE
docs: clarify helm options for kubernetes ipam

### DIFF
--- a/Documentation/concepts/networking/ipam/kubernetes.rst
+++ b/Documentation/concepts/networking/ipam/kubernetes.rst
@@ -63,3 +63,11 @@ The following ConfigMap options exist to configure Kubernetes hostscope:
    an IPv4 PodCIDR is made available via the Kubernetes node resource.
  * ``k8s-require-ipv6-pod-cidr: true``: instructs the Cilium agent to wait until
    an IPv6 PodCIDR is made available via the Kubernetes node resource.
+
+With helm the previous options can be defined as:
+
+ * ``ipam: kubernetes``: ``--set config.ipam=kubernetes``.
+ * ``k8s-require-ipv4-pod-cidr: true``: ``--set global.k8s.requireIPv4PodCIDR=true``,
+   which only works with ``--set config.ipam=kubernetes``
+ * ``k8s-require-ipv6-pod-cidr: true``: ``--set global.k8s.requireIPv6PodCIDR=true``,
+   which only works with ``--set config.ipam=kubernetes``


### PR DESCRIPTION
If users want to use helm we should clarify which helm options can be used to set values the ConfigMap.

Signed-off-by: André Martins <andre@cilium.io>