### PR TITLE
v1.8 backports 2020-07-01

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -29,20 +29,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.5.6 <https://github.com/cilium/istio/releases/tag/1.5.6>`_:
+Download the `cilium enhanced istioctl version 1.5.7 <https://github.com/cilium/istio/releases/tag/1.5.7>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.6/cilium-istioctl-1.5.6-linux.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-linux.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.6/cilium-istioctl-1.5.6-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-osx.tar.gz | tar xz
 
 .. note::
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -36,7 +36,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.5.6"
+		istioVersion = "1.5.7"
 
 		// Modifiers for pre-release testing, normally empty
 		prerelease     = "" // "-beta.1"
@@ -45,9 +45,9 @@ var _ = Describe("K8sIstioTest", func() {
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.6" +
-		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.6" +
-		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.6"
+		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.7" +
+		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.7" +
+		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.7"
 		ciliumOptions = map[string]string{
 			// "global.proxy.sidecarImageRegex": "jrajahalme/istio_proxy",
 		}


### PR DESCRIPTION
 * #12353 -- istio: Update to 1.5.7 (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12353; do contrib/backporting/set-labels.py $pr done 1.8; done
```
