### PR TITLE
Correct help string for kubernetes_events_received_total metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -918,7 +918,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			KubernetesEventReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
 				Namespace: Namespace,
 				Name:      "kubernetes_events_received_total",
-				Help:      "Number of Kubernetes events processed labeled by scope, action and execution result",
+				Help:      "Number of Kubernetes events received labeled by scope, action, valid data and equalness",
 			}, []string{LabelScope, LabelAction, "valid", "equal"})
 
 			collectors = append(collectors, KubernetesEventReceived)


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

While looking at some Cilium metrics I found that the help string between `kubernetes_events_received_total` and `kubernetes_events_total` is the same which is not true given `kubernetes_events_received_total` represents something different.

