### PR TITLE
v1.6 backports 2020-08-06

### DIFF
--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -17,7 +17,7 @@ and meeting links.
 ====================== ===================================== ============= ================================================================================
 SIG                    Meeting                               Slack         Description
 ====================== ===================================== ============= ================================================================================
-Datapath               Every 2 weeks                         #sig-datapath Owner of all BPF and Linux kernel related datapath code.
+Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
 Documentation          None                                  #sig-docs     All documentation related discussions
 Envoy                  Every 2 weeks                         #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
 Policy                 Every Wed, 9:30 PT (`Policy-Zoom`_)   #sig-policy   All topics related to policy. The SIG is responsible for all security relevant APIs and the enforcement logic.
@@ -47,8 +47,8 @@ Slack channels
 ==================== ============================================================
 Name                 Purpose
 ==================== ============================================================
-#bpf                 BPF specific questions
 #development         Development discussions
+#ebpf                eBPF-specific questions
 #general             General user discussions & questions
 #git                 GitHub notifications
 #kubernetes          Kubernetes specific questions

--- a/Documentation/kubernetes/compatibility.rst
+++ b/Documentation/kubernetes/compatibility.rst
@@ -14,7 +14,10 @@ Kubernetes Compatibility
 Cilium is compatible with multiple Kubernetes API Groups. Some are deprecated
 or beta, and may only be available in specific versions of Kubernetes.
 
-All Kubernetes versions listed are compatible with Cilium:
+All Kubernetes versions listed are e2e tested and guaranteed to be compatible
+with Cilium. Older Kubernetes versions not listed in this table do not have
+Cilium support. Newer Kubernetes versions, while not listed, will depend on the
+backward compatibility offered by Kubernetes.
 
 +-------------------------------------------+---------------------------+----------------------------+
 | k8s Version                               | k8s NetworkPolicy API     | CiliumNetworkPolicy        |

--- a/Documentation/kubernetes/policy.rst
+++ b/Documentation/kubernetes/policy.rst
@@ -40,13 +40,17 @@ For more information, see the official `NetworkPolicy documentation
 
 Known missing features for Kubernetes Network Policy:
 
-+------------------------------+----------------------------------------------+
-| Feature                      | Tracking Issue                               |
-+==============================+==============================================+
-| Use of named ports           | https://github.com/cilium/cilium/issues/2942 |
-+------------------------------+----------------------------------------------+
-| Ingress CIDR-based L4 policy | https://github.com/cilium/cilium/issues/1684 |
-+------------------------------+----------------------------------------------+
++-------------------------------+----------------------------------------------+
+| Feature                       | Tracking Issue                               |
++===============================+==============================================+
+| Use of named ports            | https://github.com/cilium/cilium/issues/2942 |
++-------------------------------+----------------------------------------------+
+| Ingress CIDR-based L4 policy  | https://github.com/cilium/cilium/issues/1684 |
++-------------------------------+----------------------------------------------+
+| ``ipBlock`` set with a pod IP | https://github.com/cilium/cilium/issues/9209 |
++-------------------------------+----------------------------------------------+
+| SCTP                          | https://github.com/cilium/cilium/issues/5719 |
++-------------------------------+----------------------------------------------+
 
 .. _CiliumNetworkPolicy:
 

--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -13,8 +13,10 @@ Requirements
 Kubernetes Version
 ==================
 
-The following Kubernetes versions have been tested in the continuous integration
-system for this version of Cilium:
+All Kubernetes versions listed are e2e tested and guaranteed to be compatible
+with this Cilium version. Older Kubernetes versions not listed here do not have
+Cilium support. Newer Kubernetes versions, while not listed, will depend on the
+backward compatibility offered by Kubernetes.
 
 * 1.10
 * 1.11


### PR DESCRIPTION
 * #12766 -- doc: update #ebpf Slack channel name (@qmonnet)
 * #12783 -- Add Kubernetes compatibility documentation (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12766 12783; do contrib/backporting/set-labels.py $pr done 1.6; done
```

@qmonnet There was a conflict for #12766.
@aanm There were multiple conflicts for #12783, PTAL.