### PR TITLE
test/helpers: delete resources using generated manifest before CiliumInstall

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1465,6 +1465,14 @@ func (kub *Kubectl) Delete(filePath string) *CmdRes {
 		fmt.Sprintf("%s delete -f  %s", KubectlCmd, filePath))
 }
 
+// DeleteAndWait deletes the Kubernetes manifest at path filePath and wait
+// for the associated resources to be gone.
+func (kub *Kubectl) DeleteAndWait(filePath string) *CmdRes {
+	kub.Logger().Debugf("waiting for resources in %q to be deleted", filePath)
+	return kub.ExecShort(
+		fmt.Sprintf("%s delete -f  %s --wait", KubectlCmd, filePath))
+}
+
 // PodsHaveCiliumIdentity validates that all pods matching th podSelector have
 // a CiliumEndpoint resource mirroring it and an identity is assigned to it. If
 // any pods do not match this criteria, an error is returned.
@@ -2296,27 +2304,14 @@ func (kub *Kubectl) ciliumUninstallHelm(filename string, options map[string]stri
 
 // CiliumInstall installs Cilium with the provided Helm options.
 func (kub *Kubectl) CiliumInstall(filename string, options map[string]string) error {
-	var (
-		wg                sync.WaitGroup
-		resourcesToDelete = map[string]string{
-			"configmap":          "cilium-config",
-			"daemonset":          "cilium",
-			"daemonset ":         "cilium-node-init",
-			"deployment":         "cilium-operator",
-			"clusterrolebinding": "cilium cilium-operator",
-			"clusterrole":        "cilium cilium-operator",
-			"serviceaccount":     "cilium cilium-operator",
+	// First try to remove any existing cilium install. This is done by removing resources
+	// from the file we generate cilium install manifest to.
+	if _, err := os.Stat(filename); err == nil {
+		res := kub.DeleteAndWait(filename)
+		if !res.WasSuccessful() {
+			return res.GetErr("unable to delete existing cilium YAML")
 		}
-	)
-
-	wg.Add(len(resourcesToDelete))
-	for resourceType, resource := range resourcesToDelete {
-		go func(resource, resourceType string) {
-			_ = kub.DeleteResource(resourceType, "-n "+CiliumNamespace+" "+resource)
-			wg.Done()
-		}(resource, resourceType)
 	}
-	wg.Wait()
 
 	if err := kub.generateCiliumYaml(options, filename); err != nil {
 		return err


### PR DESCRIPTION
This commit fixes a bug introduced in b8716eda879d wherein
while testing during the deployment of cilium using the install manifest
we were removing existing cilium resources from the cluster manually
from a list in `CiliumInstall` function. This was creating problem when
testing on GKE clusters. The reason being `cilium-node-init` DaemonSet
was not getting cleaned up resulting in failure of `helm template
--validate` command.

This commit fixes the issue by using `DeleteAndWait` helper utility with
the generated cilium helm template manifest rather than removing the
resources manually using kubectl from the cluster.

Fixes b8716eda879d "test: generate cilium helm template validating
against k8s cluster"

For context take a look at this [comment](https://github.com/cilium/cilium/pull/11782#issuecomment-6674196880)

**NOTE** Do Not Merge, checking out some CI changes.

Signed-off-by: Deepesh Pathak <deepshpathak@gmail.com>
