### PR TITLE
ci: Check for gke nodepool before locking cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ test/gke/cluster-uri
 test/gke/cluster-version
 test/gke/gke-kubeconfig
 test/gke/resize-kubeconfig
+test/gke/registry-adder.yaml
 
 # Emacs backup files
 *~

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -20,6 +20,13 @@ while [ $locked -ne 0 ]; do
     echo "selecting random cluster"
     cluster_uri="$(gcloud container clusters list --project "${project}" --filter="name ~ ^cilium-ci-" --uri | sort -R | head -n 1)"
 
+	echo "checking whether cluster ${cluster_uri} has any node pools"
+	node_pools=$(gcloud container node-pools list --project "${project}" --region "${region}" --cluster "${cluster_uri}" --format="value(name)")
+	if [ -z "${node_pools}" ]; then
+		echo "no nodepools found, selecting another cluster"
+		continue
+	fi
+
     echo "getting kubeconfig for ${cluster_uri} (will store in ${KUBECONFIG})"
     gcloud container clusters get-credentials --project "${project}" --region "${region}" "${cluster_uri}"
 


### PR DESCRIPTION
If the cluster has just been recreated, it can have no nodepool yet.
Don't choose such clusters because scaling it will fail.