### PR TITLE
test/packet: set operating_system to ubuntu_18_04

### DIFF
--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -29,7 +29,7 @@ resource "packet_device" "test" {
     hostname         = "test-${count.index}"
     plan             = var.packet_plan
     facilities       = [ var.packet_location ]
-    operating_system = "ubuntu_19_04"
+    operating_system = "ubuntu_18_04"
     billing_cycle    = "hourly"
     project_id       = var.packet_project_id
 


### PR DESCRIPTION
ubuntu_19_04 seems to be broken as it is reaching EOL. Switching it to
18_04, a LTS, still works.

Fixes: 0c2d13d31de9 ("test/packet: fix packet terraform scripts")
Signed-off-by: André Martins <andre@cilium.io>