### PR TITLE
v1.7 backports 2020-06-30

### DIFF
--- a/operator/eni.go
+++ b/operator/eni.go
@@ -157,7 +157,9 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags ma
 				RunInterval: time.Minute,
 				DoFunc: func(ctx context.Context) error {
 					syncTime := instances.Resync(ctx)
-					nodeManager.Resync(ctx, syncTime)
+					if !syncTime.IsZero() {
+						nodeManager.Resync(ctx, syncTime)
+					}
 					return nil
 				},
 			})

--- a/operator/eni.go
+++ b/operator/eni.go
@@ -143,8 +143,7 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags ma
 	}
 
 	// Initial blocking synchronization of all ENIs and subnets
-	resyncTime := instances.Resync(context.TODO())
-	if resyncTime.IsZero() {
+	if _, ok := nodeManager.InstancesAPIResync(context.TODO()); !ok {
 		return fmt.Errorf("Initial synchronization with instances API failed")
 	}
 
@@ -159,8 +158,7 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags ma
 			controller.ControllerParams{
 				RunInterval: time.Minute,
 				DoFunc: func(ctx context.Context) error {
-					syncTime := instances.Resync(ctx)
-					if !syncTime.IsZero() {
+					if syncTime, ok := nodeManager.InstancesAPIResync(context.TODO()); ok {
 						nodeManager.Resync(ctx, syncTime)
 					}
 					return nil

--- a/operator/eni.go
+++ b/operator/eni.go
@@ -143,7 +143,10 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags ma
 	}
 
 	// Initial blocking synchronization of all ENIs and subnets
-	instances.Resync(context.TODO())
+	resyncTime := instances.Resync(context.TODO())
+	if resyncTime.IsZero() {
+		return fmt.Errorf("Initial synchronization with instances API failed")
+	}
 
 	// Start an interval based  background resync for safety, it will
 	// synchronize the state regularly and resolve eventual deficit if the

--- a/pkg/aws/eni/node_manager.go
+++ b/pkg/aws/eni/node_manager.go
@@ -108,7 +108,9 @@ func NewNodeManager(instancesAPI nodeManagerAPI, ec2API ec2API, k8sAPI k8sAPI, m
 		MetricsObserver: metrics.ResyncTrigger(),
 		TriggerFunc: func(reasons []string) {
 			syncTime := instancesAPI.Resync(context.TODO())
-			mngr.Resync(context.TODO(), syncTime)
+			if !syncTime.IsZero() {
+				mngr.Resync(context.TODO(), syncTime)
+			}
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
* #11231 -- Protect ENI and Azure IPAM from misbehaving cloud APIs (@tgraf)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11231; do contrib/backporting/set-labels.py $pr done 1.7; done
```