### PR TITLE
style(errors.Is): To enforce errors.Is usage instead of comparison

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,9 +65,15 @@ issues:
       text: "SA9003: empty branch"
     - linters: [staticcheck]
       text: "SA2001: empty critical section"
+    - linters: [goerr113]
+      text: "do not define dynamic errors, use wrapped static errors instead" # This rule to avoid opinionated check fmt.Errorf("text")
+    - path: _test\.go                # Skip 1.13 errors check for test files
+      linters:
+        - goerr113
 linters:
   disable-all: true
   enable:
+    - goerr113
     - gofmt
     - govet
     - ineffassign

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -336,7 +337,7 @@ func execCommand(prompt string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
 	defer cancel()
 	output, err := exec.CommandContext(ctx, "bash", "-c", prompt).CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return "", fmt.Errorf("exec timeout")
 	}
 	return string(output), err
@@ -369,7 +370,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool
 		defer cancel()
 		if _, err := exec.CommandContext(ctx, "kubectl", "exec",
 			args[1], "-n", args[3], "--", "which",
-			args[5]).CombinedOutput(); err != nil || ctx.Err() == context.DeadlineExceeded {
+			args[5]).CombinedOutput(); err != nil || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			os.Remove(f.Name())
 			return
 		}

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -270,7 +271,7 @@ func runMonitor(args []string) {
 		case err == nil:
 		// no-op
 
-		case err == io.EOF, err == io.ErrUnexpectedEOF:
+		case err == io.EOF, errors.Is(err, io.ErrUnexpectedEOF):
 			log.WithError(err).Warn("connection closed")
 			continue
 

--- a/daemon/cmd/agenthealth.go
+++ b/daemon/cmd/agenthealth.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"syscall"
@@ -79,7 +80,7 @@ func (d *Daemon) startAgentHealthHTTPService(addr string) {
 
 	go func() {
 		err := srv.Serve(ln)
-		if err == http.ErrServerClosed {
+		if errors.Is(err, http.ErrServerClosed) {
 			log.Info("healthz status API server shutdown")
 		} else if err != nil {
 			log.WithError(err).Fatal("Unable to start healthz status API server")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -148,7 +149,7 @@ func Hint(err error) error {
 		return err
 	}
 
-	if err == context.DeadlineExceeded {
+	if errors.Is(err, context.DeadlineExceeded) {
 		return fmt.Errorf("Cilium API client timeout exceeded")
 	}
 

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -16,6 +16,7 @@ package completion
 
 import (
 	"context"
+	"errors"
 
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -81,7 +82,7 @@ func updateError(old, new error) error {
 	// 1. 'old' is nil, or
 	// 2. 'old' is a timeout, or
 	// 3. 'old' is a cancel and the 'new' error value is not a timeout
-	if old == nil || old == context.DeadlineExceeded || (old == context.Canceled && new != context.DeadlineExceeded) {
+	if old == nil || errors.Is(old, context.DeadlineExceeded) || (errors.Is(old, context.Canceled) && !errors.Is(new, context.DeadlineExceeded)) {
 		return new
 	}
 	return old

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -15,6 +15,7 @@
 package linux
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -889,14 +890,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) && err != unix.EAFNOSUPPORT {
+		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {
 			return fmt.Errorf("Delete previous IPv6 decrypt rule failed: %s", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) && err != unix.EAFNOSUPPORT {
+		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {
 			return fmt.Errorf("Delete previous IPv6 encrypt rule failed: %s", err)
 		}
 	}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -118,7 +118,7 @@ func CheckMinRequirements() {
 	}
 
 	_, err = netlink.RuleList(netlink.FAMILY_V4)
-	if err == unix.EAFNOSUPPORT {
+	if errors.Is(err, unix.EAFNOSUPPORT) {
 		log.WithError(err).Error("Policy routing:NOT OK. " +
 			"Please enable kernel configuration item CONFIG_IP_MULTIPLE_TABLES")
 	}

--- a/pkg/endpointmanager/errors.go
+++ b/pkg/endpointmanager/errors.go
@@ -37,7 +37,7 @@ func (e ErrInvalidPrefix) Error() string {
 // IsErrUnsupportedID returns true if the given error is the type of
 // ErrUnsupportedID.
 func IsErrUnsupportedID(err error) bool {
-	return err == ErrUnsupportedID
+	return errors.Is(err, ErrUnsupportedID)
 }
 
 // IsErrInvalidPrefix returns true if the given error is the type of

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -16,6 +16,7 @@ package endpointmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -506,7 +507,7 @@ func (mgr *EndpointManager) AddHostEndpoint(ctx context.Context, owner regenerat
 	newCtx, cancel := context.WithTimeout(ctx, launchTime)
 	defer cancel()
 	ep.UpdateLabels(newCtx, epLabels, nil, true)
-	if newCtx.Err() == context.DeadlineExceeded {
+	if errors.Is(newCtx.Err(), context.DeadlineExceeded) {
 		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for host endpoint")
 	}
 

--- a/pkg/envoy/xds/stream.go
+++ b/pkg/envoy/xds/stream.go
@@ -16,6 +16,7 @@ package xds
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 
@@ -58,7 +59,7 @@ func (s *MockStream) Send(resp *envoy_service_discovery.DiscoveryResponse) error
 	select {
 	case <-subCtx.Done():
 		cancel()
-		if subCtx.Err() == context.Canceled {
+		if errors.Is(subCtx.Err(), context.Canceled) {
 			return io.EOF
 		}
 		return subCtx.Err()
@@ -74,7 +75,7 @@ func (s *MockStream) Recv() (*envoy_service_discovery.DiscoveryRequest, error) {
 	select {
 	case <-subCtx.Done():
 		cancel()
-		if subCtx.Err() == context.Canceled {
+		if errors.Is(subCtx.Err(), context.Canceled) {
 			return nil, io.EOF
 		}
 		return nil, subCtx.Err()
@@ -91,7 +92,7 @@ func (s *MockStream) SendRequest(req *envoy_service_discovery.DiscoveryRequest) 
 	select {
 	case <-subCtx.Done():
 		cancel()
-		if subCtx.Err() == context.Canceled {
+		if errors.Is(subCtx.Err(), context.Canceled) {
 			return io.EOF
 		}
 		return subCtx.Err()
@@ -108,7 +109,7 @@ func (s *MockStream) RecvResponse() (*envoy_service_discovery.DiscoveryResponse,
 	select {
 	case <-subCtx.Done():
 		cancel()
-		if subCtx.Err() == context.Canceled {
+		if errors.Is(subCtx.Err(), context.Canceled) {
 			return nil, io.EOF
 		}
 		return nil, subCtx.Err()

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -389,7 +389,7 @@ func (r *flowsReader) Next(ctx context.Context) (*observerpb.GetFlowsResponse, e
 			}
 			e, err = r.ringReader.Next()
 			if err != nil {
-				if err == container.ErrInvalidRead {
+				if errors.Is(err, container.ErrInvalidRead) {
 					// this error is sent over the wire and presented to the user
 					return nil, errors.New("requested data has been overwritten and is no longer available")
 				}
@@ -464,7 +464,7 @@ func newRingReader(ring *container.Ring, req *observerpb.GetFlowsRequest, whitel
 	// correct index, then create a new reader that starts from there
 	for i := ring.Len(); i > 0; i, idx = i-1, idx-1 {
 		e, err := reader.Previous()
-		if err == container.ErrInvalidRead {
+		if errors.Is(err, container.ErrInvalidRead) {
 			idx++ // we went backward 1 too far
 			break
 		} else if err != nil {

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -15,6 +15,7 @@
 package informer
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -34,7 +35,7 @@ func init() {
 		utilRuntime.PanicHandlers,
 		func(r interface{}) {
 			// from k8s library
-			if r == http.ErrAbortHandler {
+			if err, ok := r.(error); ok && errors.Is(err, http.ErrAbortHandler) {
 				// honor the http.ErrAbortHandler sentinel panic value:
 				//   ErrAbortHandler is a sentinel panic value to abort a handler.
 				//   While any panic from ServeHTTP aborts the response to the client,

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -200,7 +200,7 @@ func (k *K8sWatcher) addK8sPodV1(pod *slim_corev1.Pod) error {
 		return nil
 	case err != nil:
 		msg := "Unable to update ipcache map entry on pod add"
-		if err == errIPCacheOwnedByNonK8s {
+		if errors.Is(err, errIPCacheOwnedByNonK8s) {
 			logger.WithError(err).Debug(msg)
 		} else {
 			logger.WithError(err).Warning(msg)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -348,7 +348,7 @@ func (e *etcdClient) GetLockSessionLeaseID() client.LeaseID {
 // it as an Orphan() the session would be considered expired after the leaseTTL
 // By make it orphan we guarantee the session will be marked to be renewed.
 func (e *etcdClient) checkSession(err error, leaseID client.LeaseID) {
-	if err == v3rpcErrors.ErrLeaseNotFound {
+	if errors.Is(err, v3rpcErrors.ErrLeaseNotFound) {
 		e.closeSession(leaseID)
 	}
 }
@@ -359,7 +359,7 @@ func (e *etcdClient) checkSession(err error, leaseID client.LeaseID) {
 // it as an Orphan() the session would be considered expired after the leaseTTL
 // By make it orphan we guarantee the session will be marked to be renewed.
 func (e *etcdClient) checkLockSession(err error, leaseID client.LeaseID) {
-	if err == v3rpcErrors.ErrLeaseNotFound {
+	if errors.Is(err, v3rpcErrors.ErrLeaseNotFound) {
 		e.closeLockSession(leaseID)
 	}
 }
@@ -977,7 +977,7 @@ reList:
 					// revision that may no longer exist,
 					// recreate the watcher and try to
 					// watch on the next possible revision
-					if err == v3rpcErrors.ErrCompacted {
+					if errors.Is(err, v3rpcErrors.ErrCompacted) {
 						scopedLog.WithError(Hint(err)).Debug("Tried watching on compacted revision")
 					}
 

--- a/pkg/mountinfo/mountinfo.go
+++ b/pkg/mountinfo/mountinfo.go
@@ -16,6 +16,7 @@ package mountinfo
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -144,7 +145,7 @@ func IsMountFS(mntType int64, path string) (bool, bool, error) {
 
 	err := unix.Lstat(path, &st)
 	if err != nil {
-		if err == unix.ENOENT {
+		if errors.Is(err, unix.ENOENT) {
 			// non-existent path can't be a mount point
 			return false, false, nil
 		}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -15,6 +15,7 @@
 package probe
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -85,7 +86,7 @@ func HaveFullLPM() bool {
 // loaded.
 func HaveIPv6Support() bool {
 	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM, 0)
-	if err == unix.EAFNOSUPPORT || err == unix.EPROTONOSUPPORT {
+	if errors.Is(err, unix.EAFNOSUPPORT) || errors.Is(err, unix.EPROTONOSUPPORT) {
 		return false
 	}
 	unix.Close(fd)

--- a/pkg/service/healthserver/healthserver.go
+++ b/pkg/service/healthserver/healthserver.go
@@ -189,7 +189,7 @@ func (h *httpHealthHTTPServerFactory) newHTTPHealthServer(port uint16, svc *Serv
 			logfields.ServiceHealthCheckNodePort: port,
 		}).Debug("Starting new service health server")
 
-		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 			svc := srv.loadService()
 			if errors.Is(err, unix.EADDRINUSE) {
 				log.WithError(err).WithFields(logrus.Fields{

--- a/proxylib/npds/client.go
+++ b/proxylib/npds/client.go
@@ -16,6 +16,7 @@ package npds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -24,7 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/proxylib/proxylib"
 
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_service_disacovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
 	log "github.com/sirupsen/logrus"
@@ -186,7 +187,7 @@ func (c *Client) Run(connected func()) (err error) {
 		// Receive next policy configuration. This will block until the
 		// server has a new version to send, which may take a long time.
 		resp, err := stream.Recv()
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
 			log.Debugf("NPDS: Client %s stream on %s closed.", c.nodeId, c.path)
 			break
 		}


### PR DESCRIPTION
Inspired by recent PR review comments, which encourage using errors.Is(). 
I used the go-err113 (supported by golangci-lint) to do correction. Found 
one bug https://github.com/Djarvur/go-err113/issues/15, fixed and applied in this PR.

Exclude io.EOF as per https://github.com/golang/go/issues/39155

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
style(errors.Is): To enforce errors.Is usage instead of comparison
```
