### PR TITLE
ci: Delete cilium-node-init ds before cilium install

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2301,6 +2301,7 @@ func (kub *Kubectl) CiliumInstall(filename string, options map[string]string) er
 		resourcesToDelete = map[string]string{
 			"configmap":          "cilium-config",
 			"daemonset":          "cilium",
+			"daemonset ":         "cilium-node-init",
 			"deployment":         "cilium-operator",
 			"clusterrolebinding": "cilium cilium-operator",
 			"clusterrole":        "cilium cilium-operator",


### PR DESCRIPTION
`--validate` helm flag introduced in 82cc7c3d07 caused ci to fail in gke
where we enable node init daemonset. It needs to be cleared before
cilium installation.