### PR TITLE
contrib: Tighten search for list of PRs

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -49,7 +49,7 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push origin "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
-prs=$(grep "set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
+prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
 echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels


### PR DESCRIPTION
Previously, if "set-labels.py" was in the PR title, then the `grep`
would pick up extraneous lines which throw off the parsing. See failed
example below:

```
$ ./contrib/backporting/submit-backport v1.8
...
Updating labels for PRs  * #12640 -- backporting: Report progress in set-labels.py (@pchaigno)
12640 12626 12632 12654 12651 12652 12659 12521 12683

Set labels for all PRs above? [y/N] y
usage: set-labels.py [-h] pr_number {pending,done} [version]
set-labels.py: error: argument pr_number: invalid int value: 'api'

Signal ERR caught!
```

Fixes: 3c4d43af8f ("contrib: Fix submit-backport PR set-labels detection")
