### PR TITLE
Makefile: process packages in subshells for bench targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,17 +227,23 @@ endif
 	$(MAKE) stop-kvstores
 
 bench: start-kvstores
-	$(QUIET)$(foreach pkg,$(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)),\
+	# Process the packages in different subshells. See comment in the
+	# "unit-tests" target above for an explanation.
+	$(QUIET)for pkg in $(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)); do \
 		$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) \
-			$(pkg) \
-		|| exit 1;)
+			$$pkg \
+		|| exit 1; \
+	done
 	$(MAKE) stop-kvstores
 
 bench-privileged:
-	$(QUIET)$(foreach pkg,$(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)),\
+	# Process the packages in different subshells. See comment in the
+	# "unit-tests" target above for an explanation.
+	$(QUIET)for pkg in $(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)); do \
 		$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) \
-			-tags=privileged_tests $(pkg) \
-		|| exit 1;)
+			-tags=privileged_tests $$pkg \
+		|| exit 1; \
+	done
 
 clean-tags:
 	@$(ECHO_CLEAN) tags


### PR DESCRIPTION
In certain environments, the argument list might become large enough so
`make bench` or `make bench-privileged` fail with:

    make: execvp: /bin/bash: Argument list too long

Follow the approach from commit cfa665d3d971 ("Explicitly break
unit-tests foreach into for loop.") for the `bench` and
`bench-privileged` targets as well to fix this.