### PR TITLE
docs: Clarify that identity transfer is an optimization

### DIFF
--- a/Documentation/concepts/networking/routing.rst
+++ b/Documentation/concepts/networking/routing.rst
@@ -60,8 +60,7 @@ Auto-configuration
 Identity context
   Encapsulation protocols allow for the carrying of metadata along with the
   network packet. Cilium makes use of this ability to transfer metadata such as
-  the source security identity and load balancing state to perform
-  direct-server-return (DSR).
+  the source security identity.
 
 
 Disadvantages of the model

--- a/Documentation/concepts/networking/routing.rst
+++ b/Documentation/concepts/networking/routing.rst
@@ -60,7 +60,8 @@ Auto-configuration
 Identity context
   Encapsulation protocols allow for the carrying of metadata along with the
   network packet. Cilium makes use of this ability to transfer metadata such as
-  the source security identity.
+  the source security identity. The identity transfer is an optimization
+  designed to avoid one identity lookup on the remote node.
 
 
 Disadvantages of the model


### PR DESCRIPTION
This small change should clarify that the identity transfer in overlay mode is an optimization and not a requirement. We have had several users confused by this paragraph asking how security identity was obtained in direct routing mode.
