### PR TITLE
build: Update runtime image, add a guard rail

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -22,6 +22,11 @@ jobs:
         with:
           entrypoint: make
           args: -C images lint
+      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
+        name: Check if runtime and builder images are up-to-date
+        with:
+          entrypoint: make
+          args: -C images check-runtime-image check-builder-image
   build-and-push:
     if: (github.repository == 'cilium/cilium' && github.event_name != 'pull_request')
     name: Build and push all images

--- a/images/Makefile
+++ b/images/Makefile
@@ -28,11 +28,17 @@ runtime-image: .buildx_builder
 update-runtime-image:
 	scripts/update-cilium-runtime-image.sh
 
+check-runtime-image:
+	CHECK=true scripts/update-cilium-runtime-image.sh
+
 builder-image: .buildx_builder
 	TEST=true scripts/build-image.sh cilium-builder-dev images/builder linux/amd64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-builder-image:
 	scripts/update-cilium-builder-image.sh
+
+check-builder-image:
+	CHECK=true scripts/update-cilium-builder-image.sh
 
 cilium-image: .buildx_builder
 	ROOT_CONTEXT=true scripts/build-image.sh cilium-dev images/cilium linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:b030f1ed16c21608d78564124a870a18ca485444
-ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:f9cb7188204f011045cb18378128c9ed6268fd86
+ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:74992a84a55860ffe1b0c4d6b702c8520db0d4b1
 
 FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder
 

--- a/images/scripts/update-cilium-builder-image.sh
+++ b/images/scripts/update-cilium-builder-image.sh
@@ -24,3 +24,8 @@ used_by=($(git grep -l CILIUM_BUILDER_IMAGE= images/*/Dockerfile))
 for i in "${used_by[@]}" ; do
   sed "s|\(CILIUM_BUILDER_IMAGE=\)${image}:.*\$|\1${image}:${image_tag}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
 done
+
+do_check="${CHECK:-false}"
+if [ "${do_check}" = "true" ] ; then
+    git diff --exit-code "${used_by[@]}"
+fi

--- a/images/scripts/update-cilium-runtime-image.sh
+++ b/images/scripts/update-cilium-runtime-image.sh
@@ -24,3 +24,8 @@ used_by=($(git grep -l CILIUM_RUNTIME_IMAGE= images/*/Dockerfile))
 for i in "${used_by[@]}" ; do
   sed "s|\(CILIUM_RUNTIME_IMAGE=\)${image}:.*\$|\1${image}:${image_tag}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
 done
+
+do_check="${CHECK:-false}"
+if [ "${do_check}" = "true" ] ; then
+    git diff --exit-code "${used_by[@]}"
+fi


### PR DESCRIPTION
This was missed out from aa796a2c282e. A check is added
to ensure this doesn't happen again.

Fixes: aa796a2c282e (build: Fix shellcheck linter)