### PR TITLE
Fix typo in nproc invocation

### DIFF
--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.defs
 
-FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc -all) -O2
+FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc --all) -O2
 BPF_CC_FLAGS :=  ${FLAGS} -target bpf -emit-llvm
 BPF_LLC_FLAGS   := -march=bpf -mcpu=probe -filetype=obj
 


### PR DESCRIPTION
The backport in v1.7 was leaving out a dash, which leads to:

    nproc: invalid option -- 'a'

This was correct in v1.8 and in master branch.

Fixes commit 6247cc5990fd723af0bbc553b825ce619d0095f3.

Fixes: #12070