### PR TITLE
Fix clustermesh policy with endpoint-routes mode

### DIFF
--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -86,7 +86,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	ctx->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
+	ctk->mark |= MARK_MAGIC_IDENTITY;
+	set_identity_mark(ctx, seclabel)
 	return redirect_peer(ep->ifindex, 0);
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
@@ -126,7 +127,8 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	ctx->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
+	ctk->mark |= MARK_MAGIC_IDENTITY;
+	set_identity_mark(ctx, seclabel)
 	return redirect_peer(ep->ifindex, 0);
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);


### PR DESCRIPTION
In endpoint-routes mode, we encode the source identity in the `ctx->mark`
when locally routing the packet to the destination device for ingress
policy assessment. Previously we only encoded the local cluster
identity in the mark, thereby omitting the original cluster portion of
the identity.

Found by code inspection.

Fixes: 654303a20def ("bpf: Skip ingress policy at egress of source if egress prog is in use")

This unlikely to affect many users as by default users do not typically configure clustermesh + endpoint-routes (or ENI) mode at the same time.