### PR TITLE
test: Use `--no-cache` docker flag in gke builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ JOB_BASE_NAME ?= cilium_test
 GO_VERSION := $(shell cat GO_VERSION)
 GOARCH := $(shell $(GO) env GOARCH)
 
+DOCKER_FLAGS ?=
+
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 \
 	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
 	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -7,10 +7,11 @@ docker-cilium-image-for-developers:
 	# DOCKER_BUILDKIT allows for faster build as well as the ability to use
 	# a dedicated dockerignore file per Dockerfile.
 	$(QUIET)DOCKER_BUILDKIT=1 $(CONTAINER_ENGINE) build \
-	     --build-arg LOCKDEBUG=\
-	     --build-arg V=\
-	     --build-arg LIBNETWORK_PLUGIN=\
-	     -t $(DOCKER_DEV_ACCOUNT)/cilium-dev:latest . -f ./cilium-dev.Dockerfile
+		$(DOCKER_FLAGS) \
+		--build-arg LOCKDEBUG=\
+		--build-arg V=\
+		--build-arg LIBNETWORK_PLUGIN=\
+		-t $(DOCKER_DEV_ACCOUNT)/cilium-dev:latest . -f ./cilium-dev.Dockerfile
 
 docker-image: clean docker-image-no-clean docker-plugin-image docker-hubble-relay-image
 	$(MAKE) docker-operator-image
@@ -26,6 +27,7 @@ docker-image-unstripped: clean docker-image-no-clean-unstripped docker-plugin-im
 
 docker-image-no-clean: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/Dockerfile \
+		$(DOCKER_FLAGS) \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg V=${V} \
@@ -46,6 +48,7 @@ docker-cilium-manifest:
 
 dev-docker-image: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/Dockerfile \
+		$(DOCKER_FLAGS) \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg V=${V} \
@@ -69,6 +72,7 @@ docker-cilium-dev-manifest:
 # to build also 'docker-operator-image', where the stem would be empty otherwise
 docker-opera%-image: GIT_VERSION $(BUILD_DIR)/cilium-opera%.Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build \
+		$(DOCKER_FLAGS) \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
@@ -87,6 +91,7 @@ docker-operator-manifest:
 
 docker-plugin-image: GIT_VERSION $(BUILD_DIR)/cilium-docker-plugin.Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build \
+		$(DOCKER_FLAGS) \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
@@ -105,7 +110,7 @@ docker-plugin-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh docker-plugin $(DOCKER_IMAGE_TAG)
 
 docker-image-runtime:
-	cd contrib/packaging/docker && $(CONTAINER_ENGINE) build --build-arg ARCH=$(GOARCH) -t cilium/cilium-runtime:$(UTC_DATE) -f Dockerfile.runtime .
+	cd contrib/packaging/docker && $(CONTAINER_ENGINE) build $(DOCKER_FLAGS) --build-arg ARCH=$(GOARCH) -t cilium/cilium-runtime:$(UTC_DATE) -f Dockerfile.runtime .
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-runtime:$(UTC_DATE) cilium/cilium-runtime:$(UTC_DATE)-${GOARCH}
 
 docker-cilium-runtime-manifest:
@@ -113,7 +118,7 @@ docker-cilium-runtime-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-runtime $(UTC_DATE)
 
 docker-image-builder:
-	$(QUIET)$(CONTAINER_ENGINE) build --build-arg ARCH=$(GOARCH) -t cilium/cilium-builder:$(UTC_DATE) -f Dockerfile.builder .
+	$(QUIET)$(CONTAINER_ENGINE) build $(DOCKER_FLAGS) --build-arg ARCH=$(GOARCH) -t cilium/cilium-builder:$(UTC_DATE) -f Dockerfile.builder .
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-builder:$(UTC_DATE) cilium/cilium-builder:$(UTC_DATE)-${GOARCH}
 
 docker-cilium-builder-manifest:
@@ -122,6 +127,7 @@ docker-cilium-builder-manifest:
 
 docker-hubble-relay-image: $(BUILD_DIR)/hubble-relay.Dockerfile build-context-update
 	$(QUIET)$(CONTAINER_ENGINE) build \
+		$(DOCKER_FLAGS) \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
             parallel {
                 stage('Make Cilium images') {
                     steps {
-                        sh 'cd ${TESTDIR}; ./make-images-push-to-local-registry.sh $(./print-node-ip.sh) ${TAG}'
+                        sh 'cd ${TESTDIR}; ./make-images-push-to-local-registry.sh $(./print-node-ip.sh) ${TAG} "--no-cache"'
                     }
                     post {
                         unsuccessful {

--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -3,7 +3,7 @@
 set -e
 
 cd ..
-DOCKER_BUILDKIT=1 make docker-image DOCKER_IMAGE_TAG="$2"
+DOCKER_BUILDKIT=1 make docker-image DOCKER_IMAGE_TAG="$2" DOCKER_FLAGS="$3"
 
 docker tag "cilium/cilium:$2" "$1/cilium/cilium:$2"
 docker tag "cilium/cilium:$2" "$1/cilium/cilium-dev:$2"


### PR DESCRIPTION
Because we are running gke builds concurrently, there is a danger that cached image may be overwrtitten by another job while cleanup, resulting in building empty docker image which will fail the build.