### PR TITLE
build: Fix shellcheck linter

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,5 +1,7 @@
 name: Images
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - master
@@ -9,10 +11,22 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
 
 jobs:
-  build-and-push:
+  lint:
     if: github.repository == 'cilium/cilium'
+    name: Lint image build logic
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
+        name: Run make lint
+        with:
+          entrypoint: make
+          args: -C images lint
+  build-and-push:
+    if: (github.repository == 'cilium/cilium' && github.event_name != 'pull_request')
     name: Build and push all images
     runs-on: ubuntu-18.04
+    needs: lint
     steps:
       - uses: actions/checkout@v1
       - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c

--- a/images/runtime/download-cni.sh
+++ b/images/runtime/download-cni.sh
@@ -9,7 +9,7 @@ set -o pipefail
 set -o nounset
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=/src/images/runtime/cni-version.sh
+# shellcheck source=cni-version.sh
 source "${script_dir}/cni-version.sh"
 
 for arch in amd64 arm64 ; do

--- a/images/scripts/lint.sh
+++ b/images/scripts/lint.sh
@@ -15,4 +15,9 @@ if [ -z "${MAKER_CONTAINER+x}" ] ; then
    exec docker run --rm --volume "${root_dir}:/src" --workdir /src/images "${MAKER_IMAGE}" "/src/images/scripts/$(basename "${0}")"
 fi
 
-find . -name '*.sh' -executable -exec shellcheck -x {} +
+# shellcheck disable=SC2207
+scripts=($(find . -name '*.sh' -executable))
+
+for script in "${scripts[@]}" ; do
+  shellcheck --external-source --source-path="$(dirname "${script}")" "${script}"
+done


### PR DESCRIPTION
- do not assume absolute path, it is different inside GitHub Actions
- use `--source-path` flag to set script dir
- use long flag name (`-x`/`--external-source`) for readablity
- ensure linter also runs on each PR

Fixes: e091612061d9 (build: New runtime image with multi-platform support)
Fixes: 6f83fb8f3d02 (build: Fix shellcheck errors)