### PR TITLE
Fix Spelling Errors for endpoint pkg

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1319,7 +1319,7 @@ func (e *Endpoint) RequireARPPassthrough() bool {
 	return e.DatapathConfiguration.RequireArpPassthrough
 }
 
-// RequireEgressProg returns true if the endpoint requires bpf_lxc with esction
+// RequireEgressProg returns true if the endpoint requires bpf_lxc with section
 // "to-container" to be attached at egress on the host facing veth pair
 func (e *Endpoint) RequireEgressProg() bool {
 	return e.DatapathConfiguration.RequireEgressProg

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -178,7 +178,7 @@ func (ep *epInfoCache) RequireARPPassthrough() bool {
 	return ep.requireARPPassthrough
 }
 
-// RequireEgressProg returns true if the endpoint requires bpf_lxc with esction
+// RequireEgressProg returns true if the endpoint requires bpf_lxc with section
 // "to-container" to be attached at egress on the host facing veth pair
 func (ep *epInfoCache) RequireEgressProg() bool {
 	return ep.requireEgressProg


### PR DESCRIPTION
2 spelling errors are fixed which may lead to confusing
for the meaning of the whole sentence and src code.

Signed-off-by: trevor tao <trevor.tao@arm.com>