### PR TITLE
Ensure that the socket is removed when api.SetDefaultPermissions fail

### DIFF
--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -217,7 +217,7 @@ type Server struct {
 	MaxHeaderSize    int
 
 	SocketPath string
-	domainSocketL net.Listener
+	domainSocketL *net.UnixListener
 
 	Host string
 	Port int
@@ -326,10 +326,10 @@ func (s *Server) Serve() (err error) {
 			domainSocket.IdleTimeout = s.CleanupTimeout
 		}
 
-		configureServer(domainSocket, "unix", string(s.SocketPath))
+		configureServer(domainSocket, "unix", s.SocketPath)
 
 		if os.Getuid() == 0 {
-		    err := api.SetDefaultPermissions(string(s.SocketPath))
+			err := api.SetDefaultPermissions(s.SocketPath)
 			if err != nil {
 				return err
 			}
@@ -510,13 +510,17 @@ func (s *Server) Listen() error {
 		}
   }
 
-  if s.hasScheme(schemeUnix) {
-    domSockListener, err := net.Listen("unix", string(s.SocketPath))
-    if err != nil {
-      return err
-    }
-    s.domainSocketL = domSockListener
-  }
+	if s.hasScheme(schemeUnix) {
+		addr, err := net.ResolveUnixAddr("unix", s.SocketPath)
+		if err != nil {
+			return err
+		}
+		domSockListener, err := net.ListenUnix("unix", addr)
+		if err != nil {
+			return err
+		}
+		s.domainSocketL = domSockListener
+	}
 
   if s.hasScheme(schemeHTTP) {
     listener, err := net.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)))
@@ -613,7 +617,7 @@ func (s *Server) SetHandler(handler http.Handler) {
 }
 
 // UnixListener returns the domain socket listener
-func (s *Server) UnixListener() (net.Listener, error) {
+func (s *Server) UnixListener() (*net.UnixListener, error) {
 	if !s.hasListeners {
 		if err := s.Listen(); err != nil {
 			return nil, err


### PR DESCRIPTION
Consistently remove the socket when we fail to set its owner and/or permission.