### PR TITLE
fqdn/dnsproxy: set SO_REUSEPORT on listening socket

### DIFF
--- a/pkg/fqdn/dnsproxy/udp.go
+++ b/pkg/fqdn/dnsproxy/udp.go
@@ -102,6 +102,9 @@ func listenConfig(mark int, ipv4, ipv6 bool) *net.ListenConfig {
 				if opErr == nil {
 					opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
 				}
+				if opErr == nil {
+					opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+				}
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Forward port of #12728

Once we start re-using the same port for the DNS proxy across
restarts (see #12794), it's useful to set the `SO_REUSEPORT` option on the
listening port. This given the proxy a better chance to re-`bind()` upon
restarts.

Updates #12794