### PR TITLE
test(github): Bump required protoc version to 3.12.3

### DIFF
--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -80,7 +80,7 @@ jobs:
           path: src/github.com/cilium/cilium
       - name: Install protobuf dependencies
         env:
-          PROTOBUF_VERSION: 3.11.4
+          PROTOBUF_VERSION: 3.12.3
         run: |
           curl -Lo protoc-$PROTOBUF_VERSION-linux-x86_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-x86_64.zip
           unzip protoc-$PROTOBUF_VERSION-linux-x86_64.zip


### PR DESCRIPTION
This is to make version in sync with api/v1/Makefile

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Note: Keen to hear on how to avoid such discrepancy in future.

```release-note
test(github): Bump required protoc version to 3.12.3
```
