### PR TITLE
fix(3891): mirror parent pod labels to cilium endpoints

### DIFF
--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -159,6 +159,9 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 										BlockOwnerDeletion: func() *bool { a := true; return &a }(),
 									},
 								},
+								// Mirror the labels of parent pod in CiliumEndpoint object to enable
+								// label based selection for CiliumEndpoints.
+								Labels: pod.GetObjectMeta().GetLabels(),
 							},
 						}
 						localCEP, err = ciliumClient.CiliumEndpoints(namespace).Create(ctx, cep, meta_v1.CreateOptions{})


### PR DESCRIPTION
* Fixes #3891

This allows label based selection for CiliumEndpoints.

![image](https://user-images.githubusercontent.com/21292343/87159033-4981e800-c2de-11ea-89fa-24b0d7948d1a.png)


