### PR TITLE
docs(e2e): Update kube version in e2e docs

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -122,10 +122,6 @@ contain any characters after it.
 
 The Kubernetes tests support the following Kubernetes versions:
 
-* 1.8
-* 1.9
-* 1.10
-* 1.11
 * 1.12
 * 1.13
 * 1.14
@@ -135,7 +131,7 @@ The Kubernetes tests support the following Kubernetes versions:
 * 1.18
 * 1.19
 
-By default, the Vagrant VMs are provisioned with Kubernetes 1.18. To run with any other
+By default, the Vagrant VMs are provisioned with Kubernetes 1.19. To run with any other
 supported version of Kubernetes, run the test suite with the following format:
 
 ::


### PR DESCRIPTION
This PR is to update the default version to 1.19 if K8S_VERSION in not
passed, as well as to remove old versions that cilium is no longer
supported.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Note: I ran `K8S_VERSION=1.8 ginkgo -v --focus="K8s" -noColor` locally to check if this still works, but it didn't. Not sure if anyone is still running test with <1.12 version, I just removed it in the docs.

```release-note
docs(e2e): Update kube version in e2e docs
```
