### PR TITLE
docker: Generate .dockerignore for BUILDKIT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,7 +52,7 @@ outgoing
 man/
 
 tests/cilium-files
-test/test_results
+test/test_results*
 test/.vagrant
 test/tmp.yaml
 test/*_manifest.yaml
@@ -61,6 +61,20 @@ test/*.json
 test/*.log
 test/bpf/_results
 test/cilium-[0-9a-f]*.yaml
+test/*tmp
+test/cilium-istioctl
+
+# generated test files
+test/k8sT/manifests/cnp-second-namespaces.yaml
+test/cilium.conf.ginkgo
+
+# GKE temporary files
+test/gke/cluster-name
+test/gke/cluster-uri
+test/gke/cluster-version
+test/gke/gke-kubeconfig
+test/gke/resize-kubeconfig
+test/gke/registry-adder.yaml
 
 # Emacs backup files
 *~

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -23,10 +23,24 @@ build-context-update: GIT_VERSION
 # Generic rule for augmented .dockerignore files. For 'Dockerfile' the stem ('%') matches just the 'D'.
 # '.git' can not be ignored in the top level '.dockerignore' as builds directly from the Dockerfiles
 # (e.g., on Docker hub and Quay) depend on '.git' for the git SHA.
-_build/%ockerfile.dockerignore: .dockerignore
+.PRECIOUS: _build/%ockerfile.dockerignore
+GIT_IGNORE_FILES := $(shell find . -not -path "./_build*" -not -path "./vendor*" -name .gitignore -print)
+_build/%ockerfile.dockerignore: $(GIT_IGNORE_FILES) Makefile.buildkit
 	@-mkdir -p $(dir $@)
-	@cp $< $@
+	@echo "/hack" > $@
 	@echo ".git" >> $@
+	echo $(dir $(GIT_IGNORE_FILES)) | tr ' ' '\n' | xargs -P1 -n1 -I {DIR} sed \
+		-e '# Remove lines with white space, comments and files that must be passed to docker, "$$" due to make. #' \
+			-e '/^[[:space:]]*$$/d' -e '/^#/d' -e '/GIT_VERSION/d' \
+		-e '# Apply pattern in all directories if it contains no "/", keep "!" up front. #' \
+			-e '/^[^!/][^/]*$$/s<^<**/<' -e '/^![^/]*$$/s<^!<!**/<' \
+		-e '# Prepend with the directory name, keep "!" up front. #' \
+			-e '/^[^!]/s<^<{DIR}<' -e '/^!/s<^!<!{DIR}<'\
+		-e '# Remove leading "./", keep "!" up front. #' \
+			-e 's<^\./<<' -e 's<^!\./<!<' \
+		-e '# Append newline to the last line if missing. GNU sed does not do this automatically. #' \
+			-e '$$a\' \
+		{DIR}.gitignore >> $@
 
 # Generic rule for Dockerfiles. For 'Dockerfile' the stem ('%') matches just the 'D'.
 _build/%ockerfile: %ockerfile _build/%ockerfile.dockerignore force

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -76,7 +76,7 @@ endif
 CILIUM_ENVOY_SHA=$(shell grep -o "FROM.*cilium/cilium-envoy:[0-9a-fA-F]*" $(ROOT_DIR)/Dockerfile | cut -d : -f 2)
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 
-# Use git only if in a Git repo, otherwise depend on file BPF_SRCFILES existing
+# Use git only if in a Git repo, otherwise find the files from the file system
 BPF_SRCFILES_IGNORE = bpf/.gitignore
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
 	BPF_SRCFILES := $(shell git ls-files $(ROOT_DIR)/bpf/ | sort | tr "\n" ' ')


### PR DESCRIPTION
Generate `_build/Dockerfile.dockerignore` files automatically from all
the `.gitignore` files in the repo. This requires the following
transformations:

1. In `.gitignore` a pattern without a leading or middle `/` applies
also in all subdirectories. In `.dockerignore` such patterns behave
the same as if they started with a `/`. A special `**/` wildcard needs
to be prepended to apply the patters in any (sub) directory.

2. `.gitignore` patterns are relative to the path in which they
reside, while `.dockerignore` is always relative to the docker build
context root. Hence the subdirectory of a `.gitignore` file must be
prepended to the pattern.

3. Inclusion flag `!` must be kept at the beginning of the line
through the above transformations.

With this the docker build context size on my repo shrinks from ~700MB
to ~90MB. This helps speed up the builds as well as conserve disk space.
