### PR TITLE
test(quick-install): Dump related logs and events for cilium, hubble and connectivity checks in GH actions

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -70,6 +70,40 @@ jobs:
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=5m
 
+      - name: Dump cilium related logs and events
+        if: ${{ failure() }}
+        env:
+          LOG_TIME: 30m
+        run: |
+          kubectl -n kube-system describe daemonsets.apps cilium
+          kubectl -n kube-system logs daemonset/cilium --all-containers --since=$LOG_TIME
+
+      - name: Dump connectivity related logs and events
+        if: ${{ failure() }}
+        env:
+          LOG_TIME: 30m
+        run: |
+          kubectl describe service echo-a
+          kubectl logs service/echo-a --all-containers --since=$LOG_TIME
+          kubectl describe service echo-b
+          kubectl logs service/echo-b --all-containers --since=$LOG_TIME
+          kubectl describe service echo-b-headless
+          kubectl logs service/echo-b-headless --all-containers --since=$LOG_TIME
+          kubectl describe service echo-b-host-headless
+          kubectl logs service/echo-b-host-headless --all-containers --since=$LOG_TIME
+
+      - name: Dump hubble related logs and events
+        if: ${{ failure() &&  matrix.target.name == 'experimental-install' }}
+        env:
+          LOG_TIME: 30m
+        run: |
+          kubectl -n kube-system describe service hubble-metrics
+          kubectl -n kube-system logs service/hubble-metrics --all-containers --since=$LOG_TIME
+          kubectl -n kube-system describe service hubble-relay
+          kubectl -n kube-system logs service/hubble-relay --all-containers --since=$LOG_TIME
+          kubectl -n kube-system describe service hubble-ui
+          kubectl -n kube-system logs service/hubble-ui --all-containers --since=$LOG_TIME
+
   conformance-test:
     runs-on: ubuntu-latest
     steps:
@@ -115,3 +149,25 @@ jobs:
         run: |
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=5m
+
+      - name: Dump cilium related logs and events
+        if: ${{ failure() }}
+        env:
+          LOG_TIME: 30m
+        run: |
+          kubectl -n kube-system describe daemonsets.apps cilium
+          kubectl -n kube-system logs daemonset/cilium --all-containers --since=$LOG_TIME
+
+      - name: Dump connectivity related logs and events
+        if: ${{ failure() }}
+        env:
+          LOG_TIME: 30m
+        run: |
+          kubectl describe service echo-a
+          kubectl logs service/echo-a --all-containers --since=$LOG_TIME
+          kubectl describe service echo-b
+          kubectl logs service/echo-b --all-containers --since=$LOG_TIME
+          kubectl describe service echo-b-headless
+          kubectl logs service/echo-b-headless --all-containers --since=$LOG_TIME
+          kubectl describe service echo-b-host-headless
+          kubectl logs service/echo-b-host-headless --all-containers --since=$LOG_TIME


### PR DESCRIPTION
Dump related logs and events for cilium, hubble and connectivity checks

Relates #12279

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
test(quick-install): Dump related logs and events for cilium, hubble and connectivity checks
```
