### PR TITLE
feat(helm): Add serviceAccount field for hubble-ui

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       securityContext:
         runAsUser: 1001
       {{- end }}
+      serviceAccount: hubble-ui
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -750,6 +750,7 @@ spec:
     spec:
       securityContext:
         runAsUser: 1001
+      serviceAccount: hubble-ui
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui


### PR DESCRIPTION
Coming out from https://github.com/cilium/cilium/pull/12650#discussion_r460086060, I scan all the charts and find that hubble-ui is missing serviceAccount field.

This serviceAccount was deprecated in kube 1.18, however this should be
added to support earlier kube version

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
feat(helm): Add serviceAccount field for hubble-ui
```
