### PR TITLE
cilium/build Add GOPATH check for generate-k8s-api

### DIFF
--- a/contrib/scripts/check-k8s-code-gen.sh
+++ b/contrib/scripts/check-k8s-code-gen.sh
@@ -3,6 +3,11 @@
 set -e
 set -o pipefail
 
+if [[ ! -d "${GOPATH}" ]]; then
+  echo "Please set a valid GOPATH"
+  exit 1
+fi
+
 # Delete all zz_generated.deepcopy.go files
 find . -not -path "./vendor/*" -not -path "./_build/*" -iname "*zz_generated.deepcopy.go" -exec rm  {} \;
 # Delete all zz_generated.deepequal.go files


### PR DESCRIPTION
The GOPATH needs to be correctly set with respect to
the cilium repository location so that k8s api
files are generated at the right paths.

Signed-off-by: Aditi Ghag <aditi@cilium.io>
