### PR TITLE
v1.7 backports 2020-07-30

### DIFF
--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -26,9 +26,9 @@ Label                               Description
 ``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
 ``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
 ``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels
-``k8s:kubernetes.io``               Ignore all other ``kubernetes.io`` labels
-``k8s:beta.kubernetes.io``          Ignore all ``beta.kubernetes.io`` labels
-``k8s:k8s.io``                      Ignore all ``k8s.io`` labels
+``k8s:!kubernetes.io``              Ignore all other ``kubernetes.io`` labels
+``k8s:!beta.kubernetes.io``         Ignore all ``beta.kubernetes.io`` labels
+``k8s:!k8s.io``                     Ignore all ``k8s.io`` labels
 ``k8s:!pod-template-generation``    Ignore all ``pod-template-generation`` labels
 ``k8s:!pod-template-hash``          Ignore all ``pod-template-hash`` labels
 ``k8s:!controller-revision-hash``   Ignore all ``controller-revision-hash`` labels

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -38,6 +38,7 @@ old_label_len = len(pr_labels)
 
 cilium_labels = cilium.get_labels()
 
+print("Setting labels for PR $pr... ", end="")
 if action == "pending":
     pr_labels = [l for l in pr_labels
                  if l.name != "needs-backport/"+version]
@@ -52,7 +53,6 @@ if action == "pending":
         print("error adding backport-pending/"+version+" label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
-    sys.exit(0)
 
 if action == "done":
     pr_labels = [l for l in pr_labels
@@ -68,4 +68,5 @@ if action == "done":
         print("error adding backport-done/"+version+" label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
-    sys.exit(0)
+
+print("✓")

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -38,7 +38,7 @@ old_label_len = len(pr_labels)
 
 cilium_labels = cilium.get_labels()
 
-print("Setting labels for PR $pr... ", end="")
+print("Setting labels for PR {}... ".format(pr_number), end="")
 if action == "pending":
     pr_labels = [l for l in pr_labels
                  if l.name != "needs-backport/"+version]

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -55,8 +55,6 @@ echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels
 if [ "$set_all_labels" = "y" ]; then
     for pr in $prs; do
-        echo -n "Setting labels for PR $pr... "
         $DIR/set-labels.py $pr pending $BRANCH;
-        echo "✓"
     done
 fi

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -49,7 +49,7 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push origin "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
-prs=$(grep "set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
+prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
 echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -49,20 +49,14 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push origin "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
-prs=$(sed -e 's/^.*#\([0-9]\+\) .*$/\1/g' -e '/^[^0-9]\+/d' $SUMMARY | tr '\n' ' ')
+prs=$(grep "set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
 echo -n "Set labels for all PRs above? [y/N] "
 read set_all_labels
-for pr in $prs; do
-    if [ "$set_all_labels" = "y" ]; then
+if [ "$set_all_labels" = "y" ]; then
+    for pr in $prs; do
         echo -n "Setting labels for PR $pr... "
         $DIR/set-labels.py $pr pending $BRANCH;
-    else
-        echo -n "Set labels for $pr? [y/N] "
-        read setlabels
-        if [ "$setlabels" = "y" ]; then
-            $DIR/set-labels.py $pr pending $BRANCH;
-        fi
-    fi
-    echo "✓"
-done
+        echo "✓"
+    done
+fi

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -169,7 +169,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 	}, nil)
 
 	s.repo = policy.NewPolicyRepository(nil, nil)
-	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: 500 * time.Millisecond, SingleInflight: true}
+	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 


### PR DESCRIPTION
* #11912 -- contrib: Fix submit-backport PR set-labels detection (@joestringer)
 * #12606 -- fqdn/dnsproxy/proxy_test: increase again timeout for DNS TCP exchanges (@qmonnet)
 * #12640 -- backporting: Report progress in set-labels.py (@pchaigno)
 * #12639 -- docs(identity): Correct discrepancy between label and descriptions (@sayboras)
 * #12704 -- contrib: Print PR number in set-labels.py (@christarazi)
 * #12703 -- contrib: Tighten search for list of PRs (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11912 12606 12640 12639 12704 12703; do contrib/backporting/set-labels.py $pr done 1.7; done
```