### PR TITLE
build: Skip 'clean' and 'clean-container' before docker image builds.

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build docker images
         run: |
-          make docker-image-no-clean
+          make docker-cilium-image
           make docker-operator-generic-image
 
       - name: Create kind cluster

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build docker images
         run: |
-          make docker-image-no-clean
+          make docker-cilium-image
           make docker-operator-generic-image
 
       - name: Create kind cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG LIBNETWORK_PLUGIN
 # as that will mess with caching for incremental builds!
 #
 RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
-    SKIP_DOCS=true DESTDIR=/tmp/install clean-container build-container install-container
+    SKIP_DOCS=true DESTDIR=/tmp/install build-container install-container
 
 #
 # Cilium runtime install.

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -36,7 +36,7 @@ Anyone can build official release images using the make target below.
 
 ::
 
-    DOCKER_IMAGE_TAG=v1.4.0 make docker-image
+    DOCKER_IMAGE_TAG=v1.4.0 make docker-images-all
 
 Official Cilium repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -98,7 +98,7 @@ If you intent to release a new feature release, see the
 
    ::
 
-      DOCKER_IMAGE_TAG=v1.0.3 make docker-image
+      DOCKER_IMAGE_TAG=v1.0.3 make docker-images-all
       docker push cilium/cilium:v1.0.3
 
    .. note:

--- a/Makefile
+++ b/Makefile
@@ -591,5 +591,5 @@ update-images-go-version:
 	$(QUIET) $(MAKE) -C images update-golang-image
 	@echo "Updated go version in image Dockerfiles to $(GO_VERSION)"
 
-.PHONY: force generate-api generate-health-api install build-context-update dev-docker-image clean-build clean clean-container veryclean
+.PHONY: force generate-api generate-health-api install build-context-update clean-build clean clean-container veryclean
 force :;

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -13,19 +13,15 @@ docker-cilium-image-for-developers:
 		--build-arg LIBNETWORK_PLUGIN=\
 		-t $(DOCKER_DEV_ACCOUNT)/cilium-dev:latest . -f ./cilium-dev.Dockerfile
 
-docker-image: clean docker-image-no-clean docker-plugin-image docker-hubble-relay-image
-	$(MAKE) docker-operator-image
-	$(MAKE) docker-operator-aws-image
-	$(MAKE) docker-operator-azure-image
-	$(MAKE) docker-operator-generic-image
+docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-operator-images-all
 
-docker-image-unstripped: clean docker-image-no-clean-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped
-	$(MAKE) docker-operator-image-unstripped
-	$(MAKE) docker-operator-aws-image-unstripped
-	$(MAKE) docker-operator-azure-image-unstripped
-	$(MAKE) docker-operator-generic-image-unstripped
+docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-operator-images-all-unstripped
 
-docker-image-no-clean: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
+docker-operator-images-all: docker-operator-image docker-operator-aws-image docker-operator-azure-image docker-operator-generic-image
+
+docker-operator-images-all-unstripped: docker-operator-image-unstripped docker-operator-aws-image-unstripped docker-operator-azure-image-unstripped docker-operator-generic-image-unstripped
+
+docker-cilium-image: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/Dockerfile \
 		$(DOCKER_FLAGS) \
 		--build-arg NOSTRIP=${NOSTRIP} \
@@ -38,9 +34,9 @@ docker-image-no-clean: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
 	@echo "Push like this when ready:"
 	@echo "${CONTAINER_ENGINE} push cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
-docker-image-no-clean-unstripped: NOSTRIP=1
-docker-image-no-clean-unstripped: UNSTRIPPED=-unstripped
-docker-image-no-clean-unstripped: docker-image-no-clean
+docker-cilium-image-unstripped: NOSTRIP=1
+docker-cilium-image-unstripped: UNSTRIPPED=-unstripped
+docker-cilium-image-unstripped: docker-cilium-image
 
 docker-cilium-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium $(DOCKER_IMAGE_TAG)
@@ -140,3 +136,5 @@ docker-hubble-relay-image: $(BUILD_DIR)/hubble-relay.Dockerfile build-context-up
 docker-hubble-relay-image-unstripped: NOSTRIP=1
 docker-hubble-relay-image-unstripped: UNSTRIPPED=-unstripped
 docker-hubble-relay-image-unstripped: docker-hubble-relay-image
+
+.PHONY: docker-image-runtime docker-image-builder docker-cilium-manifest docker-cilium-dev-manifest docker-operator-manifest docker-plugin-manifest docker-cilium-runtime-manifest docker-cilium-builder-manifest

--- a/contrib/scripts/minikube.sh
+++ b/contrib/scripts/minikube.sh
@@ -11,7 +11,7 @@ minikube start
 # TODO(mrostecki): Support cri-o and buildah.
 eval $(minikube docker-env)
 
-make docker-image DOCKER_IMAGE_TAG=dev
+make docker-images-all DOCKER_IMAGE_TAG=dev
 
 cp "install/kubernetes/quick-install.yaml" /tmp/cilium-minikube.yaml
 

--- a/images/README.md
+++ b/images/README.md
@@ -112,13 +112,13 @@ FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder
 ## mount Cilium repo in `GOPATH`, also mount caches
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
   ## build natively and install the binaries to /out/linux/amd64
-  make clean-container build-container install-container \
+  make build-container install-container \
     DESTDIR=/out/linux/amd64
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
   ## cross-compile for arm64 and install the binaries to /out/linux/arm64
   env GOARCH=arm64 CC=aarch64-linux-gnu-gcc \
-    make clean-container build-container install-container \
+    make build-container install-container \
       DESTDIR=/out/linux/arm64 \
       # HOST_CC and HOST_STRIP are required by `bpf/Makefile`
       HOST_CC=aarch64-linux-gnu-gcc HOST_STRIP=aarch64-linux-gnu-strip

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -12,12 +12,12 @@ ARG NOSTRIP
 ARG LOCKDEBUG
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  make clean-container build-container install-container \
+  make build-container install-container \
     NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/out/linux/amd64
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
   env GOARCH=arm64 CC=aarch64-linux-gnu-gcc \
-    make clean-container build-container install-container \
+    make build-container install-container \
       NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/out/linux/arm64 \
       HOST_CC=aarch64-linux-gnu-gcc HOST_STRIP=aarch64-linux-gnu-strip
 

--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -3,7 +3,7 @@
 set -e
 
 cd ..
-DOCKER_BUILDKIT=1 make docker-image DOCKER_IMAGE_TAG="$2" DOCKER_FLAGS="$3"
+DOCKER_BUILDKIT=1 make docker-images-all DOCKER_IMAGE_TAG="$2" DOCKER_FLAGS="$3"
 
 docker tag "cilium/cilium:$2" "$1/cilium/cilium:$2"
 docker tag "cilium/cilium:$2" "$1/cilium/cilium-dev:$2"

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -35,7 +35,7 @@ then
 
       if [[ "${CILIUM_IMAGE}" == "" ]]; then
         echo "building cilium container image..."
-        DOCKER_BUILDKIT=1 make LOCKDEBUG=1 docker-image-no-clean
+        DOCKER_BUILDKIT=1 make LOCKDEBUG=1 docker-cilium-image
         echo "tagging cilium image..."
         docker tag cilium/cilium "${REGISTRY}/${CILIUM_TAG}"
         echo "pushing cilium image to ${REGISTRY}/${CILIUM_TAG}..."

--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -30,7 +30,7 @@ docker run -d -p 5000:5000 --name registry -v ${certs_dir}:/certs \
         -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/kubernetes.pem \
         -e REGISTRY_HTTP_TLS_KEY=/certs/kubernetes-key.pem \
         registry:2
-make docker-image
+make docker-images-all
 docker tag cilium/cilium:${DOCKER_IMAGE_TAG} localhost:5000/cilium:${DOCKER_IMAGE_TAG}
 docker push localhost:5000/cilium:${DOCKER_IMAGE_TAG}
 SCRIPT


### PR DESCRIPTION
Running 'make clean' will not change 'go build' output, so it is not
necessary, especially now that building with 'DOCKER_BUILDKIT=1' works
and the '.dockerignore' files are automatically generated so that
binaries, temporary files, etc. are not tranferred to the docker build
container.

This will make the build output easier to read and save some build time, too.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
