### PR TITLE
api: add missing audit mode enum values for EndpointPolicyEnabled

### DIFF
--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1216,7 +1216,9 @@ definitions:
       - ingress
       - egress
       - both
-
+      - audit-ingress
+      - audit-egress
+      - audit-both
   EndpointPolicy:
     description: Policy information of an endpoint
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2078,7 +2078,10 @@ func init() {
         "none",
         "ingress",
         "egress",
-        "both"
+        "both",
+        "audit-ingress",
+        "audit-egress",
+        "audit-both"
       ]
     },
     "EndpointPolicyStatus": {
@@ -5707,7 +5710,10 @@ func init() {
         "none",
         "ingress",
         "egress",
-        "both"
+        "both",
+        "audit-ingress",
+        "audit-egress",
+        "audit-both"
       ]
     },
     "EndpointPolicyStatus": {


### PR DESCRIPTION
PR  #11011 added only the generated APIs, but not the changes to
openapi.yaml and embedded_spec.go. Otherwise the respective consts are
removed when regenerating the API. Add them to api/v1/openapi.yaml now.

Fixes: 514a38b11a6e ("Handle audit mode in cilium endpoint list and kubectl get cep")