### PR TITLE
.travis:fix up TestShuffle failure on Arm64

### DIFF
--- a/pkg/rand/safe_rand_test.go
+++ b/pkg/rand/safe_rand_test.go
@@ -44,7 +44,7 @@ func TestShuffle(t *testing.T) {
 	copy(s2, s1)
 
 	var same int
-	for retry := 0; retry < 1; retry++ {
+	for retry := 0; retry < 10; retry++ {
 		same = 0
 
 		r0.Shuffle(len(s2), func(i, j int) {


### PR DESCRIPTION
After shuffling, there is a small probability event that
the order of elements has not changed;
The results of multiple tests should prevail.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Fixes: #12512 

