### PR TITLE
pkg/k8s: remove unused variable

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -36,11 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// subsysK8s is the value for logfields.LogSubsys
-	subsysK8s = "k8s"
-)
-
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 


### PR DESCRIPTION
Fixes: 56a9c1fe9368 ("pkg/k8s: remove manual generated DeepCopyInto function")
Signed-off-by: André Martins <andre@cilium.io>
