### PR TITLE
docs: update documentation for kubectl usage

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -24,7 +24,7 @@ cilium-bugtool [OPTIONS] [flags]
 	NAME                          READY     STATUS    RESTARTS   AGE
 	cilium-kg8lv                  1/1       Running   0          13m
 	[...]
-	$ kubectl -n kube-system exec cilium-kg8lv cilium-bugtool
+	$ kubectl -n kube-system exec cilium-kg8lv -- cilium-bugtool
 	$ kubectl cp kube-system/cilium-kg8lv:/tmp/cilium-bugtool-243785589.tar /tmp/cilium-bugtool-243785589.tar
 ```
 

--- a/Documentation/gettingstarted/cassandra.rst
+++ b/Documentation/gettingstarted/cassandra.rst
@@ -287,7 +287,7 @@ whether requests are forwarded or denied.   First, use "kubectl exec" to access 
 ::
 
   $ CILIUM_POD=$(kubectl get pods -n kube-system -l k8s-app=cilium -o jsonpath='{.items[0].metadata.name}')
-  $ kubectl exec -it -n kube-system $CILIUM_POD /bin/bash
+  $ kubectl exec -it -n kube-system $CILIUM_POD -- /bin/bash
   root@minikube:~#
 
 Next, start Cilium monitor, and limit the output to only "l7" type messages using the "-t" flag:

--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -293,7 +293,7 @@ this command inside any Cilium pod in any cluster:
 
 .. code:: bash
 
-    $ kubectl -n kube-system exec -ti cilium-g6btl cilium node list
+    $ kubectl -n kube-system exec -ti cilium-g6btl -- cilium node list
     Name                                                   IPv4 Address    Endpoint CIDR   IPv6 Address   Endpoint CIDR
     cluster5/ip-172-0-117-60.us-west-2.compute.internal    172.0.117.60    10.2.2.0/24     <nil>          f00d::a02:200:0:0/112
     cluster5/ip-172-0-186-231.us-west-2.compute.internal   172.0.186.231   10.2.3.0/24     <nil>          f00d::a02:300:0:0/112
@@ -306,7 +306,7 @@ this command inside any Cilium pod in any cluster:
 
 .. code:: bash
 
-    $ kubectl exec -ti pod-cluster5-xxx curl <pod-ip-cluster7>
+    $ kubectl exec -ti pod-cluster5-xxx -- curl <pod-ip-cluster7>
     [...]
 
 Load-balancing with Global Services
@@ -429,7 +429,7 @@ Control Plane Connectivity
       consisting of the IP to reach the remote etcd as well as the required
       certificates to connect to that etcd.
 
-    * Run a ``kubectl exec -ti [...] bash`` in one of the Cilium pods and check
+    * Run a ``kubectl exec -ti [...] -- bash`` in one of the Cilium pods and check
       the contents of the directory ``/var/lib/cilium/clustermesh/``. It must
       contain a configuration file for each remote cluster along with all the
       required SSL certificates and keys. The filenames must match the cluster

--- a/Documentation/gettingstarted/memcached.rst
+++ b/Documentation/gettingstarted/memcached.rst
@@ -99,7 +99,7 @@ In the terminal window dedicated for the A-wing pod, exec in, use python to impo
 
 .. parsed-literal::
 
-    $ kubectl exec -ti $AWING_POD sh
+    $ kubectl exec -ti $AWING_POD -- sh
     # python
     Python 3.7.0 (default, Sep  5 2018, 03:25:31)
     [GCC 6.3.0 20170516] on linux
@@ -111,7 +111,7 @@ In the terminal window dedicated for the Alliance-Tracker, exec in, use python t
 
 .. parsed-literal::
 
-    $ kubectl exec -ti $TRACKER_POD sh
+    $ kubectl exec -ti $TRACKER_POD -- sh
     # python
     Python 3.7.0 (default, Sep  5 2018, 03:25:31)
     [GCC 6.3.0 20170516] on linux

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -103,7 +103,7 @@ In the above example, for one of the ``deathstar`` pods the endpoint id is 568. 
 
     # Get a shell on the Cilium pod
 
-    $ kubectl exec -ti cilium-88k78 -n kube-system /bin/bash
+    $ kubectl exec -ti cilium-88k78 -n kube-system -- /bin/bash
 
     # print out the ingress labels
     # clean up the data

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -743,7 +743,7 @@ bit different
       kubernetes-dashboard-6xvc7    1/1       Running   0          1h
 
     # Run the bugtool from this pod
-    $ kubectl -n kube-system exec cilium-kg8lv cilium-bugtool
+    $ kubectl -n kube-system exec cilium-kg8lv -- cilium-bugtool
       [...]
 
     # Copy the archive from the pod

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -46,7 +46,7 @@ var BugtoolRootCmd = &cobra.Command{
 	NAME                          READY     STATUS    RESTARTS   AGE
 	cilium-kg8lv                  1/1       Running   0          13m
 	[...]
-	$ kubectl -n kube-system exec cilium-kg8lv cilium-bugtool
+	$ kubectl -n kube-system exec cilium-kg8lv -- cilium-bugtool
 	$ kubectl cp kube-system/cilium-kg8lv:/tmp/cilium-bugtool-243785589.tar /tmp/cilium-bugtool-243785589.tar`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runTool()

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -218,7 +218,7 @@ function k8s_num_ready {
   local NAMESPACE=$1
   local CILIUM_POD=$2
   local FILTER=$3
-  kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep $FILTER | grep -v -e 'not-ready' -e 'reserved' | grep -c 'ready' || true
+  kubectl -n ${NAMESPACE} exec ${CILIUM_POD} -- cilium endpoint list | grep $FILTER | grep -v -e 'not-ready' -e 'reserved' | grep -c 'ready' || true
   restore_flag $save "e"
 }
 
@@ -249,7 +249,7 @@ function wait_for_k8s_endpoints {
       exit 1
     else
       overwrite $iter '
-        kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list
+        kubectl -n ${NAMESPACE} exec -- ${CILIUM_POD} cilium endpoint list
         echo -n " [${found}/${NUM}]"
       '
       sleep $sleep_time
@@ -259,7 +259,7 @@ function wait_for_k8s_endpoints {
     ((iter++))
   done
 
-  overwrite $iter 'kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list'
+  overwrite $iter 'kubectl -n ${NAMESPACE} exec ${CILIUM_POD} -- cilium endpoint list'
   restore_flag $save "e"
 }
 
@@ -277,7 +277,7 @@ function wait_for_kubectl_cilium_status {
   namespace=$1
   pod=$2
   local NUM_DESIRED="1"
-  local CMD="kubectl -n ${namespace} exec ${pod} cilium status | grep "Cilium:" | grep -c 'OK' || true"
+  local CMD="kubectl -n ${namespace} exec ${pod} -- cilium status | grep "Cilium:" | grep -c 'OK' || true"
   local INFO_CMD="true"
   local MAX_MINS="2"
   local ERROR_OUTPUT="Timeout while waiting for Cilium to be ready"


### PR DESCRIPTION
Signed-off-by: JieJhih Jhang <jiejhihjhang@gmail.com>

<!-- Description of change -->
As of kubectl v1.8.x, when running commands like this from the documentation:
https://docs.cilium.io/en/v1.7/gettingstarted/clustermesh/#test-pod-connectivity-between-clusters
```
$ kubectl -n kube-system exec -ti cilium-g6btl cilium node list
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.
...
```
This PR is modify where are not using this ``--`` form.
Fixes: #11379 

```release-note
Update documentation for kubectl usage
```
