### PR TITLE
bpf: clear getpeername{4,6} progs

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -652,6 +652,8 @@ else
 	bpf_clear_cgroups $CGROUP_ROOT sendmsg6
 	bpf_clear_cgroups $CGROUP_ROOT recvmsg4
 	bpf_clear_cgroups $CGROUP_ROOT recvmsg6
+	bpf_clear_cgroups $CGROUP_ROOT getpeername4
+	bpf_clear_cgroups $CGROUP_ROOT getpeername6
 fi
 
 if [ "$IPSEC" == "true" ]; then


### PR DESCRIPTION
Attempt to clear previously loaded getpeername progs in bpf/init.sh in
case $HOSTLB/$HOSTLB_PEER are disabled.