### PR TITLE
v1.8 backports 2020-08-03

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -189,7 +189,7 @@ We are currently testing following kernel - k8s version pairs in our CI:
 +--------------------+------------------+
 | GKE clusters                          |
 +--------------------+------------------+
-| 1.14.10            | 4.14.138+        |
+| 1.15.12            | 4.19.112+        |
 +--------------------+------------------+
 
 .. _trigger_phrases:

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1306,14 +1306,15 @@ func runDaemon() {
 		restoredEndpoints.restored, d.endpointManager)
 	bootstrapStats.enableConntrack.End(true)
 
-	bootstrapStats.k8sInit.Start()
-
 	if option.Config.KVStore == "" {
 		log.Info("Skipping kvstore configuration")
 	} else {
+		bootstrapStats.kvstore.Start()
 		d.initKVStore()
+		bootstrapStats.kvstore.End(true)
 	}
 
+	bootstrapStats.k8sInit.Start()
 	// Wait only for certain caches, but not all!
 	// (Check Daemon.initK8sSubsystem() for more info)
 	<-d.k8sCachesSynced

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -77,6 +77,7 @@ type bootstrapStatistics struct {
 	proxyStart      spanstat.SpanStat
 	fqdn            spanstat.SpanStat
 	enableConntrack spanstat.SpanStat
+	kvstore         spanstat.SpanStat
 }
 
 func (b *bootstrapStatistics) updateMetrics() {
@@ -109,6 +110,7 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"proxyStart":      &b.proxyStart,
 		"fqdn":            &b.fqdn,
 		"enableConntrack": &b.enableConntrack,
+		"kvstore":         &b.kvstore,
 	}
 }
 


### PR DESCRIPTION
* #12719 -- Parallelise CRD registration to improve bootstrap time (@tgraf)
 * #12709 -- test/K8sServices: Fix externalTrafficPolicy=Local with kube-proxy (on GKE) (@gandro)
    * Skipping commit 208ef7a65bb2, which fixes an issue from 82cc7c3d0761 (#12409), not backported

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12719 12709; do contrib/backporting/set-labels.py $pr done 1.8; done
```