### PR TITLE
v1.6 backports 2020-07-28

### DIFF
--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -1,0 +1,108 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _identity-relevant-labels:
+
+*********************************
+Limiting Identity-Relevant Labels
+*********************************
+
+We recommend that operators in larger environments limit the set of
+identity-relevant labels to avoid frequent creation of new security identities.
+Many Kubernetes labels are not useful for policy enforcement or visibility. A
+few good examples of such labels include timestamps or hashes. These labels,
+when included in evaluation, cause Cilium to generate a unique identity for each
+pod instead of a single identity for all of the pods that comprise a service or
+application.
+
+By default, Cilium evaluates the following labels:
+
+================================ ==============================================
+Label                            Description
+-------------------------------- ----------------------------------------------
+k8s:io.kubernetes.pod.namespace  Include all io.kubernetes.pod.namespace labels
+k8s:app.kubernetes.io            Include all app.kubernetes.io labels
+k8s:!io.kubernetes               Ignore all io.kubernetes labels
+k8s:kubernetes.io                Ignore all other kubernetes.io labels
+k8s:beta.kubernetes.io           Ignore all beta.kubernetes.io labels
+k8s:k8s.io                       Ignore all k8s.io labels
+k8s:!pod-template-generation     Ignore all pod-template-generation labels
+k8s:!pod-template-hash           Ignore all pod-template-hash labels
+k8s:!controller-revision-hash    Ignore all controller-revision-hash labels
+k8s:!annotation.*                Ignore all annotation labels
+k8s:!etcd_node                   Ignore all etcd_node labels
+================================ ==============================================
+
+Configuring Identity-Relevant Labels
+------------------------------------
+
+To limit the labels used for evaluating Cilium identities, edit the Cilium
+ConfigMap object using "kubectl edit cm -n kube-system cilium-config"
+and insert a line to define the labels to include or exclude.
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    data:
+    ...
+      kube-proxy-replacement: partial
+      labels: ...
+      masquerade: "true"
+      monitor-aggregation: medium
+    ...
+
+
+After saving the ConfigMap, restart the Cilium Agents to pickup the new labels
+setting.
+
+Existing identities will not change as a result of this new configuration. To
+apply the new label setting to existing identities, restart the associated pods.
+Upon restart, new identities will be created. The old identities will be garbage
+collected by the Cilium Operator once they are no longer used by any Cilium
+endpoints.
+
+When specifying multiple labels to evaluate, provide the list of labels as a
+space-separated string.
+
+.. code-block:: bash
+
+	 labels: "prefix:labelA prefix:labelB"
+
+Including Labels
+----------------
+
+Labels can be defined as a list of labels to include. Only the labels specified
+will be used to evaluate Cilium identities:
+
+.. code-block:: bash
+
+    labels: "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
+
+The above configuration would only include the following labels when evaluating
+Cilium identities:
+
+- io.kubernetes.pod.namespace=*
+- k8s-app=*
+- app=*
+- name=*
+
+Excluding Labels
+----------------
+
+Labels can also be specified as a list of exclusions. Exclude a label by placing
+an exclamation mark after colon separating the prefix and label. When defined as a
+list of exclusions, Cilium will include the set of default labels, but will
+exclude any matches in the provided list when evaluating Cilium identities:
+
+.. code-block:: bash
+
+    labels: "k8s:!controller-uid k8s:!job-name"
+
+The provided example would cause Cilium to exclude any of the following label
+matches:
+
+- k8s:controller-uid=*
+- k8s:job-name=*

--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -10,7 +10,7 @@
 Limiting Identity-Relevant Labels
 *********************************
 
-We recommend that operators in larger environments limit the set of
+We recommend that operators with larger environments limit the set of
 identity-relevant labels to avoid frequent creation of new security identities.
 Many Kubernetes labels are not useful for policy enforcement or visibility. A
 few good examples of such labels include timestamps or hashes. These labels,
@@ -20,27 +20,29 @@ application.
 
 By default, Cilium evaluates the following labels:
 
-================================ ==============================================
-Label                            Description
--------------------------------- ----------------------------------------------
-k8s:io.kubernetes.pod.namespace  Include all io.kubernetes.pod.namespace labels
-k8s:app.kubernetes.io            Include all app.kubernetes.io labels
-k8s:!io.kubernetes               Ignore all io.kubernetes labels
-k8s:kubernetes.io                Ignore all other kubernetes.io labels
-k8s:beta.kubernetes.io           Ignore all beta.kubernetes.io labels
-k8s:k8s.io                       Ignore all k8s.io labels
-k8s:!pod-template-generation     Ignore all pod-template-generation labels
-k8s:!pod-template-hash           Ignore all pod-template-hash labels
-k8s:!controller-revision-hash    Ignore all controller-revision-hash labels
-k8s:!annotation.*                Ignore all annotation labels
-k8s:!etcd_node                   Ignore all etcd_node labels
-================================ ==============================================
+=================================== ==================================================
+Label                               Description
+----------------------------------- --------------------------------------------------
+``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
+``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
+``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels
+``k8s:kubernetes.io``               Ignore all other ``kubernetes.io`` labels
+``k8s:beta.kubernetes.io``          Ignore all ``beta.kubernetes.io`` labels
+``k8s:k8s.io``                      Ignore all ``k8s.io`` labels
+``k8s:!pod-template-generation``    Ignore all ``pod-template-generation`` labels
+``k8s:!pod-template-hash``          Ignore all ``pod-template-hash`` labels
+``k8s:!controller-revision-hash``   Ignore all ``controller-revision-hash`` labels
+``k8s:!annotation.*``               Ignore all ``annotation labels``
+``k8s:!etcd_node``                  Ignore all ``etcd_node`` labels
+=================================== ==================================================
+
+
 
 Configuring Identity-Relevant Labels
 ------------------------------------
 
 To limit the labels used for evaluating Cilium identities, edit the Cilium
-ConfigMap object using "kubectl edit cm -n kube-system cilium-config"
+ConfigMap object using ``kubectl edit cm -n kube-system cilium-config``
 and insert a line to define the labels to include or exclude.
 
 .. code-block:: yaml
@@ -49,14 +51,19 @@ and insert a line to define the labels to include or exclude.
     data:
     ...
       kube-proxy-replacement: partial
-      labels: ...
+      labels:  "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
       masquerade: "true"
       monitor-aggregation: medium
     ...
 
 
-After saving the ConfigMap, restart the Cilium Agents to pickup the new labels
-setting.
+Upon defining a custom list of labels in the ConfigMap, Cilium will override
+the default list of labels with the list provided. After saving the ConfigMap,
+restart the Cilium Agents to pickup the new labels setting.
+
+.. code-block:: bash
+
+    kubectl delete pods -n kube-system -l k8s-app=cilium
 
 Existing identities will not change as a result of this new configuration. To
 apply the new label setting to existing identities, restart the associated pods.
@@ -66,10 +73,6 @@ endpoints.
 
 When specifying multiple labels to evaluate, provide the list of labels as a
 space-separated string.
-
-.. code-block:: bash
-
-	 labels: "prefix:labelA prefix:labelB"
 
 Including Labels
 ----------------

--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -26,9 +26,9 @@ Label                               Description
 ``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
 ``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
 ``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels
-``k8s:kubernetes.io``               Ignore all other ``kubernetes.io`` labels
-``k8s:beta.kubernetes.io``          Ignore all ``beta.kubernetes.io`` labels
-``k8s:k8s.io``                      Ignore all ``k8s.io`` labels
+``k8s:!kubernetes.io``              Ignore all other ``kubernetes.io`` labels
+``k8s:!beta.kubernetes.io``         Ignore all ``beta.kubernetes.io`` labels
+``k8s:!k8s.io``                     Ignore all ``k8s.io`` labels
 ``k8s:!pod-template-generation``    Ignore all ``pod-template-generation`` labels
 ``k8s:!pod-template-hash``          Ignore all ``pod-template-hash`` labels
 ``k8s:!controller-revision-hash``   Ignore all ``controller-revision-hash`` labels

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -71,6 +71,7 @@ Operations
    :glob:
 
    grafana
+   identity-relevant-labels
 
 Istio
 -----
@@ -94,4 +95,3 @@ Other Orchestrators
 The best way to get help if you get stuck is to ask a question on the `Cilium
 Slack channel <https://cilium.herokuapp.com>`_.  With Cilium contributors
 across the globe, there is almost always someone available to help.
-

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -608,6 +608,7 @@ ubuntu
 Ubuntu
 udp
 ui
+uid
 uint
 Uncomment
 underrepresents

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -465,13 +465,6 @@ files and execute some commands. If ``kubectl`` is detected, it will search for
 Cilium pods. The default label being ``k8s-app=cilium``, but this and the
 namespace can be changed via ``k8s-namespace`` and ``k8s-label`` respectively.
 
-If you'd prefer to browse the dump, there is a HTTP flag.
-
-.. code:: bash
-
-    $ cilium-bugtool --serve
-
-
 If you want to capture the archive from a Kubernetes pod, then the process is a
 bit different
 

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -38,6 +38,7 @@ old_label_len = len(pr_labels)
 
 cilium_labels = cilium.get_labels()
 
+print("Setting labels for PR $pr... ", end="")
 if action == "pending":
     pr_labels = [l for l in pr_labels
                  if l.name != "needs-backport/"+version]
@@ -52,7 +53,6 @@ if action == "pending":
         print("error adding backport-pending/"+version+" label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
-    sys.exit(0)
 
 if action == "done":
     pr_labels = [l for l in pr_labels
@@ -68,4 +68,5 @@ if action == "done":
         print("error adding backport-done/"+version+" label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
-    sys.exit(0)
+
+print("✓")

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -55,8 +55,6 @@ echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels
 if [ "$set_all_labels" = "y" ]; then
     for pr in $prs; do
-        echo -n "Setting labels for PR $pr... "
         $DIR/set-labels.py $pr pending $BRANCH;
-        echo "✓"
     done
 fi

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -720,9 +720,12 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
 			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
 	}
+
 	if headerfileChanged {
 		datapathRegenCtxt.regenerationLevel = regeneration.RegenerateWithDatapathRewrite
-		if err = e.writeHeaderfile(nextDir); err != nil {
+	}
+	if datapathRegenCtxt.regenerationLevel >= regeneration.RegenerateWithDatapathRewrite {
+		if err := e.writeHeaderfile(nextDir); err != nil {
 			return false, fmt.Errorf("unable to write header file: %s", err)
 		}
 	}

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -25,10 +25,14 @@ import (
 // - All members of this structure are optional. If omitted or empty, the
 //   member will have no effect on the rule.
 //
-// - For now, combining ToPorts and ToCIDR in the same rule is not supported
-//   and such rules will be rejected. In the future, this will be supported and
-//   if if multiple members of the structure are specified, then all members
-//   must match in order for the rule to take effect.
+// - If multiple members of the structure are specified, then all members
+//   must match in order for the rule to take effect. The exception to this
+//   rule is the ToRequires member; the effects of any Requires field in any
+//   rule will apply to all other rules as well.
+//
+// - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are
+//   mutually exclusive. Only one of these members may be present within an
+//   individual rule.
 type EgressRule struct {
 	// ToEndpoints is a list of endpoints identified by an EndpointSelector to
 	// which the endpoints subject to the rule are allowed to communicate.


### PR DESCRIPTION
* #12517 -- Adds documentation for limiting identity-relevant labels used when evaluating Cilium Identities (@seanmwinn)
   * Backporter's notes: the conflict resolution was to put the docs under the
     `getting-started` section.
 * #12532 -- docs(troubleshooting):  Remove bugtool related step with --serve flag (@sayboras)
 * #12524 -- endpoint: Write headerfile under full regeneration (@christarazi)
 * #12525 -- Clarify egress policy rule documentation (@joestringer)
 * #12640 -- backporting: Report progress in set-labels.py (@pchaigno)
 * #12639 -- docs(identity): Correct discrepancy between label and descriptions  (@sayboras)

Skipped due to conflicts:
 * #12307 -- pkg/endpoint: wait for security identity on restore (@aanm)
 * #12559 -- bpf: Fix monitor aggregation for 'from-network' (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12517 12532 12524 12525 12640 12639; do contrib/backporting/set-labels.py $pr done 1.6; done
```