### PR TITLE
policy: Enable ingress CIDR-dependent L3 policy (FromCIDR + ToPorts)

### DIFF
--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -30,12 +30,9 @@ import (
 //   the effects of any Requires field in any rule will apply to all other
 //   rules as well.
 //
-// - For now, combining ToPorts, FromCIDR, and FromEndpoints in the same rule
-//   is not supported and any such rules will be rejected. In the future, this
-//   will be supported and if multiple members of this structure are specified,
-//   then all members must match in order for the rule to take effect. The
-//   exception to this rule is the Requires field, the effects of any Requires
-//   field in any rule will apply to all other rules as well.
+// - FromEndpoints, FromCIDR, FromCIDRSet and FromEntities are mutually
+//   exclusive. Only one of these members may be present within an individual
+//   rule.
 type IngressRule struct {
 	// FromEndpoints is a list of endpoints identified by an
 	// EndpointSelector which are allowed to communicate with the endpoint

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -111,12 +111,6 @@ func (i *IngressRule) sanitize() error {
 		"FromCIDRSet":   len(i.FromCIDRSet),
 		"FromEntities":  len(i.FromEntities),
 	}
-	l3DependentL4Support := map[interface{}]bool{
-		"FromEndpoints": true,
-		"FromCIDR":      false,
-		"FromCIDRSet":   false,
-		"FromEntities":  true,
-	}
 	l7Members := countL7Rules(i.ToPorts)
 	l7IngressSupport := map[string]bool{
 		"DNS":   false,
@@ -129,11 +123,6 @@ func (i *IngressRule) sanitize() error {
 			if m2 != m1 && l3Members[m1] > 0 && l3Members[m2] > 0 {
 				return fmt.Errorf("Combining %s and %s is not supported yet", m1, m2)
 			}
-		}
-	}
-	for member := range l3Members {
-		if l3Members[member] > 0 && len(i.ToPorts) > 0 && !l3DependentL4Support[member] {
-			return fmt.Errorf("Combining %s and ToPorts is not supported yet", member)
 		}
 	}
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1068,6 +1068,16 @@ func (kub *Kubectl) MonitorStart(namespace, pod string) (res *CmdRes, cancel fun
 	return kub.ExecInBackground(ctx, cmd, ExecOptions{SkipLog: true}), cancel
 }
 
+// MonitorEndpointStart runs cilium monitor only on a specified endpoint. This
+// function is the same as MonitorStart.
+func (kub *Kubectl) MonitorEndpointStart(namespace, pod string, epID int64) (res *CmdRes, cancel func()) {
+	cmd := fmt.Sprintf("%s exec -n %s %s -- cilium monitor -vv --related-to %d",
+		KubectlCmd, namespace, pod, epID)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return kub.ExecInBackground(ctx, cmd, ExecOptions{SkipLog: true}), cancel
+}
+
 // BackgroundReport dumps the result of the given commands on cilium pods each
 // five seconds.
 func (kub *Kubectl) BackgroundReport(commands ...string) (context.CancelFunc, error) {

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -16,6 +16,7 @@ package helpers
 
 import (
 	"fmt"
+	"net"
 	"strings"
 )
 
@@ -141,4 +142,25 @@ func PythonBind(addr string, port uint16, proto string) string {
 	return fmt.Sprintf(
 		`/usr/bin/python3 -c 'import socket; socket.socket(%s).bind((%q, %d))`,
 		strings.Join(opts, ", "), addr, port)
+}
+
+// IPAddRoute returns a string representing the command to add a route to a
+// given IP address and a gateway via the iproute2 utility suite. The function
+// takes in a flag called replace which will convert the action to replace the
+// route being added if another route exists and matches. This allows for
+// idempotency as the "replace" action will not fail if another matching route
+// exists, whereas "add" will fail.
+func IPAddRoute(ip, gw net.IP, replace bool) string {
+	action := "add"
+	if replace {
+		action = "replace"
+	}
+
+	return fmt.Sprintf("ip route %s %s via %s", action, ip.String(), gw.String())
+}
+
+// IPDelRoute returns a string representing the command to delete a route to a
+// given IP address and a gateway via the iproute2 utility suite.
+func IPDelRoute(ip, gw net.IP) string {
+	return fmt.Sprintf("ip route del %s via %s", ip.String(), gw.String())
 }

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -756,12 +756,14 @@ func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNod
 
 		if expectPodIP {
 			// Make pods reachable from the host which doesn't run Cilium
-			_, err := kubectl.ExecInHostNetNSByLabel(context.TODO(), helpers.GetNodeWithoutCilium(),
-				fmt.Sprintf("ip r a %s via %s", podIP, hostIP))
+			_, err := kubectl.ExecInHostNetNSByLabel(context.TODO(),
+				helpers.GetNodeWithoutCilium(),
+				helpers.IPAddRoute(podIP, hostIP, false))
 			ExpectWithOffset(1, err).Should(BeNil(), "Failed to add ip route")
 			defer func() {
-				_, err := kubectl.ExecInHostNetNSByLabel(context.TODO(), helpers.GetNodeWithoutCilium(),
-					fmt.Sprintf("ip r d %s via %s", podIP, hostIP))
+				_, err := kubectl.ExecInHostNetNSByLabel(context.TODO(),
+					helpers.GetNodeWithoutCilium(),
+					helpers.IPDelRoute(podIP, hostIP))
 				ExpectWithOffset(1, err).Should(BeNil(), "Failed to del ip route")
 			}()
 		}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1170,16 +1170,11 @@ var _ = Describe("K8sPolicyTest", func() {
 			Context("with remote-node identity disabled", func() {
 				BeforeAll(func() {
 					By("Reconfiguring Cilium to disable remote-node identity")
-					newCfg := map[string]string{
-						"global.remoteNodeIdentity": "false",
-						"global.hostFirewall":       "false",
-					}
-					for k, v := range daemonCfg {
-						if _, ok := newCfg[k]; !ok {
-							newCfg[k] = v
-						}
-					}
-					RedeployCilium(kubectl, ciliumFilename, newCfg)
+					RedeployCiliumWithMerge(kubectl, ciliumFilename, daemonCfg,
+						map[string]string{
+							"global.remoteNodeIdentity": "false",
+							"global.hostFirewall":       "false",
+						})
 				})
 
 				It("Allows from all hosts with cnp fromEntities host policy", func() {
@@ -1208,13 +1203,10 @@ var _ = Describe("K8sPolicyTest", func() {
 			Context("with remote-node identity enabled", func() {
 				BeforeAll(func() {
 					By("Reconfiguring Cilium to enable remote-node identity")
-					newCfg := map[string]string{
-						"global.remoteNodeIdentity": "true",
-					}
-					for k, v := range daemonCfg {
-						newCfg[k] = v
-					}
-					RedeployCilium(kubectl, ciliumFilename, newCfg)
+					RedeployCiliumWithMerge(kubectl, ciliumFilename, daemonCfg,
+						map[string]string{
+							"global.remoteNodeIdentity": "true",
+						})
 				})
 
 				It("Validates fromEntities remote-node policy", func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -804,14 +804,15 @@ var _ = Describe("K8sServicesTest", func() {
 			tftpURL := getTFTPLink(svcExternalIP, data.Spec.Ports[1].Port)
 
 			// Add the route on the outside node to the external IP addr
-			cmd := fmt.Sprintf("ip r a %s/32 via %s", svcExternalIP, k8s1IP)
+			cmd := helpers.IPAddRoute(net.ParseIP(svcExternalIP), net.ParseIP(k8s1IP), false)
 			res, err := kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName, cmd)
 			ExpectWithOffset(1, err).Should(BeNil(), "Cannot exec in outside node %s", outsideNodeName)
 			ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
 				"Can not exec %q on outside node %s", cmd, outsideNodeName)
 			defer func() {
-				cmd = fmt.Sprintf("ip r d %s/32 via %s", svcExternalIP, k8s1IP)
-				kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName, cmd)
+				kubectl.ExecInHostNetNS(context.TODO(),
+					outsideNodeName,
+					helpers.IPDelRoute(net.ParseIP(svcExternalIP), net.ParseIP(k8s1IP)))
 			}()
 
 			// Should work from outside via the external IP

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -127,6 +127,27 @@ func RedeployCilium(vm *helpers.Kubectl, ciliumFilename string, options map[stri
 	ExpectCiliumOperatorReady(vm)
 }
 
+// RedeployCiliumWithMerge merges the configuration passed as "from" into
+// "options", allowing the caller to preserve the previous Cilium
+// configuration, along with passing new configuration. This function behaves
+// equivalently to RedeployCilium. Note that "options" is deep copied, meaning
+// it will NOT be modified. Any modifications will be local to this function.
+func RedeployCiliumWithMerge(vm *helpers.Kubectl,
+	ciliumFilename string,
+	from, options map[string]string) {
+
+	// Merge configuration
+	newOpts := make(map[string]string, len(options))
+	for k, v := range from {
+		newOpts[k] = v
+	}
+	for k, v := range options {
+		newOpts[k] = v
+	}
+
+	RedeployCilium(vm, ciliumFilename, newOpts)
+}
+
 // DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster
 func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, options map[string]string) {
 	redeployCilium(vm, ciliumFilename, options)

--- a/test/k8sT/manifests/cnp-ingress-from-cidr-to-ports.yaml
+++ b/test/k8sT/manifests/cnp-ingress-from-cidr-to-ports.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "Policy to allow traffic external to cluster inwards via CIDR and port"
+metadata:
+  name: "cnp-ingress-from-cidr-to-ports"
+spec:
+  endpointSelector:
+    matchLabels:
+      zgroup: testDS
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+    fromCIDR:
+      - 192.168.36.13/32


### PR DESCRIPTION
See commit msgs.

Updates: https://github.com/cilium/cilium/issues/4129

**Note to backporters**: If there are conflicts with the tests, then test coverage commits do not need to be backported; only enabling the policy.