### PR TITLE
Hubble UI/Relay PodSecurityPolicy

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         k8s-app: {{ .Chart.Name }}
     spec:
+      serviceAccountName: hubble-relay
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
@@ -1,0 +1,52 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: hubble-relay-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+  volumes:
+    - secret
+    - hostPath
+  allowedHostPaths:
+    - pathPrefix: /var/run/cilium
+      readOnly: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hubble-relay-psp
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - hubble-relay-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hubble-relay-psp
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hubble-relay-psp
+subjects:
+- kind: ServiceAccount
+  name: hubble-relay

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-relay
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -27,3 +27,6 @@ retryTimeout: ~
 
 # Port to use for the k8s service backed by hubble-relay pods.
 servicePort: 80
+
+serviceAccount:
+  annotations: {}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/podsecuritypolicy.yaml
@@ -1,0 +1,58 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: hubble-ui-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+  volumes:
+    - secret
+    - downwardAPI
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hubble-ui-psp
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - hubble-ui-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hubble-ui-psp
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hubble-ui-psp
+subjects:
+- kind: ServiceAccount
+  name: hubble-ui


### PR DESCRIPTION
Adds resources needed to deploy hubble ui/relay on a cluster with PodSecurityPolicy enabled.
