### PR TITLE
policy/api: Support unmanaged entity in policies

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -312,6 +312,10 @@ health
     The health entity represents the health endpoints, used to check cluster
     connectivity health. Each node managed by Cilium hosts a health endpoint.
     See `cluster_connectivity_health` for details on health checks.
+unmanaged
+    The unmanaged entity represents endpoints not managed by Cilium. Unmanaged
+    endpoints are considered part of the cluster and are included in the
+    cluster entity.
 world
     The world entity corresponds to all endpoints outside of the cluster.
     Allowing to world is identical to allowing to CIDR 0.0.0.0/0. An alternative

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -42,6 +42,9 @@ const (
 	// EntityInit is an entity that represents an initializing endpoint
 	EntityInit Entity = "init"
 
+	// EntityUnmanaged is an entity that represents unamanaged endpoints.
+	EntityUnmanaged Entity = "unmanaged"
+
 	// EntityRemoteNode is an entity that represents all remote nodes
 	EntityRemoteNode Entity = "remote-node"
 
@@ -76,6 +79,7 @@ var (
 		EntityInit:       {endpointSelectorInit},
 		EntityRemoteNode: {endpointSelectorRemoteNode},
 		EntityHealth:     {endpointSelectorHealth},
+		EntityUnmanaged:  {endpointSelectorUnmanaged},
 		EntityNone:       {EndpointSelectorNone},
 
 		// EntityCluster is populated with an empty entry to allow the


### PR DESCRIPTION
0a9685e introduced the `reserved:unmanaged` identity, but did not introduce the associated entity. This commit fixes it and allows the following in policies:

    - fromEntity:
      - unmanaged

The goal is to allow policies to work even before all pods are restarted and managed by Cilium. In particular, this can be an issue with host policies since the host is more likely than pods to need to talk with unmanaged pods (e.g., on GKE right after deploying Cilium).

Fixes: #5898
