### PR TITLE
v1.7 backports 2020-08-06

### DIFF
--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -17,7 +17,7 @@ and meeting links.
 ====================== ===================================== ============= ================================================================================
 SIG                    Meeting                               Slack         Description
 ====================== ===================================== ============= ================================================================================
-Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all BPF and Linux kernel related datapath code.
+Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
 Documentation          None                                  #sig-docs     All documentation related discussions
 Envoy                  Biweekly on Thursdays, 09:00 PT       #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
 Policy                 None                                  #sig-policy   All topics related to policy. The SIG is responsible for all security relevant APIs and the enforcement logic.
@@ -47,8 +47,8 @@ Slack channels
 ==================== ============================================================
 Name                 Purpose
 ==================== ============================================================
-#bpf                 BPF specific questions
 #development         Development discussions
+#ebpf                eBPF-specific questions
 #general             General user discussions & questions
 #git                 GitHub notifications
 #kubernetes          Kubernetes specific questions

--- a/Documentation/kubernetes/compatibility.rst
+++ b/Documentation/kubernetes/compatibility.rst
@@ -14,7 +14,10 @@ Kubernetes Compatibility
 Cilium is compatible with multiple Kubernetes API Groups. Some are deprecated
 or beta, and may only be available in specific versions of Kubernetes.
 
-All Kubernetes versions listed are compatible with Cilium:
+All Kubernetes versions listed are e2e tested and guaranteed to be compatible
+with this Cilium version. Older Kubernetes versions not listed here do not have
+Cilium support. Newer Kubernetes versions, while not listed, will depend on the
+backward compatibility offered by Kubernetes.
 
 +------------------------------------+---------------------------+----------------------------+
 | k8s Version                        | k8s NetworkPolicy API     | CiliumNetworkPolicy        |

--- a/Documentation/kubernetes/policy.rst
+++ b/Documentation/kubernetes/policy.rst
@@ -46,13 +46,17 @@ For more information, see the official `NetworkPolicy documentation
 
 Known missing features for Kubernetes Network Policy:
 
-+------------------------------+----------------------------------------------+
-| Feature                      | Tracking Issue                               |
-+==============================+==============================================+
-| Use of named ports           | https://github.com/cilium/cilium/issues/2942 |
-+------------------------------+----------------------------------------------+
-| Ingress CIDR-based L4 policy | https://github.com/cilium/cilium/issues/1684 |
-+------------------------------+----------------------------------------------+
++-------------------------------+----------------------------------------------+
+| Feature                       | Tracking Issue                               |
++===============================+==============================================+
+| Use of named ports            | https://github.com/cilium/cilium/issues/2942 |
++-------------------------------+----------------------------------------------+
+| Ingress CIDR-based L4 policy  | https://github.com/cilium/cilium/issues/1684 |
++-------------------------------+----------------------------------------------+
+| ``ipBlock`` set with a pod IP | https://github.com/cilium/cilium/issues/9209 |
++-------------------------------+----------------------------------------------+
+| SCTP                          | https://github.com/cilium/cilium/issues/5719 |
++-------------------------------+----------------------------------------------+
 
 .. _CiliumNetworkPolicy:
 

--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -13,8 +13,10 @@ Requirements
 Kubernetes Version
 ==================
 
-The following Kubernetes versions have been tested in the continuous integration
-system for this version of Cilium:
+All Kubernetes versions listed are e2e tested and guaranteed to be compatible
+with this Cilium version. Older Kubernetes versions not listed here do not have
+Cilium support. Newer Kubernetes versions, while not listed, will depend on the
+backward compatibility offered by Kubernetes.
 
 * 1.11
 * 1.12

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2370,10 +2370,7 @@ func (kub *Kubectl) ExecInFirstPod(ctx context.Context, namespace, selector, cmd
 }
 
 // ExecInPods runs given command on all pods in given namespace that match selector and returns map pod-name->CmdRes
-func (kub *Kubectl) ExecInPods(ctx context.Context, namespace, selector, cmd string, wait bool, options ...ExecOptions) (results map[string]*CmdRes, err error) {
-	if wait {
-		kub.WaitforPods(namespace, "-l "+selector, HelperTimeout)
-	}
+func (kub *Kubectl) ExecInPods(ctx context.Context, namespace, selector, cmd string, options ...ExecOptions) (results map[string]*CmdRes, err error) {
 	names, err := kub.GetPodNamesContext(ctx, namespace, selector)
 	if err != nil {
 		return nil, err
@@ -3062,7 +3059,7 @@ func (kub *Kubectl) reportMap(path string, reportCmds map[string]string, ns, sel
 // commands are run on all pods matching selector
 func (kub *Kubectl) reportMapContext(ctx context.Context, path string, reportCmds map[string]string, ns, selector string) {
 	for cmd, logfile := range reportCmds {
-		results, err := kub.ExecInPods(ctx, ns, selector, cmd, true, ExecOptions{SkipLog: true})
+		results, err := kub.ExecInPods(ctx, ns, selector, cmd, ExecOptions{SkipLog: true})
 		if err != nil {
 			log.WithError(err).Errorf("cannot retrieve command output '%s': %s", cmd, err)
 		}

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -34,7 +34,12 @@ const (
 	namespaceTest = "external-ips-test"
 )
 
-var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
+func skipSuite(name string, t func()) bool {
+	return false
+}
+
+// Replace "skipSuite" with "Describe" to enable the suite.
+var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 	var (
 		kubectl             *helpers.Kubectl
 		ciliumFilename      string


### PR DESCRIPTION
 * #11696 -- test: Add externalIPs tests to K8sServicesTest and disable K8sKubeProxyFreeMatrix (@brb) (only partially backported, see note below)
 * #12547 -- Stop waiting for pod when collecting logs (@Weil0ng)
 * #12766 -- doc: update #ebpf Slack channel name (@qmonnet)
 * #12783 -- Add Kubernetes compatibility documentation (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11696 12547 12766 12783; do contrib/backporting/set-labels.py $pr done 1.7; done
```

@pchaigno For #11696, the first 2 commits didn't apply cleanly at all so I skipped them and kept only e09d991a1970ffd4a286382322091ffc64d40add as instructed [here](https://github.com/cilium/cilium/pull/11696#issuecomment-669238826)
@aanm #12783 did not apply cleanly. PTAL.