### PR TITLE
contrib: fix branch check in `start-backport` script

### DIFF
--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -41,7 +41,7 @@ fi
 DATE=$(date --rfc-3339=date)
 PRBRANCH="pr/v${BRANCH}-backport-${DATE}${SUFFIX}"
 
-if ! (git --no-pager branch | grep -q "${PRBRANCH}"); then
+if (git --no-pager branch | grep -q "${PRBRANCH}"); then
     echo "Error: branch '${PRBRANCH}' already exists"
     echo "Consider passing a suffix as the second parameter"
     echo


### PR DESCRIPTION
The `if` condition is actually inverted which makes it impossible to
create a backport branch. This commit fixes this issue.

ref: #12351 
cc @christarazi 