### PR TITLE
Consolidate kernel options probing and provide brief descriptions for missing parameters, in logs or for "cilium kernel-check".

### DIFF
--- a/cilium/cmd/kernel_check.go
+++ b/cilium/cmd/kernel_check.go
@@ -35,9 +35,10 @@ var kernelCheckCmd = &cobra.Command{
 
 // KernelParamSupport contains fields required for dumping JSON output
 type KernelParamSupport struct {
-	Feature   probes.KernelParam
-	Supported bool
-	Required  bool
+	Feature     probes.KernelParam
+	Supported   bool
+	Required    bool
+	Description string
 }
 
 func kernelCheck() {
@@ -46,17 +47,19 @@ func kernelCheck() {
 	requiredParams := probeManager.GetRequiredConfig()
 	for f, s := range requiredParams {
 		listParams = append(listParams, KernelParamSupport{
-			Feature:   f,
-			Supported: s,
-			Required:  true,
+			Feature:     f,
+			Supported:   s.Enabled,
+			Required:    true,
+			Description: s.Description,
 		})
 	}
 	optionalParams := probeManager.GetOptionalConfig()
 	for f, s := range optionalParams {
 		listParams = append(listParams, KernelParamSupport{
-			Feature:   f,
-			Supported: s,
-			Required:  false,
+			Feature:     f,
+			Supported:   s.Enabled,
+			Required:    false,
+			Description: s.Description,
 		})
 	}
 	if command.OutputJSON() {
@@ -67,9 +70,9 @@ func kernelCheck() {
 		return
 	}
 	w := tabwriter.NewWriter(os.Stdout, 30, 8, 0, ' ', 0)
-	fmt.Fprintln(w, "FEATURE\tSUPPORTED\tREQUIRED")
+	fmt.Fprintln(w, "FEATURE\tSUPPORTED\tREQUIRED\tDESCRIPTION")
 	for _, p := range listParams {
-		fmt.Fprintf(w, "%s\t%t\t%t\n", p.Feature, p.Supported, p.Required)
+		fmt.Fprintf(w, "%s\t%t\t%t\t%s\n", p.Feature, p.Supported, p.Required, p.Description)
 	}
 	w.Flush()
 }


### PR DESCRIPTION
Follow-up for #11339 

- [x] employ function for erroring out kernel-check on failure (kernel config not being available) 

- [x] regarding `GetOptionalConfig`: have a small description that would tell the users which features are they losing by not having these kernel features enabled for each of these options. 

- [x]  consolidation with SystemConfigProbes() in the same file, which could call Get*Config() so we avoid having lists of required/optional functions in several functions. Should be easy to pass the name of each parameter to print it in case of error, with slightly more handling to do for the few cases where kernel parameter (or module) is to be printed.

As discussed [here](https://github.com/cilium/cilium/pull/11339#discussion_r446105033) and [here](https://github.com/cilium/cilium/pull/11339#discussion_r446110757)

```release-note
Consolidate kernel options probing and provide brief descriptions for missing parameters, in logs or for "cilium kernel-check".
```