### PR TITLE
fix(9966): fix creation of multiple KVStore watchers for CNPs and CCNPs

### DIFF
--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -23,12 +23,12 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy/groups"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -57,19 +57,22 @@ func enableCCNPWatcher() error {
 	}
 
 	if kvstoreEnabled() {
+		ccnpStatusMgr = k8s.NewCCNPStatusEventHandler(ccnpStore, operatorOption.Config.CNPStatusUpdateInterval)
 		ccnpSharedStore, err := store.JoinSharedStore(store.Configuration{
 			Prefix: k8s.CCNPStatusesPath,
 			KeyCreator: func() store.Key {
 				return &k8s.CNPNSWithMeta{}
 			},
+			Observer: ccnpStatusMgr,
 		})
 		if err != nil {
 			return err
 		}
 
-		ccnpStatusMgr = k8s.NewCCNPStatusEventHandler(ccnpSharedStore, ccnpStore, operatorOption.Config.CNPStatusUpdateInterval)
-
-		go ccnpStatusMgr.WatchForCCNPStatusEvents()
+		// It is safe to update the CCNP store here given the CCNP Store
+		// will only be used by StartStatusHandler method which is used in the
+		// cilium v2 controller below.
+		ccnpStatusMgr.UpdateCNPStore(ccnpSharedStore)
 	}
 
 	ciliumV2Controller := informer.NewInformerWithStore(

--- a/pkg/k8s/ccnpstatus.go
+++ b/pkg/k8s/ccnpstatus.go
@@ -15,16 +15,15 @@
 package k8s
 
 import (
-	"context"
 	"path"
 	"time"
 
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 
 	"k8s.io/client-go/tools/cache"
 )
 
+// CCNPStatusesPath is the KVStore key prefix for CCNP status
 var CCNPStatusesPath = path.Join(kvstore.BaseKeyPrefix, "state", "ccnpstatuses", "v2")
 
 // CCNPStatusEventHandler handles status updates events for all the CCNPs
@@ -39,19 +38,8 @@ type CCNPStatusEventHandler struct {
 
 // NewCCNPStatusEventHandler returns a new CCNPStatusEventHandler.
 // which is more or less a wrapper around the CNPStatusEventHandler itself.
-func NewCCNPStatusEventHandler(cnpStore *store.SharedStore, k8sStore cache.Store, updateInterval time.Duration) *CCNPStatusEventHandler {
+func NewCCNPStatusEventHandler(k8sStore cache.Store, updateInterval time.Duration) *CCNPStatusEventHandler {
 	return &CCNPStatusEventHandler{
-		CNPStatusEventHandler: NewCNPStatusEventHandler(cnpStore, k8sStore, updateInterval),
-	}
-}
-
-// WatchForCCNPStatusEvents starts a watcher for all the Clusterwide policy
-// updates from the key-value store.
-func (c *CCNPStatusEventHandler) WatchForCCNPStatusEvents() {
-	watcher := kvstore.Client().ListAndWatch(context.TODO(), "ccnpStatusWatcher", CCNPStatusesPath, 512)
-
-	// Loop and block for this network policy watch event.
-	for {
-		c.watchForCNPStatusEvents(watcher)
+		CNPStatusEventHandler: NewCNPStatusEventHandler(k8sStore, updateInterval),
 	}
 }


### PR DESCRIPTION
* Fixes #9966
* Implement Observer for CNPStatusEventHandler to remove the need of extra
  KVstore watcher.

