### PR TITLE
.travis:fix up PodCIDRSuite failure on Arm64

### DIFF
--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -2067,7 +2067,9 @@ func (s *PodCIDRSuite) TestNewNodesPodCIDRManager(c *C) {
 	case <-time.Tick(5 * time.Second):
 		c.Error("The controller should have tried to delete the node by now")
 	}
+	nm.Mutex.Lock()
 	c.Assert(nm.ciliumNodesToK8s, checker.DeepEquals, map[string]*ciliumNodeK8sOp{})
+	nm.Mutex.Unlock()
 	// Wait for the controller to try more times, the number of deletedCalls
 	// should not be different because we have successfully deleted the node.
 	time.Sleep(2 * time.Second)


### PR DESCRIPTION
Add mutex to protect the situation that invoke
c.Assert before ciliumNodesToK8s be deleted.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Fixes: #12306 

