### PR TITLE
Remove agent options deprecated in v1.8

### DIFF
--- a/Documentation/concepts/networking/ipam/hostscope.rst
+++ b/Documentation/concepts/networking/ipam/hostscope.rst
@@ -60,8 +60,6 @@ the needs of your environment.
 |       |                | return.                                          |
 +-------+----------------+--------------------------------------------------+
 
-The size of the IPv4 cluster prefix can be changed with the
-``--ipv4-cluster-cidr-mask-size`` option. The size of the IPv6 cluster prefix
-is currently fixed sized at ``/48``. The node allocation prefixes can be
-specified manually with the option ``--ipv4-range`` respectively
-``--ipv6-range``.
+The size of the IPv6 cluster prefix is currently fixed sized at ``/48``. The
+node allocation prefixes can be specified manually with the options
+``--ipv4-range`` and ``--ipv6-range``, respectively.

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -342,8 +342,8 @@ New Metrics
 Removed options
 ~~~~~~~~~~~~~~~
 
-* ``disable-ipv4``, ``keep-bpf-templates``: These options were deprecated in
-  Cilium 1.8 and are now removed.
+* ``disable-ipv4``, ``ipv4-cluster-cidr-mask-size``, ``keep-bpf-templates``:
+  These options were deprecated in Cilium 1.8 and are now removed.
 * The ``prometheus-serve-addr-deprecated`` option is now removed. Please use
   ``prometheus-serve-addr`` instead.
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -339,6 +339,12 @@ New Metrics
 
 .. _1.8_upgrade_notes:
 
+Removed options
+~~~~~~~~~~~~~~~
+
+* The ``prometheus-serve-addr-deprecated`` option is now removed. Please use
+  ``prometheus-serve-addr`` instead.
+
 1.8 Upgrade Notes
 -----------------
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -342,6 +342,8 @@ New Metrics
 Removed options
 ~~~~~~~~~~~~~~~
 
+* ``disable-ipv4``, ``keep-bpf-templates``: These options were deprecated in
+  Cilium 1.8 and are now removed.
 * The ``prometheus-serve-addr-deprecated`` option is now removed. Please use
   ``prometheus-serve-addr`` instead.
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -272,11 +272,6 @@ func init() {
 	flags.Bool(option.DisableConntrack, false, "Disable connection tracking")
 	option.BindEnv(option.DisableConntrack)
 
-	flags.Bool(option.LegacyDisableIPv4Name, false, "Disable IPv4 mode")
-	flags.MarkDeprecated(option.LegacyDisableIPv4Name, "This option has been deprecated and will be removed in v1.9")
-	flags.MarkHidden(option.LegacyDisableIPv4Name)
-	option.BindEnv(option.LegacyDisableIPv4Name)
-
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
 	option.BindEnv(option.EnableEndpointRoutes)
 
@@ -474,10 +469,6 @@ func init() {
 
 	flags.Bool(option.KeepConfig, false, "When restoring state, keeps containers' configuration in place")
 	option.BindEnv(option.KeepConfig)
-
-	flags.Bool(option.KeepBPFTemplates, false, "Do not restore BPF template files from binary")
-	option.BindEnv(option.KeepBPFTemplates)
-	flags.MarkDeprecated(option.KeepBPFTemplates, "This option is no longer supported and will be removed in v1.9")
 
 	flags.String(option.KVStore, "", "Key-value store type")
 	option.BindEnv(option.KVStore)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -419,10 +419,6 @@ func init() {
 	flags.String(option.IPAM, ipamOption.IPAMHostScopeLegacy, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
-	flags.Int(option.IPv4ClusterCIDRMaskSize, 8, "Mask size for the cluster wide CIDR")
-	option.BindEnv(option.IPv4ClusterCIDRMaskSize)
-	flags.MarkDeprecated(option.IPv4ClusterCIDRMaskSize, "This option has been deprecated and will be removed in v1.9")
-
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(option.IPv4Range)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -211,11 +211,6 @@ const (
 	// KeepConfig when restoring state, keeps containers' configuration in place
 	KeepConfig = "keep-config"
 
-	// KeepBPFTemplates do not restore BPF template files from binary
-	// Deprecated: This option is no longer available since cilium-agent does
-	//             not include the BPF templates anymore.
-	KeepBPFTemplates = "keep-bpf-templates"
-
 	// KVStore key-value store type
 	KVStore = "kvstore"
 
@@ -551,10 +546,6 @@ const (
 	// EnableIPv4Name is the name of the option to enable IPv4 support
 	EnableIPv4Name = "enable-ipv4"
 
-	// LegacyDisableIPv4Name is the name of the legacy option to disable
-	// IPv4 support
-	LegacyDisableIPv4Name = "disable-ipv4"
-
 	// EnableIPv6Name is the name of the option to enable IPv6 support
 	EnableIPv6Name = "enable-ipv6"
 
@@ -818,7 +809,6 @@ var HelpFlagSections = []FlagsSection{
 		Name: "BPF flags",
 		Flags: []string{
 			BPFRoot,
-			KeepBPFTemplates,
 			CTMapEntriesGlobalTCPName,
 			CTMapEntriesGlobalAnyName,
 			CTMapEntriesTimeoutSYNName,
@@ -2262,7 +2252,7 @@ func (c *DaemonConfig) Populate() {
 	c.DebugVerbose = viper.GetStringSlice(DebugVerbose)
 	c.DirectRoutingDevice = viper.GetString(DirectRoutingDevice)
 	c.DisableConntrack = viper.GetBool(DisableConntrack)
-	c.EnableIPv4 = getIPv4Enabled()
+	c.EnableIPv4 = viper.GetBool(EnableIPv4Name)
 	c.EnableIPv6 = viper.GetBool(EnableIPv6Name)
 	c.EnableIPv6NDP = viper.GetBool(EnableIPv6NDPName)
 	c.IPv6MCastDevice = viper.GetString(IPv6MCastDevice)
@@ -2879,14 +2869,6 @@ func sanitizeIntParam(paramName string, paramDefault int) int {
 		return paramDefault
 	}
 	return intParam
-}
-
-func getIPv4Enabled() bool {
-	if viper.GetBool(LegacyDisableIPv4Name) {
-		return false
-	}
-
-	return viper.GetBool(EnableIPv4Name)
 }
 
 func getHostDevice() string {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -158,9 +158,6 @@ const (
 	// which allows to use reserved label for fixed identities
 	FixedIdentityMapping = "fixed-identity-mapping"
 
-	// IPv4ClusterCIDRMaskSize is the mask size for the cluster wide CIDR
-	IPv4ClusterCIDRMaskSize = "ipv4-cluster-cidr-mask-size"
-
 	// IPv4Range is the per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16
 	IPv4Range = "ipv4-range"
 
@@ -940,7 +937,6 @@ var HelpFlagSections = []FlagsSection{
 			EnableIPv6NDPName,
 			IPAllocationTimeout,
 			IPAM,
-			IPv4ClusterCIDRMaskSize,
 			IPv4NodeAddr,
 			IPv6NodeAddr,
 			IPv4PodSubnets,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -349,9 +349,6 @@ const (
 	// PrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 	PrometheusServeAddr = "prometheus-serve-addr"
 
-	// PrometheusServeAddrDeprecated IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-	PrometheusServeAddrDeprecated = "prometheus-serve-addr-deprecated"
-
 	// CMDRef is the path to cmdref output directory
 	CMDRef = "cmdref"
 
@@ -2364,7 +2361,7 @@ func (c *DaemonConfig) Populate() {
 	c.PProf = viper.GetBool(PProf)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
-	c.PrometheusServeAddr = getPrometheusServerAddr()
+	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
 	c.BlacklistConflictingRoutes = viper.GetBool(BlacklistConflictingRoutes)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
@@ -2890,14 +2887,6 @@ func getIPv4Enabled() bool {
 	}
 
 	return viper.GetBool(EnableIPv4Name)
-}
-
-func getPrometheusServerAddr() string {
-	promAddr := viper.GetString(PrometheusServeAddr)
-	if promAddr == "" {
-		return viper.GetString("prometheus-serve-addr-deprecated")
-	}
-	return promAddr
 }
 
 func getHostDevice() string {


### PR DESCRIPTION
Remove the following Cilium agent options deprecated in v1.8 announced to be removed in v1.9:

* ``disable-ipv4``
* ~``disable-k8s-services``~ - split out of this PR as it needs further discussion, see https://github.com/cilium/cilium/pull/12642#issuecomment-663522021)
* ``ipv4-cluster-cidr-mask-size``
* ``keep-bpf-templates``

as well as the `--prometheus-serve-addr-deprecated` which other than it's name (which already states it is deprecated) has no functional difference to the existing `prometheus-serve-addr` option.

Reviewable by commit.

Note: This PR does not remove the deprecated options `--tofqdns-enable-poller` and `--tofqdns-enable-poller-events`. These will be addressed in a separate PR removing the DNS Poller, see #8604.
