### PR TITLE
daemon: Skip devices without hardware address during device detection

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -356,6 +356,14 @@ func disableNodePort() {
 	option.Config.EnableExternalIPs = false
 }
 
+func hasHardwareAddress(ifIndex int) bool {
+	iface, err := netlink.LinkByIndex(ifIndex)
+	if err != nil {
+		return false
+	}
+	return len(iface.Attrs().HardwareAddr) > 0
+}
+
 // detectDevices tries to detect device names which are going to be used for
 // (a) NodePort BPF, (b) direct routing in NodePort BPF.
 //
@@ -374,7 +382,9 @@ func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 			"Cannot retrieve host IP addrs for BPF NodePort device detection")
 	} else {
 		for _, a := range addrs {
-			ifidxByAddr[a.IP.String()] = a.LinkIndex
+			if hasHardwareAddress(a.LinkIndex) {
+				ifidxByAddr[a.IP.String()] = a.LinkIndex
+			}
 		}
 	}
 


### PR DESCRIPTION
We need NodePort and direct routing devices to have a MAC address. If they don't, init.sh fails with the following error:

    level=warning msg="+ for NATIVE_DEV in ${NATIVE_DEVS//;/ }" subsys=datapath-loader
    level=warning msg="++ cat /sys/class/net/lo/ifindex" subsys=datapath-loader
    level=warning msg="+ IDX=1" subsys=datapath-loader
    level=warning msg="++ ip link show lo" subsys=datapath-loader
    level=warning msg="++ grep ether" subsys=datapath-loader
    level=warning msg="++ awk '{print $2}'" subsys=datapath-loader
    level=warning msg="+ MAC=" subsys=datapath-loader
    level=error msg="Error while initializing daemon" error="exit status 1" subsys=daemon
    level=fatal msg="Error while creating daemon" error="exit status 1" subsys=daemon

Thus, we need to skip auto-detected devices that don't have a MAC address. This commit implements that and was tested by injecting a loopback interface with an IP address in the code, in the dev. VM:

    loAddr, err := netlink.ParseAddr("192.168.33.11/32")
    if err == nil {
        loAddr.LinkIndex = 1
        addrs = append(addrs, *loAddr)
    }

Fixes: #12228
Fixes: #12304
Fixes: #11894
/cc @brb 

```release-note
Fix failure to start agent when detected devices don't have hardware addresses
```