### PR TITLE
refactor stringSlice type CLI arguments

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1231,7 +1231,12 @@ func LogRegisteredOptions(entry *logrus.Entry) {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		entry.Infof("  --%s='%s'", k, viper.GetString(k))
+		v := viper.GetStringSlice(k)
+		if len(v) > 0 {
+			entry.Infof("  --%s='%s'", k, strings.Join(v, ","))
+		} else {
+			entry.Infof("  --%s='%s'", k, viper.GetString(k))
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: JieJhih Jhang <jiejhihjhang@gmail.com>
<!-- Description of change -->
The type of option ``--log-driver`` is string slice, which make this line ``entry.Infof("  --%s='%s'", k, viper.GetString(k))`` will get the empty string. For the options should handle both type string and string slice, otherwise just print the empty string at the final.
Fixes: #12132 

```release-note
Fix string slice type CLI arguments
```
