### PR TITLE
install/kubernetes: re-add removed permissions from clusterrole

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -50,6 +50,16 @@ rules:
   - nodes/status
   verbs:
   - patch
+# extensions/ingresses is deprecated remove in 1.8
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/install/kubernetes/cilium/charts/preflight/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/clusterrole.yaml
@@ -50,6 +50,16 @@ rules:
   - nodes/status
   verbs:
   - patch
+# extensions/ingresses is deprecated remove in 1.8
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -200,6 +200,16 @@ rules:
   - nodes/status
   verbs:
   - patch
+# extensions/ingresses is deprecated remove in 1.8
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
During a rolling upgrade across minor versions, Cilium's clusterrole
might change. When doing this upgrade the newer Cilium version cannot
have permissions removed from its clusterrole or the older Cilium
version might fail has it might require such permissions. Re-adding, by
having all permissions required by both versions will make sure that
Cilium can run successfully while the rolling upgrade happens.

Signed-off-by: André Martins <andre@cilium.io>

Related with https://github.com/cilium/cilium/issues/12715