### PR TITLE
hubble: Add new monitor consumer implementation

### DIFF
--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -1,0 +1,124 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"time"
+
+	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
+	monitorConsumer "github.com/cilium/cilium/pkg/monitor/agent/consumer"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Observer is the receiver of MonitorEvents
+type Observer interface {
+	GetEventsChannel() chan *observerTypes.MonitorEvent
+	GetLogger() logrus.FieldLogger
+}
+
+// consumer implements monitorConsumer.MonitorConsumer
+type consumer struct {
+	observer      Observer
+	numEventsLost uint64
+}
+
+// NewConsumer returns an initialized pointer to consumer.
+func NewConsumer(observer Observer) monitorConsumer.MonitorConsumer {
+	mc := &consumer{
+		observer:      observer,
+		numEventsLost: 0,
+	}
+	return mc
+}
+
+// sendEventQueueLostEvents tries to send the current value of the lost events
+// counter to the observer. If it succeeds to enqueue a notification, it
+// resets the counter.
+func (c *consumer) sendNumLostEvents() {
+	numEventsLostNotification := &observerTypes.MonitorEvent{
+		Timestamp: time.Now(),
+		NodeName:  nodeTypes.GetName(),
+		Payload: &observerTypes.LostEvent{
+			Source:        observerTypes.LostEventSourceEventsQueue,
+			NumLostEvents: c.numEventsLost,
+		},
+	}
+	select {
+	case c.observer.GetEventsChannel() <- numEventsLostNotification:
+		// We now now safely reset the counter, as at this point have
+		// successfully notified the observer about the amount of events
+		// that were lost since the previous LostEvent message
+		c.numEventsLost = 0
+	default:
+		// We do not need to bump the numEventsLost counter here, as we will
+		// try to send a new LostEvent notification again during the next
+		// invocation of sendEvent
+	}
+}
+
+// sendEvent enqueues an event in the observer. If this is not possible, it
+// keeps a counter of lost events, which it will regularly try to send to the
+// observer as well
+func (c *consumer) sendEvent(event *observerTypes.MonitorEvent) {
+	if c.numEventsLost > 0 {
+		c.sendNumLostEvents()
+	}
+
+	select {
+	case c.observer.GetEventsChannel() <- event:
+	default:
+		c.observer.GetLogger().Debug("hubble events queue is full, dropping message")
+		c.numEventsLost++
+	}
+}
+
+// NotifyAgentEvent implements monitorConsumer.MonitorConsumer
+func (c *consumer) NotifyAgentEvent(typ int, message interface{}) {
+	c.sendEvent(&observerTypes.MonitorEvent{
+		Timestamp: time.Now(),
+		NodeName:  nodeTypes.GetName(),
+		Payload: &observerTypes.AgentEvent{
+			Type:    typ,
+			Message: message,
+		},
+	})
+}
+
+// NotifyPerfEvent implements monitorConsumer.MonitorConsumer
+func (c *consumer) NotifyPerfEvent(data []byte, cpu int) {
+	c.sendEvent(&observerTypes.MonitorEvent{
+		Timestamp: time.Now(),
+		NodeName:  nodeTypes.GetName(),
+		Payload: &observerTypes.PerfEvent{
+			Data: data,
+			CPU:  cpu,
+		},
+	})
+}
+
+// NotifyPerfEventLost implements monitorConsumer.MonitorConsumer
+func (c *consumer) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
+	c.sendEvent(&observerTypes.MonitorEvent{
+		Timestamp: time.Now(),
+		NodeName:  nodeTypes.GetName(),
+		Payload: &observerTypes.LostEvent{
+			Source:        observerTypes.LostEventSourcePerfRingBuffer,
+			NumLostEvents: numLostEvents,
+			CPU:           cpu,
+		},
+	})
+}

--- a/pkg/hubble/monitor/consumer_test.go
+++ b/pkg/hubble/monitor/consumer_test.go
@@ -1,0 +1,130 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package monitor
+
+import (
+	"testing"
+	"time"
+
+	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
+	"github.com/cilium/cilium/pkg/monitor/api"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeObserver struct {
+	events chan *observerTypes.MonitorEvent
+	logger *logrus.Entry
+}
+
+func (f fakeObserver) GetEventsChannel() chan *observerTypes.MonitorEvent {
+	return f.events
+}
+
+func (f fakeObserver) GetLogger() logrus.FieldLogger {
+	return f.logger
+}
+
+func TestHubbleConsumer(t *testing.T) {
+	observer := fakeObserver{
+		// For testing, we an events queue with a buffer size of 1
+		events: make(chan *observerTypes.MonitorEvent, 1),
+		logger: logrus.NewEntry(logrus.New()),
+	}
+	consumer := NewConsumer(observer)
+	data := []byte{0, 1, 2, 3, 4}
+	cpu := 5
+
+	consumer.NotifyPerfEvent(data, cpu)
+	expected := &observerTypes.MonitorEvent{
+		NodeName: nodeTypes.GetName(),
+		Payload: &observerTypes.PerfEvent{
+			Data: data,
+			CPU:  cpu,
+		},
+	}
+	received := <-observer.GetEventsChannel()
+	assert.Equal(t, expected.NodeName, received.NodeName)
+	assert.Equal(t, expected.Payload, received.Payload)
+
+	numLostEvents := uint64(7)
+	consumer.NotifyPerfEventLost(numLostEvents, cpu)
+	expected = &observerTypes.MonitorEvent{
+		NodeName: nodeTypes.GetName(),
+		Payload: &observerTypes.LostEvent{
+			Source:        observerTypes.LostEventSourcePerfRingBuffer,
+			NumLostEvents: numLostEvents,
+			CPU:           cpu,
+		},
+	}
+	received = <-observer.GetEventsChannel()
+	assert.Equal(t, expected.NodeName, received.NodeName)
+	assert.Equal(t, expected.Payload, received.Payload)
+
+	typ := api.MessageTypeAccessLog
+	message := &accesslog.LogRecord{Timestamp: time.RFC3339}
+	consumer.NotifyAgentEvent(typ, message)
+	expected = &observerTypes.MonitorEvent{
+		NodeName: nodeTypes.GetName(),
+		Payload: &observerTypes.AgentEvent{
+			Type:    typ,
+			Message: message,
+		},
+	}
+	received = <-observer.GetEventsChannel()
+	assert.Equal(t, expected.NodeName, received.NodeName)
+	assert.Equal(t, expected.Payload, received.Payload)
+
+	// The first notification will get through, the other two will be dropped
+	consumer.NotifyAgentEvent(1, nil)
+	consumer.NotifyPerfEventLost(0, 0) // dropped
+	consumer.NotifyPerfEvent(nil, 0)   // dropped
+	expected = &observerTypes.MonitorEvent{
+		NodeName: nodeTypes.GetName(),
+		Payload: &observerTypes.AgentEvent{
+			Type: 1,
+		},
+	}
+	received = <-observer.GetEventsChannel()
+	assert.Equal(t, expected.NodeName, received.NodeName)
+	assert.Equal(t, expected.Payload, received.Payload)
+
+	// Now that the channel has one slot again, send another message
+	// (which will be dropped) to get a lost event notifications
+	consumer.NotifyAgentEvent(0, nil) // dropped
+
+	expected = &observerTypes.MonitorEvent{
+		NodeName: nodeTypes.GetName(),
+		Payload: &observerTypes.LostEvent{
+			Source:        observerTypes.LostEventSourceEventsQueue,
+			NumLostEvents: 2,
+		},
+	}
+	received = <-observer.GetEventsChannel()
+	assert.Equal(t, expected.NodeName, received.NodeName)
+	assert.Equal(t, expected.Payload, received.Payload)
+
+	// Verify that the events channel is empty now.
+	select {
+	case ev := <-observer.GetEventsChannel():
+		assert.Fail(t, "Unexpected event", ev)
+	default:
+	}
+}

--- a/pkg/hubble/observer/types/types.go
+++ b/pkg/hubble/observer/types/types.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "time"
+
+const (
+	// LostEventSourceUnspec indicates an event has been lost at an unknown
+	// source
+	LostEventSourceUnspec = iota
+	// LostEventSourcePerfRingBuffer indicates an event has been lost because
+	// the perf event ring buffer was not read before it was overwritten.
+	LostEventSourcePerfRingBuffer
+	// LostEventSourceEventsQueue indicates that an event has been dropped
+	// because the events queue was full.
+	LostEventSourceEventsQueue
+)
+
+// MonitorEvent is the top-level type for all events consumed by the observer
+type MonitorEvent struct {
+	// Timestamp when the event was received by the consumer
+	Timestamp time.Time
+	// NodeName where the event occurred
+	NodeName string
+	// Payload is one of: AgentEvent, PerfEvent or LostEvent
+	Payload interface{}
+}
+
+// AgentEvent is any agent event
+type AgentEvent struct {
+	// Type is a monitorAPI.MessageType* value
+	Type int
+	// Message is the agent message, e.g. accesslog.LogRecord, monitorAPI.AgentNotify
+	Message interface{}
+}
+
+// PerfEvent is a raw event obtained from a BPF perf ring buffer
+type PerfEvent struct {
+	// Data is the raw data payload of the perf event
+	Data []byte
+	// CPU is the cpu number on which the perf event occurred
+	CPU int
+}
+
+// LostEvent indicates that a number of events were lost at the indicated source
+type LostEvent struct {
+	// Source is where the events were dropped
+	Source int
+	// NumLostEvents is the number of events lost
+	NumLostEvents uint64
+	// CPU is the cpu number if for events lost in the perf ring buffer
+	CPU int
+}


### PR DESCRIPTION
This is the second of three PRs to remove the need to go through GOB encoding when accessing agent notifications in Hubble. The three PRs depend on each other, but I split them for easier reviewability.

1. monitor: Add new consumer interface which avoids gob encoded messages #12710
2. hubble: Add new monitor consumer implementation (**This PR**)
3. hubble: Switch GetEventsChannel to new consumer interface #12712

---

This adds a Hubble-specific implementation for the glue code between the
monitor agent and the Hubble observer. It is similar to the existing
listener implementation, but will deals with data types instead of GOB
encoded binary data and keeps track of the number of events dropped if
the Hubble observer is unavailable.