### PR TITLE
test: retrieve pods based on node label, not name

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -786,10 +786,15 @@ func (kub *Kubectl) GetPodsNodes(namespace string, filter string) (map[string]st
 	return res.KVOutput(), nil
 }
 
-func (kub *Kubectl) GetPodOnNodeWithOffset(nodeName string, podFilter string, callOffset int) (string, string) {
-	var podName string
-
+// GetPodOnNodeLabeledWithOffset retrieves name and ip of a pod matching filter and residing on a node with label cilium.io/ci-node=<label>
+func (kub *Kubectl) GetPodOnNodeLabeledWithOffset(label string, podFilter string, callOffset int) (string, string) {
 	callOffset++
+
+	nodeName, err := kub.GetNodeNameByLabel(label)
+	gomega.ExpectWithOffset(callOffset, err).Should(gomega.BeNil())
+	gomega.ExpectWithOffset(callOffset, nodeName).ShouldNot(gomega.BeEmpty(), "Cannot retrieve node name with label cilium.io/ci-node=%s", label)
+
+	var podName string
 
 	podsNodes, err := kub.GetPodsNodes(DefaultNamespace, fmt.Sprintf("-l %s", podFilter))
 	gomega.ExpectWithOffset(callOffset, err).Should(gomega.BeNil(), "Cannot retrieve pods nodes with filter %q", podFilter)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1130,7 +1130,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				//cnpFromEntitiesWorld      string
 				//cnpFromEntitiesAll        string
 
-				k8s1Name, k8s2Name   string
+				k8s1Name             string
 				k8s1PodIP, k8s2PodIP string
 			)
 
@@ -1138,10 +1138,11 @@ var _ = Describe("K8sPolicyTest", func() {
 				cnpFromEntitiesHost = helpers.ManifestGet(kubectl.BasePath(), "cnp-from-entities-host.yaml")
 				cnpFromEntitiesRemoteNode = helpers.ManifestGet(kubectl.BasePath(), "cnp-from-entities-remote-node.yaml")
 				cnpFromEntitiesWorld = helpers.ManifestGet(kubectl.BasePath(), "cnp-from-entities-world.yaml")
-				k8s1Name, _ = kubectl.GetNodeInfo(helpers.K8s1)
-				k8s2Name, _ = kubectl.GetNodeInfo(helpers.K8s2)
-				_, k8s1PodIP = kubectl.GetPodOnNodeWithOffset(k8s1Name, testDS, 0)
-				_, k8s2PodIP = kubectl.GetPodOnNodeWithOffset(k8s2Name, testDS, 0)
+				var err error
+				k8s1Name, err = kubectl.GetNodeNameByLabel(helpers.K8s1)
+				Expect(err).To(BeNil(), "cannot get k8s1 node name")
+				_, k8s1PodIP = kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDS, 0)
+				_, k8s2PodIP = kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s2, testDS, 0)
 			})
 
 			AfterAll(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -527,8 +527,8 @@ var _ = Describe("K8sServicesTest", func() {
 			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.CiliumNamespace, helpers.K8s2)
 			ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 
-			_, dstPodIPK8s1 := kubectl.GetPodOnNodeWithOffset(helpers.K8s1, testDS, 1)
-			_, dstPodIPK8s2 := kubectl.GetPodOnNodeWithOffset(helpers.K8s2, testDS, 1)
+			_, dstPodIPK8s1 := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDS, 1)
+			_, dstPodIPK8s2 := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s2, testDS, 1)
 
 			// Get initial number of packets for the flow we test
 			// from conntrack table. The flow is probably not in
@@ -1108,7 +1108,7 @@ var _ = Describe("K8sServicesTest", func() {
 			// Get testDSClient and testDS pods running on k8s1.
 			// This is because we search for new packets in the
 			// conntrack table for node k8s1.
-			clientPod, _ := kubectl.GetPodOnNodeWithOffset(helpers.K8s1, testDSClient, 1)
+			clientPod, _ := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDSClient, 1)
 
 			err := kubectl.Get(helpers.DefaultNamespace, "service test-nodeport").Unmarshal(&data)
 			ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve service")
@@ -1188,7 +1188,7 @@ var _ = Describe("K8sServicesTest", func() {
 				count := 10
 				fails := 0
 				// Client from k8s1
-				clientPod, _ := kubectl.GetPodOnNodeWithOffset(helpers.K8s1, testDSClient, 1)
+				clientPod, _ := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDSClient, 0)
 				// Destination is a NodePort in k8s2, curl (in k8s1) binding to the same local port as the DNS proxy port
 				// in k8s2
 				url := getTFTPLink(k8s2IP, data.Spec.Ports[1].NodePort) + fmt.Sprintf(" --local-port %d", DNSProxyPort2)


### PR DESCRIPTION
This change removes reliance on hardcoded node names when retrieving
pods in several tests, which caused GKE tests (where we don't control
node names) to fail.