### PR TITLE
Register logging flags with operator main cmd

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -51,6 +51,8 @@ cilium-operator-aws [flags]
       --kvstore-opt map                         Key-value store options (default map[])
       --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                      Logging endpoints to use for example syslog
+      --log-opt map                             Log driver options for cilium-operator (default map[])
       --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
       --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -50,6 +50,8 @@ cilium-operator-azure [flags]
       --kvstore-opt map                         Key-value store options (default map[])
       --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                      Logging endpoints to use for example syslog
+      --log-opt map                             Log driver options for cilium-operator (default map[])
       --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
       --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -48,6 +48,8 @@ cilium-operator-generic [flags]
       --kvstore-opt map                         Key-value store options (default map[])
       --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                      Logging endpoints to use for example syslog
+      --log-opt map                             Log driver options for cilium-operator (default map[])
       --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
       --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -53,6 +53,8 @@ cilium-operator [flags]
       --kvstore-opt map                         Key-value store options (default map[])
       --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                      Logging endpoints to use for example syslog
+      --log-opt map                             Log driver options for cilium-operator (default map[])
       --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
       --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -115,6 +115,14 @@ func init() {
 	flags.Bool(operatorOption.EnableMetrics, false, "Enable Prometheus metrics")
 	option.BindEnv(operatorOption.EnableMetrics)
 
+	// Logging flags
+	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
+	option.BindEnv(option.LogDriver)
+
+	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil),
+		option.LogOpt, "Log driver options for cilium-operator")
+	option.BindEnv(option.LogOpt)
+
 	var defaultIPAM string
 	switch binaryName {
 	case "cilium-operator":


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

Fixes https://github.com/cilium/cilium/pull/11133.

In https://github.com/cilium/cilium/pull/11133 JSON logging was added in the operator but the flags were never exposed to the command.

If we pass `--log-opt` flag now to the operator we get:
```
Error: unknown flag: --log-opt
Flags:
....
unknown flag: --log-opt
```

```release-note
Register "log-driver" and "log-opt" flags with the cilium-operator command.
```
