### PR TITLE
v1.7 backports 2020-06-30

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -138,6 +138,7 @@ cilium-agent [flags]
       --monitor-queue-size int                        Size of the event queue when reading monitor events
       --mtu int                                       Overwrite auto-detected MTU of underlying network
       --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --native-routing-cidr string                    Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
       --node-port-bind-protection                     Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-mode string                         BPF NodePort mode ("snat", "dsr") (default "snat")
       --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])

--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/k8s"
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2_validation "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/validator"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
 	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	"github.com/cilium/cilium/pkg/logging"
@@ -29,9 +29,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,13 +81,18 @@ func validateCNPs() error {
 		return fmt.Errorf("Unable to create API extensions clientset for k8s CRD: %w", err)
 	}
 
+	npValidator, err := v2_validation.NewNPValidator()
+	if err != nil {
+		return err
+	}
+
 	ctx, initCancel := context.WithTimeout(context.Background(), validateK8sPoliciesTimeout)
 	defer initCancel()
-	cnpErr := validateNPResources(ctx, apiExtensionsClient, &v2.CNPCRV, "ciliumnetworkpolicies", "CiliumNetworkPolicy")
+	cnpErr := validateNPResources(ctx, apiExtensionsClient, npValidator.ValidateCNP, "ciliumnetworkpolicies", "CiliumNetworkPolicy")
 
 	ctx, initCancel2 := context.WithTimeout(context.Background(), validateK8sPoliciesTimeout)
 	defer initCancel2()
-	ccnpErr := validateNPResources(ctx, apiExtensionsClient, &v2.CNPCRV, "ciliumclusterwidenetworkpolicies", "CiliumClusterwideNetworkPolicy")
+	ccnpErr := validateNPResources(ctx, apiExtensionsClient, npValidator.ValidateCCNP, "ciliumclusterwidenetworkpolicies", "CiliumClusterwideNetworkPolicy")
 
 	if cnpErr != nil {
 		return cnpErr
@@ -102,7 +104,13 @@ func validateCNPs() error {
 	return nil
 }
 
-func validateNPResources(ctx context.Context, apiExtensionsClient apiextensionsclient.Interface, crv *v1beta1.CustomResourceValidation, name, shortName string) error {
+func validateNPResources(
+	ctx context.Context,
+	apiExtensionsClient apiextensionsclient.Interface,
+	validator func(cnp *unstructured.Unstructured) error,
+	name,
+	shortName string,
+) error {
 	// check if the crd is installed at all
 	_, err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(name+"."+ciliumGroup, metav1.GetOptions{})
 	switch {
@@ -110,20 +118,6 @@ func validateNPResources(ctx context.Context, apiExtensionsClient apiextensionsc
 	case k8sErrors.IsNotFound(err):
 		return nil
 	default:
-		return err
-	}
-
-	var internal apiextensionsinternal.CustomResourceValidation
-	err = v1beta1.Convert_v1beta1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(
-		crv,
-		&internal,
-		nil,
-	)
-	if err != nil {
-		return err
-	}
-	validator, _, err := validation.NewSchemaValidator(&internal)
-	if err != nil {
 		return err
 	}
 
@@ -156,9 +150,9 @@ func validateNPResources(ctx context.Context, apiExtensionsClient apiextensionsc
 			} else {
 				cnpName = cnp.GetName()
 			}
-			if errs := validation.ValidateCustomResource(nil, &cnp, validator); len(errs) > 0 {
+			if err := validator(&cnp); err != nil {
 				log.Errorf("Validating %s '%s': unexpected validation error: %s",
-					shortName, cnpName, errs.ToAggregate())
+					shortName, cnpName, err)
 				policyErr = fmt.Errorf("Found invalid %s", shortName)
 			} else {
 				log.Infof("Validating %s '%s': OK!", shortName, cnpName)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -517,6 +517,9 @@ func init() {
 	flags.Bool(option.NodePortBindProtection, true, "Reject application bind(2) requests to service ports in the NodePort range")
 	option.BindEnv(option.NodePortBindProtection)
 
+	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.")
+	option.BindEnv(option.IPv4NativeRoutingCIDR)
+
 	flags.String(option.LibDir, defaults.LibraryPath, "Directory path to store runtime build environment")
 	option.BindEnv(option.LibDir)
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -278,6 +278,9 @@ data:
   iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
 {{- end }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
+  {{- if .Values.global.nativeRoutingCIDR }}
+  native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
+  {{- end }}
 
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -278,9 +278,9 @@ data:
   iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
 {{- end }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
-  {{- if .Values.global.nativeRoutingCIDR }}
+{{- if .Values.global.nativeRoutingCIDR }}
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
-  {{- end }}
+{{- end }}
 
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -115,6 +115,10 @@ global:
   # nodes if worker nodes share a common L2 network segment.
   autoDirectNodeRoutes: false
 
+  # nativeRoutingCIDR allows to explicitly specify the CIDR for native routing. This
+  # value corresponds to the configured cluster-cidr.
+  nativeRoutingCIDR: ""
+
   # endpointRoutes enables use of per endpoint routes instead of routing vis
   # the cilium_host interface
   endpointRoutes:

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -43,7 +43,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.17"
+	CustomResourceDefinitionSchemaVersion = "1.18"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -190,7 +190,7 @@ func createCNPCRD(clientset apiextensionsclient.Interface) error {
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
 			Scope:      apiextensionsv1beta1.NamespaceScoped,
-			Validation: &CNPCRV,
+			Validation: CNPCRV,
 		},
 	}
 	// Kubernetes < 1.12 does not support having the field Type set in the root
@@ -242,7 +242,7 @@ func createCCNPCRD(clientset apiextensionsclient.Interface) error {
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
 			Scope:      apiextensionsv1beta1.ClusterScoped,
-			Validation: &CNPCRV,
+			Validation: CNPCRV,
 		},
 	}
 	// Kubernetes < 1.12 does not support having the field Type set in the root
@@ -624,7 +624,7 @@ var (
 		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{},
 	}
 
-	CNPCRV = apiextensionsv1beta1.CustomResourceValidation{
+	CNPCRV = &apiextensionsv1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
 			// TODO: remove the following comment when we add checker
 			// to detect if we should install the CNP validation for k8s > 1.11
@@ -1063,6 +1063,13 @@ var (
 					"whose key field is \"key\", the operator is \"In\", and the values array " +
 					"contains only \"value\". The requirements are ANDed.",
 				Type: "object",
+				AdditionalProperties: &apiextensionsv1beta1.JSONSchemaPropsOrBool{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type:      "string",
+						MaxLength: getInt64(63),
+						Pattern:   `^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`,
+					},
+				},
 			},
 			"matchExpressions": {
 				Description: "matchExpressions is a list of label selector requirements. " +

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -871,7 +871,8 @@ var (
 			},
 		},
 	}
-	EndpointSelector = *LabelSelector.DeepCopy()
+
+	EndpointSelector = initEndpointSelector()
 
 	IngressRule = apiextensionsv1beta1.JSONSchemaProps{
 		Type: "object",
@@ -1236,7 +1237,7 @@ var (
 					"secret",
 				},
 			},
-			"rules": L7Rules,
+			"rules": initPortRule(),
 		},
 	}
 
@@ -1458,7 +1459,7 @@ var (
 					Schema: &EgressRule,
 				},
 			},
-			"endpointSelector": EndpointSelector,
+			"endpointSelector": initRuleEndpointSelector(),
 			"ingress": {
 				Description: "Ingress is a list of IngressRule which are enforced at ingress. " +
 					"If omitted or empty, this rule does not apply at ingress.",
@@ -1485,7 +1486,7 @@ var (
 		Description: "Service wraps around selectors for services",
 		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 			"k8sService":         K8sServiceNamespace,
-			"k8sServiceSelector": ServiceSelector,
+			"k8sServiceSelector": initK8sServiceSelector(),
 		},
 	}
 
@@ -1503,7 +1504,7 @@ var (
 		},
 	}
 
-	spec = *Rule.DeepCopy()
+	spec = initSpec()
 
 	specs = apiextensionsv1beta1.JSONSchemaProps{
 		Description: "Specs is a list of desired Cilium specific rule specification.",
@@ -1514,26 +1515,37 @@ var (
 	}
 )
 
-func init() {
-	EndpointSelector.Description = "EndpointSelector is a wrapper for k8s LabelSelector."
+func initEndpointSelector() apiextensionsv1beta1.JSONSchemaProps {
+	es := LabelSelector.DeepCopy()
+	es.Description = "EndpointSelector is a wrapper for k8s LabelSelector."
+	return *es
+}
 
-	portRuleProps := PortRule.Properties["rules"]
+func initPortRule() apiextensionsv1beta1.JSONSchemaProps {
+	portRuleProps := L7Rules.DeepCopy()
 	portRuleProps.Description = "Rules is a list of additional port level rules which must be " +
 		"met in order for the PortRule to allow the traffic. If omitted or empty, " +
 		"no layer 7 rules are enforced."
-	PortRule.Properties["rules"] = portRuleProps
+	return *portRuleProps
+}
 
-	ruleProps := Rule.Properties["endpointSelector"]
+func initRuleEndpointSelector() apiextensionsv1beta1.JSONSchemaProps {
+	ruleProps := EndpointSelector.DeepCopy()
 	ruleProps.Description = "EndpointSelector selects all endpoints which should be subject " +
 		"to this rule. Cannot be empty."
-	Rule.Properties["endpointSelector"] = ruleProps
+	return *ruleProps
+}
 
-	serviceProps := Service.Properties["k8sServiceSelector"]
+func initK8sServiceSelector() apiextensionsv1beta1.JSONSchemaProps {
+	serviceProps := ServiceSelector.DeepCopy()
 	serviceProps.Description = "K8sServiceSelector selects services by k8s labels. " +
 		"Not supported yet"
-	Service.Properties["k8sServiceSelector"] = serviceProps
+	return *serviceProps
+}
 
+func initSpec() apiextensionsv1beta1.JSONSchemaProps {
+	spec := Rule.DeepCopy()
 	spec.Description = "Spec is the desired Cilium specific rule specification."
 	spec.Type = "object"
-
+	return *spec
 }

--- a/pkg/k8s/apis/cilium.io/v2/register_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/register_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ func (s *CiliumV2RegisterSuite) getTestUpToDateDefinition() *apiextensionsv1beta
 			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Validation: &CNPCRV,
+			Validation: CNPCRV,
 		},
 	}
 }

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+
+	"github.com/go-openapi/validate"
+	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// NPValidator is a validator structure used to validate CNP.
+type NPValidator struct {
+	cnpValidator  *validate.SchemaValidator
+	ccnpValidator *validate.SchemaValidator
+}
+
+func NewNPValidator() (*NPValidator, error) {
+	// There are some default variables set by the CustomResourceValidation
+	// Marshaller so we need to marshal and unmarshal the CNPCRV to have those
+	// default values, the same way k8s api-server has it.
+	cnpCRVJSONBytes, err := json.Marshal(v2.CNPCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to marshall CNPCRV: %w", err)
+	}
+	var cnpCRV apiextensionsv1beta1.CustomResourceValidation
+	err = json.Unmarshal(cnpCRVJSONBytes, &cnpCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to unmarshall CNPCRV: %w", err)
+	}
+
+	var cnpInternal apiextensionsinternal.CustomResourceValidation
+	err = apiextensionsv1beta1.Convert_v1beta1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(
+		&cnpCRV,
+		&cnpInternal,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cnpValidator, _, err := validation.NewSchemaValidator(&cnpInternal)
+	if err != nil {
+		return nil, err
+	}
+
+	// There are some default variables set by the CustomResourceValidation
+	// Marshaller so we need to marshal and unmarshal the CNPCRV to have those
+	// default values, the same way k8s api-server has it.
+	ccnpCRVJSONBytes, err := json.Marshal(v2.CNPCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to marshall CCNPCRV: %w", err)
+	}
+	var ccnpCRV apiextensionsv1beta1.CustomResourceValidation
+	err = json.Unmarshal(ccnpCRVJSONBytes, &ccnpCRV)
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to unmarshall CCNPCRV: %w", err)
+	}
+
+	var ccnpInternal apiextensionsinternal.CustomResourceValidation
+	err = apiextensionsv1beta1.Convert_v1beta1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(
+		&ccnpCRV,
+		&ccnpInternal,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ccnpValidator, _, err := validation.NewSchemaValidator(&ccnpInternal)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NPValidator{
+		cnpValidator:  cnpValidator,
+		ccnpValidator: ccnpValidator,
+	}, nil
+}
+
+// ValidateCNP validates the given CNP accordingly the CNP validation schema.
+func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
+	if errs := validation.ValidateCustomResource(nil, &cnp, n.cnpValidator); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	return nil
+}
+
+// ValidateCCNP validates the given CCNP accordingly the CCNP validation schema.
+func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
+	if errs := validation.ValidateCustomResource(nil, &ccnp, n.ccnpValidator); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	return nil
+}

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -1,0 +1,189 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package validator
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+// Hook up gocheck into the "go test" runner.
+type CNPValidationSuite struct {
+}
+
+var _ = Suite(&CNPValidationSuite{})
+
+func (s *CNPValidationSuite) Test_GH10643(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: exampleapp
+  namespace: examplens
+spec:
+  egress:
+  - toFQDNs:
+    - matchPattern: prefix*.tier.location.example.com
+    toPorts:
+    - ports:
+      - port "8050"
+      - protocl TCP
+      - port "8051"
+      - protocl TCP
+      - port "8052"
+      - protocl TCP
+      - port "8053"
+      - protocl TCP
+      - port "8054"
+      - protocl TCP
+      - port "8055"
+      - protocl TCP
+      - port "8056"
+      - protocl TCP
+      - port "8057"
+      - protocl TCP
+      - port "8058"
+      - protocl TCP
+      - port "8059"
+      - protocl TCP
+  endpointSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - example-app-0-spark-worker
+      - example-app-0-spark-driver
+      - example-app-0-spark-worker-qe3
+      - example-app-0-spark-driver-qe3
+      - example-app-1-spark-worker
+      - example-app-1-spark-driver
+      - example-app-1-spark-worker-qe3
+      - example-app-1-spark-driver-qe3
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	// Err can't be nil since validation should detect the policy is not correct.
+	c.Assert(err, Not(IsNil))
+}
+
+func (s *CNPValidationSuite) Test_BadMatchLabels(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-test-1
+  namespace: ns-2
+spec:
+  egress:
+  - toServices:
+    - k8sService:
+        namespace: default
+        serviceName: kubernetes
+  endpointSelector:
+    matchLabels:
+      key: app
+      operator: In
+      values:
+      - prometheus
+      - kube-state-metrics
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	// Err can't be nil since validation should detect the policy is not correct.
+	c.Assert(err, Not(IsNil))
+}
+
+func (s *CNPValidationSuite) Test_GoodCNP(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-test-1
+  namespace: ns-2
+spec:
+  egress:
+  - toServices:
+    - k8sService:
+        namespace: default
+        serviceName: kubernetes
+  endpointSelector:
+    matchLabels:
+      key: app
+      operator: In
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	c.Assert(err, IsNil)
+}
+
+func (s *CNPValidationSuite) Test_GoodCCNP(c *C) {
+	ccnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: cnp-test-1
+spec:
+  egress:
+  - toServices:
+    - k8sService:
+        namespace: default
+        serviceName: kubernetes
+  endpointSelector:
+    matchLabels:
+      key: app
+      operator: In
+`)
+	jsnByte, err := yaml.YAMLToJSON(ccnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCCNP(&us)
+	c.Assert(err, IsNil)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1637,6 +1637,10 @@ func (c *DaemonConfig) Validate() error {
 		return fmt.Errorf("specified PolicyMap max entries %d must not exceed maximum %d",
 			c.PolicyMapMaxEntries, policyMapMax)
 	}
+	if err := c.checkIPv4NativeRoutingCIDR(); err != nil {
+		return nil
+	}
+
 	// Validate that the KVStore Lease TTL value lies between a particular range.
 	if c.KVstoreLeaseTTL > defaults.KVstoreLeaseMaxTTL || c.KVstoreLeaseTTL < defaults.LockLeaseTTL {
 		return fmt.Errorf("KVstoreLeaseTTL does not lie in required range(%ds, %ds)",
@@ -2098,6 +2102,15 @@ func (c *DaemonConfig) populateHostServicesProtos() error {
 			return fmt.Errorf("Protocol other than %s,%s not supported for host reachable services: %s",
 				HostServicesTCP, HostServicesUDP, hostServicesProtos[i])
 		}
+	}
+
+	return nil
+}
+
+func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
+	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled && c.IPAM != IPAMENI {
+		return fmt.Errorf("native routing cidr must be configured with option --%s in combination with --%s --%s=%s --%s=%s",
+			IPv4NativeRoutingCIDR, Masquerade, TunnelName, c.Tunnel, IPAM, c.IPAM)
 	}
 
 	return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2108,9 +2108,13 @@ func (c *DaemonConfig) populateHostServicesProtos() error {
 }
 
 func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
-	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled && c.IPAM != IPAMENI {
-		return fmt.Errorf("native routing cidr must be configured with option --%s in combination with --%s --%s=%s --%s=%s",
-			IPv4NativeRoutingCIDR, Masquerade, TunnelName, c.Tunnel, IPAM, c.IPAM)
+	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled &&
+		c.IPAM != IPAMENI && c.EnableIPv4 {
+		return fmt.Errorf(
+			"native routing cidr must be configured with option --%s "+
+				"in combination with --%s --%s=%s --%s=%s --%s=true",
+			IPv4NativeRoutingCIDR, Masquerade, TunnelName, c.Tunnel,
+			IPAM, c.IPAM, EnableIPv4Name)
 	}
 
 	return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1638,7 +1638,7 @@ func (c *DaemonConfig) Validate() error {
 			c.PolicyMapMaxEntries, policyMapMax)
 	}
 	if err := c.checkIPv4NativeRoutingCIDR(); err != nil {
-		return nil
+		return err
 	}
 
 	// Validate that the KVStore Lease TTL value lies between a particular range.

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -252,6 +252,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Tunnel:                TunnelDisabled,
 				IPAM:                  IPAMCRD,
 				ipv4NativeRoutingCIDR: cidr.MustParseCIDR("10.127.64.0/18"),
+				EnableIPv4:            true,
 			},
 			wantErr: false,
 		},
@@ -261,6 +262,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: false,
 				Tunnel:     TunnelDisabled,
 				IPAM:       IPAMCRD,
+				EnableIPv4: true,
 			},
 			wantErr: false,
 		},
@@ -270,6 +272,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: true,
 				Tunnel:     TunnelVXLAN,
 				IPAM:       IPAMCRD,
+				EnableIPv4: true,
 			},
 			wantErr: false,
 		},
@@ -279,6 +282,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: true,
 				Tunnel:     TunnelDisabled,
 				IPAM:       IPAMENI,
+				EnableIPv4: true,
 			},
 			wantErr: false,
 		},
@@ -288,6 +292,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 				Masquerade: true,
 				Tunnel:     TunnelDisabled,
 				IPAM:       IPAMCRD,
+				EnableIPv4: true,
 			},
 			wantErr: true,
 		},
@@ -301,6 +306,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 func (s *OptionSuite) TestEndpointStatusValues(c *C) {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -101,6 +101,7 @@ var (
 		"global.etcd.leaseTTL":          "30s",
 		"global.ipv4.enabled":           "true",
 		"global.ipv6.enabled":           "true",
+		"global.nativeRoutingCIDR":      "10.0.0.0/16",
 	}
 
 	flannelHelmOverrides = map[string]string{


### PR DESCRIPTION
* #12180 -- Fix native routing cidr missing flag in daemon (@aanm)
 I had to backport the following PRs due lack of existing code:
   * #11132 -- Add possibility to configure native-routing-cidr in helm chart (@zbindenren )
   * #12198 -- option: Require native-routing-cidr only if IPv4 is enabled (@brb )
 * #12117 -- pkg/k8s: add validation schema for MatchLabels (@aanm)
 * #12106 -- Use right CCNP validation (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12180 12117 11132 12198 12106; do contrib/backporting/set-labels.py $pr done 1.7; done
```