### PR TITLE
Fix RuntimeKVStoreTest flake

### DIFF
--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -76,7 +76,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 			By("Starting Cilium with consul as kvstore")
 			vm.ExecInBackground(
 				ctx,
-				"sudo cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug")
+				"sudo cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug 2>&1 | logger -t cilium")
 			err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
 			Expect(err).Should(BeNil())
 
@@ -96,7 +96,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 			By("Starting Cilium with etcd as kvstore")
 			vm.ExecInBackground(
 				ctx,
-				"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001 2>&1 | logger -t cilium")
+				"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001 --debug 2>&1 | logger -t cilium")
 			err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
 			Expect(err).Should(BeNil(), "Timed out waiting for VM to be ready after restarting Cilium")
 

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -16,6 +16,7 @@ package RuntimeTest
 
 import (
 	"context"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -25,8 +26,8 @@ import (
 )
 
 var _ = Describe("RuntimeKVStoreTest", func() {
-
 	var vm *helpers.SSHMeta
+	var testStartTime time.Time
 
 	BeforeAll(func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
@@ -50,6 +51,10 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		ExpectCiliumNotRunning(vm)
 	}, 150)
 
+	JustBeforeEach(func() {
+		testStartTime = time.Now()
+	})
+
 	AfterEach(func() {
 		containers(helpers.Delete)
 		err := vm.RestartCilium()
@@ -57,7 +62,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 	})
 
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 	})
 
 	AfterFailed(func() {
@@ -68,8 +73,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		vm.CloseSSHClient()
 	})
 
-	SkipContextIf(helpers.SkipQuarantined, "KVStore tests under quarantine", func() {
-
+	Context("KVStore tests", func() {
 		It("Consul KVStore", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()


### PR DESCRIPTION
The `RuntimeKVStoreTest` tests (both Consul and Etcd) have been failing for a while because our `ValidateNoErrorsInLogs` check sometimes finds errors in the logs. This pull request fixes it.

The first commit fixes the Consul test for which no Cilium logs were registered.

Wait... what?! Then how is `ValidateNoErrorsInLogs` failing if we don't even print the logs??

Second commit's message:
> As for most tests, at the end of `RuntimeKVStoreTest`, we validate the logs don't contain any worrisome messages with:
>
>     vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
>
> `CurrentGinkgoTestDescription().Duration` [includes the execution of all `ginkgo.BeforeEach`](https://github.com/onsi/ginkgo/blob/9c254cb251dc962dc20ca91d0279c870095cfcf9/internal/spec/spec.go#L132-L134). In `RuntimeKVStoreTest`, one of our `ginkgo.BeforeEach` calls stops the Cilium systemd service (because we run cilium-agent as a standalone binary in the test itself). Stopping Cilium can result in worrisome messages in the logs e.g., if the compilation of BPF programs is terminated abruptly. This in turn makes the tests fail once in a while.
>
> To fix this, we can replace `CurrentGinkgoTestDescription().Duration` with our own "time counter" that doesn't include any of the `ginkgo.BeforeEach` executions.
>
> To validate this fix, I ran the whole `RuntimeKVStoreTest` with this change 60 times locally and 60 times in the CI (#12419). The tests passed all 120 times. Before applying the fix, the Consul test would fail ~1/30 times, both locally and in CI.

I am not marking this for backport just yet. I'd like to see it run a couple time successfully in master before. It wouldn't be the first time we erroneously think we fixed a flake. 

Fixes: #11895
Fixes: #3211
Fixes: #1733