### PR TITLE
[v1.7] Extend FQDN test to validate DNS proxy during restart

### DIFF
--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -137,25 +137,6 @@ var _ = Describe("K8sFQDNTest", func() {
 		ExpectAllPodsTerminated(kubectl)
 		ExpectCiliumReady(kubectl)
 
-		// @TODO This endpoint ready call SHOULD NOT be here
-		// Here some packets can be lost due to two different scenarios:
-		//
-		// 1) On restore the endpoint/fqdn policies, the identity ID for the
-		// CIDRSet can be different, so if one endpoint start to regenerate and
-		// other still have the old identity things can mess around and some
-		// IPs are not white listed correctly. To prevent this, a restore for
-		// local-identities will be added in the future.
-		//
-		// 2) On restore, the Kubernetes watcher is sending the CNP back to
-		// Cilium, and before the endoint is restored the CNP can be applied
-		// without the ToCIDRSet, this means that there is no TOCIDR rule in
-		// the cilium policy and traffic will be drop.
-
-		// As mentioned above, these endpoints ready should not be there, the only
-		// reason to have this piece of code here is to reduce a flaky test.
-		err = kubectl.CiliumEndpointWaitReady()
-		Expect(err).To(BeNil(), "Endpoints are not ready after Cilium restarts")
-
 		By("Testing connectivity when cilium is *restored* using IPs without DNS")
 		connectivityTestIPs(kubectl, appPods, worldTargetIP, worldInvalidTargetIP)
 


### PR DESCRIPTION
See commit msgs.

We can consider forward-porting this to newer branches + `master`, if deemed valuable.

Follow up from https://github.com/cilium/cilium/pull/12718 and
https://github.com/cilium/cilium/pull/12731