### PR TITLE
plugins/cilium-cni: add Interface index to the CNI result

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -515,6 +515,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		Sandbox: args.Netns,
 	})
 
+	// Add to the result the Interface as index of Interfaces
+	for i := range res.Interfaces {
+		res.IPs[i].Interface = cniTypesVer.Int(i)
+	}
+
 	// Specify that endpoint must be regenerated synchronously. See GH-4409.
 	ep.SyncBuildEndpoint = true
 	if err = c.EndpointCreate(ep); err != nil {


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

This adds the corresponding Interface index to the CNI result.

CNI plugins like `tc-redirect-tap` expect this field to be filled.

```release-note
add Interface index to the CNI result
```
