### PR TITLE
Parallelise CRD registration to improve bootstrap time

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1304,14 +1304,15 @@ func runDaemon() {
 		restoredEndpoints.restored, d.endpointManager)
 	bootstrapStats.enableConntrack.End(true)
 
-	bootstrapStats.k8sInit.Start()
-
 	if option.Config.KVStore == "" {
 		log.Info("Skipping kvstore configuration")
 	} else {
+		bootstrapStats.kvstore.Start()
 		d.initKVStore()
+		bootstrapStats.kvstore.End(true)
 	}
 
+	bootstrapStats.k8sInit.Start()
 	// Wait only for certain caches, but not all!
 	// (Check Daemon.initK8sSubsystem() for more info)
 	<-d.k8sCachesSynced

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -77,6 +77,7 @@ type bootstrapStatistics struct {
 	proxyStart      spanstat.SpanStat
 	fqdn            spanstat.SpanStat
 	enableConntrack spanstat.SpanStat
+	kvstore         spanstat.SpanStat
 }
 
 func (b *bootstrapStatistics) updateMetrics() {
@@ -109,6 +110,7 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"proxyStart":      &b.proxyStart,
 		"fqdn":            &b.fqdn,
 		"enableConntrack": &b.enableConntrack,
+		"kvstore":         &b.kvstore,
 	}
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"golang.org/x/sync/errgroup"
 	"time"
 
 	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -56,29 +57,31 @@ var (
 // CreateCustomResourceDefinitions creates our CRD objects in the kubernetes
 // cluster
 func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) error {
-	if err := createCNPCRD(clientset); err != nil {
-		return err
-	}
+	g, _ := errgroup.WithContext(context.Background())
 
-	if err := createCCNPCRD(clientset); err != nil {
-		return err
-	}
+	g.Go(func() error {
+		return createCNPCRD(clientset)
+	})
 
-	if err := createCEPCRD(clientset); err != nil {
-		return err
-	}
+	g.Go(func() error {
+		return createCCNPCRD(clientset)
+	})
 
-	if err := createNodeCRD(clientset); err != nil {
-		return err
-	}
+	g.Go(func() error {
+		return createCEPCRD(clientset)
+	})
+
+	g.Go(func() error {
+		return createNodeCRD(clientset)
+	})
 
 	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD {
-		if err := createIdentityCRD(clientset); err != nil {
-			return err
-		}
+		g.Go(func() error {
+			return createIdentityCRD(clientset)
+		})
 	}
 
-	return nil
+	return g.Wait()
 }
 
 // createCNPCRD creates and updates the CiliumNetworkPolicies CRD. It should be called


### PR DESCRIPTION
Unscientific measurement:

Before:
```
cilium_agent_bootstrap_seconds                        outcome="success" scope="k8sInit"                                                                 2.103586

```


After:
```
cilium_agent_bootstrap_seconds                        scope="k8sInit" outcome="success"                                                                 0.581899
cilium_agent_bootstrap_seconds                        outcome="success" scope="kvstore"                                                                 0.001010
```