### PR TITLE
docs: Switch hostfw tech-preview -> beta

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1065,13 +1065,12 @@ that do not need it. See the `Kubernetes documentation <https://kubernetes.io/do
 for instructions.
 
 
-
 .. _HostPolicies:
 
-Host Policies
-=============
+Host Policies (beta)
+====================
 
-.. include:: ../tech-preview.rst
+.. include:: ../beta.rst
 
 Host policies take the form of a `CiliumClusterwideNetworkPolicy` with a
 :ref:`NodeSelector` instead of an `EndpointSelector`. Host policies can have


### PR DESCRIPTION
After discussion from the Cilium community meeting, we determined that
the beta designation is more appropriate for the state of the host
firewall feature.