### PR TITLE
docs: Janitors should update backport PR labels

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -385,6 +385,12 @@ steps 1 to 2 times per day. Works best if done first thing in the working day.
 
 #. Merge PRs with the ``ready-to-merge`` label set `here <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+sort%3Aupdated-asc+label%3Aready-to-merge+>`_
 
+#. If the PR is a backport PR, update the labels of cherry-picked PRs with the command included at the end of the original post. For example:
+
+   .. code-block:: bash
+   
+       $ for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done
+
 Triage issues for Triage team
 -----------------------------
 

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -200,12 +200,12 @@ The comment must not contain any other characters.
 After the backports are merged
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After the backport PR is merged, mark all backported PRs with
-``backport-done/X.Y`` label and clear the ``backport-pending/X.Y`` label(s). If
-the backport pull request description was generated using the scripts above,
-then the full command is listed in the pull request description.
+After the backport PR is merged, if the person who merged the PR didn't take
+care of it already, mark all backported PRs with ``backport-done/X.Y`` label
+and clear the ``backport-pending/X.Y`` label(s). If the backport pull request
+description was generated using the scripts above, then the full command is
+listed in the pull request description.
 
 .. code-block:: bash
 
-   # Set PR 1234's v1.0 backporting labels to done
-   contrib/backporting/set-labels.py 1234 done 1.0.
+   $ for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done


### PR DESCRIPTION
This commit updates the documentation to clarify that members of the Janitors team should take care of updating labels when merging backport PRs.

This commit also updates the example set-labels.py commands.

Related: https://github.com/cilium/cilium/pull/12346#issuecomment-652574319
Reported-by: @Rolinh 