### PR TITLE
envoy: Require Node only on the first request of a stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:052d54ab9c88db3d3e1a9320783ca94e4e34de0b@sha256:e38e48cf7ec78b02f7ae6b4f5568fb3f8bcae33500742c91a391feede8fe4292 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:ccad480c59aa8b946d98aaf79f8e9e38d6731fdc@sha256:215442a52fcd1022a97d7eae658c503ec693194a6f09f3488b8a360e509d5945 as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -684,8 +684,9 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 				ResourceApiVersion: envoy_config_core.ApiVersion_V3,
 				ConfigSourceSpecifier: &envoy_config_core.ConfigSource_ApiConfigSource{
 					ApiConfigSource: &envoy_config_core.ApiConfigSource{
-						ApiType:             envoy_config_core.ApiConfigSource_GRPC,
-						TransportApiVersion: envoy_config_core.ApiVersion_V3,
+						ApiType:                   envoy_config_core.ApiConfigSource_GRPC,
+						TransportApiVersion:       envoy_config_core.ApiVersion_V3,
+						SetNodeOnFirstMessageOnly: true,
 						GrpcServices: []*envoy_config_core.GrpcService{
 							{
 								TargetSpecifier: &envoy_config_core.GrpcService_EnvoyGrpc_{


### PR DESCRIPTION
xDS request's Node field has grown huge and Envoy optionally only
sends it in the first request. Use this option an adapt xDS stream
processing accordingly.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
