### PR TITLE
k8s,node: Fix init of labels with Operator IPAM

### DIFF
--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -215,6 +215,7 @@ func GetNodeSpec() error {
 
 		log.WithFields(logrus.Fields{
 			logfields.NodeName:         n.Name,
+			logfields.Labels:           logfields.Repr(n.Labels),
 			logfields.IPAddr + ".ipv4": nodeIP4,
 			logfields.IPAddr + ".ipv6": nodeIP6,
 			logfields.V4Prefix:         n.IPv4AllocCIDR,

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -52,6 +52,7 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node Node) {
 		Cluster:       option.Config.ClusterName,
 		ClusterID:     option.Config.ClusterID,
 		Source:        source.CustomResource,
+		Labels:        n.ObjectMeta.Labels,
 	}
 
 	for _, cidrString := range n.Spec.IPAM.PodCIDRs {
@@ -112,7 +113,8 @@ func (n *Node) ToCiliumNode() *ciliumv2.CiliumNode {
 
 	return &ciliumv2.CiliumNode{
 		ObjectMeta: v1.ObjectMeta{
-			Name: n.Name,
+			Name:   n.Name,
+			Labels: n.Labels,
 		},
 		Spec: ciliumv2.NodeSpec{
 			Addresses: ipAddrs,

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -132,6 +132,7 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.IPv6AllocCIDR = node.GetIPv6AllocRange()
 	n.LocalNode.ClusterID = option.Config.ClusterID
 	n.LocalNode.EncryptionKey = node.GetIPsecKeyIdentity()
+	n.LocalNode.Labels = node.GetLabels()
 
 	if node.GetExternalIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
@@ -291,6 +292,8 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
 		typesNode := nodeInterface.(*k8sTypes.Node)
 		k8sNodeParsed := k8s.ParseNode(typesNode, source.Unspec)
 		k8sNodeAddresses = k8sNodeParsed.IPAddresses
+
+		nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels
 
 		for _, k8sAddress := range k8sNodeAddresses {
 			k8sAddressStr := k8sAddress.IP.String()


### PR DESCRIPTION
When using the Operator IPAM, the node labels are not properly initialized simply because the labels are not copied from K8s nodes to `CiliumNode` objects and vice-versa. This commit fixes it.

Fixes: #11659

```release-note
Fix node label initialization with Operator IPAM
```
