### PR TITLE
hubble/metrics: Add protocol labels to `flows_processed_total`

### DIFF
--- a/pkg/hubble/metrics/flow/handler.go
+++ b/pkg/hubble/metrics/flow/handler.go
@@ -34,7 +34,7 @@ func (h *flowHandler) Init(registry *prometheus.Registry, options api.Options) e
 	}
 	h.context = c
 
-	labels := []string{"type", "subtype", "verdict"}
+	labels := []string{"protocol", "type", "subtype", "verdict"}
 	labels = append(labels, h.context.GetLabelNames()...)
 
 	h.flows = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -80,7 +80,8 @@ func (h *flowHandler) ProcessFlow(flow v1.Flow) {
 		subType = monitorAPI.TraceObservationPoints[uint8(flow.GetEventType().SubType)]
 	}
 
-	labels := []string{typeName, subType, flow.GetVerdict().String()}
+	labels := []string{v1.FlowProtocol(flow), typeName, subType, flow.GetVerdict().String()}
 	labels = append(labels, h.context.GetLabelValues(flow)...)
+
 	h.flows.WithLabelValues(labels...).Inc()
 }

--- a/pkg/hubble/metrics/flow/handler_test.go
+++ b/pkg/hubble/metrics/flow/handler_test.go
@@ -66,16 +66,19 @@ func TestFlowHandler(t *testing.T) {
 		assert.Equal(t, "destination", *metric.Label[0].Name)
 		assert.Equal(t, "bar", *metric.Label[0].Value)
 
-		assert.Equal(t, "source", *metric.Label[1].Name)
-		assert.Equal(t, "foo", *metric.Label[1].Value)
+		assert.Equal(t, "protocol", *metric.Label[1].Name)
+		assert.Equal(t, "HTTP", *metric.Label[1].Value)
 
-		assert.Equal(t, "subtype", *metric.Label[2].Name)
-		assert.Equal(t, "HTTP", *metric.Label[2].Value)
+		assert.Equal(t, "source", *metric.Label[2].Name)
+		assert.Equal(t, "foo", *metric.Label[2].Value)
 
-		assert.Equal(t, "type", *metric.Label[3].Name)
-		assert.Equal(t, "L7", *metric.Label[3].Value)
+		assert.Equal(t, "subtype", *metric.Label[3].Name)
+		assert.Equal(t, "HTTP", *metric.Label[3].Value)
 
-		assert.Equal(t, "verdict", *metric.Label[4].Name)
-		assert.Equal(t, "FORWARDED", *metric.Label[4].Value)
+		assert.Equal(t, "type", *metric.Label[4].Name)
+		assert.Equal(t, "L7", *metric.Label[4].Value)
+
+		assert.Equal(t, "verdict", *metric.Label[5].Name)
+		assert.Equal(t, "FORWARDED", *metric.Label[5].Value)
 	})
 }

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -77,7 +77,7 @@ var _ = Describe("K8sHubbleTest", func() {
 		}
 	}
 
-	removeVisbilityAnnotation := func(ns, podLabels string) {
+	removeVisibilityAnnotation := func(ns, podLabels string) {
 		By("Removing visibility annotation on pod with labels %s", app1Labels)
 		res := kubectl.Exec(fmt.Sprintf("%s annotate pod -n %s -l %s %s-", helpers.KubectlCmd, ns, podLabels, annotation.ProxyVisibility))
 		res.ExpectSuccess("removing proxy visibility annotation failed")
@@ -105,7 +105,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			"hubble observe: filter %q never matched expected string %q", filter, expected)
 	}
 
-	// Skipping on GKE due to hubbler-relay not getting ready
+	// Skipping on GKE due to hubble-relay not getting ready
 	SkipContextIf(helpers.SkipGKEQuarantined, "All Hubble Tests", func() {
 		BeforeAll(func() {
 			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
@@ -198,7 +198,7 @@ var _ = Describe("K8sHubbleTest", func() {
 				res, err = kubectl.ExecInHostNetNS(ctx, k8s1NodeName, helpers.CurlFail(metricsUrl))
 				Expect(err).To(BeNil(), "failed to execute curl on node %q", k8s1NodeName)
 				res.ExpectSuccess("%s/%s cannot curl metrics %q", helpers.CiliumNamespace, ciliumPodK8s1, app1ClusterIP)
-				res.ExpectContains(`hubble_flows_processed_total{subtype="to-endpoint",type="Trace",verdict="FORWARDED"}`)
+				res.ExpectContains(`hubble_flows_processed_total{protocol="TCP",subtype="to-endpoint",type="Trace",verdict="FORWARDED"}`)
 			})
 
 			It("Test L3/L4 Flow with hubble-relay", func() {
@@ -222,7 +222,7 @@ var _ = Describe("K8sHubbleTest", func() {
 
 			It("Test L7 Flow", func() {
 				addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
-				defer removeVisbilityAnnotation(namespaceForTest, app1Labels)
+				defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
 
 				ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
 				defer cancel()
@@ -243,12 +243,12 @@ var _ = Describe("K8sHubbleTest", func() {
 				res, err = kubectl.ExecInHostNetNS(ctx, k8s1NodeName, helpers.CurlFail(metricsUrl))
 				Expect(err).To(BeNil(), "failed to execute curl on node %q", k8s1NodeName)
 				res.ExpectSuccess("%s/%s cannot curl metrics %q", helpers.CiliumNamespace, ciliumPodK8s1, app1ClusterIP)
-				res.ExpectContains(`hubble_flows_processed_total{subtype="HTTP",type="L7",verdict="FORWARDED"}`)
+				res.ExpectContains(`hubble_flows_processed_total{protocol="HTTP",subtype="HTTP",type="L7",verdict="FORWARDED"}`)
 			})
 
 			It("Test L7 Flow with hubble-relay", func() {
 				addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
-				defer removeVisbilityAnnotation(namespaceForTest, app1Labels)
+				defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
 
 				res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
 					helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))


### PR DESCRIPTION
Add protocol labels to `flows_processed_total`

Closes #12656

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
hubble/metrics: Add protocol labels to `flows_processed_total`
```
