### PR TITLE
gitignore: Add test/gke/registry-adder.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ test/gke/cluster-uri
 test/gke/cluster-version
 test/gke/gke-kubeconfig
 test/gke/resize-kubeconfig
+test/gke/registry-adder.yaml
 
 # Emacs backup files
 *~

--- a/test/eks/release-cluster.sh
+++ b/test/eks/release-cluster.sh
@@ -14,4 +14,4 @@ eksctl scale nodegroup -r $region --cluster $cluster -n $ng -N 0
 echo "releasing cluster lock from $cluster"
 kubectl annotate deployment lock lock-
 
-rm cluster-name
+rm -f cluster-name registry-adder.yaml

--- a/test/gke/release-cluster.sh
+++ b/test/gke/release-cluster.sh
@@ -14,5 +14,4 @@ export KUBECONFIG="${script_dir}/resize-kubeconfig"
 gcloud container clusters get-credentials --project "${project}" --region "europe-west4" management-cluster-0
 kubectl delete containerclusters.container.cnrm.cloud.google.com -n test-clusters "${cluster_name}"
 
-
-rm -f "${script_dir}/cluster-uri" "${script_dir}/cluster-name" "${script_dir}/cluster-version"
+rm -f "${script_dir}/cluster-uri" "${script_dir}/cluster-name" "${script_dir}/cluster-version" "${script_dir}/registry-adder.yaml"


### PR DESCRIPTION
(GKE) Builds fail now if there are any untracked, non-ignored files in the source tree.
Fix this by adding test/gke/registry-adder.yaml into .gitignore and deleting it in
release-cluster.sh.

Note: This was a race between the parallel step of building cilium images and selecting
the cluster. If cluster selection created the registry-adder.yaml before the build was
finished, the build would find an untracked file and fail.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
