### PR TITLE
[v1.7] etcd: Fix firstSession error handling

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -265,7 +265,7 @@ type etcdClient struct {
 	// is set up in the etcd client. If an error occurred and the initial
 	// session cannot be established, the error is provided via the
 	// channel.
-	firstSession chan error
+	firstSession chan struct{}
 
 	// stopStatusChecker is closed when the status checker can be terminated
 	stopStatusChecker chan struct{}
@@ -280,9 +280,10 @@ type etcdClient struct {
 	// statusCheckErrors receives all errors reported by statusChecker()
 	statusCheckErrors chan error
 
-	// protects sessions from concurrent access
+	// protects all sessions and sessionErr from concurrent access
 	lock.RWMutex
 
+	sessionErr    error
 	session       *concurrency.Session
 	sessionCancel context.CancelFunc
 
@@ -445,8 +446,8 @@ func (e *etcdClient) isConnectedAndHasQuorum(ctx context.Context) error {
 
 	select {
 	// Wait for the the initial connection to be established
-	case err := <-e.firstSession:
-		if err != nil {
+	case <-e.firstSession:
+		if err := e.sessionError(); err != nil {
 			return err
 		}
 	// Client is closing
@@ -692,7 +693,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		configPath:           cfgPath,
 		session:              &s,
 		lockSession:          &ls,
-		firstSession:         errChan,
+		firstSession:         make(chan struct{}),
 		controllers:          controller.NewManager(),
 		latestStatusSnapshot: "Waiting for initial connection to be established",
 		stopStatusChecker:    make(chan struct{}),
@@ -701,25 +702,33 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		statusCheckErrors:    make(chan error, 128),
 	}
 
+	handleSessionError := func(err error) {
+		ec.RWMutex.Lock()
+		ec.sessionErr = err
+		ec.RWMutex.Unlock()
+		errChan <- err
+	}
+
 	// wait for session to be created also in parallel
 	go func() {
 		defer close(errChan)
+		defer close(ec.firstSession)
 
 		select {
 		case err = <-errorChan:
 			if err != nil {
-				errChan <- err
+				handleSessionError(err)
 				return
 			}
 		case <-time.After(initialConnectionTimeout):
-			errChan <- fmt.Errorf("timed out while waiting for etcd session. Ensure that etcd is running on %s", config.Endpoints)
+			handleSessionError(fmt.Errorf("timed out while waiting for etcd session. Ensure that etcd is running on %s", config.Endpoints))
 			return
 		}
 
 		ec.getLogger().Info("Initial etcd session established")
 
 		if err := ec.checkMinVersion(ctx); err != nil {
-			errChan <- fmt.Errorf("unable to validate etcd version: %s", err)
+			handleSessionError(fmt.Errorf("unable to validate etcd version: %s", err))
 		}
 	}()
 
@@ -790,6 +799,13 @@ func getEPVersion(ctx context.Context, c client.Maintenance, etcdEP string, time
 	return v, nil
 }
 
+func (e *etcdClient) sessionError() (err error) {
+	e.RWMutex.RLock()
+	err = e.sessionErr
+	e.RWMutex.RUnlock()
+	return
+}
+
 // checkMinVersion checks the minimal version running on etcd cluster.  This
 // function should be run whenever the etcd client is connected for the first
 // time and whenever the session is renewed.
@@ -824,8 +840,8 @@ func (e *etcdClient) checkMinVersion(ctx context.Context) error {
 
 func (e *etcdClient) waitForInitialSession(ctx context.Context) error {
 	select {
-	case err := <-e.firstSession:
-		if err != nil {
+	case <-e.firstSession:
+		if err := e.sessionError(); err != nil {
 			return err
 		}
 	case <-ctx.Done():


### PR DESCRIPTION
The commit bf8e4327448 ("etcd: Ensure that firstSession is closed")
incorrectly assumed that only a single reader exists for firstSession. This is
not the case and the error returned via the channel will only be read by one of
the readers, the other readers will assume success and continue in their code
logic even though the etcd client is being shut down.

Fixes: bf8e4327448

Cherry-picked from https://github.com/cilium/cilium/pull/12773

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12773; do contrib/backporting/set-labels.py $pr done 1.7; done
```