### PR TITLE
install/kubernetes: do not schedule cilium-operator pods in same node

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -36,6 +36,20 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+{{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -829,6 +829,18 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -574,6 +574,18 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map


### PR DESCRIPTION
Since Cilium Operator is running in host network, 2 or more pods can't
run in the same node at the same time or they will clash the open
ports they use for liveness and / or readiness health check.

Fixes: 930bde726974 ("install: update helm templates to add HA capabilities for operator")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
avoid schedule cilium-operator pods in same node for HA mode
```
