### PR TITLE
 monitor: Add consumer interface for internal subscribers 

### DIFF
--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -244,21 +244,27 @@ func (a *Agent) handleEvents(stopCtx context.Context) {
 			continue
 		}
 
-		a.Lock()
-		plType := payload.EventSample
-		if record.LostSamples > 0 {
-			plType = payload.RecordLost
-			a.MonitorStatus.Lost += int64(record.LostSamples)
-		}
-		pl := payload.Payload{
-			Data: record.RawSample,
-			CPU:  record.CPU,
-			Lost: record.LostSamples,
-			Type: plType,
-		}
-		a.sendLocked(&pl)
-		a.Unlock()
+		a.processPerfRecord(record)
 	}
+}
+
+// processPerfRecord processes a record from the datapath and sends it to any
+// registered subscribers
+func (a *Agent) processPerfRecord(record perf.Record) {
+	a.Lock()
+	plType := payload.EventSample
+	if record.LostSamples > 0 {
+		plType = payload.RecordLost
+		a.MonitorStatus.Lost += int64(record.LostSamples)
+	}
+	pl := payload.Payload{
+		Data: record.RawSample,
+		CPU:  record.CPU,
+		Lost: record.LostSamples,
+		Type: plType,
+	}
+	a.sendLocked(&pl)
+	a.Unlock()
 }
 
 // State returns the current status of the monitor

--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -118,7 +118,7 @@ func (a *Agent) SendEvent(typ int, event interface{}) error {
 	}
 
 	p := payload.Payload{Data: buf.Bytes(), CPU: 0, Lost: 0, Type: payload.EventSample}
-	a.send(&p)
+	a.sendToListeners(&p)
 
 	return nil
 }
@@ -263,7 +263,7 @@ func (a *Agent) processPerfRecord(record perf.Record) {
 		Lost: record.LostSamples,
 		Type: plType,
 	}
-	a.sendLocked(&pl)
+	a.sendToListenersLocked(&pl)
 	a.Unlock()
 }
 
@@ -285,15 +285,15 @@ func (a *Agent) State() *models.MonitorStatus {
 	return &status
 }
 
-// send enqueues the payload to all listeners.
-func (a *Agent) send(pl *payload.Payload) {
+// sendToListeners enqueues the payload to all listeners.
+func (a *Agent) sendToListeners(pl *payload.Payload) {
 	a.Lock()
 	defer a.Unlock()
-	a.sendLocked(pl)
+	a.sendToListenersLocked(pl)
 }
 
-// sendLocked enqueues the payload to all listeners while holding the monitor lock.
-func (a *Agent) sendLocked(pl *payload.Payload) {
+// sendToListenersLocked enqueues the payload to all listeners while holding the monitor lock.
+func (a *Agent) sendToListenersLocked(pl *payload.Payload) {
 	for ml := range a.listeners {
 		ml.Enqueue(pl)
 	}

--- a/pkg/monitor/agent/consumer/consumer.go
+++ b/pkg/monitor/agent/consumer/consumer.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumer
+
+// MonitorConsumer is a consumer of decoded monitor events
+type MonitorConsumer interface {
+	// NotifyAgentEvent informs the consumer about a new monitor event
+	// sent from cilium-agent. The concrete type of the message parameter
+	// depends on the value of typ:
+	//  - MessageTypeAccessLog:		accesslog.LogRecord
+	//  - MessageTypeAgent:			api.AgentNotify
+	NotifyAgentEvent(typ int, message interface{})
+
+	// NotifyPerfEvent informs the consumer about an datapath event obtained
+	// via perf events ring buffer.
+	// Data contains the raw binary encoded perf payload. The underlying type
+	// depends on the value of typ:
+	// 	- MessageTypeDrop:			monitor.DropNotify
+	// 	- MessageTypeDebug:			monitor.DebugMsg
+	// 	- MessageTypeCapture:		monitor.DebugCapture
+	// 	- MessageTypeTrace:			monitor.TraceNotify
+	// 	- MessageTypePolicyVerdict:	monitor.PolicyVerdictNotify
+	NotifyPerfEvent(data []byte, cpu int)
+
+	// NotifyPerfEventLost informs the consumer that a number of events have
+	// been lost due to the perf event ring buffer not being read.
+	NotifyPerfEventLost(numLostEvents uint64, cpu int)
+}


### PR DESCRIPTION
This is the first of three PRs to remove the need to go through GOB encoding when accessing agent notifications in Hubble. The three PRs depend on each other, but I split them for easier reviewability.

1. monitor: Add new consumer interface which avoids gob encoded messages (**This PR**)
2. hubble: Add new monitor consumer implementation #12711
3. hubble: Switch GetEventsChannel to new consumer interface #12712

---

This adds the a new subscriber type to the monitor agent. The new type is called consumer and is very similar to how monitor listeners work, with the big exception that it does not perform any GOB encoding before sending agent events to the subscriber. In addition, it removes the dependency on the payload type which was designed for the existing unix socket listeners and is not useful in the context of Hubble.

This interface is intended for Hubble and will eventually superseded the existing listener interface. However, for now we will support both consumers and listeners on the agent, as we want to support both monitor socket listeners as well as the Hubble observer.