### PR TITLE
Use the global Azure key

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -66,7 +66,7 @@ Deploy Cilium release via Helm:
      --set global.cni.chainingMode=generic-veth \\
      --set global.cni.customConf=true \\
      --set global.nodeinit.enabled=true \\
-     --set nodeinit.azure=true \\
+     --set global.azure.enabled=true \\
      --set global.cni.configMap=cni-configuration \\
      --set global.tunnel=disabled \\
      --set global.masquerade=false

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -148,7 +148,7 @@ spec:
               ip -4 a
               ip -6 a
 
-{{- if .Values.azure }}
+{{- if .Values.global.azure.enabled }}
               # Azure specific: Transparent bridge mode is required in order
               # for proxy-redirection to work
               until [ -f /var/run/azure-vnet.json ]; do

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -11,9 +11,5 @@ reconfigureKubelet: false
 # Delete the cbr0 bridge if it exists (GKE)
 removeCbrBridge: false
 
-# Wait for the /var/run/azure-vnet.json file to be created before continuing the
-# script
-azure: false
-
 # Revert nodeinit changes via preStop container lifecycle hook
 revertReconfigureKubelet: false


### PR DESCRIPTION
Just setting `nodeinit.azure` isn't enough, `global.azure.enabled` must
be set to true to have Network Policies with Azure. To avoid confusion,
the parameter has been removed from the `nodeinit` chart to use the
global one, like the `config` and `operator` charts do.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

```release-note
Use the global Azure key in helm
```