### PR TITLE
use os.user instead of reading /etc/group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,6 @@ JOB_BASE_NAME ?= cilium_test
 GO_VERSION := $(shell cat GO_VERSION)
 GOARCH := $(shell $(GO) env GOARCH)
 
-comma:= ,
-
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 \
 	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
 	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \
@@ -87,11 +85,8 @@ endef
 
 define generate_k8s_api_all
 	$(call generate_k8s_api,all,github.com/cilium/cilium/pkg/k8s/client,$(1),$(2))
-	$(call generate_deepequal,"$(subst $(space),$(comma),$(foreach pkg,$(2),$(1)/$(subst ",,$(subst :,/,$(pkg)))))")
+	$(call generate_deepequal,"$(call join-with-comma,$(foreach pkg,$(2),$(1)/$(subst ",,$(subst :,/,$(pkg)))))")
 endef
-
-empty:=
-space:= $(empty) $(empty)
 
 define generate_k8s_api_deepcopy_deepequal
 	$(call generate_k8s_api,deepcopy,github.com/cilium/cilium/pkg/k8s/client,$(1),$(2))
@@ -102,12 +97,12 @@ define generate_k8s_api_deepcopy_deepequal
 	@#    "$pkg", with the characters replaced, create a new string with the
 	@#    prefix $(1)
 	@#   Finally replace all spaces with commas from the generated strings.
-	$(call generate_deepequal,"$(subst $(space),$(comma),$(foreach pkg,$(2),$(1)/$(subst ",,$(subst :,/,$(pkg)))))")
+	$(call generate_deepequal,"$(call join-with-comma,$(foreach pkg,$(2),$(1)/$(subst ",,$(subst :,/,$(pkg)))))")
 endef
 
 define generate_k8s_api_deepcopy_deepequal_client
 	$(call generate_k8s_api,deepcopy$(comma)client,github.com/cilium/cilium/pkg/k8s/slim/k8s/client,$(1),$(2))
-	$(call generate_deepequal,"$(subst $(space),$(comma),$(foreach pkg,$(2),$(1)/$(subst ",,$(subst :,/,$(pkg)))))")
+	$(call generate_deepequal,"$(call join-with-comma,$(foreach pkg,$(2),$(1)/$(subst ",,$(subst :,/,$(pkg)))))")
 endef
 
 define generate_k8s_protobuf

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -54,6 +54,8 @@ GO_BUILD_FLAGS =
 GO_TEST_FLAGS =
 GO_CLEAN_FLAGS =
 GO_BUILD_LDFLAGS =
+# go build/test -tags values
+GO_TAGS_FLAGS = osusergo
 
 # This is declared here as it is needed to change the covermode depending on if
 # RACE is specified.
@@ -134,11 +136,11 @@ else
 endif
 
 ifneq ($(LOCKDEBUG),)
-    GO_BUILD_FLAGS += -tags lockdebug
-    GO_TEST_FLAGS += -tags lockdebug
+    GO_TAGS_FLAGS += lockdebug
 endif
 
-GO_BUILD_FLAGS += -ldflags '$(GO_BUILD_LDFLAGS) $(EXTRA_GO_BUILD_LDFLAGS)' $(EXTRA_GO_BUILD_FLAGS)
+GO_BUILD_FLAGS += -ldflags '$(GO_BUILD_LDFLAGS) $(EXTRA_GO_BUILD_LDFLAGS)' -tags=$(call join-with-comma,$(GO_TAGS_FLAGS)) $(EXTRA_GO_BUILD_FLAGS)
+GO_TEST_FLAGS += -tags=$(call join-with-comma,$(GO_TAGS_FLAGS))
 
 GO_BUILD += $(GO_BUILD_FLAGS)
 GO_BUILD_WITH_CGO += $(GO_BUILD_FLAGS)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -138,7 +138,7 @@ GO_BUILD += $(GO_BUILD_FLAGS)
 GO_BUILD_WITH_CGO += $(GO_BUILD_FLAGS)
 
 GO_TEST = $(GO) test $(GO_TEST_FLAGS)
-GO_CLEAN = $(GO) clean $(GO_TEST_FLAGS)
+GO_CLEAN = $(GO) clean $(GO_CLEAN_FLAGS)
 # TODO: remove `GO111MODULE=off` once Go 1.13 is deprecated by Go maintainers
 GO_VET = GO111MODULE=off $(GO) vet
 GO_LIST = GO111MODULE=off $(GO) list

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -4,6 +4,12 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 
+# define a function replacing spaces with commas in a list
+empty :=
+space := $(empty) $(empty)
+comma := ,
+join-with-comma = $(subst $(space),$(comma),$(strip $1))
+
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 RELATIVE_DIR := $(shell echo $(realpath .) | sed "s;$(ROOT_DIR)[/]*;;")
 include $(ROOT_DIR)/Makefile.quiet

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -9,14 +9,14 @@ TARGETS := cilium-operator cilium-operator-generic cilium-operator-aws cilium-op
 
 all: $(TARGETS)
 
-cilium-operator: OPERATOR_TAGS=ipam_provider_aws,ipam_provider_azure,ipam_provider_operator
-cilium-operator-generic: OPERATOR_TAGS=ipam_provider_operator
-cilium-operator-aws: OPERATOR_TAGS=ipam_provider_aws
-cilium-operator-azure: OPERATOR_TAGS=ipam_provider_azure
+cilium-operator: GO_TAGS_FLAGS+=ipam_provider_aws,ipam_provider_azure,ipam_provider_operator
+cilium-operator-generic: GO_TAGS_FLAGS+=ipam_provider_operator
+cilium-operator-aws: GO_TAGS_FLAGS+=ipam_provider_aws
+cilium-operator-azure: GO_TAGS_FLAGS+=ipam_provider_azure
 
 $(TARGETS):
 	@$(ECHO_GO)
-	$(QUIET)$(GO_BUILD) -tags $(OPERATOR_TAGS) -o $(@)
+	$(QUIET)$(GO_BUILD) -o $(@)
 
 $(TARGET):
 	@$(ECHO_GO)

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,12 +20,10 @@ import (
 )
 
 const (
-	// GroupFilePath is the unix group file path.
-	GroupFilePath = "/etc/group"
 	// CiliumGroupName is the cilium's unix group name.
 	CiliumGroupName = "cilium"
 	// SocketFileMode is the default file mode for the sockets.
 	SocketFileMode os.FileMode = 0660
-	//ClientTimeout specifies timeout to be used by clients
+	// ClientTimeout specifies timeout to be used by clients
 	ClientTimeout = 90 * time.Second
 )


### PR DESCRIPTION
Use `os/user` from Go stdlib to map the group name to the gid instead of searching through /etc/group. Couple of comments changes on the way.