### PR TITLE
chore(misspell): To enable misspell linter for go codes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,16 @@ run:
   #  - ".*\\.my\\.go$"
   #  - lib/bad.go
 
+# all available settings of specific linters
+linters-settings:
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # locale: US
+    ignore-words:
+      - rela # This is for elf.SHT_RELA
+
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
@@ -61,6 +71,7 @@ linters:
     - gofmt
     - govet
     - ineffassign
+    - misspell
     - staticcheck
 
 # To enable later if makes sense

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -259,7 +259,7 @@ func runCleanup() {
 	cleanAll = viper.GetBool(allFlagName) || viper.GetBool(cleanCiliumEnvVar)
 	cleanBPF = viper.GetBool(bpfFlagName) || viper.GetBool(cleanBpfEnvVar)
 
-	// if no flags are specifed then clean all
+	// if no flags are specified then clean all
 	if (cleanAll || cleanBPF) == false {
 		cleanAll = true
 	}

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -64,7 +64,7 @@ func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
 	assertOnMetric(c, string(models.EndpointStateWaitingForIdentity), 0)
 	assertOnMetric(c, string(models.EndpointStateInvalid), 0)
 
-	// Endpoint is created with inital label as well as disallowed
+	// Endpoint is created with initial label as well as disallowed
 	// reserved:world label.
 	epTemplate.Labels = append(epTemplate.Labels, "reserved:init")
 	_, code, err = ds.d.createEndpoint(context.TODO(), ds, epTemplate)
@@ -132,7 +132,7 @@ func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
 
 func (ds *DaemonSuite) TestUpdateLabelsFailed(c *C) {
 	cancelledContext, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
-	cancelFunc() // Cancel immediatly to trigger the codepath to test.
+	cancelFunc() // Cancel immediately to trigger the codepath to test.
 
 	// Create the endpoint without any labels.
 	epTemplate := getEPTemplate(c, ds.d)

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -57,7 +57,7 @@ const (
 // details about the kvstore implementation.
 //
 // A node takes a reference to an identity when it is in-use on that node, and
-// the identity remains in-use if there is any node refernce to it. When an
+// the identity remains in-use if there is any node reference to it. When an
 // identity no longer has any node references, it may be garbage collected. No
 // guarantees are made at that point and the numeric identity may be reused.
 // Note that the numeric IDs are selected locally and verified with the Backend.

--- a/pkg/azure/api/metadata.go
+++ b/pkg/azure/api/metadata.go
@@ -39,7 +39,7 @@ func GetResourceGroupName(ctx context.Context) (string, error) {
 	return getMetadataString(ctx, "instance/compute/resourceGroupName")
 }
 
-// getMetadataString returns the text represantation of a field from the Azure IMS (instance metadata service)
+// getMetadataString returns the text representation of a field from the Azure IMS (instance metadata service)
 // more can be found at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service#instance-api
 func getMetadataString(ctx context.Context, path string) (string, error) {
 	client := &http.Client{

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -176,7 +176,7 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 		// -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST" -j CILIUM_POST
 		if strings.Contains(rule, match) {
 			// do not remove feeder for chains that are set to be disabled
-			// ie catch the begining of the rule like -A POSTROUTING to match it against
+			// ie catch the beginning of the rule like -A POSTROUTING to match it against
 			// disabled chains
 			skipFeeder := false
 			for _, disabledChain := range option.Config.DisableIptablesFeederRules {

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -253,7 +253,7 @@ func (p *ProbeManager) SystemConfigProbes() error {
 }
 
 // GetRequiredConfig performs a check of mandatory kernel configuration options. It
-// returns a map indicating which required kernel paramaters are enabled - and which are not.
+// returns a map indicating which required kernel parameters are enabled - and which are not.
 // GetRequiredConfig is being used by CLI "cilium kernel-check".
 func (p *ProbeManager) GetRequiredConfig() map[KernelParam]bool {
 	config := p.features.SystemConfig
@@ -271,7 +271,7 @@ func (p *ProbeManager) GetRequiredConfig() map[KernelParam]bool {
 }
 
 // GetOptionalConfig performs a check of *optional* kernel configuration options. It
-// returns a map indicating which optional/non-mandatory kernel paramaters are enabled.
+// returns a map indicating which optional/non-mandatory kernel parameters are enabled.
 // GetOptionalConfig is being used by CLI "cilium kernel-check".
 func (p *ProbeManager) GetOptionalConfig() map[KernelParam]bool {
 	config := p.features.SystemConfig

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -47,7 +47,7 @@ type RoutingInfo struct {
 // parsed and validated. Note, this code assumes IPv4 values because IPv4
 // (on either ENI or Azure interface) is the only supported path currently.
 // Azure does not support masquerade yet (subnets CIDRs aren't provided):
-// untill it does, we forward a masquerade bool to opt out ipam.Cidrs use.
+// until it does, we forward a masquerade bool to opt out ipam.Cidrs use.
 func NewRoutingInfo(gateway string, cidrs []string, mac string, masquerade bool) (*RoutingInfo, error) {
 	return parse(gateway, cidrs, mac, masquerade)
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -162,7 +162,7 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	// We don't add the symlink for the host endpoint so that it is not
 	// restored when downgrading to <1.8. To avoid linking to a
 	// nonexistent file, only create the symlink if the header file
-	// creation/replacement file suceeded above.
+	// creation/replacement file succeeded above.
 	if !e.IsHost() && err == nil {
 		oldHeaderPath := filepath.Join(prefix, common.OldCHeaderFileName)
 		if _, err := os.Stat(oldHeaderPath); err != nil {
@@ -1370,7 +1370,7 @@ func (e *Endpoint) GetPolicyVerdictLogFilter() uint32 {
 type linkCheckerFunc func(string) error
 
 // ValidateConnectorPlumbing checks whether the endpoint is correctly plumbed
-// depending on if it is conected via veth or IPVLAN.
+// depending on if it is connected via veth or IPVLAN.
 func (e *Endpoint) ValidateConnectorPlumbing(linkChecker linkCheckerFunc) error {
 	if e.HasIpvlanDataPath() {
 		// FIXME: We cannot check whether ipvlan slave netdev exists,

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -288,7 +288,7 @@ func (e *Endpoint) restoreIdentity() error {
 		// block the restoring of the endpoint.
 		// If the endpoint is removed, this controller will cancel the allocator
 		// WaitForInitialGlobalIdentities function.
-		controllerName := fmt.Sprintf("waiting-initial-global-identitites-ep (%v)", e.ID)
+		controllerName := fmt.Sprintf("waiting-initial-global-identities-ep (%v)", e.ID)
 		var gotInitialGlobalIdentities = make(chan struct{})
 		e.UpdateController(controllerName,
 			controller.ControllerParams{

--- a/pkg/hubble/container/ring.go
+++ b/pkg/hubble/container/ring.go
@@ -182,7 +182,7 @@ func (r *Ring) read(read uint64) (*v1.Event, error) {
 	// and the ring has mask = 0x3 (7). This means there will be a total of 8
 	// slots to be written in the ring buffer and a total of 32 cycles.
 	// As writing is performed in parallel, the way we check if the read is
-	// valid is by checking if the read was performed withing a 'valid cycle'.
+	// valid is by checking if the read was performed within a 'valid cycle'.
 	// For example, if the last write was at index 3 cycle 0, it means we can
 	// read since index 2 cycle 0 all the way back to index 4 cycle 31 (0x1f).
 	// We can't read index 3 cycle 0 because we might not have written into it

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -476,7 +476,7 @@ func TestRing_LastWrite(t *testing.T) {
 func TestRingFunctionalityInParallel(t *testing.T) {
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
-		t.Errorf("r.data should have a lenght of 0x10. Got %x", len(r.data))
+		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}
 	if r.mask != 0xf {
 		t.Errorf("r.mask should be 0xf. Got %x", r.mask)
@@ -521,7 +521,7 @@ func TestRingFunctionalityInParallel(t *testing.T) {
 func TestRingFunctionalitySerialized(t *testing.T) {
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
-		t.Errorf("r.data should have a lenght of 0x10. Got %x", len(r.data))
+		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}
 	if r.mask != 0xf {
 		t.Errorf("r.mask should be 0xf. Got %x", r.mask)
@@ -565,10 +565,10 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
-		t.Errorf("r.data should have a lenght of 0x10. Got %x", len(r.data))
+		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}
 	if r.dataLen != 0x10 {
-		t.Errorf("r.dataLen should have a lenght of 0x10. Got %x", r.dataLen)
+		t.Errorf("r.dataLen should have a length of 0x10. Got %x", r.dataLen)
 	}
 	if r.mask != 0xf {
 		t.Errorf("r.mask should be 0xf. Got %x", r.mask)

--- a/pkg/hubble/filters/protocol.go
+++ b/pkg/hubble/filters/protocol.go
@@ -33,7 +33,7 @@ func filterByProtocol(protocols []string) (FilterFunc, error) {
 		case "dns", "http", "kafka":
 			l7Protocols = append(l7Protocols, proto)
 		default:
-			return nil, fmt.Errorf("unkown protocol: %q", p)
+			return nil, fmt.Errorf("unknown protocol: %q", p)
 		}
 	}
 

--- a/pkg/hubble/metrics/tcp/handler.go
+++ b/pkg/hubble/metrics/tcp/handler.go
@@ -40,7 +40,7 @@ func (h *tcpHandler) Init(registry *prometheus.Registry, options api.Options) er
 	h.tcpFlags = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: api.DefaultPrometheusNamespace,
 		Name:      "tcp_flags_total",
-		Help:      "TCP flag occurences",
+		Help:      "TCP flag occurrences",
 	}, labels)
 
 	registry.MustRegister(h.tcpFlags)

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -346,7 +346,7 @@ func decodeFlow(payloadParser *parser.Parser, pl *flowpb.Payload) (*flowpb.Flow,
 }
 
 // flowsReader reads flows using a RingReader. It applies the flow request
-// criterias (blacklist, whitelist, follow, ...) before returning flows.
+// criteria (blacklist, whitelist, follow, ...) before returning flows.
 type flowsReader struct {
 	ringReader           *container.RingReader
 	whitelist, blacklist filters.FilterFuncs
@@ -357,7 +357,7 @@ type flowsReader struct {
 }
 
 // newFlowsReader creates a new flowsReader that uses the given RingReader to
-// read through the ring buffer. Only flows that match the request criterias
+// read through the ring buffer. Only flows that match the request criteria
 // are returned.
 func newFlowsReader(r *container.RingReader, req *observerpb.GetFlowsRequest, log logrus.FieldLogger, whitelist, blacklist filters.FilterFuncs) (*flowsReader, error) {
 	log.WithFields(logrus.Fields{
@@ -388,7 +388,7 @@ func newFlowsReader(r *container.RingReader, req *observerpb.GetFlowsRequest, lo
 	return reader, nil
 }
 
-// Next returns the next flow that matches the request criterias.
+// Next returns the next flow that matches the request criteria.
 func (r *flowsReader) Next(ctx context.Context) (*flowpb.Flow, error) {
 	for {
 		select {

--- a/pkg/hubble/peer/serviceoption/option.go
+++ b/pkg/hubble/peer/serviceoption/option.go
@@ -25,7 +25,7 @@ type Option func(o *Options)
 // WithMaxSendBufferSize sets the maximum size of the send buffer. When the
 // send buffer is full, for example due to errors in the transport, the server
 // disconnects the corresponding client.
-// The maximum buffer size should be large enough to accomodate the burst of
+// The maximum buffer size should be large enough to accommodate the burst of
 // peer change notifications than happens on an initial call where all nodes in
 // the cluster are notified as being added.
 func WithMaxSendBufferSize(size int) Option {

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -83,7 +83,7 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	c.Assert(err, Not(IsNil))
 	// Let expiration timer expire
 	time.Sleep(2 * timeout)
-	// Must suceed, IP must be released again
+	// Must succeed, IP must be released again
 	err = ipam.AllocateIP(ip, "foo")
 	c.Assert(err, IsNil)
 	// register new expiration timer

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -217,7 +217,7 @@ func deriveVpcCIDR(node *ciliumv2.CiliumNode) (result *cidr.CIDR) {
 
 // hasMinimumIPsInPool returns true if the required number of IPs is available
 // in the allocation pool. It also returns the number of IPs required and
-// avalable.
+// available.
 func (n *nodeStore) hasMinimumIPsInPool() (minimumReached bool, required, numAvailable int) {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
@@ -636,7 +636,7 @@ func (a *crdAllocator) totalPoolSize() int {
 	return 0
 }
 
-// Dump provides a status report and lists all allocated IP addressess
+// Dump provides a status report and lists all allocated IP addresses
 func (a *crdAllocator) Dump() (map[string]string, string) {
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -48,25 +48,25 @@ spec:
     toPorts:
     - ports:
       - port "8050"
-      - protocl TCP
+      - protocol TCP
       - port "8051"
-      - protocl TCP
+      - protocol TCP
       - port "8052"
-      - protocl TCP
+      - protocol TCP
       - port "8053"
-      - protocl TCP
+      - protocol TCP
       - port "8054"
-      - protocl TCP
+      - protocol TCP
       - port "8055"
-      - protocl TCP
+      - protocol TCP
       - port "8056"
-      - protocl TCP
+      - protocol TCP
       - port "8057"
-      - protocl TCP
+      - protocol TCP
       - port "8058"
-      - protocl TCP
+      - protocol TCP
       - port "8059"
-      - protocl TCP
+      - protocol TCP
   endpointSelector:
     matchExpressions:
     - key: app

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -44,7 +44,7 @@ var (
 	ipv4AllocRange      *cidr.CIDR
 	ipv6AllocRange      *cidr.CIDR
 
-	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is prefered)
+	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is preferred)
 	k8sNodeIP net.IP
 
 	ipsecKeyIdentity uint8

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -224,7 +224,7 @@ func (n *Node) getNodeIP(ipv6 bool) (net.IP, addressing.AddressType) {
 }
 
 // GetK8sNodeIPs returns k8s Node IP (either InternalIP or ExternalIP or nil;
-// the former is prefered).
+// the former is preferred).
 func (n *Node) GetK8sNodeIP() net.IP {
 	var externalIP net.IP
 

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -688,7 +688,7 @@ func Test_populateNodePortRange(t *testing.T) {
 				fs := flag.NewFlagSet(NodePortRange, flag.ContinueOnError)
 				fs.StringSlice(
 					NodePortRange,
-					[]string{}, // Explicity has no defaults.
+					[]string{}, // Explicitly has no defaults.
 					"")
 
 				BindEnv(NodePortRange)

--- a/pkg/policy/api/groups.go
+++ b/pkg/policy/api/groups.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	providers = sync.Map{} // map with the list of providers to callback to retrive info from.
+	providers = sync.Map{} // map with the list of providers to callback to retrieve info from.
 )
 
 // GroupProviderFunc is a func that need to be register to be able to

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -33,7 +33,7 @@ type PortProtocol struct {
 	// parsed as a single uint16. In the future, this field may support
 	// ranges in the form "1024-2048
 	// Port can also be a port name, which must contain at least one [a-z],
-	// and may also contain [0-9] and '-' anywhere exept adjacent to another
+	// and may also contain [0-9] and '-' anywhere except adjacent to another
 	// '-' or in the beginning or the end.
 	Port string `json:"port"`
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -199,7 +199,7 @@ type MapChanges struct {
 // applicable.
 //
 // The caller is responsible for making sure the same identity is not
-// present in both 'adds' and 'deletes'.  Accross multiple calls we
+// present in both 'adds' and 'deletes'.  Across multiple calls we
 // maintain the adds and deletes within the MapChanges are disjoint in
 // cases where an identity is first added and then deleted, or first
 // deleted and then added.

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -27,7 +27,7 @@ const (
 	Local Source = "local"
 
 	// KVStore is the source used for state derived from a key value store.
-	// State in the key value stored takes precendence over orchestration
+	// State in the key value stored takes precedence over orchestration
 	// system state such as Kubernetes.
 	KVStore Source = "kvstore"
 

--- a/test/ginkgo-ext/junit_reporter.go
+++ b/test/ginkgo-ext/junit_reporter.go
@@ -169,7 +169,7 @@ func (reporter *JUnitReporter) failureTypeForState(state types.SpecState) string
 	}
 }
 
-// reportChecks filters the given string from the stodout and substract the
+// reportChecks filters the given string from the stdout and subtract the
 // information that is within the <Checks></Checks> labels. It'll return the
 // given output as first result, and the check output in the second string.
 func reportChecks(output string) (string, string) {

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -368,7 +368,7 @@ func (s *SSHMeta) BasePath() string {
 }
 
 // MonitorStart starts the  monitor command in background and returns a callback
-// function wich stops the monitor when the user needs. When the callback is
+// function which stops the monitor when the user needs. When the callback is
 // called the command will stop and monitor's output is saved on
 // `monitorLogFileName` file.
 func (s *SSHMeta) MonitorStart() func() error {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1693,7 +1693,7 @@ func (kub *Kubectl) validateServicePlumbingInCiliumPod(fullName, ciliumPod strin
 	return nil
 }
 
-// ValidateServicePlumbing ensures that a service in a namespace sucessfully
+// ValidateServicePlumbing ensures that a service in a namespace successfully
 // plumbed by all Cilium pods in the cluster:
 // - The service and endpoints are found in `cilium service list`
 // - The service and endpoints are found in `cilium bpf lb list`

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -477,7 +477,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 
 		By("Ensure connectivity to other domains is still block")
 		res = vm.ContainerExec(helpers.App1, helpers.CurlFail("http://world2.outside.test"))
-		res.ExpectFail("Connectivity to outside domain successfull when it should be block")
+		res.ExpectFail("Connectivity to outside domain successfully when it should be block")
 
 	})
 
@@ -1088,11 +1088,11 @@ INITSYSTEM=SYSTEMD`
 		By("Starting Cilium again")
 		Expect(vm.RestartCilium()).To(BeNil(), "Cilium cannot be started correctly")
 
-		// Policies on docker are not persistant, so the restart connectivity is not tested at all
+		// Policies on docker are not persistent, so the restart connectivity is not tested at all
 	})
 })
 
-// getMapValues retuns an array of interfaces with the map values.
+// getMapValues returns an array of interfaces with the map values.
 // returned array will be sorted by map keys, the reason is that Golang does
 // not support ordered maps and for DNS-config the values need to be always
 // sorted.


### PR DESCRIPTION
Inspired by recent PRs:
- https://github.com/cilium/cilium/pull/12394
- https://github.com/cilium/cilium/pull/12488

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
chore(misspell): To enable misspell linter for go codes
```
