### PR TITLE
ci: add startup-script to local node repo

### DIFF
--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -21,6 +21,12 @@ docker push "$1/cilium/operator-aws:$2"
 docker push "$1/cilium/operator-azure:$2"
 docker push "$1/cilium/hubble-relay:$2"
 
+# push startup-script image with proper tag to repo
+nodeInitTag="af2a99046eca96c0138551393b21a5c044c7fe79"
+docker pull "cilium/startup-script:$nodeInitTag"
+docker tag "cilium/startup-script:$nodeInitTag" "$1/cilium/startup-script:$nodeInitTag"
+docker push "$1/cilium/startup-script:$nodeInitTag"
+
 cilium_git_version="$(cat GIT_VERSION)"
 
 counter=0


### PR DESCRIPTION
Lack of this image is reason for gke tests to fail, if it's available
node init should run properly in gke.