### PR TITLE
.github/cilium-actions: remove github action helper message

### DIFF
--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -39,9 +39,8 @@ require-msgs-in-commit:
 block-pr-with:
   labels-unset:
     - regex-label: "release-note/.*"
-      helper: "Please set the appropriate release note label."
       set-labels:
-        - "dont-merge/needs-release-note"
+        - "dont-merge/needs-release-note-label"
   labels-set:
     - regex-label: "dont-merge/.*"
       helper: "Blocking mergeability of PR as 'dont-merge/.*' labels are set"


### PR DESCRIPTION
Setting a label to avoid the PR from being merged should be sufficient
for a Cilium janitor to set the appropriate release note label of a
particular PR. Having a helper message might also be confusing for new
corners where they won't be able to set labels for a PR so it might be
confusing for them to fix the errors presented by the maintainer's
little helper.

Signed-off-by: André Martins <andre@cilium.io>