### PR TITLE
v1.7 backports 2020-07-22

### DIFF
--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -1,0 +1,108 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _identity-relevant-labels:
+
+*********************************
+Limiting Identity-Relevant Labels
+*********************************
+
+We recommend that operators in larger environments limit the set of
+identity-relevant labels to avoid frequent creation of new security identities.
+Many Kubernetes labels are not useful for policy enforcement or visibility. A
+few good examples of such labels include timestamps or hashes. These labels,
+when included in evaluation, cause Cilium to generate a unique identity for each
+pod instead of a single identity for all of the pods that comprise a service or
+application.
+
+By default, Cilium evaluates the following labels:
+
+================================ ==============================================
+Label                            Description
+-------------------------------- ----------------------------------------------
+k8s:io.kubernetes.pod.namespace  Include all io.kubernetes.pod.namespace labels
+k8s:app.kubernetes.io            Include all app.kubernetes.io labels
+k8s:!io.kubernetes               Ignore all io.kubernetes labels
+k8s:kubernetes.io                Ignore all other kubernetes.io labels
+k8s:beta.kubernetes.io           Ignore all beta.kubernetes.io labels
+k8s:k8s.io                       Ignore all k8s.io labels
+k8s:!pod-template-generation     Ignore all pod-template-generation labels
+k8s:!pod-template-hash           Ignore all pod-template-hash labels
+k8s:!controller-revision-hash    Ignore all controller-revision-hash labels
+k8s:!annotation.*                Ignore all annotation labels
+k8s:!etcd_node                   Ignore all etcd_node labels
+================================ ==============================================
+
+Configuring Identity-Relevant Labels
+------------------------------------
+
+To limit the labels used for evaluating Cilium identities, edit the Cilium
+ConfigMap object using "kubectl edit cm -n kube-system cilium-config"
+and insert a line to define the labels to include or exclude.
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    data:
+    ...
+      kube-proxy-replacement: partial
+      labels: ...
+      masquerade: "true"
+      monitor-aggregation: medium
+    ...
+
+
+After saving the ConfigMap, restart the Cilium Agents to pickup the new labels
+setting.
+
+Existing identities will not change as a result of this new configuration. To
+apply the new label setting to existing identities, restart the associated pods.
+Upon restart, new identities will be created. The old identities will be garbage
+collected by the Cilium Operator once they are no longer used by any Cilium
+endpoints.
+
+When specifying multiple labels to evaluate, provide the list of labels as a
+space-separated string.
+
+.. code-block:: bash
+
+	 labels: "prefix:labelA prefix:labelB"
+
+Including Labels
+----------------
+
+Labels can be defined as a list of labels to include. Only the labels specified
+will be used to evaluate Cilium identities:
+
+.. code-block:: bash
+
+    labels: "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
+
+The above configuration would only include the following labels when evaluating
+Cilium identities:
+
+- io.kubernetes.pod.namespace=*
+- k8s-app=*
+- app=*
+- name=*
+
+Excluding Labels
+----------------
+
+Labels can also be specified as a list of exclusions. Exclude a label by placing
+an exclamation mark after colon separating the prefix and label. When defined as a
+list of exclusions, Cilium will include the set of default labels, but will
+exclude any matches in the provided list when evaluating Cilium identities:
+
+.. code-block:: bash
+
+    labels: "k8s:!controller-uid k8s:!job-name"
+
+The provided example would cause Cilium to exclude any of the following label
+matches:
+
+- k8s:controller-uid=*
+- k8s:job-name=*

--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -10,7 +10,7 @@
 Limiting Identity-Relevant Labels
 *********************************
 
-We recommend that operators in larger environments limit the set of
+We recommend that operators with larger environments limit the set of
 identity-relevant labels to avoid frequent creation of new security identities.
 Many Kubernetes labels are not useful for policy enforcement or visibility. A
 few good examples of such labels include timestamps or hashes. These labels,
@@ -20,27 +20,29 @@ application.
 
 By default, Cilium evaluates the following labels:
 
-================================ ==============================================
-Label                            Description
--------------------------------- ----------------------------------------------
-k8s:io.kubernetes.pod.namespace  Include all io.kubernetes.pod.namespace labels
-k8s:app.kubernetes.io            Include all app.kubernetes.io labels
-k8s:!io.kubernetes               Ignore all io.kubernetes labels
-k8s:kubernetes.io                Ignore all other kubernetes.io labels
-k8s:beta.kubernetes.io           Ignore all beta.kubernetes.io labels
-k8s:k8s.io                       Ignore all k8s.io labels
-k8s:!pod-template-generation     Ignore all pod-template-generation labels
-k8s:!pod-template-hash           Ignore all pod-template-hash labels
-k8s:!controller-revision-hash    Ignore all controller-revision-hash labels
-k8s:!annotation.*                Ignore all annotation labels
-k8s:!etcd_node                   Ignore all etcd_node labels
-================================ ==============================================
+=================================== ==================================================
+Label                               Description
+----------------------------------- --------------------------------------------------
+``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
+``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
+``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels
+``k8s:kubernetes.io``               Ignore all other ``kubernetes.io`` labels
+``k8s:beta.kubernetes.io``          Ignore all ``beta.kubernetes.io`` labels
+``k8s:k8s.io``                      Ignore all ``k8s.io`` labels
+``k8s:!pod-template-generation``    Ignore all ``pod-template-generation`` labels
+``k8s:!pod-template-hash``          Ignore all ``pod-template-hash`` labels
+``k8s:!controller-revision-hash``   Ignore all ``controller-revision-hash`` labels
+``k8s:!annotation.*``               Ignore all ``annotation labels``
+``k8s:!etcd_node``                  Ignore all ``etcd_node`` labels
+=================================== ==================================================
+
+
 
 Configuring Identity-Relevant Labels
 ------------------------------------
 
 To limit the labels used for evaluating Cilium identities, edit the Cilium
-ConfigMap object using "kubectl edit cm -n kube-system cilium-config"
+ConfigMap object using ``kubectl edit cm -n kube-system cilium-config``
 and insert a line to define the labels to include or exclude.
 
 .. code-block:: yaml
@@ -49,14 +51,19 @@ and insert a line to define the labels to include or exclude.
     data:
     ...
       kube-proxy-replacement: partial
-      labels: ...
+      labels:  "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
       masquerade: "true"
       monitor-aggregation: medium
     ...
 
 
-After saving the ConfigMap, restart the Cilium Agents to pickup the new labels
-setting.
+Upon defining a custom list of labels in the ConfigMap, Cilium will override
+the default list of labels with the list provided. After saving the ConfigMap,
+restart the Cilium Agents to pickup the new labels setting.
+
+.. code-block:: bash
+
+    kubectl delete pods -n kube-system -l k8s-app=cilium
 
 Existing identities will not change as a result of this new configuration. To
 apply the new label setting to existing identities, restart the associated pods.
@@ -66,10 +73,6 @@ endpoints.
 
 When specifying multiple labels to evaluate, provide the list of labels as a
 space-separated string.
-
-.. code-block:: bash
-
-	 labels: "prefix:labelA prefix:labelB"
 
 Including Labels
 ----------------

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -72,6 +72,7 @@ Operations
    :glob:
 
    grafana
+   identity-relevant-labels
 
 Istio
 -----
@@ -95,4 +96,3 @@ Other Orchestrators
 The best way to get help if you get stuck is to ask a question on the `Cilium
 Slack channel <https://cilium.herokuapp.com>`_.  With Cilium contributors
 across the globe, there is almost always someone available to help.
-

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -560,6 +560,7 @@ triaged
 tuples
 ubuntu
 udp
+uid
 uint
 uninline
 unix

--- a/pkg/contexthelpers/context.go
+++ b/pkg/contexthelpers/context.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contexthelpers
+
+import (
+	"context"
+	"time"
+)
+
+type SuccessChan chan bool
+
+// NewConditionalTimeoutContext returns a context which is cancelled when
+// success is not reported within the specified timeout
+func NewConditionalTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc, SuccessChan) {
+	ch := make(SuccessChan)
+	c, cancel := context.WithCancel(ctx)
+
+	go func() {
+		select {
+		case success := <-ch:
+			if !success {
+				cancel()
+				return
+			}
+		case <-time.After(timeout):
+			cancel()
+		}
+	}()
+
+	return c, cancel, ch
+}

--- a/pkg/contexthelpers/context_test.go
+++ b/pkg/contexthelpers/context_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package contexthelpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type ContextSuite struct{}
+
+var _ = check.Suite(&ContextSuite{})
+
+func (b *ContextSuite) TestConditionalTimeoutContext(c *check.C) {
+	ctx, cancel, ch := NewConditionalTimeoutContext(context.Background(), 10*time.Millisecond)
+	c.Assert(ctx, check.Not(check.IsNil))
+	c.Assert(cancel, check.Not(check.IsNil))
+	c.Assert(ch, check.Not(check.IsNil))
+
+	// validate that the context is being cancelled due to the 10
+	// millisecond timeout specified
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		c.Errorf("conditional timeout was not triggered")
+	}
+
+	ctx, cancel, ch = NewConditionalTimeoutContext(context.Background(), 10*time.Millisecond)
+	// report success via the channel
+	ch <- true
+	close(ch)
+
+	// validate that the context is not being cancelled as success has been
+	// reported
+	select {
+	case <-ctx.Done():
+		c.Errorf("context cancelled despite reporting success")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+}

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -43,7 +43,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.18"
+	CustomResourceDefinitionSchemaVersion = "1.18.1"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -801,12 +801,17 @@ var (
 				},
 			},
 			"toGroups": {
-				Type: "object",
+				Type: "array",
 				Description: `ToGroups is a list of constraints that will
 				gather data from third-party providers and create a new
 				derived policy.`,
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-					"aws": AWSGroup,
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+							"aws": AWSGroup,
+						},
+					},
 				},
 			},
 			"toFQDNs": {

--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -349,7 +349,7 @@ func (c *CNPStatusUpdateContext) updateViaKVStore(ctx context.Context, cnp *type
 	)
 
 	if err := <-kvstore.Client().Connected(ctx); err != nil {
-		return nil
+		return fmt.Errorf("kvstore is unavailable: %w", err)
 	}
 
 	capabilities := k8sversion.Capabilities()

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -249,8 +249,10 @@ func Hint(err error) error {
 
 type etcdClient struct {
 	// firstSession is a channel that will be closed once the first session
-	// is set up in the etcd Client.
-	firstSession chan struct{}
+	// is set up in the etcd client. If an error occurred and the initial
+	// session cannot be established, the error is provided via the
+	// channel.
+	firstSession chan error
 
 	// stopStatusChecker is closed when the status checker can be terminated
 	stopStatusChecker chan struct{}
@@ -427,7 +429,10 @@ func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) error {
 
 	select {
 	// Wait for the the initial connection to be established
-	case <-e.firstSession:
+	case err := <-e.firstSession:
+		if err != nil {
+			return err
+		}
 	// Client is closing
 	case <-e.client.Ctx().Done():
 		return fmt.Errorf("client is closing")
@@ -496,12 +501,8 @@ func (e *etcdClient) Disconnected() <-chan struct{} {
 }
 
 func (e *etcdClient) renewSession(ctx context.Context) error {
-	select {
-	// wait for initial session to be established
-	case <-e.firstSession:
-	// controller has stopped or etcd client is closing
-	case <-ctx.Done():
-		return nil
+	if err := e.waitForInitialSession(ctx); err != nil {
+		return err
 	}
 
 	select {
@@ -544,12 +545,8 @@ func (e *etcdClient) renewSession(ctx context.Context) error {
 }
 
 func (e *etcdClient) renewLockSession(ctx context.Context) error {
-	select {
-	// wait for initial session to be established
-	case <-e.firstSession:
-	// controller has stopped or etcd client is closing
-	case <-ctx.Done():
-		return nil
+	if err := e.waitForInitialSession(ctx); err != nil {
+		return err
 	}
 
 	e.RWMutex.RLock()
@@ -615,7 +612,6 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	}).Info("Connecting to etcd server...")
 
 	var s, ls concurrency.Session
-	firstSession := make(chan struct{})
 	errorChan := make(chan error)
 
 	// create session in parallel as this is a blocking operation
@@ -646,7 +642,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		configPath:           cfgPath,
 		session:              &s,
 		lockSession:          &ls,
-		firstSession:         firstSession,
+		firstSession:         errChan,
 		controllers:          controller.NewManager(),
 		latestStatusSnapshot: "Waiting for initial connection to be established",
 		stopStatusChecker:    make(chan struct{}),
@@ -671,7 +667,6 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		}
 
 		ec.getLogger().Debugf("Session received")
-		close(ec.firstSession)
 
 		if err := ec.checkMinVersion(ctx); err != nil {
 			errChan <- fmt.Errorf("unable to validate etcd version: %s", err)
@@ -777,11 +772,22 @@ func (e *etcdClient) checkMinVersion(ctx context.Context) error {
 	return nil
 }
 
-func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error) {
+func (e *etcdClient) waitForInitialSession(ctx context.Context) error {
 	select {
-	case <-e.firstSession:
+	case err := <-e.firstSession:
+		if err != nil {
+			return err
+		}
 	case <-ctx.Done():
-		return nil, fmt.Errorf("lock cancelled via context: %s", ctx.Err())
+		return fmt.Errorf("interrupt while waiting for initial session to be established: %w", ctx.Err())
+	}
+
+	return nil
+}
+
+func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error) {
+	if err := e.waitForInitialSession(ctx); err != nil {
+		return nil, err
 	}
 
 	// Create the context first so that if a connectivity issue causes the
@@ -1210,10 +1216,8 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 
 // UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
 func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error {
-	select {
-	case <-e.firstSession:
-	case <-ctx.Done():
-		return fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	if err := e.waitForInitialSession(ctx); err != nil {
+		return err
 	}
 
 	var (
@@ -1245,10 +1249,8 @@ func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byt
 func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease bool) (err error) {
 	defer Trace("Update", err, logrus.Fields{fieldKey: key, fieldValue: string(value), fieldAttachLease: lease})
 
-	select {
-	case <-e.firstSession:
-	case <-ctx.Done():
-		return fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	if err = e.waitForInitialSession(ctx); err != nil {
+		return
 	}
 
 	if lease {
@@ -1274,11 +1276,10 @@ func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, 
 		Trace("UpdateIfDifferentIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: value, fieldAttachLease: lease, "recreated": recreated})
 	}()
 
-	select {
-	case <-e.firstSession:
-	case <-ctx.Done():
-		return false, fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	if err = e.waitForInitialSession(ctx); err != nil {
+		return false, err
 	}
+
 	duration := spanstat.Start()
 	e.limiter.Wait(ctx)
 	cnds := lock.Comparator().(client.Cmp)
@@ -1322,10 +1323,8 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 		Trace("UpdateIfDifferent", err, logrus.Fields{fieldKey: key, fieldValue: value, fieldAttachLease: lease, "recreated": recreated})
 	}()
 
-	select {
-	case <-e.firstSession:
-	case <-ctx.Done():
-		return false, fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	if err = e.waitForInitialSession(ctx); err != nil {
+		return false, err
 	}
 
 	duration := spanstat.Start()

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/pkg/contexthelpers"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
@@ -269,8 +270,12 @@ type etcdClient struct {
 
 	// protects sessions from concurrent access
 	lock.RWMutex
-	session     *concurrency.Session
-	lockSession *concurrency.Session
+
+	session       *concurrency.Session
+	sessionCancel context.CancelFunc
+
+	lockSession       *concurrency.Session
+	lockSessionCancel context.CancelFunc
 
 	// statusLock protects latestStatusSnapshot and latestErrorStatus for
 	// read/write access
@@ -520,21 +525,36 @@ func (e *etcdClient) renewSession(ctx context.Context) error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, statusCheckTimeout)
-	defer cancel()
+	// Cancel any eventual old session context
+	if e.sessionCancel != nil {
+		e.sessionCancel()
+		e.sessionCancel = nil
+	}
+
+	// Create a context representing the lifetime of the session. It will
+	// timeout if the session creation does not succeed in time and then
+	// persists until any of the below conditions are met:
+	//  - The parent context is cancelled due to the etcd client closing or
+	//    the controller being shut down
+	//  - The above call to sessionCancel() cancels the session due to the
+	//  session ending and requiring renewal.
+	sessionContext, sessionCancel, sessionSuccess := contexthelpers.NewConditionalTimeoutContext(ctx, statusCheckTimeout)
+	defer close(sessionSuccess)
 
 	newSession, err := concurrency.NewSession(
 		e.client,
 		concurrency.WithTTL(int(option.Config.KVstoreLeaseTTL.Seconds())),
-		concurrency.WithContext(timeoutCtx),
+		concurrency.WithContext(sessionContext),
 	)
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd session: %s", err)
 	}
+	sessionSuccess <- true
 	log.Infof("Got new lease ID %x", newSession.Lease())
 
 	e.session = newSession
+	e.sessionCancel = sessionCancel
 	e.UnlockIgnoreTime()
 
 	e.getLogger().WithField(fieldSession, newSession).Debug("Renewing etcd session")
@@ -568,20 +588,35 @@ func (e *etcdClient) renewLockSession(ctx context.Context) error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, statusCheckTimeout)
-	defer cancel()
+	if e.lockSessionCancel != nil {
+		e.lockSessionCancel()
+		e.lockSessionCancel = nil
+	}
+
+	// Create a context representing the lifetime of the lock session. It
+	// will timeout if the session creation does not succeed in time and
+	// persists until any of the below conditions are met:
+	//  - The parent context is cancelled due to the etcd client closing or
+	//    the controller being shut down
+	//  - The above call to sessionCancel() cancels the session due to the
+	//  session ending and requiring renewal.
+	sessionContext, sessionCancel, sessionSuccess := contexthelpers.NewConditionalTimeoutContext(ctx, statusCheckTimeout)
+	defer close(sessionSuccess)
+
 	newSession, err := concurrency.NewSession(
 		e.client,
 		concurrency.WithTTL(int(defaults.LockLeaseTTL.Seconds())),
-		concurrency.WithContext(timeoutCtx),
+		concurrency.WithContext(sessionContext),
 	)
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd lock session: %s", err)
 	}
+	sessionSuccess <- true
 	log.Infof("Got new lock lease ID %x", newSession.Lease())
 
 	e.lockSession = newSession
+	e.lockSessionCancel = sessionCancel
 	e.UnlockIgnoreTime()
 
 	e.getLogger().WithField(fieldSession, newSession).Debug("Renewing etcd lock session")

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -666,7 +666,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 			return
 		}
 
-		ec.getLogger().Debugf("Session received")
+		ec.getLogger().Info("Initial etcd session established")
 
 		if err := ec.checkMinVersion(ctx); err != nil {
 			errChan <- fmt.Errorf("unable to validate etcd version: %s", err)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -503,9 +503,13 @@ func (e *etcdClient) renewSession(ctx context.Context) error {
 		return err
 	}
 
+	e.RLock()
+	sessionChan := e.session.Done()
+	e.RUnlock()
+
 	select {
 	// session has ended
-	case <-e.session.Done():
+	case <-sessionChan:
 	// controller has stopped or etcd client is closing
 	case <-ctx.Done():
 		return nil


### PR DESCRIPTION
 * #12440 -- Fix small CRD issue with toGroups (@lbernail)
 * #12517 -- Adds documentation for limiting identity-relevant labels used when evaluating Cilium Identities (@seanmwinn)
 * #12605 -- etcd: Fix several etcd related issues (@tgraf)

Backport notes:
 #12440 -- ./pkg/apis/cilium.io/v2/client/register.go is here ./pkg/apis/cilium.io/v2/register.go otherwise applied cleanly
 #12517 -- concepts/scalability/index.rst does not exist so I put the identity-relevant-labels.rst in the getting started index
 #12605 -- added 12605 to get going in the pipeline, it applied cleanly.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12440 12517 12605; do contrib/backporting/set-labels.py $pr done 1.7; done
```