### PR TITLE
[1.7] etcd: Disable heartbeat quorum check by default

### DIFF
--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -45,6 +45,10 @@ type ExtraOptions struct {
 
 	// NoLockQuorumCheck disables the lock acquisition quorum check
 	NoLockQuorumCheck bool
+
+	// HeartbeatHealthCheck enables use of the heartbeat when determining
+	// health
+	HeartbeatHealthCheck bool
 }
 
 // StatusCheckInterval returns the interval of status checks depending on the


### PR DESCRIPTION
Disable the heartbeat check by default as the sudden requirement for the
cilium-operator to be always available can come to a surprise to existing 1.7
users.

Require etcd.enableHeartbeat=true to be set in order to enable the requirement
for the heartbeat.