### PR TITLE
IPAM metric renames

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -317,6 +317,18 @@ Annotations:
    upgrade. Connections should successfully re-establish without requiring
    clients to reconnect.
 
+.. _1.9_upgrade_notes:
+
+1.9 Upgrade Notes
+-----------------
+
+Renamed Metrics
+~~~~~~~~~~~~~~~
+
+The following metrics have been renamed:
+
+* ``cilium_operator_ipam_ec2_resync`` to ``cilium_operator_ipam_resync``
+
 .. _1.8_upgrade_notes:
 
 1.8 Upgrade Notes
@@ -549,9 +561,9 @@ New ConfigMap Options
     On upgrades of existing installations, this option is disabled by default,
     i.e. it is set to 0.0. Users wanting to use this feature need to enable it
     explicitly in their `ConfigMap`, see section :ref:`upgrade_configmap`.
-  
+
   * ``enable-health-check-nodeport`` has been added to allow to configure
-    NodePort server health check when kube-proxy is disabled. 
+    NodePort server health check when kube-proxy is disabled.
 
 Deprecated options
 ~~~~~~~~~~~~~~~~~~

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -106,7 +106,7 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 	// of dashboard, keep the metric name deficit_resolver unchanged
 	m.poolMaintainer = NewTriggerMetrics(namespace, "deficit_resolver")
 	m.k8sSync = NewTriggerMetrics(namespace, "k8s_sync")
-	m.resync = NewTriggerMetrics(namespace, "ec2_resync")
+	m.resync = NewTriggerMetrics(namespace, "resync")
 
 	registry.MustRegister(m.IPsAllocated)
 	registry.MustRegister(m.AllocateIpOps)

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -99,7 +99,7 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
 		Name:      "resync_total",
-		Help:      "Number of resync operations to synchronize AWS EC2 metadata",
+		Help:      "Number of resync operations to synchronize and resolve IP deficit of nodes",
 	})
 
 	// pool_maintainer is a more generic name, but for backward compatibility


### PR DESCRIPTION
While deploying into Azure I observed that we still had metrics on the `cilium-operator` that were referencing `ec2`.

2 changes:
- Rename help string for ipam_resync_total to be generic, old one was still referencing ec2 which is not accurate anymore singe the re-work of the node manager framework
- Rename ipam_ec2_resync -> ipam_resync metric to be generic, same reason as above

@tgraf how should we do the `ipam_ec2_resync` -> `ipam_resync` swap? Do you think it is worth doing a real deprecation or is it safe to do a breaking change given we did not really document the metric via https://docs.cilium.io/en/latest/configuration/metrics/#ipam-metrics.

```release-note
Remove `ec2` notion from generic `cilium-operator` IPAM metrics.
```
