### PR TITLE
Fix small CRD issue with toGroups

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -725,12 +725,17 @@ var (
 				},
 			},
 			"toGroups": {
-				Type: "object",
+				Type: "array",
 				Description: `ToGroups is a list of constraints that will
 				gather data from third-party providers and create a new
 				derived policy.`,
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-					"aws": AWSGroup,
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+							"aws": AWSGroup,
+						},
+					},
 				},
 			},
 			"toFQDNs": {

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -31,7 +31,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.21"
+	CustomResourceDefinitionSchemaVersion = "1.22"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"


### PR DESCRIPTION
Fixes: f0049da ("pkg/k8s: fix all structural issues with CNP validation")

In 1.8.1, the CNP CRD uses the following for egress toGroups rules:
```
			"toGroups": {
				Type: "object",
				Description: `ToGroups is a list of constraints that will
				gather data from third-party providers and create a new
				derived policy.`,
				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
					"aws": AWSGroup,
				},
			}
```
However the rule expects toGroups to be an array. From the doc example:
```
  egress:
  - toGroups:
    - aws:
        securityGroupsIds:
        - 'sg-0f2146100a88d03c3'
```

This commit modifies the CRD to be consistent with the rule spec to avoid validation errors from Kubernetes.

```release-note
Fix toGroups CRD to address validation errors 
```