### PR TITLE
v1.8 backports 2020-06-29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 #
 # Hubble CLI
 #
-FROM quay.io/cilium/hubble:v0.6.0@sha256:8dff5b76c99dea0f88b3ed27878380b9486f001741d60c33bcb1112607ca31ec as hubble
+FROM quay.io/cilium/hubble:v0.6.1@sha256:5155deebbf12546437978536d72ba2e87f093a542d979b42f4f95070f502cd73 as hubble
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -28,6 +28,7 @@ cilium-operator-aws [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -28,6 +28,7 @@ cilium-operator-azure [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -26,6 +26,7 @@ cilium-operator-generic [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -30,6 +30,7 @@ cilium-operator [flags]
       --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
+      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                   Enable debugging mode
       --enable-ipv4                             Enable IPv4 support (default true)
       --enable-ipv6                             Enable IPv6 support (default true)

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -44,7 +44,7 @@ eBPF-based
 
 The eBPF-based implementation is the most efficient
 implementation. It requires Linux kernel 4.19 and can be enabled with
-the ``global.bpfMasquerade=true`` helm option (enabled by default).
+the ``config.bpfMasquerade=true`` helm option (enabled by default).
 
 The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-free>`.
 The dependency will be removed in the Cilium v1.9 release.

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -79,7 +79,7 @@ Deploy Cilium release via Helm:
       --set global.cni.configMap=cni-configuration \\
       --set global.tunnel=disabled \\
       --set global.masquerade=false \\
-      --set global.enableIdentityMark=false
+      --set config.enableIdentityMark=false
 
 .. note::
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -308,6 +308,10 @@ init
     security identity has not been resolved yet. This is typically only
     observed in non-Kubernetes environments. See section
     :ref:`endpoint_lifecycle` for details.
+health
+    The health entity represents the health endpoints, used to check cluster
+    connectivity health. Each node managed by Cilium hosts a health endpoint.
+    See `cluster_connectivity_health` for details on health checks.
 world
     The world entity corresponds to all endpoints outside of the cluster.
     Allowing to world is identical to allowing to CIDR 0/0. An alternative

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1065,13 +1065,12 @@ that do not need it. See the `Kubernetes documentation <https://kubernetes.io/do
 for instructions.
 
 
-
 .. _HostPolicies:
 
-Host Policies
-=============
+Host Policies (beta)
+====================
 
-.. include:: ../tech-preview.rst
+.. include:: ../beta.rst
 
 Host policies take the form of a `CiliumClusterwideNetworkPolicy` with a
 :ref:`NodeSelector` instead of an `EndpointSelector`. Host policies can have

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -383,6 +383,8 @@ pod
       Warning  Unhealthy  6s (x6 over 56s)   kubelet, agent1    Readiness probe failed: curl: (7) Failed to connect to echo-b-host-headless port 40000: Connection refused
       Warning  Unhealthy  2s (x3 over 52s)   kubelet, agent1    Liveness probe failed: curl: (7) Failed to connect to echo-b-host-headless port 40000: Connection refused
 
+.. _cluster_connectivity_health:
+
 Checking cluster connectivity health
 ------------------------------------
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -88,7 +88,7 @@ docker-operator-manifest:
 docker-plugin-image: GIT_VERSION $(BUILD_DIR)/cilium-docker-plugin.Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build \
 		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEUBG} \
+		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		-f $(BUILD_DIR)/cilium-docker-plugin.Dockerfile \
 		-t cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -36,6 +36,7 @@ NODE_PORT_BIND=${18}
 MCPU=${19}
 NODE_PORT_IPV4_ADDRS=${20}
 NODE_PORT_IPV6_ADDRS=${21}
+NR_CPUS=${22}
 
 ID_HOST=1
 ID_WORLD=2
@@ -271,18 +272,18 @@ function bpf_compile()
 	TYPE=$3
 	EXTRA_OPTS=$4
 
-	clang -O2 -target bpf -std=gnu89 -nostdinc -emit-llvm		\
-	      -Wall -Wextra -Werror -Wshadow				\
-	      -Wno-address-of-packed-member				\
-	      -Wno-unknown-warning-option				\
-	      -Wno-gnu-variable-sized-type-not-at-end			\
-	      -Wdeclaration-after-statement				\
-	      -I. -I$DIR -I$LIB -I$LIB/include				\
-	      -D__NR_CPUS__=$(nproc --all)					\
-	      -DENABLE_ARP_RESPONDER=1					\
-	      -DHANDLE_NS=1						\
-	      $EXTRA_OPTS						\
-	      -c $LIB/$IN -o - |					\
+	clang -O2 -target bpf -std=gnu89 -nostdinc -emit-llvm	\
+	      -Wall -Wextra -Werror -Wshadow			\
+	      -Wno-address-of-packed-member			\
+	      -Wno-unknown-warning-option			\
+	      -Wno-gnu-variable-sized-type-not-at-end		\
+	      -Wdeclaration-after-statement			\
+	      -I. -I$DIR -I$LIB -I$LIB/include			\
+	      -D__NR_CPUS__=$NR_CPUS				\
+	      -DENABLE_ARP_RESPONDER=1				\
+	      -DHANDLE_NS=1					\
+	      $EXTRA_OPTS					\
+	      -c $LIB/$IN -o - |				\
 	llc -march=bpf -mcpu=$MCPU -mattr=dwarfris -filetype=$TYPE -o $OUT
 }
 

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -281,7 +281,6 @@ function bpf_compile()
 	      -I. -I$DIR -I$LIB -I$LIB/include			\
 	      -D__NR_CPUS__=$NR_CPUS				\
 	      -DENABLE_ARP_RESPONDER=1				\
-	      -DHANDLE_NS=1					\
 	      $EXTRA_OPTS					\
 	      -c $LIB/$IN -o - |				\
 	llc -march=bpf -mcpu=$MCPU -mattr=dwarfris -filetype=$TYPE -o $OUT

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -349,6 +349,7 @@ enum {
 #define DROP_NAT_NOT_NEEDED	-173 /* Mapped as drop code, though drop not necessary. */
 #define DROP_IS_CLUSTER_IP	-174
 #define DROP_FRAG_NOT_FOUND	-175
+#define DROP_FORBIDDEN_ICMP6	-176
 
 #define NAT_PUNT_TO_STACK	DROP_NAT_NOT_NEEDED
 

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -15,6 +15,21 @@
 #define ICMP6_ND_TARGET_OFFSET (sizeof(struct ipv6hdr) + sizeof(struct icmp6hdr))
 #define ICMP6_ND_OPTS (sizeof(struct ipv6hdr) + sizeof(struct icmp6hdr) + sizeof(struct in6_addr))
 
+#define ICMP6_UNREACH_MSG_TYPE		1
+#define ICMP6_PARAM_ERR_MSG_TYPE	4
+#define ICMP6_ECHO_REQUEST_MSG_TYPE	128
+#define ICMP6_ECHO_REPLY_MSG_TYPE	129
+#define ICMP6_MULT_LIST_QUERY_TYPE	130
+#define ICMP6_NS_MSG_TYPE		135
+#define ICMP6_NA_MSG_TYPE		136
+#define ICMP6_RR_MSG_TYPE		138
+#define ICMP6_INV_NS_MSG_TYPE		141
+#define ICMP6_MULT_LIST_REPORT_V2_TYPE	143
+#define ICMP6_SEND_NS_MSG_TYPE		148
+#define ICMP6_SEND_NA_MSG_TYPE		149
+#define ICMP6_MULT_RA_MSG_TYPE		151
+#define ICMP6_MULT_RT_MSG_TYPE		153
+
 /* If not specific action is specified, drop unknown neighbour solication
  * messages */
 #ifndef ACTION_UNKNOWN_ICMP6_NS
@@ -392,7 +407,7 @@ static __always_inline int icmp6_handle(struct __ctx_buff *ctx, int nh_off,
 	BPF_V6(router_ip, ROUTER_IP);
 
 	switch(type) {
-	case 135:
+	case ICMP6_NS_MSG_TYPE:
 		return icmp6_handle_ns(ctx, nh_off, direction);
 	case ICMPV6_ECHO_REQUEST:
 		if (!ipv6_addrcmp((union v6addr *) &ip6->daddr, &router_ip))
@@ -404,6 +419,74 @@ static __always_inline int icmp6_handle(struct __ctx_buff *ctx, int nh_off,
 	 * remaining traffic is subject to forwarding to containers.
 	 */
 	return 0;
+}
+
+static __always_inline int
+icmp6_host_handle(struct __ctx_buff *ctx __maybe_unused)
+{
+	__u8 type __maybe_unused;
+
+#ifdef ENABLE_HOST_FIREWALL
+	/* When the host firewall is enabled, we drop and allow ICMPv6 messages
+	 * according to RFC4890, except for echo request and reply messages which
+	 * are handled by host policies and can be dropped.
+	 * |          ICMPv6 Message         |   Action     | Type |
+	 * |---------------------------------|--------------|------|
+	 * |          ICMPv6-unreach         |  CTX_ACT_OK  |   1  |
+	 * |          ICMPv6-too-big         |  CTX_ACT_OK  |   2  |
+	 * |           ICMPv6-timed          |  CTX_ACT_OK  |   3  |
+	 * |         ICMPv6-parameter        |  CTX_ACT_OK  |   4  |
+	 * |    ICMPv6-err-private-exp-100   | CTX_ACT_DROP |  100 |
+	 * |    ICMPv6-err-private-exp-101   | CTX_ACT_DROP |  101 |
+	 * |       ICMPv6-err-expansion      | CTX_ACT_DROP |  127 |
+	 * |       ICMPv6-echo-message       |   Firewall   |  128 |
+	 * |        ICMPv6-echo-reply        |   Firewall   |  129 |
+	 * |      ICMPv6-mult-list-query     |  CTX_ACT_OK  |  130 |
+	 * |      ICMPv6-mult-list-report    |  CTX_ACT_OK  |  131 |
+	 * |      ICMPv6-mult-list-done      |  CTX_ACT_OK  |  132 |
+	 * |      ICMPv6-router-solici       |  CTX_ACT_OK  |  133 |
+	 * |      ICMPv6-router-advert       |  CTX_ACT_OK  |  134 |
+	 * |     ICMPv6-neighbor-solicit     |  CTX_ACT_OK  |  135 |
+	 * |      ICMPv6-neighbor-advert     |  CTX_ACT_OK  |  136 |
+	 * |     ICMPv6-redirect-message     | CTX_ACT_DROP |  137 |
+	 * |      ICMPv6-router-renumber     |  CTX_ACT_OK  |  138 |
+	 * |      ICMPv6-node-info-query     | CTX_ACT_DROP |  139 |
+	 * |     ICMPv6-node-info-response   | CTX_ACT_DROP |  140 |
+	 * |   ICMPv6-inv-neighbor-solicit   |  CTX_ACT_OK  |  141 |
+	 * |    ICMPv6-inv-neighbor-advert   |  CTX_ACT_OK  |  142 |
+	 * |    ICMPv6-mult-list-report-v2   |  CTX_ACT_OK  |  143 |
+	 * | ICMPv6-home-agent-disco-request | CTX_ACT_DROP |  144 |
+	 * |  ICMPv6-home-agent-disco-reply  | CTX_ACT_DROP |  145 |
+	 * |      ICMPv6-mobile-solicit      | CTX_ACT_DROP |  146 |
+	 * |      ICMPv6-mobile-advert       | CTX_ACT_DROP |  147 |
+	 * |      ICMPv6-send-solicit        |  CTX_ACT_OK  |  148 |
+	 * |       ICMPv6-send-advert        |  CTX_ACT_OK  |  149 |
+	 * |       ICMPv6-mobile-exp         | CTX_ACT_DROP |  150 |
+	 * |    ICMPv6-mult-router-advert    |  CTX_ACT_OK  |  151 |
+	 * |    ICMPv6-mult-router-solicit   |  CTX_ACT_OK  |  152 |
+	 * |     ICMPv6-mult-router-term     |  CTX_ACT_OK  |  153 |
+	 * |         ICMPv6-FMIPv6           | CTX_ACT_DROP |  154 |
+	 * |       ICMPv6-rpl-control        | CTX_ACT_DROP |  155 |
+	 * |   ICMPv6-info-private-exp-200   | CTX_ACT_DROP |  200 |
+	 * |   ICMPv6-info-private-exp-201   | CTX_ACT_DROP |  201 |
+	 * |      ICMPv6-info-expansion      | CTX_ACT_DROP |  255 |
+	 * |       ICMPv6-unallocated        | CTX_ACT_DROP |      |
+	 * |       ICMPv6-unassigned         | CTX_ACT_DROP |      |
+	 */
+	type = icmp6_load_type(ctx, ETH_HLEN);
+	if (type == ICMP6_ECHO_REQUEST_MSG_TYPE || type == ICMP6_ECHO_REPLY_MSG_TYPE)
+		return CTX_ACT_OK;
+
+	if ((ICMP6_UNREACH_MSG_TYPE <= type && type <= ICMP6_PARAM_ERR_MSG_TYPE) ||
+		(ICMP6_MULT_LIST_QUERY_TYPE <= type && type <= ICMP6_NA_MSG_TYPE) ||
+		(ICMP6_INV_NS_MSG_TYPE <= type && type <= ICMP6_MULT_LIST_REPORT_V2_TYPE) ||
+		(ICMP6_SEND_NS_MSG_TYPE <= type && type <= ICMP6_SEND_NA_MSG_TYPE) ||
+		(ICMP6_MULT_RA_MSG_TYPE <= type && type <= ICMP6_MULT_RT_MSG_TYPE))
+		return CTX_ACT_OK;
+	return DROP_FORBIDDEN_ICMP6;
+#else
+	return CTX_ACT_OK;
+#endif /* ENABLE_HOST_FIREWALL */
 }
 
 #endif

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -17,6 +17,7 @@
 #include "signal.h"
 #include "conntrack.h"
 #include "conntrack_map.h"
+#include "icmp6.h"
 
 enum {
 	NAT_DIR_EGRESS  = TUPLE_F_OUT,
@@ -1000,7 +1001,8 @@ static __always_inline __maybe_unused int snat_v6_process(struct __ctx_buff *ctx
 		if (ctx_load_bytes(ctx, off, &icmp6hdr, sizeof(icmp6hdr)) < 0)
 			return DROP_INVALID;
 		/* Letting neighbor solicitation / advertisement pass through. */
-		if (icmp6hdr.icmp6_type == 135 || icmp6hdr.icmp6_type == 136)
+		if (icmp6hdr.icmp6_type == ICMP6_NS_MSG_TYPE ||
+			icmp6hdr.icmp6_type == ICMP6_NA_MSG_TYPE)
 			return CTX_ACT_OK;
 		if (icmp6hdr.icmp6_type != ICMPV6_ECHO_REQUEST &&
 		    icmp6hdr.icmp6_type != ICMPV6_ECHO_REPLY)

--- a/bpf/netdev_config.h
+++ b/bpf/netdev_config.h
@@ -9,7 +9,6 @@
 #ifndef SKIP_DEBUG
 #define DEBUG
 #endif
-#define HANDLE_NS
 #define ENCAP_IFINDEX 1
 #define SECLABEL 2
 #define SECLABEL_NB 0xfffff

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1260,7 +1260,9 @@ func runDaemon() {
 		bootstrapStats.k8sInit.End(true)
 	}
 
-	d, restoredEndpoints, err := NewDaemon(server.ServerCtx, linuxdatapath.NewDatapath(datapathConfig, iptablesManager))
+	d, restoredEndpoints, err := NewDaemon(server.ServerCtx,
+		WithDefaultEndpointManager(),
+		linuxdatapath.NewDatapath(datapathConfig, iptablesManager))
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating daemon")
 		return

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -356,6 +356,14 @@ func disableNodePort() {
 	option.Config.EnableExternalIPs = false
 }
 
+func hasHardwareAddress(ifIndex int) bool {
+	iface, err := netlink.LinkByIndex(ifIndex)
+	if err != nil {
+		return false
+	}
+	return len(iface.Attrs().HardwareAddr) > 0
+}
+
 // detectDevices tries to detect device names which are going to be used for
 // (a) NodePort BPF, (b) direct routing in NodePort BPF.
 //
@@ -374,7 +382,9 @@ func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 			"Cannot retrieve host IP addrs for BPF NodePort device detection")
 	} else {
 		for _, a := range addrs {
-			ifidxByAddr[a.IP.String()] = a.LinkIndex
+			if hasHardwareAddress(a.LinkIndex) {
+				ifidxByAddr[a.IP.String()] = a.LinkIndex
+			}
 		}
 	}
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -10,6 +10,7 @@
 {{- $defaultBpfCtAnyMax := 262144 -}}
 {{- $enableIdentityMark := "true" -}}
 {{- $fragmentTracking := "true" -}}
+{{- $crdWaitTimeout := "5m" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -585,4 +586,10 @@ data:
 {{- if hasKey .Values "blacklistConflictingRoutes" }}
   # Configure blacklisting of local routes not owned by Cilium.
   blacklist-conflicting-routes: {{ .Values.blacklistConflictingRoutes | quote }}
+{{- end }}
+
+{{- if hasKey .Values "crdWaitTimeout" }}
+  crd-wait-timeout: {{ .Values.crdWaitTimeout | quote }}
+{{- else if ( ne $crdWaitTimeout "5m" ) }}
+  crd-wait-timeout: {{ $crdWaitTimeout | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -352,7 +352,7 @@ data:
   cni-chaining-mode: {{ .Values.global.cni.chainingMode }}
 
 {{- if hasKey .Values "enableIdentityMark"}}
-  enable-identity-mark: {{ .Values.global.enableIdentityMark | quote }}
+  enable-identity-mark: {{ .Values.enableIdentityMark | quote }}
 {{- else if (ne $enableIdentityMark "true") }}
   enable-identity-mark: "false"
 {{- end }}

--- a/install/kubernetes/cilium/charts/config/values.yaml
+++ b/install/kubernetes/cilium/charts/config/values.yaml
@@ -50,3 +50,7 @@
 # enables passing identity on local routes by using the mark fields. However,
 # in cases where this conflicts with a chained CNI plugin it may be disabled.
 #enableIdentityMark: true
+
+# Operator will exit if CRDs are not available within this duration upon
+# startup.
+#crdWaitTimeout: 5m

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -5,7 +5,7 @@ image:
   # tag is the container image tag to use.
   # Ref: https://github.com/cilium/hubble-ui/releases
   # Ref: https://quay.io/repository/cilium/hubble-ui?tab=tags
-  tag: v0.6.0
+  tag: v0.6.1
   # pullPolicy is the container image pull policy
   pullPolicy: IfNotPresent
 replicas: 1

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -773,7 +773,7 @@ spec:
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui
-          image: "quay.io/cilium/hubble-ui:v0.6.0"
+          image: "quay.io/cilium/hubble-ui:v0.6.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV

--- a/operator/crd.go
+++ b/operator/crd.go
@@ -18,7 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -28,10 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	toolswatch "k8s.io/client-go/tools/watch"
-)
-
-const (
-	defaultTimeout = 5 * time.Minute
 )
 
 // waitForCRD waits for the given CRD to be available with the given context.
@@ -78,7 +75,7 @@ func waitForCRD(ctx context.Context, client clientset.Interface, name string) er
 // after which cilium-agent should be ready. Returns an error when timeout
 // is exceeded.
 func WaitForCRD(client clientset.Interface, name string) error {
-	ctx, cancelFunc := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), operatorOption.Config.CRDWaitTimeout)
 	defer cancelFunc()
 	return waitForCRD(ctx, client, name)
 }

--- a/operator/crd_test.go
+++ b/operator/crd_test.go
@@ -67,7 +67,7 @@ func (s *crdTestSuite) TestGetCRD(c *C) {
 	c.Assert(err, IsNil)
 
 	// Try to get existing CRD
-	err = WaitForCRD(client, "foo")
+	err = waitForCRD(context.TODO(), client, "foo")
 	c.Assert(err, IsNil)
 
 	// Try to get non-existing CRD

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -285,5 +285,8 @@ func init() {
 	flags.Duration(option.K8sHeartbeatTimeout, 30*time.Second, "Configures the timeout for api-server heartbeat, set to 0 to disable")
 	option.BindEnv(option.K8sHeartbeatTimeout)
 
+	flags.Duration(operatorOption.CRDWaitTimeout, 5*time.Minute, "Operator will exit if CRDs are not available within this duration upon startup")
+	option.BindEnv(operatorOption.CRDWaitTimeout)
+
 	viper.BindPFlags(flags)
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -155,6 +155,9 @@ const (
 
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup = "azure-resource-group"
+
+	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
+	CRDWaitTimeout = "crd-wait-timeout"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -273,6 +276,9 @@ type OperatorConfig struct {
 
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup string
+
+	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
+	CRDWaitTimeout time.Duration
 }
 
 func (c *OperatorConfig) Populate() {
@@ -296,6 +302,7 @@ func (c *OperatorConfig) Populate() {
 	c.IPAMOperatorV4CIDR = viper.GetStringSlice(IPAMOperatorV4CIDR)
 	c.IPAMOperatorV6CIDR = viper.GetStringSlice(IPAMOperatorV6CIDR)
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
+	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
 
 	// AWS options
 

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -150,7 +150,7 @@ type Allocator struct {
 	initialListDone waitChan
 
 	// idPool maintains a pool of available ids for allocation.
-	idPool *idpool.IDPool
+	idPool idpool.IDPool
 
 	// enableMasterKeyProtection if true, causes master keys that are still in
 	// local use to be automatically re-created

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -488,7 +488,7 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 	return append(m.waitArgs,
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
-		"-m", "socket", "--transparent", "--nowildcard",
+		"-m", "socket", "--transparent",
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark)

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -63,6 +63,7 @@ const (
 	initBPFCPU
 	initArgNodePortIPv4Addrs
 	initArgNodePortIPv6Addrs
+	initArgNrCPUs
 	initArgMax
 )
 
@@ -290,6 +291,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	args[initBPFCPU] = GetBPFCPU()
+	args[initArgNrCPUs] = fmt.Sprintf("%d", common.GetNumPossibleCPUs(log))
 
 	clockSource := []string{"ktime", "jiffies"}
 	log.Infof("Setting up base BPF datapath (BPF %s instruction set, %s clock source)",

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -259,14 +259,36 @@ func (e *Endpoint) restoreIdentity() error {
 	// endpoints that don't have a fixed identity or are
 	// not well known.
 	if !identity.IsFixed() && !identity.IsWellKnown() {
-		identityCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
-		defer cancel()
+		// Getting the initial global identities while we are restoring should
+		// block the restoring of the endpoint.
+		// If the endpoint is removed, this controller will cancel the allocator
+		// WaitForInitialGlobalIdentities function.
+		controllerName := fmt.Sprintf("waiting-initial-global-identitites-ep (%v)", e.ID)
+		var gotInitialGlobalIdentities = make(chan struct{})
+		e.UpdateController(controllerName,
+			controller.ControllerParams{
+				DoFunc: func(ctx context.Context) (err error) {
+					identityCtx, cancel := context.WithTimeout(ctx, option.Config.KVstoreConnectivityTimeout)
+					defer cancel()
 
-		err := e.allocator.WaitForInitialGlobalIdentities(identityCtx)
-		if err != nil {
-			scopedLog.WithError(err).Warn("Failed while waiting for initial global identities")
-			return err
+					err = e.allocator.WaitForInitialGlobalIdentities(identityCtx)
+					if err != nil {
+						scopedLog.WithError(err).Warn("Failed while waiting for initial global identities")
+						return err
+					}
+					close(gotInitialGlobalIdentities)
+					return nil
+				},
+			})
+
+		// Wait until we either the initial global identities or the endpoint
+		// is deleted.
+		select {
+		case <-e.aliveCtx.Done():
+			return ErrNotAlive
+		case <-gotInitialGlobalIdentities:
 		}
+
 		if option.Config.KVStore != "" {
 			ipcache.WaitForKVStoreSync()
 		}

--- a/pkg/endpointmanager/idallocator/allocator.go
+++ b/pkg/endpointmanager/idallocator/allocator.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,9 +29,12 @@ var (
 	pool = idpool.NewIDPool(minID, maxID)
 )
 
-// ReallocatePool starts over with a new pool.
+// ReallocatePool starts over with a new pool. This function is only used for
+// tests and its implementation is not optimized for production.
 func ReallocatePool() {
-	pool = idpool.NewIDPool(minID, maxID)
+	for i := uint16(minID); i <= uint16(maxID); i++ {
+		Release(i)
+	}
 }
 
 // Allocate returns a new random ID from the pool

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -173,7 +173,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 	}, nil)
 
 	s.repo = policy.NewPolicyRepository(nil, nil)
-	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: 100 * time.Millisecond, SingleInflight: true}
+	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: 500 * time.Millisecond, SingleInflight: true}
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
@@ -360,8 +360,8 @@ func (s *DNSProxyTestSuite) TestRespondViaCorrectProtocol(c *C) {
 
 	request := new(dns.Msg)
 	request.SetQuestion(query, dns.TypeA)
-	response, _, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
-	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed"))
+	response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v)", rtt))
 	c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s", response))
 	c.Assert(response.Answer[0].String(), Equals, "cilium.io.\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
 

--- a/pkg/idpool/idpool.go
+++ b/pkg/idpool/idpool.go
@@ -76,15 +76,12 @@ type IDPool struct {
 }
 
 // NewIDPool returns a new ID pool
-func NewIDPool(minID ID, maxID ID) *IDPool {
-	p := &IDPool{
-		minID: minID,
-		maxID: maxID,
+func NewIDPool(minID ID, maxID ID) IDPool {
+	return IDPool{
+		minID:   minID,
+		maxID:   maxID,
+		idCache: newIDCache(minID, maxID),
 	}
-
-	p.idCache = newIDCache(p.minID, p.maxID)
-
-	return p
 }
 
 // LeaseAvailableID returns an available ID at random from the pool.

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -38,7 +38,7 @@ func (s *IDPoolTestSuite) TestLeaseAvailableID(c *C) {
 	minID, maxID := 1, 5
 	p := NewIDPool(ID(minID), ID(maxID))
 
-	leaseAllIDs(p, minID, maxID, c)
+	leaseAllIDs(&p, minID, maxID, c)
 }
 
 func (s *IDPoolTestSuite) TestInsertIDs(c *C) {
@@ -51,7 +51,7 @@ func (s *IDPoolTestSuite) TestInsertIDs(c *C) {
 		c.Assert(p.Insert(ID(i)), Equals, false)
 	}
 
-	leaseAllIDs(p, minID-1, maxID+1, c)
+	leaseAllIDs(&p, minID-1, maxID+1, c)
 }
 
 func (s *IDPoolTestSuite) TestInsertRemoveIDs(c *C) {
@@ -119,7 +119,7 @@ func (s *IDPoolTestSuite) TestReleaseID(c *C) {
 
 	// Lease all ids. This time, remove them before
 	// releasing them.
-	leaseAllIDs(p, minID, maxID, c)
+	leaseAllIDs(&p, minID, maxID, c)
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p.Remove(ID(i)), Equals, false)
 	}
@@ -134,40 +134,40 @@ func (s *IDPoolTestSuite) TestOperationsOnAvailableIDs(c *C) {
 
 	// Leasing available IDs should move its state to leased.
 	p0 := NewIDPool(ID(minID), ID(maxID))
-	leaseAllIDs(p0, minID, maxID, c)
+	leaseAllIDs(&p0, minID, maxID, c)
 	// Check all IDs are in leased state.
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p0.Release(ID(i)), Equals, true)
 	}
-	leaseAllIDs(p0, minID, maxID, c)
+	leaseAllIDs(&p0, minID, maxID, c)
 
 	// Releasing available IDs should not have any effect.
 	p1 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p1.Release(ID(i)), Equals, false)
 	}
-	leaseAllIDs(p1, minID, maxID, c)
+	leaseAllIDs(&p1, minID, maxID, c)
 
 	// Using available IDs should not have any effect.
 	p2 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p2.Use(ID(i)), Equals, false)
 	}
-	leaseAllIDs(p2, minID, maxID, c)
+	leaseAllIDs(&p2, minID, maxID, c)
 
 	// Inserting available IDs should not have any effect.
 	p3 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p3.Insert(ID(i)), Equals, false)
 	}
-	leaseAllIDs(p3, minID, maxID, c)
+	leaseAllIDs(&p3, minID, maxID, c)
 
 	// Removing available IDs should make them unavailable.
 	p4 := NewIDPool(ID(minID), ID(maxID))
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p4.Remove(ID(i)), Equals, true)
 	}
-	leaseAllIDs(p4, minID, minID-1, c)
+	leaseAllIDs(&p4, minID, minID-1, c)
 	for i := minID; i <= maxID; i++ {
 		c.Assert(p4.Release(ID(i)), Equals, false)
 	}
@@ -177,8 +177,8 @@ func (s *IDPoolTestSuite) TestOperationsOnLeasedIDs(c *C) {
 	minID, maxID := 1, 5
 	var poolWithAllIDsLeased = func() *IDPool {
 		p := NewIDPool(ID(minID), ID(maxID))
-		leaseAllIDs(p, minID, maxID, c)
-		return p
+		leaseAllIDs(&p, minID, maxID, c)
+		return &p
 	}
 
 	// Releasing leased IDs should make it available again.
@@ -228,7 +228,7 @@ func (s *IDPoolTestSuite) TestOperationsOnUnavailableIDs(c *C) {
 		for i := minID; i <= maxID; i++ {
 			c.Assert(p.Remove(ID(i)), Equals, true)
 		}
-		return p
+		return &p
 	}
 
 	// Releasing unavailable IDs should not have any effect.

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -331,7 +331,9 @@ func (s *IDPoolTestSuite) TestAllocateID(c *C) {
 		go func() {
 			for i := 1; i <= maxID; i++ {
 				id := p.AllocateID()
-				c.Assert(id, Not(Equals), NoID)
+				if id == NoID {
+					c.Error("ID expected to be allocated")
+				}
 				allocated <- id
 			}
 			allocators.Done()
@@ -344,6 +346,8 @@ func (s *IDPoolTestSuite) TestAllocateID(c *C) {
 	}()
 
 	for id := range allocated {
-		c.Assert(p.Insert(id), Equals, true)
+		if p.Insert(id) != true {
+			c.Error("ID insertion failed")
+		}
 	}
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -655,13 +655,17 @@ func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error
 		return nil, fmt.Errorf("lock cancelled via context: %s", ctx.Err())
 	}
 
+	// Create the context first so that if a connectivity issue causes the
+	// RLock acquisition below to block, this timeout will run concurrently
+	// with the timeouts in renewSession() rather than running serially.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	e.RLock()
 	mu := concurrency.NewMutex(e.lockSession, path)
 	leaseID := e.lockSession.Lease()
 	e.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
 	err := mu.Lock(ctx)
 	if err != nil {
 		e.checkLockSession(err, leaseID)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -434,7 +434,7 @@ func (e *etcdClient) Disconnected() <-chan struct{} {
 	return ch
 }
 
-func (e *etcdClient) renewSession() error {
+func (e *etcdClient) renewSession(ctx context.Context) error {
 	<-e.firstSession
 	<-e.session.Done()
 	// This is an attempt to avoid concurrent access of a session that was
@@ -443,7 +443,11 @@ func (e *etcdClient) renewSession() error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(option.Config.KVstoreLeaseTTL.Seconds())))
+	newSession, err := concurrency.NewSession(
+		e.client,
+		concurrency.WithTTL(int(option.Config.KVstoreLeaseTTL.Seconds())),
+		concurrency.WithContext(ctx),
+	)
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd session: %s", err)
@@ -462,7 +466,7 @@ func (e *etcdClient) renewSession() error {
 	return nil
 }
 
-func (e *etcdClient) renewLockSession() error {
+func (e *etcdClient) renewLockSession(ctx context.Context) error {
 	<-e.firstSession
 	<-e.lockSession.Done()
 	// This is an attempt to avoid concurrent access of a session that was
@@ -471,7 +475,11 @@ func (e *etcdClient) renewLockSession() error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(defaults.LockLeaseTTL.Seconds())))
+	newSession, err := concurrency.NewSession(
+		e.client,
+		concurrency.WithTTL(int(defaults.LockLeaseTTL.Seconds())),
+		concurrency.WithContext(ctx),
+	)
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd lock session: %s", err)
@@ -584,7 +592,18 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	ec.controllers.UpdateController("kvstore-etcd-session-renew",
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return ec.renewSession()
+				// Ignore the controller context here. Use the
+				// etcd client context instead, as this is
+				// renewing the session for that client.
+				// In the event of controller stop we'd expect
+				// the client context to be cancelled anyway
+				// and using the etcd context should generally
+				// integrate better with any code on the etcd
+				// client side.
+				parentCtx := ec.client.Ctx()
+				timedCtx, cancel := context.WithTimeout(parentCtx, statusCheckTimeout)
+				defer cancel()
+				return ec.renewSession(timedCtx)
 			},
 			RunInterval: time.Duration(10) * time.Millisecond,
 		},
@@ -593,7 +612,11 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	ec.controllers.UpdateController("kvstore-etcd-lock-session-renew",
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return ec.renewLockSession()
+				// Same context logic as above.
+				parentCtx := ec.client.Ctx()
+				timedCtx, cancel := context.WithTimeout(parentCtx, statusCheckTimeout)
+				defer cancel()
+				return ec.renewLockSession(timedCtx)
 			},
 			RunInterval: time.Duration(10) * time.Millisecond,
 		},

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -77,6 +77,7 @@ var errors = map[uint8]string{
 	173: "NAT not needed",
 	174: "Is a ClusterIP",
 	175: "First logical datagram fragment not found",
+	176: "Forbidden ICMPv6 message",
 }
 
 // DropReason prints the drop reason in a human readable string

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,9 @@ const (
 	// EntityRemoteNode is an entity that represents all remote nodes
 	EntityRemoteNode Entity = "remote-node"
 
+	// EntityHealth is an entity that represents all health endpoints.
+	EntityHealth Entity = "health"
+
 	// EntityNone is an entity that can be selected but never exist
 	EntityNone Entity = "none"
 )
@@ -58,6 +61,8 @@ var (
 
 	endpointSelectorRemoteNode = NewESFromLabels(labels.NewLabel(labels.IDNameRemoteNode, "", labels.LabelSourceReserved))
 
+	endpointSelectorHealth = NewESFromLabels(labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved))
+
 	EndpointSelectorNone = NewESFromLabels(labels.NewLabel(labels.IDNameNone, "", labels.LabelSourceReserved))
 
 	endpointSelectorUnmanaged = NewESFromLabels(labels.NewLabel(labels.IDNameUnmanaged, "", labels.LabelSourceReserved))
@@ -70,6 +75,7 @@ var (
 		EntityHost:       {endpointSelectorHost},
 		EntityInit:       {endpointSelectorInit},
 		EntityRemoteNode: {endpointSelectorRemoteNode},
+		EntityHealth:     {endpointSelectorHealth},
 		EntityNone:       {EndpointSelectorNone},
 
 		// EntityCluster is populated with an empty entry to allow the
@@ -106,6 +112,7 @@ func InitEntities(clusterName string, treatRemoteNodeAsHost bool) {
 		endpointSelectorHost,
 		endpointSelectorRemoteNode,
 		endpointSelectorInit,
+		endpointSelectorHealth,
 		endpointSelectorUnmanaged,
 		NewESFromLabels(labels.NewLabel(k8sapi.PolicyLabelCluster, clusterName, labels.LabelSourceK8s)),
 	}

--- a/pkg/policy/api/entity_test.go
+++ b/pkg/policy/api/entity_test.go
@@ -41,18 +41,21 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:none")), Equals, true) // in a white-list model, All trumps None
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("id=foo")), Equals, true)
 
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:init")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
@@ -64,6 +67,7 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("id=foo")), Equals, false)
@@ -71,6 +75,7 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:init")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("id=foo")), Equals, false)
@@ -84,6 +89,15 @@ func (s *PolicyAPITestSuite) TestEntitySliceMatches(c *C) {
 	slice := EntitySlice{EntityHost, EntityWorld}
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("id=foo")), Equals, false)
+
+	slice = EntitySlice{EntityHost, EntityHealth}
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(slice.matches(labels.ParseLabelArray("id=foo")), Equals, false)

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -163,7 +163,7 @@ func (s *SSHMeta) WaitEndpointsDeleted() bool {
 	body := func() bool {
 		cmd := `cilium endpoint list -o json | jq '. | length'`
 		res := s.Exec(cmd)
-		numEndpointsRunning := strings.TrimSpace(res.GetStdOut())
+		numEndpointsRunning := strings.TrimSpace(res.Stdout())
 		if numEndpointsRunning == desiredState {
 			return true
 		}
@@ -656,7 +656,7 @@ func (s *SSHMeta) ValidateEndpointsAreCorrect(dockerNetwork string) error {
 func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 	logsCmd := fmt.Sprintf(`sudo journalctl -au %s --since '%v seconds ago'`,
 		DaemonName, duration.Seconds())
-	logs := s.Exec(logsCmd, ExecOptions{SkipLog: true}).Output().String()
+	logs := s.Exec(logsCmd, ExecOptions{SkipLog: true}).Stdout()
 
 	defer func() {
 		// Keep the cilium logs for the given test in a separate file.

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -32,6 +32,108 @@ import (
 	"k8s.io/client-go/util/jsonpath"
 )
 
+// CmdStreamBuffer is a buffer that buffers the stream output of a command.
+type CmdStreamBuffer struct {
+	*Buffer
+	cmd string
+}
+
+// Cmd returns the command that generated the stream.
+func (b CmdStreamBuffer) Cmd() string {
+	return b.cmd
+}
+
+// ByLines returns res's stdout split by the newline character and, if the
+// stdout contains `\r\n`, it will be split by carriage return and new line
+// characters.
+func (b *CmdStreamBuffer) ByLines() []string {
+	out := b.String()
+	sep := "\n"
+	if strings.Contains(out, "\r\n") {
+		sep = "\r\n"
+	}
+	out = strings.TrimRight(out, sep)
+	return strings.Split(out, sep)
+}
+
+// KVOutput returns a map of the stdout of res split based on
+// the separator '='.
+// For example, the following strings would be split as follows:
+//             a=1
+//             b=2
+//             c=3
+//             a=1
+//             b=2
+//             c=3
+func (b *CmdStreamBuffer) KVOutput() map[string]string {
+	result := make(map[string]string)
+	for _, line := range b.ByLines() {
+		vals := strings.Split(line, "=")
+		if len(vals) == 2 {
+			result[vals[0]] = vals[1]
+		}
+	}
+	return result
+}
+
+// Filter returns the contents of res's stdout filtered using the provided
+// JSONPath filter in a buffer. Returns an error if the unmarshalling of the
+// contents of res's stdout fails.
+func (b *CmdStreamBuffer) Filter(filter string) (*FilterBuffer, error) {
+	var data interface{}
+	result := new(bytes.Buffer)
+
+	err := json.Unmarshal(b.Bytes(), &data)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse JSON from command %q", b.Cmd())
+	}
+	parser := jsonpath.New("").AllowMissingKeys(true)
+	parser.Parse(filter)
+	err = parser.Execute(result, data)
+	if err != nil {
+		return nil, err
+	}
+	return &FilterBuffer{result}, nil
+}
+
+// FilterLinesJSONPath decodes each line as JSON and applies the JSONPath
+// filter to each line. Returns an array with the result for each line.
+func (b *CmdStreamBuffer) FilterLinesJSONPath(filter *jsonpath.JSONPath) ([]FilterBuffer, error) {
+	lines := b.ByLines()
+	results := make([]FilterBuffer, 0, len(lines))
+	for i, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+
+		var data interface{}
+		result := new(bytes.Buffer)
+		err := json.Unmarshal([]byte(line), &data)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse %q as JSON (line %d of %q)", line, i, b.Cmd())
+		}
+
+		err = filter.Execute(result, data)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, FilterBuffer{result})
+	}
+	return results, nil
+}
+
+// FilterLines works like Filter, but applies the JSONPath filter to each line
+// separately and returns returns a Buffer for each line. An error is
+// returned only for the first line which cannot be unmarshalled.
+func (b *CmdStreamBuffer) FilterLines(filter string) ([]FilterBuffer, error) {
+	parsedFilter := jsonpath.New("").AllowMissingKeys(true)
+	err := parsedFilter.Parse(filter)
+	if err != nil {
+		return nil, err
+	}
+	return b.FilterLinesJSONPath(parsedFilter)
+}
+
 // CmdRes contains a variety of data which results from running a command.
 type CmdRes struct {
 	cmd      string          // Command to run
@@ -55,14 +157,30 @@ func (res *CmdRes) GetExitCode() int {
 	return res.exitcode
 }
 
-// GetStdOut returns the contents of the stdout buffer of res as a string.
-func (res *CmdRes) GetStdOut() string {
-	return res.stdout.String()
+// GetStdOut returns res's stdout.
+func (res *CmdRes) GetStdOut() *CmdStreamBuffer {
+	return &CmdStreamBuffer{
+		res.stdout,
+		res.cmd,
+	}
 }
 
-// GetStdErr returns the contents of the stderr buffer of res as a string.
-func (res *CmdRes) GetStdErr() string {
-	return res.stderr.String()
+// GetStdErr returns res's stderr.
+func (res *CmdRes) GetStdErr() *CmdStreamBuffer {
+	return &CmdStreamBuffer{
+		res.stderr,
+		res.cmd,
+	}
+}
+
+// Stdout returns the contents of the stdout buffer of res as a string.
+func (res *CmdRes) Stdout() string {
+	return res.GetStdOut().String()
+}
+
+// Stderr returns the contents of the stderr buffer of res as a string.
+func (res *CmdRes) Stderr() string {
+	return res.GetStdErr().String()
 }
 
 // SendToLog writes to `TestLogWriter` the debug message for the running
@@ -104,7 +222,7 @@ func (res *CmdRes) ExpectFail(optionalDescription ...interface{}) bool {
 func (res *CmdRes) ExpectFailWithError(data string, optionalDescription ...interface{}) bool {
 	return gomega.ExpectWithOffset(1, res).ShouldNot(
 		CMDSuccess(), optionalDescription...) &&
-		gomega.ExpectWithOffset(1, res.GetStdErr()).To(
+		gomega.ExpectWithOffset(1, res.Stderr()).To(
 			gomega.ContainSubstring(data), optionalDescription...)
 }
 
@@ -119,7 +237,7 @@ func (res *CmdRes) ExpectSuccess(optionalDescription ...interface{}) bool {
 // command. It accepts an optional parameter that can be used to annotate
 // failure messages.
 func (res *CmdRes) ExpectContains(data string, optionalDescription ...interface{}) bool {
-	return gomega.ExpectWithOffset(1, res.Output().String()).To(
+	return gomega.ExpectWithOffset(1, res.Stdout()).To(
 		gomega.ContainSubstring(data), optionalDescription...)
 }
 
@@ -127,7 +245,7 @@ func (res *CmdRes) ExpectContains(data string, optionalDescription ...interface{
 // matches the regexp. It accepts an optional parameter that can be
 // used to annotate failure messages.
 func (res *CmdRes) ExpectMatchesRegexp(regexp string, optionalDescription ...interface{}) bool {
-	return gomega.ExpectWithOffset(1, res.Output().String()).To(
+	return gomega.ExpectWithOffset(1, res.Stdout()).To(
 		gomega.MatchRegexp(regexp), optionalDescription...)
 }
 
@@ -147,7 +265,7 @@ func (res *CmdRes) ExpectContainsFilterLine(filter, expected string, optionalDes
 // the executed command. It accepts an optional parameter that can be used to
 // annotate failure messages.
 func (res *CmdRes) ExpectDoesNotContain(data string, optionalDescription ...interface{}) bool {
-	return gomega.ExpectWithOffset(1, res.Output().String()).ToNot(
+	return gomega.ExpectWithOffset(1, res.Stdout()).ToNot(
 		gomega.ContainSubstring(data), optionalDescription...)
 }
 
@@ -155,7 +273,7 @@ func (res *CmdRes) ExpectDoesNotContain(data string, optionalDescription ...inte
 // doesn't match the regexp. It accepts an optional parameter that can be used
 // to annotate failure messages.
 func (res *CmdRes) ExpectDoesNotMatchRegexp(regexp string, optionalDescription ...interface{}) bool {
-	return gomega.ExpectWithOffset(1, res.Output().String()).ToNot(
+	return gomega.ExpectWithOffset(1, res.Stdout()).ToNot(
 		gomega.MatchRegexp(regexp), optionalDescription...)
 }
 
@@ -194,7 +312,6 @@ func (res *CmdRes) IntOutput() (int, error) {
 // the unmarshalling of the stdout of res fails.
 // TODO - what exactly is the need for this vs. Filter function below?
 func (res *CmdRes) FindResults(filter string) ([]reflect.Value, error) {
-
 	var data interface{}
 	var result []reflect.Value
 
@@ -215,96 +332,37 @@ func (res *CmdRes) FindResults(filter string) ([]reflect.Value, error) {
 // JSONPath filter in a buffer. Returns an error if the unmarshalling of the
 // contents of res's stdout fails.
 func (res *CmdRes) Filter(filter string) (*FilterBuffer, error) {
-	var data interface{}
-	result := new(bytes.Buffer)
-
-	err := json.Unmarshal(res.stdout.Bytes(), &data)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse JSON from command %q",
-			res.cmd)
-	}
-	parser := jsonpath.New("").AllowMissingKeys(true)
-	parser.Parse(filter)
-	err = parser.Execute(result, data)
-	if err != nil {
-		return nil, err
-	}
-	return &FilterBuffer{result}, nil
+	return res.GetStdOut().Filter(filter)
 }
 
-// filterLinesJSONPath decodes each line as JSON and applies the JSONPath
+// FilterLinesJSONPath decodes each line as JSON and applies the JSONPath
 // filter to each line. Returns an array with the result for each line.
-func (res *CmdRes) filterLinesJSONPath(filter *jsonpath.JSONPath) ([]FilterBuffer, error) {
-	lines := res.ByLines()
-	results := make([]FilterBuffer, 0, len(lines))
-	for i, line := range lines {
-		if len(line) == 0 {
-			continue
-		}
-
-		var data interface{}
-		result := new(bytes.Buffer)
-		err := json.Unmarshal([]byte(line), &data)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse %q as JSON (line %d of %q)",
-				line, i, res.cmd)
-		}
-
-		err = filter.Execute(result, data)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, FilterBuffer{result})
-	}
-
-	return results, nil
+func (res *CmdRes) FilterLinesJSONPath(filter *jsonpath.JSONPath) ([]FilterBuffer, error) {
+	return res.GetStdOut().FilterLinesJSONPath(filter)
 }
 
 // FilterLines works like Filter, but applies the JSONPath filter to each line
-// separately and returns returns a FilterBuffer for each line. An error is
+// separately and returns returns a buffer for each line. An error is
 // returned only for the first line which cannot be unmarshalled.
 func (res *CmdRes) FilterLines(filter string) ([]FilterBuffer, error) {
-	parsedFilter := jsonpath.New("").AllowMissingKeys(true)
-	err := parsedFilter.Parse(filter)
-	if err != nil {
-		return nil, err
-	}
-
-	return res.filterLinesJSONPath(parsedFilter)
+	return res.GetStdOut().FilterLines(filter)
 }
 
-// ByLines returns res's stdout split by the newline character and, if the stdout
-// contains `\r\n`, it will be split by carriage return and new line characters.
+// ByLines returns res's stdout split by the newline character and, if the
+// stdout contains `\r\n`, it will be split by carriage return and new line
+// characters.
 func (res *CmdRes) ByLines() []string {
-	stdoutStr := res.stdout.String()
-	sep := "\n"
-	if strings.Contains(stdoutStr, "\r\n") {
-		sep = "\r\n"
-	}
-	stdoutStr = strings.TrimRight(stdoutStr, sep)
-	return strings.Split(stdoutStr, sep)
+	return res.GetStdOut().ByLines()
 }
 
 // KVOutput returns a map of the stdout of res split based on
 // the separator '='.
 // For example, the following strings would be split as follows:
-// 		a=1
-// 		b=2
-// 		c=3
+//		a=1
+//		b=2
+//		c=3
 func (res *CmdRes) KVOutput() map[string]string {
-	result := make(map[string]string)
-	for _, line := range res.ByLines() {
-		vals := strings.Split(line, "=")
-		if len(vals) == 2 {
-			result[vals[0]] = vals[1]
-		}
-	}
-	return result
-}
-
-// Output returns res's stdout.
-func (res *CmdRes) Output() *Buffer {
-	return res.stdout
+	return res.GetStdOut().KVOutput()
 }
 
 // OutputPrettyPrint returns a string with the ExitCode, stdout and stderr in a
@@ -326,15 +384,15 @@ func (res *CmdRes) OutputPrettyPrint() string {
 		"Exitcode: %d \n%sStdout:\n %s\nStderr:\n %s\n",
 		res.GetExitCode(),
 		errStr,
-		format(res.GetStdOut()),
-		format(res.GetStdErr()))
+		format(res.Stdout()),
+		format(res.Stderr()))
 }
 
 // ExpectEqual asserts whether cmdRes.Output().String() and expected are equal.
 // It accepts an optional parameter that can be used to annotate failure
 // messages.
 func (res *CmdRes) ExpectEqual(expected string, optionalDescription ...interface{}) bool {
-	return gomega.ExpectWithOffset(1, res.Output().String()).Should(
+	return gomega.ExpectWithOffset(1, res.Stdout()).Should(
 		gomega.Equal(expected), optionalDescription...)
 }
 
@@ -379,7 +437,7 @@ func (res *CmdRes) WaitUntilMatch(substr string) error {
 func (res *CmdRes) WaitUntilMatchRegexp(expr string, timeout time.Duration) error {
 	r := regexp.MustCompile(expr)
 	body := func() bool {
-		return r.Match(res.Output().Bytes())
+		return r.Match(res.GetStdOut().Bytes())
 	}
 
 	return WithTimeout(
@@ -400,7 +458,7 @@ func (res *CmdRes) WaitUntilMatchFilterLineTimeout(filter, expected string, time
 
 	errChan := make(chan error, 1)
 	body := func() bool {
-		lines, err := res.filterLinesJSONPath(parsedFilter)
+		lines, err := res.FilterLinesJSONPath(parsedFilter)
 		if err != nil {
 			errChan <- err
 			return true
@@ -430,7 +488,7 @@ func (res *CmdRes) WaitUntilMatchFilterLineTimeout(filter, expected string, time
 	return nil
 }
 
-// WaitUntilMatchFilterLineTimeout applies the JSONPath 'filter' to each line of
+// WaitUntilMatchFilterLine applies the JSONPath 'filter' to each line of
 // `CmdRes.stdout` and waits until a line matches the 'expected' output.
 // If helpers.HelperTimout is reached it will return an error.
 func (res *CmdRes) WaitUntilMatchFilterLine(filter, expected string) error {

--- a/test/helpers/filterBuffer.go
+++ b/test/helpers/filterBuffer.go
@@ -26,7 +26,13 @@ type FilterBuffer struct {
 
 // ByLines returns buf string plit by the newline characters
 func (buf *FilterBuffer) ByLines() []string {
-	return strings.Split(buf.String(), "\n")
+	out := buf.String()
+	sep := "\n"
+	if strings.Contains(out, "\r\n") {
+		sep = "\r\n"
+	}
+	out = strings.TrimRight(out, sep)
+	return strings.Split(out, sep)
 }
 
 // KVOutput returns a map of the buff string split based on

--- a/test/helpers/filterBuffer.go
+++ b/test/helpers/filterBuffer.go
@@ -32,9 +32,9 @@ func (buf *FilterBuffer) ByLines() []string {
 // KVOutput returns a map of the buff string split based on
 // the separator '='.
 // For example, the following strings would be split as follows:
-// 		a=1
-// 		b=2
-// 		c=3
+//		a=1
+//		b=2
+//		c=3
 func (buf *FilterBuffer) KVOutput() map[string]string {
 	result := make(map[string]string)
 	for _, line := range buf.ByLines() {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -672,7 +672,7 @@ func (kub *Kubectl) ExecKafkaPodCmd(namespace string, pod string, arg string) er
 			res.GetCmd(), res.OutputPrettyPrint())
 	}
 
-	if strings.Contains(res.GetStdErr(), "ERROR") {
+	if strings.Contains(res.Stderr(), "ERROR") {
 		return fmt.Errorf("ExecKafkaPodCmd: command '%s' failed '%s'",
 			res.GetCmd(), res.OutputPrettyPrint())
 	}
@@ -759,7 +759,7 @@ func (kub *Kubectl) WaitForCRDCount(filter string, count int, timeout time.Durat
 			log.Error(res.GetErr("kubectl get crds failed"))
 			return false
 		}
-		return len(regex.FindAllString(res.GetStdOut(), -1)) == count
+		return len(regex.FindAllString(res.Stdout(), -1)) == count
 	}
 	return WithTimeout(
 		body,
@@ -957,7 +957,7 @@ func (kub *Kubectl) GetNodeNameByLabelContext(ctx context.Context, label string)
 		return "", fmt.Errorf("cannot retrieve node to read name: %s", res.CombineOutput())
 	}
 
-	out := strings.Trim(res.GetStdOut(), "\n")
+	out := strings.Trim(res.Stdout(), "\n")
 
 	if len(out) == 0 {
 		return "", fmt.Errorf("no matching node to read name with label '%v'", label)
@@ -980,7 +980,7 @@ func (kub *Kubectl) GetNodeIPByLabel(label string, external bool) (string, error
 		return "", fmt.Errorf("cannot retrieve node to read IP: %s", res.CombineOutput())
 	}
 
-	out := strings.Trim(res.GetStdOut(), "\n")
+	out := strings.Trim(res.Stdout(), "\n")
 	if len(out) == 0 {
 		return "", fmt.Errorf("no matching node to read IP with label '%v'", label)
 	}
@@ -1174,7 +1174,7 @@ func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 func (kub *Kubectl) EnsureNamespaceExists(name string) error {
 	ginkgoext.By("Ensuring the namespace %s exists", name)
 	res := kub.ExecShort(fmt.Sprintf("%s create namespace %s", KubectlCmd, name))
-	if !res.success && !strings.Contains(res.GetStdErr(), "AlreadyExists") {
+	if !res.success && !strings.Contains(res.Stderr(), "AlreadyExists") {
 		return res.err
 	}
 	return nil
@@ -2004,12 +2004,12 @@ func (kub *Kubectl) WaitCleanAllTerminatingPodsInNs(ns string, timeout time.Dura
 			return false
 		}
 
-		if res.Output().String() == "" {
+		if res.Stdout() == "" {
 			// Output is empty so no terminating containers
 			return true
 		}
 
-		podsTerminating := len(strings.Split(res.Output().String(), " "))
+		podsTerminating := len(strings.Split(res.Stdout(), " "))
 		kub.Logger().WithField("Terminating pods", podsTerminating).Info("List of pods terminating")
 		if podsTerminating > 0 {
 			return false
@@ -2575,7 +2575,7 @@ func (kub *Kubectl) CiliumExecUntilMatch(pod, cmd, substr string) error {
 		ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
 		defer cancel()
 		res := kub.CiliumExecContext(ctx, pod, cmd)
-		return strings.Contains(res.Output().String(), substr)
+		return strings.Contains(res.Stdout(), substr)
 	}
 
 	return WithTimeout(
@@ -2661,7 +2661,7 @@ func (kub *Kubectl) LoadedPolicyInFirstAgent() (string, error) {
 		defer cancel()
 		res := kub.CiliumExecContext(ctx, pod, "cilium policy get")
 		if !res.WasSuccessful() {
-			return "", fmt.Errorf("cannot execute cilium policy get: %s", res.Output())
+			return "", fmt.Errorf("cannot execute cilium policy get: %s", res.Stdout())
 		}
 		return res.CombineOutput().String(), nil
 	}
@@ -2701,7 +2701,7 @@ func (kub *Kubectl) CiliumPolicyRevision(pod string) (int, error) {
 	defer cancel()
 	res := kub.CiliumExecContext(ctx, pod, "cilium policy get -o json")
 	if !res.WasSuccessful() {
-		return -1, fmt.Errorf("cannot get the revision %s", res.Output())
+		return -1, fmt.Errorf("cannot get the revision %s", res.Stdout())
 	}
 
 	revision, err := res.Filter("{.revision}")
@@ -2972,12 +2972,12 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 	netpols := kub.ExecContextShort(ctx, fmt.Sprintf(
 		"%s get netpol -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, policiesFilter))
-	fmt.Fprintf(CheckLogs, "Netpols loaded: %v\n", netpols.Output())
+	fmt.Fprintf(CheckLogs, "Netpols loaded: %v\n", netpols.GetStdOut())
 
 	cnp := kub.ExecContextShort(ctx, fmt.Sprintf(
 		"%s get cnp -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, policiesFilter))
-	fmt.Fprintf(CheckLogs, "CiliumNetworkPolicies loaded: %v\n", cnp.Output())
+	fmt.Fprintf(CheckLogs, "CiliumNetworkPolicies loaded: %v\n", cnp.GetStdOut())
 
 	cepFilter := `{range .items[*]}{.metadata.name}{"="}{.status.policy.ingress.enforcing}{":"}{.status.policy.egress.enforcing}{"\n"}{end}`
 	cepStatus := kub.ExecContextShort(ctx, fmt.Sprintf(
@@ -3057,11 +3057,11 @@ func (kub *Kubectl) ValidateListOfErrorsInLogs(duration time.Duration, blacklist
 		KubectlCmd, GetCiliumNamespace(GetCurrentIntegration()), duration.Seconds())
 	res := kub.ExecContext(ctx, fmt.Sprintf("%s --previous", cmd), ExecOptions{SkipLog: true})
 	if res.WasSuccessful() {
-		logs += res.Output().String()
+		logs += res.Stdout()
 	}
 	res = kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 	if res.WasSuccessful() {
-		logs += res.Output().String()
+		logs += res.Stdout()
 	}
 	defer func() {
 		// Keep the cilium logs for the given test in a separate file.
@@ -3181,7 +3181,7 @@ func (kub *Kubectl) ExecInHostNetNSByLabel(ctx context.Context, label, cmd strin
 		return "", fmt.Errorf("Failed to exec %q cmd on %q node: %s", cmd, nodeName, res.GetErr(""))
 	}
 
-	return res.GetStdOut(), nil
+	return res.Stdout(), nil
 }
 
 // DumpCiliumCommandOutput runs a variety of commands (CiliumKubCLICommands) and writes the results to
@@ -3360,7 +3360,7 @@ func (kub *Kubectl) GetCiliumPodOnNode(namespace string, node string) (string, e
 		return "", fmt.Errorf("Cilium pod not found on node '%s'", node)
 	}
 
-	return res.Output().String(), nil
+	return res.Stdout(), nil
 }
 
 // GetNodeInfo provides the node name and IP address based on the label
@@ -3472,7 +3472,7 @@ func (kub *Kubectl) ciliumStatusPreFlightCheck() error {
 		if !status.WasSuccessful() {
 			return fmt.Errorf("cilium-agent '%s' is unhealthy: %s", pod, status.OutputPrettyPrint())
 		}
-		if reNoQuorum.Match(status.Output().Bytes()) {
+		if reNoQuorum.Match(status.GetStdOut().Bytes()) {
 			return fmt.Errorf("KVStore doesn't have quorum: %s", status.OutputPrettyPrint())
 		}
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2921,12 +2921,16 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		kub.GatherLogs(ctx)
+	}()
 
 	go func() {
 		defer wg.Done()
 		kub.DumpCiliumCommandOutput(ctx, namespace)
-		kub.GatherLogs(ctx)
 	}()
 
 	kub.CiliumCheckReport(ctx)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2181,7 +2181,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 
 		if RunsOnNetNextOr419Kernel() {
-			opts["global.bpfMasquerade"] = "true"
+			opts["config.bpfMasquerade"] = "true"
 		}
 
 		for key, value := range opts {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -385,7 +385,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-hostnetns.yaml")
 			res := kubectl.ExecMiddle("mktemp")
 			res.ExpectSuccess()
-			tmpEchoPodPath = strings.Trim(res.GetStdOut(), "\n")
+			tmpEchoPodPath = strings.Trim(res.Stdout(), "\n")
 			kubectl.ExecMiddle(fmt.Sprintf("sed 's/NODE_WITHOUT_CILIUM/%s/' %s > %s",
 				helpers.GetNodeWithoutCilium(), echoPodPath, tmpEchoPodPath)).ExpectSuccess()
 			kubectl.ApplyDefault(tmpEchoPodPath).ExpectSuccess("Cannot install echoserver application")
@@ -395,11 +395,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// Setup ip-masq-agent configmap dir
 			res = kubectl.ExecMiddle("mktemp -d")
 			res.ExpectSuccess()
-			tmpConfigMapDirPath = strings.Trim(res.GetStdOut(), "\n")
+			tmpConfigMapDirPath = strings.Trim(res.Stdout(), "\n")
 			tmpConfigMapPath = filepath.Join(tmpConfigMapDirPath, "config")
 			res = kubectl.ExecMiddle("mktemp")
 			res.ExpectSuccess()
-			tmpConfigYAMLPath = strings.Trim(res.GetStdOut(), "\n")
+			tmpConfigYAMLPath = strings.Trim(res.Stdout(), "\n")
 
 			// Deploy empty ip-masq-agent config to prevent the ipmasq agent from
 			// adding the default nonMasq CIDRs which include the echoserver's
@@ -772,7 +772,7 @@ func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNod
 
 			if expectNodeIP || expectPodIP {
 				// Parse the IPs to avoid issues with 4-in-6 formats
-				sourceIP := net.ParseIP(strings.TrimSpace(strings.Split(res.GetStdOut(), "=")[1]))
+				sourceIP := net.ParseIP(strings.TrimSpace(strings.Split(res.Stdout(), "=")[1]))
 				if expectNodeIP {
 					Expect(sourceIP).To(Equal(hostIP), "Expected node IP")
 				}

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -91,7 +91,7 @@ var _ = Describe("K8sHealthTest", func() {
 		By("checking that `cilium-health --probe` succeeds")
 		healthCmd := "cilium-health status --probe -o json"
 		status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd)
-		Expect(status.Output()).ShouldNot(ContainSubstring("error"))
+		Expect(status.Stdout()).ShouldNot(ContainSubstring("error"))
 
 		apiPaths := []string{
 			"endpoint.icmp",

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1113,7 +1113,7 @@ var _ = Describe("K8sServicesTest", func() {
 			testExternalTrafficPolicyLocal()
 		})
 
-		SkipContextIf(helpers.RunsWithoutKubeProxy, "with L4 policy", func() {
+		Context("with L4 policy", func() {
 			var (
 				demoPolicy string
 			)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -176,12 +176,12 @@ var _ = Describe("K8sServicesTest", func() {
 			res, err := kubectl.ExecInHostNetNS(context.TODO(), k8s1NodeName, testCommand("echo FOOBAR", 1, 0))
 			ExpectWithOffset(1, err).To(BeNil(), "Cannot run script in host netns")
 			ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Test script could not 'echo'")
-			res.ExpectContains("FOOBAR", "Test script failed to execute echo: %s", res.Output())
+			res.ExpectContains("FOOBAR", "Test script failed to execute echo: %s", res.Stdout())
 
 			res, err = kubectl.ExecInHostNetNS(context.TODO(), k8s1NodeName, testCommand("FOOBAR", 3, 0))
 			ExpectWithOffset(1, err).To(BeNil(), "Cannot run script in host netns")
 			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(), "Test script successfully executed FOOBAR")
-			res.ExpectMatchesRegexp("failed: :[0-9]*/1=127:[0-9]*/2=127:[0-9]*/3=127", "Test script failed to execute echo 3 times: %s", res.Output())
+			res.ExpectMatchesRegexp("failed: :[0-9]*/1=127:[0-9]*/2=127:[0-9]*/3=127", "Test script failed to execute echo 3 times: %s", res.Stdout())
 
 			res, err = kubectl.ExecInHostNetNS(context.TODO(), k8s1NodeName, testCommand("FOOBAR", 1, 1))
 			ExpectWithOffset(1, err).To(BeNil(), "Cannot run script in host netns")
@@ -190,7 +190,7 @@ var _ = Describe("K8sServicesTest", func() {
 			res, err = kubectl.ExecInHostNetNS(context.TODO(), k8s1NodeName, testCommand("echo FOOBAR", 3, 0))
 			ExpectWithOffset(1, err).To(BeNil(), "Cannot run script in host netns")
 			ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Test script could not 'echo' three times")
-			res.ExpectMatchesRegexp("(?s)(FOOBAR.*exit code: 0.*){3}", "Test script failed to execute echo 3 times: %s", res.Output())
+			res.ExpectMatchesRegexp("(?s)(FOOBAR.*exit code: 0.*){3}", "Test script failed to execute echo 3 times: %s", res.Stdout())
 		})
 	})
 
@@ -464,7 +464,7 @@ var _ = Describe("K8sServicesTest", func() {
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
 					"%s host can not connect to service %q", fromPod, url)
 				res.ExpectContains(expectedCode, "Request from %s to %q returned HTTP Code %q, expected %q",
-					fromPod, url, res.Output(), expectedCode)
+					fromPod, url, res.GetStdOut(), expectedCode)
 			}
 		}
 
@@ -488,7 +488,7 @@ var _ = Describe("K8sServicesTest", func() {
 						"Can not connect to service %q from outside cluster", url)
 					if checkSourceIP {
 						// Parse the IPs to avoid issues with 4-in-6 formats
-						sourceIP := net.ParseIP(strings.TrimSpace(strings.Split(res.GetStdOut(), "=")[1]))
+						sourceIP := net.ParseIP(strings.TrimSpace(strings.Split(res.Stdout(), "=")[1]))
 						outsideIP := net.ParseIP(outsideIP)
 						ExpectWithOffset(1, sourceIP).To(Equal(outsideIP))
 					}
@@ -532,13 +532,13 @@ var _ = Describe("K8sServicesTest", func() {
 			patternInK8s1 := fmt.Sprintf("UDP IN [^:]+:%d -> %s", srcPort, endpointK8s1)
 			cmdInK8s1 := fmt.Sprintf(cmdIn, patternInK8s1)
 			res := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdInK8s1)
-			countInK8s1, _ := strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+			countInK8s1, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 
 			endpointK8s2 := fmt.Sprintf("%s:%d", dstPodIPK8s2, dstPodPort)
 			patternInK8s2 := fmt.Sprintf("UDP IN [^:]+:%d -> %s", srcPort, endpointK8s2)
 			cmdInK8s2 := fmt.Sprintf(cmdIn, patternInK8s2)
 			res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s2, cmdInK8s2)
-			countInK8s2, _ := strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+			countInK8s2, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 
 			// Field #11 is "TxPackets=<n>"
 			cmdOut := "cilium bpf ct list global | awk '/%s/ { sub(\".*=\",\"\", $11); print $11 }'"
@@ -553,7 +553,7 @@ var _ = Describe("K8sServicesTest", func() {
 			patternOutK8s1 := fmt.Sprintf("UDP OUT [^:]+:%d -> %s", srcPort, endpointK8s1)
 			cmdOutK8s1 := fmt.Sprintf(cmdOut, patternOutK8s1)
 			res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdOutK8s1)
-			countOutK8s1, _ := strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+			countOutK8s1, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 
 			// If kube-proxy is enabled, the two commands are the same and
 			// there's no point executing it twice.
@@ -562,7 +562,7 @@ var _ = Describe("K8sServicesTest", func() {
 			cmdOutK8s2 := fmt.Sprintf(cmdOut, patternOutK8s2)
 			if hasDNAT {
 				res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdOutK8s2)
-				countOutK8s2, _ = strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+				countOutK8s2, _ = strconv.Atoi(strings.TrimSpace(res.Stdout()))
 			}
 
 			// Send datagram
@@ -589,22 +589,22 @@ var _ = Describe("K8sServicesTest", func() {
 			// backend pod received the datagram, so we check for
 			// each node.
 			res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdInK8s1)
-			newCountInK8s1, _ := strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+			newCountInK8s1, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 			res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s2, cmdInK8s2)
-			newCountInK8s2, _ := strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+			newCountInK8s2, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 			ExpectWithOffset(2, []int{newCountInK8s1, newCountInK8s2}).To(SatisfyAny(
 				Equal([]int{countInK8s1, countInK8s2 + delta}),
 				Equal([]int{countInK8s1 + delta, countInK8s2}),
 			), "Failed to account for IPv4 fragments to %s (in)", dstIP)
 
 			res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdOutK8s1)
-			newCountOutK8s1, _ := strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+			newCountOutK8s1, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 			// If kube-proxy is enabled, the two commands are the same and
 			// there's no point executing it twice.
 			newCountOutK8s2 := 0
 			if hasDNAT {
 				res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdOutK8s2)
-				newCountOutK8s2, _ = strconv.Atoi(strings.TrimSpace(res.GetStdOut()))
+				newCountOutK8s2, _ = strconv.Atoi(strings.TrimSpace(res.Stdout()))
 			}
 			ExpectWithOffset(2, []int{newCountOutK8s1, newCountOutK8s2}).To(SatisfyAny(
 				Equal([]int{countOutK8s1, countOutK8s2 + delta}),
@@ -617,13 +617,13 @@ var _ = Describe("K8sServicesTest", func() {
 			res, err := kubectl.ExecInHostNetNS(context.TODO(), nodeName, cmd)
 			ExpectWithOffset(2, err).To(BeNil(), cmd)
 			res.ExpectSuccess(cmd)
-			ipv4 := strings.Trim(res.GetStdOut(), "\n")
+			ipv4 := strings.Trim(res.Stdout(), "\n")
 
 			cmd = fmt.Sprintf("ip -6 -o a s dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)
 			res, err = kubectl.ExecInHostNetNS(context.TODO(), nodeName, cmd)
 			ExpectWithOffset(2, err).To(BeNil(), cmd)
 			res.ExpectSuccess(cmd)
-			ipv6 := strings.Trim(res.GetStdOut(), "\n")
+			ipv6 := strings.Trim(res.Stdout(), "\n")
 
 			return ipv4, ipv6
 		}
@@ -904,7 +904,7 @@ var _ = Describe("K8sServicesTest", func() {
 				}
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
 					"Cannot connect to service %q from %s (%d/%d)", httpURL, from, i, count)
-				pod := strings.TrimSpace(strings.Split(res.GetStdOut(), ": ")[1])
+				pod := strings.TrimSpace(strings.Split(res.Stdout(), ": ")[1])
 				if i == 1 {
 					// Retrieve the destination pod from the first request
 					dstPod = pod
@@ -950,7 +950,7 @@ var _ = Describe("K8sServicesTest", func() {
 				}
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
 					"Cannot connect to service %q from %s (%d/%d) after restart", httpURL, from, i, count)
-				pod := strings.TrimSpace(strings.Split(res.GetStdOut(), ": ")[1])
+				pod := strings.TrimSpace(strings.Split(res.Stdout(), ": ")[1])
 				if i == 1 {
 					// Retrieve the destination pod from the first request
 					ExpectWithOffset(1, dstPod).ShouldNot(Equal(pod))
@@ -1033,10 +1033,10 @@ var _ = Describe("K8sServicesTest", func() {
 			ExpectWithOffset(1, err).Should(BeNil(), "Cannot determine cilium pod name")
 
 			res := kubectl.CiliumExecContext(context.TODO(), pod, "cilium service list | grep "+k8s2IP+":"+httpHostPortStr+" | grep HostPort")
-			ExpectWithOffset(1, res.GetStdOut()).ShouldNot(BeEmpty(), "No HostPort entry for "+k8s2IP+":"+httpHostPortStr)
+			ExpectWithOffset(1, res.Stdout()).ShouldNot(BeEmpty(), "No HostPort entry for "+k8s2IP+":"+httpHostPortStr)
 
 			res = kubectl.CiliumExecContext(context.TODO(), pod, "cilium service list | grep "+k8s2IP+":"+tftpHostPortStr+" | grep HostPort")
-			ExpectWithOffset(1, res.GetStdOut()).ShouldNot(BeEmpty(), "No HostPort entry for "+k8s2IP+":"+tftpHostPortStr)
+			ExpectWithOffset(1, res.Stdout()).ShouldNot(BeEmpty(), "No HostPort entry for "+k8s2IP+":"+tftpHostPortStr)
 
 			// Cluster-internal connectivity to HostPort
 			httpURL = getHTTPLink(k8s2IP, httpHostPort)
@@ -1373,7 +1373,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 					testCurlFromOutsideWithLocalPort(url, 1, true, sourcePortForCTGCtest)
 					res := kubectl.CiliumExecContext(context.TODO(), pod, fmt.Sprintf("cilium bpf nat list | grep %d", sourcePortForCTGCtest))
-					ExpectWithOffset(1, res.GetStdOut()).ShouldNot(BeEmpty(), "NAT entry was not evicted")
+					ExpectWithOffset(1, res.Stdout()).ShouldNot(BeEmpty(), "NAT entry was not evicted")
 					// Flush CT maps to trigger eviction of the NAT entries (simulates CT GC)
 					res = kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium bpf ct flush global", "Unable to flush CT maps")
 					res = kubectl.CiliumExecContext(context.TODO(), pod, fmt.Sprintf("cilium bpf nat list | grep %d", sourcePortForCTGCtest))

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -97,7 +97,7 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 		res := vm.Exec(fmt.Sprintf(
 			"%s -n %s get pods -l k8s-app=cilium-pre-flight-check",
 			helpers.KubectlCmd, helpers.CiliumNamespace))
-		warningMessage = res.Output().String()
+		warningMessage = res.Stdout()
 	}
 	Expect(err).To(BeNil(), "cilium pre-flight check is not ready after timeout, pods status:\n %s", warningMessage)
 }

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -117,7 +117,7 @@ var _ = Describe("K8sDemosTest", func() {
 
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlFail("http://%s/v1", deathstarFQDN))
-		res.ExpectSuccess("unable to curl %s/v1: %s", deathstarFQDN, res.Output())
+		res.ExpectSuccess("unable to curl %s/v1: %s", deathstarFQDN, res.Stdout())
 
 		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
 		_, err = kubectl.CiliumPolicyAction(
@@ -131,12 +131,12 @@ var _ = Describe("K8sDemosTest", func() {
 		By("Showing how alliance cannot access %q without force header in API request after importing L7 Policy", exhaustPortPath)
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT http://%s", exhaustPortPath))
-		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.Output())
+		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.Stdout())
 
 		By("Showing how alliance can access %q with force header in API request to attack the deathstar", exhaustPortPath)
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT -H 'X-Has-Force: True' http://%s", exhaustPortPath))
 		By("Expecting 503 to be returned when using force header to attack the deathstar")
-		res.ExpectContains("503", "unable to access %s when policy allows it; %s", exhaustPortPath, res.Output())
+		res.ExpectContains("503", "unable to access %s when policy allows it; %s", exhaustPortPath, res.Stdout())
 	})
 })

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1892,7 +1892,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		By("Verifying that trace says that %q can reach %q", httpd2Label, httpd1Label)
 
 		res := vm.Exec(fmt.Sprintf(`cilium policy trace -s %s -d %s/TCP`, httpd2Label, httpd1Label))
-		Expect(res.Output().String()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
+		Expect(res.Stdout()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
 
 		endpointIDS, err := vm.GetEndpointsIds()
 		Expect(err).To(BeNil(), "Unable to get IDs of endpoints")

--- a/test/runtime/benchmark.go
+++ b/test/runtime/benchmark.go
@@ -132,12 +132,12 @@ var _ = Describe("BenchmarkNetperfPerformance", func() {
 
 	superNetperfRRLog := func(client string, server string, num int) {
 		res := superNetperfRR(vm, client, server, num)
-		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.GetStdOut(), "\n"))
+		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.Stdout(), "\n"))
 	}
 
 	superNetperfStreamLog := func(client string, server string, num int) {
 		res := superNetperfStream(vm, client, server, num)
-		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.GetStdOut(), "\n"))
+		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.Stdout(), "\n"))
 	}
 
 	Context("Benchmark Netperf Tests", func() {

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -102,14 +102,14 @@ var _ = Describe("RuntimeChaos", func() {
 		ips := vm.Exec(`
 		curl -s --unix-socket /var/run/cilium/cilium.sock \
 		http://localhost/v1beta/healthz/ | jq ".ipam.ipv4|length"`)
-		Expect(originalIps.Output().String()).To(Equal(ips.Output().String()))
+		Expect(originalIps.Stdout()).To(Equal(ips.Stdout()))
 
 		EndpointList := vm.Exec(endpointListCmd)
-		By("original: %s", originalEndpointList.Output().String())
-		By("new: %s", EndpointList.Output().String())
-		Expect(EndpointList.Output().String()).To(Equal(originalEndpointList.Output().String()))
-		Expect(hasher.Sum(EndpointList.Output().Bytes())).To(
-			Equal(hasher.Sum(originalEndpointList.Output().Bytes())))
+		By("original: %s", originalEndpointList.Stdout())
+		By("new: %s", EndpointList.Stdout())
+		Expect(EndpointList.Stdout()).To(Equal(originalEndpointList.Stdout()))
+		Expect(hasher.Sum(EndpointList.GetStdOut().Bytes())).To(
+			Equal(hasher.Sum(originalEndpointList.GetStdOut().Bytes())))
 
 	}, 300)
 

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -121,20 +121,20 @@ var _ = Describe("RuntimeCLI", func() {
 
 		It("root command help should print to stdout", func() {
 			res := vm.ExecCilium("help")
-			Expect(res.GetStdErr()).Should(BeEmpty())
-			Expect(res.GetStdOut()).Should(ContainSubstring("Use \"cilium [command] --help\" for more information about a command."))
+			Expect(res.Stderr()).Should(BeEmpty())
+			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium [command] --help\" for more information about a command."))
 		})
 
 		It("subcommand help should print to stdout", func() {
 			res := vm.ExecCilium("help bpf")
-			Expect(res.GetStdErr()).Should(BeEmpty())
-			Expect(res.GetStdOut()).Should(ContainSubstring("Use \"cilium bpf [command] --help\" for more information about a command."))
+			Expect(res.Stderr()).Should(BeEmpty())
+			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium bpf [command] --help\" for more information about a command."))
 		})
 
 		It("failed subcommand should print help to stdout", func() {
 			res := vm.ExecCilium("endpoint confi 173")
-			Expect(res.GetStdErr()).Should(BeEmpty())
-			Expect(res.GetStdOut()).Should(ContainSubstring("Use \"cilium endpoint [command] --help\" for more information about a command."))
+			Expect(res.Stderr()).Should(BeEmpty())
+			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium endpoint [command] --help\" for more information about a command."))
 		})
 
 	})

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -178,7 +178,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		By("Create sample containers in %q docker network", helpers.WorldDockerNetwork)
 		res := vm.Exec(fmt.Sprintf("docker network create %s", helpers.WorldDockerNetwork))
 		if !res.WasSuccessful() {
-			if !strings.Contains(res.GetStdErr(), "network with name world already exists") {
+			if !strings.Contains(res.Stderr(), "network with name world already exists") {
 				res.ExpectSuccess(
 					"%q network cant be created", helpers.WorldDockerNetwork)
 			}
@@ -295,7 +295,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		GinkgoPrint(vm.Exec(
 			`docker ps -q | xargs -n 1 docker inspect --format ` +
 				`'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}} {{ .Name }}'` +
-				`| sed 's/ \// /'`).Output().String())
+				`| sed 's/ \// /'`).Stdout())
 		vm.ReportFailed("cilium policy get")
 	})
 
@@ -304,7 +304,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		jqfilter := fmt.Sprintf(`jq -c '.[] | select(.identities|length >= %d) | select(.users|length > 0) | .selector | match("^MatchName: (\\w+\\.%s|), MatchPattern: ([\\w*]+\\.%s|)$") | length > 0'`, minNumIDs, escapedDomain, escapedDomain)
 		body := func() bool {
 			res := vm.Exec(fmt.Sprintf(`cilium policy selectors -o json | %s`, jqfilter))
-			return strings.HasPrefix(res.GetStdOut(), "true")
+			return strings.HasPrefix(res.Stdout(), "true")
 		}
 		err := helpers.WithTimeout(
 			body,

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -90,7 +90,7 @@ var _ = Describe("RuntimeLB", func() {
 		frontendAddress, err := vm.ServiceGetFrontendAddress(1)
 		Expect(err).Should(BeNil())
 		Expect(frontendAddress).To(ContainSubstring("[::]:80"),
-			"failed to retrieve frontend address: %q", result.Output())
+			"failed to retrieve frontend address: %q", result.GetStdOut())
 
 		//TODO: This need to be with Wait,Timeout
 		helpers.Sleep(5)
@@ -99,8 +99,8 @@ var _ = Describe("RuntimeLB", func() {
 
 		result = vm.ExecCilium("bpf lb list")
 		result.ExpectSuccess("bpf lb map cannot be retrieved correctly")
-		Expect(result.Output()).To(ContainSubstring("[::1]:90"), fmt.Sprintf(
-			"service backends not added to BPF map: %q", result.Output()))
+		Expect(result.Stdout()).To(ContainSubstring("[::1]:90"), fmt.Sprintf(
+			"service backends not added to BPF map: %q", result.GetStdOut()))
 
 		By("Adding services that should not be allowed")
 
@@ -190,7 +190,7 @@ var _ = Describe("RuntimeLB", func() {
 				"Service ids %s do not match old service ids %s", svcIds, oldSvcIds)
 			newSvc := vm.ServiceList()
 			newSvc.ExpectSuccess("Cannot retrieve service list after restart")
-			newSvc.ExpectEqual(oldSvc.Output().String(), "Service list does not match")
+			newSvc.ExpectEqual(oldSvc.Stdout(), "Service list does not match")
 
 			By("Checking that BPF LB maps match the service")
 

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -123,7 +123,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 				vm.ContainerExec(k, helpers.Ping(helpers.Httpd1))
 				Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 					"%q is not in the output after timeout", filter)
-				Expect(res.Output().String()).Should(ContainSubstring(filter))
+				Expect(res.Stdout()).Should(ContainSubstring(filter))
 			}
 		})
 
@@ -155,7 +155,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 				Expect(res.WaitUntilMatch(v)).To(BeNil(),
 					"%q is not in the output after timeout", v)
 				Expect(res.CountLines()).Should(BeNumerically(">", 3))
-				Expect(res.Output().String()).Should(ContainSubstring(v))
+				Expect(res.Stdout()).Should(ContainSubstring(v))
 				cancel()
 			}
 
@@ -180,7 +180,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			for _, v := range eventTypes {
 				Expect(res.WaitUntilMatch(v)).To(BeNil(),
 					"%q is not in the output after timeout", v)
-				Expect(res.Output().String()).Should(ContainSubstring(v))
+				Expect(res.Stdout()).Should(ContainSubstring(v))
 			}
 
 			Expect(res.CountLines()).Should(BeNumerically(">", 3))
@@ -206,10 +206,10 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 				"%q is not in the output after timeout", filter)
 			Expect(res.CountLines()).Should(BeNumerically(">", 3))
-			Expect(res.Output().String()).Should(ContainSubstring(filter))
+			Expect(res.Stdout()).Should(ContainSubstring(filter))
 
 			//MonitorDebug mode shouldn't have DROP lines
-			Expect(res.Output().String()).ShouldNot(ContainSubstring("DROP"))
+			Expect(res.Stdout()).ShouldNot(ContainSubstring("DROP"))
 		})
 
 		It("cilium monitor check --to", func() {
@@ -233,7 +233,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 				"%q is not in the output after timeout", filter)
 			Expect(res.CountLines()).Should(BeNumerically(">=", 3))
-			Expect(res.Output().String()).Should(ContainSubstring(filter))
+			Expect(res.Stdout()).Should(ContainSubstring(filter))
 		})
 
 		It("cilium monitor check --related-to", func() {
@@ -257,7 +257,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			Expect(res.WaitUntilMatch(filter)).To(BeNil(),
 				"%q is not in the output after timeout", filter)
 			Expect(res.CountLines()).Should(BeNumerically(">=", 3))
-			Expect(res.Output().String()).Should(ContainSubstring(filter))
+			Expect(res.Stdout()).Should(ContainSubstring(filter))
 		})
 
 		It("delivers the same information to multiple monitors", func() {


### PR DESCRIPTION
* #12290 -- hubble: Bump images to v0.6.1 (@gandro)
 * #12282 -- test: split log gathering goroutine (@nebril)
 * #12292 -- Fix bug where etcd session renew would block indefinitely, causing endpoint provision to fail (@joestringer)
 * #12299 -- docs: fix enableIdentityMark helm chart option (@aanm)
 * #12177 -- operator: Make CRD availability timeout configurable (@mrostecki)
 * #12302 -- docs: Fix bpfMasquerade option (@sayboras)
 * #12195 -- Fix various issues (data races, flakes) related to DaemonSuite and Endpoint related test code (@christarazi)
 * #12307 -- pkg/endpoint: wait for security identity on restore (@aanm)
 * #12199 -- policy/api: Add reserved:health entity (@pchaigno)
 * #12305 -- fqdn/dnsproxy/proxy_test: increase timeout for DNS TCP client exchanges (@qmonnet)
 * #12310 -- bpf: Share __NR_CPUS__ value with Golang side (@pchaigno)
 * #12252 -- test/helpers: introduce CmdStreamBuffer to manipulate a command's output (@Rolinh)
 * #12318 -- make: fix LOCKDEBUG env variable reference for docker-plugin-image (@Rolinh)
 * #12248 -- iptables: Remove '--nowildcard' from socket match (@jrajahalme)
 * #12321 -- daemon: Skip devices without hardware address during device detection (@pchaigno)
 * #12049 -- bpf: Handle ICMPv6 NS/NA in host firewall (@pchaigno)
 * #12325 -- docs: Switch hostfw tech-preview -> beta (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12290 12282 12292 12299 12177 12302 12195 12307 12199 12305 12310 12252 12318 12248 12321 12049 12325; do contrib/backporting/set-labels.py $pr done 1.8; done
```