### PR TITLE
hubble/relay: expose options to configure flows sorting

### DIFF
--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -30,13 +30,15 @@ import (
 )
 
 type flags struct {
-	debug         bool
-	pprof         bool
-	gops          bool
-	dialTimeout   time.Duration
-	listenAddress string
-	peerService   string
-	retryTimeout  time.Duration
+	debug                  bool
+	pprof                  bool
+	gops                   bool
+	dialTimeout            time.Duration
+	listenAddress          string
+	peerService            string
+	retryTimeout           time.Duration
+	sortBufferMaxLen       int
+	sortBufferDrainTimeout time.Duration
 }
 
 // New creates a new serve command.
@@ -75,6 +77,14 @@ func New() *cobra.Command {
 		&f.peerService, "peer-service",
 		relayoption.Default.HubbleTarget,
 		"Address of the server that implements the peer gRPC service")
+	cmd.Flags().IntVar(
+		&f.sortBufferMaxLen, "sort-buffer-len-max",
+		relayoption.Default.SortBufferMaxLen,
+		"Max number of flows that can be buffered for sorting before being sent to the client (per request)")
+	cmd.Flags().DurationVar(
+		&f.sortBufferDrainTimeout, "sort-buffer-drain-timeout",
+		relayoption.Default.SortBufferDrainTimeout,
+		"When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode)")
 	return cmd
 }
 
@@ -84,6 +94,8 @@ func runServe(f flags) error {
 		relayoption.WithHubbleTarget(f.peerService),
 		relayoption.WithListenAddress(f.listenAddress),
 		relayoption.WithRetryTimeout(f.retryTimeout),
+		relayoption.WithSortBufferMaxLen(f.sortBufferMaxLen),
+		relayoption.WithSortBufferDrainTimeout(f.sortBufferDrainTimeout),
 	}
 	if f.debug {
 		opts = append(opts, relayoption.WithDebug())

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -45,6 +45,12 @@ spec:
 {{- if .Values.retryTimeout }}
             - "--retry-timeout={{ .Values.retryTimeout }}"
 {{- end }}
+{{- if .Values.sortBufferLenMax }}
+            - "--sort-buffer-len-max={{ .Values.sortBufferLenMax }}"
+{{- end }}
+{{- if .Values.sortBufferDrainTimeout }}
+            - "--sort-buffer-drain-timeout={{ .Values.sortBufferDrainTimeout }}"
+{{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.listenPort }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -25,5 +25,13 @@ dialTimeout: ~
 # Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
 retryTimeout: ~
 
+# Max number of flows that can be buffered for sorting before being sent to the
+# client (per request) (e.g. 100).
+sortBufferLenMax: ~
+
+# When the per-request flows sort buffer is not full, a flow is drained every
+# time this timeout is reached (only affects requests in follow-mode) (e.g. "1s").
+sortBufferDrainTimeout: ~
+
 # Port to use for the k8s service backed by hubble-relay pods.
 servicePort: 80

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -62,6 +62,14 @@ hubble-relay:
   # # Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
   # retryTimeout: ~
   #
+  # Max number of flows that can be buffered for sorting before being sent to
+  # the client (per request) (e.g. 100).
+  # sortBufferLenMax: ~
+  #
+  # When the per-request flows sort buffer is not full, a flow is drained every
+  # time this timeout is reached (only affects requests in follow-mode)
+  # sortBufferDrainTimeout: ~
+  #
   # # Port to use for the k8s service backed by hubble-relay pods.
   # servicePort: 80
 

--- a/pkg/hubble/relay/observer.go
+++ b/pkg/hubble/relay/observer.go
@@ -237,7 +237,7 @@ func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, stream observerpb.Obs
 	}()
 
 	peers := s.peerList()
-	qlen := s.opts.BufferMaxLen // we don't want to buffer too many flows
+	qlen := s.opts.SortBufferMaxLen // we don't want to buffer too many flows
 	if nqlen := req.GetNumber() * uint64(len(peers)); nqlen > 0 && nqlen < uint64(qlen) {
 		// don't make the queue bigger than necessary as it would be a problem
 		// with the priority queue (we pop out when the queue is full)
@@ -283,7 +283,7 @@ func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, stream observerpb.Obs
 	}()
 
 	aggregated := aggregateErrors(ctx, flows, s.opts.ErrorAggregationWindow)
-	sortedFlows := sortFlows(ctx, aggregated, qlen, s.opts.BufferDrainTimeout)
+	sortedFlows := sortFlows(ctx, aggregated, qlen, s.opts.SortBufferDrainTimeout)
 
 	// inform the client about the nodes from which we expect to receive flows first
 	if len(connectedNodes) > 0 {

--- a/pkg/hubble/relay/relayoption/defaults.go
+++ b/pkg/hubble/relay/relayoption/defaults.go
@@ -30,7 +30,7 @@ var Default = Options{
 	ListenAddress: fmt.Sprintf(":%d", hubbledefaults.RelayPort),
 	Debug:         false,
 
-	BufferMaxLen:           100,
-	BufferDrainTimeout:     1 * time.Second,
+	SortBufferMaxLen:       100,
+	SortBufferDrainTimeout: 1 * time.Second,
 	ErrorAggregationWindow: 10 * time.Second,
 }

--- a/pkg/hubble/relay/relayoption/option.go
+++ b/pkg/hubble/relay/relayoption/option.go
@@ -28,8 +28,8 @@ type Options struct {
 	ListenAddress string
 	Debug         bool
 
-	BufferMaxLen           int
-	BufferDrainTimeout     time.Duration
+	SortBufferMaxLen       int
+	SortBufferDrainTimeout time.Duration
 	ErrorAggregationWindow time.Duration
 }
 
@@ -82,34 +82,34 @@ func WithDebug() Option {
 	}
 }
 
-// WithBufferMaxLen sets the maximum number of flows that can be buffered
-// before being sent to the client. This affects operations such as flows
-// sorting. The provided value must be greater than 0 and is to be understood
-// per client request. Therefore, it is advised to keep the value moderate (a
-// value between 30 and 100 should constitute a good choice in most cases).
-func WithBufferMaxLen(i int) Option {
+// WithSortBufferMaxLen sets the maximum number of flows that can be buffered
+// for sorting before being sent to the client. The provided value must be
+// greater than 0 and is to be understood per client request. Therefore, it is
+// advised to keep the value moderate (a value between 30 and 100 should
+// constitute a good choice in most cases).
+func WithSortBufferMaxLen(i int) Option {
 	return func(o *Options) error {
 		if i <= 0 {
-			return fmt.Errorf("value for BufferMaxLen must be greater than 0: %d", i)
+			return fmt.Errorf("value for SortBufferMaxLen must be greater than 0: %d", i)
 		}
-		o.BufferMaxLen = i
+		o.SortBufferMaxLen = i
 		return nil
 	}
 }
 
-// WithBufferDrainTimeout sets the buffer drain timeout value. For flows
-// requests where the total number of flows cannot be determined (typically for
-// flows requests in follow mode), a flow is taken out of the buffer and sent
-// to the client after duration d if the buffer is not full. This value must be
-// greater than 0. Setting this value too low would render the flows sorting
-// operation ineffective. A value between 500 milliseconds and 3 seconds should
-// be constitute a good choice in most cases.
-func WithBufferDrainTimeout(d time.Duration) Option {
+// WithSortBufferDrainTimeout sets the sort buffer drain timeout value. For
+// flows requests where the total number of flows cannot be determined
+// (typically for flows requests in follow mode), a flow is taken out of the
+// buffer and sent to the client after duration d if the buffer is not full.
+// This value must be greater than 0. Setting this value too low would render
+// the flows sorting operation ineffective. A value between 500 milliseconds
+// and 3 seconds should be constitute a good choice in most cases.
+func WithSortBufferDrainTimeout(d time.Duration) Option {
 	return func(o *Options) error {
 		if d <= 0 {
-			return fmt.Errorf("value for BufferDrainTimeout must be greater than 0: %d", d)
+			return fmt.Errorf("value for SortBufferDrainTimeout must be greater than 0: %d", d)
 		}
-		o.BufferDrainTimeout = d
+		o.SortBufferDrainTimeout = d
 		return nil
 	}
 }


### PR DESCRIPTION
This PR adds new Hubble Relay options to allow for configuring flows sorting options. While there, rename options to `SortBuffer...` as this is more descriptive than just `Buffer...`.