### PR TITLE
Move update-ec2-apdater-limit-via-api flag to be on the cilium-operator-aws binary

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -59,7 +59,6 @@ cilium-operator-azure [flags]
       --synchronize-k8s-nodes                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                Synchronize Kubernetes services to kvstore (default true)
       --unmanaged-pod-watcher-interval int      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api        Use the EC2 API to update the instance type to adapter limits
       --version                                 Print version information
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -57,7 +57,6 @@ cilium-operator-generic [flags]
       --synchronize-k8s-nodes                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                Synchronize Kubernetes services to kvstore (default true)
       --unmanaged-pod-watcher-interval int      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api        Use the EC2 API to update the instance type to adapter limits
       --version                                 Print version information
 ```
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -60,9 +60,6 @@ func init() {
 	flags.Int64(operatorOption.ParallelAllocWorkers, defaults.ParallelAllocWorkers, "Maximum number of parallel IPAM workers")
 	option.BindEnv(operatorOption.ParallelAllocWorkers)
 
-	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
-	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPI)
-
 	// Clustermesh dedicated flags
 	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
 	option.BindEnv(option.ClusterIDName)

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -41,4 +41,7 @@ func init() {
 	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(operatorOption.ENITags)
+
+	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
+	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPI)
 }


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

While we did the operator functionality split this flag was missed and not added to the `aws` version of the operator.

Fixes: https://github.com/cilium/cilium/commit/d16af4a8838c70fe585469aa309b43e41f7ab199

```release-note
Add the `update-ec2-apdater-limit-via-api` flag to the `cilium-operator-aws`.
```
