### PR TITLE
bpf: Share __NR_CPUS__ value with Golang side

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -36,6 +36,7 @@ NODE_PORT_BIND=${18}
 MCPU=${19}
 NODE_PORT_IPV4_ADDRS=${20}
 NODE_PORT_IPV6_ADDRS=${21}
+NR_CPUS=${22}
 
 ID_HOST=1
 ID_WORLD=2
@@ -271,18 +272,18 @@ function bpf_compile()
 	TYPE=$3
 	EXTRA_OPTS=$4
 
-	clang -O2 -target bpf -std=gnu89 -nostdinc -emit-llvm		\
-	      -Wall -Wextra -Werror -Wshadow				\
-	      -Wno-address-of-packed-member				\
-	      -Wno-unknown-warning-option				\
-	      -Wno-gnu-variable-sized-type-not-at-end			\
-	      -Wdeclaration-after-statement				\
-	      -I. -I$DIR -I$LIB -I$LIB/include				\
-	      -D__NR_CPUS__=$(nproc --all)					\
-	      -DENABLE_ARP_RESPONDER=1					\
-	      -DHANDLE_NS=1						\
-	      $EXTRA_OPTS						\
-	      -c $LIB/$IN -o - |					\
+	clang -O2 -target bpf -std=gnu89 -nostdinc -emit-llvm	\
+	      -Wall -Wextra -Werror -Wshadow			\
+	      -Wno-address-of-packed-member			\
+	      -Wno-unknown-warning-option			\
+	      -Wno-gnu-variable-sized-type-not-at-end		\
+	      -Wdeclaration-after-statement			\
+	      -I. -I$DIR -I$LIB -I$LIB/include			\
+	      -D__NR_CPUS__=$NR_CPUS				\
+	      -DENABLE_ARP_RESPONDER=1				\
+	      -DHANDLE_NS=1					\
+	      $EXTRA_OPTS					\
+	      -c $LIB/$IN -o - |				\
 	llc -march=bpf -mcpu=$MCPU -mattr=dwarfris -filetype=$TYPE -o $OUT
 }
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -63,6 +63,7 @@ const (
 	initBPFCPU
 	initArgNodePortIPv4Addrs
 	initArgNodePortIPv6Addrs
+	initArgNrCPUs
 	initArgMax
 )
 
@@ -286,6 +287,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	args[initBPFCPU] = GetBPFCPU()
+	args[initArgNrCPUs] = fmt.Sprintf("%d", common.GetNumPossibleCPUs(log))
 
 	clockSource := []string{"ktime", "jiffies"}
 	log.Infof("Setting up base BPF datapath (BPF %s instruction set, %s clock source)",


### PR DESCRIPTION
On Golang side we get the number of CPUs from `/sys/devices/system/cpu/possible`. On BPF side, we use `$(nproc -all)`. `nproc` calls `num_processors()` from the gnulib. That function, however, may not always return the value from the `/sys` file above.

Instead, we should use the exact same source as Golang side to ensure both sides have the same value and avoid issues later on. See #12070 for details.

The `__NR_CPUS__` values in `test/bpf/Makefile` and `bpf/Makefile.bpf` do not need to be in sync. with Golang values because these files are only used for unit tests, sparse, and compile testing.

Fixes: #12121
/cc @gandro 

```release-note
Fix silent cilium monitor on systems with offline CPUs
```