### PR TITLE
contrib: Use fixed string search in grep

### DIFF
--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -17,16 +17,16 @@ for release in $(grep "General Announcement" README.rst \
                  | sed 's/.*tree\/\(v'"$MAJ_REGEX"'\).*/\1/'); do
     latest=$(git describe --tags $REMOTE/$release \
              | sed 's/v//' | sed 's/\('"$MIN_REGEX"'\).*/\1/')
-    if grep -q $latest README.rst; then
+    if grep -q -F $latest README.rst; then
         continue
     fi
 
-    current=$(grep $release README.rst \
+    current=$(grep -F $release README.rst \
               | sed 's/.*\('"$MIN_REGEX"'\).*/\1/')
     old_date=$(git log -1 -s --format="%cI" $current | sed "$REGEX_FILTER_DATE")
     new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
     elease=$(echo $release | sed 's/v//')
-    old_proj=$(grep "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
+    old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
                | sed "$PROJECTS_REGEX")
     new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep project \
                | sed "$PROJECTS_REGEX")


### PR DESCRIPTION
This fixes the following error when running the script:

```
$ ./contrib/release/bump-readme.sh
Updating v1.8:
  1.8.1 on 2020-07-02 with project 118
119 to
  1.8.2 on 2020-07-23 with project 121
sed: -e expression #1, char 19: unterminated `s' command

Signal ERR caught!

Traceback (line function script):
39 main ./contrib/release/bump-readme.sh
```

This was caused by the current GitHub project ID being "118" which would
match the regex of "1.8", because the dot will match any character. This
commit fixes this issue by doing a fixed string search instead of regex.