### PR TITLE
[v1.6] k8s: Fix CRD schema version to 1.15.1

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -43,7 +43,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.16"
+	CustomResourceDefinitionSchemaVersion = "1.15.1"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"


### PR DESCRIPTION
As per the discussions from https://github.com/cilium/cilium/pull/12493,
we should not increment the v1.6 schema version to 1.16 as this would
conflict with early v1.7 cycle versions. Fix it to 1.15.1 instead.

The 1.16 version was never part of a released v1.6.x version of Cilium.

Fixes: bd5bc5b0aa2b ("Fix small CRD issue with toGroups")