### PR TITLE
test: Use smaller, updated docker images

### DIFF
--- a/examples/kubernetes-grpc/Dockerfile
+++ b/examples/kubernetes-grpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as builder
+FROM docker.io/library/ubuntu:20.04 as builder
 
 # Install dependencies
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -y \
     apache2 \
     curl \
     git \
-    libapache2-mod-php7.2 \
-    php7.2 \
-    php7.2-mysql \
+    libapache2-mod-php7.4 \
+    php7.4 \
+    php7.4-mysql \
     python3.4 \
     python3-pip
 RUN pip3 install grpcio grpcio-tools
@@ -27,7 +27,7 @@ RUN python3 -m grpc_tools.protoc \
     --grpc_python_out=. \
     ../../../examples/protos/cloudcity.proto
 
-FROM ubuntu:18.04
+FROM docker.io/library/ubuntu:20.04
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/examples/kubernetes-grpc/cc-door-app.yaml
+++ b/examples/kubernetes-grpc/cc-door-app.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: cc-door-mgr
-        image: docker.io/cilium/cc-grpc-demo:v2.0
+        image: docker.io/cilium/cc-grpc-demo:v3.0
         imagePullPolicy: IfNotPresent
         command: ["python3"]
         args: ["/cloudcity/cc_door_server.py"]
@@ -64,7 +64,7 @@ metadata:
 spec:
   containers:
   - name: cc-door-client
-    image: docker.io/cilium/cc-grpc-demo:v2.0
+    image: docker.io/cilium/cc-grpc-demo:v3.0
     imagePullPolicy: IfNotPresent
     command: ["sleep"]
     args: ["300000"]

--- a/examples/kubernetes-memcached/memcd-sw-app.yaml
+++ b/examples/kubernetes-memcached/memcd-sw-app.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: starfighter
-        image: cilium/python-bmemcached
+        image: docker.io/cilium/python-bmemcached:v0.0.2
         command: ["sleep"]
         args: ["30000"]
 ---
@@ -91,6 +91,6 @@ spec:
     spec:
       containers:
       - name: starfigher
-        image: cilium/python-bmemcached
+        image: docker.io/cilium/python-bmemcached:v0.0.2
         command: ["sleep"]
         args: ["30000"]

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -22,7 +22,7 @@ const (
 	HttpdImage = "docker.io/cilium/demo-httpd:latest"
 
 	// DNSSECContainerImage is the image used for starting a DNSSec client.
-	DNSSECContainerImage = "docker.io/cilium/dnssec-client:v0.1"
+	DNSSECContainerImage = "docker.io/cilium/dnssec-client:v0.2"
 
 	// BindContainerImage is the image used for DNS binding testing.
 	BindContainerImage = "docker.io/cilium/docker-bind:v0.3"
@@ -43,7 +43,7 @@ const (
 	MemcacheDImage = "docker.io/library/memcached:1.5.11"
 
 	// MemcacheBinClient is the image used during binary memcached parser tests.
-	MemcacheBinClient = "docker.io/cilium/python-bmemcached:v0.0.1"
+	MemcacheBinClient = "docker.io/cilium/python-bmemcached:v0.0.2"
 
 	// AlpineImage is used during the memcached tests as the text client.
 	AlpineImage = "docker.io/library/alpine:3.9"


### PR DESCRIPTION
The `dnssec-client` and `python-bmemcached` images have been updated as shown in cilium/dnssec-client#1 and cilium/python-bmemcached#1 respectively. The `cc-grpc-demo` image has been updated as per the first commit in this PR.

Updates: cilium/packer-ci-build#227