### PR TITLE
backporting: Report progress in set-labels.py

### DIFF
--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -38,6 +38,7 @@ old_label_len = len(pr_labels)
 
 cilium_labels = cilium.get_labels()
 
+print("Setting labels for PR $pr... ", end="")
 if action == "pending":
     pr_labels = [l for l in pr_labels
                  if l.name != "needs-backport/"+version]
@@ -52,7 +53,6 @@ if action == "pending":
         print("error adding backport-pending/"+version+" label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
-    sys.exit(0)
 
 if action == "done":
     pr_labels = [l for l in pr_labels
@@ -68,4 +68,5 @@ if action == "done":
         print("error adding backport-done/"+version+" label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
-    sys.exit(0)
+
+print("✓")

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -55,8 +55,6 @@ echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels
 if [ "$set_all_labels" = "y" ]; then
     for pr in $prs; do
-        echo -n "Setting labels for PR $pr... "
         $DIR/set-labels.py $pr pending $BRANCH;
-        echo "✓"
     done
 fi


### PR DESCRIPTION
When working on the backport PRs, there are two steps where we update PR labels: when we create the backport PR and when we merge it. On master, if submitting the backport PR with `submit-backport`, it reports the progress as it's updating the labels. However, running the command below, included in the PR, to update labels once merged doesn't report any progress.

    contrib/backporting/set-labels.py 12345 12346 done 1.8

This small commit fixes that to report progress in both cases.