### PR TITLE
Host Policies can break kube if applied incorrectly. 

### DIFF
--- a/examples/policies/host/lock-down-ingress.yaml
+++ b/examples/policies/host/lock-down-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   nodeSelector:
     matchLabels:
-      type: worker
+      type: ingress-worker
   ingress:
   - toPorts:
     - ports:
@@ -20,3 +20,5 @@ spec:
         protocol: TCP
       - port: "8472"
         protocol: UDP
+      - port: "REMOVE_ME_AFTER_DOUBLE_CHECKING_PORTS"
+        protocol: TCP


### PR DESCRIPTION
If a user unintentionally applies an overly aggressive host-level netpolicy it
will break access to their nodes and break Kube. Given the blast radius of a
mistake and the undocumented fix, I discussed an initial solution in the docs
with Paul Chaignon and we agreed that a good start is preventing an example 
policy from loading until the user changes example values.

This has the benefit of explicitly requiring some thought from users before
applying a policy that could lead to a k8s outage.

Happy to discuss alternative ideas here but the goal is to protect operators
from breaking their environments while testing this feature.

Signed-off-by: Jed Salazar <jed@isovalent.com>