### PR TITLE
v1.8 cillium & hubble PodSecurityPolicies

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -79,4 +79,3 @@ spec:
           path: {{ dir .Values.global.hubble.socketPath }}
           type: Directory
         name: hubble-sock-dir
-      serviceAccount: hubble-relay

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -79,3 +79,4 @@ spec:
           path: {{ dir .Values.global.hubble.socketPath }}
           type: Directory
         name: hubble-sock-dir
+      serviceAccount: hubble-relay

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
@@ -2,13 +2,8 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: cilium-psp
+  name: hubble-relay-psp
 spec:
-  privileged: true
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - NET_ADMIN
-    - SYS_MODULE
   volumes:
     - 'configMap'
     - 'emptyDir'
@@ -16,22 +11,6 @@ spec:
     - 'secret'
     - 'downwardAPI'
     - 'hostPath'
-  hostNetwork: true
-  hostPorts:
-{{- if .Values.global.operatorPrometheus.enabled }}
-    - min: {{ .Values.global.operatorPrometheus.port }}
-      max: {{ .Values.global.operatorPrometheus.port }}
-{{- end }}
-{{- if .Values.global.prometheus.enabled }}
-    - min: {{ .Values.global.prometheus.port }}
-      max: {{ .Values.global.prometheus.port }}
-{{- end }}
-{{- if .Values.global.hubble.metrics.enabled }}
-    - min: {{ .Values.global.hubble.metrics.port }}
-      max: {{ .Values.global.hubble.metrics.port }}
-{{- end }}
-  hostIPC: false
-  hostPID: false
   runAsUser:
     rule: 'RunAsAny'
   seLinux:
@@ -51,27 +30,24 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cilium-psp
+  name: hubble-relay-psp
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - cilium-psp
+  - hubble-relay-psp
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cilium-psp
+  name: hubble-relay-psp
 roleRef:
   kind: ClusterRole
-  name: cilium-psp
+  name: hubble-relay-psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: cilium
-  namespace: {{ .Release.Namespace }}
-- kind: ServiceAccount
-  name: cilium-operator
+  name: hubble-relay
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/podsecuritypolicy.yaml
@@ -2,13 +2,8 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: cilium-psp
+  name: hubble-ui-psp
 spec:
-  privileged: true
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - NET_ADMIN
-    - SYS_MODULE
   volumes:
     - 'configMap'
     - 'emptyDir'
@@ -16,22 +11,6 @@ spec:
     - 'secret'
     - 'downwardAPI'
     - 'hostPath'
-  hostNetwork: true
-  hostPorts:
-{{- if .Values.global.operatorPrometheus.enabled }}
-    - min: {{ .Values.global.operatorPrometheus.port }}
-      max: {{ .Values.global.operatorPrometheus.port }}
-{{- end }}
-{{- if .Values.global.prometheus.enabled }}
-    - min: {{ .Values.global.prometheus.port }}
-      max: {{ .Values.global.prometheus.port }}
-{{- end }}
-{{- if .Values.global.hubble.metrics.enabled }}
-    - min: {{ .Values.global.hubble.metrics.port }}
-      max: {{ .Values.global.hubble.metrics.port }}
-{{- end }}
-  hostIPC: false
-  hostPID: false
   runAsUser:
     rule: 'RunAsAny'
   seLinux:
@@ -51,27 +30,24 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cilium-psp
+  name: hubble-ui-psp
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - cilium-psp
+  - hubble-ui-psp
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cilium-psp
+  name: hubble-ui-psp
 roleRef:
   kind: ClusterRole
-  name: cilium-psp
+  name: hubble-ui-psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: cilium
-  namespace: {{ .Release.Namespace }}
-- kind: ServiceAccount
-  name: cilium-operator
+  name: hubble-ui
   namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
For the Kubernetes cluster with PodSecurityPolicy admission controller enabled the cilium helm chart cannot be installed due to lack of various policies:

1. For Cilium in case Prometheus is enabled
2. For Hubble in case Prometheus is enabled
3. For Hubble metrics in case metrics are enabled

This PR introduces required PSPs and changes in cilium-psp for Prometheus

Signed-off-by: Michał Koziejko <Michal_Koziejko@epam.com>