### PR TITLE
v1.6 backports 2020-06-30

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright 2020 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/../release/lib/common.sh
+source $DIR/common.sh
+
+BRANCH="${1:-}"
+if [ "$BRANCH" = "" ]; then
+    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
+fi
+BRANCH=$(echo "$BRANCH" | sed 's/^v//')
+
+SUMMARY=${2:-}
+if [ "$SUMMARY" = "" ]; then
+    SUMMARY="v$BRANCH-backport-$(date --rfc-3339=date).txt"
+fi
+
+if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+    echo "usage: $0 [branch version] [pr-summary]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
+    exit 1
+fi
+
+if ! hub help | grep -q "pull-request"; then
+    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+    echo "Please install this tool first." 1>&2
+    exit 1
+fi
+
+echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+cat $SUMMARY 1>&2
+echo -e "\nSending pull request..." 2>&1
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git push origin "$PR_BRANCH"
+hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
+
+prs=$(grep "set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
+echo -e "\nUpdating labels for PRs $prs\n" 2>&1
+echo -n "Set labels for all PRs above? [y/N] "
+read set_all_labels
+if [ "$set_all_labels" = "y" ]; then
+    for pr in $prs; do
+        echo -n "Setting labels for PR $pr... "
+        $DIR/set-labels.py $pr pending $BRANCH;
+        echo "✓"
+    done
+fi

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
 {{- if .Values.global.ipv4.enabled }}
             host: '127.0.0.1'
 {{- else }}
-            host: '[::1]'
+            host: '::1'
 {{- end }}
             path: /healthz
             port: 9234

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -342,7 +342,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				}
 				if versionInfo < nonce {
 					// versions after VersionInfo, upto and including ResponseNonce are NACKed
-					requestLog.Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
+					requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
 					// Watcher will behave as if the sent version was acked.
 					// Otherwise we will just be sending the same failing
 					// version over and over filling logs.

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -672,13 +672,17 @@ func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error
 		return nil, fmt.Errorf("lock cancelled via context: %s", ctx.Err())
 	}
 
+	// Create the context first so that if a connectivity issue causes the
+	// RLock acquisition below to block, this timeout will run concurrently
+	// with the timeouts in renewSession() rather than running serially.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	e.RLock()
 	mu := concurrency.NewMutex(e.lockSession, path)
 	leaseID := e.lockSession.Lease()
 	e.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
 	err := mu.Lock(ctx)
 	if err != nil {
 		e.checkLockSession(err, leaseID)

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -301,6 +301,9 @@ const (
 	// XDSResource is an xDS resource message.
 	XDSResource = "xdsResource"
 
+	// XDSDetail is detail string included in XDS NACKs.
+	XDSDetail = "xdsDetail"
+
 	// K8s-specific
 
 	// K8sNodeID is the k8s ID of a K8sNode

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1834,6 +1834,10 @@ func (c *DaemonConfig) Populate() {
 			log.Warningf("Running Cilium with %q=%q requires endpoint CRDs. Changing %s to %t", KVStore, c.KVStore, DisableCiliumEndpointCRDName, false)
 			c.DisableCiliumEndpointCRD = false
 		}
+		if c.K8sEventHandover {
+			log.Warningf("Running Cilium with %q=%q requires KVStore capability. Changing %s to %t", KVStore, c.KVStore, K8sEventHandover, false)
+			c.K8sEventHandover = false
+		}
 	}
 
 	// Hidden options


### PR DESCRIPTION
* #12016 -- envoy: Include detail in NACK warning (@jrajahalme)
 * #11986 -- contrib/backporting: remove requires-janitor-review label (@aanm)
 * #12025 -- ginkgo-ext: Fix data-race in Writer (@gandro)
 * #12146 -- pkg/option: disable K8sEventHandover if Cilium is running without KVStore (@aanm)
 * #12223 -- helm/operator: fix IPv6 liveness probe address for operator (@Rolinh)
 * #12292 -- Fix bug where etcd session renew would block indefinitely, causing endpoint provision to fail (@joestringer)

Skipped prs due to conflicts:
 * #11995 -- test: Wait for POD policy revision increment in all cases. (@jrajahalme)
 * #12106 -- Use right CCNP validation (@aanm)
 * #12214 -- istio: Update to 1.5.6 (@jrajahalme)
 * #12307 -- pkg/endpoint: wait for security identity on restore (@aanm)
 * #12248 -- iptables: Remove '--nowildcard' from socket match (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12016 11986 12025 12146 12223 12292 ; do contrib/backporting/set-labels.py $pr done 1.6; done
```