### PR TITLE
hubble: Trim FQDN trailing dots in GetNames

### DIFF
--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -200,7 +201,13 @@ func (d *Daemon) GetNamesOf(sourceEpID uint32, ip net.IP) []string {
 	if ep == nil {
 		return nil
 	}
-	return ep.DNSHistory.LookupIP(ip)
+	names := ep.DNSHistory.LookupIP(ip)
+
+	for i := range names {
+		names[i] = strings.TrimSuffix(names[i], ".")
+	}
+
+	return names
 }
 
 // GetServiceByAddr looks up service by IP/port. Hubble uses this function to annotate flows

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -27,7 +27,8 @@ import (
 // DNSGetter ...
 type DNSGetter interface {
 	// GetNamesOf fetches FQDNs of a given IP from the perspective of
-	// the endpoint with ID sourceEpID
+	// the endpoint with ID sourceEpID. The returned names must not have
+	// trailing dots.
 	GetNamesOf(sourceEpID uint32, ip net.IP) (names []string)
 }
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1005,6 +1005,14 @@ var _ = Describe("K8sPolicyTest", func() {
 				} else {
 					ExpectWithOffset(1, err).ToNot(BeNil(), "traffic was redirected to the proxy when it should have not been redirected")
 				}
+
+				if parser == policy.ParserTypeDNS && redirected {
+					By("Checking that Hubble is correctly annotating the DNS names")
+					res := kubectl.HubbleObserve(helpers.CiliumNamespace, ciliumPod,
+						fmt.Sprintf("--last 1 --from-pod %s/%s --to-fqdn %q",
+							namespaceForTest, appPods[helpers.App2], "*.cilium.io"))
+					res.ExpectContainsFilterLine("{.destination_names[0]}", "vagrant-cache.ci.cilium.io")
+				}
 			}
 
 			proxyVisibilityTest := func(resource, podToAnnotate, anno string, parserType policy.L7ParserType, retryCurl bool) {


### PR DESCRIPTION
Hubble v0.5 used to display FQDN names without a trailing dot for
absolute paths, i.e. `cilium.io` instead of `cilium.io.`

We accidentally changed this in Hubble v0.6 when we started accessing
the Cilium DNS cache directly. This in in turn broke filtering on FQDNs
(`--{from-,to-,}fqdn`), as the filtering logic does not work with trailing
dots. Output in Hubble UI, Hubble CLI and metrics also are incompatible
with v0.5.

This PR restores the old behavior of stripping trailing dots from
the source and destination name via `DNSGetter`. A test is added to CI
to ensure we don't regress again.
