### PR TITLE
docs: add note on sctp for kube-proxy replacement as known limitation

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -972,6 +972,8 @@ Limitations
     * Cilium's DSR NodePort mode currently does not operate well in environments with
       TCP Fast Open (TFO) enabled. It is recommended to switch to ``snat`` mode in this
       situation.
+    * Cilium's BPF kube-proxy replacement does not support the SCTP transport protocol.
+      Only TCP and UDP is supported as a transport for services at this point.
 
 Further Readings
 ################


### PR DESCRIPTION
Noticed we didn't mention anything about it yet, so state it explicitly here.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>