### PR TITLE
hubble/relay: fix report of unavailable nodes

### DIFF
--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/status"
 )
 
@@ -40,6 +41,17 @@ func newObserverClient(cc pool.ClientConn) observerpb.ObserverClient {
 		return observerpb.NewObserverClient(conn)
 	}
 	return nil
+}
+
+func isAvailable(conn pool.ClientConn) bool {
+	if conn == nil {
+		return false
+	}
+	switch conn.GetState() {
+	case connectivity.Ready, connectivity.Idle:
+		return true
+	}
+	return false
 }
 
 func retrieveFlowsFromPeer(

--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -87,7 +87,7 @@ func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, stream observerpb.Obs
 
 	for _, p := range peers {
 		p := p
-		if p.Conn == nil {
+		if !isAvailable(p.Conn) {
 			s.opts.log.WithField("address", p.Address.String()).Infof(
 				"No connection to peer %s, skipping", p.Name,
 			)
@@ -164,7 +164,7 @@ func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusR
 	statuses := make(chan *observerpb.ServerStatusResponse, len(peers))
 	for _, p := range peers {
 		p := p
-		if p.Conn == nil {
+		if !isAvailable(p.Conn) {
 			s.opts.log.WithField("address", p.Address.String()).Infof(
 				"No connection to peer %s, skipping", p.Name,
 			)


### PR DESCRIPTION
This commit fixes reporting of unavailable nodes. The previous code
incorrectly assumed that nodes were unavailable only when their
associated `ClientConn` is `nil`. However, a peer may still be
unavailable if its `ClientConn` is not healthy. The connection state can
be checked by using the `GetState()` which is what the new helper
function does. Any state that is not `Ready` or `Idle` is assumed to be
non-healthy.
