### PR TITLE
v1.8 backport 2020 06 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGI
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-06-08
+FROM quay.io/cilium/cilium-runtime:2020-06-26-v1.8@sha256:996c1580ea515937562c1ea74003354c9abb98733db55081188ea662f256dd6b
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776@sha256:9d3f6fb67ce3b910450378a7232ef1999c5bdff755457092155a11e5296ec346 as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 
 #
 # Hubble CLI
 #
-FROM quay.io/cilium/hubble:v0.6.0 as hubble
+FROM quay.io/cilium/hubble:v0.6.0@sha256:8dff5b76c99dea0f88b3ed27878380b9486f001741d60c33bcb1112607ca31ec as hubble
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-06-08 as builder
+FROM quay.io/cilium/cilium-builder:2020-06-08@sha256:06868f045a14e38e8ff0e8ac03d66630cfa42eacffd777ae126e5692367fd8a6 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Documentation/concepts/ebpf/lifeofapacket.rst
+++ b/Documentation/concepts/ebpf/lifeofapacket.rst
@@ -48,9 +48,7 @@ the normal flow.
 veth-based versus ipvlan-based datapath
 =======================================
 
-.. note:: The ipvlan-based datapath is currently only in technology preview
-          and to be used for experimentation purposes. This restriction will
-          be lifted in future Cilium releases.
+.. include:: ../../tech-preview.rst
 
 By default Cilium CNI operates in veth-based datapath mode which allows for
 more flexibility in that all BPF programs are managed by Cilium out of the host

--- a/Documentation/concepts/networking/ipam/kubernetes.rst
+++ b/Documentation/concepts/networking/ipam/kubernetes.rst
@@ -63,3 +63,11 @@ The following ConfigMap options exist to configure Kubernetes hostscope:
    an IPv4 PodCIDR is made available via the Kubernetes node resource.
  * ``k8s-require-ipv6-pod-cidr: true``: instructs the Cilium agent to wait until
    an IPv6 PodCIDR is made available via the Kubernetes node resource.
+
+With helm the previous options can be defined as:
+
+ * ``ipam: kubernetes``: ``--set config.ipam=kubernetes``.
+ * ``k8s-require-ipv4-pod-cidr: true``: ``--set global.k8s.requireIPv4PodCIDR=true``,
+   which only works with ``--set config.ipam=kubernetes``
+ * ``k8s-require-ipv6-pod-cidr: true``: ``--set global.k8s.requireIPv6PodCIDR=true``,
+   which only works with ``--set config.ipam=kubernetes``

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -188,15 +188,17 @@ framework in the ``test/`` directory and interact with ginkgo directly:
 ::
 
     $ cd test/
-    $ ginkgo . -- --help | grep -A 1 cilium
+    $ ginkgo . -- -cilium.help
       -cilium.SSHConfig string
             Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')
       -cilium.benchmarks
             Specifies benchmark tests should be run which may increase test time
+      -cilium.help
+            Display this help message.
       -cilium.holdEnvironment
             On failure, hold the environment in its current state
       -cilium.hubble-relay-image string
-            Specifies which image of Hubble Relay to use during tests
+            Specifies which image of hubble-relay to use during tests
       -cilium.image string
             Specifies which image of cilium to use during tests
       -cilium.kubeconfig string
@@ -214,7 +216,7 @@ framework in the ``test/`` directory and interact with ginkgo directly:
       -cilium.registry string
             docker registry hostname for Cilium image
       -cilium.runQuarantined
-        Run tests that are under quarantine.
+            Run tests that are under quarantine.
       -cilium.showCommands
             Output which commands are ran to stdout
       -cilium.skipLogs
@@ -223,6 +225,9 @@ framework in the ``test/`` directory and interact with ginkgo directly:
             Specifies scope of test to be ran (k8s, Nightly, runtime)
       -cilium.timeout duration
             Specifies timeout for test run (default 24h0m0s)
+
+    Ginkgo ran 1 suite in 5.04417992s
+    Test Suite Failed
 
 For more information about other built-in options to Ginkgo, consult the
 `Ginkgo documentation`_.

--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -10,9 +10,9 @@
 Networking and security observability with Hubble
 *************************************************
 
-This guide provides a walkthrough of setting up a local multi-node Kubernetes
-cluster on Docker using `kind <https://kind.sigs.k8s.io/>`_ in order to
-demonstrate some of Hubble's capabilities.
+This guide provides a walkthrough of setting up a local Kubernetes cluster with
+Hubble and Cilium installed, in order to demonstrate some of Hubble's
+capabilities.
 
 If you haven't read the :ref:`intro` yet, we'd encourage you to do that first.
 
@@ -20,33 +20,99 @@ The best way to get help if you get stuck is to ask a question on the `Cilium
 Slack channel <https://cilium.herokuapp.com>`_.  With Cilium contributors
 across the globe, there is almost always someone available to help.
 
-.. include:: kind-install.rst
+Set up a Kubernetes cluster
+===========================
+
+To run a Kubernetes cluster on your local machine, you have the choice to
+either set up a single-node cluster with
+`minikube <https://kubernetes.io/docs/setup/learning-environment/minikube/>`_,
+or a local multi-node cluster on Docker using
+`kind <https://kind.sigs.k8s.io/>`_:
+
+- ``minikube`` runs a single-node Kubernetes cluster inside a Virtual Machine
+  (VM) and is the easiest way to run a Kubernetes cluster locally.
+- ``kind`` runs a multi-node Kubernetes using Docker container to emulate
+  cluster nodes. It allows you to experiment with the cluster-wide observability
+  features of Hubble Relay.
+
+When unsure about the option to pick, follow the instructions for ``minikube``
+as it is less likely to cause friction.
+
+.. tabs::
+
+    .. group-tab:: Single-node cluster with ``minikube``
+
+        **Install kubectl & minikube**
+
+        .. include:: minikube-install.rst
+        .. include directive in tab requires three newlines to terminate correctly
+
+
+
+    .. group-tab:: Multi-node cluster with ``kind``
+
+        **Install dependencies**
+
+        .. include:: kind-install-deps.rst
+
+        **Configure kind**
+
+        .. include:: kind-configure.rst
+
+        **Create a cluster**
+
+        .. include:: kind-create-cluster.rst
+
+        **Preload images**
+
+        .. include:: kind-preload.rst
+        .. include directive in tab requires three newlines to terminate correctly
+
+
 
 Deploy Cilium and Hubble
 ========================
 
-.. include:: k8s-install-download-release.rst
-.. include:: kind-preload.rst
+This section shows how to install Cilium, enable Hubble and deploy Hubble
+Relay and Hubble's graphical UI.
 
-Install Cilium, enable Hubble and deploy Hubble Relay and Hubble's graphical UI
-in one command using Helm:
+.. tabs::
 
-.. parsed-literal::
+    .. group-tab:: Single-node cluster with ``minikube``
 
-   helm install cilium |CHART_RELEASE| \\
-      --namespace kube-system \\
-      --set global.nodeinit.enabled=true \\
-      --set global.kubeProxyReplacement=partial \\
-      --set global.hostServices.enabled=false \\
-      --set global.externalIPs.enabled=true \\
-      --set global.nodePort.enabled=true \\
-      --set global.hostPort.enabled=true \\
-      --set global.pullPolicy=IfNotPresent \\
-      --set config.ipam=kubernetes \\
-      --set global.hubble.enabled=true \\
-      --set global.hubble.listenAddress=":4244" \\
-      --set global.hubble.relay.enabled=true \\
-      --set global.hubble.ui.enabled=true
+       Deploy Hubble and Cilium with the provided pre-rendered YAML manifest:
+
+       .. parsed-literal::
+
+            kubectl create -f |SCM_WEB|/install/kubernetes/experimental-install.yaml
+
+    .. group-tab:: Multi-node cluster with ``kind``
+
+        .. include:: k8s-install-download-release.rst
+
+        Deploy Hubble and Cilium with the following Helm command:
+
+            .. parsed-literal::
+
+               helm install cilium |CHART_RELEASE| \\
+                  --namespace kube-system \\
+                  --set global.nodeinit.enabled=true \\
+                  --set global.kubeProxyReplacement=partial \\
+                  --set global.hostServices.enabled=false \\
+                  --set global.externalIPs.enabled=true \\
+                  --set global.nodePort.enabled=true \\
+                  --set global.hostPort.enabled=true \\
+                  --set global.pullPolicy=IfNotPresent \\
+                  --set config.ipam=kubernetes \\
+                  --set global.hubble.enabled=true \\
+                  --set global.hubble.listenAddress=":4244" \\
+                  --set global.hubble.relay.enabled=true \\
+                  --set global.hubble.ui.enabled=true
+
+.. note::
+
+    Please note that Hubble Relay and Hubble UI are currently in beta status
+    and are not yet recommended for production use.
 
 Validate the Installation
 =========================
@@ -236,5 +302,14 @@ Cleanup
 Once you are done experimenting with Hubble, you can remove all traces of the
 cluster by running the following command:
 
-.. parsed-literal::
-   kind delete cluster
+.. tabs::
+
+    .. group-tab:: Single-node cluster with ``minikube``
+
+        .. parsed-literal::
+           minikube delete
+
+    .. group-tab:: Multi-node cluster with ``kind``
+
+        .. parsed-literal::
+           kind delete cluster

--- a/Documentation/gettingstarted/kind-configure.rst
+++ b/Documentation/gettingstarted/kind-configure.rst
@@ -1,21 +1,3 @@
-Install Dependencies
-====================
-
-1. Install ``docker`` stable as described in
-   `Install Docker Engine <https://docs.docker.com/engine/install/>`_
-
-2. Install ``kubectl`` version >= v1.14.0 as described in the
-   `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
-
-3. Install ``helm`` >= v3.0.3 per Helm documentation:
-   `Installing Helm <https://helm.sh/docs/intro/install/>`_
-
-4. Install ``kind`` >= v0.7.0 per kind documentation:
-   `Installation and Usage <https://kind.sigs.k8s.io/#installation-and-usage>`_
-
-Configure kind
-==============
-
 Configuring kind cluster creation is done using a YAML configuration file.
 This step is necessary in order to disable the default CNI and replace it with
 Cilium.
@@ -53,26 +35,3 @@ documentation for more information.
            disableDefaultCNI: true
            podSubnet: "10.10.0.0/16"
            serviceSubnet: "10.11.0.0/16"
-
-Create a cluster
-================
-
-To create a cluster with the configuration defined above, pass the
-``kind-config.yaml`` you created with the ``--config`` flag of kind.
-
-.. code:: bash
-
-    kind create cluster --config=kind-config.yaml
-
-After a couple of seconds or minutes, a 4 nodes cluster should be created.
-
-A new ``kubectl`` context (``kind-kind``) should be added to ``KUBECONFIG`` or, if unset,
-to ``${HOME}/.kube/config``:
-
-.. code:: bash
-
-    kubectl cluster-info --context kind-kind
-
-.. note::
-   The cluster nodes will remain in state ``NotReady`` until Cilium is deployed.
-   This behavior is expected.

--- a/Documentation/gettingstarted/kind-create-cluster.rst
+++ b/Documentation/gettingstarted/kind-create-cluster.rst
@@ -1,0 +1,19 @@
+To create a cluster with the configuration defined above, pass the
+``kind-config.yaml`` you created with the ``--config`` flag of kind.
+
+.. code:: bash
+
+    kind create cluster --config=kind-config.yaml
+
+After a couple of seconds or minutes, a 4 nodes cluster should be created.
+
+A new ``kubectl`` context (``kind-kind``) should be added to ``KUBECONFIG`` or, if unset,
+to ``${HOME}/.kube/config``:
+
+.. code:: bash
+
+    kubectl cluster-info --context kind-kind
+
+.. note::
+   The cluster nodes will remain in state ``NotReady`` until Cilium is deployed.
+   This behavior is expected.

--- a/Documentation/gettingstarted/kind-install-deps.rst
+++ b/Documentation/gettingstarted/kind-install-deps.rst
@@ -1,0 +1,11 @@
+1. Install ``docker`` stable as described in
+   `Install Docker Engine <https://docs.docker.com/engine/install/>`_
+
+2. Install ``kubectl`` version >= v1.14.0 as described in the
+   `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
+
+3. Install ``helm`` >= v3.0.3 per Helm documentation:
+   `Installing Helm <https://helm.sh/docs/intro/install/>`_
+
+4. Install ``kind`` >= v0.7.0 per kind documentation:
+   `Installation and Usage <https://kind.sigs.k8s.io/#installation-and-usage>`_

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -14,7 +14,20 @@ This guide uses `kind <https://kind.sigs.k8s.io/>`_ to demonstrate deployment
 and operation of Cilium in a multi-node Kubernetes cluster running locally on
 Docker.
 
-.. include:: kind-install.rst
+Install Dependencies
+====================
+
+.. include:: kind-install-deps.rst
+
+Configure kind
+==============
+
+.. include:: kind-configure.rst
+
+Create a cluster
+================
+
+.. include:: kind-create-cluster.rst
 
 .. _kind_install_cilium:
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -369,7 +369,7 @@ implementations for Kubernetes such as `MetalLB <https://metallb.universe.tf/>`_
 acceleration can be enabled only on a single device which is used for direct routing.
 
 For high-scale environments, also consider tweaking the default map sizes to a larger
-number of entries e.g. through setting a higher ``global.bpf.mapDynamicSizeRatio``.
+number of entries e.g. through setting a higher ``config.bpfMapDynamicSizeRatio``.
 See :ref:`bpf_map_limitations` for further details.
 
 The ``global.nodePort.acceleration`` setting is supported for DSR, SNAT and hybrid

--- a/Documentation/gettingstarted/minikube-install.rst
+++ b/Documentation/gettingstarted/minikube-install.rst
@@ -1,0 +1,36 @@
+1. Install ``kubectl`` version >= v1.10.0 as described in the
+   `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
+
+2. Install ``minikube`` >= v1.3.1 as per minikube documentation:
+   `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
+
+.. note::
+
+   It is important to validate that you have minikube v1.3.1 installed. Older
+   versions of minikube are shipping a kernel configuration that is *not*
+   compatible with the TPROXY requirements of Cilium >= 1.6.0.
+
+::
+
+     minikube version
+     minikube version: v1.3.1
+     commit: ca60a424ce69a4d79f502650199ca2b52f29e631
+
+3. Create a minikube cluster:
+
+::
+
+     minikube start --network-plugin=cni --memory=4096
+
+4. Mount the BPF filesystem
+
+::
+
+     minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf
+
+.. note::
+
+   In case of installing Cilium for a specific Kubernetes version, the
+   ``--kubernetes-version vx.y.z`` parameter can be appended to the ``minikube
+   start`` command for bootstrapping the local cluster. By default, minikube
+   will install the most recent version of Kubernetes.

--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -18,41 +18,7 @@ that run on Linux, macOS, and Windows.
 Install kubectl & minikube
 ==========================
 
-1. Install ``kubectl`` version >= v1.10.0 as described in the `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_.
-
-2. Install ``minikube`` >= v1.3.1 as per minikube documentation: `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
-
-.. note::
-
-   It is important to validate that you have minikube v1.3.1 installed. Older
-   versions of minikube are shipping a kernel configuration that is *not*
-   compatible with the TPROXY requirements of Cilium >= 1.6.0.
-
-::
-
-     minikube version
-     minikube version: v1.3.1
-     commit: ca60a424ce69a4d79f502650199ca2b52f29e631
-
-3. Create a minikube cluster:
-
-::
-
-     minikube start --network-plugin=cni --memory=4096
-
-4. Mount the BPF filesystem
-
-::
-
-     minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf
-
-.. note::
-
-   In case of installing Cilium for a specific Kubernetes version, the
-   ``--kubernetes-version vx.y.z`` parameter can be appended to the ``minikube
-   start`` command for bootstrapping the local cluster. By default, minikube
-   will install the most recent version of Kubernetes.
-
+.. include:: minikube-install.rst
 .. include:: quick-install.rst
 .. include:: k8s-install-validate.rst
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -165,7 +165,7 @@ the initial deployment:
 
       helm template |CHART_RELEASE| \\
         --set config.upgradeCompatibility=1.7 \\
-        --agent.keepDeprecatedProbes=true \\
+        --set agent.keepDeprecatedProbes=true \\
         --namespace kube-system \\
         > cilium.yaml
       kubectl apply -f cilium.yaml
@@ -179,7 +179,7 @@ the initial deployment:
       helm upgrade cilium |CHART_RELEASE| \\
         --namespace=kube-system \\
         --set config.upgradeCompatibility=1.7 \\
-        --agent.keepDeprecatedProbes=true
+        --set agent.keepDeprecatedProbes=true
 
 .. note::
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1067,6 +1067,8 @@ for instructions.
 Host Policies
 =============
 
+.. include:: ../tech-preview.rst
+
 Host policies take the form of a `CiliumClusterwideNetworkPolicy` with a
 :ref:`NodeSelector` instead of an `EndpointSelector`. Host policies can have
 layer 3 and layer 4 rules on both ingress and egress. They cannot have layer

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -542,6 +542,7 @@ pre
 prebuild
 prefilter
 preflight
+preload
 prem
 prepend
 priori

--- a/Documentation/tech-preview.rst
+++ b/Documentation/tech-preview.rst
@@ -1,0 +1,3 @@
+.. note:: This feature is currently only in technology preview and to be used
+          for experimentation purposes. This restriction will be lifted in
+          future Cilium releases.

--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-aws /usr/bin/cilium-operator-aws
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator-aws"]

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-azure /usr/bin/cilium-operator-azure
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator-azure"]

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-generic /usr/bin/cilium-operator-generic
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator-generic"]

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -17,11 +17,23 @@ ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
+FROM docker.io/library/golang:1.14.4 as gops
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
+RUN go get -d github.com/google/gops && \
+    cd /go/src/github.com/google/gops && \
+    git checkout -b v0.3.6 v0.3.6 && \
+    git --no-pager remote -v && \
+    git --no-pager log -1 && \
+    CGO_ENABLED=0 go install && \
+    strip /go/bin/gops
+
 FROM scratch
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
 CMD ["/usr/bin/cilium-operator"]

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -47,8 +47,10 @@ WORKDIR /tmp
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl ca-certificates xz-utils binutils && \
-    curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${ARCH}-v0.7.5.tgz -o cni.tar.gz && \
-    tar -xvf cni.tar.gz ./loopback && \
+    curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${ARCH}-v0.8.6.tgz -o cni-plugins-linux-${ARCH}-v0.8.6.tgz && \
+    curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${ARCH}-v0.8.6.tgz.sha512 -o cni-plugins-linux-${ARCH}-v0.8.6.tgz.sha512 && \
+    sha512sum -c cni-plugins-linux-${ARCH}-v0.8.6.tgz.sha512 && \
+    tar -xvf cni-plugins-linux-${ARCH}-v0.8.6.tgz ./loopback && \
     strip -s ./loopback
 COPY --from=docker.io/cilium/cilium-llvm:178583d8925906270379830fb44641c38f7cc062 /bin/clang /bin/llc /bin/
 COPY --from=docker.io/cilium/cilium-bpftool:f0bbd0cb389ce92b33ff29f0489c17c8e33f9da7 /bin/bpftool /bin/

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -9,6 +9,7 @@
 {{- $defaultBpfCtTcpMax := 524288 -}}
 {{- $defaultBpfCtAnyMax := 262144 -}}
 {{- $enableIdentityMark := "true" -}}
+{{- $fragmentTracking := "true" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -401,6 +402,12 @@ data:
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nativeRoutingCIDR }}
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
+{{- end }}
+
+{{- if hasKey .Values "fragmentTracking" }}
+  enable-ipv4-fragment-tracking: {{ .Values.fragmentTracking | quote }}
+{{- else if (ne $fragmentTracking "true") }}
+  enable-ipv4-fragment-tracking: "false"
 {{- end }}
 
 {{- if .Values.global.hostFirewall }}

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -23,7 +23,11 @@ spec:
 {{- end }}
       containers:
         - name: node-init
-          image: docker.io/cilium/startup-script:af2a99046eca96c0138551393b21a5c044c7fe79
+{{- if contains "/" .Values.image }}
+          image: "{{ .Values.image }}:{{ .Values.tag }}"
+{{- else }}
+          image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.tag }}"
+{{- end }}
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -1,3 +1,6 @@
+image: startup-script
+tag: af2a99046eca96c0138551393b21a5c044c7fe79
+
 # Restart existing pods when initializing the node to force all pods being
 # managed by Cilium (GKE, EKS)
 restartPods: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -281,13 +281,6 @@ global:
     # policyMapMax is the maximum number of entries in endpoint policy map (per endpoint)
     policyMapMax: 16384
 
-    # mapDynamicSizeRatio is the ratio (0.0-1.0) of total system memory to use
-    # for dynamic sizing of CT, NAT, neighbor and SockRevNAT BPF maps. If set to
-    # 0.0, dynamic sizing of BPF maps is disabled. The default value of 0.0025
-    # (0.25%) leads to approximately the default CT size kube-proxy sets on a
-    # node with 16 GiB of total system memory.
-    mapDynamicSizeRatio: 0.0025
-
     # monitorAggregation is the level of aggregation for datapath trace events
     monitorAggregation: medium
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -321,6 +321,9 @@ global:
     # interface is the interface to use for encryption
     # interface: eth0
 
+  # fragmentTracking enables IPv4 fragment tracking support in the datapath.
+  fragmentTracking: true
+
   # hostFirewall enables the enforcement of host policies in the BPF datapath
   hostFirewall: false
 

--- a/pkg/hubble/peer/buffer.go
+++ b/pkg/hubble/peer/buffer.go
@@ -89,6 +89,13 @@ func (b *buffer) Pop() (*peerpb.ChangeNotification, error) {
 			return nil, io.EOF
 		}
 	}
+	//While waiting for b.mu.Lock, b.buffer may be closed.
+	select {
+	case <-b.stop:
+		b.mu.Unlock()
+		return nil, io.EOF
+	default:
+	}
 	cn := b.buf[0]
 	b.buf[0] = nil
 	b.buf = b.buf[1:]

--- a/pkg/hubble/peer/buffer_test.go
+++ b/pkg/hubble/peer/buffer_test.go
@@ -82,3 +82,20 @@ func TestBufferPop(t *testing.T) {
 	assert.Equal(t, 0, buf.Len())
 	assert.Equal(t, 0, buf.Cap())
 }
+
+func TestBufferPopWithClosedStopChan(t *testing.T) {
+	max := 8
+	buf := newBuffer(max)
+	assert.NotNil(t, buf)
+	assert.Equal(t, 0, buf.Len())
+	assert.Equal(t, 0, buf.Cap())
+
+	for i := 0; i < max; i++ {
+		assert.NoError(t, buf.Push(&peerpb.ChangeNotification{}))
+		assert.Equal(t, i+1, buf.Len())
+	}
+	close(buf.stop)
+	cn, err := buf.Pop()
+	assert.Nil(t, cn)
+	assert.Equal(t, io.EOF, err)
+}

--- a/pkg/hubble/peer/buffer_test.go
+++ b/pkg/hubble/peer/buffer_test.go
@@ -17,6 +17,7 @@
 package peer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -39,6 +40,12 @@ func TestBufferPush(t *testing.T) {
 	err := buf.Push(&peerpb.ChangeNotification{})
 	assert.Equal(t, fmt.Errorf("max buffer size=%d reached", max), err)
 	assert.Equal(t, max, buf.Len())
+
+	buf.Close()
+	err = buf.Push(&peerpb.ChangeNotification{})
+	assert.Equal(t, errors.New("buffer closed"), err)
+	assert.Equal(t, 0, buf.Len())
+
 }
 
 func TestBufferPop(t *testing.T) {

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -46,6 +46,7 @@ type CiliumTestConfigType struct {
 	// node. If false, some tests will silently skip multinode checks.
 	Multinode      bool
 	RunQuarantined bool
+	Help           bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -54,7 +55,7 @@ var CiliumTestConfig = CiliumTestConfigType{}
 
 // ParseFlags parses commandline flags relevant to testing.
 func (c *CiliumTestConfigType) ParseFlags() {
-	flagset := flag.NewFlagSet("cilium", flag.PanicOnError)
+	flagset := flag.NewFlagSet("cilium", flag.ExitOnError)
 	flagset.BoolVar(&c.Reprovision, "cilium.provision", true,
 		"Provision Vagrant boxes and Cilium before running test")
 	flagset.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
@@ -88,10 +89,14 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Enable tests across multiple nodes. If disabled, such tests may silently pass")
 	flagset.BoolVar(&c.RunQuarantined, "cilium.runQuarantined", false,
 		"Run tests that are under quarantine.")
+	flagset.BoolVar(&c.Help, "cilium.help", false, "Display this help message.")
 
 	args := make([]string, 0, len(os.Args))
 	for index, flag := range os.Args {
-		if strings.Contains(flag, "-cilium") {
+		if flag == "-cilium.help" {
+			flagset.PrintDefaults()
+			os.Exit(1)
+		} else if strings.Contains(flag, "-cilium") {
 			args = append(args, flag)
 			os.Args[index] = ""
 		}

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -77,6 +77,9 @@ func (res *CmdRes) SendToLog(quietMode bool) {
 
 	logformat := "cmd: %q exitCode: %d duration: %s stdout:\n%s\n"
 	log := fmt.Sprintf(logformat, res.cmd, res.GetExitCode(), res.duration, res.stdout.String())
+	if res.err != nil {
+		log = fmt.Sprintf("%serr:\n%s\n", log, res.err)
+	}
 	if res.stderr.Len() > 0 {
 		log = fmt.Sprintf("%sstderr:\n%s\n", log, res.stderr.String())
 	}
@@ -315,9 +318,14 @@ func (res *CmdRes) OutputPrettyPrint() string {
 		return strings.Join(result, "\n")
 
 	}
+	errStr := ""
+	if res.err != nil {
+		errStr = fmt.Sprintf("Err: %s\n", res.err)
+	}
 	return fmt.Sprintf(
-		"Exitcode: %d \nStdout:\n %s\nStderr:\n %s\n",
+		"Exitcode: %d \n%sStdout:\n %s\nStderr:\n %s\n",
 		res.GetExitCode(),
+		errStr,
 		format(res.GetStdOut()),
 		format(res.GetStdErr()))
 }


### PR DESCRIPTION
v1.8 backports 2020-06-26

 * #12257 -- hubble/peer: fix buf.Pop() crash issue (@Jianlin-lv)
 * #12271 -- docs: fix set flag in upgrade guide (@aanm)
 * #12102 -- install/kubernetes: Helm option for fragment tracking (@pchaigno)
 * #12267 -- test: Fix ginkgo -cilium help output (@pchaigno)
 * #12276 -- docs: clarify helm options for kubernetes ipam (@aanm)
 * #12275 -- install/kubernetes: remove mapDynamicSizeRatio leftover (@aanm)
 * #12262 -- docs: Support minikube in Hubble getting started guide (@gandro)
 * #12254 -- build: install gops binary in operator images (@tklauser)
 * #12269 -- hubble:Add unit test for Pop with closed stop chan (@Jianlin-lv)
 * #12239 -- test: Display error in case command fails (@pchaigno)
 * #12287 -- packaging/docker: update cni loopback to 0.8.6 (@aanm)
 * #12274 -- Helm: Make nodeinit image, tag and registry configurable using helm values (@seanmwinn)
 * #12272 -- docs: Mark host-policies as tech preview (@joestringer)
 * #12285 -- hubble/peer: prevent pushing to buffer when it's closed (@Rolinh)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12257 12271 12102 12267 12276 12275 12262 12254 12269 12239 12287 12274 12272 12285; do contrib/backporting/set-labels.py $pr done 1.8; done
```