### PR TITLE
Enable modification of config. for endpoints with reserved labels

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -678,7 +678,7 @@ func (d *Daemon) EndpointUpdate(id string, cfg *models.EndpointConfigurationSpec
 		return api.Error(PatchEndpointIDInvalidCode, err)
 	} else if ep == nil {
 		return api.New(PatchEndpointIDConfigNotFoundCode, "endpoint %s not found", id)
-	} else if err = endpoint.APICanModify(ep); err != nil {
+	} else if err := ep.APICanModifyConfig(cfg.Options); err != nil {
 		return api.Error(PatchEndpointIDInvalidCode, err)
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1582,6 +1582,29 @@ func APICanModify(e *Endpoint) error {
 	return nil
 }
 
+// APICanModifyConfig determines whether API requests from users are allowed to
+// modify the configuration of the endpoint.
+func (e *Endpoint) APICanModifyConfig(n models.ConfigurationMap) error {
+	if !e.OpLabels.OrchestrationIdentity.IsReserved() {
+		return nil
+	}
+	for config, val := range n {
+		if optionSetting, err := option.NormalizeBool(val); err == nil {
+			if e.Options.Opts[config] == optionSetting {
+				// The option won't be changed.
+				continue
+			}
+			if config != option.Debug && config != option.DebugLB &&
+				config != option.TraceNotify && config != option.PolicyVerdictNotify &&
+				config != option.PolicyAuditMode && config != option.MonitorAggregation &&
+				config != option.PolicyTracing {
+				return fmt.Errorf("%s cannot be modified for endpoints with reserved labels", config)
+			}
+		}
+	}
+	return nil
+}
+
 // MetadataResolverCB provides an implementation for resolving the endpoint
 // metadata for an endpoint such as the associated labels and annotations.
 type MetadataResolverCB func(ns, podName string) (pod *slim_corev1.Pod, _ []slim_corev1.ContainerPort, identityLabels labels.Labels, infoLabels labels.Labels, annotations map[string]string, err error)

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -321,12 +321,7 @@ func (s *SSHMeta) GetEndpointsIds() (map[string]string, error) {
 	if !endpoints.WasSuccessful() {
 		return nil, fmt.Errorf("%q failed: %s", cmd, endpoints.CombineOutput())
 	}
-
-	// Special case the host endpoint: GH-12037
-	result := endpoints.KVOutput()
-	delete(result, "")
-
-	return result, nil
+	return endpoints.KVOutput(), nil
 }
 
 // GetEndpointsIdentityIds returns a mapping of a Docker container name to it's


### PR DESCRIPTION
Master currently disallows users from modifying the configuration of endpoints with reserved labels, except for the `reserved:init` label. This restriction prevents e.g., the use of the debug mode for the host endpoint.

This commit removes that restriction for some of the configuration options:

Config                    | Default  | Can modify
--------------------------|----------|------------
Conntrack                 | Enabled  |
ConntrackAccounting       | Enabled  |
ConntrackLocal            | Disabled |
Debug                     | Disabled |     x
DebugLB                   | Disabled |     x
DropNotification          | Enabled  |     x
MonitorAggregationLevel   | None     |     x
NAT46                     | Disabled |
PolicyAuditMode           | Disabled |     x
PolicyVerdictNotification | Enabled  |     x
TraceNotification         | Enabled  |     x

To summarize, for endpoints with reserved labels, only audit mode and configuration options that decide what logs are sent to `cilium monitor` can be changed for endpoints with reserved labels.

Fixes: #12037