### PR TITLE
v1.7 backports 2020-07-01

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -29,20 +29,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.5.6 <https://github.com/cilium/istio/releases/tag/1.5.6>`_:
+Download the `cilium enhanced istioctl version 1.5.7 <https://github.com/cilium/istio/releases/tag/1.5.7>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.6/cilium-istioctl-1.5.6-linux.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-linux.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.6/cilium-istioctl-1.5.6-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-osx.tar.gz | tar xz
 
 .. note::
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -49,7 +49,7 @@ const (
 	ciliumPreMangleChain        = "CILIUM_PRE_mangle"
 	ciliumPreRawChain           = "CILIUM_PRE_raw"
 	ciliumForwardChain          = "CILIUM_FORWARD"
-	CiliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
+	ciliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
 	feederDescription           = "cilium-feeder:"
 	xfrmDescription             = "cilium-xfrm-notrack:"
 )
@@ -164,7 +164,7 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 	for scanner.Scan() {
 		rule := scanner.Text()
 		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering removing %s rule", prog)
-		if match != CiliumTransientForwardChain && strings.Contains(rule, CiliumTransientForwardChain) {
+		if match != ciliumTransientForwardChain && strings.Contains(rule, ciliumTransientForwardChain) {
 			continue
 		}
 
@@ -200,7 +200,7 @@ func (c *customChain) remove(waitArgs []string, quiet bool) {
 			// present, log the error.
 			// This is to help debug #11276.
 			msgChainNotFound := ": No chain/target/match by that name.\n"
-			debugTransientRules := c.name == CiliumTransientForwardChain &&
+			debugTransientRules := c.name == ciliumTransientForwardChain &&
 				string(combinedOutput) != prog+msgChainNotFound
 			if !quiet || debugTransientRules {
 				log.Warnf(string(combinedOutput))
@@ -322,7 +322,7 @@ var ciliumChains = []customChain{
 }
 
 var transientChain = customChain{
-	name:       CiliumTransientForwardChain,
+	name:       ciliumTransientForwardChain,
 	table:      "filter",
 	hook:       "FORWARD",
 	feederArgs: []string{""},
@@ -721,7 +721,7 @@ func getDeliveryInterface(ifName string) string {
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
 	transient := ""
-	if forwardChain == CiliumTransientForwardChain {
+	if forwardChain == ciliumTransientForwardChain {
 		transient = " (transient)"
 	}
 
@@ -833,7 +833,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 // TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
 func (m *IptablesManager) TransientRulesEnd(quiet bool) {
 	if option.Config.EnableIPv4 {
-		m.removeCiliumRules("filter", "iptables", CiliumTransientForwardChain)
+		m.removeCiliumRules("filter", "iptables", ciliumTransientForwardChain)
 		transientChain.remove(m.waitArgs, quiet)
 	}
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cilium/cilium/test/ginkgo-ext"
@@ -212,16 +211,15 @@ const (
 
 	// Logs messages that should not be in the cilium logs.
 	panicMessage        = "panic:"
-	deadLockHeader      = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault   = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived        = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed       = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
-	sizeMismatch        = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
-	emptyBPFInitArg     = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
-	RemovingMapMsg      = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
-	logBufferMessage    = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
-	removeTransientRule = "Unable to process chain " +
-		iptables.CiliumTransientForwardChain + " with ip" // from https://github.com/cilium/cilium/issues/11276
+	deadLockHeader      = "POTENTIAL DEADLOCK:"                                      // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault   = "segmentation fault"                                       // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived        = "NACK received for version"                                // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed       = "JoinEP: "                                                 // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch        = "size mismatch for BPF map"                                // from https://github.com/cilium/cilium/issues/7851
+	emptyBPFInitArg     = "empty argument passed to bpf/init.sh"                     // from https://github.com/cilium/cilium/issues/10228
+	RemovingMapMsg      = "Removing map to allow for property upgrade"               // from https://github.com/cilium/cilium/pull/10626
+	logBufferMessage    = "Log buffer too small to dump verifier log"                // from https://github.com/cilium/cilium/issues/10517
+	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"

--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -37,6 +37,7 @@ var (
 
 // Executor executes commands
 type Executor interface {
+	IsLocal() bool
 	CloseSSHClient()
 	Exec(cmd string, options ...ExecOptions) *CmdRes
 	ExecContext(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes
@@ -63,6 +64,11 @@ type LocalExecutor struct {
 // CreateLocalExecutor returns a local executor
 func CreateLocalExecutor(env []string) *LocalExecutor {
 	return &LocalExecutor{env: env}
+}
+
+// IsLocal returns true if commands are executed on the Ginkgo host
+func (s *LocalExecutor) IsLocal() bool {
+	return true
 }
 
 // Logger returns logger for executor

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -53,6 +53,11 @@ func CreateSSHMeta(host string, port int, user string) *SSHMeta {
 	}
 }
 
+// IsLocal returns true if commands are executed on the Ginkgo host
+func (s *SSHMeta) IsLocal() bool {
+	return false
+}
+
 // Logger returns logger for SSHMeta
 func (s *SSHMeta) Logger() *logrus.Entry {
 	return s.logger

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -36,7 +36,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.5.6"
+		istioVersion = "1.5.7"
 
 		// Modifiers for pre-release testing, normally empty
 		prerelease     = "" // "-beta.1"
@@ -45,9 +45,9 @@ var _ = Describe("K8sIstioTest", func() {
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.6" +
-		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.6" +
-		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.6"
+		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.7" +
+		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.7" +
+		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.7"
 		ciliumOptions = map[string]string{
 			// "global.proxy.sidecarImageRegex": "jrajahalme/istio_proxy",
 		}

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -87,7 +87,7 @@ var _ = Describe("K8sIstioTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		By("Downloading cilium-istioctl")
-		res := kubectl.Exec(fmt.Sprintf("curl -L %s | tar xz", ciliumIstioctlURL))
+		res := kubectl.Exec(fmt.Sprintf("curl --retry 5 -L %s | tar xz", ciliumIstioctlURL))
 		res.ExpectSuccess("unable to download %s", ciliumIstioctlURL)
 		res = kubectl.ExecShort("./cilium-istioctl version")
 		res.ExpectSuccess("unable to execute cilium-istioctl")

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -58,7 +58,6 @@ var _ = Describe("K8sIstioTest", func() {
 			"linux":  "linux",
 		}
 
-		ciliumIstioctlURL = "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-" + ciliumIstioctlOSes[runtime.GOOS] + ".tar.gz"
 		// istioServiceNames is the set of Istio services needed for the tests
 		istioServiceNames = []string{
 			"istio-ingressgateway",
@@ -87,6 +86,12 @@ var _ = Describe("K8sIstioTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		By("Downloading cilium-istioctl")
+		os := "linux"
+		if kubectl.IsLocal() {
+			// Use Ginkgo runtime OS instead when commands are executed in the local Ginkgo host
+			os = ciliumIstioctlOSes[runtime.GOOS]
+		}
+		ciliumIstioctlURL := "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-" + os + ".tar.gz"
 		res := kubectl.Exec(fmt.Sprintf("curl --retry 5 -L %s | tar xz", ciliumIstioctlURL))
 		res.ExpectSuccess("unable to download %s", ciliumIstioctlURL)
 		res = kubectl.ExecShort("./cilium-istioctl version")

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -17,6 +17,7 @@ package k8sTest
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -51,7 +52,13 @@ var _ = Describe("K8sIstioTest", func() {
 			// "global.proxy.sidecarImageRegex": "jrajahalme/istio_proxy",
 		}
 
-		ciliumIstioctlURL = "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-linux.tar.gz"
+		// Map of tested runtimes for cilium-istioctl
+		ciliumIstioctlOSes = map[string]string{
+			"darwin": "osx",
+			"linux":  "linux",
+		}
+
+		ciliumIstioctlURL = "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-" + ciliumIstioctlOSes[runtime.GOOS] + ".tar.gz"
 		// istioServiceNames is the set of Istio services needed for the tests
 		istioServiceNames = []string{
 			"istio-ingressgateway",
@@ -92,7 +99,7 @@ var _ = Describe("K8sIstioTest", func() {
 		res = kubectl.NamespaceLabel(helpers.DefaultNamespace, "istio-injection=enabled")
 		res.ExpectSuccess("unable to label namespace %q", helpers.DefaultNamespace)
 
-		By("Deplying Istio")
+		By("Deploying Istio")
 		res = kubectl.Exec("./cilium-istioctl manifest apply -y" + istioctlParams)
 		res.ExpectSuccess("unable to deploy Istio")
 	})
@@ -169,7 +176,7 @@ var _ = Describe("K8sIstioTest", func() {
 
 	// This is a subset of Services's "Bookinfo Demo" test suite, with the pods
 	// injected with Istio sidecar proxies and Istio mTLS enabled.
-	Context("Istio Bookinfo Demo", func() {
+	SkipContextIf(func() bool { return ciliumIstioctlOSes[runtime.GOOS] == "" }, "Istio Bookinfo Demo", func() {
 
 		var (
 			resourceYAMLPaths []string


### PR DESCRIPTION
 * #11905 -- test: Skip Istio test if Ginkgo runs on unsupported runtime. (@jrajahalme)
 * #11993 -- test: Add retries to curl command (@christarazi)
 * #12074 -- test: Remove ginkgo linux dependency (@jrajahalme)
 * #12109 -- test: Download correct cilium-istioctl for the executing OS. (@jrajahalme)
 * #12353 -- istio: Update to 1.5.7 (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11905 11993 12074 12109 12353; do contrib/backporting/set-labels.py $pr done 1.7; done
```
