### PR TITLE
Remove stale remote cluster information on disconnect

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -341,7 +341,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 			if k8s.IsEnabled() {
 				// Also wait for all cluster mesh to be synchronized with the
 				// datapath before proceeding.
-				if option.Config.ClusterID != 0 {
+				if option.Config.ClusterMeshConfig != "" {
 					err := d.clustermesh.ClustersSynced(context.Background())
 					if err != nil {
 						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -853,5 +853,7 @@ func (rc *RemoteCache) Close() {
 	delete(rc.allocator.remoteCaches, rc)
 	rc.allocator.remoteCachesMutex.Unlock()
 
+	// stop receiving updates
 	rc.cache.stop()
+	rc.cache.deleteEntries()
 }

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -223,7 +223,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					return err
 				}
 
-				ipCacheWatcher := ipcache.NewIPIdentityWatcher(backend)
+				ipCacheWatcher := ipcache.NewIPIdentityWatcher(backend, rc.name)
 				go ipCacheWatcher.Watch(ctx)
 
 				rc.mutex.Lock()

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -215,6 +215,10 @@ const (
 	// a kvstore path for too long.
 	KVStoreStaleLockTimeout = 30 * time.Second
 
+	// KVStoreFailureTimeout is the timeout after which a failure is
+	// declared persistent and the etcd connection is restarted
+	KVStoreFailureTimeout = 3 * time.Minute
+
 	// IPAllocationTimeout is the timeout when allocating CIDRs
 	IPAllocationTimeout = 2 * time.Minute
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -398,6 +398,16 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 	return true, namedPortsChanged
 }
 
+func (ipc *IPCache) deleteClusterEntries(cluster string, src source.Source) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+	for ip, m := range ipc.ipToK8sMetadata {
+		if m.Cluster == cluster {
+			ipc.deleteLocked(ip, src)
+		}
+	}
+}
+
 // DumpToListenerLocked dumps the entire contents of the IPCache by triggering
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
 func (ipc *IPCache) DumpToListenerLocked(listener IPIdentityMappingListener) {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -63,6 +63,8 @@ type K8sMetadata struct {
 	PodName string
 	// NamedPorts is the set of named ports for the pod
 	NamedPorts policy.NamedPortsMap
+	// Cluster is the name of th cluster
+	Cluster string
 }
 
 // IPCache is a collection of mappings:
@@ -258,6 +260,7 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 				logfields.K8sPodName:   k8sMeta.PodName,
 				logfields.K8sNamespace: k8sMeta.Namespace,
 				logfields.NamedPorts:   k8sMeta.NamedPorts,
+				logfields.ClusterName:  k8sMeta.Cluster,
 			})
 		}
 	}
@@ -599,5 +602,5 @@ func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
 			return false
 		}
 	}
-	return m.Namespace == o.Namespace && m.PodName == o.PodName
+	return m.Namespace == o.Namespace && m.PodName == o.PodName && m.Cluster == o.Cluster
 }

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -359,6 +359,12 @@ func (iw *IPIdentityWatcher) Close() {
 	})
 }
 
+// DeleteEntries deletes all entries in the ipcache which were previously
+// created as a result of the watcher
+func (iw *IPIdentityWatcher) DeleteEntries() {
+	IPIdentityCache.deleteClusterEntries(iw.cluster, source.KVStore)
+}
+
 func (iw *IPIdentityWatcher) waitForInitialSync() {
 	<-iw.synced
 }

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -506,6 +506,7 @@ func (k *K8sWatcher) updatePodHostData(pod *slim_corev1.Pod) (bool, error) {
 	k8sMeta := &ipcache.K8sMetadata{
 		Namespace: pod.Namespace,
 		PodName:   pod.Name,
+		Cluster:   option.Config.LocalClusterName(),
 	}
 
 	// Store Named ports, if any.


### PR DESCRIPTION
Failure in connecting to a remote cluster has so far not resulted in removal of any state of that cluster. This can be desirable as the state may still be valid. It can also be undesirable if the cluster never reappears.

Switch to removal of state but only after a timeout has expired. The timeout can be configured with: `--kvstore-opt etcd.failureTimeout=5m` (default is 3m). Once an etcd connection has been in failure state for 