### PR TITLE
Reduce memory allocations during endpoint restore

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -15,7 +15,6 @@
 package common
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -93,28 +92,6 @@ func FindEPConfigCHeader(basePath string, epFiles []os.FileInfo) string {
 		}
 	}
 	return ""
-}
-
-// GetCiliumVersionString returns the first line containing CiliumCHeaderPrefix.
-func GetCiliumVersionString(epCHeaderFilePath string) (string, error) {
-	f, err := os.Open(epCHeaderFilePath)
-	if err != nil {
-		return "", err
-	}
-	br := bufio.NewReader(f)
-	defer f.Close()
-	for {
-		s, err := br.ReadString('\n')
-		if err == io.EOF {
-			return "", nil
-		}
-		if err != nil {
-			return "", err
-		}
-		if strings.Contains(s, CiliumCHeaderPrefix) {
-			return s, nil
-		}
-	}
 }
 
 // RequireRootPrivilege checks if the user running cmd is root. If not, it exits the program


### PR DESCRIPTION
First commit is preparatory and moves a function from `pkg/common`
into `pkg/endpoint` which is only used there.

Second commit avoids excessive allocations during endpoint restore:
    
The way endpoint state currently is restored from header files could
potentially lead to a lot of memory allocations, partially due to the fact
that the respective base64 encoded state is converted to a string after
being read and then converted back to a byte slice in order to decode
it. Since every conversion of a byte slice to a string allocates (due to
the fact that strings are immutable in Go), this essentially doubles the
memory that is used which could lead to memory allocation spikes during
restore.
    
Avoid this by reading the base64 encoded endpoint state into a
byte slice directly and thus reducing the size and number of
allocations.
    
Before:
```    
EndpointSuite.BenchmarkReadEPsFromDirNames        5000            399980 ns/op           83665 B/op        743 allocs/op
```
After:
```    
EndpointSuite.BenchmarkReadEPsFromDirNames        5000            369643 ns/op           73479 B/op        731 allocs/op
```

For #12367 to slightly reduce chances of OOM.

```release-note
Reduce memory allocations during endpoint restore
```