### PR TITLE
chore(lint): To enable linter for test files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,10 +10,11 @@ run:
   issues-exit-code: 1
 
   # include test files or not, default is true
-  tests: false
+  tests: true
 
   # list of build tags, all linters use it. Default is empty list.
-  # build-tags:
+  build-tags:
+    - !privileged_tests
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
@@ -24,8 +25,8 @@ run:
   # default value is empty list, but next dirs are always skipped independently
   # from this option's value:
   #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs:
-    - ^test.*
+  #  skip-dirs:
+  #    - ^test.*
 
   # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit

--- a/pkg/addressing/ip_test.go
+++ b/pkg/addressing/ip_test.go
@@ -55,7 +55,7 @@ func (s *AddressingSuite) TestCiliumIPv4(c *C) {
 	// Lacking a better Equals method, checking if the stringified IP is consistent
 	c.Assert(ip.String() == ip2.String(), Equals, false)
 
-	ip, err = NewCiliumIPv4("b007::")
+	_, err = NewCiliumIPv4("b007::")
 	c.Assert(err, Not(Equals), nil)
 }
 

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -512,7 +512,7 @@ func TestRingFunctionalityInParallel(t *testing.T) {
 		t.Errorf("Read Event should be %+v, got %+v instead", &timestamp.Timestamp{Seconds: 0}, entry.Timestamp)
 	}
 	lastWrite--
-	entry, err = r.read(lastWrite)
+	_, err = r.read(lastWrite)
 	if err != ErrInvalidRead {
 		t.Errorf("Should not be able to read position %x, got %v", lastWrite, err)
 	}
@@ -543,12 +543,12 @@ func TestRingFunctionalitySerialized(t *testing.T) {
 		t.Errorf("lastWrite should be 0x1. Got %x", lastWrite)
 	}
 
-	entry, err := r.read(lastWrite)
+	_, err := r.read(lastWrite)
 	if err != io.EOF {
 		t.Errorf("Should not be able to read position %x, got %v", lastWrite, err)
 	}
 	lastWrite--
-	entry, err = r.read(lastWrite)
+	entry, err := r.read(lastWrite)
 	if err != nil {
 		t.Errorf("Should be able to read position %x, got %v", lastWrite, err)
 	}

--- a/pkg/identity/cache/local_test.go
+++ b/pkg/identity/cache/local_test.go
@@ -66,7 +66,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	}
 
 	// Allocation must fail as we are out of IDs
-	id, _, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}))
+	_, _, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}))
 	c.Assert(err, Not(IsNil))
 
 	// release all identities, this must decrement the reference count but not release the identities yet

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -677,7 +677,7 @@ func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 	blacklist := GetBadLogMessages()
 	failIfContainsBadLogMsg(logs, blacklist)
 
-	fmt.Fprintf(CheckLogs, logutils.LogErrorsSummary(logs))
+	fmt.Fprint(CheckLogs, logutils.LogErrorsSummary(logs))
 }
 
 // PprofReport runs pprof each 5 minutes and saves the data into the test

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2667,8 +2667,9 @@ func (kub *Kubectl) LoadedPolicyInFirstAgent() (string, error) {
 		res := kub.CiliumExecContext(ctx, pod, "cilium policy get")
 		if !res.WasSuccessful() {
 			return "", fmt.Errorf("cannot execute cilium policy get: %s", res.Stdout())
+		} else {
+			return res.CombineOutput().String(), nil
 		}
-		return res.CombineOutput().String(), nil
 	}
 	return "", fmt.Errorf("no running cilium pods")
 }
@@ -3086,7 +3087,7 @@ func (kub *Kubectl) ValidateListOfErrorsInLogs(duration time.Duration, blacklist
 
 	failIfContainsBadLogMsg(logs, blacklist)
 
-	fmt.Fprintf(CheckLogs, logutils.LogErrorsSummary(logs))
+	fmt.Fprint(CheckLogs, logutils.LogErrorsSummary(logs))
 }
 
 // GatherCiliumCoreDumps copies core dumps if are present in the /tmp folder

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -168,27 +168,27 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 			// some messages to be already there by the producer.
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqAnnounce))
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprint(prodHqAnnounce))
 			Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic empire-announce")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprint(conOutpostAnnoune))
 			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqDeathStar))
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprint(prodHqDeathStar))
 			Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic deathstar-plans")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutDeathStar))
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprint(conOutDeathStar))
 			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic deathstar-plans")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[backupApp], fmt.Sprintf(prodBackAnnounce))
+				helpers.DefaultNamespace, appPods[backupApp], fmt.Sprint(prodBackAnnounce))
 			Expect(err).Should(BeNil(), "Failed to produce to backup on topic empire-announce")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprint(prodOutAnnounce))
 			Expect(err).Should(BeNil(), "Failed to produce to outpost on topic empire-announce")
 
 			By("Apply L7 kafka policy and wait")
@@ -200,31 +200,31 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 
 			By("Testing Kafka L7 policy enforcement status")
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqAnnounce))
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprint(prodHqAnnounce))
 			Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic empire-announce")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprint(conOutpostAnnoune))
 			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqDeathStar))
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprint(prodHqDeathStar))
 			Expect(err).Should(BeNil(), "Failed to produce from empire-hq on topic deathstar-plans")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprint(conOutpostAnnoune))
 			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[backupApp], fmt.Sprintf(prodBackAnnounce))
+				helpers.DefaultNamespace, appPods[backupApp], fmt.Sprint(prodBackAnnounce))
 			Expect(err).Should(HaveOccurred(), " Produce to backup on topic empire-announce should have been denied")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutDeathStar))
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprint(conOutDeathStar))
 			Expect(err).Should(HaveOccurred(), " Consume from outpost on topic deathstar-plans should have been denied")
 
 			err = kubectl.ExecKafkaPodCmd(
-				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprint(prodOutAnnounce))
 			Expect(err).Should(HaveOccurred(), "Produce to outpost on topic empire-announce should have been denied")
 		})
 	})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1465,7 +1465,7 @@ var _ = Describe("K8sServicesTest", func() {
 					res := kubectl.CiliumExecContext(context.TODO(), pod, fmt.Sprintf("cilium bpf nat list | grep %d", sourcePortForCTGCtest))
 					ExpectWithOffset(1, res.Stdout()).ShouldNot(BeEmpty(), "NAT entry was not evicted")
 					// Flush CT maps to trigger eviction of the NAT entries (simulates CT GC)
-					res = kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium bpf ct flush global", "Unable to flush CT maps")
+					_ = kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium bpf ct flush global", "Unable to flush CT maps")
 					res = kubectl.CiliumExecContext(context.TODO(), pod, fmt.Sprintf("cilium bpf nat list | grep %d", sourcePortForCTGCtest))
 					res.ExpectFail("NAT entry was not evicted")
 				}

--- a/test/logger/logs.go
+++ b/test/logger/logs.go
@@ -47,7 +47,7 @@ func (h *LogHook) Levels() []logrus.Level {
 func (h *LogHook) Fire(entry *logrus.Entry) (err error) {
 	line, err := Formatter.Format(entry)
 	if err == nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, string(line))
+		fmt.Fprint(ginkgo.GinkgoWriter, string(line))
 	} else {
 		fmt.Fprintf(os.Stderr, "LogHook.Fire: unable to format log entry (%v)", err)
 	}


### PR DESCRIPTION
To enable the same linting rules for *_test files as well

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Some ground work for https://github.com/cilium/cilium/pull/11554#issuecomment-631347734

/cc @mrostecki 

```release-note
chore(lint): To enable linter for test files
```
