### PR TITLE
Update stable releases

### DIFF
--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -3,33 +3,33 @@ column: "In progress"
 move-to-projects-for-labels-xored:
   v1.8:
     needs-backport/1.8:
-      project: "https://github.com/cilium/cilium/projects/117"
+      project: "https://github.com/cilium/cilium/projects/119"
       column: "Needs backport from master"
     backport-pending/1.8:
-      project: "https://github.com/cilium/cilium/projects/117"
+      project: "https://github.com/cilium/cilium/projects/119"
       column: "Backport pending to v1.8"
     backport-done/1.8:
-      project: "https://github.com/cilium/cilium/projects/117"
+      project: "https://github.com/cilium/cilium/projects/119"
       column: "Backport done to v1.8"
   v1.7:
     needs-backport/1.7:
-      project: "https://github.com/cilium/cilium/projects/116"
+      project: "https://github.com/cilium/cilium/projects/120"
       column: "Needs backport from master"
     backport-pending/1.7:
-      project: "https://github.com/cilium/cilium/projects/116"
+      project: "https://github.com/cilium/cilium/projects/120"
       column: "Backport pending to v1.7"
     backport-done/1.7:
-      project: "https://github.com/cilium/cilium/projects/116"
+      project: "https://github.com/cilium/cilium/projects/120"
       column: "Backport done to v1.7"
   v1.6:
     needs-backport/1.6:
-      project: "https://github.com/cilium/cilium/projects/115"
+      project: "https://github.com/cilium/cilium/projects/118"
       column: "Needs backport from master"
     backport-pending/1.6:
-      project: "https://github.com/cilium/cilium/projects/115"
+      project: "https://github.com/cilium/cilium/projects/118"
       column: "Backport pending to v1.6"
     backport-done/1.6:
-      project: "https://github.com/cilium/cilium/projects/115"
+      project: "https://github.com/cilium/cilium/projects/118"
       column: "Backport done to v1.6"
 require-msgs-in-commit:
   - msg: "Signed-off-by"

--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,11 @@ Listed below are the actively maintained release branches along with their lates
 minor release, corresponding image pull tags and their release notes:
 
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.8 <https://github.com/cilium/cilium/tree/v1.8>`__ | 2020-06-22 | ``docker.io/cilium/cilium:v1.8.0``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.8.0>`__  | `General Announcement <https://cilium.io/blog/2020/06/22/cilium-18>`__ |
+| `v1.8 <https://github.com/cilium/cilium/tree/v1.8>`__ | 2020-07-02 | ``docker.io/cilium/cilium:v1.8.1``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.8.1>`__  | `General Announcement <https://cilium.io/blog/2020/06/22/cilium-18>`__ |
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.7 <https://github.com/cilium/cilium/tree/v1.7>`__ | 2020-06-12 | ``docker.io/cilium/cilium:v1.7.5``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.7.5>`__  | `General Announcement <https://cilium.io/blog/2020/02/18/cilium-17>`__ |
+| `v1.7 <https://github.com/cilium/cilium/tree/v1.7>`__ | 2020-07-02 | ``docker.io/cilium/cilium:v1.7.6``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.7.6>`__  | `General Announcement <https://cilium.io/blog/2020/02/18/cilium-17>`__ |
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.6 <https://github.com/cilium/cilium/tree/v1.6>`__ | 2020-06-05 | ``docker.io/cilium/cilium:v1.6.9``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.6.9>`__  | `General Announcement <https://cilium.io/blog/2019/08/20/cilium-16>`__ |
+| `v1.6 <https://github.com/cilium/cilium/tree/v1.6>`__ | 2020-07-02 | ``docker.io/cilium/cilium:v1.6.10``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.6.10>`__  | `General Announcement <https://cilium.io/blog/2019/08/20/cilium-16>`__ |
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
 
 Functionality Overview


### PR DESCRIPTION
We've released 1.8.1, 1.7.6, 1.6.10 today; bump the readme.