### PR TITLE
hubble: Bump images to v0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 #
 # Hubble CLI
 #
-FROM quay.io/cilium/hubble:v0.6.0@sha256:8dff5b76c99dea0f88b3ed27878380b9486f001741d60c33bcb1112607ca31ec as hubble
+FROM quay.io/cilium/hubble:v0.6.1@sha256:5155deebbf12546437978536d72ba2e87f093a542d979b42f4f95070f502cd73 as hubble
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -5,7 +5,7 @@ image:
   # tag is the container image tag to use.
   # Ref: https://github.com/cilium/hubble-ui/releases
   # Ref: https://quay.io/repository/cilium/hubble-ui?tab=tags
-  tag: v0.6.0
+  tag: v0.6.1
   # pullPolicy is the container image pull policy
   pullPolicy: IfNotPresent
 replicas: 1

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -773,7 +773,7 @@ spec:
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui
-          image: "quay.io/cilium/hubble-ui:v0.6.0"
+          image: "quay.io/cilium/hubble-ui:v0.6.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV


### PR DESCRIPTION
This bumps the docker image tags for Hubble and Hubble UI to v0.6.1. Neither versions contain any functional changes, only the underlying base images have been updated to address issues found by the Quay vulnerability scanner.