### PR TITLE
v1.8 backports 2020-07-30

### DIFF
--- a/Documentation/concepts/scalability/identity-relevant-labels.rst
+++ b/Documentation/concepts/scalability/identity-relevant-labels.rst
@@ -26,9 +26,9 @@ Label                               Description
 ``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
 ``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
 ``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels
-``k8s:kubernetes.io``               Ignore all other ``kubernetes.io`` labels
-``k8s:beta.kubernetes.io``          Ignore all ``beta.kubernetes.io`` labels
-``k8s:k8s.io``                      Ignore all ``k8s.io`` labels
+``k8s:!kubernetes.io``              Ignore all other ``kubernetes.io`` labels
+``k8s:!beta.kubernetes.io``         Ignore all ``beta.kubernetes.io`` labels
+``k8s:!k8s.io``                     Ignore all ``k8s.io`` labels
 ``k8s:!pod-template-generation``    Ignore all ``pod-template-generation`` labels
 ``k8s:!pod-template-hash``          Ignore all ``pod-template-hash`` labels
 ``k8s:!controller-revision-hash``   Ignore all ``controller-revision-hash`` labels

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -38,7 +38,7 @@ old_label_len = len(pr_labels)
 
 cilium_labels = cilium.get_labels()
 
-print("Setting labels for PR $pr... ", end="")
+print("Setting labels for PR {}... ".format(pr_number), end="")
 if action == "pending":
     pr_labels = [l for l in pr_labels
                  if l.name != "needs-backport/"+version]

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -49,7 +49,7 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push origin "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
-prs=$(grep "set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
+prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
 echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
                   values:
                     - cilium
             topologyKey: "kubernetes.io/hostname"
+      serviceAccount: hubble-relay
+      serviceAccountName: hubble-relay
       containers:
         - name: hubble-relay
 {{- if contains "/" .Values.image.repository }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-relay
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -35,3 +35,7 @@ sortBufferDrainTimeout: ~
 
 # Port to use for the k8s service backed by hubble-relay pods.
 servicePort: 80
+
+# Specifies annotation for service accounts
+serviceAccount:
+  annotations: {}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/ingress.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/ingress.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "14") }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: hubble-ui

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: hubble-ui
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.serviceAccount.annotations }}
+{{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
-  {{- end }}
+{{- end }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -6,6 +6,13 @@ metadata:
   name: cilium
   namespace: kube-system
 ---
+# Source: cilium/charts/hubble-relay/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+---
 # Source: cilium/charts/hubble-ui/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -699,6 +706,8 @@ spec:
                   values:
                     - cilium
             topologyKey: "kubernetes.io/hostname"
+      serviceAccount: hubble-relay
+      serviceAccountName: hubble-relay
       containers:
         - name: hubble-relay
           image: "docker.io/cilium/hubble-relay:v1.8.2"


### PR DESCRIPTION
* #12639 -- docs(identity): Correct discrepancy between label and descriptions (@sayboras)
 * #12704 -- contrib: Print PR number in set-labels.py (@christarazi)
 * #12703 -- contrib: Tighten search for list of PRs (@christarazi)
 * #12650 -- helm: add Hubble Relay service account (@m4rx0)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12639 12704 12703 12650; do contrib/backporting/set-labels.py $pr done 1.8; done
```