### PR TITLE
bpf,lbmap: Fix affinity v6 map and add runtime check for BPF map representation key/val sizes

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -130,6 +130,14 @@ type Map struct {
 
 // NewMap creates a new Map instance - object representing a BPF map
 func NewMap(name string, mapType MapType, mapKey MapKey, keySize int, mapValue MapValue, valueSize, maxEntries int, flags uint32, innerID uint32, dumpParser DumpParser) *Map {
+	if size := reflect.TypeOf(mapKey).Elem().Size(); size != uintptr(keySize) {
+		panic(fmt.Sprintf("Invalid %s map key size (%d != %d)", name, size, keySize))
+	}
+
+	if size := reflect.TypeOf(mapValue).Elem().Size(); size != uintptr(valueSize) {
+		panic(fmt.Sprintf("Invalid %s map value size (%d != %d)", name, size, valueSize))
+	}
+
 	m := &Map{
 		MapInfo: MapInfo{
 			MapType:       mapType,

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -61,10 +61,10 @@ var (
 		bpf.ConvertKeyValue,
 	)
 	Affinity6Map = bpf.NewMap(
-		Affinity4MapName,
+		Affinity6MapName,
 		bpf.MapTypeLRUHash,
 		&Affinity6Key{},
-		int(unsafe.Sizeof(Affinity4Key{})),
+		int(unsafe.Sizeof(Affinity6Key{})),
 		&AffinityValue{},
 		int(unsafe.Sizeof(AffinityValue{})),
 		MaxEntries,


### PR DESCRIPTION
Please see commit messages.

Regarding the check: I was thinking about removing the actual sizes, and deriving it from the passed interfaces instead. However, having both adds more safety.

Fixes: 5ca1f7d7c6 ("bpf: Add session affinity maps")