### PR TITLE
Fixes printk.

### DIFF
--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -49,13 +49,6 @@ static __u64 BPF_FUNC(get_netns_cookie, void *ctx);
 static __printf(1, 3) void
 BPF_FUNC(trace_printk, const char *fmt, int fmt_size, ...);
 
-#ifndef printt
-# define printt(fmt, ...)						\
-	({								\
-		trace_printk(____fmt, ##__VA_ARGS__);			\
-	})
-#endif
-
 /* Random numbers */
 static __u32 BPF_FUNC(get_prandom_u32);
 

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -138,9 +138,22 @@ enum {
 #include "common.h"
 #include "utils.h"
 
+/* This takes both literals and modifiers, e.g.,
+ * printk("hello\n");
+ * printk("%d\n", ret);
+ *
+ * Three caveats when using this:
+ * - message needs to end with newline
+ *
+ * - only a subset of specifier are supported:
+ *   https://elixir.bootlin.com/linux/v5.7.7/source/kernel/trace/bpf_trace.c#L325
+ *
+ * - cannot use more than 3 format specifiers in the format string
+ *   because BPF helpers take a maximum of 5 arguments
+ */
 # define printk(fmt, ...)					\
 		({						\
-			char ____fmt[] = fmt;			\
+			const char ____fmt[] = fmt;		\
 			trace_printk(____fmt, sizeof(____fmt),	\
 				     ##__VA_ARGS__);		\
 		})


### PR DESCRIPTION
Previously the printk macro lacks a `const` modifier to actually work, resulting in print messages being skipped.
This adds that needed `const` :)

Signed-off-by: Weilong Cui <cuiwl@google.com>
