### PR TITLE
pkg/k8s: use copy of objectmeta when fetching from local stores

### DIFF
--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -103,8 +103,9 @@ func GetPodMetadata(k8sNs *slim_corev1.Namespace, pod *slim_corev1.Pod) (contain
 	})
 	scopedLog.Debug("Connecting to k8s local stores to retrieve labels for pod")
 
-	annotations := pod.Annotations
-	k8sLabels := pod.Labels
+	objMetaCpy := pod.ObjectMeta.DeepCopy()
+	annotations := objMetaCpy.Annotations
+	k8sLabels := objMetaCpy.Labels
 	if k8sLabels == nil {
 		k8sLabels = map[string]string{}
 	}


### PR DESCRIPTION
This commit fixes a bug introduced by 9975bba1637c where we were
accidentally writing into the object metadata of the local pod store,
which should never happen. Doing that could cause k8s update pod
events to give to the Update function handlers an old pod structure with
such fields modified.

Fixes: 9975bba1637c ("pkg/endpoint: fetch pod and namespace labels from local stores")

Reported-by: Deepesh Pathak <deepshpathak@gmail.com>
Signed-off-by: André Martins <andre@cilium.io>