### PR TITLE
Replace bpf bitfields with a single u8 field and masks

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -280,7 +280,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (sock4_skip_xlate(svc, orig_key.address))
 		return -EPERM;
 
-	if (svc->affinity) {
+	if (lb4_svc_is_affinity(svc)) {
 		/* Note, for newly created affinity entries there is a
 		 * small race window. Two processes on two different
 		 * CPUs but the same netns may select different backends
@@ -323,7 +323,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 		return -ENOENT;
 	}
 
-	if (svc->affinity && !backend_from_affinity)
+	if (lb4_svc_is_affinity(svc) && !backend_from_affinity)
 		lb4_update_affinity_by_netns(svc, &id, backend_id);
 
 	if (sock4_update_revnat(ctx_full, backend, &orig_key,
@@ -705,7 +705,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (sock6_skip_xlate(svc, &orig_key.address))
 		return -EPERM;
 
-	if (svc->affinity) {
+	if (lb6_svc_is_affinity(svc)) {
 		backend_id = lb6_affinity_backend_id_by_netns(svc, &id);
 		backend_from_affinity = true;
 
@@ -735,7 +735,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 		return -ENOENT;
 	}
 
-	if (svc->affinity && !backend_from_affinity)
+	if (lb6_svc_is_affinity(svc) && !backend_from_affinity)
 		lb6_update_affinity_by_netns(svc, &id, backend_id);
 
 	if (sock6_update_revnat(ctx, backend, &orig_key,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -520,6 +520,16 @@ enum {
 	CT_RELATED,
 };
 
+/* Service flags (lb{4,6}_service->flags) */
+enum {
+	SVC_FLAG_EXTERNAL_IP  = (1 << 0),  /* K8s External IPs */
+	SVC_FLAG_NODEPORT     = (1 << 1),  /* K8s NodePort service */
+	SVC_FLAG_LOCAL_SCOPE  = (1 << 2),  /* K8s externalTrafficPolicy=Local */
+	SVC_FLAG_HOSTPORT     = (1 << 3),  /* K8s hostPort forwarding */
+	SVC_FLAG_AFFINITY     = (1 << 4),  /* K8s sessionAffinity=clientIP */
+	SVC_FLAG_LOADBALANCER = (1 << 5),  /* K8s LoadBalancer service */
+};
+
 struct ipv6_ct_tuple {
 	/* Address fields are reversed, i.e.,
 	 * these field names are correct for reply direction traffic.
@@ -603,13 +613,7 @@ struct lb6_service {
 	};
 	__u16 count;
 	__u16 rev_nat_index;
-	__u8 external:1,	/* K8s External IPs */
-	     nodeport:1,	/* K8s NodePort service */
-	     local_scope:1,	/* K8s externalTrafficPolicy=Local */
-	     hostport:1,	/* K8s hostPort forwarding */
-	     affinity:1,	/* K8s sessionAffinity=clientIP */
-	     loadbalancer:1,	/* K8s LoadBalancer service */
-	     reserved:2;
+	__u8 flags;
 	__u8 pad[3];
 };
 
@@ -658,13 +662,7 @@ struct lb4_service {
 	 */
 	__u16 count;
 	__u16 rev_nat_index;	/* Reverse NAT ID in lb4_reverse_nat */
-	__u8 external:1,	/* K8s External IPs */
-	     nodeport:1,	/* K8s NodePort service */
-	     local_scope:1,	/* K8s externalTrafficPolicy=Local */
-	     hostport:1,	/* K8s hostPort forwarding */
-	     affinity:1,	/* K8s sessionAffinity=clientIP */
-	     loadbalancer:1,	/* K8s LoadBalancer service */
-	     reserved:2;
+	__u8 flags;
 	__u8 pad[3];
 };
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -549,10 +549,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if (!svc || (!lb6_svc_is_loadbalancer(svc) &&
-		     !lb6_svc_is_nodeport(svc) &&
-		     !lb6_svc_is_external_ip(svc) &&
-		     !lb6_svc_is_hostport(svc))) {
+	if (!svc || !lb6_svc_is_routable(svc)) {
 		if (svc)
 			return DROP_IS_CLUSTER_IP;
 
@@ -1227,10 +1224,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if (!svc || (!lb4_svc_is_loadbalancer(svc) &&
-		     !lb4_svc_is_nodeport(svc) &&
-		     !lb4_svc_is_external_ip(svc) &&
-		     !lb4_svc_is_hostport(svc))) {
+	if (!svc || !lb4_svc_is_routable(svc)) {
 		if (svc)
 			return DROP_IS_CLUSTER_IP;
 


### PR DESCRIPTION

The purpose of this is to ensure that the compiler will not rearrange the bitfields and create issues with the Go code that access them, and, also, allow for some optimizations on checks using flags.

The first commit changes the bitfields to a single field, the second uses masks for checks, and the third introduces a test that checks whether Go and bpf see the same values for the flags using cgo.

Instead of doing a test, we could use the cgo code to directly get the values for the flags for the Go side, but the code is somewhat ugly and I'm not sure we want to do that.