### PR TITLE
bpf: remove dead stores in tail_nodeport_nat_ipv{4,6}

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -435,9 +435,7 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 			ret = DROP_MISSED_TAIL_CALL;
 			goto drop_err;
 		}
-		if (ret == NAT_PUNT_TO_STACK)
-			ret = CTX_ACT_OK;
-		else
+		if (ret != NAT_PUNT_TO_STACK)
 			goto drop_err;
 	}
 
@@ -1115,9 +1113,7 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 			ret = DROP_MISSED_TAIL_CALL;
 			goto drop_err;
 		}
-		if (ret == NAT_PUNT_TO_STACK)
-			ret = CTX_ACT_OK;
-		else
+		if (ret != NAT_PUNT_TO_STACK)
 			goto drop_err;
 	}
 


### PR DESCRIPTION
The assignment ret = CTX_ACT_OK is either overwritten or unused in all
successive code paths and thus a dead store.

Found using the clang static analyzer.