### PR TITLE
datapath/linux/probes: make ErrKernelConfigNotFound a sentinel error value

### DIFF
--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -17,6 +17,7 @@
 package probes
 
 import (
+	"errors"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -254,7 +255,7 @@ func (s *ProbesTestSuite) TestSystemConfigProbes(c *C) {
 			features: Features{SystemConfig: tc.systemConfig},
 		}
 		err := manager.SystemConfigProbes()
-		if _, ok := err.(*ErrKernelConfigNotFound); ok {
+		if errors.Is(err, ErrKernelConfigNotFound) {
 			return
 		}
 		if tc.expectErr {

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -15,6 +15,7 @@
 package linux
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -177,7 +178,7 @@ func CheckMinRequirements() {
 		probeManager := probes.NewProbeManager()
 		if err := probeManager.SystemConfigProbes(); err != nil {
 			errMsg := "BPF system config check: NOT OK."
-			if _, ok := err.(*probes.ErrKernelConfigNotFound); ok {
+			if errors.Is(err, probes.ErrKernelConfigNotFound) {
 				log.WithError(err).Info(errMsg)
 			} else {
 				log.WithError(err).Warn(errMsg)


### PR DESCRIPTION
This is idiomatic in Go and allows to use errors.Is on error values
returned by (*ProbeManager).SystemConfigProbes instead of a type
assertion.

Also use fmt.Errorf instead of the external github.com/pkg/errors to
wrap error values in (*ProbeManager).SystemConfigProbes

Noticed while reviewing #12335 