### PR TITLE
daemon: Fatal on incompatible host firewall options

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1137,6 +1137,9 @@ func initEnv(cmd *cobra.Command) {
 		if !option.Config.EnableRemoteNodeIdentity {
 			log.Fatalf("%s must be enabled to use the host firewall.", option.EnableRemoteNodeIdentity)
 		}
+		if option.Config.EnableEndpointRoutes {
+			log.Fatalf("%s cannot be used with the host firewall. Packets must be routed through the host device.", option.EnableEndpointRoutes)
+		}
 	}
 
 	// If there is one device specified, use it to derive better default

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1130,8 +1130,13 @@ func initEnv(cmd *cobra.Command) {
 	initClockSourceOption()
 	initSockmapOption()
 
-	if option.Config.EnableHostFirewall && option.Config.EnableIPSec {
-		log.Fatal("IPSec cannot be used with the host firewall.")
+	if option.Config.EnableHostFirewall {
+		if option.Config.EnableIPSec {
+			log.Fatal("IPSec cannot be used with the host firewall.")
+		}
+		if !option.Config.EnableRemoteNodeIdentity {
+			log.Fatalf("%s must be enabled to use the host firewall.", option.EnableRemoteNodeIdentity)
+		}
 	}
 
 	// If there is one device specified, use it to derive better default

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -332,6 +332,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"global.autoDirectNodeRoutes":   "true",
 				"global.endpointRoutes.enabled": "true",
 				"global.ipv6.enabled":           "false",
+				"global.hostFirewall":           "false",
 			}
 			// Needed to bypass bug with masquerading when devices are set. See #12141.
 			if helpers.RunsWithKubeProxy() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1186,9 +1186,12 @@ var _ = Describe("K8sPolicyTest", func() {
 					By("Reconfiguring Cilium to disable remote-node identity")
 					newCfg := map[string]string{
 						"global.remoteNodeIdentity": "false",
+						"global.hostFirewall":       "false",
 					}
 					for k, v := range daemonCfg {
-						newCfg[k] = v
+						if _, ok := newCfg[k]; !ok {
+							newCfg[k] = v
+						}
 					}
 					RedeployCilium(kubectl, ciliumFilename, newCfg)
 				})


### PR DESCRIPTION
See commits for details.

In particular, the message of the second commit, which disallows per-endpoint routes with the host firewall, discusses an alternative:
> Per-endpoint routes is a recommended setting in some cases (e.g., GKE).
In such cases, it would be possible to have a partial host firewall
enforcement, with all traffic to and from pods whitelisted. The host
firewall would then only enforce policies on packets to and from world on
the native devices (likely the first use case for the host firewall).
>
> This commit does not implement this second approach and prefers to forbid
per-endpoint routes with the host firewall because a partial enforcement
would likely be confusing to users.

Updates: #11799
```release-note
Fatal if the host firewall is used without remote node identities
Fatal if the host firewall is used with per-endpoint routes
```