### PR TITLE
IPAM EC2 metric renames

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -328,6 +328,8 @@ Renamed Metrics
 The following metrics have been renamed:
 
 * ``cilium_operator_ipam_ec2_resync`` to ``cilium_operator_ipam_resync``
+* ``ipam_cilium_operator_api_duration_seconds`` to ``cilium_operator_ec2_api_duration_seconds``
+* ``ipam_cilium_operator_api_rate_limit_duration_seconds`` to ``cilium_operator_ec2_api_rate_limit_duration_seconds``
 
 .. _1.8_upgrade_notes:
 

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -349,7 +349,7 @@ func (c *Client) CreateNetworkInterface(ctx context.Context, toAllocate int64, s
 	sinceStart := spanstat.Start()
 	create := c.ec2Client.CreateNetworkInterfaceRequest(createReq)
 	resp, err := create.Send(ctx)
-	c.metricsAPI.ObserveAPICall("CreateNetworkInterfaceRequest", deriveStatus(create.Request, err), sinceStart.Seconds())
+	c.metricsAPI.ObserveAPICall("CreateNetworkInterface", deriveStatus(create.Request, err), sinceStart.Seconds())
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -84,7 +84,7 @@ func (*AllocatorAWS) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (allocato
 	cfg.Region = instance.Region
 
 	if operatorOption.Config.EnableMetrics {
-		aMetrics = apiMetrics.NewPrometheusMetrics("ipam", operatorMetrics.Namespace, operatorMetrics.Registry)
+		aMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "ec2", operatorMetrics.Registry)
 		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
 	} else {
 		aMetrics = &apiMetrics.NoOpMetrics{}


### PR DESCRIPTION
Two commits:
- 1st one a metric param rename for `CreateNetworkInterfaceRequest` -> `CreateNetworkInterface` to be in line with the rest of the parameters
- 2nd commit is the main change which swaps makes the IPAM API EC2 metric names specific (added the renames to the upgrade guide).

```release-note
Rename IPAM API metrics to be `ec2` specific.
```
