### PR TITLE
datapath/linux: protect against concurrent access in NodeValidateImplementation

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1150,6 +1150,9 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 // NodeValidateImplementation is called to validate the implementation of the
 // node in the datapath
 func (n *linuxNodeHandler) NodeValidateImplementation(nodeToValidate nodeTypes.Node) error {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
 	return n.nodeUpdate(nil, &nodeToValidate, false)
 }
 


### PR DESCRIPTION
The `linuxNodeHandler.neighByNode` map is also protected by
`linuxNodeHandler.mutex` in all other code paths. Protect access to it in
`(*linuxNodeHandler).NodeValidateImplementation as well.

Fixes #12460

Fixes: 6c06c51926bc ("node: Remove permanent ARP entry when remote node is deleted")