### PR TITLE
health: Differentiate between unknown and unreachable state

### DIFF
--- a/pkg/metrics/status.go
+++ b/pkg/metrics/status.go
@@ -139,11 +139,15 @@ func (s *statusCollector) Collect(ch chan<- prometheus.Metric) {
 	)
 
 	for _, nodeStatus := range healthStatusResponse.Payload.Nodes {
-		if !healthClientPkg.PathIsHealthy(healthClientPkg.GetHostPrimaryAddress(nodeStatus)) {
+		switch healthClientPkg.GetPathConnectivityStatusType(healthClientPkg.GetHostPrimaryAddress(nodeStatus)) {
+		case healthClientPkg.ConnStatusUnreachable:
 			unreachableNodes++
 		}
-		if nodeStatus.Endpoint != nil && !healthClientPkg.PathIsHealthy(nodeStatus.Endpoint) {
-			unreachableEndpoints++
+		if nodeStatus.Endpoint != nil {
+			switch healthClientPkg.GetPathConnectivityStatusType(nodeStatus.Endpoint) {
+			case healthClientPkg.ConnStatusUnreachable:
+				unreachableEndpoints++
+			}
 		}
 	}
 


### PR DESCRIPTION
Before this change, adding a new node with Cilium to the Kubernetes
cluster resulted in the new node being reported as unreachable in
cilium-health. That's because before Cilium gets fully provisions, the
node status is going to contain empty status (for HTTP probe).

That behavior was increasing the unreachable nodes Prometheus metric,
thus false alarming Cilium users and suggesting, that the provisioning
of the new node failed.

This change differentiates between unreachable and unhealthy status. In
order to be considered as unreachable, the status has to contain an
explicit error message, which is always set by the prober when it really
has problems with reaching already provisioned Cilium endpoint.
Otherwise its status is considered to be uknkown, which usually should
mean that the node is being provisioned.

Fixes #11874

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

```release-note
health: Differentiate between unknown and unreachable state in Cilium status
```

Outputs **Before the fix** when the 2nd node is provisioning:

```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ cilium metrics list | grep nodes
cilium_nodes_all_datapath_validations_total                                         37.000000
cilium_nodes_all_events_received_total        eventType="add" source="kvstore"      1.000000
cilium_nodes_all_events_received_total        eventType="add" source="local"        1.000000
cilium_nodes_all_events_received_total        source="kvstore" eventType="update"   4.000000
cilium_nodes_all_num                                                                2.000000
cilium_unreachable_nodes                                                            1.000000
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ cilium-health status --succinct
Cluster health:      1/2 reachable   (2020-07-16T11:12:45Z)
  Name               IP              Reachable   Endpoints reachable
  k8s1 (localhost)   192.168.33.11   true        true
  k8s2               192.168.33.12   false       false
```

Outputs **after the fix** when the 2nd node is provisioning:

```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ cilium metrics list | grep nodes
cilium_nodes_all_datapath_validations_total                                         43.000000
cilium_nodes_all_events_received_total        eventType="add" source="kvstore"      1.000000
cilium_nodes_all_events_received_total        eventType="add" source="local"        1.000000
cilium_nodes_all_events_received_total        source="kvstore" eventType="update"   4.000000
cilium_nodes_all_num                                                                2.000000
cilium_unreachable_nodes                                                            0.000000
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ cilium-health status --succinct
Cluster health:      2/2 reachable   (2020-07-16T11:48:37Z)
  Name               IP              Node        Endpoints
  k8s1 (localhost)   192.168.33.11   reachable   reachable
  k8s2               192.168.33.12   unknown     unknown
```