### PR TITLE
Add Kubernetes compatibility documentation

### DIFF
--- a/Documentation/concepts/kubernetes/compatibility.rst
+++ b/Documentation/concepts/kubernetes/compatibility.rst
@@ -14,7 +14,10 @@ Kubernetes Compatibility
 Cilium is compatible with multiple Kubernetes API Groups. Some are deprecated
 or beta, and may only be available in specific versions of Kubernetes.
 
-All Kubernetes versions listed are compatible with Cilium:
+All Kubernetes versions listed are e2e tested and guaranteed to be compatible
+with Cilium. Older Kubernetes versions not listed in this table do not have
+Cilium support. Newer Kubernetes versions, while not listed, will depend on the
+backward compatibility offered by Kubernetes.
 
 +------------------------------------------------+---------------------------+----------------------------+
 | k8s Version                                    | k8s NetworkPolicy API     | CiliumNetworkPolicy        |

--- a/Documentation/concepts/kubernetes/policy.rst
+++ b/Documentation/concepts/kubernetes/policy.rst
@@ -44,6 +44,16 @@ NetworkPolicy
 For more information, see the official `NetworkPolicy documentation
 <https://kubernetes.io/docs/concepts/services-networking/network-policies/>`_.
 
+Known missing features for Kubernetes Network Policy:
+
++-------------------------------+----------------------------------------------+
+| Feature                       | Tracking Issue                               |
++===============================+==============================================+
+| ``ipBlock`` set with a pod IP | https://github.com/cilium/cilium/issues/9209 |
++-------------------------------+----------------------------------------------+
+| SCTP                          | https://github.com/cilium/cilium/issues/5719 |
++-------------------------------+----------------------------------------------+
+
 .. _CiliumNetworkPolicy:
 
 CiliumNetworkPolicy

--- a/Documentation/concepts/kubernetes/requirements.rst
+++ b/Documentation/concepts/kubernetes/requirements.rst
@@ -13,8 +13,10 @@ Requirements
 Kubernetes Version
 ==================
 
-The following Kubernetes versions have been tested in the continuous integration
-system for this version of Cilium:
+All Kubernetes versions listed are e2e tested and guaranteed to be compatible
+with this Cilium version. Older Kubernetes versions not listed here do not have
+Cilium support. Newer Kubernetes versions, while not listed, will depend on the
+backward compatibility offered by Kubernetes.
 
 * 1.12
 * 1.13


### PR DESCRIPTION
Marked for backport on all branches so that users are clarify about this on all Cilium versions. Ping me if the backport didn't apply correctly.