### PR TITLE
k8s/watchers: stop init of local endpoint in success case

### DIFF
--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -167,16 +167,17 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 							return err
 						}
 
-						needInit = false
-
 						// continue the execution so we update the endpoint
 						// status immediately upon endpoint creation
 					case err != nil:
 						scopedLog.WithError(err).Warn("Error getting CEP")
 						return err
 					default:
-
 					}
+
+					// We return earlier for all error cases so we don't need
+					// to init the local endpoint in non-error cases.
+					needInit = false
 				}
 
 				// We have no localCEP copy. We need to fetch it for updates, below.


### PR DESCRIPTION
If we can get a local copy of the CEP we no longer need to keep getting
it from Kubernetes.

Fixes: 469475ba4f0b ("watchers/endpointsynchronizer: do not delete CEP on initialization")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
avoid performing useless GETs of Cilium Endpoints
```
