### PR TITLE
[DEBUG] proxy_test: evaluate rtt value for DNS requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ tests-privileged:
 	# cilium-map-migrate is a dependency of some unit tests.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf cilium-map-migrate
 	$(MAKE) init-coverage
-	for pkg in $(patsubst %,github.com/cilium/cilium/%,$(PRIV_TEST_PKGS)); do \
+	for pkg in github.com/cilium/cilium/pkg/fqdn/dnsproxy; do \
 		PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) $(TEST_LDFLAGS) $$pkg $(GOTEST_PRIV_OPTS) $(GOTEST_COVER_OPTS) \
 		|| exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out; \


### PR DESCRIPTION
As an attempt to debug a flake in the runtime privileged tests where the DNS request times out, runs the relevant test many times (10^6) and observe the RTT duration to see if it sometimes get longer than the current timeout value used for the server (100ms).

On my local setup I get 1 run out of 20k at more than 10ms, and 1 in 1M above 30ms, so the 100ms seems way enough... But let's see what Jenkins says.

Tweak test files and Makefile to run just the function we want, and make sure we fail at the end so we get logs.
