### PR TITLE
datapath: Fix ICMP ECHO tuple ports

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -345,12 +345,12 @@ static __always_inline int ct_lookup6(const void *map,
 				tuple->flags |= TUPLE_F_RELATED;
 				break;
 
-			case ICMPV6_ECHO_REPLY:
-				tuple->sport = identifier;
-				break;
-
 			case ICMPV6_ECHO_REQUEST:
-				tuple->dport = identifier;
+			case ICMPV6_ECHO_REPLY:
+				if (dir == CT_INGRESS)
+					tuple->sport = identifier;
+				else
+					tuple->dport = identifier;
 				/* fall through */
 			default:
 				action = ACTION_CREATE;
@@ -529,11 +529,11 @@ static __always_inline int ct_lookup4(const void *map,
 				break;
 
 			case ICMP_ECHOREPLY:
-				tuple->sport = identifier;
-				break;
-
 			case ICMP_ECHO:
-				tuple->dport = identifier;
+				if (dir == CT_INGRESS)
+					tuple->sport = identifier;
+				else
+					tuple->dport = identifier;
 				/* fall through */
 			default:
 				action = ACTION_CREATE;

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -229,7 +229,7 @@ type GCFilter struct {
 	// RemoveExpired enables removal of all entries that have expired
 	RemoveExpired bool
 
-	// Time is the reference timestamp to reomove expired entries. If
+	// Time is the reference timestamp to remove expired entries. If
 	// RemoveExpired is true and lifetime is lesser than Time, the entry is
 	// removed
 	Time uint32


### PR DESCRIPTION
Previously, when an ICMP EchoRequest was sent from one node A to another node B with `Echo ID > NAT_MIN_EGRESS`, the ICMP EchoReply sent from `B -> A` created a CT entry and NAT entries which could not be related by GC. E.g. node A (`192.168.34.12`) pings node B (`192.168.34.11`):

        ICMP IN 192.168.34.12:0 -> 192.168.34.11:38193 XLATE_DST
        192.168.34.11:38193 Created=6292sec HostLocal=1
        ICMP OUT 192.168.34.11:38193 -> 192.168.34.12:0 XLATE_SRC
        192.168.34.11:38193 Created=6292sec HostLocal=1

        ICMP OUT 192.168.34.11:0 -> 192.168.34.12:38193 expires=16783063
        RxPackets=0 RxBytes=0 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=1
        TxBytes=50 TxFlagsSeen=0x00 LastTxReport=16783005 Flags=0x0000 [ ]
        RevNAT=0 SourceSecurityID=0 IfIndex=0

This made the NAT entries to escape the CT GC meaning that the CT entry was removed, while the NAT entries were kept which made them to stay forever until a user manually ran `cilium bpf nat flush`.

Fix this by setting ICMP Echo ID in a port which belongs to addr of the local node, so that the CT GC could relate the NAT entries. In the previous example, the CT entry after the fix is the following:

        ICMP OUT 192.168.34.11:38193 -> 192.168.34.12:0 expires=16783063
        RxPackets=0 RxBytes=0 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=1
        TxBytes=50 TxFlagsSeen=0x00 LastTxReport=16783005 Flags=0x0000 [ ]
        RevNAT=0 SourceSecurityID=0 IfIndex=0

The fix does not change the ID placement in a port for the case when B -> A sends ICMP EchoRequest.

Fix #12625 