### PR TITLE
bpf/lb: Skip service handling for ICMP packets

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -96,7 +96,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 		ret = lb6_extract_key(ctx, tuple, l4_off, &key, &csum_off,
 				      CT_EGRESS);
 		if (IS_ERR(ret)) {
-			if (ret == DROP_UNKNOWN_L4)
+			if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 				goto skip_service_lookup;
 			else
 				return ret;
@@ -485,7 +485,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 		ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off,
 				      CT_EGRESS);
 		if (IS_ERR(ret)) {
-			if (ret == DROP_UNKNOWN_L4)
+			if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 				goto skip_service_lookup;
 			else
 				return ret;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -370,7 +370,8 @@ static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 
 	case IPPROTO_ICMPV6:
 	case IPPROTO_ICMP:
-		break;
+		/* No need to perform a service lookup for ICMP packets */
+		return DROP_NO_SERVICE;
 
 	default:
 		/* Pass unknown L4 to stack */
@@ -407,7 +408,7 @@ static __always_inline int reverse_map_l4_port(struct __ctx_buff *ctx, __u8 next
 
 	case IPPROTO_ICMPV6:
 	case IPPROTO_ICMP:
-		break;
+		return CTX_ACT_OK;
 
 	default:
 		return DROP_UNKNOWN_L4;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -541,7 +541,9 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 
 	ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
 	if (IS_ERR(ret)) {
-		if (ret == DROP_UNKNOWN_L4)
+		if (ret == DROP_NO_SERVICE)
+			goto skip_service_lookup;
+		else if (ret == DROP_UNKNOWN_L4)
 			return CTX_ACT_OK;
 		else
 			return ret;
@@ -562,6 +564,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 		if (svc)
 			return DROP_IS_CLUSTER_IP;
 
+skip_service_lookup:
 		ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 
 		if (nodeport_uses_dsr6(&tuple))
@@ -1252,7 +1255,9 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 
 	ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off, CT_EGRESS);
 	if (IS_ERR(ret)) {
-		if (ret == DROP_UNKNOWN_L4)
+		if (ret == DROP_NO_SERVICE)
+			goto skip_service_lookup;
+		else if (ret == DROP_UNKNOWN_L4)
 			return CTX_ACT_OK;
 		else
 			return ret;
@@ -1274,6 +1279,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		if (svc)
 			return DROP_IS_CLUSTER_IP;
 
+skip_service_lookup:
 		ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 
 #ifndef ENABLE_MASQUERADE


### PR DESCRIPTION
In case of ICMP{,v6}, a service lookup is performed with a 0 port. No service mapping is found for that port, but it can still lead to
unnecessary map lookups and code execution.

To avoid that, we can instead return `DROP_NO_SERVICE` for ICMP{,v6} packets and skip all service handling for that return code.