### PR TITLE
Add missing Node annotations in documentation

### DIFF
--- a/Documentation/concepts/networking/ipam/kubernetes.rst
+++ b/Documentation/concepts/networking/ipam/kubernetes.rst
@@ -37,12 +37,16 @@ Field                Description
 
 **via v1.Node annotation**
 
-=================================== ============================================================
-Annotation                          Description
-=================================== ============================================================
-``io.cilium.network.ipv4-pod-cidr`` IPv4 PodCIDR range
-``io.cilium.network.ipv6-pod-cidr`` IPv6 PodCIDR range
-=================================== ============================================================
+====================================== ==========================================================
+Annotation                             Description
+====================================== ==========================================================
+``io.cilium.network.ipv4-pod-cidr``    IPv4 PodCIDR range
+``io.cilium.network.ipv6-pod-cidr``    IPv6 PodCIDR range
+``io.cilium.network.ipv4-cilium-host`` IPv4 address of the cilium host interface
+``io.cilium.network.ipv6-cilium-host`` IPv6 address of the cilium host interface
+``io.cilium.network.ipv4-health-ip``   IPv4 address of the cilium-health endpoint
+``io.cilium.network.ipv6-health-ip``   IPv6 address of the cilium-health endpoint
+====================================== ==========================================================
 
 .. note:: The annotation-based mechanism is primarily useful in combination with
 	  older Kubernetes versions which do not support ``spec.podCIDRs`` yet


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

<!-- Description of change -->

Adds `io.cilium.network.ipvn-cilium-host` and `io.cilium.network.ipvn-health-ip` annotations since they are visible on k8s nodes.

https://github.com/cilium/cilium/blob/ba9031bb45a0da79ee3a843a8c9b50807d0e40be/pkg/annotation/k8s.go#L33-L46.

Signed-off-by: David Bouchare <david.bouchare@datadoghq.com>