### PR TITLE
hubble/relay: compose ClientConn interface with grpc.ClientConnInterface

### DIFF
--- a/pkg/hubble/relay/pool/types/client.go
+++ b/pkg/hubble/relay/pool/types/client.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"context"
 	"io"
 
 	peerTypes "github.com/cilium/cilium/pkg/hubble/peer/types"
@@ -37,16 +36,7 @@ type ClientConn interface {
 	// GetState returns the connectivity.State of ClientConn.
 	GetState() connectivity.State
 	io.Closer
-
-	// TODO: compose with grpc.ClientConnInterface once
-	// "google.golang.org/grpc" is bumped to v1.27+ and remove the following
-	// two methods (which are part of grpc.ClientConnInterface).
-
-	// Invoke performs a unary RPC and returns after the response is received
-	// into reply.
-	Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error
-	// NewStream begins a streaming RPC.
-	NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error)
+	grpc.ClientConnInterface
 }
 
 var _ ClientConn = (*grpc.ClientConn)(nil)


### PR DESCRIPTION
The `grpc` dependency was recently bumped and this version defines an
interface for `ClientConn` which can be composed with `pool.ClientConn`
as it defines the same methods that were already defined in the
interface.
