### PR TITLE
v1.6: operator: Fix usage of IdentityAllocationMode

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -343,7 +343,7 @@ func runOperator(cmd *cobra.Command) {
 		startKvstoreWatchdog()
 	}
 
-	switch option.Config.IdentityAllocationMode {
+	switch identityAllocationMode {
 	case option.IdentityAllocationModeCRD:
 		if !k8s.IsEnabled() {
 			log.Fatal("CRD Identity allocation mode requires k8s to be configured.")


### PR DESCRIPTION
The backport of \[1\] missed the fact that cilium-operator does not use `pkg/option.Config.IdentityAllocationMode`, but instead uses a local variable which is initialized from the `--identity-allocation-mode` flag. This prevented from CRD GC being started.

\[1\]: https://github.com/cilium/cilium/commit/1f907666e82253fb2698cd346068ba10930f1dbd

Fixes: 1f907666e ("daemon/operator: Fatal on startup when Identity CRD is enabled without k8s")
Fix #12465

```release-note
Fix regression to identity garbage collection due to identity allocation flag in cilium operator
```