### PR TITLE
install/kubernetes: re-add removed permissions from clusterrole

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -80,5 +80,7 @@ rules:
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
+# deprecated remove in v1.9
+  - ciliumidentities/status
   verbs:
   - '*'

--- a/install/kubernetes/cilium/charts/preflight/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/clusterrole.yaml
@@ -80,5 +80,7 @@ rules:
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
+# deprecated remove in v1.9
+  - ciliumidentities/status
   verbs:
   - '*'

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -223,6 +223,8 @@ rules:
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
+# deprecated remove in v1.9
+  - ciliumidentities/status
   verbs:
   - '*'
 ---

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -196,6 +196,8 @@ rules:
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
+# deprecated remove in v1.9
+  - ciliumidentities/status
   verbs:
   - '*'
 ---


### PR DESCRIPTION
During a rolling upgrade across minor versions, Cilium's clusterrole
might change. When doing this upgrade the newer Cilium version cannot
have permissions removed from its clusterrole or the older Cilium
version might fail has it might require such permissions. Re-adding, by
having all permissions required by both versions will make sure that
Cilium can run successfully while the rolling upgrade happens.

Signed-off-by: André Martins <andre@cilium.io>

Related with https://github.com/cilium/cilium/issues/12715

```release-note
Re-add removed rule 'ciliumidentities/status' for Cilium's and Preflight's Kubernetes ClusterRole
```