### PR TITLE
contrib: Add ability to pass suffix for branch 

### DIFF
--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -39,5 +39,16 @@ if ! git branch -a | grep -q "origin/v$BRANCH$" ; then
 fi
 
 DATE=$(date --rfc-3339=date)
-git checkout -b "pr/v$BRANCH-backport-$DATE${SUFFIX}" origin/v$BRANCH
+PRBRANCH="pr/v${BRANCH}-backport-${DATE}${SUFFIX}"
+
+if ! (git --no-pager branch | grep -q "${PRBRANCH}"); then
+    echo "Error: branch '${PRBRANCH}' already exists"
+    echo "Consider passing a suffix as the second parameter"
+    echo
+    echo "Example:"
+    echo "  ./contrib/backporting/start-backport ${BRANCH} \"-2\""
+    common::exit 1
+fi
+
+git checkout -b "${PRBRANCH}" origin/v$BRANCH
 contrib/backporting/check-stable $BRANCH v$BRANCH-backport-$DATE.txt

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -27,13 +27,17 @@ if [ "$BRANCH" = "" ]; then
 fi
 BRANCH=$(echo "$BRANCH" | sed 's/^v//')
 
+# Extra optional suffix in cases where there are multiple backport PRs that
+# have the same conflicting branch name.
+SUFFIX="${2}"
+
 git fetch origin
 if ! git branch -a | grep -q "origin/v$BRANCH$" ; then
-    echo "usage: start-backport <branch version>" 1>&2
+    echo "usage: start-backport <branch version> [suffix]" 1>&2
     echo "  (detected branch $BRANCH)" 1>&2
     common::exit 1
 fi
 
 DATE=$(date --rfc-3339=date)
-git checkout -b pr/v$BRANCH-backport-$DATE origin/v$BRANCH
+git checkout -b "pr/v$BRANCH-backport-$DATE${SUFFIX}" origin/v$BRANCH
 contrib/backporting/check-stable $BRANCH v$BRANCH-backport-$DATE.txt


### PR DESCRIPTION
This is useful in cases where a backport PR is started on the same day
that another backport PR was created, for the same branch (e.g. v1.6).
In this case, the developer would have to manually modify the script to
create a non-conflicting branch name.

This commit allows the developer instead to pass a suffix to
disambiguate the branch name, without need to modify the script.

Example usage:

```
$ ./contrib/backporting/start-backport 1.6 "-2"
```

This creates a backport branch name `pr/v1.6-backport-2020-06-30-2`.