### PR TITLE
cmd: Allow to filter metrics with regexp

### DIFF
--- a/Documentation/cmdref/cilium_metrics_list.md
+++ b/Documentation/cmdref/cilium_metrics_list.md
@@ -15,8 +15,9 @@ cilium metrics list [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   json| jsonpath='{}'
+  -h, --help                   help for list
+  -p, --match-pattern string   Show only metrics whose names match matchpattern
+  -o, --output string          json| jsonpath='{}'
 ```
 
 ### Options inherited from parent commands

--- a/cilium/cmd/metrics_list.go
+++ b/cilium/cmd/metrics_list.go
@@ -3,12 +3,16 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/spf13/cobra"
 )
+
+var matchPattern string
 
 // MetricsListCmd dumps all metrics into stdout
 var MetricsListCmd = &cobra.Command{
@@ -20,8 +24,20 @@ var MetricsListCmd = &cobra.Command{
 			Fatalf("Cannot get metrics list: %s", err)
 		}
 
+		re, err := regexp.Compile(matchPattern)
+		if err != nil {
+			Fatalf("Cannot compile regex: %s", err)
+		}
+
+		metrics := make([]*models.Metric, 0, len(res.Payload))
+		for _, metric := range res.Payload {
+			if re.MatchString(metric.Name) {
+				metrics = append(metrics, metric)
+			}
+		}
+
 		if command.OutputJSON() {
-			if err := command.PrintOutput(res.Payload); err != nil {
+			if err := command.PrintOutput(metrics); err != nil {
 				os.Exit(1)
 			}
 			return
@@ -30,7 +46,7 @@ var MetricsListCmd = &cobra.Command{
 		w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
 
 		fmt.Fprintln(w, "Metric\tLabels\tValue")
-		for _, metric := range res.Payload {
+		for _, metric := range metrics {
 			label := ""
 			if len(metric.Labels) > 0 {
 				labelArray := []string{}
@@ -48,5 +64,6 @@ var MetricsListCmd = &cobra.Command{
 
 func init() {
 	metricsCmd.AddCommand(MetricsListCmd)
+	MetricsListCmd.Flags().StringVarP(&matchPattern, "match-pattern", "p", "", "Show only metrics whose names match matchpattern")
 	command.AddJSONOutput(MetricsListCmd)
 }


### PR DESCRIPTION
This change adds the --matchpattern/-p argument to the `cilium metrics
list` commands which allows to filter metrics by names.

Example:

```
$ cilium metrics list -p nodes
Metric                                        Labels                                Value
cilium_nodes_all_datapath_validations_total                                         37.000000
cilium_nodes_all_events_received_total        eventType="add" source="kvstore"      1.000000
cilium_nodes_all_events_received_total        eventType="add" source="local"        1.000000
cilium_nodes_all_events_received_total        source="kvstore" eventType="update"   4.000000
cilium_nodes_all_num                                                                2.000000
cilium_unreachable_nodes                                                            1.000000
```

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

```release-note
cmd: Allow to filter metrics with regexp
```
