### PR TITLE
test/K8sServices: Fix externalTrafficPolicy=Local with kube-proxy (on GKE)

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -189,7 +189,7 @@ We are currently testing following kernel - k8s version pairs in our CI:
 +--------------------+------------------+
 | GKE clusters                          |
 +--------------------+------------------+
-| 1.14.10            | 4.14.138+        |
+| 1.15.12            | 4.19.112+        |
 +--------------------+------------------+
 
 .. _trigger_phrases:

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2301,6 +2301,7 @@ func (kub *Kubectl) CiliumInstall(filename string, options map[string]string) er
 		resourcesToDelete = map[string]string{
 			"configmap":          "cilium-config",
 			"daemonset":          "cilium",
+			"daemonset ":         "cilium-node-init",
 			"deployment":         "cilium-operator",
 			"clusterrolebinding": "cilium cilium-operator",
 			"clusterrole":        "cilium cilium-operator",

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -991,6 +991,9 @@ var _ = Describe("K8sServicesTest", func() {
 
 			count := 10
 
+			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s2)
+			ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s2")
+
 			if helpers.ExistNodeWithoutCilium() {
 				httpURL = getHTTPLink(k8s1IP, data.Spec.Ports[0].NodePort)
 				tftpURL = getTFTPLink(k8s1IP, data.Spec.Ports[1].NodePort)
@@ -1026,20 +1029,35 @@ var _ = Describe("K8sServicesTest", func() {
 				testCurlFromPodInHostNetNS(httpURL, count, 0, k8s1NodeName)
 				testCurlFromPodInHostNetNS(tftpURL, count, 0, k8s1NodeName)
 			}
-			// In-cluster connectivity from k8s2 to k8s1 IP will still work in
-			// kube-proxy free case since we'll hit the wildcard rule in bpf_sock
+			// In-cluster connectivity from k8s2 to k8s1 IP will still work with
+			// HostReachableServices (regardless of if we are running with or
+			// without kube-proxy) since we'll hit the wildcard rule in bpf_sock
 			// and k8s1 IP is in ipcache as REMOTE_NODE_ID. But that is fine since
 			// it's all in-cluster connectivity w/ client IP preserved.
-			if helpers.RunsWithoutKubeProxy() {
+			// This is a known incompatibility with kube-proxy:
+			// kube-proxy 1.15+ will only load-balance requests from k8s1 to k8s1,
+			// but not from k8s2 to k8s1. In the k8s2 to k8s1 case, kube-proxy
+			// would send traffic to k8s1, where it would be subsequently
+			// dropped, because k8s1 has no service backend.
+			// However, if HostReachableServices is enabled, then Cilium does
+			// the service translation already on the client node, bypassing
+			// kube-proxy completely.
+			hostReachableServicesTCP := kubectl.HasHostReachableServices(ciliumPodK8s2, true, false)
+			hostReachableServicesUDP := kubectl.HasHostReachableServices(ciliumPodK8s2, false, true)
+			if hostReachableServicesTCP {
 				testCurlFromPodInHostNetNS(httpURL, count, 0, k8s2NodeName)
-				testCurlFromPodInHostNetNS(tftpURL, count, 0, k8s2NodeName)
 			} else {
 				testCurlFailFromPodInHostNetNS(httpURL, 1, k8s2NodeName)
+			}
+			if hostReachableServicesUDP {
+				testCurlFromPodInHostNetNS(tftpURL, count, 0, k8s2NodeName)
+			} else {
 				testCurlFailFromPodInHostNetNS(tftpURL, 1, k8s2NodeName)
 			}
+
 			// Requests from a non-Cilium node to k8s1 IP will fail though.
 			if helpers.ExistNodeWithoutCilium() {
-				testCurlFailFromOutside(httpURL, 1)
+
 				testCurlFailFromOutside(tftpURL, 1)
 			}
 		}


### PR DESCRIPTION
This commit fixes the test harness for `externalTrafficPolicy=Local` in
the case where we are accessing a node IP without a local backend from a
node with host reachable services enabled.

This is a known incompatibility between our kube-proxy replacement and
upstream kube-proxy. The existing test harness assumed that we only need
to handle this case if we are running without kube-proxy. This
assumption however is wrong, as we are running these tests in hybrid
mode, where we are running with both kube-proxy and Cilium's kube-proxy
replacement.

This has not been hit in our existing test suites up until recently,
because we did not have a test setup with both kube-proxy and the
kube-proxy replacement enabled at the same time. As GKE has been
upgraded to Linux 4.19, it is now using the described hybrid setup which has
caused the tests to break.

The test matrix as of writing now looks as follows:

| Test Suite                 | kube-proxy | kube-proxy replacement  |
| -------------------------- | ---------- | ----------------------- |
| K8s-1.18-kernel-4.9        | Yes        | No  (Kernel 4.9.x)      |
| K8s-1.17-Kernel-4.19       | No         | Yes (Kernel 4.19.57)    |
| K8s-1.12-Kernel-netnext    | No         | Yes (Kernel 5.8.0-rc1+) |
| Cilium-PR-Ginkgo-Tests-k8s | Yes        | No  (Kernel 4.9.x)      |
| Cilium-PR-K8s-GKE          | Yes        | Yes (Kernel 4.19.112+)  |

Fixes: 67f85e3 ("tests: enable additional externalTrafficPolicy=Local tests")