### PR TITLE
docs: Fix bpfMasquerade option

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -44,7 +44,7 @@ eBPF-based
 
 The eBPF-based implementation is the most efficient
 implementation. It requires Linux kernel 4.19 and can be enabled with
-the ``global.bpfMasquerade=true`` helm option (enabled by default).
+the ``config.bpfMasquerade=true`` helm option (enabled by default).
 
 The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-free>`.
 The dependency will be removed in the Cilium v1.9 release.

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2181,7 +2181,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 
 		if RunsOnNetNextOr419Kernel() {
-			opts["global.bpfMasquerade"] = "true"
+			opts["config.bpfMasquerade"] = "true"
 		}
 
 		for key, value := range opts {


### PR DESCRIPTION
The value of bpfMasquerade should be coming from config chart only.
However, few places are still referring to global.

Relates 8ec15e20c

```release-note
docs: Fix bpfMasquerade option
```


Fixes https://github.com/cilium/cilium/issues/12219