### PR TITLE
test: bump k8s libraries to 1.16.12

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1558,7 +1558,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
 [[projects]]
   digest = "1:3a3169935f116c03f1b538e5ea55a2978b13511035136b345d427761ec8063ee"
@@ -1574,7 +1574,7 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
 [[projects]]
   digest = "1:ad8ce875829241250e2c4d455f9a42b09e0a7d1ed5ef9ebd8a42400f804f6e6b"
@@ -1626,7 +1626,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
 [[projects]]
   digest = "1:421721461ab2987bb721dd8ecb397b7ab1aafb3ed2bbcda185af0db2f8b1099e"
@@ -1741,7 +1741,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "4e53353d513604b5f88d2f1e68d3ee03ea9def4f"
+  revision = "db9e84cc70f6cc2db0081b4cecc0e4e4f3df4c27"
   source = "https://github.com/cilium/client-go"
 
 [[projects]]
@@ -1760,14 +1760,14 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
 [[projects]]
   digest = "1:5e496d711fa03e4aaf3cab0d7de079634a9465ebf940613b69b34f5cc6513db8"
   name = "k8s.io/cri-api"
   packages = ["pkg/apis/runtime/v1alpha2"]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
 [[projects]]
   digest = "1:d233b263f74608ab5528c04453935d899a2b9fb0bf02b03d38a4a11f91442a5c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -514,28 +514,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -543,7 +543,7 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   source = "https://github.com/cilium/client-go"
-  revision = "4e53353d513604b5f88d2f1e68d3ee03ea9def4f"
+  revision = "db9e84cc70f6cc2db0081b4cecc0e4e4f3df4c27"
 
   # main-usage = "pkg/k8s"
   # on-revision = "TODO @aanm is on 4e53353d513604b5f88d2f1e68d3ee03ea9def4f as it contains the hotfix for the metrics path"
@@ -557,7 +557,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -578,7 +578,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/cri-api"
-  revision = "kubernetes-1.16.11"
+  revision = "kubernetes-1.16.12"
 
   # main-usage = "pkg/workloads"
   # on-revision = ""

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -17,7 +17,7 @@ CONTAINER_RUNTIME=$5
 CNI_INTEGRATION=$6
 # Pinned to the last version of k8s 1.16 branch so we can do
 # kubectl apply on older k8s test frameworks
-K8S_KUBECTL_APPLY_FORCE="1.16.11"
+K8S_KUBECTL_APPLY_FORCE="1.16.12"
 
 # Kubeadm default parameters
 export KUBEADM_ADDR='192.168.36.11'


### PR DESCRIPTION
Also, bump tests to 1.16.12

Signed-off-by: André Martins <andre@cilium.io>