### PR TITLE
iptables, loader: add rules for multi-node NodePort traffic on EKS

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1036,6 +1036,16 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		}
 	}
 
+	// AWS ENI requires to mark packets ingressing on the primary interface
+	// and route them back the same way even if the pod responding is using
+	// the IP of a different interface. Please see note in Reinitialize()
+	// in pkg/datapath/loader for more details.
+	if option.Config.IPAM == ipamOption.IPAMENI {
+		if err := m.addCiliumENIRules(); err != nil {
+			return fmt.Errorf("cannot install rules for ENI multi-node NodePort: %w", err)
+		}
+	}
+
 	if option.Config.EnableIPSec {
 		if err := m.addCiliumNoTrackXfrmRules(); err != nil {
 			return fmt.Errorf("cannot install xfrm rules: %s", err)
@@ -1139,4 +1149,28 @@ func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 		return m.ciliumNoTrackXfrmRules("iptables", "-I")
 	}
 	return nil
+}
+
+func (m *IptablesManager) addCiliumENIRules() error {
+	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
+	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+	if err := runProg("iptables", append(
+		m.waitArgs,
+		"-t", "mangle",
+		"-A", ciliumPreMangleChain,
+		"-i", "eth0",
+		"-m", "comment", "--comment", "cilium: primary ENI",
+		"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
+		"-j", "CONNMARK", "--set-xmark", nfmask+"/"+ctmask),
+		false); err != nil {
+		return err
+	}
+	return runProg("iptables", append(
+		m.waitArgs,
+		"-t", "mangle",
+		"-A", ciliumPreMangleChain,
+		"-i", "lxc+",
+		"-m", "comment", "--comment", "cilium: primary ENI",
+		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask),
+		false)
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -34,6 +34,15 @@ const (
 	// RouteMarkMask is the mask required for the route mark value
 	RouteMarkMask = 0xF00
 
+	// MarkMultinodeNodeport is used for AWS ENI to mark traffic from
+	// another node, so that it gets routed back through the relevant
+	// interface.
+	MarkMultinodeNodeport = 0x80
+
+	// MaskMultinodeNodeport is the mask associated with the
+	// RouterMarkNodePort
+	MaskMultinodeNodeport = 0x80
+
 	// IPSecProtocolID IP protocol ID for IPSec defined in RFC4303
 	RouteProtocolIPSec = 50
 
@@ -45,6 +54,13 @@ const (
 	// RulePriorityEgress is the priority of the rule used for egress routing
 	// of endpoints. This priority is after the local table priority.
 	RulePriorityEgress = 110
+
+	// RulePriorityNodeport is the priority of the rule used with AWS ENI to
+	// make sure that lookups for multi-node NodePort traffic are NOT done
+	// from the table for the VPC to which the endpoint's CIDR is
+	// associated, but from the main routing table instead.
+	// This priority is before the egress priority.
+	RulePriorityNodeport = RulePriorityEgress - 1
 
 	// TunnelDeviceName the default name of the tunnel device when using vxlan
 	TunnelDeviceName = "cilium_vxlan"

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,9 +30,12 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -292,6 +295,35 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	clockSource := []string{"ktime", "jiffies"}
 	log.Infof("Setting up base BPF datapath (BPF %s instruction set, %s clock source)",
 		args[initBPFCPU], clockSource[option.Config.ClockSource])
+
+	// AWS ENI mode requires symmetric routing, see
+	// iptables.addCiliumENIRules().
+	// The default AWS daemonset installs the following rules that are used
+	// for NodePort traffic between nodes:
+	//
+	// # sysctl -w net.ipv4.conf.eth0.rp_filter=2
+	// # iptables -t mangle -A PREROUTING -i eth0 -m comment --comment "AWS, primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
+	// # iptables -t mangle -A PREROUTING -i eni+ -m comment --comment "AWS, primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
+	// # ip rule add fwmark 0x80/0x80 lookup main
+	//
+	// It marks packets coming from another node through eth0, and restores
+	// the mark on the return path to force a lookup into the main routing
+	// table. Without these rules, the "ip rules" set by the cilium-cni
+	// plugin tell the host to lookup into the table related to the VPC for
+	// which the CIDR used by the endpoint has been configured.
+	//
+	// We want to reproduce equivalent rules to ensure correct routing.
+	if option.Config.IPAM == ipamOption.IPAMENI {
+		sysSettings = append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
+		if err := route.ReplaceRule(route.Rule{
+			Priority: linux_defaults.RulePriorityNodeport,
+			Mark:     linux_defaults.MarkMultinodeNodeport,
+			Mask:     linux_defaults.MaskMultinodeNodeport,
+			Table:    route.MainTable,
+		}); err != nil {
+			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+		}
+	}
 
 	for _, s := range sysSettings {
 		log.Infof("Setting sysctl %s=%s", s.name, s.val)


### PR DESCRIPTION
## Description

Multi-node NodePort traffic for EKS needs a set of specific rules that are usually set by the aws daemonset:

    # sysctl -w net.ipv4.conf.eth0.rp_filter=2
    # iptables -t mangle -A PREROUTING -i eth0 -m comment --comment "AWS, primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
    # iptables -t mangle -A PREROUTING -i eni+ -m comment --comment "AWS, primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
    # ip rule add fwmark 0x80/0x80 lookup main

These rules mark packets coming from another node through eth0, and restore the mark on the return path to force a lookup into the main routing table. Without them, the `ip rules` set by the cilium-cni plugin tell the host to lookup into the table related to the VPC for which the CIDR used by the endpoint has been configured.

We want to reproduce equivalent rules to ensure correct routing, or multi-node NodePort traffic will not be routed correctly. This could be observed with the `pod-to-b-multi-node-nodeport` pod from connectivity check never getting ready.

This commit makes the loader and iptables module create the relevant rules when IPAM is ENI and egress masquerading is in use. The rules are nearly identical to those from the aws daemonset (different comments, different interface prefix for conntrack return path, explicit preference for ip rule):

    # sysctl -w net.ipv4.conf.<egressMasqueradeInterfaces>.rp_filter=2
    # iptables -t mangle -A PREROUTING -i <egressMasqueradeInterfaces> -m comment --comment "cilium: primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
    # iptables -t mangle -A PREROUTING -i lxc+ -m comment --comment "cilium: primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
    # ip rule add fwmark 0x80/0x80 lookup main pref 109

## Steps for verification

Apply the patch, build and push the Docker image:

```
$ DOCKER_DEV_ACCOUNT=qmonnet make dev-docker-image
$ docker push qmonnet/cilium-dev:latest
```

Follow the instructions to [install Cilium on AWS EKS](https://docs.cilium.io/en/v1.8/gettingstarted/k8s-install-eks/). When deploying Cilium with Helm, do not forget to pass the location of the custom image for the agent:

```
$ helm install cilium [...] --set agent.image=docker.io/qmonnet/cilium-dev
```

Deploy the connectivity check. Pick the version from Cilium v1.8 (latest version does not have `pod-to-b-multi-node-nodeport`):

```
$ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.8/examples/kubernetes/connectivity-check/connectivity-check.yaml
```

Wait a few seconds. On a cilium pod, the newly-added rules should be visible:

```
# sysctl net.ipv4.conf.eth0.rp_filter
net.ipv4.conf.eth0.rp_filter = 2
# iptables-save|grep -w 0x80
-A CILIUM_PRE_mangle -i eth0 -m comment --comment "cilium: primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
-A CILIUM_PRE_mangle -i lxc+ -m comment --comment "cilium: primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
# ip rule|grep -w 0x80
109:    from all fwmark 0x80/0x80 lookup main 
```

All pods from the connectivity-check should be marked as ready, in particular the `pod-to-b-multi-node-nodeport`:

```
$ kubectl get pods
NAME                                                     READY   STATUS    RESTARTS   AGE
echo-a-58dd59998d-ct49w                                  1/1     Running   0          3m8s
echo-b-865969889d-xlb2v                                  1/1     Running   0          3m8s
echo-b-host-659c674bb6-895qn                             1/1     Running   2          3m8s
host-to-b-multi-node-clusterip-6fb94d9df6-7lk9s          1/1     Running   1          3m8s
host-to-b-multi-node-headless-7c4ff79cd-9zk4c            1/1     Running   1          3m8s
pod-to-a-5c8dcf69f7-5jnmh                                1/1     Running   0          3m8s
pod-to-a-allowed-cnp-75684d58cc-flpb9                    1/1     Running   0          3m8s
pod-to-a-external-1111-669ccfb85f-mljxd                  1/1     Running   0          3m7s
pod-to-a-l3-denied-cnp-7b8bfcb66c-tnqqf                  1/1     Running   0          3m8s
pod-to-b-intra-node-74997967f8-phb8v                     1/1     Running   0          3m8s
pod-to-b-intra-node-nodeport-775f967f47-8tjkq            1/1     Running   1          3m8s
pod-to-b-multi-node-clusterip-587678cbc4-4kzpg           1/1     Running   0          3m7s
pod-to-b-multi-node-headless-574d9f5894-vsbjt            1/1     Running   1          3m7s
pod-to-b-multi-node-nodeport-7944d9f9fc-wn4j2            1/1     Running   1          3m7s
pod-to-external-fqdn-allow-google-cnp-6dd57bc859-4h4pj   1/1     Running   0          3m7s
```

## Discussion

I am not entirely sure of my implementation. In particular, reviewers might want to consider:

- Is this the best location to add the rules? I initially considered the AWS-related code for the cilium-cni but I don't think this is used to manage the node itself.
- Should the rules depend on masquerading being used? I was under the impression we always use it for EKS, and that the interface we use for egress masquerading is the one to target with the rules. But I may be wrong.
- I picked a preference for the `ip rule` (`linux_defaults.RulePriorityEgress - 1`) so it gets looked up just before the rule we want to avoid, but maybe I should create a new constant in `linux_defaults` for that? Not sure if this is worth.
- Style: The processing of interface names for the `ip rule` addition feels a bit cumbersome (with this `+` prefix to process). I'm not sure we have a helper for this somewhere, I could not find one (other `lxc+`-style names are passed directly to iptables from what I could see). We do have a helper somewhere for setting `rp_filter` but it is not used in `Reinitialize()` from the `loader`, so I just stuck to local code and appended to `sysSettings`.

## Tests

None in this PR. Ready-state can be tested with connectivity check from Cilium v1.8 (I didn't realise [it was gone](https://github.com/cilium/cilium/commit/8a03d54da11a1c15302f4f90de8bf1e539252784) until writing this description).

Follow-up: Re-introduce `pod-to-b-multi-node-nodeport` or equivalent in connectivity checks.

Fixes: #12098

```release-note
Fix bug in ENI environments where connections to NodePort would fail due to asymmetric routing
```