### PR TITLE
docs: fix enableIdentityMark helm chart option

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -79,7 +79,7 @@ Deploy Cilium release via Helm:
       --set global.cni.configMap=cni-configuration \\
       --set global.tunnel=disabled \\
       --set global.masquerade=false \\
-      --set global.enableIdentityMark=false
+      --set config.enableIdentityMark=false
 
 .. note::
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -352,7 +352,7 @@ data:
   cni-chaining-mode: {{ .Values.global.cni.chainingMode }}
 
 {{- if hasKey .Values "enableIdentityMark"}}
-  enable-identity-mark: {{ .Values.global.enableIdentityMark | quote }}
+  enable-identity-mark: {{ .Values.enableIdentityMark | quote }}
 {{- else if (ne $enableIdentityMark "true") }}
   enable-identity-mark: "false"
 {{- end }}


### PR DESCRIPTION
This option exist in the 'config' chart so we should set it with
`config.enableIdentityMark` and not with `global.enableIdentityMark'

Fixes: 1cc79c1fb522 ("cilium: chaining mode skb->mark can be mangled by iptables allow opt-out")
Signed-off-by: André Martins <andre@cilium.io>