### PR TITLE
endpoint: Break circular dependency with EndpointPolicy

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2258,6 +2258,11 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 		e.DeleteBPFProgramLocked()
 	}
 
+	// Break circular dependencies between the endpoint and it's policies
+	// (policy.EndpointPolicy points back to Endpoint via PolicyOwner)
+	e.desiredPolicy = nil
+	e.realizedPolicy = nil
+
 	return errs
 }
 


### PR DESCRIPTION
Set both desired and realized policy to nil when deleting the
Endpoint, as otherwise GC of neither Endpoint nor EndpointPolicy is
not possible as EndpointPolicy.PolicyOwner points back to the
Endpoint.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
