### PR TITLE
Document kvstore leases, update links

### DIFF
--- a/Documentation/kvstore.rst
+++ b/Documentation/kvstore.rst
@@ -34,7 +34,7 @@ Key                                                          Value
 ``cilium/state/nodes/v1/<cluster>/<node>``                   node.Node_
 ============================================================ ====================
 
-.. _node.Node: https://godoc.org/github.com/cilium/cilium/pkg/node/types#Node
+.. _node.Node: https://pkg.go.dev/github.com/cilium/cilium/pkg/node/types#Node
 
 All node keys are attached to a lease owned by the agent of the respective
 node.
@@ -52,7 +52,7 @@ Key                                                           Value
 ``cilium/state/services/v1/<cluster>/<namespace>/<service>``  serviceStore.ClusterService_
 ============================================================= ====================
 
-.. _serviceStore.ClusterService: https://godoc.org/github.com/cilium/cilium/pkg/service/store#ClusterService
+.. _serviceStore.ClusterService: https://pkg.go.dev/github.com/cilium/cilium/pkg/service/store#ClusterService
 
 Identities
 ----------
@@ -68,8 +68,8 @@ Key                                                           Value
 ``cilium/state/identities/v1/value/<labels>/<node>``          identity.NumericIdentity_
 ============================================================= ====================
 
-.. _identity.NumericIdentity: https://godoc.org/github.com/cilium/cilium/pkg/identity#NumericIdentity
-.. _labels.LabelArray: https://godoc.org/github.com/cilium/cilium/pkg/labels#LabelArray
+.. _identity.NumericIdentity: https://pkg.go.dev/github.com/cilium/cilium/pkg/identity#NumericIdentity
+.. _labels.LabelArray: https://pkg.go.dev/github.com/cilium/cilium/pkg/labels#LabelArray
 
 Endpoints
 ---------
@@ -84,7 +84,7 @@ Key                                                           Value
 ``cilium/state/ip/v1/<cluster>/<ip>``                         identity.IPIdentityPair_
 ============================================================= ====================
 
-.. _identity.IPIdentityPair: https://godoc.org/github.com/cilium/cilium/pkg/identity#IPIdentityPair
+.. _identity.IPIdentityPair: https://pkg.go.dev/github.com/cilium/cilium/pkg/identity#IPIdentityPair
 
 CiliumNetworkPolicyNodeStatus
 -----------------------------
@@ -101,7 +101,7 @@ Key                                                              Value
 ``cilium/state/cnpstatuses/v2/<UID>/<namespace>/<name>/<node>``  k8s.CNPNSWithMeta_
 ================================================================ ====================
 
-.. _k8s.CNPNSWithMeta: https://godoc.org/github.com/cilium/cilium/pkg/k8s#CNPNSWithMeta
+.. _k8s.CNPNSWithMeta: https://pkg.go.dev/github.com/cilium/cilium/pkg/k8s#CNPNSWithMeta
 
 Leases
 ======

--- a/Documentation/kvstore.rst
+++ b/Documentation/kvstore.rst
@@ -114,7 +114,26 @@ store in the event that an agent dies on a particular and never reappears.
 
 The lease lifetime is set to 15 minutes. The exact expiration behavior is
 dependent on the kvstore implementation but the expiration typically occurs
-after double the lifetime
+after double the lease lifetime.
+
+In addition to regular entry leases, all locks in the key-value store are
+owned by a particular agent running on the node with a separate "lock lease"
+attached. The lock lease has a default lifetime of 25 seconds.
+
+=============================================================== ================ ========================================
+Key                                                             Lease Timeout    Default expiry
+=============================================================== ================ ========================================
+``cilium/.initlock/<random>/<lease-ID>``                        LockLeaseTTL_    25 seconds
+``cilium/state/cnpstatuses/v2/<UID>/<namespace>/<name>/<node>`` KVstoreLeaseTTL_ 15 minutes
+``cilium/state/identities/v1/id/<identity>``                    None             Garbage collected by ``cilium-operator``
+``cilium/state/identities/v1/value/<labels>/<node>``            KVstoreLeaseTTL_ 15 minutes
+``cilium/state/ip/v1/<cluster>/<ip>``                           KVstoreLeaseTTL_ 15 minutes
+``cilium/state/nodes/v1/<cluster>/<node>``                      KVstoreLeaseTTL_ 15 minutes
+``cilium/state/services/v1/<cluster>/<namespace>/<service>``    KVstoreLeaseTTL_ 15 minutes
+=============================================================== ================ ========================================
+
+.. _LockLeaseTTL: https://pkg.go.dev/github.com/cilium/cilium/pkg/defaults?tab=doc#LockLeaseTTL
+.. _KVstoreLeaseTTL: https://pkg.go.dev/github.com/cilium/cilium/pkg/defaults?tab=doc#KVstoreLeaseTTL
 
 Debugging
 =========


### PR DESCRIPTION
* Update the `kvstore` code links to pkg.go.dev
* List the objects by lease-ID with lease/GC behaviour in a nice table