### PR TITLE
ci: release gke nodepool

### DIFF
--- a/test/gke/release-cluster.sh
+++ b/test/gke/release-cluster.sh
@@ -13,5 +13,6 @@ gcloud container clusters delete --quiet --zone ${region} "${cluster_uri}"
 export KUBECONFIG="${script_dir}/resize-kubeconfig"
 gcloud container clusters get-credentials --project "${project}" --region "europe-west4" management-cluster-0
 kubectl delete containerclusters.container.cnrm.cloud.google.com -n test-clusters "${cluster_name}"
+kubectl delete containernodepools.container.cnrm.cloud.google.com -n test-clusters "${cluster_name}"
 
 rm -f "${script_dir}/cluster-uri" "${script_dir}/cluster-name" "${script_dir}/cluster-version" "${script_dir}/registry-adder.yaml"


### PR DESCRIPTION
Nodepools were having trouble being recreated after only cluster objects
were deleted. Deleting nodepools from cluster causes nodepools to be
recreated properly.