### PR TITLE
Add portmap+proxy conformance test

### DIFF
--- a/examples/kubernetes/connectivity-check/Makefile
+++ b/examples/kubernetes/connectivity-check/Makefile
@@ -95,7 +95,7 @@ list:
 $(SERVERS_OUT): $(SRC)
 	@echo > $(SERVERS_OUT)
 	@for name in $(SERVERS_NAME); do \
-		$(CUE) cmd -t name=$$name dump >> $@; \
+		$(CUE) cmd -t component=all -t name=$$name dump >> $@; \
 	done
 
 .PHONY: all clean deploy eval generate_all help inspect list $(ALL_TARGETS)

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -1072,8 +1072,181 @@ apiVersion: v1
 kind: Service
 
 ---
+metadata:
+  name: echo-c
+  labels:
+    name: echo-c
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-c
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-c-container
+        ports:
+        - containerPort: 80
+          hostPort: 40001
+        image: docker.io/cilium/json-mock:1.2
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+  selector:
+    matchLabels:
+      name: echo-c
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: echo-c
+  labels:
+    name: echo-c
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - port: 80
+  type: ClusterIP
+  selector:
+    name: echo-c
+apiVersion: v1
+kind: Service
+---
+metadata:
+  name: echo-c
+  labels:
+    name: echo-c
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: echo-c
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - path: /public$
+          method: GET
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
 
 ---
+metadata:
+  name: echo-c-host
+  labels:
+    name: echo-c-host
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-c-host
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-c-host-container
+        env:
+        - name: PORT
+          value: "41001"
+        ports: []
+        image: docker.io/cilium/json-mock:1.2
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:41001
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:41001
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-c
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: echo-c-host
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
 
 ---
+metadata:
+  name: echo-c-host-headless
+  labels:
+    name: echo-c-host-headless
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports: []
+  type: ClusterIP
+  selector:
+    name: echo-c-host
+  clusterIP: None
+apiVersion: v1
+kind: Service
 

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -865,8 +865,181 @@ apiVersion: v1
 kind: Service
 
 ---
+metadata:
+  name: echo-c
+  labels:
+    name: echo-c
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-c
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-c-container
+        ports:
+        - containerPort: 80
+          hostPort: 40001
+        image: docker.io/cilium/json-mock:1.2
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+  selector:
+    matchLabels:
+      name: echo-c
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: echo-c
+  labels:
+    name: echo-c
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - port: 80
+  type: ClusterIP
+  selector:
+    name: echo-c
+apiVersion: v1
+kind: Service
+---
+metadata:
+  name: echo-c
+  labels:
+    name: echo-c
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: echo-c
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - path: /public$
+          method: GET
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
 
 ---
+metadata:
+  name: echo-c-host
+  labels:
+    name: echo-c-host
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-c-host
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-c-host-container
+        env:
+        - name: PORT
+          value: "41001"
+        ports: []
+        image: docker.io/cilium/json-mock:1.2
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:41001
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:41001
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-c
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: echo-c-host
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
 
 ---
+metadata:
+  name: echo-c-host-headless
+  labels:
+    name: echo-c-host-headless
+    topology: any
+    component: proxy-check
+    traffic: internal
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports: []
+  type: ClusterIP
+  selector:
+    name: echo-c-host
+  clusterIP: None
+apiVersion: v1
+kind: Service
 

--- a/test/k8sT/Conformance.go
+++ b/test/k8sT/Conformance.go
@@ -25,11 +25,13 @@ var _ = Describe("K8sConformance", func() {
 	var kubectl *helpers.Kubectl
 	var ciliumFilename string
 	var connectivityCheckYaml string
+	var connectivityCheckYamlQuarantine string
 	var connectivityCheckYamlSimple string
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		connectivityCheckYaml = kubectl.GetFilePath("../examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml")
+		connectivityCheckYamlQuarantine = kubectl.GetFilePath("../examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml")
 		connectivityCheckYamlSimple = kubectl.GetFilePath("../examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml")
 
 		deployOpts := map[string]string{
@@ -53,6 +55,7 @@ var _ = Describe("K8sConformance", func() {
 
 	AfterEach(func() {
 		kubectl.Delete(connectivityCheckYaml)
+		kubectl.Delete(connectivityCheckYamlQuarantine)
 		kubectl.Delete(connectivityCheckYamlSimple)
 		ExpectAllPodsInNsTerminated(kubectl, "default")
 	})
@@ -93,5 +96,14 @@ var _ = Describe("K8sConformance", func() {
 			ExpectWithOffset(1, err).Should(BeNil(), "connectivity-check pods are not ready after timeout")
 		})
 
+		// FIXME: GH-12700 L7 policy breaks connectivity to hostport services.
+		//        When this is resolved, remove 'quarantine: true' label in examples/kubernetes/connectivity-check/proxy.cue.
+		//        The tests will be merged into the above checks, so this test can be removed.
+		XIt("Check connectivity-check compliance with proxy and portmap chaining", func() {
+			kubectl.ApplyDefault(connectivityCheckYamlQuarantine).ExpectSuccess("cannot install connectivity-check")
+
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "connectivity-check pods are not ready after timeout")
+		})
 	})
 })


### PR DESCRIPTION
Extend the k8s conformance tests to include proxy + portmap tests (which currently fail due to #12700).

Related: #12714