### PR TITLE
daemon: start DNS proxy before k8s

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -692,6 +693,28 @@ func (m *IptablesManager) iptProxyRules(cmd string, proxyPort uint16, ingress bo
 
 func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
 	return m.iptProxyRules("-A", proxyPort, ingress, name)
+}
+
+func GetProxyPort(name string) uint16 {
+	prog := "iptables"
+	if !option.Config.EnableIPv4 {
+		prog = "ip6tables"
+	}
+
+	res, err := runProgCombinedOutput(prog, []string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, false)
+	if err != nil {
+		return 0
+	}
+
+	re := regexp.MustCompile(name + ".*TPROXY redirect 0.0.0.0:([1-9][0-9]*) mark")
+	str := re.FindString(string(res))
+	portStr := re.ReplaceAllString(str, "$1")
+	portInt, err := strconv.Atoi(portStr)
+	if err != nil {
+		log.WithError(err).Debugf("Port number cannot be parsed: %s", portStr)
+		return 0
+	}
+	return uint16(portInt)
 }
 
 func (m *IptablesManager) RemoveProxyRules(proxyPort uint16, ingress bool, name string) error {


### PR DESCRIPTION
Split the endpoint restoration process into more stages so that the saved endpoint DNS history can be used earlier in the bootstrap to start the DNS proxy. This helps ensure that the first regeneration of an Endpoint does not (temporarily) remove the policy keys needed to keep old traffic flowing.

TPROXY rules for the DNS proxy can only be installed couple of seconds later in the bootstrap process. To mitigate this and allow the DNS proxy start serving traffic sooner, it now reads the old TPROXY rule, if available, and tries to re-use the same proxy port number as before the restart. This allows the old datapath config to start feeding traffic to the new proxy instance even before the datapath config can be rewritten.

For new DNS resolutions to be added to the Endpoint's policy the restored endpoint's must still have their first regeneration completed. Before this it is also likely that the DNS proxy will not serve requests but answers with an error response instead.

Fixes: #11004

```release-note
DNS Proxy is started earlier in the Cilium agent bootstrap to make it available to running endpoints sooner.
```
