### PR TITLE
operator: rate limit GC of security identities

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -39,6 +39,8 @@ cilium-operator-aws [flags]
   -h, --help                                    help for cilium-operator-aws
       --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
       --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                             Backend to use for IPAM (default "eni")
       --k8s-api-server string                   Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -38,6 +38,8 @@ cilium-operator-azure [flags]
   -h, --help                                    help for cilium-operator-azure
       --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
       --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                             Backend to use for IPAM (default "azure")
       --k8s-api-server string                   Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -36,6 +36,8 @@ cilium-operator-generic [flags]
   -h, --help                                    help for cilium-operator-generic
       --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
       --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                             Backend to use for IPAM (default "hostscope-legacy")
       --k8s-api-server string                   Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -41,6 +41,8 @@ cilium-operator [flags]
   -h, --help                                    help for cilium-operator
       --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration           GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
       --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                             Backend to use for IPAM (default "hostscope-legacy")
       --k8s-api-server string                   Kubernetes API server URL

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -229,6 +229,14 @@ func init() {
 	flags.Duration(operatorOption.IdentityGCInterval, defaults.KVstoreLeaseTTL, "GC interval for security identities")
 	option.BindEnv(operatorOption.IdentityGCInterval)
 
+	flags.Duration(operatorOption.IdentityGCRateInterval, time.Minute,
+		"Interval used for rate limiting the GC of security identities")
+	option.BindEnv(operatorOption.IdentityGCRateInterval)
+
+	flags.Int(operatorOption.IdentityGCRateLimit, 250,
+		fmt.Sprintf("Maximum number of security identities that will be deleted within the %s", operatorOption.IdentityGCRateInterval))
+	option.BindEnv(operatorOption.IdentityGCRateLimit)
+
 	flags.String(option.KVStore, "", "Key-value store type")
 	option.BindEnv(option.KVStore)
 

--- a/operator/k8s_identity.go
+++ b/operator/k8s_identity.go
@@ -40,7 +40,12 @@ var identityStore cache.Store
 // deleteIdentity deletes an identity. It includes the resource version and
 // will error if the object has since been changed.
 func deleteIdentity(ctx context.Context, identity *v2.CiliumIdentity) error {
-	err := ciliumK8sClient.CiliumV2().CiliumIdentities().Delete(
+	// Wait until we can delete an identity
+	err := identityRateLimiter.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	err = ciliumK8sClient.CiliumV2().CiliumIdentities().Delete(
 		ctx,
 		identity.Name,
 		metav1.DeleteOptions{

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -62,6 +62,14 @@ const (
 	// attempted to be expired from the kvstore
 	IdentityGCInterval = "identity-gc-interval"
 
+	// IdentityGCRateInterval is the interval used for rate limiting the GC of
+	// identities.
+	IdentityGCRateInterval = "identity-gc-rate-interval"
+
+	// IdentityGCRateLimit is the maximum identities used for rate limiting the
+	// GC of identities.
+	IdentityGCRateLimit = "identity-gc-rate-limit"
+
 	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
 	IdentityHeartbeatTimeout = "identity-heartbeat-timeout"
 
@@ -198,6 +206,14 @@ type OperatorConfig struct {
 	// attempted to be expired from the kvstore
 	IdentityGCInterval time.Duration
 
+	// IdentityGCRateInterval is the interval used for rate limiting the GC of
+	// identities.
+	IdentityGCRateInterval time.Duration
+
+	// IdentityGCRateLimit is the maximum identities used for rate limiting the
+	// GC of identities.
+	IdentityGCRateLimit int64
+
 	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
 	IdentityHeartbeatTimeout time.Duration
 
@@ -290,6 +306,8 @@ func (c *OperatorConfig) Populate() {
 	c.EnableMetrics = viper.GetBool(EnableMetrics)
 	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.IdentityGCInterval = viper.GetDuration(IdentityGCInterval)
+	c.IdentityGCRateInterval = viper.GetDuration(IdentityGCRateInterval)
+	c.IdentityGCRateLimit = viper.GetInt64(IdentityGCRateLimit)
 	c.IdentityHeartbeatTimeout = viper.GetDuration(IdentityHeartbeatTimeout)
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
 	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/uuid"
 
 	"github.com/sirupsen/logrus"
@@ -242,7 +243,7 @@ type Backend interface {
 	// by cilium-agent.
 	// Note: not all Backend implemenations rely on this, such as the kvstore
 	// backends, and may use leases to expire keys.
-	RunGC(ctx context.Context, staleKeysPrevRound map[string]uint64) (map[string]uint64, error)
+	RunGC(ctx context.Context, rateLimit *rate.Limiter, staleKeysPrevRound map[string]uint64) (map[string]uint64, error)
 
 	// RunLocksGC reaps stale or unused locks within the Backend. It is used by
 	// the cilium-operator and is not invoked by cilium-agent. Returns
@@ -739,8 +740,8 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 }
 
 // RunGC scans the kvstore for unused master keys and removes them
-func (a *Allocator) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uint64, error) {
-	return a.backend.RunGC(context.TODO(), staleKeysPrevRound)
+func (a *Allocator) RunGC(rateLimit *rate.Limiter, staleKeysPrevRound map[string]uint64) (map[string]uint64, error) {
+	return a.backend.RunGC(context.TODO(), rateLimit, staleKeysPrevRound)
 }
 
 // RunLocksGC scans the kvstore for stale locks and removes them

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/rate"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
@@ -125,7 +126,7 @@ func (c *crdBackend) RunLocksGC(_ context.Context, _ map[string]kvstore.Value) (
 	return nil, nil
 }
 
-func (c *crdBackend) RunGC(ctx context.Context, staleKeysPrevRound map[string]uint64) (map[string]uint64, error) {
+func (c *crdBackend) RunGC(context.Context, *rate.Limiter, map[string]uint64) (map[string]uint64, error) {
 	return nil, nil
 }
 

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/rand"
+	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
@@ -268,11 +269,13 @@ func (s *AllocatorSuite) TestGC(c *C) {
 
 	allocator.Release(context.Background(), shortKey)
 
+	rateLimiter := rate.NewLimiter(10*time.Second, 100)
+
 	keysToDelete := map[string]uint64{}
-	keysToDelete, err = allocator.RunGC(keysToDelete)
+	keysToDelete, err = allocator.RunGC(rateLimiter, keysToDelete)
 	c.Assert(err, IsNil)
 	c.Assert(len(keysToDelete), Equals, 1)
-	keysToDelete, err = allocator.RunGC(keysToDelete)
+	keysToDelete, err = allocator.RunGC(rateLimiter, keysToDelete)
 	c.Assert(err, IsNil)
 	c.Assert(len(keysToDelete), Equals, 0)
 
@@ -348,8 +351,9 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	}
 
 	staleKeysPreviousRound := map[string]uint64{}
+	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 	// running the GC should not evict any entries
-	staleKeysPreviousRound, err = a.RunGC(staleKeysPreviousRound)
+	staleKeysPreviousRound, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
 	c.Assert(err, IsNil)
 
 	v, err := kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
@@ -362,9 +366,9 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	}
 
 	// running the GC should evict all entries
-	staleKeysPreviousRound, err = a.RunGC(staleKeysPreviousRound)
+	staleKeysPreviousRound, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
 	c.Assert(err, IsNil)
-	_, err = a.RunGC(staleKeysPreviousRound)
+	_, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
 	c.Assert(err, IsNil)
 
 	v, err = kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))

--- a/pkg/rate/doc.go
+++ b/pkg/rate/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rate provides a rate limiter to rate limit requests that can be
+// burstable but they should only allowed N per a period defined.
+// This package differs from the "golang.org/x/time/rate" package as it does not
+// implement the token bucket algorithm.
+package rate

--- a/pkg/rate/limiter.go
+++ b/pkg/rate/limiter.go
@@ -1,0 +1,117 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rate
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// Limiter is used to limit the number of operations done.
+type Limiter struct {
+	semaphore   *semaphore.Weighted
+	currWeights int64
+	ticker      *time.Ticker
+	cancelFunc  context.CancelFunc
+	ctx         context.Context
+}
+
+// NewLimiter returns a new Limiter that allows events up to b tokens during
+// the given interval.
+// This Limiter has a different implementation from the 'x/time/rate's Limiter
+// implementation. 'x/time/rate.Limiter' sends a constant stream of updates
+// (at a rate of few dozen events per second) over the period of a N minutes
+// which is the behavior of the token bucket algorithm. It is designed to
+// flatten bursts in a signal to a fixed output rate.
+// This rate.Limiter does the opposite of 'x/time/rate.Limiter'. It takes a
+// somewhat fixed-rate stream of updates and turns it into a stream of
+// controlled small bursts every N minutes.
+func NewLimiter(interval time.Duration, b int64) *Limiter {
+	ticker := time.NewTicker(interval)
+	ctx, cancel := context.WithCancel(context.Background())
+	l := &Limiter{
+		semaphore:   semaphore.NewWeighted(b),
+		ticker:      ticker,
+		currWeights: 0,
+		ctx:         ctx,
+		cancelFunc:  cancel,
+	}
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+			case <-l.ctx.Done():
+				return
+			}
+			currWeights := atomic.LoadInt64(&l.currWeights)
+			atomic.AddInt64(&l.currWeights, -currWeights)
+			l.semaphore.Release(currWeights)
+		}
+	}()
+	return l
+}
+
+// Stop stops the internal components used for the rate limiter logic.
+func (lim *Limiter) Stop() {
+	lim.cancelFunc()
+	lim.ticker.Stop()
+}
+
+func (lim *Limiter) assertAlive() {
+	select {
+	case <-lim.ctx.Done():
+		panic("limiter misuse: Allow / Wait / WaitN called concurrently after Stop")
+	default:
+	}
+}
+
+// Allow is shorthand for AllowN(time.Now(), 1).
+func (lim *Limiter) Allow() bool {
+	return lim.AllowN(1)
+}
+
+// AllowN returns true if it's possible to allow n tokens.
+func (lim *Limiter) AllowN(n int64) bool {
+	lim.assertAlive()
+	acq := lim.semaphore.TryAcquire(n)
+	if acq {
+		atomic.AddInt64(&lim.currWeights, n)
+		return true
+	}
+	return false
+}
+
+// Wait is shorthand for WaitN(ctx, 1).
+func (lim *Limiter) Wait(ctx context.Context) error {
+	return lim.WaitN(ctx, 1)
+}
+
+// WaitN acquires n tokens, blocking until resources are available or ctx is
+// done. On success, returns nil. On failure, returns ctx.Err() and leaves the
+// limiter unchanged.
+//
+// If ctx is already done, WaitN may still succeed without blocking.
+func (lim *Limiter) WaitN(ctx context.Context, n int64) error {
+	lim.assertAlive()
+	err := lim.semaphore.Acquire(ctx, n)
+	if err != nil {
+		return err
+	}
+	atomic.AddInt64(&lim.currWeights, n)
+	return nil
+}

--- a/pkg/rate/limiter_test.go
+++ b/pkg/rate/limiter_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package rate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type ControllerSuite struct{}
+
+var _ = Suite(&ControllerSuite{})
+
+func (b *ControllerSuite) TestLimiter(c *C) {
+	l := NewLimiter(1*time.Second, 100)
+
+	// We should be allowed to do this
+	c.Assert(l.AllowN(100), Equals, true)
+	// We shouldn't be allowed to get any left
+	c.Assert(l.Allow(), Equals, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	err := l.WaitN(ctx, 100)
+	cancel()
+	// The limiter should have 100 spaces available within 1.5 seconds.
+	c.Assert(err, IsNil)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = l.Wait(ctx)
+	cancel()
+	// The limiter should not have 1 spaces available within 100 milliseconds.
+	c.Assert(err, Not(IsNil))
+
+	l.Stop()
+
+	defer func() {
+		r := recover()
+		// Panic if we try to use the limiter after stopping it
+		c.Assert(r, Equals, "limiter misuse: Allow / Wait / WaitN called concurrently after Stop")
+	}()
+	l.Allow()
+}

--- a/pkg/rate/limiter_test.go
+++ b/pkg/rate/limiter_test.go
@@ -53,6 +53,12 @@ func (b *ControllerSuite) TestLimiter(c *C) {
 	// The limiter should not have 1 spaces available within 100 milliseconds.
 	c.Assert(err, Not(IsNil))
 
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = l.WaitN(ctx, 101)
+	cancel()
+	// The limiter won't be able to handle that many burst requests.
+	c.Assert(err, Not(IsNil))
+
 	l.Stop()
 
 	defer func() {


### PR DESCRIPTION
To prevent bursts of security identities from being deleted in the
KVStore, possibly causing Cilium agent to have a high CPU usage due
policy calculation, this commit adds a rate limiter for such KVStore
deletes. For example, in case there are 1000 identities to GCed, the
operator will delete 250 every minute until all 1000 identities are
GCed.

The 1.7 version is here https://github.com/cilium/cilium/pull/12450