### PR TITLE
build: Fix shellcheck errors

### DIFF
--- a/images/runtime/download-cni.sh
+++ b/images/runtime/download-cni.sh
@@ -8,7 +8,9 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-source /tmp/cni-version.sh
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/src/images/runtime/cni-version.sh
+source "${script_dir}/cni-version.sh"
 
 for arch in amd64 arm64 ; do
   curl --fail --show-error --silent --location "https://github.com/containernetworking/plugins/releases/download/v${cni_version}/cni-plugins-linux-${arch}-v${cni_version}.tgz" --output "/tmp/cni-${arch}.tgz"

--- a/images/scripts/lint.sh
+++ b/images/scripts/lint.sh
@@ -15,4 +15,4 @@ if [ -z "${MAKER_CONTAINER+x}" ] ; then
    exec docker run --rm --volume "${root_dir}:/src" --workdir /src/images "${MAKER_IMAGE}" "/src/images/scripts/$(basename "${0}")"
 fi
 
-find . -name '*.sh' -exec shellcheck {} +
+find . -name '*.sh' -executable -exec shellcheck -x {} +

--- a/images/scripts/update-cni-version.sh
+++ b/images/scripts/update-cni-version.sh
@@ -7,8 +7,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"


### PR DESCRIPTION
- specify the path to cni-version.sh
- only lint executable shell scripts
- remove unused variable