### PR TITLE
replace Deployment with Job for example

### DIFF
--- a/examples/kubernetes/kernel-check/kernel-check.yaml
+++ b/examples/kubernetes/kernel-check/kernel-check.yaml
@@ -1,22 +1,15 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
-  labels:
-    app: bpf-kernel-check
   name: bpf-kernel-check
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: bpf-kernel-check
   template:
-    metadata:
-      labels:
-        app: bpf-kernel-check
     spec:
       nodeSelector:
-      # run deployment on specific node, e. g. nodename:cilium
+      # e. g. node.kubernetes.io/cni: cilium
       containers:
         - name: cilium
           image: docker.io/cilium/cilium:latest
           command: ["cilium", "kernel-check"]
+      restartPolicy: Never
+  backoffLimit: 1


### PR DESCRIPTION
Related:  #12384

`Job` is more suited than `Deployment` as we won't have restarting pods which could annoy the user. 
Thanks @sayboras for pointing out. 

Signed-off-by: Philipp Gniewosz <philipp.gniewosz@posteo.de>

