### PR TITLE
clustermesh: Tidy up services connection on failure to reconnect

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -196,6 +196,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 
 				remoteIdentityCache, err := allocator.WatchRemoteIdentities(backend)
 				if err != nil {
+					remoteServices.Close(context.TODO())
 					remoteNodes.Close(context.TODO())
 					backend.Close()
 					return err


### PR DESCRIPTION
In the case where there is a failure to watch remote identities from the
peer cluster when reconnecting to a peer cluster, we would not close
out the connection to the services store properly. Fix it up.

The context usage in this code should also be investigated more closely
but we can fix that up in a subsequent commit.

Fixes: f28f6cd ("clustermesh: Use remote kvstore backend")