### PR TITLE
bpf: Fix BPF masq when running with non-hybrid DSR

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1290,7 +1290,8 @@ out:
 
 #if defined(ENABLE_NODEPORT) && \
 	(!defined(ENABLE_DSR) || \
-	 (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)))
+	 (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) || \
+	 defined(ENABLE_MASQUERADE))
 	if ((ctx->mark & MARK_MAGIC_SNAT_DONE) != MARK_MAGIC_SNAT_DONE) {
 		ret = nodeport_nat_fwd(ctx);
 		if (IS_ERR(ret))


### PR DESCRIPTION
Previously, BPF masquerading could not be performed when running with non-hybrid DSR due to a call to` nodeport_nat_fwd()` being compiled out. The latter is responsible for SNATing packets from pods to world.

Fix: 0962c02984 ("datapath: Enable BPF MASQ for veth mode in IPv4")