### PR TITLE
Enable doc building for arm64 in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,11 +503,7 @@ install-manpages:
 	mandb
 
 postcheck: build
-ifeq ("$(GOARCH)","amd64")
 	$(QUIET)$(MAKE) $(SUBMAKEOPTS) -C Documentation update-cmdref check
-else
-	@echo "Skip Documentation building on $(GOARCH)"
-endif
 
 minikube:
 	$(QUIET) contrib/scripts/minikube.sh


### PR DESCRIPTION
The doc building was originally disabled for arm64 since
it does not work on arm64. Now the building is ok for arm64
because the PR: https://github.com/cilium/cilium/pull/12231
was merged.

It would also enable the doc building for arm64 in the Travis CI.

Signed-off-by: trevor tao <trevor.tao@arm.com>

