### PR TITLE
docs(troubleshooting):  Remove bugtool related step with --serve flag

### DIFF
--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -722,13 +722,6 @@ files and execute some commands. If ``kubectl`` is detected, it will search for
 Cilium pods. The default label being ``k8s-app=cilium``, but this and the
 namespace can be changed via ``k8s-namespace`` and ``k8s-label`` respectively.
 
-If you'd prefer to browse the dump, there is a HTTP flag.
-
-.. code:: bash
-
-    $ cilium-bugtool --serve
-
-
 If you want to capture the archive from a Kubernetes pod, then the process is a
 bit different
 


### PR DESCRIPTION
The flag --serve is removed in bugtool by PR #6237, hence related docs
should be removed as well.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
docs(troubleshooting): Remove bugtool related step with --serve flag
```
