### PR TITLE
Replace use of github.com/pkg/errors and golang.org/x/xerrors with Go stdlib functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/c9s/goprocinfo v0.0.0-20190309065803-0b2ad9ac246b
 	github.com/cilium/arping v1.0.1-0.20190728065459-c5eaf8d7a710
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
-	github.com/cilium/ebpf v0.0.0-20200612163523-d7bee28bad96
+	github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
 	github.com/cilium/ipam v0.0.0-20200420133938-2f672ef3ad54
 	github.com/cilium/proxy v0.0.0-20200710041639-052d54ab9c88
 	github.com/containernetworking/cni v0.7.1

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/optiopay/kafka v0.0.0-00010101000000-000000000000
 	github.com/pborman/uuid v1.2.0
-	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.2.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7Al
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e/go.mod h1:c4R5wxGyXhbM6zyKeRKNIc9aab5EZi4z4oOSZvUMvZA=
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3 h1:wenYMyWJ08dgEUUj0Ija8qdK/V9vL3ThAD5sjOYlFlg=
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3/go.mod h1:cXN7jgo+gsGlNvQ7Vqu2ELdc3f7i7PPgupHqSkLzzBo=
-github.com/cilium/ebpf v0.0.0-20200612163523-d7bee28bad96 h1:nRVsLliaPVzNAjotxTdn8fNc7nu1ZMsTRirpoppfmFw=
-github.com/cilium/ebpf v0.0.0-20200612163523-d7bee28bad96/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=
+github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775 h1:cHzBGGVew0ezFsq2grfy2RsB8hO/eNyBgOLHBCqfR1U=
+github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
 github.com/cilium/ipam v0.0.0-20200420133938-2f672ef3ad54 h1:YOrdErbkc+X+6wflk5idOHZ1IJtLNr3Vnz8JlznG0VI=
 github.com/cilium/ipam v0.0.0-20200420133938-2f672ef3ad54/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -28,8 +28,6 @@ import (
 	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-
-	"github.com/pkg/errors"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-azure")
@@ -55,7 +53,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 		log.Debug("SubscriptionID was not specified via CLI, retrieving it via Azure IMS")
 		subID, err := azureAPI.GetSubscriptionID(context.TODO())
 		if err != nil {
-			return nil, errors.Wrap(err, "Azure subscription ID was not specified via CLI and retrieving it from the Azure IMS was not possible")
+			return nil, fmt.Errorf("Azure subscription ID was not specified via CLI and retrieving it from the Azure IMS was not possible: %w", err)
 		}
 		subscriptionID = subID
 		log.WithField("subscriptionID", subscriptionID).Debug("Detected subscriptionID via Azure IMS")
@@ -66,7 +64,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 		log.Debug("ResourceGroupName was not specified via CLI, retrieving it via Azure IMS")
 		rgName, err := azureAPI.GetResourceGroupName(context.TODO())
 		if err != nil {
-			return nil, errors.Wrap(err, "Azure resource group name was not specified via CLI and retrieving it from the Azure IMS was not possible")
+			return nil, fmt.Errorf("Azure resource group name was not specified via CLI and retrieving it from the Azure IMS was not possible: %w", err)
 		}
 		resourceGroupName = rgName
 		log.WithField("resourceGroupName", resourceGroupName).Debug("Detected resource group name via Azure IMS")

--- a/pkg/monitor/agent/monitor.go
+++ b/pkg/monitor/agent/monitor.go
@@ -16,6 +16,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"time"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -194,7 +194,7 @@ func (m *Monitor) handleEvents(stopCtx context.Context) {
 				m.Unlock()
 			} else {
 				scopedLog.WithError(err).Warn("Error received while reading from perf buffer")
-				if errors.Cause(err) == unix.EBADFD {
+				if errors.Is(err, unix.EBADFD) {
 					return
 				}
 			}

--- a/pkg/mtu/detect_linux.go
+++ b/pkg/mtu/detect_linux.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -40,7 +39,7 @@ func getRoute(externalProbe string) ([]netlink.Route, error) {
 
 	routes, err := netlink.RouteGet(ip)
 	if err != nil {
-		return nil, fmt.Errorf("unable to lookup route to %s: %s", externalProbe, err)
+		return nil, fmt.Errorf("unable to lookup route to %s: %w", externalProbe, err)
 	}
 
 	if len(routes) == 0 {
@@ -69,7 +68,7 @@ func autoDetect() (int, error) {
 
 	link, err := netlink.LinkByIndex(routes[0].LinkIndex)
 	if err != nil {
-		return 0, fmt.Errorf("unable to find interface of default route: %s", err)
+		return 0, fmt.Errorf("unable to find interface of default route: %w", err)
 	}
 
 	if mtu := link.Attrs().MTU; mtu != 0 {
@@ -84,7 +83,7 @@ func autoDetect() (int, error) {
 func getMTUFromIf(ip net.IP) (int, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return 0, errors.Wrap(err, "Unable to list interfaces")
+		return 0, fmt.Errorf("unable to list interfaces: %w", err)
 	}
 
 	for _, iface := range ifaces {

--- a/vendor/github.com/cilium/ebpf/abi.go
+++ b/vendor/github.com/cilium/ebpf/abi.go
@@ -3,14 +3,13 @@ package ebpf
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"syscall"
 
 	"github.com/cilium/ebpf/internal"
-
-	"golang.org/x/xerrors"
 )
 
 // MapABI are the attributes of a Map which are available across all supported kernels.
@@ -35,7 +34,7 @@ func newMapABIFromSpec(spec *MapSpec) *MapABI {
 func newMapABIFromFd(fd *internal.FD) (string, *MapABI, error) {
 	info, err := bpfGetMapInfoByFD(fd)
 	if err != nil {
-		if xerrors.Is(err, syscall.EINVAL) {
+		if errors.Is(err, syscall.EINVAL) {
 			abi, err := newMapABIFromProc(fd)
 			return "", abi, err
 		}
@@ -98,7 +97,7 @@ func newProgramABIFromSpec(spec *ProgramSpec) *ProgramABI {
 func newProgramABIFromFd(fd *internal.FD) (string, *ProgramABI, error) {
 	info, err := bpfGetProgInfoByFD(fd)
 	if err != nil {
-		if xerrors.Is(err, syscall.EINVAL) {
+		if errors.Is(err, syscall.EINVAL) {
 			return newProgramABIFromProc(fd)
 		}
 
@@ -127,7 +126,7 @@ func newProgramABIFromProc(fd *internal.FD) (string, *ProgramABI, error) {
 		"prog_type": &abi.Type,
 		"prog_tag":  &name,
 	})
-	if xerrors.Is(err, errMissingFields) {
+	if errors.Is(err, errMissingFields) {
 		return "", nil, &internal.UnsupportedFeatureError{
 			Name:           "reading ABI from /proc/self/fdinfo",
 			MinimumVersion: internal.Version{4, 11, 0},
@@ -153,12 +152,12 @@ func scanFdInfo(fd *internal.FD, fields map[string]interface{}) error {
 	defer fh.Close()
 
 	if err := scanFdInfoReader(fh, fields); err != nil {
-		return xerrors.Errorf("%s: %w", fh.Name(), err)
+		return fmt.Errorf("%s: %w", fh.Name(), err)
 	}
 	return nil
 }
 
-var errMissingFields = xerrors.New("missing fields")
+var errMissingFields = errors.New("missing fields")
 
 func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 	var (
@@ -179,7 +178,7 @@ func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 		}
 
 		if n, err := fmt.Fscanln(bytes.NewReader(parts[1]), field); err != nil || n != 1 {
-			return xerrors.Errorf("can't parse field %s: %v", name, err)
+			return fmt.Errorf("can't parse field %s: %v", name, err)
 		}
 
 		scanned++

--- a/vendor/github.com/cilium/ebpf/elf_reader.go
+++ b/vendor/github.com/cilium/ebpf/elf_reader.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -13,8 +15,6 @@ import (
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 type elfCode struct {
@@ -35,7 +35,7 @@ func LoadCollectionSpec(file string) (*CollectionSpec, error) {
 
 	spec, err := LoadCollectionSpecFromReader(f)
 	if err != nil {
-		return nil, xerrors.Errorf("file %s: %w", file, err)
+		return nil, fmt.Errorf("file %s: %w", file, err)
 	}
 	return spec, nil
 }
@@ -50,7 +50,7 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	symbols, err := f.Symbols()
 	if err != nil {
-		return nil, xerrors.Errorf("load symbols: %v", err)
+		return nil, fmt.Errorf("load symbols: %v", err)
 	}
 
 	ec := &elfCode{f, symbols, symbolsPerSection(symbols), "", 0}
@@ -79,13 +79,13 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 			dataSections[elf.SectionIndex(i)] = sec
 		case sec.Type == elf.SHT_REL:
 			if int(sec.Info) >= len(ec.Sections) {
-				return nil, xerrors.Errorf("found relocation section %v for missing section %v", i, sec.Info)
+				return nil, fmt.Errorf("found relocation section %v for missing section %v", i, sec.Info)
 			}
 
 			// Store relocations under the section index of the target
 			idx := elf.SectionIndex(sec.Info)
 			if relSections[idx] != nil {
-				return nil, xerrors.Errorf("section %d has multiple relocation sections", sec.Info)
+				return nil, fmt.Errorf("section %d has multiple relocation sections", sec.Info)
 			}
 			relSections[idx] = sec
 		case sec.Type == elf.SHT_PROGBITS && (sec.Flags&elf.SHF_EXECINSTR) != 0 && sec.Size > 0:
@@ -95,44 +95,52 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	ec.license, err = loadLicense(licenseSection)
 	if err != nil {
-		return nil, xerrors.Errorf("load license: %w", err)
+		return nil, fmt.Errorf("load license: %w", err)
 	}
 
 	ec.version, err = loadVersion(versionSection, ec.ByteOrder)
 	if err != nil {
-		return nil, xerrors.Errorf("load version: %w", err)
+		return nil, fmt.Errorf("load version: %w", err)
 	}
 
 	btfSpec, err := btf.LoadSpecFromReader(rd)
 	if err != nil {
-		return nil, xerrors.Errorf("load BTF: %w", err)
+		return nil, fmt.Errorf("load BTF: %w", err)
+	}
+
+	relocations, referencedSections, err := ec.loadRelocations(relSections)
+	if err != nil {
+		return nil, fmt.Errorf("load relocations: %w", err)
 	}
 
 	maps := make(map[string]*MapSpec)
 	if err := ec.loadMaps(maps, mapSections); err != nil {
-		return nil, xerrors.Errorf("load maps: %w", err)
+		return nil, fmt.Errorf("load maps: %w", err)
 	}
 
 	if len(btfMaps) > 0 {
 		if err := ec.loadBTFMaps(maps, btfMaps, btfSpec); err != nil {
-			return nil, xerrors.Errorf("load BTF maps: %w", err)
+			return nil, fmt.Errorf("load BTF maps: %w", err)
 		}
 	}
 
 	if len(dataSections) > 0 {
-		if err := ec.loadDataSections(maps, dataSections, btfSpec); err != nil {
-			return nil, xerrors.Errorf("load data sections: %w", err)
+		for idx := range dataSections {
+			if !referencedSections[idx] {
+				// Prune data sections which are not referenced by any
+				// instructions.
+				delete(dataSections, idx)
+			}
 		}
-	}
 
-	relocations, err := ec.loadRelocations(relSections)
-	if err != nil {
-		return nil, xerrors.Errorf("load relocations: %w", err)
+		if err := ec.loadDataSections(maps, dataSections, btfSpec); err != nil {
+			return nil, fmt.Errorf("load data sections: %w", err)
+		}
 	}
 
 	progs, err := ec.loadPrograms(progSections, relocations, btfSpec)
 	if err != nil {
-		return nil, xerrors.Errorf("load programs: %w", err)
+		return nil, fmt.Errorf("load programs: %w", err)
 	}
 
 	return &CollectionSpec{maps, progs}, nil
@@ -140,11 +148,12 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 func loadLicense(sec *elf.Section) (string, error) {
 	if sec == nil {
-		return "", xerrors.New("missing license section")
+		return "", nil
 	}
+
 	data, err := sec.Data()
 	if err != nil {
-		return "", xerrors.Errorf("section %s: %v", sec.Name, err)
+		return "", fmt.Errorf("section %s: %v", sec.Name, err)
 	}
 	return string(bytes.TrimRight(data, "\000")), nil
 }
@@ -156,12 +165,12 @@ func loadVersion(sec *elf.Section, bo binary.ByteOrder) (uint32, error) {
 
 	var version uint32
 	if err := binary.Read(sec.Open(), bo, &version); err != nil {
-		return 0, xerrors.Errorf("section %s: %v", sec.Name, err)
+		return 0, fmt.Errorf("section %s: %v", sec.Name, err)
 	}
 	return version, nil
 }
 
-func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, relocations map[elf.SectionIndex]map[uint64]elf.Symbol, btf *btf.Spec) (map[string]*ProgramSpec, error) {
+func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, relocations map[elf.SectionIndex]map[uint64]elf.Symbol, btfSpec *btf.Spec) (map[string]*ProgramSpec, error) {
 	var (
 		progs []*ProgramSpec
 		libs  []*ProgramSpec
@@ -170,35 +179,36 @@ func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, 
 	for idx, sec := range progSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return nil, xerrors.Errorf("section %v: missing symbols", sec.Name)
+			return nil, fmt.Errorf("section %v: missing symbols", sec.Name)
 		}
 
 		funcSym, ok := syms[0]
 		if !ok {
-			return nil, xerrors.Errorf("section %v: no label at start", sec.Name)
+			return nil, fmt.Errorf("section %v: no label at start", sec.Name)
 		}
 
 		insns, length, err := ec.loadInstructions(sec, syms, relocations[idx])
 		if err != nil {
-			return nil, xerrors.Errorf("program %s: can't unmarshal instructions: %w", funcSym.Name, err)
+			return nil, fmt.Errorf("program %s: can't unmarshal instructions: %w", funcSym.Name, err)
 		}
 
-		progType, attachType := getProgType(sec.Name)
+		progType, attachType, attachTo := getProgType(sec.Name)
 
 		spec := &ProgramSpec{
 			Name:          funcSym.Name,
 			Type:          progType,
 			AttachType:    attachType,
+			AttachTo:      attachTo,
 			License:       ec.license,
 			KernelVersion: ec.version,
 			Instructions:  insns,
 			ByteOrder:     ec.ByteOrder,
 		}
 
-		if btf != nil {
-			spec.BTF, err = btf.Program(sec.Name, length)
-			if err != nil {
-				return nil, xerrors.Errorf("BTF for section %s (program %s): %w", sec.Name, funcSym.Name, err)
+		if btfSpec != nil {
+			spec.BTF, err = btfSpec.Program(sec.Name, length)
+			if err != nil && !errors.Is(err, btf.ErrNoExtendedInfo) {
+				return nil, fmt.Errorf("program %s: %w", funcSym.Name, err)
 			}
 		}
 
@@ -216,7 +226,7 @@ func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, 
 	for _, prog := range progs {
 		err := link(prog, libs)
 		if err != nil {
-			return nil, xerrors.Errorf("program %s: %w", prog.Name, err)
+			return nil, fmt.Errorf("program %s: %w", prog.Name, err)
 		}
 		res[prog.Name] = prog
 	}
@@ -237,14 +247,14 @@ func (ec *elfCode) loadInstructions(section *elf.Section, symbols, relocations m
 			return insns, offset, nil
 		}
 		if err != nil {
-			return nil, 0, xerrors.Errorf("offset %d: %w", offset, err)
+			return nil, 0, fmt.Errorf("offset %d: %w", offset, err)
 		}
 
 		ins.Symbol = symbols[offset].Name
 
 		if rel, ok := relocations[offset]; ok {
 			if err = ec.relocateInstruction(&ins, rel); err != nil {
-				return nil, 0, xerrors.Errorf("offset %d: can't relocate instruction: %w", offset, err)
+				return nil, 0, fmt.Errorf("offset %d: can't relocate instruction: %w", offset, err)
 			}
 		}
 
@@ -265,7 +275,7 @@ func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) err
 		// from the section itself.
 		idx := int(rel.Section)
 		if idx > len(ec.Sections) {
-			return xerrors.New("out-of-bounds section index")
+			return errors.New("out-of-bounds section index")
 		}
 
 		name = ec.Sections[idx].Name
@@ -285,7 +295,7 @@ outer:
 			// section. Weirdly, the offset of the real symbol in the
 			// section is encoded in the instruction stream.
 			if bind != elf.STB_LOCAL {
-				return xerrors.Errorf("direct load: %s: unsupported relocation %s", name, bind)
+				return fmt.Errorf("direct load: %s: unsupported relocation %s", name, bind)
 			}
 
 			// For some reason, clang encodes the offset of the symbol its
@@ -307,13 +317,13 @@ outer:
 
 		case elf.STT_OBJECT:
 			if bind != elf.STB_GLOBAL {
-				return xerrors.Errorf("load: %s: unsupported binding: %s", name, bind)
+				return fmt.Errorf("load: %s: unsupported binding: %s", name, bind)
 			}
 
 			ins.Src = asm.PseudoMapFD
 
 		default:
-			return xerrors.Errorf("load: %s: unsupported relocation: %s", name, typ)
+			return fmt.Errorf("load: %s: unsupported relocation: %s", name, typ)
 		}
 
 		// Mark the instruction as needing an update when creating the
@@ -324,18 +334,18 @@ outer:
 
 	case ins.OpCode.JumpOp() == asm.Call:
 		if ins.Src != asm.PseudoCall {
-			return xerrors.Errorf("call: %s: incorrect source register", name)
+			return fmt.Errorf("call: %s: incorrect source register", name)
 		}
 
 		switch typ {
 		case elf.STT_NOTYPE, elf.STT_FUNC:
 			if bind != elf.STB_GLOBAL {
-				return xerrors.Errorf("call: %s: unsupported binding: %s", name, bind)
+				return fmt.Errorf("call: %s: unsupported binding: %s", name, bind)
 			}
 
 		case elf.STT_SECTION:
 			if bind != elf.STB_LOCAL {
-				return xerrors.Errorf("call: %s: unsupported binding: %s", name, bind)
+				return fmt.Errorf("call: %s: unsupported binding: %s", name, bind)
 			}
 
 			// The function we want to call is in the indicated section,
@@ -344,23 +354,23 @@ outer:
 			// A value of -1 references the first instruction in the section.
 			offset := int64(int32(ins.Constant)+1) * asm.InstructionSize
 			if offset < 0 {
-				return xerrors.Errorf("call: %s: invalid offset %d", name, offset)
+				return fmt.Errorf("call: %s: invalid offset %d", name, offset)
 			}
 
 			sym, ok := ec.symbolsPerSection[rel.Section][uint64(offset)]
 			if !ok {
-				return xerrors.Errorf("call: %s: no symbol at offset %d", name, offset)
+				return fmt.Errorf("call: %s: no symbol at offset %d", name, offset)
 			}
 
 			ins.Constant = -1
 			name = sym.Name
 
 		default:
-			return xerrors.Errorf("call: %s: invalid symbol type %s", name, typ)
+			return fmt.Errorf("call: %s: invalid symbol type %s", name, typ)
 		}
 
 	default:
-		return xerrors.Errorf("relocation for unsupported instruction: %s", ins.OpCode)
+		return fmt.Errorf("relocation for unsupported instruction: %s", ins.OpCode)
 	}
 
 	ins.Reference = name
@@ -371,11 +381,11 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 	for idx, sec := range mapSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return xerrors.Errorf("section %v: no symbols", sec.Name)
+			return fmt.Errorf("section %v: no symbols", sec.Name)
 		}
 
 		if sec.Size%uint64(len(syms)) != 0 {
-			return xerrors.Errorf("section %v: map descriptors are not of equal size", sec.Name)
+			return fmt.Errorf("section %v: map descriptors are not of equal size", sec.Name)
 		}
 
 		var (
@@ -385,11 +395,11 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 		for i, offset := 0, uint64(0); i < len(syms); i, offset = i+1, offset+size {
 			mapSym, ok := syms[offset]
 			if !ok {
-				return xerrors.Errorf("section %s: missing symbol for map at offset %d", sec.Name, offset)
+				return fmt.Errorf("section %s: missing symbol for map at offset %d", sec.Name, offset)
 			}
 
 			if maps[mapSym.Name] != nil {
-				return xerrors.Errorf("section %v: map %v already exists", sec.Name, mapSym)
+				return fmt.Errorf("section %v: map %v already exists", sec.Name, mapSym)
 			}
 
 			lr := io.LimitReader(r, int64(size))
@@ -399,19 +409,19 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 			}
 			switch {
 			case binary.Read(lr, ec.ByteOrder, &spec.Type) != nil:
-				return xerrors.Errorf("map %v: missing type", mapSym)
+				return fmt.Errorf("map %v: missing type", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.KeySize) != nil:
-				return xerrors.Errorf("map %v: missing key size", mapSym)
+				return fmt.Errorf("map %v: missing key size", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.ValueSize) != nil:
-				return xerrors.Errorf("map %v: missing value size", mapSym)
+				return fmt.Errorf("map %v: missing value size", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.MaxEntries) != nil:
-				return xerrors.Errorf("map %v: missing max entries", mapSym)
+				return fmt.Errorf("map %v: missing max entries", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.Flags) != nil:
-				return xerrors.Errorf("map %v: missing flags", mapSym)
+				return fmt.Errorf("map %v: missing flags", mapSym)
 			}
 
 			if _, err := io.Copy(internal.DiscardZeroes{}, lr); err != nil {
-				return xerrors.Errorf("map %v: unknown and non-zero fields in definition", mapSym)
+				return fmt.Errorf("map %v: unknown and non-zero fields in definition", mapSym)
 			}
 
 			maps[mapSym.Name] = &spec
@@ -423,84 +433,116 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 
 func (ec *elfCode) loadBTFMaps(maps map[string]*MapSpec, mapSections map[elf.SectionIndex]*elf.Section, spec *btf.Spec) error {
 	if spec == nil {
-		return xerrors.Errorf("missing BTF")
+		return fmt.Errorf("missing BTF")
 	}
 
 	for idx, sec := range mapSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return xerrors.Errorf("section %v: no symbols", sec.Name)
+			return fmt.Errorf("section %v: no symbols", sec.Name)
 		}
 
 		for _, sym := range syms {
 			name := sym.Name
 			if maps[name] != nil {
-				return xerrors.Errorf("section %v: map %v already exists", sec.Name, sym)
+				return fmt.Errorf("section %v: map %v already exists", sec.Name, sym)
 			}
 
-			btfMap, btfMapMembers, err := spec.Map(name)
+			mapSpec, err := mapSpecFromBTF(spec, name)
 			if err != nil {
-				return xerrors.Errorf("map %v: can't get BTF: %w", name, err)
+				return fmt.Errorf("map %v: %w", name, err)
 			}
 
-			spec, err := mapSpecFromBTF(btfMap, btfMapMembers)
-			if err != nil {
-				return xerrors.Errorf("map %v: %w", name, err)
-			}
-
-			maps[name] = spec
+			maps[name] = mapSpec
 		}
 	}
 
 	return nil
 }
 
-func mapSpecFromBTF(btfMap *btf.Map, btfMapMembers []btf.Member) (*MapSpec, error) {
+func mapSpecFromBTF(spec *btf.Spec, name string) (*MapSpec, error) {
+	btfMap, btfMapMembers, err := spec.Map(name)
+	if err != nil {
+		return nil, fmt.Errorf("can't get BTF: %w", err)
+	}
+
+	keyType := btf.MapKey(btfMap)
+	size, err := btf.Sizeof(keyType)
+	if err != nil {
+		return nil, fmt.Errorf("can't get size of BTF key: %w", err)
+	}
+	keySize := uint32(size)
+
+	valueType := btf.MapValue(btfMap)
+	size, err = btf.Sizeof(valueType)
+	if err != nil {
+		return nil, fmt.Errorf("can't get size of BTF value: %w", err)
+	}
+	valueSize := uint32(size)
+
 	var (
 		mapType, flags, maxEntries uint32
-		err                        error
 	)
 	for _, member := range btfMapMembers {
 		switch member.Name {
 		case "type":
 			mapType, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, xerrors.Errorf("can't get type: %w", err)
+				return nil, fmt.Errorf("can't get type: %w", err)
 			}
 
 		case "map_flags":
 			flags, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, xerrors.Errorf("can't get BTF map flags: %w", err)
+				return nil, fmt.Errorf("can't get BTF map flags: %w", err)
 			}
 
 		case "max_entries":
 			maxEntries, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, xerrors.Errorf("can't get BTF map max entries: %w", err)
+				return nil, fmt.Errorf("can't get BTF map max entries: %w", err)
 			}
 
-		case "key":
-		case "value":
+		case "key_size":
+			if _, isVoid := keyType.(*btf.Void); !isVoid {
+				return nil, errors.New("both key and key_size given")
+			}
+
+			keySize, err = uintFromBTF(member.Type)
+			if err != nil {
+				return nil, fmt.Errorf("can't get BTF key size: %w", err)
+			}
+
+		case "value_size":
+			if _, isVoid := valueType.(*btf.Void); !isVoid {
+				return nil, errors.New("both value and value_size given")
+			}
+
+			valueSize, err = uintFromBTF(member.Type)
+			if err != nil {
+				return nil, fmt.Errorf("can't get BTF value size: %w", err)
+			}
+
+		case "pinning":
+			pinning, err := uintFromBTF(member.Type)
+			if err != nil {
+				return nil, fmt.Errorf("can't get pinning: %w", err)
+			}
+
+			if pinning != 0 {
+				return nil, fmt.Errorf("'pinning' attribute not supported: %w", ErrNotSupported)
+			}
+
+		case "key", "value":
 		default:
-			return nil, xerrors.Errorf("unrecognized field %s in BTF map definition", member.Name)
+			return nil, fmt.Errorf("unrecognized field %s in BTF map definition", member.Name)
 		}
-	}
-
-	keySize, err := btf.Sizeof(btf.MapKey(btfMap))
-	if err != nil {
-		return nil, xerrors.Errorf("can't get size of BTF key: %w", err)
-	}
-
-	valueSize, err := btf.Sizeof(btf.MapValue(btfMap))
-	if err != nil {
-		return nil, xerrors.Errorf("can't get size of BTF value: %w", err)
 	}
 
 	return &MapSpec{
 		Type:       MapType(mapType),
-		KeySize:    uint32(keySize),
-		ValueSize:  uint32(valueSize),
+		KeySize:    keySize,
+		ValueSize:  valueSize,
 		MaxEntries: maxEntries,
 		Flags:      flags,
 		BTF:        btfMap,
@@ -512,12 +554,12 @@ func mapSpecFromBTF(btfMap *btf.Map, btfMapMembers []btf.Member) (*MapSpec, erro
 func uintFromBTF(typ btf.Type) (uint32, error) {
 	ptr, ok := typ.(*btf.Pointer)
 	if !ok {
-		return 0, xerrors.Errorf("not a pointer: %v", typ)
+		return 0, fmt.Errorf("not a pointer: %v", typ)
 	}
 
 	arr, ok := ptr.Target.(*btf.Array)
 	if !ok {
-		return 0, xerrors.Errorf("not a pointer to array: %v", typ)
+		return 0, fmt.Errorf("not a pointer to array: %v", typ)
 	}
 
 	return arr.Nelems, nil
@@ -525,7 +567,7 @@ func uintFromBTF(typ btf.Type) (uint32, error) {
 
 func (ec *elfCode) loadDataSections(maps map[string]*MapSpec, dataSections map[elf.SectionIndex]*elf.Section, spec *btf.Spec) error {
 	if spec == nil {
-		return xerrors.New("data sections require BTF, make sure all consts are marked as static")
+		return errors.New("data sections require BTF, make sure all consts are marked as static")
 	}
 
 	for _, sec := range dataSections {
@@ -536,11 +578,11 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec, dataSections map[e
 
 		data, err := sec.Data()
 		if err != nil {
-			return xerrors.Errorf("data section %s: can't get contents: %w", sec.Name, err)
+			return fmt.Errorf("data section %s: can't get contents: %w", sec.Name, err)
 		}
 
 		if uint64(len(data)) > math.MaxUint32 {
-			return xerrors.Errorf("data section %s: contents exceed maximum size", sec.Name)
+			return fmt.Errorf("data section %s: contents exceed maximum size", sec.Name)
 		}
 
 		mapSpec := &MapSpec{
@@ -567,7 +609,7 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec, dataSections map[e
 	return nil
 }
 
-func getProgType(sectionName string) (ProgramType, AttachType) {
+func getProgType(sectionName string) (ProgramType, AttachType, string) {
 	types := map[string]struct {
 		progType   ProgramType
 		attachType AttachType
@@ -593,6 +635,7 @@ func getProgType(sectionName string) (ProgramType, AttachType) {
 		"sk_msg":                {SkMsg, AttachSkSKBStreamVerdict},
 		"lirc_mode2":            {LircMode2, AttachLircMode2},
 		"flow_dissector":        {FlowDissector, AttachFlowDissector},
+		"iter/":                 {Tracing, AttachTraceIter},
 
 		"cgroup_skb/ingress": {CGroupSKB, AttachCGroupInetIngress},
 		"cgroup_skb/egress":  {CGroupSKB, AttachCGroupInetEgress},
@@ -617,21 +660,28 @@ func getProgType(sectionName string) (ProgramType, AttachType) {
 	}
 
 	for prefix, t := range types {
-		if strings.HasPrefix(sectionName, prefix) {
-			return t.progType, t.attachType
+		if !strings.HasPrefix(sectionName, prefix) {
+			continue
 		}
+
+		if !strings.HasSuffix(prefix, "/") {
+			return t.progType, t.attachType, ""
+		}
+
+		return t.progType, t.attachType, sectionName[len(prefix):]
 	}
 
-	return UnspecifiedProgram, AttachNone
+	return UnspecifiedProgram, AttachNone, ""
 }
 
-func (ec *elfCode) loadRelocations(sections map[elf.SectionIndex]*elf.Section) (map[elf.SectionIndex]map[uint64]elf.Symbol, error) {
+func (ec *elfCode) loadRelocations(sections map[elf.SectionIndex]*elf.Section) (map[elf.SectionIndex]map[uint64]elf.Symbol, map[elf.SectionIndex]bool, error) {
 	result := make(map[elf.SectionIndex]map[uint64]elf.Symbol)
+	targets := make(map[elf.SectionIndex]bool)
 	for idx, sec := range sections {
 		rels := make(map[uint64]elf.Symbol)
 
 		if sec.Entsize < 16 {
-			return nil, xerrors.Errorf("section %s: relocations are less than 16 bytes", sec.Name)
+			return nil, nil, fmt.Errorf("section %s: relocations are less than 16 bytes", sec.Name)
 		}
 
 		r := sec.Open()
@@ -640,20 +690,22 @@ func (ec *elfCode) loadRelocations(sections map[elf.SectionIndex]*elf.Section) (
 
 			var rel elf.Rel64
 			if binary.Read(ent, ec.ByteOrder, &rel) != nil {
-				return nil, xerrors.Errorf("can't parse relocation at offset %v", off)
+				return nil, nil, fmt.Errorf("can't parse relocation at offset %v", off)
 			}
 
 			symNo := int(elf.R_SYM64(rel.Info) - 1)
 			if symNo >= len(ec.symbols) {
-				return nil, xerrors.Errorf("relocation at offset %d: symbol %v doesnt exist", off, symNo)
+				return nil, nil, fmt.Errorf("relocation at offset %d: symbol %v doesnt exist", off, symNo)
 			}
 
+			symbol := ec.symbols[symNo]
+			targets[symbol.Section] = true
 			rels[rel.Off] = ec.symbols[symNo]
 		}
 
 		result[idx] = rels
 	}
-	return result, nil
+	return result, targets, nil
 }
 
 func symbolsPerSection(symbols []elf.Symbol) map[elf.SectionIndex]map[uint64]elf.Symbol {

--- a/vendor/github.com/cilium/ebpf/go.mod
+++ b/vendor/github.com/cilium/ebpf/go.mod
@@ -1,8 +1,5 @@
 module github.com/cilium/ebpf
 
-go 1.12
+go 1.13
 
-require (
-	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
-)
+require golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9

--- a/vendor/github.com/cilium/ebpf/go.sum
+++ b/vendor/github.com/cilium/ebpf/go.sum
@@ -1,6 +1,2 @@
-golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
-golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/vendor/github.com/cilium/ebpf/internal/btf/btf.go
+++ b/vendor/github.com/cilium/ebpf/internal/btf/btf.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
@@ -14,16 +16,15 @@ import (
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 const btfMagic = 0xeB9F
 
 // Errors returned by BTF functions.
 var (
-	ErrNotSupported = internal.ErrNotSupported
-	ErrNotFound     = xerrors.New("not found")
+	ErrNotSupported   = internal.ErrNotSupported
+	ErrNotFound       = errors.New("not found")
+	ErrNoExtendedInfo = errors.New("no extended info")
 )
 
 // Spec represents decoded BTF.
@@ -76,7 +77,7 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 			}
 
 			if sec.Size > math.MaxUint32 {
-				return nil, xerrors.Errorf("section %s exceeds maximum size", sec.Name)
+				return nil, fmt.Errorf("section %s exceeds maximum size", sec.Name)
 			}
 
 			sectionSizes[sec.Name] = uint32(sec.Size)
@@ -89,7 +90,7 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 
 	symbols, err := file.Symbols()
 	if err != nil {
-		return nil, xerrors.Errorf("can't read symbols: %v", err)
+		return nil, fmt.Errorf("can't read symbols: %v", err)
 	}
 
 	variableOffsets := make(map[variable]uint32)
@@ -105,7 +106,7 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 		}
 
 		if symbol.Value > math.MaxUint32 {
-			return nil, xerrors.Errorf("section %s: symbol %s: size exceeds maximum", secName, symbol.Name)
+			return nil, fmt.Errorf("section %s: symbol %s: size exceeds maximum", secName, symbol.Name)
 		}
 
 		variableOffsets[variable{secName, symbol.Name}] = uint32(symbol.Value)
@@ -122,7 +123,7 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 
 	spec.funcInfos, spec.lineInfos, err = parseExtInfos(btfExtSection.Open(), file.ByteOrder, spec.strings)
 	if err != nil {
-		return nil, xerrors.Errorf("can't read ext info: %w", err)
+		return nil, fmt.Errorf("can't read ext info: %w", err)
 	}
 
 	return spec, nil
@@ -177,10 +178,10 @@ func LoadKernelSpec() (*Spec, error) {
 func loadKernelSpec() (*Spec, error) {
 	fh, err := os.Open("/sys/kernel/btf/vmlinux")
 	if os.IsNotExist(err) {
-		return nil, xerrors.Errorf("can't open kernel BTF at /sys/kernel/btf/vmlinux: %w", ErrNotFound)
+		return nil, fmt.Errorf("can't open kernel BTF at /sys/kernel/btf/vmlinux: %w", ErrNotFound)
 	}
 	if err != nil {
-		return nil, xerrors.Errorf("can't read kernel BTF: %s", err)
+		return nil, fmt.Errorf("can't read kernel BTF: %s", err)
 	}
 	defer fh.Close()
 
@@ -190,53 +191,53 @@ func loadKernelSpec() (*Spec, error) {
 func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) ([]rawType, stringTable, error) {
 	rawBTF, err := ioutil.ReadAll(btf)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("can't read BTF: %v", err)
+		return nil, nil, fmt.Errorf("can't read BTF: %v", err)
 	}
 
 	rd := bytes.NewReader(rawBTF)
 
 	var header btfHeader
 	if err := binary.Read(rd, bo, &header); err != nil {
-		return nil, nil, xerrors.Errorf("can't read header: %v", err)
+		return nil, nil, fmt.Errorf("can't read header: %v", err)
 	}
 
 	if header.Magic != btfMagic {
-		return nil, nil, xerrors.Errorf("incorrect magic value %v", header.Magic)
+		return nil, nil, fmt.Errorf("incorrect magic value %v", header.Magic)
 	}
 
 	if header.Version != 1 {
-		return nil, nil, xerrors.Errorf("unexpected version %v", header.Version)
+		return nil, nil, fmt.Errorf("unexpected version %v", header.Version)
 	}
 
 	if header.Flags != 0 {
-		return nil, nil, xerrors.Errorf("unsupported flags %v", header.Flags)
+		return nil, nil, fmt.Errorf("unsupported flags %v", header.Flags)
 	}
 
 	remainder := int64(header.HdrLen) - int64(binary.Size(&header))
 	if remainder < 0 {
-		return nil, nil, xerrors.New("header is too short")
+		return nil, nil, errors.New("header is too short")
 	}
 
 	if _, err := io.CopyN(internal.DiscardZeroes{}, rd, remainder); err != nil {
-		return nil, nil, xerrors.Errorf("header padding: %v", err)
+		return nil, nil, fmt.Errorf("header padding: %v", err)
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.StringOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to start of string section: %v", err)
+		return nil, nil, fmt.Errorf("can't seek to start of string section: %v", err)
 	}
 
 	rawStrings, err := readStringTable(io.LimitReader(rd, int64(header.StringLen)))
 	if err != nil {
-		return nil, nil, xerrors.Errorf("can't read type names: %w", err)
+		return nil, nil, fmt.Errorf("can't read type names: %w", err)
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.TypeOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to start of type section: %v", err)
+		return nil, nil, fmt.Errorf("can't seek to start of type section: %v", err)
 	}
 
 	rawTypes, err := readTypes(io.LimitReader(rd, int64(header.TypeLen)), bo)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("can't read types: %w", err)
+		return nil, nil, fmt.Errorf("can't read types: %w", err)
 	}
 
 	return rawTypes, rawStrings, nil
@@ -258,9 +259,13 @@ func fixupDatasec(rawTypes []rawType, rawStrings stringTable, sectionSizes map[s
 			return err
 		}
 
+		if name == ".kconfig" || name == ".ksym" {
+			return fmt.Errorf("reference to %s: %w", name, ErrNotSupported)
+		}
+
 		size, ok := sectionSizes[name]
 		if !ok {
-			return xerrors.Errorf("data section %s: missing size", name)
+			return fmt.Errorf("data section %s: missing size", name)
 		}
 
 		rawTypes[i].SizeType = size
@@ -269,17 +274,17 @@ func fixupDatasec(rawTypes []rawType, rawStrings stringTable, sectionSizes map[s
 		for j, secInfo := range secinfos {
 			id := int(secInfo.Type - 1)
 			if id >= len(rawTypes) {
-				return xerrors.Errorf("data section %s: invalid type id %d for variable %d", name, id, j)
+				return fmt.Errorf("data section %s: invalid type id %d for variable %d", name, id, j)
 			}
 
 			varName, err := rawStrings.Lookup(rawTypes[id].NameOff)
 			if err != nil {
-				return xerrors.Errorf("data section %s: can't get name for type %d: %w", name, id, err)
+				return fmt.Errorf("data section %s: can't get name for type %d: %w", name, id, err)
 			}
 
 			offset, ok := variableOffsets[variable{name, varName}]
 			if !ok {
-				return xerrors.Errorf("data section %s: missing offset for variable %s", name, varName)
+				return fmt.Errorf("data section %s: missing offset for variable %s", name, varName)
 			}
 
 			secinfos[j].Offset = offset
@@ -289,7 +294,12 @@ func fixupDatasec(rawTypes []rawType, rawStrings stringTable, sectionSizes map[s
 	return nil
 }
 
-func (s *Spec) marshal(bo binary.ByteOrder) ([]byte, error) {
+type marshalOpts struct {
+	ByteOrder        binary.ByteOrder
+	StripFuncLinkage bool
+}
+
+func (s *Spec) marshal(opts marshalOpts) ([]byte, error) {
 	var (
 		buf       bytes.Buffer
 		header    = new(btfHeader)
@@ -301,9 +311,14 @@ func (s *Spec) marshal(bo binary.ByteOrder) ([]byte, error) {
 	_, _ = buf.Write(make([]byte, headerLen))
 
 	// Write type section, just after the header.
-	for _, typ := range s.rawTypes {
-		if err := typ.Marshal(&buf, bo); err != nil {
-			return nil, xerrors.Errorf("can't marshal BTF: %w", err)
+	for _, raw := range s.rawTypes {
+		switch {
+		case opts.StripFuncLinkage && raw.Kind() == kindFunc:
+			raw.SetLinkage(linkageStatic)
+		}
+
+		if err := raw.Marshal(&buf, opts.ByteOrder); err != nil {
+			return nil, fmt.Errorf("can't marshal BTF: %w", err)
 		}
 	}
 
@@ -325,9 +340,9 @@ func (s *Spec) marshal(bo binary.ByteOrder) ([]byte, error) {
 	}
 
 	raw := buf.Bytes()
-	err := binary.Write(sliceWriter(raw[:headerLen]), bo, header)
+	err := binary.Write(sliceWriter(raw[:headerLen]), opts.ByteOrder, header)
 	if err != nil {
-		return nil, xerrors.Errorf("can't write header: %v", err)
+		return nil, fmt.Errorf("can't write header: %v", err)
 	}
 
 	return raw, nil
@@ -337,7 +352,7 @@ type sliceWriter []byte
 
 func (sw sliceWriter) Write(p []byte) (int, error) {
 	if len(p) != len(sw) {
-		return 0, xerrors.New("size doesn't match")
+		return 0, errors.New("size doesn't match")
 	}
 
 	return copy(sw, p), nil
@@ -347,17 +362,22 @@ func (sw sliceWriter) Write(p []byte) (int, error) {
 //
 // Length is the number of bytes in the raw BPF instruction stream.
 //
-// Returns an error if there is no BTF.
+// Returns an error which may wrap ErrNoExtendedInfo if the Spec doesn't
+// contain extended BTF info.
 func (s *Spec) Program(name string, length uint64) (*Program, error) {
 	if length == 0 {
-		return nil, xerrors.New("length musn't be zero")
+		return nil, errors.New("length musn't be zero")
+	}
+
+	if s.funcInfos == nil && s.lineInfos == nil {
+		return nil, fmt.Errorf("BTF for section %s: %w", name, ErrNoExtendedInfo)
 	}
 
 	funcInfos, funcOK := s.funcInfos[name]
 	lineInfos, lineOK := s.lineInfos[name]
 
 	if !funcOK && !lineOK {
-		return nil, xerrors.Errorf("no BTF for program %s", name)
+		return nil, fmt.Errorf("no extended BTF info for section %s", name)
 	}
 
 	return &Program{s, length, funcInfos, lineInfos}, nil
@@ -374,7 +394,7 @@ func (s *Spec) Map(name string) (*Map, []Member, error) {
 
 	mapStruct, ok := mapVar.Type.(*Struct)
 	if !ok {
-		return nil, nil, xerrors.Errorf("expected struct, have %s", mapVar.Type)
+		return nil, nil, fmt.Errorf("expected struct, have %s", mapVar.Type)
 	}
 
 	var key, value Type
@@ -389,11 +409,11 @@ func (s *Spec) Map(name string) (*Map, []Member, error) {
 	}
 
 	if key == nil {
-		return nil, nil, xerrors.Errorf("map %s: missing 'key' in type", name)
+		key = (*Void)(nil)
 	}
 
 	if value == nil {
-		return nil, nil, xerrors.Errorf("map %s: missing 'value' in type", name)
+		value = (*Void)(nil)
 	}
 
 	return &Map{s, key, value}, mapStruct.Members, nil
@@ -403,7 +423,7 @@ func (s *Spec) Map(name string) (*Map, []Member, error) {
 func (s *Spec) Datasec(name string) (*Map, error) {
 	var datasec Datasec
 	if err := s.FindType(name, &datasec); err != nil {
-		return nil, xerrors.Errorf("data section %s: can't get BTF: %w", name, err)
+		return nil, fmt.Errorf("data section %s: can't get BTF: %w", name, err)
 	}
 
 	return &Map{s, &Void{}, &datasec}, nil
@@ -427,14 +447,14 @@ func (s *Spec) FindType(name string, typ Type) error {
 		}
 
 		if candidate != nil {
-			return xerrors.Errorf("type %s: multiple candidates for %T", name, typ)
+			return fmt.Errorf("type %s: multiple candidates for %T", name, typ)
 		}
 
 		candidate = typ
 	}
 
 	if candidate == nil {
-		return xerrors.Errorf("type %s: %w", name, ErrNotFound)
+		return fmt.Errorf("type %s: %w", name, ErrNotFound)
 	}
 
 	value := reflect.Indirect(reflect.ValueOf(copyType(candidate)))
@@ -456,16 +476,19 @@ func NewHandle(spec *Spec) (*Handle, error) {
 	}
 
 	if spec.byteOrder != internal.NativeEndian {
-		return nil, xerrors.Errorf("can't load %s BTF on %s", spec.byteOrder, internal.NativeEndian)
+		return nil, fmt.Errorf("can't load %s BTF on %s", spec.byteOrder, internal.NativeEndian)
 	}
 
-	btf, err := spec.marshal(internal.NativeEndian)
+	btf, err := spec.marshal(marshalOpts{
+		ByteOrder:        internal.NativeEndian,
+		StripFuncLinkage: haveFuncLinkage() != nil,
+	})
 	if err != nil {
-		return nil, xerrors.Errorf("can't marshal BTF: %w", err)
+		return nil, fmt.Errorf("can't marshal BTF: %w", err)
 	}
 
 	if uint64(len(btf)) > math.MaxUint32 {
-		return nil, xerrors.New("BTF exceeds the maximum size")
+		return nil, errors.New("BTF exceeds the maximum size")
 	}
 
 	attr := &bpfLoadBTFAttr{
@@ -549,12 +572,12 @@ func ProgramSpec(s *Program) *Spec {
 func ProgramAppend(s, other *Program) error {
 	funcInfos, err := s.funcInfos.append(other.funcInfos, s.length)
 	if err != nil {
-		return xerrors.Errorf("func infos: %w", err)
+		return fmt.Errorf("func infos: %w", err)
 	}
 
 	lineInfos, err := s.lineInfos.append(other.lineInfos, s.length)
 	if err != nil {
-		return xerrors.Errorf("line infos: %w", err)
+		return fmt.Errorf("line infos: %w", err)
 	}
 
 	s.length += other.length
@@ -608,26 +631,36 @@ func bpfLoadBTF(attr *bpfLoadBTFAttr) (*internal.FD, error) {
 	return internal.NewFD(uint32(fd)), nil
 }
 
-func minimalBTF(bo binary.ByteOrder) []byte {
+func marshalBTF(types interface{}, strings []byte, bo binary.ByteOrder) []byte {
 	const minHeaderLength = 24
 
+	typesLen := uint32(binary.Size(types))
+	header := btfHeader{
+		Magic:     btfMagic,
+		Version:   1,
+		HdrLen:    minHeaderLength,
+		TypeOff:   0,
+		TypeLen:   typesLen,
+		StringOff: typesLen,
+		StringLen: uint32(len(strings)),
+	}
+
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, bo, &header)
+	_ = binary.Write(buf, bo, types)
+	buf.Write(strings)
+
+	return buf.Bytes()
+}
+
+var haveBTF = internal.FeatureTest("BTF", "5.1", func() (bool, error) {
 	var (
 		types struct {
 			Integer btfType
 			Var     btfType
 			btfVar  struct{ Linkage uint32 }
 		}
-		typLen  = uint32(binary.Size(&types))
 		strings = []byte{0, 'a', 0}
-		header  = btfHeader{
-			Magic:     btfMagic,
-			Version:   1,
-			HdrLen:    minHeaderLength,
-			TypeOff:   0,
-			TypeLen:   typLen,
-			StringOff: typLen,
-			StringLen: uint32(len(strings)),
-		}
 	)
 
 	// We use a BTF_KIND_VAR here, to make sure that
@@ -638,16 +671,8 @@ func minimalBTF(bo binary.ByteOrder) []byte {
 	types.Var.SetKind(kindVar)
 	types.Var.SizeType = 1
 
-	buf := new(bytes.Buffer)
-	_ = binary.Write(buf, bo, &header)
-	_ = binary.Write(buf, bo, &types)
-	buf.Write(strings)
+	btf := marshalBTF(&types, strings, internal.NativeEndian)
 
-	return buf.Bytes()
-}
-
-var haveBTF = internal.FeatureTest("BTF", "5.1", func() (bool, error) {
-	btf := minimalBTF(internal.NativeEndian)
 	fd, err := bpfLoadBTF(&bpfLoadBTFAttr{
 		btf:     internal.NewSlicePointer(btf),
 		btfSize: uint32(len(btf)),
@@ -657,5 +682,35 @@ var haveBTF = internal.FeatureTest("BTF", "5.1", func() (bool, error) {
 	}
 	// Check for EINVAL specifically, rather than err != nil since we
 	// otherwise misdetect due to insufficient permissions.
-	return !xerrors.Is(err, unix.EINVAL), nil
+	return !errors.Is(err, unix.EINVAL), nil
+})
+
+var haveFuncLinkage = internal.FeatureTest("BTF func linkage", "5.6", func() (bool, error) {
+	var (
+		types struct {
+			FuncProto btfType
+			Func      btfType
+		}
+		strings = []byte{0, 'a', 0}
+	)
+
+	types.FuncProto.SetKind(kindFuncProto)
+	types.Func.SetKind(kindFunc)
+	types.Func.SizeType = 1 // aka FuncProto
+	types.Func.NameOff = 1
+	types.Func.SetLinkage(linkageGlobal)
+
+	btf := marshalBTF(&types, strings, internal.NativeEndian)
+
+	fd, err := bpfLoadBTF(&bpfLoadBTFAttr{
+		btf:     internal.NewSlicePointer(btf),
+		btfSize: uint32(len(btf)),
+	})
+	if err == nil {
+		fd.Close()
+	}
+
+	// Check for EINVAL specifically, rather than err != nil since we
+	// otherwise misdetect due to insufficient permissions.
+	return !errors.Is(err, unix.EINVAL), nil
 })

--- a/vendor/github.com/cilium/ebpf/internal/btf/btf_types.go
+++ b/vendor/github.com/cilium/ebpf/internal/btf/btf_types.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 )
 
 // btfKind describes a Type.
@@ -33,6 +31,14 @@ const (
 	kindDatasec
 )
 
+type btfFuncLinkage uint8
+
+const (
+	linkageStatic btfFuncLinkage = iota
+	linkageGlobal
+	linkageExtern
+)
+
 const (
 	btfTypeKindShift = 24
 	btfTypeKindLen   = 4
@@ -44,7 +50,7 @@ const (
 type btfType struct {
 	NameOff uint32
 	/* "info" bits arrangement
-	 * bits  0-15: vlen (e.g. # of struct's members)
+	 * bits  0-15: vlen (e.g. # of struct's members), linkage
 	 * bits 16-23: unused
 	 * bits 24-27: kind (e.g. int, ptr, array...etc)
 	 * bits 28-30: unused
@@ -130,6 +136,14 @@ func (bt *btfType) SetVlen(vlen int) {
 	bt.setInfo(uint32(vlen), btfTypeVlenMask, btfTypeVlenShift)
 }
 
+func (bt *btfType) Linkage() btfFuncLinkage {
+	return btfFuncLinkage(bt.info(btfTypeVlenMask, btfTypeVlenShift))
+}
+
+func (bt *btfType) SetLinkage(linkage btfFuncLinkage) {
+	bt.setInfo(uint32(linkage), btfTypeVlenMask, btfTypeVlenShift)
+}
+
 func (bt *btfType) Type() TypeID {
 	// TODO: Panic here if wrong kind?
 	return TypeID(bt.SizeType)
@@ -199,7 +213,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		if err := binary.Read(r, bo, &header); err == io.EOF {
 			return types, nil
 		} else if err != nil {
-			return nil, xerrors.Errorf("can't read type info for id %v: %v", id, err)
+			return nil, fmt.Errorf("can't read type info for id %v: %v", id, err)
 		}
 
 		var data interface{}
@@ -228,7 +242,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		case kindDatasec:
 			data = make([]btfVarSecinfo, header.Vlen())
 		default:
-			return nil, xerrors.Errorf("type id %v: unknown kind: %v", id, header.Kind())
+			return nil, fmt.Errorf("type id %v: unknown kind: %v", id, header.Kind())
 		}
 
 		if data == nil {
@@ -237,7 +251,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		}
 
 		if err := binary.Read(r, bo, data); err != nil {
-			return nil, xerrors.Errorf("type id %d: kind %v: can't read %T: %v", id, header.Kind(), data, err)
+			return nil, fmt.Errorf("type id %d: kind %v: can't read %T: %v", id, header.Kind(), data, err)
 		}
 
 		types = append(types, rawType{header, data})

--- a/vendor/github.com/cilium/ebpf/internal/btf/ext_info.go
+++ b/vendor/github.com/cilium/ebpf/internal/btf/ext_info.go
@@ -3,13 +3,13 @@ package btf
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
-
-	"golang.org/x/xerrors"
 )
 
 type btfExtHeader struct {
@@ -27,49 +27,49 @@ type btfExtHeader struct {
 func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (funcInfo, lineInfo map[string]extInfo, err error) {
 	var header btfExtHeader
 	if err := binary.Read(r, bo, &header); err != nil {
-		return nil, nil, xerrors.Errorf("can't read header: %v", err)
+		return nil, nil, fmt.Errorf("can't read header: %v", err)
 	}
 
 	if header.Magic != btfMagic {
-		return nil, nil, xerrors.Errorf("incorrect magic value %v", header.Magic)
+		return nil, nil, fmt.Errorf("incorrect magic value %v", header.Magic)
 	}
 
 	if header.Version != 1 {
-		return nil, nil, xerrors.Errorf("unexpected version %v", header.Version)
+		return nil, nil, fmt.Errorf("unexpected version %v", header.Version)
 	}
 
 	if header.Flags != 0 {
-		return nil, nil, xerrors.Errorf("unsupported flags %v", header.Flags)
+		return nil, nil, fmt.Errorf("unsupported flags %v", header.Flags)
 	}
 
 	remainder := int64(header.HdrLen) - int64(binary.Size(&header))
 	if remainder < 0 {
-		return nil, nil, xerrors.New("header is too short")
+		return nil, nil, errors.New("header is too short")
 	}
 
 	// Of course, the .BTF.ext header has different semantics than the
 	// .BTF ext header. We need to ignore non-null values.
 	_, err = io.CopyN(ioutil.Discard, r, remainder)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("header padding: %v", err)
+		return nil, nil, fmt.Errorf("header padding: %v", err)
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.FuncInfoOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to function info section: %v", err)
+		return nil, nil, fmt.Errorf("can't seek to function info section: %v", err)
 	}
 
 	funcInfo, err = parseExtInfo(io.LimitReader(r, int64(header.FuncInfoLen)), bo, strings)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("function info: %w", err)
+		return nil, nil, fmt.Errorf("function info: %w", err)
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.LineInfoOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to line info section: %v", err)
+		return nil, nil, fmt.Errorf("can't seek to line info section: %v", err)
 	}
 
 	lineInfo, err = parseExtInfo(io.LimitReader(r, int64(header.LineInfoLen)), bo, strings)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("line info: %w", err)
+		return nil, nil, fmt.Errorf("line info: %w", err)
 	}
 
 	return funcInfo, lineInfo, nil
@@ -92,7 +92,7 @@ type extInfo struct {
 
 func (ei extInfo) append(other extInfo, offset uint64) (extInfo, error) {
 	if other.recordSize != ei.recordSize {
-		return extInfo{}, xerrors.Errorf("ext_info record size mismatch, want %d (got %d)", ei.recordSize, other.recordSize)
+		return extInfo{}, fmt.Errorf("ext_info record size mismatch, want %d (got %d)", ei.recordSize, other.recordSize)
 	}
 
 	records := make([]extInfoRecord, 0, len(ei.records)+len(other.records))
@@ -117,7 +117,7 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 		// while the ELF tracks it in bytes.
 		insnOff := uint32(info.InsnOff / asm.InstructionSize)
 		if err := binary.Write(buf, internal.NativeEndian, insnOff); err != nil {
-			return nil, xerrors.Errorf("can't write instruction offset: %v", err)
+			return nil, fmt.Errorf("can't write instruction offset: %v", err)
 		}
 
 		buf.Write(info.Opaque)
@@ -129,12 +129,12 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[string]extInfo, error) {
 	var recordSize uint32
 	if err := binary.Read(r, bo, &recordSize); err != nil {
-		return nil, xerrors.Errorf("can't read record size: %v", err)
+		return nil, fmt.Errorf("can't read record size: %v", err)
 	}
 
 	if recordSize < 4 {
 		// Need at least insnOff
-		return nil, xerrors.New("record size too short")
+		return nil, errors.New("record size too short")
 	}
 
 	result := make(map[string]extInfo)
@@ -143,32 +143,32 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 		if err := binary.Read(r, bo, &infoHeader); err == io.EOF {
 			return result, nil
 		} else if err != nil {
-			return nil, xerrors.Errorf("can't read ext info header: %v", err)
+			return nil, fmt.Errorf("can't read ext info header: %v", err)
 		}
 
 		secName, err := strings.Lookup(infoHeader.SecNameOff)
 		if err != nil {
-			return nil, xerrors.Errorf("can't get section name: %w", err)
+			return nil, fmt.Errorf("can't get section name: %w", err)
 		}
 
 		if infoHeader.NumInfo == 0 {
-			return nil, xerrors.Errorf("section %s has invalid number of records", secName)
+			return nil, fmt.Errorf("section %s has invalid number of records", secName)
 		}
 
 		var records []extInfoRecord
 		for i := uint32(0); i < infoHeader.NumInfo; i++ {
 			var byteOff uint32
 			if err := binary.Read(r, bo, &byteOff); err != nil {
-				return nil, xerrors.Errorf("section %v: can't read extended info offset: %v", secName, err)
+				return nil, fmt.Errorf("section %v: can't read extended info offset: %v", secName, err)
 			}
 
 			buf := make([]byte, int(recordSize-4))
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, xerrors.Errorf("section %v: can't read record: %v", secName, err)
+				return nil, fmt.Errorf("section %v: can't read record: %v", secName, err)
 			}
 
 			if byteOff%asm.InstructionSize != 0 {
-				return nil, xerrors.Errorf("section %v: offset %v is not aligned with instruction size", secName, byteOff)
+				return nil, fmt.Errorf("section %v: offset %v is not aligned with instruction size", secName, byteOff)
 			}
 
 			records = append(records, extInfoRecord{uint64(byteOff), buf})

--- a/vendor/github.com/cilium/ebpf/internal/btf/strings.go
+++ b/vendor/github.com/cilium/ebpf/internal/btf/strings.go
@@ -2,10 +2,10 @@ package btf
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
-
-	"golang.org/x/xerrors"
 )
 
 type stringTable []byte
@@ -13,19 +13,19 @@ type stringTable []byte
 func readStringTable(r io.Reader) (stringTable, error) {
 	contents, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, xerrors.Errorf("can't read string table: %v", err)
+		return nil, fmt.Errorf("can't read string table: %v", err)
 	}
 
 	if len(contents) < 1 {
-		return nil, xerrors.New("string table is empty")
+		return nil, errors.New("string table is empty")
 	}
 
 	if contents[0] != '\x00' {
-		return nil, xerrors.New("first item in string table is non-empty")
+		return nil, errors.New("first item in string table is non-empty")
 	}
 
 	if contents[len(contents)-1] != '\x00' {
-		return nil, xerrors.New("string table isn't null terminated")
+		return nil, errors.New("string table isn't null terminated")
 	}
 
 	return stringTable(contents), nil
@@ -33,22 +33,22 @@ func readStringTable(r io.Reader) (stringTable, error) {
 
 func (st stringTable) Lookup(offset uint32) (string, error) {
 	if int64(offset) > int64(^uint(0)>>1) {
-		return "", xerrors.Errorf("offset %d overflows int", offset)
+		return "", fmt.Errorf("offset %d overflows int", offset)
 	}
 
 	pos := int(offset)
 	if pos >= len(st) {
-		return "", xerrors.Errorf("offset %d is out of bounds", offset)
+		return "", fmt.Errorf("offset %d is out of bounds", offset)
 	}
 
 	if pos > 0 && st[pos-1] != '\x00' {
-		return "", xerrors.Errorf("offset %d isn't start of a string", offset)
+		return "", fmt.Errorf("offset %d isn't start of a string", offset)
 	}
 
 	str := st[pos:]
 	end := bytes.IndexByte(str, '\x00')
 	if end == -1 {
-		return "", xerrors.Errorf("offset %d isn't null terminated", offset)
+		return "", fmt.Errorf("offset %d isn't null terminated", offset)
 	}
 
 	return string(str[:end]), nil

--- a/vendor/github.com/cilium/ebpf/internal/errors.go
+++ b/vendor/github.com/cilium/ebpf/internal/errors.go
@@ -2,11 +2,11 @@ package internal
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/cilium/ebpf/internal/unix"
-	"golang.org/x/xerrors"
 )
 
 // ErrorWithLog returns an error that includes logs from the
@@ -16,7 +16,7 @@ import (
 // the log. It is used to check for truncation of the output.
 func ErrorWithLog(err error, log []byte, logErr error) error {
 	logStr := strings.Trim(CString(log), "\t\r\n ")
-	if xerrors.Is(logErr, unix.ENOSPC) {
+	if errors.Is(logErr, unix.ENOSPC) {
 		logStr += " (truncated...)"
 	}
 

--- a/vendor/github.com/cilium/ebpf/internal/fd.go
+++ b/vendor/github.com/cilium/ebpf/internal/fd.go
@@ -1,15 +1,16 @@
 package internal
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"runtime"
 	"strconv"
 
 	"github.com/cilium/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
-var ErrClosedFd = xerrors.New("use of closed file descriptor")
+var ErrClosedFd = errors.New("use of closed file descriptor")
 
 type FD struct {
 	raw int64
@@ -56,8 +57,13 @@ func (fd *FD) Dup() (*FD, error) {
 
 	dup, err := unix.FcntlInt(uintptr(fd.raw), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
-		return nil, xerrors.Errorf("can't dup fd: %v", err)
+		return nil, fmt.Errorf("can't dup fd: %v", err)
 	}
 
 	return NewFD(uint32(dup)), nil
+}
+
+func (fd *FD) File(name string) *os.File {
+	fd.Forget()
+	return os.NewFile(uintptr(fd.raw), name)
 }

--- a/vendor/github.com/cilium/ebpf/internal/feature.go
+++ b/vendor/github.com/cilium/ebpf/internal/feature.go
@@ -1,14 +1,13 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"sync"
-
-	"golang.org/x/xerrors"
 )
 
 // ErrNotSupported indicates that a feature is not supported by the current kernel.
-var ErrNotSupported = xerrors.New("not supported")
+var ErrNotSupported = errors.New("not supported")
 
 // UnsupportedFeatureError is returned by FeatureTest() functions.
 type UnsupportedFeatureError struct {
@@ -67,7 +66,7 @@ func FeatureTest(name, version string, fn FeatureTestFn) func() error {
 		}
 
 		available, err := fn()
-		if xerrors.Is(err, ErrNotSupported) {
+		if errors.Is(err, ErrNotSupported) {
 			// The feature test aborted because a dependent feature
 			// is missing, which we should cache.
 			available = false
@@ -75,7 +74,7 @@ func FeatureTest(name, version string, fn FeatureTestFn) func() error {
 			// We couldn't execute the feature test to a point
 			// where it could make a determination.
 			// Don't cache the result, just return it.
-			return xerrors.Errorf("can't detect support for %s: %w", name, err)
+			return fmt.Errorf("can't detect support for %s: %w", name, err)
 		}
 
 		ft.successful = true
@@ -99,7 +98,7 @@ func NewVersion(ver string) (Version, error) {
 	var major, minor, patch uint16
 	n, _ := fmt.Sscanf(ver, "%d.%d.%d", &major, &minor, &patch)
 	if n < 2 {
-		return Version{}, xerrors.Errorf("invalid version: %s", ver)
+		return Version{}, fmt.Errorf("invalid version: %s", ver)
 	}
 	return Version{major, minor, patch}, nil
 }

--- a/vendor/github.com/cilium/ebpf/internal/io.go
+++ b/vendor/github.com/cilium/ebpf/internal/io.go
@@ -1,6 +1,6 @@
 package internal
 
-import "golang.org/x/xerrors"
+import "errors"
 
 // DiscardZeroes makes sure that all written bytes are zero
 // before discarding them.
@@ -9,7 +9,7 @@ type DiscardZeroes struct{}
 func (DiscardZeroes) Write(p []byte) (int, error) {
 	for _, b := range p {
 		if b != 0 {
-			return 0, xerrors.New("encountered non-zero byte")
+			return 0, errors.New("encountered non-zero byte")
 		}
 	}
 	return len(p), nil

--- a/vendor/github.com/cilium/ebpf/internal/unix/types_linux.go
+++ b/vendor/github.com/cilium/ebpf/internal/unix/types_linux.go
@@ -16,6 +16,7 @@ const (
 	EINVAL                   = linux.EINVAL
 	EPOLLIN                  = linux.EPOLLIN
 	EINTR                    = linux.EINTR
+	EPERM                    = linux.EPERM
 	ESRCH                    = linux.ESRCH
 	ENODEV                   = linux.ENODEV
 	BPF_F_RDONLY_PROG        = linux.BPF_F_RDONLY_PROG

--- a/vendor/github.com/cilium/ebpf/internal/unix/types_other.go
+++ b/vendor/github.com/cilium/ebpf/internal/unix/types_other.go
@@ -17,6 +17,7 @@ const (
 	ENOSPC                   = syscall.ENOSPC
 	EINVAL                   = syscall.EINVAL
 	EINTR                    = syscall.EINTR
+	EPERM                    = syscall.EPERM
 	ESRCH                    = syscall.ESRCH
 	ENODEV                   = syscall.ENODEV
 	BPF_F_RDONLY_PROG        = 0

--- a/vendor/github.com/cilium/ebpf/linker.go
+++ b/vendor/github.com/cilium/ebpf/linker.go
@@ -1,10 +1,10 @@
 package ebpf
 
 import (
+	"fmt"
+
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/btf"
-
-	"golang.org/x/xerrors"
 )
 
 // link resolves bpf-to-bpf calls.
@@ -28,7 +28,7 @@ func link(prog *ProgramSpec, libs []*ProgramSpec) error {
 
 			needed, err := needSection(insns, lib.Instructions)
 			if err != nil {
-				return xerrors.Errorf("linking %s: %w", lib.Name, err)
+				return fmt.Errorf("linking %s: %w", lib.Name, err)
 			}
 
 			if !needed {
@@ -41,7 +41,7 @@ func link(prog *ProgramSpec, libs []*ProgramSpec) error {
 
 			if prog.BTF != nil && lib.BTF != nil {
 				if err := btf.ProgramAppend(prog.BTF, lib.BTF); err != nil {
-					return xerrors.Errorf("linking BTF of %s: %w", lib.Name, err)
+					return fmt.Errorf("linking BTF of %s: %w", lib.Name, err)
 				}
 			}
 		}

--- a/vendor/github.com/cilium/ebpf/map.go
+++ b/vendor/github.com/cilium/ebpf/map.go
@@ -1,21 +1,20 @@
 package ebpf
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 // Errors returned by Map and MapIterator methods.
 var (
-	ErrKeyNotExist      = xerrors.New("key does not exist")
-	ErrKeyExist         = xerrors.New("key already exists")
-	ErrIterationAborted = xerrors.New("iteration aborted")
+	ErrKeyNotExist      = errors.New("key does not exist")
+	ErrKeyExist         = errors.New("key already exists")
+	ErrIterationAborted = errors.New("iteration aborted")
 )
 
 // MapID represents the unique ID of an eBPF map
@@ -92,7 +91,7 @@ type Map struct {
 // You should not use fd after calling this function.
 func NewMapFromFD(fd int) (*Map, error) {
 	if fd < 0 {
-		return nil, xerrors.New("invalid fd")
+		return nil, errors.New("invalid fd")
 	}
 	bpfFd := internal.NewFD(uint32(fd))
 
@@ -118,8 +117,8 @@ func NewMap(spec *MapSpec) (*Map, error) {
 	}
 
 	handle, err := btf.NewHandle(btf.MapSpec(spec.BTF))
-	if err != nil && !xerrors.Is(err, btf.ErrNotSupported) {
-		return nil, xerrors.Errorf("can't load BTF: %w", err)
+	if err != nil && !errors.Is(err, btf.ErrNotSupported) {
+		return nil, fmt.Errorf("can't load BTF: %w", err)
 	}
 
 	return newMapWithBTF(spec, handle)
@@ -131,7 +130,7 @@ func newMapWithBTF(spec *MapSpec, handle *btf.Handle) (*Map, error) {
 	}
 
 	if spec.InnerMap == nil {
-		return nil, xerrors.Errorf("%s requires InnerMap", spec.Type)
+		return nil, fmt.Errorf("%s requires InnerMap", spec.Type)
 	}
 
 	template, err := createMap(spec.InnerMap, nil, handle)
@@ -155,25 +154,25 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		}
 
 		if abi.ValueSize != 0 && abi.ValueSize != 4 {
-			return nil, xerrors.New("ValueSize must be zero or four for map of map")
+			return nil, errors.New("ValueSize must be zero or four for map of map")
 		}
 		abi.ValueSize = 4
 
 	case PerfEventArray:
 		if abi.KeySize != 0 && abi.KeySize != 4 {
-			return nil, xerrors.New("KeySize must be zero or four for perf event array")
+			return nil, errors.New("KeySize must be zero or four for perf event array")
 		}
 		abi.KeySize = 4
 
 		if abi.ValueSize != 0 && abi.ValueSize != 4 {
-			return nil, xerrors.New("ValueSize must be zero or four for perf event array")
+			return nil, errors.New("ValueSize must be zero or four for perf event array")
 		}
 		abi.ValueSize = 4
 
 		if abi.MaxEntries == 0 {
 			n, err := internal.PossibleCPUs()
 			if err != nil {
-				return nil, xerrors.Errorf("perf event array: %w", err)
+				return nil, fmt.Errorf("perf event array: %w", err)
 			}
 			abi.MaxEntries = uint32(n)
 		}
@@ -181,7 +180,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	if abi.Flags&(unix.BPF_F_RDONLY_PROG|unix.BPF_F_WRONLY_PROG) > 0 || spec.Freeze {
 		if err := haveMapMutabilityModifiers(); err != nil {
-			return nil, xerrors.Errorf("map create: %w", err)
+			return nil, fmt.Errorf("map create: %w", err)
 		}
 	}
 
@@ -197,7 +196,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		var err error
 		attr.innerMapFd, err = inner.Value()
 		if err != nil {
-			return nil, xerrors.Errorf("map create: %w", err)
+			return nil, fmt.Errorf("map create: %w", err)
 		}
 	}
 
@@ -213,7 +212,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	fd, err := bpfMapCreate(&attr)
 	if err != nil {
-		return nil, xerrors.Errorf("map create: %w", err)
+		return nil, fmt.Errorf("map create: %w", err)
 	}
 
 	m, err := newMap(fd, spec.Name, abi)
@@ -223,13 +222,13 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	if err := m.populate(spec.Contents); err != nil {
 		m.Close()
-		return nil, xerrors.Errorf("map create: can't set initial contents: %w", err)
+		return nil, fmt.Errorf("map create: can't set initial contents: %w", err)
 	}
 
 	if spec.Freeze {
 		if err := m.Freeze(); err != nil {
 			m.Close()
-			return nil, xerrors.Errorf("can't freeze map: %w", err)
+			return nil, fmt.Errorf("can't freeze map: %w", err)
 		}
 	}
 
@@ -301,9 +300,9 @@ func (m *Map) Lookup(key, valueOut interface{}) error {
 		*value = m
 		return nil
 	case *Map:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
 	case Map:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
 
 	case **Program:
 		p, err := unmarshalProgram(valueBytes)
@@ -315,9 +314,9 @@ func (m *Map) Lookup(key, valueOut interface{}) error {
 		*value = p
 		return nil
 	case *Program:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
 	case Program:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
 
 	default:
 		return unmarshalBytes(valueOut, valueBytes)
@@ -332,11 +331,11 @@ func (m *Map) LookupAndDelete(key, valueOut interface{}) error {
 
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	if err := bpfMapLookupAndDelete(m.fd, keyPtr, valuePtr); err != nil {
-		return xerrors.Errorf("lookup and delete failed: %w", err)
+		return fmt.Errorf("lookup and delete failed: %w", err)
 	}
 
 	return unmarshalBytes(valueOut, valueBytes)
@@ -350,7 +349,7 @@ func (m *Map) LookupBytes(key interface{}) ([]byte, error) {
 	valuePtr := internal.NewSlicePointer(valueBytes)
 
 	err := m.lookup(key, valuePtr)
-	if xerrors.Is(err, ErrKeyNotExist) {
+	if errors.Is(err, ErrKeyNotExist) {
 		return nil, nil
 	}
 
@@ -360,11 +359,11 @@ func (m *Map) LookupBytes(key interface{}) ([]byte, error) {
 func (m *Map) lookup(key interface{}, valueOut internal.Pointer) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	if err = bpfMapLookupElem(m.fd, keyPtr, valueOut); err != nil {
-		return xerrors.Errorf("lookup failed: %w", err)
+		return fmt.Errorf("lookup failed: %w", err)
 	}
 	return nil
 }
@@ -394,7 +393,7 @@ func (m *Map) Put(key, value interface{}) error {
 func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	var valuePtr internal.Pointer
@@ -404,11 +403,11 @@ func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 		valuePtr, err = marshalPtr(value, int(m.abi.ValueSize))
 	}
 	if err != nil {
-		return xerrors.Errorf("can't marshal value: %w", err)
+		return fmt.Errorf("can't marshal value: %w", err)
 	}
 
 	if err = bpfMapUpdateElem(m.fd, keyPtr, valuePtr, uint64(flags)); err != nil {
-		return xerrors.Errorf("update failed: %w", err)
+		return fmt.Errorf("update failed: %w", err)
 	}
 
 	return nil
@@ -420,11 +419,11 @@ func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 func (m *Map) Delete(key interface{}) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	if err = bpfMapDeleteElem(m.fd, keyPtr); err != nil {
-		return xerrors.Errorf("delete failed: %w", err)
+		return fmt.Errorf("delete failed: %w", err)
 	}
 	return nil
 }
@@ -446,7 +445,7 @@ func (m *Map) NextKey(key, nextKeyOut interface{}) error {
 	}
 
 	if err := unmarshalBytes(nextKeyOut, nextKeyBytes); err != nil {
-		return xerrors.Errorf("can't unmarshal next key: %w", err)
+		return fmt.Errorf("can't unmarshal next key: %w", err)
 	}
 	return nil
 }
@@ -463,7 +462,7 @@ func (m *Map) NextKeyBytes(key interface{}) ([]byte, error) {
 	nextKeyPtr := internal.NewSlicePointer(nextKey)
 
 	err := m.nextKey(key, nextKeyPtr)
-	if xerrors.Is(err, ErrKeyNotExist) {
+	if errors.Is(err, ErrKeyNotExist) {
 		return nil, nil
 	}
 
@@ -479,12 +478,12 @@ func (m *Map) nextKey(key interface{}, nextKeyOut internal.Pointer) error {
 	if key != nil {
 		keyPtr, err = marshalPtr(key, int(m.abi.KeySize))
 		if err != nil {
-			return xerrors.Errorf("can't marshal key: %w", err)
+			return fmt.Errorf("can't marshal key: %w", err)
 		}
 	}
 
 	if err = bpfMapGetNextKey(m.fd, keyPtr, nextKeyOut); err != nil {
-		return xerrors.Errorf("next key failed: %w", err)
+		return fmt.Errorf("next key failed: %w", err)
 	}
 	return nil
 }
@@ -537,7 +536,7 @@ func (m *Map) Clone() (*Map, error) {
 
 	dup, err := m.fd.Dup()
 	if err != nil {
-		return nil, xerrors.Errorf("can't clone map: %w", err)
+		return nil, fmt.Errorf("can't clone map: %w", err)
 	}
 
 	return newMap(dup, m.name, &m.abi)
@@ -547,7 +546,7 @@ func (m *Map) Clone() (*Map, error) {
 //
 // This requires bpffs to be mounted above fileName. See http://cilium.readthedocs.io/en/doc-1.0/kubernetes/install/#mounting-the-bpf-fs-optional
 func (m *Map) Pin(fileName string) error {
-	return bpfPinObject(fileName, m.fd)
+	return internal.BPFObjPin(fileName, m.fd)
 }
 
 // Freeze prevents a map to be modified from user space.
@@ -555,11 +554,11 @@ func (m *Map) Pin(fileName string) error {
 // It makes no changes to kernel-side restrictions.
 func (m *Map) Freeze() error {
 	if err := haveMapMutabilityModifiers(); err != nil {
-		return xerrors.Errorf("can't freeze map: %w", err)
+		return fmt.Errorf("can't freeze map: %w", err)
 	}
 
 	if err := bpfMapFreeze(m.fd); err != nil {
-		return xerrors.Errorf("can't freeze map: %w", err)
+		return fmt.Errorf("can't freeze map: %w", err)
 	}
 	return nil
 }
@@ -567,7 +566,7 @@ func (m *Map) Freeze() error {
 func (m *Map) populate(contents []MapKV) error {
 	for _, kv := range contents {
 		if err := m.Put(kv.Key, kv.Value); err != nil {
-			return xerrors.Errorf("key %v: %w", kv.Key, err)
+			return fmt.Errorf("key %v: %w", kv.Key, err)
 		}
 	}
 	return nil
@@ -578,7 +577,7 @@ func (m *Map) populate(contents []MapKV) error {
 // The function is not compatible with nested maps.
 // Use LoadPinnedMapExplicit in these situations.
 func LoadPinnedMap(fileName string) (*Map, error) {
-	fd, err := bpfGetObject(fileName)
+	fd, err := internal.BPFObjGet(fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -592,7 +591,7 @@ func LoadPinnedMap(fileName string) (*Map, error) {
 
 // LoadPinnedMapExplicit loads a map with explicit parameters.
 func LoadPinnedMapExplicit(fileName string, abi *MapABI) (*Map, error) {
-	fd, err := bpfGetObject(fileName)
+	fd, err := internal.BPFObjGet(fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +600,7 @@ func LoadPinnedMapExplicit(fileName string, abi *MapABI) (*Map, error) {
 
 func unmarshalMap(buf []byte) (*Map, error) {
 	if len(buf) != 4 {
-		return nil, xerrors.New("map id requires 4 byte value")
+		return nil, errors.New("map id requires 4 byte value")
 	}
 
 	// Looking up an entry in a nested map or prog array returns an id,
@@ -626,12 +625,12 @@ func patchValue(value []byte, typ btf.Type, replacements map[string]interface{})
 	replaced := make(map[string]bool)
 	replace := func(name string, offset, size int, replacement interface{}) error {
 		if offset+size > len(value) {
-			return xerrors.Errorf("%s: offset %d(+%d) is out of bounds", name, offset, size)
+			return fmt.Errorf("%s: offset %d(+%d) is out of bounds", name, offset, size)
 		}
 
 		buf, err := marshalBytes(replacement, size)
 		if err != nil {
-			return xerrors.Errorf("marshal %s: %w", name, err)
+			return fmt.Errorf("marshal %s: %w", name, err)
 		}
 
 		copy(value[offset:offset+size], buf)
@@ -655,7 +654,7 @@ func patchValue(value []byte, typ btf.Type, replacements map[string]interface{})
 		}
 
 	default:
-		return xerrors.Errorf("patching %T is not supported", typ)
+		return fmt.Errorf("patching %T is not supported", typ)
 	}
 
 	if len(replaced) == len(replacements) {
@@ -670,10 +669,10 @@ func patchValue(value []byte, typ btf.Type, replacements map[string]interface{})
 	}
 
 	if len(missing) == 1 {
-		return xerrors.Errorf("unknown field: %s", missing[0])
+		return fmt.Errorf("unknown field: %s", missing[0])
 	}
 
-	return xerrors.Errorf("unknown fields: %s", strings.Join(missing, ","))
+	return fmt.Errorf("unknown fields: %s", strings.Join(missing, ","))
 }
 
 // MapIterator iterates a Map.
@@ -731,7 +730,7 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		mi.prevKey = mi.prevBytes
 
 		mi.err = mi.target.Lookup(nextBytes, valueOut)
-		if xerrors.Is(mi.err, ErrKeyNotExist) {
+		if errors.Is(mi.err, ErrKeyNotExist) {
 			// Even though the key should be valid, we couldn't look up
 			// its value. If we're iterating a hash map this is probably
 			// because a concurrent delete removed the value before we
@@ -750,7 +749,7 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		return mi.err == nil
 	}
 
-	mi.err = xerrors.Errorf("%w", ErrIterationAborted)
+	mi.err = fmt.Errorf("%w", ErrIterationAborted)
 	return false
 }
 

--- a/vendor/github.com/cilium/ebpf/marshalers.go
+++ b/vendor/github.com/cilium/ebpf/marshalers.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"reflect"
 	"runtime"
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal"
-
-	"golang.org/x/xerrors"
 )
 
 func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
@@ -18,7 +18,7 @@ func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
 		if length == 0 {
 			return internal.NewPointer(nil), nil
 		}
-		return internal.Pointer{}, xerrors.New("can't use nil as key of map")
+		return internal.Pointer{}, errors.New("can't use nil as key of map")
 	}
 
 	if ptr, ok := data.(unsafe.Pointer); ok {
@@ -42,12 +42,12 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	case []byte:
 		buf = value
 	case unsafe.Pointer:
-		err = xerrors.New("can't marshal from unsafe.Pointer")
+		err = errors.New("can't marshal from unsafe.Pointer")
 	default:
 		var wr bytes.Buffer
 		err = binary.Write(&wr, internal.NativeEndian, value)
 		if err != nil {
-			err = xerrors.Errorf("encoding %T: %v", value, err)
+			err = fmt.Errorf("encoding %T: %v", value, err)
 		}
 		buf = wr.Bytes()
 	}
@@ -56,7 +56,7 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	}
 
 	if len(buf) != length {
-		return nil, xerrors.Errorf("%T doesn't marshal to %d bytes", data, length)
+		return nil, fmt.Errorf("%T doesn't marshal to %d bytes", data, length)
 	}
 	return buf, nil
 }
@@ -92,13 +92,13 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 		*value = buf
 		return nil
 	case string:
-		return xerrors.New("require pointer to string")
+		return errors.New("require pointer to string")
 	case []byte:
-		return xerrors.New("require pointer to []byte")
+		return errors.New("require pointer to []byte")
 	default:
 		rd := bytes.NewReader(buf)
 		if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
-			return xerrors.Errorf("decoding %T: %v", value, err)
+			return fmt.Errorf("decoding %T: %v", value, err)
 		}
 		return nil
 	}
@@ -113,7 +113,7 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, error) {
 	sliceType := reflect.TypeOf(slice)
 	if sliceType.Kind() != reflect.Slice {
-		return internal.Pointer{}, xerrors.New("per-CPU value requires slice")
+		return internal.Pointer{}, errors.New("per-CPU value requires slice")
 	}
 
 	possibleCPUs, err := internal.PossibleCPUs()
@@ -124,7 +124,7 @@ func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, er
 	sliceValue := reflect.ValueOf(slice)
 	sliceLen := sliceValue.Len()
 	if sliceLen > possibleCPUs {
-		return internal.Pointer{}, xerrors.Errorf("per-CPU value exceeds number of CPUs")
+		return internal.Pointer{}, fmt.Errorf("per-CPU value exceeds number of CPUs")
 	}
 
 	alignedElemLength := align(elemLength, 8)
@@ -151,7 +151,7 @@ func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, er
 func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) error {
 	slicePtrType := reflect.TypeOf(slicePtr)
 	if slicePtrType.Kind() != reflect.Ptr || slicePtrType.Elem().Kind() != reflect.Slice {
-		return xerrors.Errorf("per-cpu value requires pointer to slice")
+		return fmt.Errorf("per-cpu value requires pointer to slice")
 	}
 
 	possibleCPUs, err := internal.PossibleCPUs()
@@ -170,7 +170,7 @@ func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) erro
 
 	step := len(buf) / possibleCPUs
 	if step < elemLength {
-		return xerrors.Errorf("per-cpu element length is larger than available data")
+		return fmt.Errorf("per-cpu element length is larger than available data")
 	}
 	for i := 0; i < possibleCPUs; i++ {
 		var elem interface{}
@@ -188,7 +188,7 @@ func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) erro
 
 		err := unmarshalBytes(elem, elemBytes)
 		if err != nil {
-			return xerrors.Errorf("cpu %d: %w", i, err)
+			return fmt.Errorf("cpu %d: %w", i, err)
 		}
 
 		buf = buf[step:]

--- a/vendor/github.com/cilium/ebpf/run-tests.sh
+++ b/vendor/github.com/cilium/ebpf/run-tests.sh
@@ -15,8 +15,13 @@ if [[ "${1:-}" = "--in-vm" ]]; then
   export GOPROXY=file:///run/go-root/pkg/mod/cache/download
   export GOCACHE=/run/go-cache
 
+  elfs=""
+  if [[ -d "/run/input/bpf" ]]; then
+    elfs="/run/input/bpf"
+  fi
+
   echo Running tests...
-  /usr/local/bin/go test -coverprofile="$1/coverage.txt" -covermode=atomic -v ./...
+  /usr/local/bin/go test -coverprofile="$1/coverage.txt" -covermode=atomic -v -elfs "$elfs" ./...
   touch "$1/success"
   exit 0
 fi
@@ -39,20 +44,34 @@ if [[ -z "${kernel_version}" ]]; then
 fi
 
 readonly kernel="linux-${kernel_version}.bz"
+readonly selftests="linux-${kernel_version}-selftests-bpf.bz"
+readonly input="$(mktemp -d)"
 readonly output="$(mktemp -d)"
-readonly tmp_dir="${TMPDIR:-$(mktemp -d)}"
+readonly tmp_dir="${TMPDIR:-/tmp}"
+readonly branch="${BRANCH:-master}"
 
-test -e "${tmp_dir}/${kernel}" || {
-  echo Fetching "${kernel}"
-  curl --fail -L "https://github.com/cilium/ci-kernels/blob/master/${kernel}?raw=true" -o "${tmp_dir}/${kernel}"
+fetch() {
+    echo Fetching "${1}"
+    wget -nv -N -P "${tmp_dir}" "https://github.com/cilium/ci-kernels/raw/${branch}/${1}"
 }
+
+fetch "${kernel}"
+
+if fetch "${selftests}"; then
+  mkdir "${input}/bpf"
+  tar --strip-components=4 -xjf "${tmp_dir}/${selftests}" -C "${input}/bpf"
+else
+  echo "No selftests found, disabling"
+fi
 
 echo Testing on "${kernel_version}"
 $sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 512M --pwd \
+  --rwdir=/run/input="${input}" \
   --rwdir=/run/output="${output}" \
   --rodir=/run/go-path="$(go env GOPATH)" \
   --rwdir=/run/go-cache="$(go env GOCACHE)" \
-  --script-sh "$(realpath "$0") --in-vm /run/output"
+  --script-sh "$(realpath "$0") --in-vm /run/output" \
+  --qemu-opts -smp 2 # need at least two CPUs for some tests
 
 if [[ ! -e "${output}/success" ]]; then
   echo "Test failed on ${kernel_version}"
@@ -66,4 +85,5 @@ else
   fi
 fi
 
+$sudo rm -r "${input}"
 $sudo rm -r "${output}"

--- a/vendor/github.com/cilium/ebpf/types.go
+++ b/vendor/github.com/cilium/ebpf/types.go
@@ -187,6 +187,9 @@ const (
 	AttachTraceRawTp
 	AttachTraceFEntry
 	AttachTraceFExit
+	AttachModifyReturn
+	AttachLSMMac
+	AttachTraceIter
 )
 
 // AttachFlags of the eBPF program used in BPF_PROG_ATTACH command

--- a/vendor/github.com/cilium/ebpf/types_string.go
+++ b/vendor/github.com/cilium/ebpf/types_string.go
@@ -120,11 +120,14 @@ func _() {
 	_ = x[AttachTraceRawTp-23]
 	_ = x[AttachTraceFEntry-24]
 	_ = x[AttachTraceFExit-25]
+	_ = x[AttachModifyReturn-26]
+	_ = x[AttachLSMMac-27]
+	_ = x[AttachTraceIter-28]
 }
 
-const _AttachType_name = "AttachNoneAttachCGroupInetEgressAttachCGroupInetSockCreateAttachCGroupSockOpsAttachSkSKBStreamParserAttachSkSKBStreamVerdictAttachCGroupDeviceAttachSkMsgVerdictAttachCGroupInet4BindAttachCGroupInet6BindAttachCGroupInet4ConnectAttachCGroupInet6ConnectAttachCGroupInet4PostBindAttachCGroupInet6PostBindAttachCGroupUDP4SendmsgAttachCGroupUDP6SendmsgAttachLircMode2AttachFlowDissectorAttachCGroupSysctlAttachCGroupUDP4RecvmsgAttachCGroupUDP6RecvmsgAttachCGroupGetsockoptAttachCGroupSetsockoptAttachTraceRawTpAttachTraceFEntryAttachTraceFExit"
+const _AttachType_name = "AttachNoneAttachCGroupInetEgressAttachCGroupInetSockCreateAttachCGroupSockOpsAttachSkSKBStreamParserAttachSkSKBStreamVerdictAttachCGroupDeviceAttachSkMsgVerdictAttachCGroupInet4BindAttachCGroupInet6BindAttachCGroupInet4ConnectAttachCGroupInet6ConnectAttachCGroupInet4PostBindAttachCGroupInet6PostBindAttachCGroupUDP4SendmsgAttachCGroupUDP6SendmsgAttachLircMode2AttachFlowDissectorAttachCGroupSysctlAttachCGroupUDP4RecvmsgAttachCGroupUDP6RecvmsgAttachCGroupGetsockoptAttachCGroupSetsockoptAttachTraceRawTpAttachTraceFEntryAttachTraceFExitAttachModifyReturnAttachLSMMacAttachTraceIter"
 
-var _AttachType_index = [...]uint16{0, 10, 32, 58, 77, 100, 124, 142, 160, 181, 202, 226, 250, 275, 300, 323, 346, 361, 380, 398, 421, 444, 466, 488, 504, 521, 537}
+var _AttachType_index = [...]uint16{0, 10, 32, 58, 77, 100, 124, 142, 160, 181, 202, 226, 250, 275, 300, 323, 346, 361, 380, 398, 421, 444, 466, 488, 504, 521, 537, 555, 567, 582}
 
 func (i AttachType) String() string {
 	if i >= AttachType(len(_AttachType_index)-1) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -90,7 +90,7 @@ github.com/cilium/arping
 ## explicit
 github.com/cilium/deepequal-gen
 github.com/cilium/deepequal-gen/generators
-# github.com/cilium/ebpf v0.0.0-20200612163523-d7bee28bad96
+# github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
 ## explicit
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm
@@ -485,7 +485,6 @@ github.com/pelletier/go-toml
 # github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5
 github.com/petermattis/goid
 # github.com/pkg/errors v0.8.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit


### PR DESCRIPTION
Use the Go stdlib error handling functionality (`errors` package and `fmt.Errorf`) [available since Go 1.13](https://blog.golang.org/error-handling-and-go) instead of the external packages github.com/pkg/errors and golang.org/x/xerrors.

Reviewable by commit.