### PR TITLE
v1.7 backports 2020-07-30

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1261,12 +1261,16 @@ func runDaemon() {
 	// subsystem as well in parallel so caches will start to be synchronized
 	// with k8s.
 	k8sCachesSynced := d.k8sWatcher.InitK8sSubsystem()
+
 	if option.Config.KVStore == "" {
 		log.Info("Skipping kvstore configuration")
 	} else {
+		bootstrapStats.kvstore.Start()
 		d.initKVStore()
+		bootstrapStats.kvstore.End(true)
 	}
 
+	bootstrapStats.k8sInit.Start()
 	// Wait only for certain caches, but not all!
 	// (Check Daemon.initK8sSubsystem() for more info)
 	<-k8sCachesSynced

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -77,6 +77,7 @@ type bootstrapStatistics struct {
 	proxyStart      spanstat.SpanStat
 	fqdn            spanstat.SpanStat
 	enableConntrack spanstat.SpanStat
+	kvstore         spanstat.SpanStat
 }
 
 func (b *bootstrapStatistics) updateMetrics() {
@@ -109,6 +110,7 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"proxyStart":      &b.proxyStart,
 		"fqdn":            &b.fqdn,
 		"enableConntrack": &b.enableConntrack,
+		"kvstore":         &b.kvstore,
 	}
 }
 

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -473,6 +473,7 @@ golang.org/x/net/trace
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e => golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 => golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
 golang.org/x/sys/cpu


### PR DESCRIPTION
* #12719 -- Parallelise CRD registration to improve bootstrap time (@tgraf)
   * Note: conflict resolution:
       * First commit: vendored in `errgroup`
        * Second commit: kept the `k8sCachesSynced` channel which was moved to another location in the latest tree.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12719; do contrib/backporting/set-labels.py $pr done 1.7; done
```