### PR TITLE
cleanup: Use value receiver instead of pointer receiver for CIDR struct

### DIFF
--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -33,9 +33,9 @@ type CIDR string
 var CIDRMatchAll = []CIDR{CIDR("0.0.0.0/0"), CIDR("::/0")}
 
 // MatchesAll determines whether the CIDR matches all traffic.
-func (c *CIDR) MatchesAll() bool {
+func (c CIDR) MatchesAll() bool {
 	for _, wildcard := range CIDRMatchAll {
-		if *c == wildcard {
+		if c == wildcard {
 			return true
 		}
 	}

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -400,8 +400,8 @@ func (pp *PortProtocol) Sanitize() error {
 
 // sanitize the given CIDR. If successful, returns the prefixLength specified
 // in the cidr and nil. Otherwise, returns (0, nil).
-func (cidr CIDR) sanitize() (prefixLength int, err error) {
-	strCIDR := string(cidr)
+func (c CIDR) sanitize() (prefixLength int, err error) {
+	strCIDR := string(c)
 	if strCIDR == "" {
 		return 0, fmt.Errorf("IP must be specified")
 	}


### PR DESCRIPTION
Use value receiver instead of pointer receiver for CIDR type

Relates #12558

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
cleanup: Use value receiver instead of pointer receiver for CIDR
```
