### PR TITLE
Fix etcd failure behavior when user or client context ends

### DIFF
--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -350,10 +350,8 @@ func (c *CNPStatusUpdateContext) updateViaKVStore(ctx context.Context, cnp *type
 		annotations map[string]string
 	)
 
-	select {
-	case <-kvstore.Client().Connected(ctx):
-	case <-ctx.Done():
-		return ctx.Err()
+	if err := <-kvstore.Client().Connected(ctx); err != nil {
+		return nil
 	}
 
 	capabilities := k8sversion.Capabilities()

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -15,7 +15,6 @@
 package watchers
 
 import (
-	"context"
 	"net"
 	"sync"
 
@@ -97,7 +96,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, as
 		k.k8sAPIGroups.addAPI(k8sAPIGroupCiliumEndpointV2)
 		go ciliumEndpointInformer.Run(isConnected)
 
-		<-kvstore.Client().Connected(context.TODO())
+		<-kvstore.Connected()
 		close(isConnected)
 
 		log.Info("Connected to key-value store, stopping CiliumEndpoint watcher")

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -15,7 +15,6 @@
 package watchers
 
 import (
-	"context"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/k8s"
@@ -102,7 +101,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 		k.k8sAPIGroups.addAPI(k8sAPIGroupCiliumNodeV2)
 		go ciliumNodeInformer.Run(isConnected)
 
-		<-kvstore.Client().Connected(context.TODO())
+		<-kvstore.Connected()
 		close(isConnected)
 
 		log.Info("Connected to key-value store, stopping CiliumNode watcher")

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -15,7 +15,6 @@
 package watchers
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -164,8 +163,7 @@ func (k *K8sWatcher) podsInit(k8sClient kubernetes.Interface, asyncControllers *
 
 		// Replace pod controller by only receiving events from our own
 		// node once we are connected to the kvstore.
-
-		<-kvstore.Client().Connected(context.TODO())
+		<-kvstore.Connected()
 		close(isConnected)
 
 		log.WithField(logfields.Node, nodeTypes.GetName()).Info("Connected to KVStore, watching for pod events on node")

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -130,8 +130,8 @@ func getBackend(name string) backendModule {
 // tracing layer.
 type BackendOperations interface {
 	// Connected returns a channel which is closed whenever the kvstore client
-	// is connected to the kvstore server. (Only implemented for etcd)
-	Connected(ctx context.Context) <-chan struct{}
+	// is connected to the kvstore server.
+	Connected(ctx context.Context) <-chan error
 
 	// Disconnected returns a channel which is closed whenever the kvstore
 	// client is not connected to the kvstore server. (Only implemented for etcd)

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -421,8 +421,8 @@ func (c *consulClient) waitForInitLock(ctx context.Context) <-chan struct{} {
 }
 
 // Connected closes the returned channel when the consul client is connected.
-func (c *consulClient) Connected(ctx context.Context) <-chan struct{} {
-	ch := make(chan struct{})
+func (c *consulClient) Connected(ctx context.Context) <-chan error {
+	ch := make(chan error)
 	go func() {
 		for {
 			qo := &consulAPI.QueryOptions{}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -428,6 +428,9 @@ func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) error {
 	select {
 	// Wait for the the initial connection to be established
 	case <-e.firstSession:
+	// Client is closing
+	case <-e.client.Ctx().Done():
+		return fmt.Errorf("client is closing")
 	// Timeout while waiting for initial connection, no success
 	case <-ctxTimeout.Done():
 		recordQuorumError("timeout")

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -385,6 +385,10 @@ func (e *etcdClient) waitForInitLock(ctx context.Context) <-chan bool {
 	go func() {
 		for {
 			select {
+			case <-e.client.Ctx().Done():
+				initLockSucceeded <- false
+				close(initLockSucceeded)
+				return
 			case <-ctx.Done():
 				initLockSucceeded <- false
 				close(initLockSucceeded)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -815,6 +815,14 @@ func (e *etcdClient) Watch(ctx context.Context, w *Watcher) {
 
 reList:
 	for {
+		select {
+		case <-e.client.Ctx().Done():
+			return
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		e.limiter.Wait(ctx)
 		res, err := e.client.Get(ctx, w.prefix, client.WithPrefix(),
 			client.WithSerializable())
@@ -880,6 +888,10 @@ reList:
 			client.WithPrefix(), client.WithRev(nextRev))
 		for {
 			select {
+			case <-e.client.Ctx().Done():
+				return
+			case <-ctx.Done():
+				return
 			case <-w.stopWatch:
 				close(w.Events)
 				w.stopWait.Done()


### PR DESCRIPTION
Several code paths which are blocking on other channels or waiting for certain conditions to be met do not properly respect the user and client context to abort.

The most serious consequence can be endless loops attempting to retry an etcd operation forever.