### PR TITLE
daemon: Add "datapath" opt to --debug-verbose flag

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -548,6 +548,10 @@ Upgrading from >=1.7.0 to 1.8.y
       helm upgrade cilium --namespace=kube-system \\
       --set global.bpf.natMax=841429
 
+* Setting debug mode with ``debug: "true"`` no longer enables datapath debug
+  messages which could have been read with ``cilium monitor -v``. To enable
+  them, add ``"datapath"`` to the ``debug-verbose`` option.
+
 New ConfigMap Options
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -465,6 +465,13 @@ be a trade-off of CPU for ``conntrack-gc-interval``, and for
 ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
 consumed.
 
+Enabling datapath debug messages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, datapath debug messages are disabled, and therefore not shown in
+``cilium monitor -v`` output. To enable them, add ``"datapath"`` to
+the ``debug-verbose`` option.
+
 Policy Troubleshooting
 ======================
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -81,9 +81,10 @@ import (
 
 const (
 	// list of supported verbose debug groups
-	argDebugVerboseFlow    = "flow"
-	argDebugVerboseKvstore = "kvstore"
-	argDebugVerboseEnvoy   = "envoy"
+	argDebugVerboseFlow     = "flow"
+	argDebugVerboseKvstore  = "kvstore"
+	argDebugVerboseEnvoy    = "envoy"
+	argDebugVerboseDatapath = "datapath"
 
 	apiTimeout   = 60 * time.Second
 	daemonSubsys = "daemon"
@@ -846,6 +847,8 @@ func restoreExecPermissions(searchDir string, patterns ...string) error {
 }
 
 func initEnv(cmd *cobra.Command) {
+	var debugDatapath bool
+
 	option.Config.SetMapElementSizes(
 		// for the conntrack and NAT element size we assume the largest possible
 		// key size, i.e. IPv6 keys
@@ -881,6 +884,9 @@ func initEnv(cmd *cobra.Command) {
 		case argDebugVerboseEnvoy:
 			log.Debugf("Enabling Envoy tracing")
 			envoy.EnableTracing()
+		case argDebugVerboseDatapath:
+			log.Debugf("Enabling datapath debug messages")
+			debugDatapath = true
 		default:
 			log.Warningf("Unknown verbose debug group: %s", grp)
 		}
@@ -1013,8 +1019,8 @@ func initEnv(cmd *cobra.Command) {
 	bpf.CheckOrMountFS(option.Config.BPFRoot, k8s.IsEnabled())
 	cgroups.CheckOrMountCgrpFS(option.Config.CGroupRoot)
 
-	option.Config.Opts.SetBool(option.Debug, false)
-	option.Config.Opts.SetBool(option.DebugLB, false)
+	option.Config.Opts.SetBool(option.Debug, debugDatapath)
+	option.Config.Opts.SetBool(option.DebugLB, debugDatapath)
 	option.Config.Opts.SetBool(option.DropNotify, true)
 	option.Config.Opts.SetBool(option.TraceNotify, true)
 	option.Config.Opts.SetBool(option.PolicyVerdictNotify, true)


### PR DESCRIPTION
This PR adds a support for the `"datapath"` option to `--debug-verbose`

Adding the `"datapath"` to `--debug-verbose` enables debug messages produced by the datapath.

Previously, it could have been enabled for new endpoints by invoking `cilium config Debug{,LB}=Enabled` on each node, and for existing - by `cilium config $EID Debug{,LB}=Enabled`.

Added `needs-backport/1.8`, as it will ease debugging of 1.8 user datapath issues.

```release-note
daemon: Add "datapath" opt to --debug-verbose flag to enable datapath debug messages
```