### PR TITLE
Makefile: Fix render-docs with parallel make jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,8 @@ update-authors:
 	@cat .authors.aux >> AUTHORS
 
 render-docs:
-	$(MAKE) -C Documentation html run-server
+	$(MAKE) -C Documentation html
+	$(MAKE) -C Documentation run-server
 
 render-docs-live-preview:
 	$(MAKE) -C Documentation live-preview


### PR DESCRIPTION
When running make with parallel jobs (make -j N), the ordering between
the build of the html and running the server was not guaranteed. Split
them into separate make commands in the target to ensure the build
happens first.