### PR TITLE
Improve etcd fail-over scenarios

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -921,6 +921,7 @@ func (e *etcdClient) statusChecker() {
 		if quorumError != nil {
 			quorumString = quorumError.Error()
 			consecutiveQuorumErrors++
+			quorumString += fmt.Sprintf(", consecutive-errors=%d", consecutiveQuorumErrors)
 		} else {
 			consecutiveQuorumErrors = 0
 		}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -384,7 +384,7 @@ func (e *etcdClient) waitForInitLock(ctx context.Context) <-chan bool {
 	return initLockSucceeded
 }
 
-func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) bool {
+func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) error {
 	ctxTimeout, cancel := context.WithTimeout(ctx, statusCheckTimeout)
 	defer cancel()
 
@@ -393,7 +393,7 @@ func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) bool {
 	case <-e.firstSession:
 	// Timeout while waiting for initial connection, no success
 	case <-ctxTimeout.Done():
-		return false
+		return fmt.Errorf("timeout while waiting for initial connection")
 	}
 
 	e.RLock()
@@ -404,10 +404,14 @@ func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) bool {
 	select {
 	// Catch disconnect event, no success
 	case <-ch:
-		return false
+		return fmt.Errorf("etcd session ended")
 	// wait for initial lock to succeed
 	case success := <-initLockSucceeded:
-		return success
+		if success {
+			return nil
+		}
+
+		return fmt.Errorf("timeout while attempting to acquire lock")
 	}
 }
 
@@ -415,7 +419,7 @@ func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) bool {
 func (e *etcdClient) Connected(ctx context.Context) <-chan struct{} {
 	out := make(chan struct{})
 	go func() {
-		for !e.isConnectedAndHasQuorum(ctx) {
+		for e.isConnectedAndHasQuorum(ctx) != nil {
 			time.Sleep(100 * time.Millisecond)
 		}
 		close(out)
@@ -875,7 +879,7 @@ func (e *etcdClient) statusChecker() {
 		newStatus := []string{}
 		ok := 0
 
-		hasQuorum := e.isConnectedAndHasQuorum(ctx)
+		quorumError := e.isConnectedAndHasQuorum(ctx)
 
 		endpoints := e.client.Endpoints()
 		for _, ep := range endpoints {
@@ -894,9 +898,14 @@ func (e *etcdClient) statusChecker() {
 		lockSessionLeaseID := e.lockSession.Lease()
 		e.RWMutex.RUnlock()
 
+		quorumString := "true"
+		if quorumError != nil {
+			quorumString = quorumError.Error()
+		}
+
 		e.statusLock.Lock()
-		e.latestStatusSnapshot = fmt.Sprintf("etcd: %d/%d connected, lease-ID=%x, lock lease-ID=%x, has-quorum=%t: %s",
-			ok, len(endpoints), sessionLeaseID, lockSessionLeaseID, hasQuorum, strings.Join(newStatus, "; "))
+		e.latestStatusSnapshot = fmt.Sprintf("etcd: %d/%d connected, lease-ID=%x, lock lease-ID=%x, has-quorum=%s: %s",
+			ok, len(endpoints), sessionLeaseID, lockSessionLeaseID, quorumString, strings.Join(newStatus, "; "))
 
 		// Only mark the etcd health as unstable if no etcd endpoints can be reached
 		if len(endpoints) > 0 && ok == 0 {

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -1642,3 +1642,25 @@ func TestGetSvcNamespace(t *testing.T) {
 		})
 	}
 }
+func TestShuffleEndpoints(t *testing.T) {
+	s1 := []string{"1", "2", "3", "4", "5"}
+	s2 := make([]string, len(s1))
+	copy(s2, s1)
+
+	var same int
+	for retry := 0; retry < 10; retry++ {
+		same = 0
+		shuffleEndpoints(s2)
+		for i := range s1 {
+			if s1[i] == s2[i] {
+				same++
+			}
+		}
+		if same != len(s1) {
+			break
+		}
+	}
+	if same == len(s1) {
+		t.Errorf("Shuffle() did not modify s2 in 10 retries")
+	}
+}

--- a/pkg/rand/safe_rand.go
+++ b/pkg/rand/safe_rand.go
@@ -83,3 +83,9 @@ func (sr *safeRand) Perm(n int) []int {
 	return v
 
 }
+
+func (sr *safeRand) Shuffle(n int, swap func(i, j int)) {
+	sr.mu.Lock()
+	sr.r.Shuffle(n, swap)
+	sr.mu.Unlock()
+}

--- a/pkg/rand/safe_rand_test.go
+++ b/pkg/rand/safe_rand_test.go
@@ -18,6 +18,7 @@ package rand
 
 import (
 	"testing"
+	"time"
 )
 
 func TestIntn(t *testing.T) {
@@ -32,5 +33,38 @@ func TestIntn(t *testing.T) {
 		if v0 != v1 {
 			t.Errorf("Intn() returned different values at iteration %d: %d != %d", i, v0, v1)
 		}
+	}
+}
+
+func TestShuffle(t *testing.T) {
+	r0 := NewSafeRand(time.Now().UnixNano())
+
+	s1 := []string{"1", "2", "3", "4", "5"}
+	s2 := make([]string, len(s1))
+	copy(s2, s1)
+
+	var same int
+	for retry := 0; retry < 1; retry++ {
+		same = 0
+
+		r0.Shuffle(len(s2), func(i, j int) {
+			s2[i], s2[j] = s2[j], s2[i]
+		})
+
+		if len(s1) != len(s2) {
+			t.Errorf("Shuffle() resulted in slices of inequal length")
+		}
+
+		for i := range s1 {
+			if s1[i] == s2[i] {
+				same++
+			}
+		}
+		if same != len(s1) {
+			break
+		}
+	}
+	if same == len(s1) {
+		t.Errorf("Shuffle() did not modify s2 in 10 retries")
 	}
 }


### PR DESCRIPTION
The main change introduced by this PR Is to fail Cilium status if etcd quorum cannot be detected for 3 consecutive status intervals. By triggering a restart of the agent, the situation can hopefully be resolved. In addition, the endpoint list is shuffled on bootstrap to further improve the chances to resolve the issue.