### PR TITLE
contrib: Print PR number in set-labels.py

### DIFF
--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -38,7 +38,7 @@ old_label_len = len(pr_labels)
 
 cilium_labels = cilium.get_labels()
 
-print("Setting labels for PR $pr... ", end="")
+print("Setting labels for PR {}... ".format(pr_number), end="")
 if action == "pending":
     pr_labels = [l for l in pr_labels
                  if l.name != "needs-backport/"+version]


### PR DESCRIPTION
Simple enough change and improves usability.

Fixes: 9fdaf24555 ("backporting: Report progress in set-labels.py")