### PR TITLE
helm: add Hubble Relay service account

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
                   values:
                     - cilium
             topologyKey: "kubernetes.io/hostname"
+      serviceAccount: hubble-relay
+      serviceAccountName: hubble-relay
       containers:
         - name: hubble-relay
 {{- if contains "/" .Values.image.repository }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-relay
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -35,3 +35,7 @@ sortBufferDrainTimeout: ~
 
 # Port to use for the k8s service backed by hubble-relay pods.
 servicePort: 80
+
+# Specifies annotation for service accounts
+serviceAccount:
+  annotations: {}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/ingress.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/ingress.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "14") }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: hubble-ui

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: hubble-ui
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.serviceAccount.annotations }}
+{{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
-  {{- end }}
+{{- end }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -6,6 +6,13 @@ metadata:
   name: cilium
   namespace: kube-system
 ---
+# Source: cilium/charts/hubble-relay/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+---
 # Source: cilium/charts/hubble-ui/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -699,6 +706,8 @@ spec:
                   values:
                     - cilium
             topologyKey: "kubernetes.io/hostname"
+      serviceAccount: hubble-relay
+      serviceAccountName: hubble-relay
       containers:
         - name: hubble-relay
           image: "docker.io/cilium/hubble-relay:latest"


### PR DESCRIPTION
helm: add Hubble Relay service account

I was not able to deploy Hubble Relay in our environment because of pod security policy which denied the use of hostPath volumes for the socket directory.

```
kubectl describe replicasets hubble-relay-7f59599cc 
[...]
  Type     Reason        Age                   From                   Message
  ----     ------        ----                  ----                   -------
  Warning  FailedCreate  4m17s (x19 over 26m)  replicaset-controller  Error creating: pods "hubble-relay-776dd8bdf-" is forbidden: unable to validate against any pod security policy: [spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used]
```

To grant privileges to I created a service account for Hubble Relay.

I guess this is required in most common cluster setups (e.g. in production environments).


```release-note
Add Hubble Relay Kubernetes service account
```