### PR TITLE
test: split log gathering goroutine

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2921,12 +2921,16 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		kub.GatherLogs(ctx)
+	}()
 
 	go func() {
 		defer wg.Done()
 		kub.DumpCiliumCommandOutput(ctx, namespace)
-		kub.GatherLogs(ctx)
 	}()
 
 	kub.CiliumCheckReport(ctx)


### PR DESCRIPTION
If Cilium pods are in crash loop backoff, `kub.DumpCiliumCommandOutput`
blocks for whole context duration, which causes subsequent `kub.GatherLogs`
call to fail immediately.

This change splits these two calls to separate goroutines.