### PR TITLE
chore(docker): Bump json-mock version to 1.2 for dual stack

### DIFF
--- a/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
           exec:
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -99,7 +99,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         env:
         - name: PORT

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
           exec:
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -99,7 +99,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         env:
         - name: PORT

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
           exec:
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -99,7 +99,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         env:
         - name: PORT

--- a/examples/kubernetes/connectivity-check/echo-a.yaml
+++ b/examples/kubernetes/connectivity-check/echo-a.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
           exec:

--- a/examples/kubernetes/connectivity-check/echo-b.yaml
+++ b/examples/kubernetes/connectivity-check/echo-b.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -65,7 +65,7 @@ spec:
       hostNetwork: true
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.0
+        image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         env:
         - name: PORT

--- a/examples/policies/kubernetes/namespace/demo-pods.yaml
+++ b/examples/policies/kubernetes/namespace/demo-pods.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: leia-container
-        image: docker.io/cilium/json-mock
+        image: docker.io/cilium/json-mock:1.2
 ---
 apiVersion: v1
 kind: Service
@@ -50,7 +50,7 @@ metadata:
 spec:
   containers:
   - name: luke-container
-    image: docker.io/cilium/json-mock
+    image: docker.io/cilium/json-mock:1.2
 ---
 apiVersion: v1
 kind: Pod
@@ -62,4 +62,4 @@ metadata:
 spec:
   containers:
   - name: vader-container
-    image: docker.io/cilium/json-mock
+    image: docker.io/cilium/json-mock:1.2

--- a/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
+++ b/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: leia
       containers:
       - name: leia-container
-        image: docker.io/cilium/json-mock
+        image: docker.io/cilium/json-mock:1.2
 ---
 apiVersion: v1
 kind: Service
@@ -51,7 +51,7 @@ spec:
   serviceAccountName: luke
   containers:
   - name: luke-container
-    image: docker.io/cilium/json-mock
+    image: docker.io/cilium/json-mock:1.2
 ---
 apiVersion: v1
 kind: Pod
@@ -61,4 +61,4 @@ spec:
   serviceAccountName: vader
   containers:
   - name: vader-container
-    image: docker.io/cilium/json-mock
+    image: docker.io/cilium/json-mock:1.2


### PR DESCRIPTION
As discussed on slack, json-mock docker image didn't support for dual stack. 

Bump json-mock version to 1.2 for dual stack

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
chore(docker): Bump json-mock version to 1.2 for dual stack
```
