### PR TITLE
v1.7 fix - test/bpf: use `nproc --all` instead of `nproc -all`

### DIFF
--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.defs
 
-FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc -all) -O2
+FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc --all) -O2
 BPF_CC_FLAGS :=  ${FLAGS} -target bpf -emit-llvm
 BPF_LLC_FLAGS   := -march=bpf -mcpu=probe -filetype=obj
 


### PR DESCRIPTION
When the `__NR_CPUS__` definitions were change to use `nproc --all` in commit
6247cc5990fd ("bpf: Use `nproc --all` for `__NR_CPUS__`") via #12363 the
change in test/bpf/Makefile was missing a `-`, leading to the following
error message in the v1.8 build:

```
make -C test/bpf/
nproc: invalid option -- 'a'
Try 'nproc --help' for more information.
```

While this is uncritical for the tests and the build, but fix it
nevertheless to get rid of the error message.