### PR TITLE
packaging/docker: update cni loopback to 0.8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGI
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-06-25
+FROM quay.io/cilium/cilium-runtime:2020-06-25-1@sha256:15864abdb280b0e4f9b772a6a754d74c0ba4c28b9f6bf2a58f3f2c7ef89037ed
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776@sha256:9d3f6fb67ce3b910450378a7232ef1999c5bdff755457092155a11e5296ec346 as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 
 #
 # Hubble CLI
 #
-FROM quay.io/cilium/hubble:v0.6.0 as hubble
+FROM quay.io/cilium/hubble:v0.6.0@sha256:8dff5b76c99dea0f88b3ed27878380b9486f001741d60c33bcb1112607ca31ec as hubble
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-06-08 as builder
+FROM quay.io/cilium/cilium-builder:2020-06-08@sha256:06868f045a14e38e8ff0e8ac03d66630cfa42eacffd777ae126e5692367fd8a6 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -47,8 +47,10 @@ WORKDIR /tmp
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl ca-certificates xz-utils binutils && \
-    curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${ARCH}-v0.7.5.tgz -o cni.tar.gz && \
-    tar -xvf cni.tar.gz ./loopback && \
+    curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${ARCH}-v0.8.6.tgz -o cni-plugins-linux-${ARCH}-v0.8.6.tgz && \
+    curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${ARCH}-v0.8.6.tgz.sha512 -o cni-plugins-linux-${ARCH}-v0.8.6.tgz.sha512 && \
+    sha512sum -c cni-plugins-linux-${ARCH}-v0.8.6.tgz.sha512 && \
+    tar -xvf cni-plugins-linux-${ARCH}-v0.8.6.tgz ./loopback && \
     strip -s ./loopback
 COPY --from=docker.io/cilium/cilium-llvm:178583d8925906270379830fb44641c38f7cc062 /bin/clang /bin/llc /bin/
 COPY --from=docker.io/cilium/cilium-bpftool:f0bbd0cb389ce92b33ff29f0489c17c8e33f9da7 /bin/bpftool /bin/


### PR DESCRIPTION
This version has a small fix in the IPv6 loopback CNI plugin. This
plugin is only installed in the system if there isn't already
installed.

Signed-off-by: André Martins <andre@cilium.io>