### PR TITLE
docs(operator): Update coredns plugin from proxy to forward

### DIFF
--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -116,25 +116,50 @@ reverse lookup on a pod IP must map back to pod name. If you are using CoreDNS,
 check the CoreDNS ConfigMap and validate that ``in-addr.arpa`` and ``ip6.arpa``
 are listed as wildcards for the kubernetes block like this:
 
-::
+    .. tabs::
+        .. group-tab:: Kubernetes 1.16+
 
-    kubectl -n kube-system edit cm coredns
-    [...]
-    apiVersion: v1
-    data:
-      Corefile: |
-        .:53 {
-            errors
-            health
-            kubernetes cluster.local in-addr.arpa ip6.arpa {
-              pods insecure
-              upstream
-              fallthrough in-addr.arpa ip6.arpa
-            }
-            prometheus :9153
-            proxy . /etc/resolv.conf
-            cache 30
-        }
+            ::
+
+                kubectl -n kube-system edit cm coredns
+                [...]
+                apiVersion: v1
+                data:
+                  Corefile: |
+                    .:53 {
+                        errors
+                        health
+                        kubernetes cluster.local in-addr.arpa ip6.arpa {
+                          pods insecure
+                          upstream
+                          fallthrough in-addr.arpa ip6.arpa
+                        }
+                        prometheus :9153
+                        forward . /etc/resolv.conf
+                        cache 30
+                    }
+
+        .. group-tab:: Kubernetes < 1.16
+
+            ::
+
+                kubectl -n kube-system edit cm coredns
+                [...]
+                apiVersion: v1
+                data:
+                  Corefile: |
+                    .:53 {
+                        errors
+                        health
+                        kubernetes cluster.local in-addr.arpa ip6.arpa {
+                          pods insecure
+                          upstream
+                          fallthrough in-addr.arpa ip6.arpa
+                        }
+                        prometheus :9153
+                        proxy . /etc/resolv.conf
+                        cache 30
+                    }
 
 The contents can look different than the above. The specific configuration that
 matters is to make sure that ``in-addr.arpa`` and ``ip6.arpa`` are listed as


### PR DESCRIPTION
Going forward from k8s 1.16, forward proxy is preferred way in
coredns.

This update to reflect the majority of k8s version going
forward.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
docs(operator): Update coredns plugin from proxy to forward
```
