### PR TITLE
Host firewall tests

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -201,6 +201,7 @@ pipeline {
                 KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
+                HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
 
                 // We need to define all ${KERNEL}-dependent env vars in stage instead of top environment block
                 // because jenkins doesn't initialize these values sequentially within one block

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -246,6 +246,7 @@ pipeline {
                         K8S_NODES="3"
                         KUBEPROXY="0"
                         NO_CILIUM_ON_NODE="k8s3"
+                        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
                     }
                     steps {
                         sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s/" | sed "s/Runtime.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'
@@ -274,6 +275,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                         K8S_VERSION="1.19"
+                        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
                     }
                     steps {
                         sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s/" | sed "s/Runtime.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -260,6 +260,9 @@ var (
 const (
 	// ReservedIdentityHealth is equivalent to pkg/identity.ReservedIdentityHealth
 	ReservedIdentityHealth = 4
+
+	// ReservedIdentityHost is equivalent to pkg/identity.ReservedIdentityHost
+	ReservedIdentityHost = 1
 )
 
 // NightlyStableUpgradesFrom maps the cilium image versions to the helm charts

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -627,6 +627,24 @@ func (kub *Kubectl) GetCiliumEndpoint(namespace string, pod string) (*cnpv2.Endp
 	return data, nil
 }
 
+// GetCiliumHostEndpointID returns the ID of the host endpoint on a given node.
+func (kub *Kubectl) GetCiliumHostEndpointID(ciliumPod string) (int64, error) {
+	cmd := fmt.Sprintf("cilium endpoint list -o jsonpath='{[?(@.status.identity.id==%d)].id}'",
+		ReservedIdentityHost)
+	res := kub.CiliumExecContext(context.Background(), ciliumPod, cmd)
+	if !res.WasSuccessful() {
+		return 0, fmt.Errorf("unable to run command '%s' to retrieve ID of host endpoint from %s: %s",
+			cmd, ciliumPod, res.OutputPrettyPrint())
+	}
+
+	hostEpID, err := strconv.ParseInt(strings.TrimSpace(res.Stdout()), 10, 64)
+	if err != nil || hostEpID == 0 {
+		return 0, fmt.Errorf("incorrect host endpoint ID %s: %s",
+			strings.TrimSpace(res.Stdout()), err)
+	}
+	return hostEpID, nil
+}
+
 // GetNumCiliumNodes returns the number of Kubernetes nodes running cilium
 func (kub *Kubectl) GetNumCiliumNodes() int {
 	getNodesCmd := fmt.Sprintf("%s get nodes -o jsonpath='{.items.*.metadata.name}'", KubectlCmd)

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -540,6 +540,11 @@ func DoesNotHaveHosts(count int) func() bool {
 	}
 }
 
+// RunsWithHostFirewall returns true is Cilium runs with the host firewall enabled.
+func RunsWithHostFirewall() bool {
+	return os.Getenv("HOST_FIREWALL") != "0"
+}
+
 // RunsWithKubeProxy returns true if cilium runs together with k8s' kube-proxy.
 func RunsWithKubeProxy() bool {
 	return os.Getenv("KUBEPROXY") != "0"

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1113,11 +1113,11 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		AfterEach(func() {
 			By("Cleaning up after the test")
-			cmd := fmt.Sprintf("%s delete --all cnp,netpol -n %s", helpers.KubectlCmd, testNamespace)
+			cmd := fmt.Sprintf("%s delete --all cnp,ccnp,netpol -n %s", helpers.KubectlCmd, testNamespace)
 			_ = kubectl.Exec(cmd)
 		})
 
-		SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "validates ingress CIDR-dependent L4 (FromCIDR + ToPorts)", func() {
+		SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "validates ingress CIDR-dependent L4", func() {
 			var (
 				outsideNodeName, outsideIP string // k8s3 node (doesn't have agent running)
 
@@ -1128,9 +1128,13 @@ var _ = Describe("K8sPolicyTest", func() {
 				hostIPOfBackendPod string
 
 				policyVerdictAllowRegex, policyVerdictDenyRegex *regexp.Regexp
+
+				ciliumNamespace string
 			)
 
 			BeforeAll(func() {
+				ciliumNamespace = helpers.GetCiliumNamespace(helpers.GetCurrentIntegration())
+
 				RedeployCiliumWithMerge(kubectl, ciliumFilename, daemonCfg,
 					map[string]string{
 						"global.tunnel":               "disabled",
@@ -1140,10 +1144,7 @@ var _ = Describe("K8sPolicyTest", func() {
 						"global.masquerade":    "false",
 						"config.bpfMasquerade": "false",
 
-						// Needed because of
-						// https://github.com/cilium/cilium/issues/12141
-						"global.devices":      "",
-						"global.hostFirewall": "false",
+						"global.hostFirewall": "true",
 					})
 
 				By("Retrieving backend pod and outside node IP addresses")
@@ -1185,7 +1186,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				RedeployCilium(kubectl, ciliumFilename, daemonCfg)
 			})
 
-			testConnectivity := func(expectSuccess bool) int {
+			testConnectivity := func(dstIP string, expectSuccess bool) int {
 				action := "allowed"
 				if !expectSuccess {
 					action = "denied"
@@ -1197,7 +1198,7 @@ var _ = Describe("K8sPolicyTest", func() {
 					res := kubectl.ExecInHostNetNS(
 						context.TODO(),
 						outsideNodeName,
-						helpers.CurlFail("http://%s:%d", backendPodIP, 80),
+						helpers.CurlFail("http://%s:%d", dstIP, 80),
 					)
 					// We want to count the number of attempts that achieved
 					// their expected result, so we can assert on how many
@@ -1216,14 +1217,12 @@ var _ = Describe("K8sPolicyTest", func() {
 			It("connectivity works from the outside before any policies", func() {
 				// Ignore the return because we don't care about `cilium
 				// monitor` output in this test.
-				_ = testConnectivity(true)
+				_ = testConnectivity(backendPodIP, true)
 			})
 
 			It("connectivity is blocked after denying ingress", func() {
 				By("Running cilium monitor in the background")
-				ciliumPod, err := kubectl.GetCiliumPodOnNode(
-					helpers.CiliumNamespace,
-					hostNodeName)
+				ciliumPod, err := kubectl.GetCiliumPodOnNode(ciliumNamespace, hostNodeName)
 				Expect(ciliumPod).ToNot(BeEmpty())
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1231,17 +1230,14 @@ var _ = Describe("K8sPolicyTest", func() {
 				Expect(ep).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 
-				monitor, monitorCancel := kubectl.MonitorEndpointStart(
-					helpers.CiliumNamespace,
-					ciliumPod,
-					ep.ID)
+				monitor, monitorCancel := kubectl.MonitorEndpointStart(ciliumNamespace, ciliumPod, ep.ID)
 
 				By("Importing a default deny policy on ingress")
 				cnpDenyIngress := helpers.ManifestGet(kubectl.BasePath(),
 					"cnp-default-deny-ingress.yaml")
 				importPolicy(kubectl, testNamespace, cnpDenyIngress, "default-deny-ingress")
 
-				count := testConnectivity(false)
+				count := testConnectivity(backendPodIP, false)
 				monitorCancel()
 
 				By("Asserting that the expected policy verdict logs are in the monitor output")
@@ -1258,9 +1254,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				importPolicy(kubectl, testNamespace, cnpDenyIngress, "default-deny-ingress")
 
 				By("Running cilium monitor in the background")
-				ciliumPod, err := kubectl.GetCiliumPodOnNode(
-					helpers.CiliumNamespace,
-					hostNodeName)
+				ciliumPod, err := kubectl.GetCiliumPodOnNode(ciliumNamespace, hostNodeName)
 				Expect(ciliumPod).ToNot(BeEmpty())
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1268,16 +1262,13 @@ var _ = Describe("K8sPolicyTest", func() {
 				Expect(ep).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 
-				monitor, monitorCancel := kubectl.MonitorEndpointStart(
-					helpers.CiliumNamespace,
-					ciliumPod,
-					ep.ID)
+				monitor, monitorCancel := kubectl.MonitorEndpointStart(ciliumNamespace, ciliumPod, ep.ID)
 
 				By("Importing fromCIDR+toPorts policy on ingress")
 				cnpAllowIngress := helpers.ManifestGet(kubectl.BasePath(),
 					"cnp-ingress-from-cidr-to-ports.yaml")
 				importPolicy(kubectl, testNamespace, cnpAllowIngress, "ingress-from-cidr-to-ports")
-				count := testConnectivity(true)
+				count := testConnectivity(backendPodIP, true)
 				monitorCancel()
 
 				By("Asserting that the expected policy verdict logs are in the monitor output")
@@ -1285,6 +1276,92 @@ var _ = Describe("K8sPolicyTest", func() {
 					len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1)),
 				).To(BeNumerically(">=", count),
 					"Monitor output does not show traffic as allowed")
+			})
+
+			SkipContextIf(helpers.RunsWithKubeProxy, "With host policy", func() {
+				BeforeAll(func() {
+					// Deploy echoserver pods in host namespace.
+					echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-cilium-hostnetns.yaml")
+					kubectl.ApplyDefault(echoPodPath).ExpectSuccess("Cannot install echoserver application")
+					Expect(kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=echoserver-hostnetns",
+						helpers.HelperTimeout)).Should(BeNil())
+
+					policyVerdictAllowRegex = regexp.MustCompile(
+						fmt.Sprintf("Policy verdict log: .+action allow.+%s:[0-9]+ -> %s:80 tcp SYN",
+							outsideIP, hostIPOfBackendPod))
+					policyVerdictDenyRegex = regexp.MustCompile(
+						fmt.Sprintf("Policy verdict log: .+action deny.+%s:[0-9]+ -> %s:80 tcp SYN",
+							outsideIP, hostIPOfBackendPod))
+				})
+
+				AfterAll(func() {
+					// Remove echoserver pods from host namespace.
+					echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-cilium-hostnetns.yaml")
+					kubectl.Delete(echoPodPath).ExpectSuccess("Cannot remove echoserver application")
+				})
+
+				It("Connectivity to hostns is blocked after denying ingress", func() {
+					By("Running cilium monitor in the background")
+					ciliumPod, err := kubectl.GetCiliumPodOnNode(ciliumNamespace, hostNodeName)
+					Expect(ciliumPod).ToNot(BeEmpty())
+					Expect(err).ToNot(HaveOccurred())
+
+					hostEpID, err := kubectl.GetCiliumHostEndpointID(ciliumPod)
+					Expect(err).ToNot(HaveOccurred())
+
+					monitor, monitorCancel := kubectl.MonitorEndpointStart(ciliumNamespace, ciliumPod, hostEpID)
+
+					By("Importing a default-deny host policy on ingress")
+					ccnpDenyHostIngress := helpers.ManifestGet(kubectl.BasePath(), "ccnp-default-deny-host-ingress.yaml")
+					importPolicy(kubectl, testNamespace, ccnpDenyHostIngress, "default-deny-host-ingress")
+
+					testConnectivity(backendPodIP, true)
+					count := testConnectivity(hostIPOfBackendPod, false)
+					monitorCancel()
+
+					By("Asserting that the expected policy verdict logs are in the monitor output")
+					Expect(
+						len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1)),
+					).To(BeNumerically(">=", count),
+						"Monitor output does not show traffic as denied: %s", policyVerdictDenyRegex)
+				})
+
+				It("Connectivity is restored after importing ingress policy", func() {
+					By("Importing a default-deny host policy on ingress")
+					ccnpDenyHostIngress := helpers.ManifestGet(kubectl.BasePath(), "ccnp-default-deny-host-ingress.yaml")
+					importPolicy(kubectl, testNamespace, ccnpDenyHostIngress, "default-deny-host-ingress")
+
+					By("Running cilium monitor in the background")
+					ciliumPod, err := kubectl.GetCiliumPodOnNode(ciliumNamespace, hostNodeName)
+					Expect(ciliumPod).ToNot(BeEmpty())
+					Expect(err).ToNot(HaveOccurred())
+
+					hostEpID, err := kubectl.GetCiliumHostEndpointID(ciliumPod)
+					Expect(err).ToNot(HaveOccurred())
+
+					monitor, monitorCancel := kubectl.MonitorEndpointStart(ciliumNamespace, ciliumPod, hostEpID)
+
+					By("Importing fromCIDR+toPorts host policy on ingress")
+					ccnpAllowHostIngress := helpers.ManifestGet(kubectl.BasePath(),
+						"ccnp-host-ingress-from-cidr-to-ports.yaml")
+					importPolicy(kubectl, testNamespace, ccnpAllowHostIngress, "host-ingress-from-cidr-to-ports")
+
+					testConnectivity(backendPodIP, true)
+					count := testConnectivity(hostIPOfBackendPod, true)
+					monitorCancel()
+
+					By("Asserting that the expected policy verdict logs are in the monitor output")
+					Expect(
+						len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1)),
+					).To(BeNumerically(">=", count),
+						"Monitor output does not show traffic as denied: %s", policyVerdictDenyRegex)
+
+					By("Removing the fromCIDR+toPorts ingress host policy")
+					// This is to ensure this policy is always removed before the default-deny one.
+					// Otherwise, connection to the nodes may be disrupted.
+					cmd := fmt.Sprintf("%s -n %s delete ccnp host-ingress-from-cidr-to-ports", helpers.KubectlCmd, testNamespace)
+					kubectl.Exec(cmd).ExpectSuccess("Failed to delete ccnp/host-ingress-from-cidr-to-ports")
+				})
 			})
 		})
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1359,6 +1359,35 @@ var _ = Describe("K8sServicesTest", func() {
 						testExternalIPs()
 					})
 
+					Context("With host policy", func() {
+						var ccnpHostPolicy string
+
+						BeforeAll(func() {
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+								"global.hostFirewall": "true",
+							})
+
+							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlApply, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be applied", ccnpHostPolicy)
+						})
+
+						AfterAll(func() {
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlDelete, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be deleted", ccnpHostPolicy)
+
+							DeployCiliumAndDNS(kubectl, ciliumFilename)
+						})
+
+						It("Tests NodePort", func() {
+							testNodePort(true, false, helpers.ExistNodeWithoutCilium(), 0)
+						})
+					})
+
 					Context("with L7 policy", func() {
 						AfterAll(func() { kubectl.Delete(demoPolicyL7) })
 
@@ -1416,6 +1445,40 @@ var _ = Describe("K8sServicesTest", func() {
 
 					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests externalIPs", func() {
 						testExternalIPs()
+					})
+
+					Context("With host policy", func() {
+						var ccnpHostPolicy string
+
+						BeforeAll(func() {
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+								"global.tunnel":               "disabled",
+								"global.autoDirectNodeRoutes": "true",
+								"global.hostFirewall":         "true",
+							})
+
+							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlApply, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be applied", ccnpHostPolicy)
+						})
+
+						AfterAll(func() {
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlDelete, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be deleted", ccnpHostPolicy)
+
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+								"global.tunnel":               "disabled",
+								"global.autoDirectNodeRoutes": "true",
+							})
+						})
+
+						It("Tests NodePort", func() {
+							testNodePort(true, false, helpers.ExistNodeWithoutCilium(), 0)
+						})
 					})
 
 					Context("with L7 policy", func() {

--- a/test/k8sT/manifests/ccnp-default-deny-host-ingress.yaml
+++ b/test/k8sT/manifests/ccnp-default-deny-host-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "default-deny-host-ingress"
+spec:
+  nodeSelector: {}
+  ingress:
+  - fromEntities:
+    - cluster
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "22"
+        protocol: TCP
+      - port: "6443"
+        protocol: TCP

--- a/test/k8sT/manifests/ccnp-host-ingress-from-cidr-to-ports.yaml
+++ b/test/k8sT/manifests/ccnp-host-ingress-from-cidr-to-ports.yaml
@@ -1,0 +1,14 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+description: "Host policy to allow traffic external to cluster inwards via CIDR and port"
+metadata:
+  name: "host-ingress-from-cidr-to-ports"
+spec:
+  nodeSelector: {}
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+    fromCIDR:
+      - 192.168.36.13/32

--- a/test/k8sT/manifests/ccnp-host-policy-nodeport-tests.yaml
+++ b/test/k8sT/manifests/ccnp-host-policy-nodeport-tests.yaml
@@ -1,0 +1,41 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-policy-nodeport-tests"
+spec:
+  nodeSelector: {}
+  ingress:
+  # Access from outside world
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "22"
+        protocol: TCP
+      - port: "6443"
+        protocol: TCP
+  # VXLAN tunnels and ICMP echos
+  - fromEntities:
+    - remote-node
+
+  egress:
+  # VXLAN tunnels, kubelet, and ICMP echos
+  - toEntities:
+    - remote-node
+  # Kubelet to node without Cilium
+  - toCIDR:
+    - 192.168.36.13/32
+    toPorts:
+    - ports:
+      - port: "10250"
+        protocol: TCP
+  # NodePort test from host namespace
+  - toEndpoints:
+    - matchLabels:
+        zgroup: testDS
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      - port: "69"
+        protocol: UDP

--- a/test/k8sT/manifests/echoserver-cilium-hostnetns.yaml
+++ b/test/k8sT/manifests/echoserver-cilium-hostnetns.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: echoserver
+  labels:
+    k8s-app: echoserver-hostnetns
+spec:
+  selector:
+    matchLabels:
+      name: echoserver-hostnetns
+  template:
+    metadata:
+      labels:
+        name: echoserver-hostnetns
+    spec:
+      containers:
+      - name: web
+        image: docker.io/cilium/echoserver:1.10.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+      hostNetwork: true
+      tolerations:
+      - operator: Exists


### PR DESCRIPTION
This PR disables the host firewall by default in CI. It will only be enabled for all tests when the label `ci/host-firewall` is set. Tests that specifically enable the host firewall (see below) will still run regardless of the label.

The two last commits then add two new tests for the host firewall:
- A test of a fromCIDR+toPorts host policy (based on the existing fromCIDR+toPorts test) from the third node.
- A NodePort test with an ingress+egress host policy (initially written to catch a potential regression on the path client->node1->backend@node2).

I verified `ci/host-firewall` works by running the tests with that label in #12672.