### PR TITLE
fix(12664): initialize gops in RootCmd execution function

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -109,6 +109,14 @@ var (
 				genMarkdown(cmd, cmdRefDir)
 				os.Exit(0)
 			}
+
+			// Open socket for using gops to get stacktraces of the agent.
+			if err := gops.Listen(gops.Options{}); err != nil {
+				errorString := fmt.Sprintf("unable to start gops: %s", err)
+				fmt.Println(errorString)
+				os.Exit(-1)
+			}
+
 			bootstrapStats.earlyInit.Start()
 			initEnv(cmd)
 			bootstrapStats.earlyInit.End(true)
@@ -136,12 +144,6 @@ func init() {
 func Execute() {
 	bootstrapStats.overall.Start()
 
-	// Open socket for using gops to get stacktraces of the agent.
-	if err := gops.Listen(gops.Options{}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
-		os.Exit(-1)
-	}
 	interruptCh := cleaner.registerSigHandler()
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
daemon/cmd: initialize gops in RootCmd execution function

This commit fixes a bug introduced in 299629d932d8 wherein `cilium-agent --help`
exits with an error(unable to start gops..). This happens because the user started
the cilium-agent process with root privileges which created the directory
`/home/vagrant/.config/gops` with the user root. Any further attempt to run
cilium-agent without root privileges will print out this error.
The commit fixes running commands like `cilium-agent --help`
`cilium-agent --cmdref <dir>` without root privileges by moving gops initialization
to a later stage in the agent.

Fixes: 299629d932d8 "daemon: open socket in agent for gops stack traces"

Fixes: #12664 