### PR TITLE
v1.6 backports 2020-07-09

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -632,10 +632,11 @@ vader
 Vader
 Vagrantcloud
 Vagrantfile
+vCPUs
+vX
 validator
 vbguest
 vbox
-vCPUs
 ve
 verifier
 Verifier

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -41,7 +41,7 @@ fi
 DATE=$(date --rfc-3339=date)
 PRBRANCH="pr/v${BRANCH}-backport-${DATE}${SUFFIX}"
 
-if ! (git --no-pager branch | grep -q "${PRBRANCH}"); then
+if (git --no-pager branch | grep -q "${PRBRANCH}"); then
     echo "Error: branch '${PRBRANCH}' already exists"
     echo "Consider passing a suffix as the second parameter"
     echo

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -39,5 +39,16 @@ if ! git branch -a | grep -q "origin/v$BRANCH$" ; then
 fi
 
 DATE=$(date --rfc-3339=date)
-git checkout -b "pr/v$BRANCH-backport-$DATE${SUFFIX}" origin/v$BRANCH
+PRBRANCH="pr/v${BRANCH}-backport-${DATE}${SUFFIX}"
+
+if ! (git --no-pager branch | grep -q "${PRBRANCH}"); then
+    echo "Error: branch '${PRBRANCH}' already exists"
+    echo "Consider passing a suffix as the second parameter"
+    echo
+    echo "Example:"
+    echo "  ./contrib/backporting/start-backport ${BRANCH} \"-2\""
+    common::exit 1
+fi
+
+git checkout -b "${PRBRANCH}" origin/v$BRANCH
 contrib/backporting/check-stable $BRANCH v$BRANCH-backport-$DATE.txt

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -27,13 +27,17 @@ if [ "$BRANCH" = "" ]; then
 fi
 BRANCH=$(echo "$BRANCH" | sed 's/^v//')
 
+# Extra optional suffix in cases where there are multiple backport PRs that
+# have the same conflicting branch name.
+SUFFIX="${2}"
+
 git fetch origin
 if ! git branch -a | grep -q "origin/v$BRANCH$" ; then
-    echo "usage: start-backport <branch version>" 1>&2
+    echo "usage: start-backport <branch version> [suffix]" 1>&2
     echo "  (detected branch $BRANCH)" 1>&2
     common::exit 1
 fi
 
 DATE=$(date --rfc-3339=date)
-git checkout -b pr/v$BRANCH-backport-$DATE origin/v$BRANCH
+git checkout -b "pr/v$BRANCH-backport-$DATE${SUFFIX}" origin/v$BRANCH
 contrib/backporting/check-stable $BRANCH v$BRANCH-backport-$DATE.txt

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -36,4 +36,4 @@ fi
 
 DATE=$(date --rfc-3339=date)
 git checkout -b pr/v$BRANCH-backport-$DATE origin/v$BRANCH
-contrib/backporting/check-stable $BRANCH $DATE.txt
+contrib/backporting/check-stable $BRANCH v$BRANCH-backport-$DATE.txt

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright 2019 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
+source $TOOL_LIB_PATH/gitlib.sh
+source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
+
+# Validate command-line
+common::argc_validate 1
+
+BRANCH="${1:-}"
+if [ "$BRANCH" = "" ]; then
+    BRANCH=$(git symbolic-ref --short HEAD)
+fi
+BRANCH=$(echo "$BRANCH" | sed 's/^v//')
+
+git fetch origin
+if ! git branch -a | grep -q "origin/v$BRANCH$" ; then
+    echo "usage: start-backport <branch version>" 1>&2
+    echo "  (detected branch $BRANCH)" 1>&2
+    common::exit 1
+fi
+
+DATE=$(date --rfc-3339=date)
+git checkout -b pr/v$BRANCH-backport-$DATE origin/v$BRANCH
+contrib/backporting/check-stable $BRANCH $DATE.txt

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -10,7 +10,7 @@ CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml"
 
 VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+.*'
 LATEST_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
-DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+-dev'
+DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
 CILIUM_PULLPOLICY_REGEX := '\(pullPolicy:\) .*'
@@ -30,9 +30,8 @@ update-versions:
 			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $(CILIUM_VALUES);			\
 			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
 		elif echo $(VERSION) | grep -q $(DEV_VERSION_REGEX); then				\
-			DEV_BRANCH=$$(echo $(VERSION) | sed 's/-dev//')					\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 $(DEV_BRANCH)/' $(CILIUM_VALUES);		\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(subst -dev,,$(VERSION))/' $(CILIUM_VALUES);	\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);			\
 		else											\
 			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $(CILIUM_VALUES);		\
 			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $(CILIUM_VALUES);	\

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -43,7 +43,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.15"
+	CustomResourceDefinitionSchemaVersion = "1.16"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -648,12 +648,17 @@ var (
 				},
 			},
 			"toGroups": {
-				Type: "object",
+				Type: "array",
 				Description: `ToGroups is a list of constraints that will
 				gather data from third-party providers and create a new
 				derived policy.`,
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-					"aws": AWSGroup,
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+							"aws": AWSGroup,
+						},
+					},
 				},
 			},
 			"toFQDNs": {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -766,7 +766,12 @@ func LogRegisteredOptions(entry *logrus.Entry) {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		entry.Infof("  --%s='%s'", k, viper.GetString(k))
+		v := viper.GetStringSlice(k)
+		if len(v) > 0 {
+			entry.Infof("  --%s='%s'", k, strings.Join(v, ","))
+		} else {
+			entry.Infof("  --%s='%s'", k, viper.GetString(k))
+		}
 	}
 }
 


### PR DESCRIPTION
Backported:
 * #12291 -- docs: add instructions for vX.Y helm charts (@aanm)
   * Minor conflicts in the Makefile, had to drop docs changes
 * #12351 -- contrib: Add ability to pass suffix for branch  (@christarazi)
   * Had to backport #9560, #10649 to introduce the script.
 * #12361 -- contrib: fix branch check in `start-backport` script (@Rolinh)
 * #12440 -- Fix small CRD issue with toGroups (@lbernail)
   * I had to manually reimplement due to file path change; I also opted to
     bump the v1.6 schema version from 1.15 -> 1.16 to ensure that when later
     upgrades to 1.7 (1.18) or 1.8 (1.20), the schema would be properly updated.
     Please take a close look.
 * #12457 -- refactor stringSlice type CLI arguments (@JieJhih)

Not backported, needs more close attention:
 * #11891 -- etcd: propagate Context from higher-level calls (@tklauser)
   * At the very least needs #9512 which has major conflicts
 * #12307 -- pkg/endpoint: wait for security identity on restore (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 9560 10649 12291 12351 12361 12440 12457; do contrib/backporting/set-labels.py $pr done 1.6; done
```