### PR TITLE
smoke-test: Print pod/deploy state on failure

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -83,6 +83,8 @@ jobs:
         env:
           LOG_TIME: 30m
         run: |
+          kubectl get pods -o wide
+          kubectl get deploy -o wide
           kubectl describe service echo-a
           kubectl logs service/echo-a --all-containers --since=$LOG_TIME
           kubectl describe service echo-b


### PR DESCRIPTION
Improve the smoke test debuggability by printing pod and deployment state when it fails.