### PR TITLE
operator: Remove options deprecated in v1.8

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -52,7 +52,7 @@ cilium-agent [flags]
       --debug-verbose strings                         List of enabled verbose debug groups
       --devices strings                               List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
       --direct-routing-device string                  Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
-      --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
+      --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
       --disable-conntrack                             Disable connection tracking
       --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings         Chains to ignore when installing feeder rules.

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -352,7 +352,8 @@ Configuration
 
 ``cilium-operator`` can be configured to serve metrics by running with the
 option ``--enable-metrics``.  By default, the operator will expose metrics on
-port 6942, the port can be changed with the option ``--metrics-address``.
+port 6942, the port can be changed with the option
+``--operator-prometheus-serve-addr``.
 
 Exported Metrics
 ^^^^^^^^^^^^^^^^

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -347,6 +347,15 @@ Removed options
 * The ``prometheus-serve-addr-deprecated`` option is now removed. Please use
   ``prometheus-serve-addr`` instead.
 
+Removed cilium-operator options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The options ``cnp-node-status-gc`` and ``ccnp-node-status-gc`` are now
+  removed. Please use ``cnp-node-status-gc-interval=0`` instead.
+
+* The ``cilium-endpoint-gc`` option is now removed. Please use
+  ``cilium-endpoint-gc-interval=0`` instead.
+
 .. _1.8_upgrade_notes:
 
 1.8 Upgrade Notes

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -339,8 +339,6 @@ New Metrics
   * ``cilium_kvstore_quorum_errors_total`` counts the number of kvstore quorum
     loss errors. The label ``error`` indicates the type of error.
 
-.. _1.8_upgrade_notes:
-
 Removed options
 ~~~~~~~~~~~~~~~
 
@@ -348,6 +346,8 @@ Removed options
   These options were deprecated in Cilium 1.8 and are now removed.
 * The ``prometheus-serve-addr-deprecated`` option is now removed. Please use
   ``prometheus-serve-addr`` instead.
+
+.. _1.8_upgrade_notes:
 
 1.8 Upgrade Notes
 -----------------

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -368,6 +368,9 @@ Removed cilium-operator options
 * The ``api-server-port`` option is now removed. Please use
   ``operator-api-serve-addr`` instead.
 
+* The ``metrics-address`` option is now removed. Please use
+  ``operator-prometheus-serve-addr`` instead.
+
 .. _1.8_upgrade_notes:
 
 1.8 Upgrade Notes

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -356,6 +356,9 @@ Removed cilium-operator options
 * The ``cilium-endpoint-gc`` option is now removed. Please use
   ``cilium-endpoint-gc-interval=0`` instead.
 
+* The ``eni-parallel-workers`` option is now removed. Please use
+  ``parallel-alloc-workers`` instead.
+
 .. _1.8_upgrade_notes:
 
 1.8 Upgrade Notes

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -359,6 +359,12 @@ Removed cilium-operator options
 * The ``eni-parallel-workers`` option is now removed. Please use
   ``parallel-alloc-workers`` instead.
 
+* The ``aws-client-burst`` option is now removed. Please use
+  ``limit-ipam-api-burst`` instead.
+
+* The ``aws-client-qps`` option is now removed. Please use
+  ``limit-ipam-api-qps`` instead.
+
 .. _1.8_upgrade_notes:
 
 1.8 Upgrade Notes

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -365,6 +365,9 @@ Removed cilium-operator options
 * The ``aws-client-qps`` option is now removed. Please use
   ``limit-ipam-api-qps`` instead.
 
+* The ``api-server-port`` option is now removed. Please use
+  ``operator-api-serve-addr`` instead.
+
 .. _1.8_upgrade_notes:
 
 1.8 Upgrade Notes

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -772,7 +772,7 @@ func init() {
 	flags.MarkHidden(option.PolicyTriggerInterval)
 	option.BindEnv(option.PolicyTriggerInterval)
 
-	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)`)
+	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)`)
 	option.BindEnv(option.DisableCNPStatusUpdates)
 
 	flags.Bool(option.PolicyAuditModeArg, false, "Enable policy audit (non-drop) mode")

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -33,14 +33,8 @@ func init() {
 
 	flags := rootCmd.Flags()
 
-	flags.Int(operatorOption.AWSClientBurstDeprecated, defaults.IPAMAPIBurst, "")
-	flags.MarkDeprecated(operatorOption.AWSClientBurstDeprecated, fmt.Sprintf("please use --%s", operatorOption.IPAMAPIBurst))
-
 	flags.Int(operatorOption.IPAMAPIBurst, defaults.IPAMAPIBurst, "Upper burst limit when accessing external APIs")
 	option.BindEnv(operatorOption.IPAMAPIBurst)
-
-	flags.Float64(operatorOption.AWSClientQPSLimitDeprecated, defaults.IPAMAPIQPSLimit, "")
-	flags.MarkDeprecated(operatorOption.AWSClientQPSLimitDeprecated, fmt.Sprintf("please use --%s", operatorOption.IPAMAPIQPSLimit))
 
 	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
 	option.BindEnv(operatorOption.IPAMAPIQPSLimit)

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -53,10 +53,6 @@ func init() {
 		"Subnets IDs (separated by commas)")
 	option.BindEnv(operatorOption.IPAMSubnetsIDs)
 
-	flags.Int64(operatorOption.ENIParallelWorkersDeprecated, defaults.ParallelAllocWorkers, "")
-	flags.MarkDeprecated(operatorOption.ENIParallelWorkersDeprecated, fmt.Sprintf("please use --%s", operatorOption.ParallelAllocWorkers))
-	option.BindEnv(operatorOption.ENIParallelWorkersDeprecated)
-
 	flags.Int64(operatorOption.ParallelAllocWorkers, defaults.ParallelAllocWorkers, "Maximum number of parallel IPAM workers")
 	option.BindEnv(operatorOption.ParallelAllocWorkers)
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -74,16 +74,6 @@ func init() {
 	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
 	option.BindEnv(option.ConfigDir)
 
-	// Deprecated, remove in 1.9
-	flags.Bool(operatorOption.EnableCCNPNodeStatusGC, true, "Enable CiliumClusterwideNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
-	option.BindEnv(operatorOption.EnableCCNPNodeStatusGC)
-	flags.MarkDeprecated(operatorOption.EnableCCNPNodeStatusGC, fmt.Sprintf("Please use %s=0 to disable CCNP Status GC", operatorOption.CNPNodeStatusGCInterval))
-
-	// Deprecated, remove in 1.9
-	flags.Bool(operatorOption.EnableCNPNodeStatusGC, true, "Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
-	option.BindEnv(operatorOption.EnableCNPNodeStatusGC)
-	flags.MarkDeprecated(operatorOption.EnableCNPNodeStatusGC, fmt.Sprintf("Please use %s=0 to disable CNP Status GC", operatorOption.CNPNodeStatusGCInterval))
-
 	flags.Duration(operatorOption.CNPNodeStatusGCInterval, 2*time.Minute, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
 	option.BindEnv(operatorOption.CNPNodeStatusGCInterval)
 
@@ -100,11 +90,6 @@ func init() {
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "")
 	flags.MarkHidden(option.DisableCiliumEndpointCRDName)
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
-
-	// Deprecated, remove in 1.9
-	flags.Bool(operatorOption.EnableCEPGC, true, "Enable CiliumEndpoint garbage collector")
-	option.BindEnv(operatorOption.EnableCEPGC)
-	flags.MarkDeprecated(operatorOption.EnableCEPGC, fmt.Sprintf("Please use %s=0 to disable CEP GC", operatorOption.EndpointGCInterval))
 
 	flags.Duration(operatorOption.EndpointGCInterval, operatorOption.EndpointGCIntervalDefault, "GC interval for cilium endpoints")
 	option.BindEnv(operatorOption.EndpointGCInterval)

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -259,10 +259,6 @@ func init() {
 	option.BindEnv(option.Version)
 
 	// Deprecated, remove in 1.9
-	flags.Uint16Var(&apiServerPort, "api-server-port", 9234, "Port on which the operator should serve API requests")
-	flags.MarkDeprecated("api-server-port", fmt.Sprintf("Please use %s instead", operatorOption.OperatorAPIServeAddr))
-
-	// Deprecated, remove in 1.9
 	flags.StringVar(&operatorMetrics.Address, "metrics-address", ":6942", "Address to serve Prometheus metrics")
 	flags.MarkDeprecated("metrics-address", fmt.Sprintf("Please use %s instead", operatorOption.OperatorPrometheusServeAddr))
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -257,10 +256,6 @@ func init() {
 
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(option.Version)
-
-	// Deprecated, remove in 1.9
-	flags.StringVar(&operatorMetrics.Address, "metrics-address", ":6942", "Address to serve Prometheus metrics")
-	flags.MarkDeprecated("metrics-address", fmt.Sprintf("Please use %s instead", operatorOption.OperatorPrometheusServeAddr))
 
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")
 	flags.MarkHidden(option.CMDRef)

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -133,11 +133,8 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 
 	}()
 
-	if operatorOption.Config.EnableCNPNodeStatusGC && operatorOption.Config.CNPNodeStatusGCInterval != 0 {
+	if operatorOption.Config.CNPNodeStatusGCInterval != 0 {
 		go runCNPNodeStatusGC("cnp-node-gc", false, ciliumNodeStore)
-	}
-
-	if operatorOption.Config.EnableCCNPNodeStatusGC && operatorOption.Config.CNPNodeStatusGCInterval != 0 {
 		go runCNPNodeStatusGC("ccnp-node-gc", true, ciliumNodeStore)
 	}
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -342,7 +342,7 @@ func runOperator(cmd *cobra.Command) {
 		}
 	}
 
-	if operatorOption.Config.EnableCEPGC && operatorOption.Config.EndpointGCInterval != 0 {
+	if operatorOption.Config.EndpointGCInterval != 0 {
 		enableCiliumEndpointSyncGC()
 	}
 

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -28,8 +28,6 @@ const Namespace = "cilium_operator"
 
 var (
 	Registry *prometheus.Registry
-
-	Address string
 )
 
 func Register() {
@@ -39,13 +37,6 @@ func Register() {
 		// The Handler function provides a default handler to expose metrics
 		// via an HTTP server. "/metrics" is the usual endpoint for that.
 		http.Handle("/metrics", promhttp.HandlerFor(Registry, promhttp.HandlerOpts{}))
-		log.Fatal(http.ListenAndServe(getPrometheusServerAddr(), nil))
+		log.Fatal(http.ListenAndServe(operatorOption.Config.OperatorPrometheusServeAddr, nil))
 	}()
-}
-
-func getPrometheusServerAddr() string {
-	if operatorOption.Config.OperatorPrometheusServeAddr == "" {
-		return Address
-	}
-	return operatorOption.Config.OperatorPrometheusServeAddr
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -35,20 +35,6 @@ const (
 	// being sent to the K8s apiserver for a given CNP.
 	CNPStatusUpdateInterval = "cnp-status-update-interval"
 
-	// EnableCEPGC enables CiliumEndpoint garbage collector
-	// Deprecated: use EndpointGCInterval and remove in 1.9
-	EnableCEPGC = "cilium-endpoint-gc"
-
-	// EnableCCNPNodeStatusGC enables CiliumClusterwideNetworkPolicy Status
-	// garbage collection for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCCNPNodeStatusGC = "ccnp-node-status-gc"
-
-	// EnableCNPNodeStatusGC enables CiliumNetworkPolicy Status garbage
-	// collection for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCNPNodeStatusGC = "cnp-node-status-gc"
-
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics = "enable-metrics"
 
@@ -179,22 +165,8 @@ type OperatorConfig struct {
 	// being sent to the K8s apiserver for a given CNP.
 	CNPStatusUpdateInterval time.Duration
 
-	// EnableCEPGC enables CiliumEndpoint garbage collector
-	// Deprecated: use EndpointGCInterval and remove in 1.9
-	EnableCEPGC bool
-
-	// EnableCNPNodeStatusGC enables CiliumNetworkPolicy Status garbage collection
-	// for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCNPNodeStatusGC bool
-
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics bool
-
-	// EnableCCNPNodeStatusGC enables CiliumClusterwideNetworkPolicy Status
-	// garbage collection for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCCNPNodeStatusGC bool
 
 	// EndpointGCInterval is the interval between attempts of the CEP GC
 	// controller.
@@ -300,9 +272,6 @@ type OperatorConfig struct {
 func (c *OperatorConfig) Populate() {
 	c.CNPNodeStatusGCInterval = viper.GetDuration(CNPNodeStatusGCInterval)
 	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
-	c.EnableCEPGC = viper.GetBool(EnableCEPGC)
-	c.EnableCNPNodeStatusGC = viper.GetBool(EnableCNPNodeStatusGC)
-	c.EnableCCNPNodeStatusGC = viper.GetBool(EnableCCNPNodeStatusGC)
 	c.EnableMetrics = viper.GetBool(EnableMetrics)
 	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.IdentityGCInterval = viper.GetDuration(IdentityGCInterval)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -131,10 +131,6 @@ const (
 	// AWS ENI IPAM.
 	ENITags = "eni-tags"
 
-	// ENIParallelWorkersDeprecated is the deprecated name of the option
-	// ParallelAllocWorkers that can be removed in Cilium 1.9
-	ENIParallelWorkersDeprecated = "eni-parallel-workers"
-
 	// ParallelAllocWorkers specifies the number of parallel workers to be used for IPAM allocation
 	ParallelAllocWorkers = "parallel-alloc-workers"
 
@@ -313,12 +309,6 @@ func (c *OperatorConfig) Populate() {
 		c.IPAMAPIQPSLimit = val
 	} else {
 		c.IPAMAPIQPSLimit = viper.GetFloat64(IPAMAPIQPSLimit)
-	}
-
-	if val := viper.GetInt64(ENIParallelWorkersDeprecated); val != 0 {
-		c.ParallelAllocWorkers = val
-	} else {
-		c.ParallelAllocWorkers = viper.GetInt64(ParallelAllocWorkers)
 	}
 
 	// Option maps and slices

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -81,12 +81,6 @@ const (
 
 	// IPAM options
 
-	// AWSClientBurstDeprecated is the deprecated version of IPAMAPIBurst and will be rewmoved in v1.9
-	AWSClientBurstDeprecated = "aws-client-burst"
-
-	// AWSClientQPSLimitDeprecated is the deprecated version of IPAMAPIQPSLimit and will be removed in v1.9
-	AWSClientQPSLimitDeprecated = "aws-client-qps"
-
 	// IPAMAPIBurst is the burst value allowed when accessing external IPAM APIs
 	IPAMAPIBurst = "limit-ipam-api-burst"
 
@@ -296,20 +290,6 @@ func (c *OperatorConfig) Populate() {
 
 	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
 	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
-
-	// Deprecated options
-
-	if val := viper.GetInt(AWSClientBurstDeprecated); val != 0 {
-		c.IPAMAPIBurst = val
-	} else {
-		c.IPAMAPIBurst = viper.GetInt(IPAMAPIBurst)
-	}
-
-	if val := viper.GetFloat64(AWSClientQPSLimitDeprecated); val != 0 {
-		c.IPAMAPIQPSLimit = val
-	} else {
-		c.IPAMAPIQPSLimit = viper.GetFloat64(IPAMAPIQPSLimit)
-	}
 
 	// Option maps and slices
 


### PR DESCRIPTION
This PR removes cilium-operator options deprecated in v1.8. Please see commit messages for the details.