### PR TITLE
feat(configmap): Add support for setting labels in config map

### DIFF
--- a/Documentation/concepts/scalability/identity-relevant-labels.rst
+++ b/Documentation/concepts/scalability/identity-relevant-labels.rst
@@ -43,7 +43,9 @@ Configuring Identity-Relevant Labels
 
 To limit the labels used for evaluating Cilium identities, edit the Cilium
 ConfigMap object using ``kubectl edit cm -n kube-system cilium-config``
-and insert a line to define the labels to include or exclude.
+and insert a line to define the labels to include or exclude. Alternatively,
+this attribute can also be set via helm option ``--set config.labels=<values>``.
+
 
 .. code-block:: yaml
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -103,6 +103,11 @@ data:
   identity-change-grace-period: {{ default "5s" .Values.identityChangeGracePeriod | quote }}
 {{- end }}
 
+{{- if hasKey .Values "labels" }}
+  # To include or exclude matched resources from cilium identity evaluation
+  labels: {{ .Values.labels | quote }}
+{{- end }}
+
   # If you want to run cilium in debug mode change this value to true
   debug: {{ .Values.global.debug.enabled | quote }}
 

--- a/install/kubernetes/cilium/charts/config/values.yaml
+++ b/install/kubernetes/cilium/charts/config/values.yaml
@@ -44,7 +44,7 @@
 
 # enables non-drop mode for installed policies. In audit mode
 # packets affected by policies will not be dropped. Policy related
-# decisions can be checked via the poicy verdict messages.
+# decisions can be checked via the policy verdict messages.
 #policyAuditMode: false
 
 # enables passing identity on local routes by using the mark fields. However,
@@ -54,3 +54,6 @@
 # Operator will exit if CRDs are not available within this duration upon
 # startup.
 #crdWaitTimeout: 5m
+
+# A list of labels to include or exclude from Cilium identity evaluation.
+#labels: "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"


### PR DESCRIPTION
This new labels in values.yaml can be added directly in config map and
is optional.

Closes #12569

Signed-off-by: Tam Mach <sayboras@yahoo.com>

<!-- Description of change -->

Fixes: #issue-number

```release-note
feat(configmap): Add support for setting labels in config map
```
