### PR TITLE
v1.8 backports 2020-08-04-2

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -50,6 +50,10 @@ jobs:
         run: |
           sed -i 's;pullPolicy: Always;pullPolicy: Never;g' install/kubernetes/cilium/values.yaml
 
+      - name: Run a single operator replica since it's a single node cluster
+        run: |
+          sed -i 's;  numReplicas: 2;  numReplicas: 1;g' install/kubernetes/cilium/values.yaml
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-rc.1
         with:

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -15,56 +15,59 @@ cilium-operator-aws [flags]
 ### Options
 
 ```
-      --aws-instance-limit-mapping map          Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
-      --aws-release-excess-ips                  Enable releasing excess free IP addresses from AWS ENI.
-      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 5m0s)
-      --cluster-id int                          Unique identifier of the cluster
-      --cluster-name string                     Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr string           IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr string           IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-node-status-gc-interval duration    GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
-      --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
-      --config string                           Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                       Configuration directory that contains a file for each option
-      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
-  -D, --debug                                   Enable debugging mode
-      --enable-ipv4                             Enable IPv4 support (default true)
-      --enable-ipv6                             Enable IPv6 support (default true)
-      --enable-k8s-api-discovery                Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice               Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
-      --enable-metrics                          Enable Prometheus metrics
-      --eni-tags map                            ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
-  -h, --help                                    help for cilium-operator-aws
-      --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration           GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
-      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ipam string                             Backend to use for IPAM (default "eni")
-      --k8s-api-server string                   Kubernetes API server URL
-      --k8s-client-burst int                    Burst value allowed for the K8s client
-      --k8s-client-qps float32                  Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string              Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --kvstore string                          Key-value store type
-      --kvstore-opt map                         Key-value store options (default map[])
-      --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
-      --log-driver strings                      Logging endpoints to use for example syslog
-      --log-opt map                             Log driver options for cilium-operator (default map[])
-      --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
-      --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")
-      --parallel-alloc-workers int              Maximum number of parallel IPAM workers (default 50)
-      --subnet-ids-filter strings               Subnets IDs (separated by commas)
-      --subnet-tags-filter stringToString       Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
-      --synchronize-k8s-nodes                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api        Use the EC2 API to update the instance type to adapter limits
-      --version                                 Print version information
+      --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
+      --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
+      --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
+      --cluster-id int                            Unique identifier of the cluster
+      --cluster-name string                       Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr string             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr string             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
+      --config string                             Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                         Configuration directory that contains a file for each option
+      --crd-wait-timeout duration                 Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
+  -D, --debug                                     Enable debugging mode
+      --enable-ipv4                               Enable IPv4 support (default true)
+      --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-metrics                            Enable Prometheus metrics
+      --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
+  -h, --help                                      help for cilium-operator-aws
+      --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration             GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ipam string                               Backend to use for IPAM (default "eni")
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --kvstore string                            Key-value store type
+      --kvstore-opt map                           Key-value store options (default map[])
+      --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                        Logging endpoints to use for example syslog
+      --log-opt map                               Log driver options for cilium-operator (default map[])
+      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
+      --subnet-ids-filter strings                 Subnets IDs (separated by commas)
+      --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
+      --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --update-ec2-apdater-limit-via-api          Use the EC2 API to update the instance type to adapter limits
+      --version                                   Print version information
 ```
 

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -15,55 +15,58 @@ cilium-operator-azure [flags]
 ### Options
 
 ```
-      --azure-resource-group string             Resource group to use for Azure IPAM
-      --azure-subscription-id string            Subscription ID to access Azure API
-      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 5m0s)
-      --cluster-id int                          Unique identifier of the cluster
-      --cluster-name string                     Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr string           IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr string           IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-node-status-gc-interval duration    GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
-      --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
-      --config string                           Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                       Configuration directory that contains a file for each option
-      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
-  -D, --debug                                   Enable debugging mode
-      --enable-ipv4                             Enable IPv4 support (default true)
-      --enable-ipv6                             Enable IPv6 support (default true)
-      --enable-k8s-api-discovery                Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice               Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
-      --enable-metrics                          Enable Prometheus metrics
-  -h, --help                                    help for cilium-operator-azure
-      --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration           GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
-      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ipam string                             Backend to use for IPAM (default "azure")
-      --k8s-api-server string                   Kubernetes API server URL
-      --k8s-client-burst int                    Burst value allowed for the K8s client
-      --k8s-client-qps float32                  Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string              Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --kvstore string                          Key-value store type
-      --kvstore-opt map                         Key-value store options (default map[])
-      --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
-      --log-driver strings                      Logging endpoints to use for example syslog
-      --log-opt map                             Log driver options for cilium-operator (default map[])
-      --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
-      --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")
-      --parallel-alloc-workers int              Maximum number of parallel IPAM workers (default 50)
-      --subnet-ids-filter strings               Subnets IDs (separated by commas)
-      --subnet-tags-filter stringToString       Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
-      --synchronize-k8s-nodes                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api        Use the EC2 API to update the instance type to adapter limits
-      --version                                 Print version information
+      --azure-resource-group string               Resource group to use for Azure IPAM
+      --azure-subscription-id string              Subscription ID to access Azure API
+      --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
+      --cluster-id int                            Unique identifier of the cluster
+      --cluster-name string                       Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr string             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr string             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
+      --config string                             Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                         Configuration directory that contains a file for each option
+      --crd-wait-timeout duration                 Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
+  -D, --debug                                     Enable debugging mode
+      --enable-ipv4                               Enable IPv4 support (default true)
+      --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-metrics                            Enable Prometheus metrics
+  -h, --help                                      help for cilium-operator-azure
+      --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration             GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ipam string                               Backend to use for IPAM (default "azure")
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --kvstore string                            Key-value store type
+      --kvstore-opt map                           Key-value store options (default map[])
+      --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                        Logging endpoints to use for example syslog
+      --log-opt map                               Log driver options for cilium-operator (default map[])
+      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
+      --subnet-ids-filter strings                 Subnets IDs (separated by commas)
+      --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
+      --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --update-ec2-apdater-limit-via-api          Use the EC2 API to update the instance type to adapter limits
+      --version                                   Print version information
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -15,53 +15,56 @@ cilium-operator-generic [flags]
 ### Options
 
 ```
-      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 5m0s)
-      --cluster-id int                          Unique identifier of the cluster
-      --cluster-name string                     Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr string           IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr string           IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-node-status-gc-interval duration    GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
-      --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
-      --config string                           Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                       Configuration directory that contains a file for each option
-      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
-  -D, --debug                                   Enable debugging mode
-      --enable-ipv4                             Enable IPv4 support (default true)
-      --enable-ipv6                             Enable IPv6 support (default true)
-      --enable-k8s-api-discovery                Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice               Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
-      --enable-metrics                          Enable Prometheus metrics
-  -h, --help                                    help for cilium-operator-generic
-      --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration           GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
-      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ipam string                             Backend to use for IPAM (default "hostscope-legacy")
-      --k8s-api-server string                   Kubernetes API server URL
-      --k8s-client-burst int                    Burst value allowed for the K8s client
-      --k8s-client-qps float32                  Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string              Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --kvstore string                          Key-value store type
-      --kvstore-opt map                         Key-value store options (default map[])
-      --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
-      --log-driver strings                      Logging endpoints to use for example syslog
-      --log-opt map                             Log driver options for cilium-operator (default map[])
-      --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
-      --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")
-      --parallel-alloc-workers int              Maximum number of parallel IPAM workers (default 50)
-      --subnet-ids-filter strings               Subnets IDs (separated by commas)
-      --subnet-tags-filter stringToString       Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
-      --synchronize-k8s-nodes                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api        Use the EC2 API to update the instance type to adapter limits
-      --version                                 Print version information
+      --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
+      --cluster-id int                            Unique identifier of the cluster
+      --cluster-name string                       Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr string             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr string             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
+      --config string                             Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                         Configuration directory that contains a file for each option
+      --crd-wait-timeout duration                 Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
+  -D, --debug                                     Enable debugging mode
+      --enable-ipv4                               Enable IPv4 support (default true)
+      --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-metrics                            Enable Prometheus metrics
+  -h, --help                                      help for cilium-operator-generic
+      --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration             GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ipam string                               Backend to use for IPAM (default "hostscope-legacy")
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --kvstore string                            Key-value store type
+      --kvstore-opt map                           Key-value store options (default map[])
+      --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                        Logging endpoints to use for example syslog
+      --log-opt map                               Log driver options for cilium-operator (default map[])
+      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
+      --subnet-ids-filter strings                 Subnets IDs (separated by commas)
+      --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
+      --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --update-ec2-apdater-limit-via-api          Use the EC2 API to update the instance type to adapter limits
+      --version                                   Print version information
 ```
 

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -15,58 +15,61 @@ cilium-operator [flags]
 ### Options
 
 ```
-      --aws-instance-limit-mapping map          Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
-      --aws-release-excess-ips                  Enable releasing excess free IP addresses from AWS ENI.
-      --azure-resource-group string             Resource group to use for Azure IPAM
-      --azure-subscription-id string            Subscription ID to access Azure API
-      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 5m0s)
-      --cluster-id int                          Unique identifier of the cluster
-      --cluster-name string                     Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr string           IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int         Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr string           IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int         Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-node-status-gc-interval duration    GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
-      --cnp-status-update-interval duration     Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
-      --config string                           Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                       Configuration directory that contains a file for each option
-      --crd-wait-timeout duration               Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
-  -D, --debug                                   Enable debugging mode
-      --enable-ipv4                             Enable IPv4 support (default true)
-      --enable-ipv6                             Enable IPv6 support (default true)
-      --enable-k8s-api-discovery                Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice               Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
-      --enable-metrics                          Enable Prometheus metrics
-      --eni-tags map                            ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
-  -h, --help                                    help for cilium-operator
-      --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration           GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration      Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int              Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
-      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ipam string                             Backend to use for IPAM (default "hostscope-legacy")
-      --k8s-api-server string                   Kubernetes API server URL
-      --k8s-client-burst int                    Burst value allowed for the K8s client
-      --k8s-client-qps float32                  Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string              Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --kvstore string                          Key-value store type
-      --kvstore-opt map                         Key-value store options (default map[])
-      --limit-ipam-api-burst int                Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                Queries per second limit when accessing external IPAM APIs (default 20)
-      --log-driver strings                      Logging endpoints to use for example syslog
-      --log-opt map                             Log driver options for cilium-operator (default map[])
-      --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
-      --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")
-      --parallel-alloc-workers int              Maximum number of parallel IPAM workers (default 50)
-      --subnet-ids-filter strings               Subnets IDs (separated by commas)
-      --subnet-tags-filter stringToString       Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
-      --synchronize-k8s-nodes                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int      Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api        Use the EC2 API to update the instance type to adapter limits
-      --version                                 Print version information
+      --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
+      --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
+      --azure-resource-group string               Resource group to use for Azure IPAM
+      --azure-subscription-id string              Subscription ID to access Azure API
+      --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
+      --cluster-id int                            Unique identifier of the cluster
+      --cluster-name string                       Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr string             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr string             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
+      --config string                             Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                         Configuration directory that contains a file for each option
+      --crd-wait-timeout duration                 Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
+  -D, --debug                                     Enable debugging mode
+      --enable-ipv4                               Enable IPv4 support (default true)
+      --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-metrics                            Enable Prometheus metrics
+      --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
+  -h, --help                                      help for cilium-operator
+      --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration             GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ipam string                               Backend to use for IPAM (default "hostscope-legacy")
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --kvstore string                            Key-value store type
+      --kvstore-opt map                           Key-value store options (default map[])
+      --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                        Logging endpoints to use for example syslog
+      --log-opt map                               Log driver options for cilium-operator (default map[])
+      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
+      --subnet-ids-filter strings                 Subnets IDs (separated by commas)
+      --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
+      --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --update-ec2-apdater-limit-via-api          Use the EC2 API to update the instance type to adapter limits
+      --version                                   Print version information
 ```
 

--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -57,3 +57,22 @@ rules:
   - get
   - list
   - watch
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between mulitple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.
+# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure
+# that we only authorize access to leases resources in supported K8s versions.
+{{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+{{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -35,6 +35,20 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+{{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -7,7 +7,14 @@ metadata:
   name: cilium-operator
   namespace: {{ .Release.Namespace }}
 spec:
+  # We support HA mode only for Kubernetes version > 1.14
+  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
+  # for more details.
+{{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
+  replicas: {{ .Values.numReplicas }}
+{{- else }}
   replicas: 1
+{{- end }}
   selector:
     matchLabels:
       io.cilium/app: operator

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -6,3 +6,8 @@ serviceAccount:
 
 # Specifies the resources for the operator container
 resources: {}
+
+
+# Number of replicas to run for cilium operator deployment.
+numReplicas: 2
+

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -18,6 +18,9 @@ config:
 operator:
   enabled: true
 
+  # Number of replicas to run for cilium-operator deployment.
+  numReplicas: 2
+
 # Include the PreFlight DaemonSet
 preflight:
   enabled: false

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -830,6 +830,18 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -339,6 +339,23 @@ rules:
   - get
   - list
   - watch
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between mulitple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.
+# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure
+# that we only authorize access to leases resources in supported K8s versions.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 # Source: cilium/charts/agent/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -793,7 +810,10 @@ metadata:
   name: cilium-operator
   namespace: kube-system
 spec:
-  replicas: 1
+  # We support HA mode only for Kubernetes version > 1.14
+  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
+  # for more details.
+  replicas: 2
   selector:
     matchLabels:
       io.cilium/app: operator

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -261,6 +261,23 @@ rules:
   - get
   - list
   - watch
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between mulitple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.
+# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure
+# that we only authorize access to leases resources in supported K8s versions.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 # Source: cilium/charts/agent/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -539,7 +556,10 @@ metadata:
   name: cilium-operator
   namespace: kube-system
 spec:
-  replicas: 1
+  # We support HA mode only for Kubernetes version > 1.14
+  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
+  # for more details.
+  replicas: 2
   selector:
     matchLabels:
       io.cilium/app: operator

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -576,6 +576,18 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -304,5 +304,17 @@ func init() {
 	flags.Duration(operatorOption.CRDWaitTimeout, 5*time.Minute, "Operator will exit if CRDs are not available within this duration upon startup")
 	option.BindEnv(operatorOption.CRDWaitTimeout)
 
+	flags.Duration(operatorOption.LeaderElectionLeaseDuration, 15*time.Second,
+		"Duration that non-leader operator candidates will wait before forcing to acquire leadership")
+	option.BindEnv(operatorOption.LeaderElectionLeaseDuration)
+
+	flags.Duration(operatorOption.LeaderElectionRenewDeadline, 10*time.Second,
+		"Duration that current acting master will retry refreshing leadership in before giving up the lock")
+	option.BindEnv(operatorOption.LeaderElectionRenewDeadline)
+
+	flags.Duration(operatorOption.LeaderElectionRetryPeriod, 2*time.Second,
+		"Duration that LeaderElector clients should wait between retries of the actions")
+	option.BindEnv(operatorOption.LeaderElectionRetryPeriod)
+
 	viper.BindPFlags(flags)
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -110,7 +110,7 @@ const (
 	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
 	IPAMSubnetsIDs = "subnet-ids-filter"
 
-	// IAPMSubnetsTags are optional tags used to filter subnets, and interfaces within those subnets
+	// IPAMSubnetsTags are optional tags used to filter subnets, and interfaces within those subnets
 	IPAMSubnetsTags = "subnet-tags-filter"
 
 	// IPAMOperatorV4CIDR is the cluster IPv4 podCIDR that should be used to
@@ -166,6 +166,18 @@ const (
 
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout = "crd-wait-timeout"
+
+	// LeaderElectionLeaseDuration is the duration that non-leader candidates will wait to
+	// force acquire leadership
+	LeaderElectionLeaseDuration = "leader-election-lease-duration"
+
+	// LeaderElectionRenewDeadline is the duration that the current acting master in HA deployment
+	// will retry refreshing leadership before giving up the lock.
+	LeaderElectionRenewDeadline = "leader-election-renew-deadline"
+
+	// LeaderElectionRetryPeriod is the duration the LeaderElector clients should wait between
+	// tries of the actions in operator HA deployment.
+	LeaderElectionRetryPeriod = "leader-election-retry-period"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -295,8 +307,21 @@ type OperatorConfig struct {
 
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout time.Duration
+
+	// LeaderElectionLeaseDuration is the duration that non-leader candidates will wait to
+	// force acquire leadership in Cilium Operator HA deployment.
+	LeaderElectionLeaseDuration time.Duration
+
+	// LeaderElectionRenewDeadline is the duration that the current acting master in HA deployment
+	// will retry refreshing leadership in before giving up the lock.
+	LeaderElectionRenewDeadline time.Duration
+
+	// LeaderElectionRetryPeriod is the duration that LeaderElector clients should wait between
+	// retries of the actions in operator HA deployment.
+	LeaderElectionRetryPeriod time.Duration
 }
 
+// Populate sets all options with the values from viper.
 func (c *OperatorConfig) Populate() {
 	c.CNPNodeStatusGCInterval = viper.GetDuration(CNPNodeStatusGCInterval)
 	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
@@ -321,6 +346,9 @@ func (c *OperatorConfig) Populate() {
 	c.IPAMOperatorV6CIDR = viper.GetStringSlice(IPAMOperatorV6CIDR)
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
 	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
+	c.LeaderElectionLeaseDuration = viper.GetDuration(LeaderElectionLeaseDuration)
+	c.LeaderElectionRenewDeadline = viper.GetDuration(LeaderElectionRenewDeadline)
+	c.LeaderElectionRetryPeriod = viper.GetDuration(LeaderElectionRetryPeriod)
 
 	// AWS options
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -385,4 +385,9 @@ const (
 	// EnableIdentityMark enables setting identity in mark field of packet
 	// for local traffic
 	EnableIdentityMark = true
+
+	// K8sEnableLeasesFallbackDiscovery enables k8s to fallback to API probing to check
+	// for the support of Leases in Kubernetes when there is an error in discovering
+	// API groups using Discovery API.
+	K8sEnableLeasesFallbackDiscovery = false
 )

--- a/pkg/k8s/config/config.go
+++ b/pkg/k8s/config/config.go
@@ -21,6 +21,8 @@ import (
 // Configuration is the configuration interface for the k8s package
 type Configuration interface {
 	K8sAPIDiscoveryEnabled() bool
+
+	K8sLeasesFallbackDiscoveryEnabled() bool
 }
 
 // DefaultConfiguration is an implementation of Configuration with default
@@ -37,4 +39,11 @@ func NewDefaultConfiguration() Configuration {
 // resources is enabled
 func (d *DefaultConfiguration) K8sAPIDiscoveryEnabled() bool {
 	return defaults.K8sEnableAPIDiscovery
+}
+
+// K8sLeasesFallbackDiscoveryEnabled returns true if we should fallback to direct API
+// probing when checking for support of Leases in case Discovery API fails to discover
+// required groups.
+func (d *DefaultConfiguration) K8sLeasesFallbackDiscoveryEnabled() bool {
+	return defaults.K8sEnableLeasesFallbackDiscovery
 }

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -19,7 +19,6 @@ package version
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	"github.com/cilium/cilium/pkg/lock"
@@ -57,6 +56,14 @@ type ServerCapabilities struct {
 	// FieldTypeInCRDSchema is set to true if Kubernetes supports having
 	// the field Type set in the CRD Schema.
 	FieldTypeInCRDSchema bool
+
+	// LeasesResourceLock is the ability of K8s server to support Lease type
+	// from coordination.k8s.io/v1 API for leader election purposes(currently only in operator).
+	// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lease-v1-coordination-k8s-io
+	//
+	// This capability was introduced in K8s version 1.14, prior to which
+	// we don't support HA mode for the cilium-operator.
+	LeasesResourceLock bool
 }
 
 type cachedVersion struct {
@@ -74,12 +81,18 @@ const (
 var (
 	cached = cachedVersion{}
 
-	discoveryAPIGroup = "discovery.k8s.io/v1beta1"
-	endpointSliceKind = "EndpointSlice"
+	discoveryAPIGroup      = "discovery.k8s.io/v1beta1"
+	coordinationV1APIGroup = "coordination.k8s.io/v1"
+	endpointSliceKind      = "EndpointSlice"
+	leaseKind              = "Lease"
 
 	isGEThanPatchConstraint        = versioncheck.MustCompile(">=1.13.0")
 	isGEThanUpdateStatusConstraint = versioncheck.MustCompile(">=1.11.0")
 	isGThanRootTypeConstraint      = versioncheck.MustCompile(">=1.12.0")
+
+	// Constraint to check support for Lease type from coordination.k8s.io/v1.
+	// Support for Lease resource was introduced in K8s version 1.14.
+	isGEThanLeaseSupportConstraint = versioncheck.MustCompile(">=1.14.0")
 
 	// isGEThanMinimalVersionConstraint is the minimal version required to run
 	// Cilium
@@ -114,16 +127,27 @@ func updateVersion(version go_version.Version) {
 	cached.capabilities.FieldTypeInCRDSchema = isGThanRootTypeConstraint(version)
 }
 
-func updateServerGroupsAndResources(apiGroups []*metav1.APIGroup, apiResourceLists []*metav1.APIResourceList) {
+func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) {
 	cached.mutex.Lock()
 	defer cached.mutex.Unlock()
 
 	cached.capabilities.EndpointSlice = false
+	cached.capabilities.LeasesResourceLock = false
 	for _, rscList := range apiResourceLists {
 		if rscList.GroupVersion == discoveryAPIGroup {
 			for _, rsc := range rscList.APIResources {
 				if rsc.Kind == endpointSliceKind {
 					cached.capabilities.EndpointSlice = true
+					break
+				}
+			}
+		}
+
+		if rscList.GroupVersion == coordinationV1APIGroup {
+			for _, rsc := range rscList.APIResources {
+				if rsc.Kind == leaseKind {
+					cached.capabilities.LeasesResourceLock = true
+					break
 				}
 			}
 		}
@@ -140,7 +164,15 @@ func Force(version string) error {
 	return nil
 }
 
-func fallbackDiscovery(client kubernetes.Interface) error {
+func endpointSlicesFallbackDiscovery(client kubernetes.Interface) error {
+	// Discovery of API groups requires the API services of the apiserver to be
+	// healthy. Such API services can depend on the readiness of regular pods
+	// which require Cilium to function correctly. By treating failure to
+	// discover API groups as fatal, a critial loop can be entered in which
+	// Cilium cannot start because the API groups can't be discovered.
+	//
+	// Here we acknowledge the lack of discovery ability as non Fatal and fall back to probing
+	// the API directly.
 	_, err := client.DiscoveryV1beta1().EndpointSlices("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 	if err == nil {
 		cached.mutex.Lock()
@@ -149,59 +181,63 @@ func fallbackDiscovery(client kubernetes.Interface) error {
 		return nil
 	}
 
-	switch t := err.(type) {
-	case *errors.StatusError:
-		if t.ErrStatus.Code == http.StatusNotFound {
-			log.WithError(err).Info("Unable to retrieve EndpointSlices for default/kubernetes. Disabling EndpointSlices")
-			// StatusNotFound is a safe error, EndpointSlices are
-			// disabled and the agent can continue
-			return nil
-		}
+	if errors.IsNotFound(err) {
+		log.WithError(err).Info("Unable to retrieve EndpointSlices for default/kubernetes. Disabling EndpointSlices")
+		// StatusNotFound is a safe error, EndpointSlices are
+		// disabled and the agent can continue.
+		return nil
 	}
 
 	// Unknown error, we can't derive whether to enable or disable
-	// EndpointSlices and need to error out
+	// EndpointSlices and need to error out.
 	return fmt.Errorf("unable to validate EndpointSlices support: %s", err)
 }
 
-// Update retrieves the version of the Kubernetes apiserver and derives the
-// capabilities. This function must be called after connectivity to the
-// apiserver has been established.
-//
-// Discovery of capabilities only works if the discovery API of the apiserver
-// is functional. If it is not available, a warning is logged and the discovery
-// falls back to probing individual API endpoints.
-func Update(client kubernetes.Interface, conf k8sconfig.Configuration) error {
+func leasesFallbackDiscovery(client kubernetes.Interface, conf k8sconfig.Configuration) error {
+	// K8sEnableLeasesFallbackDiscovery is used to fallback leases discovery to directly
+	// probing the API when we cannot discover API groups.
+	// We require to check for Leases capabilities in operator only, which uses Leases
+	// for leader election purposes in HA mode.
+	if !conf.K8sLeasesFallbackDiscoveryEnabled() {
+		log.Debugf("Skipping Leases support fallback discovery")
+		return nil
+	}
+
+	cached.mutex.RLock()
+	// Here we check if we are running a K8s version that has support for Leases.
+	if !isGEThanLeaseSupportConstraint(cached.version) {
+		cached.mutex.RUnlock()
+		return nil
+	}
+	cached.mutex.RUnlock()
+
+	// Similar to endpointSlicesFallbackDiscovery here we fallback to probing the Kubernetes
+	// API directly. `kube-controller-manager` creates a lease in the kube-system namespace
+	// and here we try and see if that Lease exists.
+	_, err := client.CoordinationV1().Leases("kube-system").Get(context.TODO(), "kube-controller-manager", metav1.GetOptions{})
+	if err == nil {
+		cached.mutex.Lock()
+		cached.capabilities.LeasesResourceLock = true
+		cached.mutex.Unlock()
+		return nil
+	}
+
+	if errors.IsNotFound(err) {
+		log.WithError(err).Info("Unable to retrieve Leases for kube-controller-manager. Disabling LeasesResourceLock")
+		// StatusNotFound is a safe error, Leases are
+		// disabled and the agent can continue
+		return nil
+	}
+
+	// Unknown error, we can't derive whether to enable or disable
+	// LeasesResourceLock and need to error out
+	return fmt.Errorf("unable to validate LeasesResourceLock support: %s", err)
+}
+
+func updateK8sServerVersion(client kubernetes.Interface) error {
 	sv, err := client.Discovery().ServerVersion()
 	if err != nil {
 		return err
-	}
-
-	if conf.K8sAPIDiscoveryEnabled() {
-		// Discovery of API groups requires the API services of the
-		// apiserver to be healthy. Such API services can depend on the
-		// readiness of regular pods which require Cilium to function
-		// correctly. By treating failure to discover API groups as
-		// fatal, a critical loop can be entered in which Cilium cannot
-		// start because the API groups can't be discovered and th API
-		// groups will only become discoverable once Cilium is up.
-		apiGroups, apiResourceLists, err := client.Discovery().ServerGroupsAndResources()
-		if err != nil {
-			// It doesn't make sense to retry the retrieval of this
-			// information at a later point because the capabilities are
-			// primiarly used while the agent is starting up. Instead, fall
-			// back to probing API endpoints directly.
-			log.WithError(err).Warning("Unable to discover API groups and resources")
-			if err := fallbackDiscovery(client); err != nil {
-				return err
-			}
-		} else {
-			updateServerGroupsAndResources(apiGroups, apiResourceLists)
-		}
-	} else {
-		if err := fallbackDiscovery(client); err != nil {
-			return err
-		}
 	}
 
 	// Try GitVersion first. In case of error fallback to MajorMinor
@@ -225,5 +261,53 @@ func Update(client kubernetes.Interface, conf k8sconfig.Configuration) error {
 	if err != nil {
 		return fmt.Errorf("cannot parse k8s server version from %+v: %s", sv, err)
 	}
+
 	return fmt.Errorf("cannot parse k8s server version from %+v", sv)
+}
+
+// Update retrieves the version of the Kubernetes apiserver and derives the
+// capabilities. This function must be called after connectivity to the
+// apiserver has been established.
+//
+// Discovery of capabilities only works if the discovery API of the apiserver
+// is functional. If it is not available, a warning is logged and the discovery
+// falls back to probing individual API endpoints.
+func Update(client kubernetes.Interface, conf k8sconfig.Configuration) error {
+	err := updateK8sServerVersion(client)
+	if err != nil {
+		return err
+	}
+
+	if conf.K8sAPIDiscoveryEnabled() {
+		// Discovery of API groups requires the API services of the
+		// apiserver to be healthy. Such API services can depend on the
+		// readiness of regular pods which require Cilium to function
+		// correctly. By treating failure to discover API groups as
+		// fatal, a critical loop can be entered in which Cilium cannot
+		// start because the API groups can't be discovered and th API
+		// groups will only become discoverable once Cilium is up.
+		_, apiResourceLists, err := client.Discovery().ServerGroupsAndResources()
+		if err != nil {
+			// It doesn't make sense to retry the retrieval of this
+			// information at a later point because the capabilities are
+			// primiarly used while the agent is starting up. Instead, fall
+			// back to probing API endpoints directly.
+			log.WithError(err).Warning("Unable to discover API groups and resources")
+			if err := endpointSlicesFallbackDiscovery(client); err != nil {
+				return err
+			}
+
+			return leasesFallbackDiscovery(client, conf)
+		}
+
+		updateServerGroupsAndResources(apiResourceLists)
+	} else {
+		if err := endpointSlicesFallbackDiscovery(client); err != nil {
+			return err
+		}
+
+		return leasesFallbackDiscovery(client, conf)
+	}
+
+	return nil
 }

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -6,7 +6,9 @@
 # once a new label is added to a pod. If we delay the identity change
 # process the test will fail.
 
-helm template install/kubernetes/cilium \
+# We generate the helm chart template validating it against the associated Kubernetes
+# Cluster.
+helm template --validate install/kubernetes/cilium \
   --namespace=kube-system \
   --set global.registry=k8s1:5000/cilium \
   --set global.tag=latest \

--- a/vendor/k8s.io/client-go/tools/leaderelection/OWNERS
+++ b/vendor/k8s.io/client-go/tools/leaderelection/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- mikedanese
+- timothysc
+reviewers:
+- wojtek-t
+- deads2k
+- mikedanese
+- gmarek
+- eparis
+- timothysc
+- ingvagabund
+- resouer

--- a/vendor/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HealthzAdaptor associates the /healthz endpoint with the LeaderElection object.
+// It helps deal with the /healthz endpoint being set up prior to the LeaderElection.
+// This contains the code needed to act as an adaptor between the leader
+// election code the health check code. It allows us to provide health
+// status about the leader election. Most specifically about if the leader
+// has failed to renew without exiting the process. In that case we should
+// report not healthy and rely on the kubelet to take down the process.
+type HealthzAdaptor struct {
+	pointerLock sync.Mutex
+	le          *LeaderElector
+	timeout     time.Duration
+}
+
+// Name returns the name of the health check we are implementing.
+func (l *HealthzAdaptor) Name() string {
+	return "leaderElection"
+}
+
+// Check is called by the healthz endpoint handler.
+// It fails (returns an error) if we own the lease but had not been able to renew it.
+func (l *HealthzAdaptor) Check(req *http.Request) error {
+	l.pointerLock.Lock()
+	defer l.pointerLock.Unlock()
+	if l.le == nil {
+		return nil
+	}
+	return l.le.Check(l.timeout)
+}
+
+// SetLeaderElection ties a leader election object to a HealthzAdaptor
+func (l *HealthzAdaptor) SetLeaderElection(le *LeaderElector) {
+	l.pointerLock.Lock()
+	defer l.pointerLock.Unlock()
+	l.le = le
+}
+
+// NewLeaderHealthzAdaptor creates a basic healthz adaptor to monitor a leader election.
+// timeout determines the time beyond the lease expiry to be allowed for timeout.
+// checks within the timeout period after the lease expires will still return healthy.
+func NewLeaderHealthzAdaptor(timeout time.Duration) *HealthzAdaptor {
+	result := &HealthzAdaptor{
+		timeout: timeout,
+	}
+	return result
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package leaderelection implements leader election of a set of endpoints.
+// It uses an annotation in the endpoints object to store the record of the
+// election state. This implementation does not guarantee that only one
+// client is acting as a leader (a.k.a. fencing).
+//
+// A client only acts on timestamps captured locally to infer the state of the
+// leader election. The client does not consider timestamps in the leader
+// election record to be accurate because these timestamps may not have been
+// produced by a local clock. The implemention does not depend on their
+// accuracy and only uses their change to indicate that another client has
+// renewed the leader lease. Thus the implementation is tolerant to arbitrary
+// clock skew, but is not tolerant to arbitrary clock skew rate.
+//
+// However the level of tolerance to skew rate can be configured by setting
+// RenewDeadline and LeaseDuration appropriately. The tolerance expressed as a
+// maximum tolerated ratio of time passed on the fastest node to time passed on
+// the slowest node can be approximately achieved with a configuration that sets
+// the same ratio of LeaseDuration to RenewDeadline. For example if a user wanted
+// to tolerate some nodes progressing forward in time twice as fast as other nodes,
+// the user could set LeaseDuration to 60 seconds and RenewDeadline to 30 seconds.
+//
+// While not required, some method of clock synchronization between nodes in the
+// cluster is highly recommended. It's important to keep in mind when configuring
+// this client that the tolerance to skew rate varies inversely to master
+// availability.
+//
+// Larger clusters often have a more lenient SLA for API latency. This should be
+// taken into account when configuring the client. The rate of leader transitions
+// should be monitored and RetryPeriod and LeaseDuration should be increased
+// until the rate is stable and acceptably low. It's important to keep in mind
+// when configuring this client that the tolerance to API latency varies inversely
+// to master availability.
+//
+// DISCLAIMER: this is an alpha API. This library will likely change significantly
+// or even be removed entirely in subsequent releases. Depend on this API at
+// your own risk.
+package leaderelection
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"k8s.io/klog"
+)
+
+const (
+	JitterFactor = 1.2
+)
+
+// NewLeaderElector creates a LeaderElector from a LeaderElectionConfig
+func NewLeaderElector(lec LeaderElectionConfig) (*LeaderElector, error) {
+	if lec.LeaseDuration <= lec.RenewDeadline {
+		return nil, fmt.Errorf("leaseDuration must be greater than renewDeadline")
+	}
+	if lec.RenewDeadline <= time.Duration(JitterFactor*float64(lec.RetryPeriod)) {
+		return nil, fmt.Errorf("renewDeadline must be greater than retryPeriod*JitterFactor")
+	}
+	if lec.LeaseDuration < 1 {
+		return nil, fmt.Errorf("leaseDuration must be greater than zero")
+	}
+	if lec.RenewDeadline < 1 {
+		return nil, fmt.Errorf("renewDeadline must be greater than zero")
+	}
+	if lec.RetryPeriod < 1 {
+		return nil, fmt.Errorf("retryPeriod must be greater than zero")
+	}
+	if lec.Callbacks.OnStartedLeading == nil {
+		return nil, fmt.Errorf("OnStartedLeading callback must not be nil")
+	}
+	if lec.Callbacks.OnStoppedLeading == nil {
+		return nil, fmt.Errorf("OnStoppedLeading callback must not be nil")
+	}
+
+	if lec.Lock == nil {
+		return nil, fmt.Errorf("Lock must not be nil.")
+	}
+	le := LeaderElector{
+		config:  lec,
+		clock:   clock.RealClock{},
+		metrics: globalMetricsFactory.newLeaderMetrics(),
+	}
+	le.metrics.leaderOff(le.config.Name)
+	return &le, nil
+}
+
+type LeaderElectionConfig struct {
+	// Lock is the resource that will be used for locking
+	Lock rl.Interface
+
+	// LeaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership. This is measured against time of
+	// last observed ack.
+	//
+	// A client needs to wait a full LeaseDuration without observing a change to
+	// the record before it can attempt to take over. When all clients are
+	// shutdown and a new set of clients are started with different names against
+	// the same leader record, they must wait the full LeaseDuration before
+	// attempting to acquire the lease. Thus LeaseDuration should be as short as
+	// possible (within your tolerance for clock skew rate) to avoid a possible
+	// long waits in the scenario.
+	//
+	// Core clients default this value to 15 seconds.
+	LeaseDuration time.Duration
+	// RenewDeadline is the duration that the acting master will retry
+	// refreshing leadership before giving up.
+	//
+	// Core clients default this value to 10 seconds.
+	RenewDeadline time.Duration
+	// RetryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions.
+	//
+	// Core clients default this value to 2 seconds.
+	RetryPeriod time.Duration
+
+	// Callbacks are callbacks that are triggered during certain lifecycle
+	// events of the LeaderElector
+	Callbacks LeaderCallbacks
+
+	// WatchDog is the associated health checker
+	// WatchDog may be null if its not needed/configured.
+	WatchDog *HealthzAdaptor
+
+	// ReleaseOnCancel should be set true if the lock should be released
+	// when the run context is cancelled. If you set this to true, you must
+	// ensure all code guarded by this lease has successfully completed
+	// prior to cancelling the context, or you may have two processes
+	// simultaneously acting on the critical path.
+	ReleaseOnCancel bool
+
+	// Name is the name of the resource lock for debugging
+	Name string
+}
+
+// LeaderCallbacks are callbacks that are triggered during certain
+// lifecycle events of the LeaderElector. These are invoked asynchronously.
+//
+// possible future callbacks:
+//  * OnChallenge()
+type LeaderCallbacks struct {
+	// OnStartedLeading is called when a LeaderElector client starts leading
+	OnStartedLeading func(context.Context)
+	// OnStoppedLeading is called when a LeaderElector client stops leading
+	OnStoppedLeading func()
+	// OnNewLeader is called when the client observes a leader that is
+	// not the previously observed leader. This includes the first observed
+	// leader when the client starts.
+	OnNewLeader func(identity string)
+}
+
+// LeaderElector is a leader election client.
+type LeaderElector struct {
+	config LeaderElectionConfig
+	// internal bookkeeping
+	observedRecord    rl.LeaderElectionRecord
+	observedRawRecord []byte
+	observedTime      time.Time
+	// used to implement OnNewLeader(), may lag slightly from the
+	// value observedRecord.HolderIdentity if the transition has
+	// not yet been reported.
+	reportedLeader string
+
+	// clock is wrapper around time to allow for less flaky testing
+	clock clock.Clock
+
+	metrics leaderMetricsAdapter
+
+	// name is the name of the resource lock for debugging
+	name string
+}
+
+// Run starts the leader election loop
+func (le *LeaderElector) Run(ctx context.Context) {
+	defer func() {
+		runtime.HandleCrash()
+		le.config.Callbacks.OnStoppedLeading()
+	}()
+	if !le.acquire(ctx) {
+		return // ctx signalled done
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go le.config.Callbacks.OnStartedLeading(ctx)
+	le.renew(ctx)
+}
+
+// RunOrDie starts a client with the provided config or panics if the config
+// fails to validate.
+func RunOrDie(ctx context.Context, lec LeaderElectionConfig) {
+	le, err := NewLeaderElector(lec)
+	if err != nil {
+		panic(err)
+	}
+	if lec.WatchDog != nil {
+		lec.WatchDog.SetLeaderElection(le)
+	}
+	le.Run(ctx)
+}
+
+// GetLeader returns the identity of the last observed leader or returns the empty string if
+// no leader has yet been observed.
+func (le *LeaderElector) GetLeader() string {
+	return le.observedRecord.HolderIdentity
+}
+
+// IsLeader returns true if the last observed leader was this client else returns false.
+func (le *LeaderElector) IsLeader() bool {
+	return le.observedRecord.HolderIdentity == le.config.Lock.Identity()
+}
+
+// acquire loops calling tryAcquireOrRenew and returns true immediately when tryAcquireOrRenew succeeds.
+// Returns false if ctx signals done.
+func (le *LeaderElector) acquire(ctx context.Context) bool {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	succeeded := false
+	desc := le.config.Lock.Describe()
+	klog.Infof("attempting to acquire leader lease  %v...", desc)
+	wait.JitterUntil(func() {
+		succeeded = le.tryAcquireOrRenew(ctx)
+		le.maybeReportTransition()
+		if !succeeded {
+			klog.V(4).Infof("failed to acquire lease %v", desc)
+			return
+		}
+		le.config.Lock.RecordEvent("became leader")
+		le.metrics.leaderOn(le.config.Name)
+		klog.Infof("successfully acquired lease %v", desc)
+		cancel()
+	}, le.config.RetryPeriod, JitterFactor, true, ctx.Done())
+	return succeeded
+}
+
+// renew loops calling tryAcquireOrRenew and returns immediately when tryAcquireOrRenew fails or ctx signals done.
+func (le *LeaderElector) renew(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	wait.Until(func() {
+		timeoutCtx, timeoutCancel := context.WithTimeout(ctx, le.config.RenewDeadline)
+		defer timeoutCancel()
+		err := wait.PollImmediateUntil(le.config.RetryPeriod, func() (bool, error) {
+			return le.tryAcquireOrRenew(timeoutCtx), nil
+		}, timeoutCtx.Done())
+
+		le.maybeReportTransition()
+		desc := le.config.Lock.Describe()
+		if err == nil {
+			klog.V(5).Infof("successfully renewed lease %v", desc)
+			return
+		}
+		le.config.Lock.RecordEvent("stopped leading")
+		le.metrics.leaderOff(le.config.Name)
+		klog.Infof("failed to renew lease %v: %v", desc, err)
+		cancel()
+	}, le.config.RetryPeriod, ctx.Done())
+
+	// if we hold the lease, give it up
+	if le.config.ReleaseOnCancel {
+		le.release()
+	}
+}
+
+// release attempts to release the leader lease if we have acquired it.
+func (le *LeaderElector) release() bool {
+	if !le.IsLeader() {
+		return true
+	}
+	leaderElectionRecord := rl.LeaderElectionRecord{
+		LeaderTransitions: le.observedRecord.LeaderTransitions,
+	}
+	if err := le.config.Lock.Update(context.TODO(), leaderElectionRecord); err != nil {
+		klog.Errorf("Failed to release lock: %v", err)
+		return false
+	}
+	le.observedRecord = leaderElectionRecord
+	le.observedTime = le.clock.Now()
+	return true
+}
+
+// tryAcquireOrRenew tries to acquire a leader lease if it is not already acquired,
+// else it tries to renew the lease if it has already been acquired. Returns true
+// on success else returns false.
+func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
+	now := metav1.Now()
+	leaderElectionRecord := rl.LeaderElectionRecord{
+		HolderIdentity:       le.config.Lock.Identity(),
+		LeaseDurationSeconds: int(le.config.LeaseDuration / time.Second),
+		RenewTime:            now,
+		AcquireTime:          now,
+	}
+
+	// 1. obtain or create the ElectionRecord
+	oldLeaderElectionRecord, oldLeaderElectionRawRecord, err := le.config.Lock.Get(ctx)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			klog.Errorf("error retrieving resource lock %v: %v", le.config.Lock.Describe(), err)
+			return false
+		}
+		if err = le.config.Lock.Create(ctx, leaderElectionRecord); err != nil {
+			klog.Errorf("error initially creating leader election record: %v", err)
+			return false
+		}
+		le.observedRecord = leaderElectionRecord
+		le.observedTime = le.clock.Now()
+		return true
+	}
+
+	// 2. Record obtained, check the Identity & Time
+	if !bytes.Equal(le.observedRawRecord, oldLeaderElectionRawRecord) {
+		le.observedRecord = *oldLeaderElectionRecord
+		le.observedRawRecord = oldLeaderElectionRawRecord
+		le.observedTime = le.clock.Now()
+	}
+	if len(oldLeaderElectionRecord.HolderIdentity) > 0 &&
+		le.observedTime.Add(le.config.LeaseDuration).After(now.Time) &&
+		!le.IsLeader() {
+		klog.V(4).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
+		return false
+	}
+
+	// 3. We're going to try to update. The leaderElectionRecord is set to it's default
+	// here. Let's correct it before updating.
+	if le.IsLeader() {
+		leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions
+	} else {
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions + 1
+	}
+
+	// update the lock itself
+	if err = le.config.Lock.Update(ctx, leaderElectionRecord); err != nil {
+		klog.Errorf("Failed to update lock: %v", err)
+		return false
+	}
+
+	le.observedRecord = leaderElectionRecord
+	le.observedTime = le.clock.Now()
+	return true
+}
+
+func (le *LeaderElector) maybeReportTransition() {
+	if le.observedRecord.HolderIdentity == le.reportedLeader {
+		return
+	}
+	le.reportedLeader = le.observedRecord.HolderIdentity
+	if le.config.Callbacks.OnNewLeader != nil {
+		go le.config.Callbacks.OnNewLeader(le.reportedLeader)
+	}
+}
+
+// Check will determine if the current lease is expired by more than timeout.
+func (le *LeaderElector) Check(maxTolerableExpiredLease time.Duration) error {
+	if !le.IsLeader() {
+		// Currently not concerned with the case that we are hot standby
+		return nil
+	}
+	// If we are more than timeout seconds after the lease duration that is past the timeout
+	// on the lease renew. Time to start reporting ourselves as unhealthy. We should have
+	// died but conditions like deadlock can prevent this. (See #70819)
+	if le.clock.Since(le.observedTime) > le.config.LeaseDuration+maxTolerableExpiredLease {
+		return fmt.Errorf("failed election to renew leadership on lease %s", le.config.Name)
+	}
+
+	return nil
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/metrics.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/metrics.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"sync"
+)
+
+// This file provides abstractions for setting the provider (e.g., prometheus)
+// of metrics.
+
+type leaderMetricsAdapter interface {
+	leaderOn(name string)
+	leaderOff(name string)
+}
+
+// GaugeMetric represents a single numerical value that can arbitrarily go up
+// and down.
+type SwitchMetric interface {
+	On(name string)
+	Off(name string)
+}
+
+type noopMetric struct{}
+
+func (noopMetric) On(name string)  {}
+func (noopMetric) Off(name string) {}
+
+// defaultLeaderMetrics expects the caller to lock before setting any metrics.
+type defaultLeaderMetrics struct {
+	// leader's value indicates if the current process is the owner of name lease
+	leader SwitchMetric
+}
+
+func (m *defaultLeaderMetrics) leaderOn(name string) {
+	if m == nil {
+		return
+	}
+	m.leader.On(name)
+}
+
+func (m *defaultLeaderMetrics) leaderOff(name string) {
+	if m == nil {
+		return
+	}
+	m.leader.Off(name)
+}
+
+type noMetrics struct{}
+
+func (noMetrics) leaderOn(name string)  {}
+func (noMetrics) leaderOff(name string) {}
+
+// MetricsProvider generates various metrics used by the leader election.
+type MetricsProvider interface {
+	NewLeaderMetric() SwitchMetric
+}
+
+type noopMetricsProvider struct{}
+
+func (_ noopMetricsProvider) NewLeaderMetric() SwitchMetric {
+	return noopMetric{}
+}
+
+var globalMetricsFactory = leaderMetricsFactory{
+	metricsProvider: noopMetricsProvider{},
+}
+
+type leaderMetricsFactory struct {
+	metricsProvider MetricsProvider
+
+	onlyOnce sync.Once
+}
+
+func (f *leaderMetricsFactory) setProvider(mp MetricsProvider) {
+	f.onlyOnce.Do(func() {
+		f.metricsProvider = mp
+	})
+}
+
+func (f *leaderMetricsFactory) newLeaderMetrics() leaderMetricsAdapter {
+	mp := f.metricsProvider
+	if mp == (noopMetricsProvider{}) {
+		return noMetrics{}
+	}
+	return &defaultLeaderMetrics{
+		leader: mp.NewLeaderMetric(),
+	}
+}
+
+// SetProvider sets the metrics provider for all subsequently created work
+// queues. Only the first call has an effect.
+func SetProvider(metricsProvider MetricsProvider) {
+	globalMetricsFactory.setProvider(metricsProvider)
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// TODO: This is almost a exact replica of Endpoints lock.
+// going forwards as we self host more and more components
+// and use ConfigMaps as the means to pass that configuration
+// data we will likely move to deprecate the Endpoints lock.
+
+type ConfigMapLock struct {
+	// ConfigMapMeta should contain a Name and a Namespace of a
+	// ConfigMapMeta object that the LeaderElector will attempt to lead.
+	ConfigMapMeta metav1.ObjectMeta
+	Client        corev1client.ConfigMapsGetter
+	LockConfig    ResourceLockConfig
+	cm            *v1.ConfigMap
+}
+
+// Get returns the election record from a ConfigMap Annotation
+func (cml *ConfigMapLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	var record LeaderElectionRecord
+	var err error
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(ctx, cml.ConfigMapMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	recordBytes, found := cml.cm.Annotations[LeaderElectionRecordAnnotationKey]
+	if found {
+		if err := json.Unmarshal([]byte(recordBytes), &record); err != nil {
+			return nil, nil, err
+		}
+	}
+	return &record, []byte(recordBytes), nil
+}
+
+// Create attempts to create a LeaderElectionRecord annotation
+func (cml *ConfigMapLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Create(ctx, &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cml.ConfigMapMeta.Name,
+			Namespace: cml.ConfigMapMeta.Namespace,
+			Annotations: map[string]string{
+				LeaderElectionRecordAnnotationKey: string(recordBytes),
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// Update will update an existing annotation on a given resource.
+func (cml *ConfigMapLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	if cml.cm == nil {
+		return errors.New("configmap not initialized, call get or create first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	cml.cm.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(ctx, cml.cm, metav1.UpdateOptions{})
+	return err
+}
+
+// RecordEvent in leader election while adding meta-data
+func (cml *ConfigMapLock) RecordEvent(s string) {
+	if cml.LockConfig.EventRecorder == nil {
+		return
+	}
+	events := fmt.Sprintf("%v %v", cml.LockConfig.Identity, s)
+	cml.LockConfig.EventRecorder.Eventf(&v1.ConfigMap{ObjectMeta: cml.cm.ObjectMeta}, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (cml *ConfigMapLock) Describe() string {
+	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (cml *ConfigMapLock) Identity() string {
+	return cml.LockConfig.Identity
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type EndpointsLock struct {
+	// EndpointsMeta should contain a Name and a Namespace of an
+	// Endpoints object that the LeaderElector will attempt to lead.
+	EndpointsMeta metav1.ObjectMeta
+	Client        corev1client.EndpointsGetter
+	LockConfig    ResourceLockConfig
+	e             *v1.Endpoints
+}
+
+// Get returns the election record from a Endpoints Annotation
+func (el *EndpointsLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	var record LeaderElectionRecord
+	var err error
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Get(ctx, el.EndpointsMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	if el.e.Annotations == nil {
+		el.e.Annotations = make(map[string]string)
+	}
+	recordBytes, found := el.e.Annotations[LeaderElectionRecordAnnotationKey]
+	if found {
+		if err := json.Unmarshal([]byte(recordBytes), &record); err != nil {
+			return nil, nil, err
+		}
+	}
+	return &record, []byte(recordBytes), nil
+}
+
+// Create attempts to create a LeaderElectionRecord annotation
+func (el *EndpointsLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Create(ctx, &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      el.EndpointsMeta.Name,
+			Namespace: el.EndpointsMeta.Namespace,
+			Annotations: map[string]string{
+				LeaderElectionRecordAnnotationKey: string(recordBytes),
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// Update will update and existing annotation on a given resource.
+func (el *EndpointsLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	if el.e == nil {
+		return errors.New("endpoint not initialized, call get or create first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	if el.e.Annotations == nil {
+		el.e.Annotations = make(map[string]string)
+	}
+	el.e.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Update(ctx, el.e, metav1.UpdateOptions{})
+	return err
+}
+
+// RecordEvent in leader election while adding meta-data
+func (el *EndpointsLock) RecordEvent(s string) {
+	if el.LockConfig.EventRecorder == nil {
+		return
+	}
+	events := fmt.Sprintf("%v %v", el.LockConfig.Identity, s)
+	el.LockConfig.EventRecorder.Eventf(&v1.Endpoints{ObjectMeta: el.e.ObjectMeta}, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (el *EndpointsLock) Describe() string {
+	return fmt.Sprintf("%v/%v", el.EndpointsMeta.Namespace, el.EndpointsMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (el *EndpointsLock) Identity() string {
+	return el.LockConfig.Identity
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
+	EndpointsResourceLock             = "endpoints"
+	ConfigMapsResourceLock            = "configmaps"
+	LeasesResourceLock                = "leases"
+	EndpointsLeasesResourceLock       = "endpointsleases"
+	ConfigMapsLeasesResourceLock      = "configmapsleases"
+)
+
+// LeaderElectionRecord is the record that is stored in the leader election annotation.
+// This information should be used for observational purposes only and could be replaced
+// with a random string (e.g. UUID) with only slight modification of this code.
+// TODO(mikedanese): this should potentially be versioned
+type LeaderElectionRecord struct {
+	// HolderIdentity is the ID that owns the lease. If empty, no one owns this lease and
+	// all callers may acquire. Versions of this library prior to Kubernetes 1.14 will not
+	// attempt to acquire leases with empty identities and will wait for the full lease
+	// interval to expire before attempting to reacquire. This value is set to empty when
+	// a client voluntarily steps down.
+	HolderIdentity       string      `json:"holderIdentity"`
+	LeaseDurationSeconds int         `json:"leaseDurationSeconds"`
+	AcquireTime          metav1.Time `json:"acquireTime"`
+	RenewTime            metav1.Time `json:"renewTime"`
+	LeaderTransitions    int         `json:"leaderTransitions"`
+}
+
+// EventRecorder records a change in the ResourceLock.
+type EventRecorder interface {
+	Eventf(obj runtime.Object, eventType, reason, message string, args ...interface{})
+}
+
+// ResourceLockConfig common data that exists across different
+// resource locks
+type ResourceLockConfig struct {
+	// Identity is the unique string identifying a lease holder across
+	// all participants in an election.
+	Identity string
+	// EventRecorder is optional.
+	EventRecorder EventRecorder
+}
+
+// Interface offers a common interface for locking on arbitrary
+// resources used in leader election.  The Interface is used
+// to hide the details on specific implementations in order to allow
+// them to change over time.  This interface is strictly for use
+// by the leaderelection code.
+type Interface interface {
+	// Get returns the LeaderElectionRecord
+	Get(ctx context.Context) (*LeaderElectionRecord, []byte, error)
+
+	// Create attempts to create a LeaderElectionRecord
+	Create(ctx context.Context, ler LeaderElectionRecord) error
+
+	// Update will update and existing LeaderElectionRecord
+	Update(ctx context.Context, ler LeaderElectionRecord) error
+
+	// RecordEvent is used to record events
+	RecordEvent(string)
+
+	// Identity will return the locks Identity
+	Identity() string
+
+	// Describe is used to convert details on current resource lock
+	// into a string
+	Describe() string
+}
+
+// Manufacture will create a lock of a given type according to the input parameters
+func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
+	endpointsLock := &EndpointsLock{
+		EndpointsMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Client:     coreClient,
+		LockConfig: rlc,
+	}
+	configmapLock := &ConfigMapLock{
+		ConfigMapMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Client:     coreClient,
+		LockConfig: rlc,
+	}
+	leaseLock := &LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Client:     coordinationClient,
+		LockConfig: rlc,
+	}
+	switch lockType {
+	case EndpointsResourceLock:
+		return endpointsLock, nil
+	case ConfigMapsResourceLock:
+		return configmapLock, nil
+	case LeasesResourceLock:
+		return leaseLock, nil
+	case EndpointsLeasesResourceLock:
+		return &MultiLock{
+			Primary:   endpointsLock,
+			Secondary: leaseLock,
+		}, nil
+	case ConfigMapsLeasesResourceLock:
+		return &MultiLock{
+			Primary:   configmapLock,
+			Secondary: leaseLock,
+		}, nil
+	default:
+		return nil, fmt.Errorf("Invalid lock-type %s", lockType)
+	}
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
+)
+
+type LeaseLock struct {
+	// LeaseMeta should contain a Name and a Namespace of a
+	// LeaseMeta object that the LeaderElector will attempt to lead.
+	LeaseMeta  metav1.ObjectMeta
+	Client     coordinationv1client.LeasesGetter
+	LockConfig ResourceLockConfig
+	lease      *coordinationv1.Lease
+}
+
+// Get returns the election record from a Lease spec
+func (ll *LeaseLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	var err error
+	ll.lease, err = ll.Client.Leases(ll.LeaseMeta.Namespace).Get(ctx, ll.LeaseMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	record := LeaseSpecToLeaderElectionRecord(&ll.lease.Spec)
+	recordByte, err := json.Marshal(*record)
+	if err != nil {
+		return nil, nil, err
+	}
+	return record, recordByte, nil
+}
+
+// Create attempts to create a Lease
+func (ll *LeaseLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	var err error
+	ll.lease, err = ll.Client.Leases(ll.LeaseMeta.Namespace).Create(ctx, &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ll.LeaseMeta.Name,
+			Namespace: ll.LeaseMeta.Namespace,
+		},
+		Spec: LeaderElectionRecordToLeaseSpec(&ler),
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// Update will update an existing Lease spec.
+func (ll *LeaseLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	if ll.lease == nil {
+		return errors.New("lease not initialized, call get or create first")
+	}
+	ll.lease.Spec = LeaderElectionRecordToLeaseSpec(&ler)
+	var err error
+	ll.lease, err = ll.Client.Leases(ll.LeaseMeta.Namespace).Update(ctx, ll.lease, metav1.UpdateOptions{})
+	return err
+}
+
+// RecordEvent in leader election while adding meta-data
+func (ll *LeaseLock) RecordEvent(s string) {
+	if ll.LockConfig.EventRecorder == nil {
+		return
+	}
+	events := fmt.Sprintf("%v %v", ll.LockConfig.Identity, s)
+	ll.LockConfig.EventRecorder.Eventf(&coordinationv1.Lease{ObjectMeta: ll.lease.ObjectMeta}, corev1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (ll *LeaseLock) Describe() string {
+	return fmt.Sprintf("%v/%v", ll.LeaseMeta.Namespace, ll.LeaseMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (ll *LeaseLock) Identity() string {
+	return ll.LockConfig.Identity
+}
+
+func LeaseSpecToLeaderElectionRecord(spec *coordinationv1.LeaseSpec) *LeaderElectionRecord {
+	var r LeaderElectionRecord
+	if spec.HolderIdentity != nil {
+		r.HolderIdentity = *spec.HolderIdentity
+	}
+	if spec.LeaseDurationSeconds != nil {
+		r.LeaseDurationSeconds = int(*spec.LeaseDurationSeconds)
+	}
+	if spec.LeaseTransitions != nil {
+		r.LeaderTransitions = int(*spec.LeaseTransitions)
+	}
+	if spec.AcquireTime != nil {
+		r.AcquireTime = metav1.Time{spec.AcquireTime.Time}
+	}
+	if spec.RenewTime != nil {
+		r.RenewTime = metav1.Time{spec.RenewTime.Time}
+	}
+	return &r
+
+}
+
+func LeaderElectionRecordToLeaseSpec(ler *LeaderElectionRecord) coordinationv1.LeaseSpec {
+	leaseDurationSeconds := int32(ler.LeaseDurationSeconds)
+	leaseTransitions := int32(ler.LeaderTransitions)
+	return coordinationv1.LeaseSpec{
+		HolderIdentity:       &ler.HolderIdentity,
+		LeaseDurationSeconds: &leaseDurationSeconds,
+		AcquireTime:          &metav1.MicroTime{ler.AcquireTime.Time},
+		RenewTime:            &metav1.MicroTime{ler.RenewTime.Time},
+		LeaseTransitions:     &leaseTransitions,
+	}
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	UnknownLeader = "leaderelection.k8s.io/unknown"
+)
+
+// MultiLock is used for lock's migration
+type MultiLock struct {
+	Primary   Interface
+	Secondary Interface
+}
+
+// Get returns the older election record of the lock
+func (ml *MultiLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	primary, primaryRaw, err := ml.Primary.Get(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secondary, secondaryRaw, err := ml.Secondary.Get(ctx)
+	if err != nil {
+		// Lock is held by old client
+		if apierrors.IsNotFound(err) && primary.HolderIdentity != ml.Identity() {
+			return primary, primaryRaw, nil
+		}
+		return nil, nil, err
+	}
+
+	if primary.HolderIdentity != secondary.HolderIdentity {
+		primary.HolderIdentity = UnknownLeader
+		primaryRaw, err = json.Marshal(primary)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return primary, ConcatRawRecord(primaryRaw, secondaryRaw), nil
+}
+
+// Create attempts to create both primary lock and secondary lock
+func (ml *MultiLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	err := ml.Primary.Create(ctx, ler)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return ml.Secondary.Create(ctx, ler)
+}
+
+// Update will update and existing annotation on both two resources.
+func (ml *MultiLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	err := ml.Primary.Update(ctx, ler)
+	if err != nil {
+		return err
+	}
+	_, _, err = ml.Secondary.Get(ctx)
+	if err != nil && apierrors.IsNotFound(err) {
+		return ml.Secondary.Create(ctx, ler)
+	}
+	return ml.Secondary.Update(ctx, ler)
+}
+
+// RecordEvent in leader election while adding meta-data
+func (ml *MultiLock) RecordEvent(s string) {
+	ml.Primary.RecordEvent(s)
+	ml.Secondary.RecordEvent(s)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (ml *MultiLock) Describe() string {
+	return ml.Primary.Describe()
+}
+
+// Identity returns the Identity of the lock
+func (ml *MultiLock) Identity() string {
+	return ml.Primary.Identity()
+}
+
+func ConcatRawRecord(primaryRaw, secondaryRaw []byte) []byte {
+	return bytes.Join([][]byte{primaryRaw, secondaryRaw}, []byte(","))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -973,6 +973,8 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/leaderelection
+k8s.io/client-go/tools/leaderelection/resourcelock
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
 k8s.io/client-go/tools/reference


### PR DESCRIPTION
 * #12409 -- Cilium operator HA mode (@fristonio)
 * #12771 -- install/kubernetes: do not schedule cilium-operator pods in same node (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12409 12771; do contrib/backporting/set-labels.py $pr done 1.8; done
```