### PR TITLE
Remove Azure based IPAM from self-managed k8s

### DIFF
--- a/Documentation/gettingstarted/k8s-install-self-managed.rst
+++ b/Documentation/gettingstarted/k8s-install-self-managed.rst
@@ -19,4 +19,3 @@ for details on when etcd is required.
    k8s-install-default
    k8s-install-etcd-operator
    k8s-install-external-etcd
-   k8s-install-azure


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

While reading the docs I realized that by mistake we added the AKS install guide to the self-manged k8s section.

```release-note
Update self-managed k8s docs to exclude Azure IPAM link (based on AKS).
```
