### PR TITLE
Ignore collisions for named ports that are not actually used in an egress policy

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -211,18 +211,18 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				var finalizeFunc revert.FinalizeFunc
 				var revertFunc revert.RevertFunc
 
-				proxyID, err := e.proxyID(l4)
-				if err != nil {
+				proxyID := e.proxyID(l4)
+				if proxyID == "" {
 					// Skip redirects for which a proxyID cannot be created.
 					// This may happen due to the named port mapping not
 					// existing or multiple PODs defining the same port name
 					// with different port values. The redirect will be created
 					// when the mapping is available or when the port name
 					// conflicts have been resolved in POD specs.
-					log.WithError(err).WithField(logfields.EndpointID, e.ID).Warning("Skipping adding redirect")
 					continue
 				}
 
+				var err error
 				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(l4, proxyID, e, proxyWaitGroup)
 				if err != nil {
 					revertStack.Revert() // Ignore errors while reverting. This is best-effort.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1159,6 +1159,17 @@ func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) er
 	return nil
 }
 
+// GetK8sPorts returns the k8sPorts, which must not be modified by the caller
+func (e *Endpoint) GetK8sPorts() (k8sPorts policy.NamedPortMap, err error) {
+	err = e.rlockAlive()
+	if err != nil {
+		return nil, err
+	}
+	k8sPorts = e.k8sPorts
+	e.mutex.RUnlock()
+	return k8sPorts, nil
+}
+
 // HaveK8sMetadata returns true once hasK8sMetadata was set
 func (e *Endpoint) HaveK8sMetadata() (metadataSet bool) {
 	e.mutex.RLock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -225,7 +225,7 @@ type Endpoint struct {
 
 	// k8sPorts contains container ports associated in the pod.
 	// It is used to enforce k8s network policies with port names.
-	k8sPorts policy.NamedPortsMap
+	k8sPorts policy.NamedPortMap
 
 	// k8sPortsSet keep track when k8sPorts was set at least one time.
 	hasK8sMetadata bool
@@ -1138,7 +1138,7 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 // Reading the 'e.k8sPorts' member (the "map pointer") *itself* requires the endpoint lock!
 // Can't really error out as that might break backwards compatibility.
 func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) error {
-	k8sPorts := make(policy.NamedPortsMap, len(containerPorts))
+	k8sPorts := make(policy.NamedPortMap, len(containerPorts))
 	for _, cp := range containerPorts {
 		if cp.Name == "" {
 			continue // silently skip unnamed ports

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -506,8 +506,8 @@ func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
 func (s *EndpointSuite) TestProxyID(c *C) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
 
-	id, err := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
-	c.Assert(err, IsNil)
+	id := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
+	c.Assert(id, Not(Equals), "")
 	endpointID, ingress, protocol, port, err := policy.ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -506,7 +506,7 @@ func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
 func (s *EndpointSuite) TestProxyID(c *C) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
 
-	id, err := e.ProxyID(nil, &policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
+	id, err := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
 	c.Assert(err, IsNil)
 	endpointID, ingress, protocol, port, err := policy.ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -16,6 +16,7 @@ package endpoint
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -40,44 +41,79 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/sirupsen/logrus"
 )
 
-// GetNamedPortsMap returns the map of named ports relevant for the given direction
+// GetNamedPort returns the port for the given name.
 // Must be called with e.mutex NOT held
-func (e *Endpoint) GetNamedPortsMap(ingress bool) (policy.NamedPortsMap, error) {
+func (e *Endpoint) GetNamedPort(ingress bool, name string, proto uint8) uint16 {
 	if ingress {
 		// Ingress only needs the ports of the POD itself
-		return e.GetK8sPorts()
+		k8sPorts, err := e.GetK8sPorts()
+		if err != nil {
+			e.getLogger().WithFields(logrus.Fields{
+				logfields.PortName:         name,
+				logfields.Protocol:         u8proto.U8proto(proto).String(),
+				logfields.TrafficDirection: "ingress",
+			}).WithError(err).Warning("Skipping named port")
+			return 0
+		}
+		return e.getNamedPortIngress(k8sPorts, name, proto)
 	}
 	// egress needs named ports of all the pods
-	return ipcache.IPIdentityCache.GetNamedPorts(), nil
+	return e.getNamedPortEgress(ipcache.IPIdentityCache.GetNamedPorts(), name, proto)
 }
 
-// GetNamedPortsMapLocked returns the map of named ports relevant for the given direction
+// GetNamedPortLocked returns port for the given name. May return an invalid (0) port
 // Must be called with e.mutex held.
-func (e *Endpoint) GetNamedPortsMapLocked(ingress bool) policy.NamedPortsMap {
+func (e *Endpoint) GetNamedPortLocked(ingress bool, name string, proto uint8) uint16 {
 	if ingress {
 		// Ingress only needs the ports of the POD itself
-		return e.k8sPorts
+		return e.getNamedPortIngress(e.k8sPorts, name, proto)
 	}
 	// egress needs named ports of all the pods
-	return ipcache.IPIdentityCache.GetNamedPorts()
+	return e.getNamedPortEgress(ipcache.IPIdentityCache.GetNamedPorts(), name, proto)
+}
+
+func (e *Endpoint) getNamedPortIngress(npMap policy.NamedPortMap, name string, proto uint8) uint16 {
+	port, err := npMap.GetNamedPort(name, proto)
+	if err != nil {
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.PortName:         name,
+			logfields.Protocol:         u8proto.U8proto(proto).String(),
+			logfields.TrafficDirection: "ingress",
+		}).WithError(err).Warning("Skipping named port")
+	}
+	return port
+}
+
+func (e *Endpoint) getNamedPortEgress(npMap policy.NamedPortMultiMap, name string, proto uint8) uint16 {
+	port, err := npMap.GetNamedPort(name, proto)
+	// Skip logging for ErrUnknownNamedPort on egress, as the destination POD with the port name
+	// is likely not scheduled yet.
+	if err != nil && !errors.Is(err, policy.ErrUnknownNamedPort) {
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.PortName:         name,
+			logfields.Protocol:         u8proto.U8proto(proto).String(),
+			logfields.TrafficDirection: "egress",
+		}).WithError(err).Warning("Skipping named port")
+	}
+	return port
 }
 
 // proxyID returns a unique string to identify a proxy mapping.
 // Must be called with e.mutex held.
-func (e *Endpoint) proxyID(l4 *policy.L4Filter) (id string, err error) {
+func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 	port := uint16(l4.Port)
 	if port == 0 && l4.PortName != "" {
-		npMap := e.GetNamedPortsMapLocked(l4.Ingress)
-		port, err = npMap.GetNamedPort(l4.PortName, uint8(l4.U8Proto))
-		if err != nil {
-			return "", err
+		port = e.GetNamedPortLocked(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+		if port == 0 {
+			return ""
 		}
 	}
-	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port), nil
+	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port)
 }
 
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -44,25 +44,48 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ProxyID returns a unique string to identify a proxy mapping.
-func (e *Endpoint) ProxyID(npMap policy.NamedPortsMap, l4 *policy.L4Filter) (string, error) {
-	return policy.ProxyIDFromFilter(e.ID, npMap, l4)
+// GetNamedPortsMap returns the map of named ports relevant for the given direction
+// Must be called with e.mutex NOT held
+func (e *Endpoint) GetNamedPortsMap(ingress bool) (policy.NamedPortsMap, error) {
+	if ingress {
+		// Ingress only needs the ports of the POD itself
+		return e.GetK8sPorts()
+	}
+	// egress needs named ports of all the pods
+	return ipcache.IPIdentityCache.GetNamedPorts(), nil
+}
+
+// GetNamedPortsMapLocked returns the map of named ports relevant for the given direction
+// Must be called with e.mutex held.
+func (e *Endpoint) GetNamedPortsMapLocked(ingress bool) policy.NamedPortsMap {
+	if ingress {
+		// Ingress only needs the ports of the POD itself
+		return e.k8sPorts
+	}
+	// egress needs named ports of all the pods
+	return ipcache.IPIdentityCache.GetNamedPorts()
+}
+
+// proxyID returns a unique string to identify a proxy mapping.
+// Must be called with e.mutex held.
+func (e *Endpoint) proxyID(l4 *policy.L4Filter) (id string, err error) {
+	port := uint16(l4.Port)
+	if port == 0 && l4.PortName != "" {
+		npMap := e.GetNamedPortsMapLocked(l4.Ingress)
+		port, err = npMap.GetNamedPort(l4.PortName, uint8(l4.U8Proto))
+		if err != nil {
+			return "", err
+		}
+	}
+	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port), nil
 }
 
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4
 // policy map key, in host byte order. Returns 0 if not found or the
 // filter doesn't require a redirect.
-// Must be called with Endpoint.Mutex held.
-func (e *Endpoint) LookupRedirectPortLocked(npMap policy.NamedPortsMap, l4Filter *policy.L4Filter) uint16 {
-	if !l4Filter.IsRedirect() {
-		return 0
-	}
-	proxyID, err := e.ProxyID(npMap, l4Filter)
-	if err != nil {
-		e.getLogger().WithError(err).Warn("ProxyID failed")
-		return 0
-	}
-	return e.realizedRedirects[proxyID]
+// Must be called with Endpoint.mutex held.
+func (e *Endpoint) LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16 {
+	return e.realizedRedirects[policy.ProxyID(e.ID, ingress, protocol, port)]
 }
 
 // Note that this function assumes that endpoint policy has already been generated!
@@ -88,7 +111,7 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 	}
 
 	// Publish the updated policy to L7 proxies.
-	return e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy.L4Policy, e.desiredPolicy.NamedPortsMap, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, proxyWaitGroup)
+	return e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, proxyWaitGroup)
 }
 
 func (e *Endpoint) useCurrentNetworkPolicy(proxyWaitGroup *completion.WaitGroup) {
@@ -181,7 +204,7 @@ func (e *Endpoint) regeneratePolicy() (retErr error) {
 		e.getLogger().WithError(err).Warning("Failed to update policy")
 		return err
 	}
-	calculatedPolicy := e.selectorPolicy.Consume(e, ipcache.IPIdentityCache.GetNamedPorts())
+	calculatedPolicy := e.selectorPolicy.Consume(e)
 
 	stats.policyCalculation.End(true)
 

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -27,7 +27,7 @@ import (
 type EndpointProxy interface {
 	CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
-	UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, npMap policy.NamedPortsMap, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
+	UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep logger.EndpointInfoSource)
 }
@@ -64,7 +64,7 @@ func (f *FakeEndpointProxy) RemoveRedirect(id string, wg *completion.WaitGroup) 
 }
 
 // UpdateNetworkPolicy does nothing.
-func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, npMap policy.NamedPortsMap, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -63,7 +63,7 @@ func (r *RedirectSuiteProxy) RemoveRedirect(id string, wg *completion.WaitGroup)
 }
 
 // UpdateNetworkPolicy does nothing.
-func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, npMap policy.NamedPortsMap, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil
 }
 

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -60,7 +60,6 @@ type EndpointInfoSource interface {
 	HasSidecarProxy() bool
 	ConntrackName() string
 	ConntrackNameLocked() string
-	ProxyID(npMap policy.NamedPortsMap, l4 *policy.L4Filter) (string, error)
 	GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error)
 }
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy/xds"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -906,7 +905,7 @@ func getWildcardNetworkPolicyRule(selectors policy.L7DataMap) *cilium.PortNetwor
 	}
 }
 
-func getDirectionNetworkPolicy(l4Policy policy.L4PolicyMap, npMap policy.NamedPortsMap, policyEnforced bool) []*cilium.PortNetworkPolicy {
+func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool) []*cilium.PortNetworkPolicy {
 	if !policyEnforced {
 		// Return an allow-all policy.
 		return allowAllPortNetworkPolicy
@@ -931,6 +930,7 @@ func getDirectionNetworkPolicy(l4Policy policy.L4PolicyMap, npMap policy.NamedPo
 		port := uint16(l4.Port)
 		if port == 0 && l4.PortName != "" {
 			var err error
+			npMap := ep.GetNamedPortsMapLocked(l4.Ingress)
 			port, err = npMap.GetNamedPort(l4.PortName, uint8(l4.U8Proto))
 			if err != nil {
 				log.WithError(err).WithField(logfields.PortName, l4.PortName).Debug("getDirectionNetworkPolicy: Skipping named port")
@@ -1016,18 +1016,18 @@ func getDirectionNetworkPolicy(l4Policy policy.L4PolicyMap, npMap policy.NamedPo
 }
 
 // getNetworkPolicy converts a network policy into a cilium.NetworkPolicy.
-func getNetworkPolicy(name string, id identity.NumericIdentity, conntrackName string, policy *policy.L4Policy,
-	npMap policy.NamedPortsMap, ingressPolicyEnforced, egressPolicyEnforced bool) *cilium.NetworkPolicy {
+func getNetworkPolicy(ep logger.EndpointUpdater, name string, policy *policy.L4Policy,
+	ingressPolicyEnforced, egressPolicyEnforced bool) *cilium.NetworkPolicy {
 	p := &cilium.NetworkPolicy{
 		Name:             name,
-		Policy:           uint64(id),
-		ConntrackMapName: conntrackName,
+		Policy:           uint64(ep.GetIdentityLocked()),
+		ConntrackMapName: ep.ConntrackNameLocked(),
 	}
 
 	// If no policy, deny all traffic. Otherwise, convert the policies for ingress and egress.
 	if policy != nil {
-		p.IngressPerPortPolicies = getDirectionNetworkPolicy(policy.Ingress, npMap, ingressPolicyEnforced)
-		p.EgressPerPortPolicies = getDirectionNetworkPolicy(policy.Egress, npMap, egressPolicyEnforced)
+		p.IngressPerPortPolicies = getDirectionNetworkPolicy(ep, policy.Ingress, ingressPolicyEnforced)
+		p.EgressPerPortPolicies = getDirectionNetworkPolicy(ep, policy.Egress, egressPolicyEnforced)
 	}
 
 	return p
@@ -1066,7 +1066,7 @@ func getNodeIDs(ep logger.EndpointUpdater, policy *policy.L4Policy) []string {
 // to L7 proxies.
 // When the proxy acknowledges the network policy update, it will result in
 // a subsequent call to the endpoint's OnProxyPolicyUpdate() function.
-func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, npMap policy.NamedPortsMap,
+func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy,
 	ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -1081,8 +1081,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 		if ip == "" {
 			continue
 		}
-		networkPolicy := getNetworkPolicy(ip, ep.GetIdentityLocked(), ep.ConntrackNameLocked(), policy, npMap,
-			ingressPolicyEnforced, egressPolicyEnforced)
+		networkPolicy := getNetworkPolicy(ep, ip, policy, ingressPolicyEnforced, egressPolicyEnforced)
 		err := networkPolicy.Validate()
 		if err != nil {
 			return fmt.Errorf("error validating generated NetworkPolicy for %s: %s", ip, err), nil

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -929,11 +928,8 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 
 		port := uint16(l4.Port)
 		if port == 0 && l4.PortName != "" {
-			var err error
-			npMap := ep.GetNamedPortsMapLocked(l4.Ingress)
-			port, err = npMap.GetNamedPort(l4.PortName, uint8(l4.U8Proto))
-			if err != nil {
-				log.WithError(err).WithField(logfields.PortName, l4.PortName).Debug("getDirectionNetworkPolicy: Skipping named port")
+			port = ep.GetNamedPortLocked(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+			if port == 0 {
 				continue
 			}
 		}

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -301,7 +301,7 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	c.Assert(cachedIdentity.Source, Equals, source.Kubernetes)
 
 	// Named ports have been updated
-	c.Assert(namedPortsChanged, Equals, true)
+	c.Assert(namedPortsChanged, Equals, false) // not before GetNamedPorts() has been called once
 	npm := IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, NotNil)
 	c.Assert(len(npm), Equals, 2)

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -108,7 +108,7 @@ func newKVReferenceCounter(s store) *kvReferenceCounter {
 // UpsertIPToKVStore updates / inserts the provided IP->Identity mapping into the
 // kvstore, which will subsequently trigger an event in NewIPIdentityWatcher().
 func UpsertIPToKVStore(ctx context.Context, IP, hostIP net.IP, ID identity.NumericIdentity, key uint8,
-	metadata, k8sNamespace, k8sPodName string, npm policy.NamedPortsMap) error {
+	metadata, k8sNamespace, k8sPodName string, npm policy.NamedPortMap) error {
 	// Sort named ports into a slice
 	namedPorts := make([]identity.NamedPort, 0, len(npm))
 	for name, value := range npm {
@@ -291,7 +291,7 @@ restart:
 					k8sMeta = &K8sMetadata{
 						Namespace:  ipIDPair.K8sNamespace,
 						PodName:    ipIDPair.K8sPodName,
-						NamedPorts: make(policy.NamedPortsMap, len(ipIDPair.NamedPorts)),
+						NamedPorts: make(policy.NamedPortMap, len(ipIDPair.NamedPorts)),
 					}
 					for _, np := range ipIDPair.NamedPorts {
 						err = k8sMeta.NamedPorts.AddPort(np.Name, int(np.Port), np.Protocol)

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -141,7 +141,7 @@ func (k *K8sWatcher) endpointUpdated(endpoint *types.CiliumEndpoint) {
 		k8sMeta := &ipcache.K8sMetadata{
 			Namespace:  endpoint.Namespace,
 			PodName:    endpoint.Name,
-			NamedPorts: make(policy.NamedPortsMap, len(endpoint.NamedPorts)),
+			NamedPorts: make(policy.NamedPortMap, len(endpoint.NamedPorts)),
 		}
 		for _, port := range endpoint.NamedPorts {
 			p, err := u8proto.ParseProtocol(port.Protocol)

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -148,9 +148,9 @@ func (k *K8sWatcher) endpointUpdated(endpoint *types.CiliumEndpoint) {
 			if err != nil {
 				continue
 			}
-			k8sMeta.NamedPorts[port.Name] = policy.NamedPort{
-				Proto: uint8(p),
+			k8sMeta.NamedPorts[port.Name] = policy.PortProto{
 				Port:  uint16(port.Port),
+				Proto: uint8(p),
 			}
 		}
 

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -608,7 +608,7 @@ func (k *K8sWatcher) updatePodHostData(pod *slim_corev1.Pod) (bool, error) {
 				return true, fmt.Errorf("ContainerPort: invalid port: %d", port.ContainerPort)
 			}
 			if k8sMeta.NamedPorts == nil {
-				k8sMeta.NamedPorts = make(policy.NamedPortsMap)
+				k8sMeta.NamedPorts = make(policy.NamedPortMap)
 			}
 			k8sMeta.NamedPorts[port.Name] = policy.NamedPort{
 				Proto: uint8(p),

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -610,9 +610,9 @@ func (k *K8sWatcher) updatePodHostData(pod *slim_corev1.Pod) (bool, error) {
 			if k8sMeta.NamedPorts == nil {
 				k8sMeta.NamedPorts = make(policy.NamedPortMap)
 			}
-			k8sMeta.NamedPorts[port.Name] = policy.NamedPort{
-				Proto: uint8(p),
+			k8sMeta.NamedPorts[port.Name] = policy.PortProto{
 				Port:  uint16(port.ContainerPort),
+				Proto: uint8(p),
 			}
 		}
 	}

--- a/pkg/logging/limiter.go
+++ b/pkg/logging/limiter.go
@@ -1,0 +1,47 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// Limiter is a wrapper around rate.Limiter that does not panic when
+// the limiter is uninitialized. The wrapping also allows more logging
+// specific functionality to be added later without changing all the call
+// sites.
+type Limiter struct {
+	bucket *rate.Limiter
+}
+
+// NewLimiter returns a new Limiter allowing log messages to be
+// emitted on average once every 'interval' and upto 'burst' messages
+// during any 'interval'.
+func NewLimiter(interval time.Duration, burst int) Limiter {
+	return Limiter{
+		bucket: rate.NewLimiter(rate.Every(interval), burst),
+	}
+}
+
+// Allow returns true if the log message is allowed under the
+// configured rate limit.
+func (ll Limiter) Allow() bool {
+	if ll.bucket == nil {
+		return true // limiter not initialized => no limit
+	}
+	return ll.bucket.Allow()
+}

--- a/pkg/logging/limiter_test.go
+++ b/pkg/logging/limiter_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package logging
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *LoggingSuite) TestLimiter(c *C) {
+	// Set up a limiter that allows one event every half second with the burts of 3.
+	// The underlying token bucket has the capacity of three and fill rate of
+	// 2 per second.
+	limiter := NewLimiter(500*time.Millisecond, 3)
+
+	// Initially tree events should be allowed and the rest denied.
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, false)
+	c.Assert(limiter.Allow(), Equals, false)
+	c.Assert(limiter.Allow(), Equals, false)
+
+	// After half second one more event should be allowed, the rest denied
+	time.Sleep(500 * time.Millisecond)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, false)
+	c.Assert(limiter.Allow(), Equals, false)
+
+	// After one more second two events should be allowed, the rest denied
+	time.Sleep(1 * time.Second)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, false)
+	c.Assert(limiter.Allow(), Equals, false)
+
+	// After two more seconds three events should be allowed, the rest denied
+	time.Sleep(2 * time.Second)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, true)
+	c.Assert(limiter.Allow(), Equals, false)
+	c.Assert(limiter.Allow(), Equals, false)
+}

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -30,7 +30,7 @@ import (
 type SelectorPolicy interface {
 	// Consume returns the policy in terms of connectivity to peer
 	// Identities.
-	Consume(owner PolicyOwner, npMap NamedPortsMap) *EndpointPolicy
+	Consume(owner PolicyOwner) *EndpointPolicy
 }
 
 // PolicyCache represents a cache of resolved policies for identities.
@@ -205,10 +205,10 @@ func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy) {
 //
 // This denotes that a particular endpoint is 'consuming' the policy from the
 // selector policy cache.
-func (cip *cachedSelectorPolicy) Consume(owner PolicyOwner, npMap NamedPortsMap) *EndpointPolicy {
+func (cip *cachedSelectorPolicy) Consume(owner PolicyOwner) *EndpointPolicy {
 	// TODO: This currently computes the EndpointPolicy from SelectorPolicy
 	// on-demand, however in future the cip is intended to cache the
 	// EndpointPolicy for this Identity and emit datapath deltas instead.
 	isHost := cip.identity.ID == identityPkg.ReservedIdentityHost
-	return cip.getPolicy().DistillPolicy(owner, npMap, isHost)
+	return cip.getPolicy().DistillPolicy(owner, isHost)
 }

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -466,8 +466,8 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 	}
 	selectorCache := testNewSelectorCache(identityCache)
 
-	npMap := NamedPortsMap{
-		"port-80": NamedPort{Proto: uint8(0), Port: uint16(80)},
+	npMap := NamedPortMap{
+		"port-80": PortProto{Proto: uint8(0), Port: uint16(80)},
 	}
 
 	tests := []struct {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -381,7 +381,8 @@ func (npm NamedPortMultiMap) GetNamedPort(name string, proto uint8) (port uint16
 // Note: It is possible for two selectors to select the same security ID.
 // To give priority for L7 redirection (e.g., for visibility purposes), we use
 // RedirectPreferredInsert() instead of directly inserting the value to the map.
-func (l4 *L4Filter) ToMapState(npMap NamedPortsMap, direction trafficdirection.TrafficDirection) MapState {
+// PolicyOwner (aka Endpoint) is locked during this call.
+func (l4 *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficdirection.TrafficDirection) MapState {
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
 
@@ -400,6 +401,7 @@ func (l4 *L4Filter) ToMapState(npMap NamedPortsMap, direction trafficdirection.T
 	// resolve named port
 	if port == 0 && l4.PortName != "" {
 		var err error
+		npMap := policyOwner.GetNamedPortsMapLocked(l4.Ingress)
 		port, err = npMap.GetNamedPort(l4.PortName, proto)
 		if err != nil {
 			logger.Debugf("ToMapState: Skipping named port: %s", err)
@@ -902,6 +904,8 @@ type L4Policy struct {
 
 	// Endpoint policies using this L4Policy
 	// These are circular references, cleaned up in Detach()
+	// This mutex is taken while Endpoint mutex is held, so Endpoint lock
+	// MUST always be taken before this mutex.
 	mutex lock.RWMutex
 	users map[*EndpointPolicy]struct{}
 }
@@ -948,12 +952,22 @@ func (l4 *L4Policy) AccumulateMapChanges(adds, deletes []identity.NumericIdentit
 	proto := uint8(l4Filter.U8Proto)
 	derivedFrom := l4Filter.DerivedFromRules
 
+	// Must take a copy of 'users' as GetNamedPortsMap() will lock the Endpoint below and
+	// the Endpoint lock may not be taken while 'l4.mutex' is held.
 	l4.mutex.RLock()
-	for epPolicy := range l4.users {
+	users := make(map[*EndpointPolicy]struct{}, len(l4.users))
+	for user := range l4.users {
+		users[user] = struct{}{}
+	}
+	l4.mutex.RUnlock()
+
+	for epPolicy := range users {
 		// resolve named port
 		if port == 0 && l4Filter.PortName != "" {
-			var err error
-			port, err = epPolicy.NamedPortsMap.GetNamedPort(l4Filter.PortName, proto)
+			npMap, err := epPolicy.PolicyOwner.GetNamedPortsMap(direction == trafficdirection.Ingress)
+			if err == nil {
+				port, err = npMap.GetNamedPort(l4Filter.PortName, proto)
+			}
 			if err != nil {
 				if option.Config.Debug {
 					logger := log.WithFields(logrus.Fields{
@@ -971,7 +985,6 @@ func (l4 *L4Policy) AccumulateMapChanges(adds, deletes []identity.NumericIdentit
 
 		epPolicy.policyMapChanges.AccumulateMapChanges(adds, deletes, port, proto, direction, redirect, derivedFrom)
 	}
-	l4.mutex.RUnlock()
 }
 
 // Detach makes the L4Policy ready for garbage collection, removing

--- a/pkg/policy/portmap.go
+++ b/pkg/policy/portmap.go
@@ -1,0 +1,174 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/iana"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+var (
+	ErrNilMap               = errors.New("nil map")
+	ErrUnknownNamedPort     = errors.New("unknown named port")
+	ErrIncompatibleProtocol = errors.New("incompatible protocol")
+	ErrNamedPortIsZero      = errors.New("named port is zero")
+	ErrDuplicateNamedPorts  = errors.New("duplicate named ports")
+)
+
+// PortProto is a pair of port number and protocol and is used as the
+// value type in named port maps.
+type PortProto struct {
+	Port  uint16 // non-0
+	Proto uint8  // 0 for any
+}
+
+// NamedPortMap maps port names to port numbers and protocols.
+type NamedPortMap map[string]PortProto
+
+// PortProtoSet is a set of unique PortProto values.
+type PortProtoSet map[PortProto]struct{}
+
+// Equal returns true if the PortProtoSets are equal.
+func (pps PortProtoSet) Equal(other PortProtoSet) bool {
+	if len(pps) != len(other) {
+		return false
+	}
+
+	for port := range pps {
+		if _, exists := other[port]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+// NamedPortMultiMap may have multiple entries for a name if multiple PODs
+// define the same name with different values.
+type NamedPortMultiMap map[string]PortProtoSet
+
+// Equal returns true if the NamedPortMultiMaps are equal.
+func (npm NamedPortMultiMap) Equal(other NamedPortMultiMap) bool {
+	if len(npm) != len(other) {
+		return false
+	}
+	for name, ports := range npm {
+		if otherPorts, exists := other[name]; !exists || !ports.Equal(otherPorts) {
+			return false
+		}
+	}
+	return true
+}
+
+// ValidatePortName checks that the port name conforms to the IANA Service Names spec
+// and converts the port name to lower case for case-insensitive comparisons.
+func ValidatePortName(name string) (string, error) {
+	if !iana.IsSvcName(name) { // Port names are formatted as IANA Service Names
+		return "", fmt.Errorf("Invalid port name \"%s\", not using as a named port", name)
+	}
+	return strings.ToLower(name), nil // Normalize for case-insensitive comparison
+}
+
+func newPortProto(port int, protocol string) (pp PortProto, err error) {
+	var u8p u8proto.U8proto
+	if protocol == "" {
+		u8p = u8proto.TCP // K8s ContainerPort protocol defaults to TCP
+	} else {
+		var err error
+		u8p, err = u8proto.ParseProtocol(protocol)
+		if err != nil {
+			return pp, err
+		}
+	}
+	if port < 1 || port > 65535 {
+		if port == 0 {
+			return pp, ErrNamedPortIsZero
+		}
+		return pp, fmt.Errorf("Port number %d out of 16-bit range", port)
+	}
+	return PortProto{
+		Proto: uint8(u8p),
+		Port:  uint16(port),
+	}, nil
+}
+
+// AddPort adds a new PortProto to the NamedPortMap
+func (npm NamedPortMap) AddPort(name string, port int, protocol string) error {
+	name, err := ValidatePortName(name)
+	if err != nil {
+		return err
+	}
+	pp, err := newPortProto(port, protocol)
+	if err != nil {
+		return err
+	}
+	npm[name] = pp
+	return nil
+}
+
+// GetNamedPort returns the port number for the named port, if any.
+func (npm NamedPortMap) GetNamedPort(name string, proto uint8) (uint16, error) {
+	if npm == nil {
+		return 0, ErrNilMap
+	}
+	pp, ok := npm[name]
+	if !ok {
+		return 0, ErrUnknownNamedPort
+	}
+	if pp.Proto != 0 && proto != pp.Proto {
+		return 0, ErrIncompatibleProtocol
+	}
+	if pp.Port == 0 {
+		return 0, ErrNamedPortIsZero
+	}
+	return pp.Port, nil
+}
+
+// GetNamedPort returns the port number for the named port, if any.
+func (npm NamedPortMultiMap) GetNamedPort(name string, proto uint8) (uint16, error) {
+	if npm == nil {
+		return 0, ErrNilMap
+	}
+	pps, ok := npm[name]
+	if !ok {
+		// Return an error the caller can filter out as this happens only for egress policy
+		// and it is likely the destination POD with the port name is simply not scheduled yet.
+		return 0, ErrUnknownNamedPort
+	}
+	// Find if there is a single port that has no proto conflict and no zero port value
+	port := uint16(0)
+	err := ErrUnknownNamedPort
+	for pp := range pps {
+		if pp.Proto != 0 && proto != pp.Proto {
+			err = ErrIncompatibleProtocol
+			continue // conflicting proto
+		}
+		if pp.Port == 0 {
+			err = ErrNamedPortIsZero
+			continue // zero port
+		}
+		if port != 0 && pp.Port != port {
+			return 0, ErrDuplicateNamedPorts
+		}
+		port = pp.Port
+	}
+	if port == 0 {
+		return 0, err
+	}
+	return port, nil
+}

--- a/pkg/policy/portmap_test.go
+++ b/pkg/policy/portmap_test.go
@@ -1,0 +1,196 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package policy
+
+import (
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	. "gopkg.in/check.v1"
+)
+
+func (ds *PolicyTestSuite) TestPolicyValidateName(c *C) {
+	name, err := ValidatePortName("Http")
+	c.Assert(err, IsNil)
+	c.Assert(name, Equals, "http")
+
+	name, err = ValidatePortName("dns-tcp")
+	c.Assert(err, IsNil)
+	c.Assert(name, Equals, "dns-tcp")
+
+	_, err = ValidatePortName("-http")
+	c.Assert(err, Not(IsNil))
+
+	_, err = ValidatePortName("http-")
+	c.Assert(err, Not(IsNil))
+
+	name, err = ValidatePortName("http-80")
+	c.Assert(err, IsNil)
+	c.Assert(name, Equals, "http-80")
+
+	_, err = ValidatePortName("http--s")
+	c.Assert(err, Not(IsNil))
+}
+
+func (ds *PolicyTestSuite) TestPolicyNewPortProto(c *C) {
+	np, err := newPortProto(80, "tcp")
+	c.Assert(err, IsNil)
+	c.Assert(np, Equals, PortProto{Port: uint16(80), Proto: uint8(6)})
+
+	_, err = newPortProto(88888, "tcp")
+	c.Assert(err, Not(IsNil))
+	c.Assert(err.Error(), Equals, "Port number 88888 out of 16-bit range")
+
+	_, err = newPortProto(80, "cccp")
+	c.Assert(err, Not(IsNil))
+	c.Assert(err.Error(), Equals, "unknown protocol 'cccp'")
+
+	np, err = newPortProto(88, "")
+	c.Assert(err, IsNil)
+	c.Assert(np, Equals, PortProto{Port: uint16(88), Proto: uint8(6)})
+}
+
+func (ds *PolicyTestSuite) TestPolicyNamedPortMap(c *C) {
+	npm := make(NamedPortMap)
+
+	err := npm.AddPort("http", 80, "tcp")
+	c.Assert(err, IsNil)
+	c.Assert(npm, HasLen, 1)
+
+	err = npm.AddPort("dns", 53, "UDP")
+	c.Assert(err, IsNil)
+	c.Assert(npm, HasLen, 2)
+
+	err = npm.AddPort("zero", 0, "TCP")
+	c.Assert(err, Equals, ErrNamedPortIsZero)
+	c.Assert(npm, HasLen, 2)
+
+	proto, err := u8proto.ParseProtocol("UDP")
+	c.Assert(err, IsNil)
+	c.Assert(uint8(proto), Equals, uint8(17))
+
+	port, err := npm.GetNamedPort("dns", uint8(proto))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
+
+	port, err = npm.GetNamedPort("dns", uint8(6))
+	c.Assert(err, Equals, ErrIncompatibleProtocol)
+	c.Assert(port, Equals, uint16(0))
+
+	port, err = npm.GetNamedPort("unknown", uint8(proto))
+	c.Assert(err, Equals, ErrUnknownNamedPort)
+	c.Assert(port, Equals, uint16(0))
+}
+
+func (ds *PolicyTestSuite) TestPolicyPortProtoSet(c *C) {
+	a := PortProtoSet{
+		PortProto{Port: 80, Proto: 6}:  struct{}{},
+		PortProto{Port: 443, Proto: 6}: struct{}{},
+		PortProto{Port: 53, Proto: 17}: struct{}{},
+	}
+	b := PortProtoSet{
+		PortProto{Port: 80, Proto: 6}:  struct{}{},
+		PortProto{Port: 443, Proto: 6}: struct{}{},
+		PortProto{Port: 53, Proto: 6}:  struct{}{},
+	}
+	c.Assert(a.Equal(a), Equals, true)
+	c.Assert(a.Equal(b), Equals, false)
+	c.Assert(b.Equal(b), Equals, true)
+}
+
+func (ds *PolicyTestSuite) TestPolicyNamedPortMultiMap(c *C) {
+	a := NamedPortMultiMap{
+		"http": PortProtoSet{
+			PortProto{Port: 80, Proto: 6}:   struct{}{},
+			PortProto{Port: 8080, Proto: 6}: struct{}{},
+		},
+		"https": PortProtoSet{
+			PortProto{Port: 443, Proto: 6}: struct{}{},
+		},
+		"zero": PortProtoSet{
+			PortProto{Port: 0, Proto: 6}: struct{}{},
+		},
+		"none": PortProtoSet{},
+		"dns": PortProtoSet{
+			PortProto{Port: 53, Proto: 17}: struct{}{},
+			PortProto{Port: 53, Proto: 6}:  struct{}{},
+		},
+	}
+	b := NamedPortMultiMap{
+		"http": PortProtoSet{
+			PortProto{Port: 80, Proto: 6}:   struct{}{},
+			PortProto{Port: 8080, Proto: 6}: struct{}{},
+		},
+		"https": PortProtoSet{
+			PortProto{Port: 443, Proto: 6}: struct{}{},
+		},
+		"zero": PortProtoSet{
+			PortProto{Port: 0, Proto: 6}: struct{}{},
+		},
+		"none": PortProtoSet{},
+		"dns": PortProtoSet{
+			PortProto{Port: 53, Proto: 0}: struct{}{},
+		},
+	}
+
+	c.Assert(a.Equal(a), Equals, true)
+	c.Assert(a.Equal(b), Equals, false)
+	c.Assert(b.Equal(b), Equals, true)
+
+	port, err := a.GetNamedPort("http", 6)
+	c.Assert(err, Equals, ErrDuplicateNamedPorts)
+	c.Assert(port, Equals, uint16(0))
+
+	port, err = a.GetNamedPort("http", 17)
+	c.Assert(err, Equals, ErrIncompatibleProtocol)
+	c.Assert(port, Equals, uint16(0))
+
+	port, err = a.GetNamedPort("zero", 6)
+	c.Assert(err, Equals, ErrNamedPortIsZero)
+	c.Assert(port, Equals, uint16(0))
+
+	port, err = a.GetNamedPort("none", 6)
+	c.Assert(err, Equals, ErrUnknownNamedPort)
+	c.Assert(port, Equals, uint16(0))
+
+	port, err = a.GetNamedPort("unknown", 6)
+	c.Assert(err, Equals, ErrUnknownNamedPort)
+	c.Assert(port, Equals, uint16(0))
+
+	port, err = NamedPortMultiMap(nil).GetNamedPort("unknown", 6)
+	c.Assert(err, Equals, ErrNilMap)
+	c.Assert(port, Equals, uint16(0))
+
+	port, err = a.GetNamedPort("https", 6)
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(443))
+
+	port, err = a.GetNamedPort("dns", 6)
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
+
+	port, err = b.GetNamedPort("dns", 6)
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
+
+	port, err = a.GetNamedPort("dns", 17)
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
+
+	port, err = b.GetNamedPort("dns", 17)
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
+}

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -37,18 +37,6 @@ func ProxyIDFromKey(endpointID uint16, key Key) string {
 	return ProxyID(endpointID, key.TrafficDirection == trafficdirection.Ingress.Uint8(), u8proto.U8proto(key.Nexthdr).String(), key.DestPort)
 }
 
-// ProxyIDFromFilter returns a unique string to identify a proxy mapping.
-func ProxyIDFromFilter(endpointID uint16, npMap NamedPortsMap, l4 *L4Filter) (id string, err error) {
-	port := uint16(l4.Port)
-	if port == 0 && l4.PortName != "" {
-		port, err = npMap.GetNamedPort(l4.PortName, uint8(l4.U8Proto))
-		if err != nil {
-			return "", err
-		}
-	}
-	return ProxyID(endpointID, l4.Ingress, string(l4.Protocol), port), nil
-}
-
 // ParseProxyID parses a proxy ID returned by ProxyID and returns its components.
 func ParseProxyID(proxyID string) (endpointID uint16, ingress bool, protocol string, port uint16, err error) {
 	comps := strings.Split(proxyID, ":")

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -77,8 +77,8 @@ type EndpointPolicy struct {
 type PolicyOwner interface {
 	GetID() uint64
 	LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16
-	GetNamedPortsMap(ingress bool) (NamedPortsMap, error)
-	GetNamedPortsMapLocked(ingress bool) NamedPortsMap
+	GetNamedPort(ingress bool, name string, proto uint8) uint16
+	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
 }
 
 // newSelectorPolicy returns an empty selectorPolicy stub.

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -178,16 +178,12 @@ func (d DummyOwner) LookupRedirectPortLocked(bool, string, uint16) uint16 {
 	return 4242
 }
 
-func (d DummyOwner) GetNamedPortsMap(ingress bool) (NamedPortsMap, error) {
-	return NamedPortMap{
-		"port-80": PortProto{Proto: uint8(0), Port: uint16(80)},
-	}, nil
+func (d DummyOwner) GetNamedPort(ingress bool, name string, proto uint8) uint16 {
+	return 80
 }
 
-func (d DummyOwner) GetNamedPortsMapLocked(ingress bool) NamedPortsMap {
-	return NamedPortMap{
-		"port-80": PortProto{Proto: uint8(0), Port: uint16(80)},
-	}
+func (d DummyOwner) GetNamedPortLocked(ingress bool, name string, proto uint8) uint16 {
+	return 80
 }
 
 func (d DummyOwner) GetID() uint64 {

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -39,7 +39,8 @@ type EndpointInfoSource interface {
 	// implementation.
 	ConntrackName() string
 	ConntrackNameLocked() string
-	ProxyID(npMap policy.NamedPortsMap, l4 *policy.L4Filter) (string, error)
+	GetNamedPortsMap(ingress bool) (policy.NamedPortsMap, error)
+	GetNamedPortsMapLocked(ingress bool) policy.NamedPortsMap
 	GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error)
 }
 

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -18,7 +18,6 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
@@ -39,8 +38,7 @@ type EndpointInfoSource interface {
 	// implementation.
 	ConntrackName() string
 	ConntrackNameLocked() string
-	GetNamedPortsMap(ingress bool) (policy.NamedPortsMap, error)
-	GetNamedPortsMapLocked(ingress bool) policy.NamedPortsMap
+	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
 	GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error)
 }
 

--- a/pkg/proxy/logger/test/epinfo.go
+++ b/pkg/proxy/logger/test/epinfo.go
@@ -46,6 +46,12 @@ func (m *ProxyUpdaterMock) GetIPv4Address() string                      { return
 func (m *ProxyUpdaterMock) GetIPv6Address() string                      { return m.Ipv6 }
 func (m *ProxyUpdaterMock) GetLabels() []string                         { return m.Labels }
 func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.Identity }
+func (m *ProxyUpdaterMock) GetNamedPortsMap(ingress bool) (policy.NamedPortsMap, error) {
+	return nil, nil
+}
+func (m *ProxyUpdaterMock) GetNamedPortsMapLocked(ingress bool) policy.NamedPortsMap {
+	return nil
+}
 func (m *ProxyUpdaterMock) ProxyID(npMap policy.NamedPortsMap, l4 *policy.L4Filter) (string, error) {
 	return "", nil
 }

--- a/pkg/proxy/logger/test/epinfo.go
+++ b/pkg/proxy/logger/test/epinfo.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
@@ -41,20 +40,14 @@ func (m *ProxyUpdaterMock) GetProxyInfoByFields() (uint64, string, string, []str
 func (m *ProxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
 func (m *ProxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 
-func (m *ProxyUpdaterMock) GetID() uint64                               { return m.Id }
-func (m *ProxyUpdaterMock) GetIPv4Address() string                      { return m.Ipv4 }
-func (m *ProxyUpdaterMock) GetIPv6Address() string                      { return m.Ipv6 }
-func (m *ProxyUpdaterMock) GetLabels() []string                         { return m.Labels }
-func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.Identity }
-func (m *ProxyUpdaterMock) GetNamedPortsMap(ingress bool) (policy.NamedPortsMap, error) {
-	return nil, nil
-}
-func (m *ProxyUpdaterMock) GetNamedPortsMapLocked(ingress bool) policy.NamedPortsMap {
-	return nil
-}
-func (m *ProxyUpdaterMock) ProxyID(npMap policy.NamedPortsMap, l4 *policy.L4Filter) (string, error) {
-	return "", nil
-}
+func (m *ProxyUpdaterMock) GetID() uint64                                 { return m.Id }
+func (m *ProxyUpdaterMock) GetIPv4Address() string                        { return m.Ipv4 }
+func (m *ProxyUpdaterMock) GetIPv6Address() string                        { return m.Ipv6 }
+func (m *ProxyUpdaterMock) GetLabels() []string                           { return m.Labels }
+func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool            { return true }
+func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool           { return true }
+func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity   { return m.Identity }
+func (m *ProxyUpdaterMock) GetNamedPortLocked(bool, string, uint8) uint16 { return 0 }
 func (m *ProxyUpdaterMock) GetLabelsSHA() string {
 	return labels.NewLabelsFromModel(m.Labels).SHA256Sum()
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -644,8 +644,8 @@ func (p *Proxy) updateRedirectMetrics() {
 }
 
 // UpdateNetworkPolicy must update the redirect configuration of an endpoint in the proxy
-func (p *Proxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, npMap policy.NamedPortsMap, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
-	return p.XDSServer.UpdateNetworkPolicy(ep, policy, npMap, ingressPolicyEnforced, egressPolicyEnforced, wg)
+func (p *Proxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+	return p.XDSServer.UpdateNetworkPolicy(ep, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
 }
 
 // UseCurrentNetworkPolicy inserts a Completion to the WaitGroup if the current network policy has not yet been acked


### PR DESCRIPTION
Do not warn of port name conflicts when ports are collected, but keep
the conflicting ports. This allows (any) warnings to be postponed until
the named ports are used in a policy.

Behavior in presence of conflicting port name/number mapping, when
the port name is used in a policy is slightly changed:

 - Now these collisions will not affect ingress policies at all
 - For egress the policy rule using the conflicting port is now ignored.
   Cilium needs to be running with debug on to see this happening.
   Previously rule was instantiated using one of the many port numbers,
   essentially selected randomly.
 - Missing port name mappings, when used in a policy applicable to
   the local node, are logged as warnings, but rate limited.

Pass Endpoint (or a subset interface) to potential users of Endpoint's
NamedPortsMap so that instead of preparing the map in advance it can
be created of demand in case it is actually needed.

NamedPortsMap is an interface that is implemented by both NamedPortMap
or NamedPortMultiMap, first of which is built from the POD spec, and
the latter is a collection of named ports across all the PODs in the
cluster. When a named port is used in an ingress policy, it can be
translated by using the PODs own NamedPortMap. When a named port is
used in an egress policy the named port can be one of any remote PODs,
so the collection of all the named ports in the cluster is used as the
individual destination POD is not known at policy computation
time. This could be optimized to the scope of PODs sharing the same
set of labels as the destination security IDs are known when policy is
configured.

Currently same port name resolving to different port numbers is
flagged as a runtime error when that specific port name is used in a
policy. Traffic to this/these ports is not allowed. To get around this the
port names should be made unique so that each name maps to the
same port number and protocol, or preferably the port names in the
egress policies should be replaced with the desired port numbers.

The maintenance of the collection of named ports across the cluster
described above is started only after first needed for computing the
bpf map entries from an egress policy that uses a port name instead
the number. This way the related overhead is avoided if named ports
are never used in egress policies.

Fixes: #12514
