### PR TITLE
v1.8 backports 2020-08-04

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -345,12 +345,12 @@ static __always_inline int ct_lookup6(const void *map,
 				tuple->flags |= TUPLE_F_RELATED;
 				break;
 
-			case ICMPV6_ECHO_REPLY:
-				tuple->sport = identifier;
-				break;
-
 			case ICMPV6_ECHO_REQUEST:
-				tuple->dport = identifier;
+			case ICMPV6_ECHO_REPLY:
+				if (dir == CT_INGRESS)
+					tuple->sport = identifier;
+				else
+					tuple->dport = identifier;
 				/* fall through */
 			default:
 				action = ACTION_CREATE;
@@ -529,11 +529,11 @@ static __always_inline int ct_lookup4(const void *map,
 				break;
 
 			case ICMP_ECHOREPLY:
-				tuple->sport = identifier;
-				break;
-
 			case ICMP_ECHO:
-				tuple->dport = identifier;
+				if (dir == CT_INGRESS)
+					tuple->sport = identifier;
+				else
+					tuple->dport = identifier;
 				/* fall through */
 			default:
 				action = ACTION_CREATE;

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -229,7 +229,7 @@ type GCFilter struct {
 	// RemoveExpired enables removal of all entries that have expired
 	RemoveExpired bool
 
-	// Time is the reference timestamp to reomove expired entries. If
+	// Time is the reference timestamp to remove expired entries. If
 	// RemoveExpired is true and lifetime is lesser than Time, the entry is
 	// removed
 	Time uint32

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1567,8 +1567,8 @@ var _ = Describe("RuntimePolicies", func() {
 					"No ingress traffic to endpoint")
 
 				By("Testing cilium monitor output")
-				monitorRes.ExpectContains(
-					fmt.Sprintf("local EP ID %s, remote ID 1, dst port 0, proto 1, ingress true, action audit", endpointID),
+				monitorRes.ExpectMatchesRegexp(
+					fmt.Sprintf("local EP ID %s, remote ID 1, dst port [0-9]*, proto 1, ingress true, action audit", endpointID),
 					"No ingress policy log record",
 				)
 


### PR DESCRIPTION
 * #12637 -- endpointsynchronizer: suppress context.Canceled errors (@ghouscht)
 * #12729 -- datapath: Fix ICMP ECHO tuple ports (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12637 12729; do contrib/backporting/set-labels.py $pr done 1.8; done
```