### PR TITLE
bpf: Fix monitor aggregation for 'from-network'

### DIFF
--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -133,6 +133,7 @@ static __always_inline bool emit_trace_notify(__u8 obs_point, __u32 monitor)
 		case TRACE_FROM_HOST:
 		case TRACE_FROM_STACK:
 		case TRACE_FROM_OVERLAY:
+		case TRACE_FROM_NETWORK:
 			return false;
 		default:
 			break;


### PR DESCRIPTION
Previously, we did not take into account 'from-network' sources in the
monitor aggregation logic check in `send_trace_notify()`, which was fine
because we rarely ever sent such events (limited to ipsec for instance).
However, since commit c470e28a82a9 we also use this in bpf_host which
suddenly means that any and all traffic from the network will trigger
monitor events, flooding the monitor output.

Fixes: 7a4b0beccbfe ("bpf: Add MonitorAggregation option")
Fixes: c470e28a82a9 ("Adds TRACE_TO_NETWORK obs label and trace pkts in to-netdev prog.")
Fixes: https://github.com/cilium/cilium/issues/12555

---
This is only problematic in v1.8 due to c470e28a82a9 , but the bug goes back to Cilium v1.2. May as well backport to all supported branches.