### PR TITLE
v1.7 backports 2020-06-29

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -12,10 +12,10 @@ Transparent Encryption (stable/beta)
 
 This guide explains how to configure Cilium to use IPsec based transparent
 encryption using Kubernetes secrets to distribute the IPsec keys. After this
-configuration is complete all traffic between Cilium
-managed endpoints, as well as Cilium managed host traffic, will be encrypted
-using IPsec. This guide uses Kubernetes secrets to distribute keys. Alternatively,
-keys may be manually distributed but that is not shown here.
+configuration is complete all traffic between Cilium-managed endpoints, as well
+as Cilium managed host traffic, will be encrypted using IPsec. This guide uses
+Kubernetes secrets to distribute keys. Alternatively, keys may be manually
+distributed, but that is not shown here.
 
 .. note::
 
@@ -26,19 +26,19 @@ keys may be manually distributed but that is not shown here.
 Generate & import the PSK
 =========================
 
-First create a Kubernetes secret for the IPsec keys to be stored.
-This will generate the necessary IPsec keys which will be distributed as a
-Kubernetes secret called ``cilium-ipsec-keys``. In this example we use
-GMC-128-AES, but any of the supported
-Linux algorithms may be used. To generate use the following
+First, create a Kubernetes secret for the IPsec keys to be stored. This will
+generate the necessary IPsec keys which will be distributed as a Kubernetes
+secret called ``cilium-ipsec-keys``. In this example we use GMC-128-AES, but
+any of the supported Linux algorithms may be used. To generate, use the
+following:
 
 .. parsed-literal::
 
     $ kubectl create -n kube-system secret generic cilium-ipsec-keys \\
         --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128"
 
-The secret can be displayed with ``kubectl -n kube-system get secret`` and will be
-listed as 'cilium-ipsec-keys'.
+The secret can be seen with ``kubectl -n kube-system get secret`` and will be
+listed as "cilium-ipsec-keys".
 
 .. parsed-literal::
     $ kubectl -n kube-system get secrets cilium-ipsec-keys
@@ -50,7 +50,7 @@ Enable Encryption in Cilium
 
 .. include:: k8s-install-download-release.rst
 
-Deploy Cilium release via Helm:
+Deploy Cilium release via Helm with the following options to enable encryption:
 
 .. parsed-literal::
 
@@ -59,16 +59,32 @@ Deploy Cilium release via Helm:
       --set global.encryption.enabled=true \\
       --set global.encryption.nodeEncryption=false
 
+These options can be provided along with other options, such as when deploying
+to GKE, with VXLAN tunneling:
+
+.. parsed-literal::
+
+    helm install cilium |CHART_RELEASE| \\
+      --namespace cilium \
+      --set global.nodeinit.enabled=true \
+      --set nodeinit.reconfigureKubelet=true \
+      --set nodeinit.removeCbrBridge=true \
+      --set global.cni.binPath=/home/kubernetes/bin \
+      --set global.tunnel=vxlan \
+      --set global.encryption.enabled=true \
+      --set global.encryption.nodeEncryption=false
+
 At this point the Cilium managed nodes will be using IPsec for all traffic. For further
 information on Cilium's transparent encryption, see :ref:`arch_guide`.
 
 Encryption interface
 --------------------
 
-If direct routing is being used an additional argument can be used to identify the
-network facing interface. If no interface is specified the default route link is
-chosen by inspecting the routing tables. This will work in many cases but depending
-on routing rules users may need to specify the encryption interface as follows:
+If direct routing is being used, an additional argument can be used to identify
+the network-facing interface. If no interface is specified, the default route
+link is chosen by inspecting the routing tables. This will work in many cases,
+but depending on routing rules, users may need to specify the encryption
+interface as follows:
 
 .. code:: bash
 
@@ -88,8 +104,8 @@ In order to enable node-to-node encryption, add:
 Validate the Setup
 ==================
 
-Run a ``bash`` shell in one of the Cilium pods with ``kubectl -n kube-system
-exec -ti cilium-7cpsm -- bash`` and execute the following commands:
+Run a ``bash`` shell in one of the Cilium pods with ``kubectl -n <k8s namespace>
+exec -ti <cilium pod> -- bash`` and execute the following commands:
 
 1. Install tcpdump
 
@@ -125,8 +141,8 @@ To replace cilium-ipsec-keys secret with a new keys,
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1
 
-Then restart cilium agents to transition to the new key. During transition the
-new and old keys will be in use. The cilium agent keeps per endpoint data on
+Then restart Cilium agents to transition to the new key. During transition the
+new and old keys will be in use. The Cilium agent keeps per endpoint data on
 which key is used by each endpoint and will use the correct key if either side
 has not yet been updated. In this way encryption will work as new keys are
 rolled out.
@@ -134,7 +150,7 @@ rolled out.
 The KEYID environment variable in the above example stores the current key ID
 used by Cilium. The key variable is a uint8 with value between 0-16 and should
 be monotonically increasing every re-key with a rollover from 16 to 0. The
-cilium agent will default to KEYID of zero if its not specified in the secret.
+Cilium agent will default to KEYID of zero if its not specified in the secret.
 
 Troubleshooting
 ===============

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -23,6 +23,12 @@ distributed, but that is not shown here.
     ENI datapath mode. In combination with encapsulation/tunneling, the feature
     is still in beta phase.
 
+.. note::
+
+    Packets destined to the same node they were sent out of are not encrypted.
+    This is a intended behavior as it doesn't provide any benefits because the
+    raw traffic on the node can be seen.
+
 Generate & import the PSK
 =========================
 

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -29,20 +29,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.5.4 <https://github.com/cilium/istio/releases/tag/1.5.4>`_:
+Download the `cilium enhanced istioctl version 1.5.6 <https://github.com/cilium/istio/releases/tag/1.5.6>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.4/cilium-istioctl-1.5.4-linux.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.6/cilium-istioctl-1.5.6-linux.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.4/cilium-istioctl-1.5.4-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.6/cilium-istioctl-1.5.6-osx.tar.gz | tar xz
 
 .. note::
 

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -78,7 +78,7 @@ below. This will ensure all pods are managed by Cilium.
       --set nodeinit.removeCbrBridge=true \\
       --set global.cni.binPath=/home/kubernetes/bin \\
       --set global.gke.enabled=true \\
-      --set global.native-routing-cidr=$NATIVE_CIDR
+      --set global.nativeRoutingCIDR=$NATIVE_CIDR
 
 The NodeInit DaemonSet is required to prepare the GKE nodes as nodes are added
 to the cluster. The NodeInit DaemonSet will perform the following actions:

--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -10,7 +10,7 @@ connectivity provided by Cilium and NetworkPolicy applies to them:
 
 ::
 
-    kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs kubectl delete pod
+    kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -L 1 -r kubectl delete pod
     pod "event-exporter-v0.2.3-f9c896d75-cbvcz" deleted
     pod "fluentd-gcp-scaler-69d79984cb-nfwwk" deleted
     pod "heapster-v1.6.0-beta.1-56d5d5d87f-qw8pv" deleted

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -308,6 +308,10 @@ init
     security identity has not been resolved yet. This is typically only
     observed in non-Kubernetes environments. See section
     :ref:`endpoint_lifecycle` for details.
+health
+    The health entity represents the health endpoints, used to check cluster
+    connectivity health. Each node managed by Cilium hosts a health endpoint.
+    See `cluster_connectivity_health` for details on health checks.
 world
     The world entity corresponds to all endpoints outside of the cluster.
     Allowing to world is identical to allowing to CIDR 0/0. An alternative

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -48,11 +48,11 @@ Holzheu
 Huapeng
 Hypercalls
 IP
+IPcache
 IPsec
 IPv
 Integrations
 IoT
-IPcache
 Istio
 JUnit
 Jakub
@@ -314,6 +314,7 @@ inlines
 inlining
 inodes
 integrations
+intra
 io
 ip
 ipcache

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ docker-operator-image: GIT_VERSION
 	$(QUIET)echo "docker push cilium/operator:$(DOCKER_IMAGE_TAG)"
 
 docker-plugin-image: GIT_VERSION
-	$(CONTAINER_ENGINE_FULL) build --build-arg LOCKDEBUG=${LOCKDEUBG} -f cilium-docker-plugin.Dockerfile -t "cilium/docker-plugin:$(DOCKER_IMAGE_TAG)" .
+	$(CONTAINER_ENGINE_FULL) build --build-arg LOCKDEBUG=${LOCKDEBUG} -f cilium-docker-plugin.Dockerfile -t "cilium/docker-plugin:$(DOCKER_IMAGE_TAG)" .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "docker push cilium/docker-plugin:$(DOCKER_IMAGE_TAG)"
 

--- a/contrib/k8s/k8s-cilium-exec.sh
+++ b/contrib/k8s/k8s-cilium-exec.sh
@@ -32,7 +32,7 @@ function cleanup {
 K8S_NAMESPACE="${K8S_NAMESPACE:-kube-system}"
 
 while read -r p; do
-	kubectl -n "${K8S_NAMESPACE}" exec -ti $p -- $*&
+	kubectl -n "${K8S_NAMESPACE}" exec -ti $p -- "${@}" &
 done <<< "$(kubectl -n ${K8S_NAMESPACE} get pods -l k8s-app=cilium | awk '{print $1}' | grep cilium)"
 
 wait

--- a/contrib/k8s/k8s-cilium-exec.sh
+++ b/contrib/k8s/k8s-cilium-exec.sh
@@ -29,8 +29,10 @@ function cleanup {
 	kill_jobs TERM
 }
 
+K8S_NAMESPACE="${K8S_NAMESPACE:-kube-system}"
+
 while read -r p; do
-	kubectl -n kube-system exec -ti $p -- $*&
-done <<< "$(kubectl -n kube-system get pods -l k8s-app=cilium | awk '{print $1}' | grep cilium)"
+	kubectl -n "${K8S_NAMESPACE}" exec -ti $p -- $*&
+done <<< "$(kubectl -n ${K8S_NAMESPACE} get pods -l k8s-app=cilium | awk '{print $1}' | grep cilium)"
 
 wait

--- a/contrib/k8s/k8s-cilium-exec.sh
+++ b/contrib/k8s/k8s-cilium-exec.sh
@@ -29,10 +29,16 @@ function cleanup {
 	kill_jobs TERM
 }
 
+function get_cilium_pods {
+    kubectl -n "${K8S_NAMESPACE}" get pods -l k8s-app=cilium | \
+       awk '{print $1}' | \
+       grep cilium
+}
+
 K8S_NAMESPACE="${K8S_NAMESPACE:-kube-system}"
 
 while read -r p; do
-	kubectl -n "${K8S_NAMESPACE}" exec -ti $p -- "${@}" &
-done <<< "$(kubectl -n ${K8S_NAMESPACE} get pods -l k8s-app=cilium | awk '{print $1}' | grep cilium)"
+	kubectl -n "${K8S_NAMESPACE}" exec -ti "${p}" -- "${@}" &
+done <<< "$(get_cilium_pods)"
 
 wait

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -145,7 +145,7 @@ spec:
 {{- if .Values.global.ipv4.enabled }}
             host: '127.0.0.1'
 {{- else }}
-            host: '[::1]'
+            host: '::1'
 {{- end }}
             path: /healthz
             port: 9234

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -470,7 +470,7 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 	return append(m.waitArgs,
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
-		"-m", "socket", "--transparent", "--nowildcard",
+		"-m", "socket", "--transparent",
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark)

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
@@ -190,13 +191,35 @@ func (e *Endpoint) restoreIdentity() error {
 	l, _ := labels.FilterLabels(e.OpLabels.AllLabels())
 	e.runlock()
 
-	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
-	defer cancel()
-	identity, _, err := e.allocator.AllocateIdentity(allocateCtx, l, true)
+	// Getting the ep's identity while we are restoring should block the
+	// restoring of the endpoint until we get its security identity ID.
+	// If the endpoint is removed, this controller will cancel the allocator
+	// requests.
+	controllerName := fmt.Sprintf("restoring-ep-identity (%v)", e.ID)
+	var (
+		identity          *identity.Identity
+		allocatedIdentity = make(chan struct{})
+	)
+	e.UpdateController(controllerName,
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) (err error) {
+				allocateCtx, cancel := context.WithTimeout(ctx, option.Config.KVstoreConnectivityTimeout)
+				defer cancel()
+				identity, _, err = e.allocator.AllocateIdentity(allocateCtx, l, true)
+				if err != nil {
+					return err
+				}
+				close(allocatedIdentity)
+				return nil
+			},
+		})
 
-	if err != nil {
-		scopedLog.WithError(err).Warn("Unable to restore endpoint")
-		return err
+	// Wait until we either get an identity or the endpoint is removed or
+	// deleted from the node.
+	select {
+	case <-e.aliveCtx.Done():
+		return ErrNotAlive
+	case <-allocatedIdentity:
 	}
 
 	// Wait for initial identities and ipcache from the
@@ -207,7 +230,7 @@ func (e *Endpoint) restoreIdentity() error {
 		identityCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 		defer cancel()
 
-		err = e.allocator.WaitForInitialGlobalIdentities(identityCtx)
+		err := e.allocator.WaitForInitialGlobalIdentities(identityCtx)
 		if err != nil {
 			scopedLog.WithError(err).Warn("Failed while waiting for initial global identities")
 			return err

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -169,7 +169,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 	}, nil)
 
 	s.repo = policy.NewPolicyRepository(nil, nil)
-	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: 100 * time.Millisecond, SingleInflight: true}
+	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: 500 * time.Millisecond, SingleInflight: true}
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
@@ -354,8 +354,8 @@ func (s *DNSProxyTestSuite) TestRespondViaCorrectProtocol(c *C) {
 
 	request := new(dns.Msg)
 	request.SetQuestion(query, dns.TypeA)
-	response, _, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
-	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed"))
+	response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v)", rtt))
 	c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s", response))
 	c.Assert(response.Answer[0].String(), Equals, "cilium.io.\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -674,13 +674,17 @@ func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error
 		return nil, fmt.Errorf("lock cancelled via context: %s", ctx.Err())
 	}
 
+	// Create the context first so that if a connectivity issue causes the
+	// RLock acquisition below to block, this timeout will run concurrently
+	// with the timeouts in renewSession() rather than running serially.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	e.RLock()
 	mu := concurrency.NewMutex(e.lockSession, path)
 	leaseID := e.lockSession.Lease()
 	e.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
 	err := mu.Lock(ctx)
 	if err != nil {
 		e.checkLockSession(err, leaseID)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -436,7 +436,7 @@ func (e *etcdClient) Disconnected() <-chan struct{} {
 	return ch
 }
 
-func (e *etcdClient) renewSession() error {
+func (e *etcdClient) renewSession(ctx context.Context) error {
 	<-e.firstSession
 	<-e.session.Done()
 	// This is an attempt to avoid concurrent access of a session that was
@@ -445,7 +445,11 @@ func (e *etcdClient) renewSession() error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(option.Config.KVstoreLeaseTTL.Seconds())))
+	newSession, err := concurrency.NewSession(
+		e.client,
+		concurrency.WithTTL(int(option.Config.KVstoreLeaseTTL.Seconds())),
+		concurrency.WithContext(ctx),
+	)
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd session: %s", err)
@@ -464,7 +468,7 @@ func (e *etcdClient) renewSession() error {
 	return nil
 }
 
-func (e *etcdClient) renewLockSession() error {
+func (e *etcdClient) renewLockSession(ctx context.Context) error {
 	<-e.firstSession
 	<-e.lockSession.Done()
 	// This is an attempt to avoid concurrent access of a session that was
@@ -473,7 +477,11 @@ func (e *etcdClient) renewLockSession() error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(defaults.LockLeaseTTL.Seconds())))
+	newSession, err := concurrency.NewSession(
+		e.client,
+		concurrency.WithTTL(int(defaults.LockLeaseTTL.Seconds())),
+		concurrency.WithContext(ctx),
+	)
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd lock session: %s", err)
@@ -580,7 +588,18 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	ec.controllers.UpdateController("kvstore-etcd-session-renew",
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return ec.renewSession()
+				// Ignore the controller context here. Use the
+				// etcd client context instead, as this is
+				// renewing the session for that client.
+				// In the event of controller stop we'd expect
+				// the client context to be cancelled anyway
+				// and using the etcd context should generally
+				// integrate better with any code on the etcd
+				// client side.
+				parentCtx := ec.client.Ctx()
+				timedCtx, cancel := context.WithTimeout(parentCtx, statusCheckTimeout)
+				defer cancel()
+				return ec.renewSession(timedCtx)
 			},
 			RunInterval: time.Duration(10) * time.Millisecond,
 		},
@@ -589,7 +608,11 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	ec.controllers.UpdateController("kvstore-etcd-lock-session-renew",
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return ec.renewLockSession()
+				// Same context logic as above.
+				parentCtx := ec.client.Ctx()
+				timedCtx, cancel := context.WithTimeout(parentCtx, statusCheckTimeout)
+				defer cancel()
+				return ec.renewLockSession(timedCtx)
 			},
 			RunInterval: time.Duration(10) * time.Millisecond,
 		},

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -211,6 +211,7 @@ func setupSyslog(logOpts map[string]string, tag string, debug bool) {
 	}
 	// TODO: switch to a per-logger version when we upgrade to logrus >1.0.3
 	logrus.AddHook(h)
+	DefaultLogger.AddHook(h)
 }
 
 // setupFormatter sets up the text formatting for logs output by logrus.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2029,6 +2029,10 @@ func (c *DaemonConfig) Populate() {
 			log.Warningf("Running Cilium with %q=%q requires endpoint CRDs. Changing %s to %t", KVStore, c.KVStore, DisableCiliumEndpointCRDName, false)
 			c.DisableCiliumEndpointCRD = false
 		}
+		if c.K8sEventHandover {
+			log.Warningf("Running Cilium with %q=%q requires KVStore capability. Changing %s to %t", KVStore, c.KVStore, K8sEventHandover, false)
+			c.K8sEventHandover = false
+		}
 	}
 
 	// Hidden options

--- a/pkg/option/monitor.go
+++ b/pkg/option/monitor.go
@@ -52,7 +52,7 @@ const (
 
 	// MonitorAggregationLevelMax is the maximum level of aggregation
 	// currently supported.
-	MonitorAggregationLevelMax = MonitorAggregationLevelMedium
+	MonitorAggregationLevelMax OptionSetting = 4
 )
 
 // monitorAggregationOption maps a user-specified string to a monitor
@@ -81,6 +81,7 @@ var monitorAggregationFormat = map[OptionSetting]string{
 	MonitorAggregationLevelLowest: "Lowest",
 	MonitorAggregationLevelLow:    "Low",
 	MonitorAggregationLevelMedium: "Medium",
+	MonitorAggregationLevelMax:    "Max",
 }
 
 // VerifyMonitorAggregationLevel validates the specified key/value for a

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,9 @@ const (
 	// EntityRemoteNode is an entity that represents all remote nodes
 	EntityRemoteNode Entity = "remote-node"
 
+	// EntityHealth is an entity that represents all health endpoints.
+	EntityHealth Entity = "health"
+
 	// EntityNone is an entity that can be selected but never exist
 	EntityNone Entity = "none"
 )
@@ -58,6 +61,8 @@ var (
 
 	endpointSelectorRemoteNode = NewESFromLabels(labels.NewLabel(labels.IDNameRemoteNode, "", labels.LabelSourceReserved))
 
+	endpointSelectorHealth = NewESFromLabels(labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved))
+
 	EndpointSelectorNone = NewESFromLabels(labels.NewLabel(labels.IDNameNone, "", labels.LabelSourceReserved))
 
 	endpointSelectorUnmanaged = NewESFromLabels(labels.NewLabel(labels.IDNameUnmanaged, "", labels.LabelSourceReserved))
@@ -70,6 +75,7 @@ var (
 		EntityHost:       {endpointSelectorHost},
 		EntityInit:       {endpointSelectorInit},
 		EntityRemoteNode: {endpointSelectorRemoteNode},
+		EntityHealth:     {endpointSelectorHealth},
 		EntityNone:       {EndpointSelectorNone},
 
 		// EntityCluster is populated with an empty entry to allow the
@@ -106,6 +112,7 @@ func InitEntities(clusterName string, treatRemoteNodeAsHost bool) {
 		endpointSelectorHost,
 		endpointSelectorRemoteNode,
 		endpointSelectorInit,
+		endpointSelectorHealth,
 		endpointSelectorUnmanaged,
 		NewESFromLabels(labels.NewLabel(k8sapi.PolicyLabelCluster, clusterName, labels.LabelSourceK8s)),
 	}

--- a/pkg/policy/api/entity_test.go
+++ b/pkg/policy/api/entity_test.go
@@ -41,18 +41,21 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityHost.matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:none")), Equals, true) // in a white-list model, All trumps None
 	c.Assert(EntityAll.matches(labels.ParseLabelArray("id=foo")), Equals, true)
 
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:init")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
 	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
@@ -64,6 +67,7 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityWorld.matches(labels.ParseLabelArray("id=foo")), Equals, false)
@@ -71,6 +75,7 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:init")), Equals, false)
 	c.Assert(EntityNone.matches(labels.ParseLabelArray("id=foo")), Equals, false)
@@ -84,6 +89,15 @@ func (s *PolicyAPITestSuite) TestEntitySliceMatches(c *C) {
 	slice := EntitySlice{EntityHost, EntityWorld}
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:health")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("id=foo")), Equals, false)
+
+	slice = EntitySlice{EntityHost, EntityHealth}
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:health")), Equals, true)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
 	c.Assert(slice.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(slice.matches(labels.ParseLabelArray("id=foo")), Equals, false)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -35,7 +35,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.5.4"
+		istioVersion = "1.5.6"
 
 		// Modifiers for pre-release testing, normally empty
 		prerelease     = "" // "-beta.1"
@@ -44,9 +44,9 @@ var _ = Describe("K8sIstioTest", func() {
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.4" +
-		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.4" +
-		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.4"
+		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.6" +
+		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.6" +
+		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.6"
 		ciliumOptions = map[string]string{
 			// "global.proxy.sidecarImageRegex": "jrajahalme/istio_proxy",
 		}


### PR DESCRIPTION
* #12025 -- ginkgo-ext: Fix data-race in Writer (@gandro)
 * #12014 -- Fix setting monitorAggregationLevel to max reflects via CLI (@soumynathan)
 * ~~#12051 -- test/k8s: keep configmap across upgrade test (@aanm)~~
   * Note: dropped as per @aanm
 * #12064 -- Update xargs usage in restart-pods documentation (@ap4y)
 * #12082 -- contrib: Add environment variable to script  to control K8s namespace (@christarazi)
 * #12088 -- doc: Misc fixups for Transparent Encryption GSG (@christarazi)
 * #12126 -- contrib: Misc. fixups for k8s-cilium-exec.sh script (@christarazi)
 * #12146 -- pkg/option: disable K8sEventHandover if Cilium is running without KVStore (@aanm)
 * #12087 -- Fix GKE Helm options for CI and docs. (@jrajahalme)
     * Note: Many commits in this PR did not need to be backported to v1.7, please take a closer look and confirm @jrajahalme
        * 0800999e4074a9e78aa84ef8b5efe48d5eff6ba6 was the only commit backported, the rest did not need to be applied to v1.7
 * #12170 -- Fix syslog hook missing in DefaultLogger (@ArthurChiao)
 * #12214 -- istio: Update to 1.5.6 (@jrajahalme)
 * #12223 -- helm/operator: fix IPv6 liveness probe address for operator (@Rolinh)
 * #12292 -- Fix bug where etcd session renew would block indefinitely, causing endpoint provision to fail (@joestringer)
 * #12307 -- pkg/endpoint: wait for security identity on restore (@aanm)
 * #12199 -- policy/api: Add reserved:health entity (@pchaigno)
 * #12305 -- fqdn/dnsproxy/proxy_test: increase timeout for DNS TCP client exchanges (@qmonnet)
 * #12318 -- make: fix LOCKDEBUG env variable reference for docker-plugin-image (@Rolinh)
 * #12248 -- iptables: Remove '--nowildcard' from socket match (@jrajahalme)
   * Note: No conflicts, ~~but this adds a new test to the Services suite~~
   * Correction: noticed in the original PR @jrajahalme calls out that changes to the tests do not need to be backported:
      * Dropped: ad96aac7742754df0fb0915e623eecc19305eab6 and a7f76f700eb9b10dcad69bd17f19cc0970fffbd0

Skipping due to non-trivial conflicts:

 * #12074 -- test: Remove ginkgo linux dependency (@jrajahalme)
 * #12121 -- bpf: Use `nproc --all` for __NR_CPUS__ (@gandro)
 * #12106 -- Use right CCNP validation (@aanm)
 * #12180 -- Fix native routing cidr missing flag in daemon (@aanm)
 * #12185 -- cilium: chaining mode skb->mark can be mangled by iptables allow opt-out (@jrfastab)
 * #12194 -- cilium: fix helm usage of enableIdentityMap -> enableIdentityMark (@jrfastab)
   * Note: this depends on PR above this one as well
 * #12117 -- pkg/k8s: add validation schema for MatchLabels (@aanm)
 * #12310 -- bpf: Share __NR_CPUS__ value with Golang side (@pchaigno)

Skipping as I'm not sure why it's marked as backport to v1.7; please take a look @Rolinh

 * ~~#12181 -- doc: ensure to use --set config.ipam=kubernetes with kind (@Rolinh)~~
 * #12144 -- doc: revamp kata containers getting started guide (@Rolinh)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12025 12014 12064 12082 12088 12126 12146 12087 12170 12214 12223 12292 12307 12199 12305 12318 12248; do contrib/backporting/set-labels.py $pr done 1.7; done
```