### PR TITLE
Condition AWS env vars in operator helm template if ENI is enabled

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -64,6 +64,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
+{{- if .Values.global.eni }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -82,6 +83,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
+{{- end }}
 {{- if .Values.global.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.global.k8sServiceHost | quote }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -843,24 +843,6 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: AWS_ACCESS_KEY_ID
-              name: cilium-aws
-              optional: true
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: AWS_SECRET_ACCESS_KEY
-              name: cilium-aws
-              optional: true
-        - name: AWS_DEFAULT_REGION
-          valueFrom:
-            secretKeyRef:
-              key: AWS_DEFAULT_REGION
-              name: cilium-aws
-              optional: true
         image: "docker.io/cilium/operator-generic:latest"
         imagePullPolicy: Always
         name: cilium-operator

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -598,24 +598,6 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: AWS_ACCESS_KEY_ID
-              name: cilium-aws
-              optional: true
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: AWS_SECRET_ACCESS_KEY
-              name: cilium-aws
-              optional: true
-        - name: AWS_DEFAULT_REGION
-          valueFrom:
-            secretKeyRef:
-              key: AWS_DEFAULT_REGION
-              name: cilium-aws
-              optional: true
         image: "docker.io/cilium/operator-generic:latest"
         imagePullPolicy: Always
         name: cilium-operator


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

While deploying the operator in Azure mode I realized that the helm template generation still includes the env vars needed when running in AWS ENI mode.

```release-note
Prevent leak of AWS-related environment variables in `cilium-operator` deployment definition when deploying the operator in Azure mode.
```
