### PR TITLE
common: remove unused func FindEPConfigCHeader

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -83,17 +83,6 @@ func goArray2C(array []byte, space bool) string {
 	return ret
 }
 
-// FindEPConfigCHeader returns the full path of the file that is the CHeaderFileName from
-// the slice of files
-func FindEPConfigCHeader(basePath string, epFiles []os.FileInfo) string {
-	for _, epFile := range epFiles {
-		if epFile.Name() == CHeaderFileName {
-			return filepath.Join(basePath, epFile.Name())
-		}
-	}
-	return ""
-}
-
 // RequireRootPrivilege checks if the user running cmd is root. If not, it exits the program
 func RequireRootPrivilege(cmd string) {
 	if os.Getuid() != 0 {


### PR DESCRIPTION
This was already removed by commit d81a5cdea511 ("pkg/endpoint: Simplify
search for C header file") when its last user disappeard, but it got
readded 74e706da2d9e ("common: Move GoArray2C to common") which moved
some code around the same time. Now remove it for good.

Fixes: 74e706da2d9e ("common: Move GoArray2C to common")
