### PR TITLE
bpf: minor fix to Makefile and includes

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -194,7 +194,7 @@ bpf_lxc.o: bpf_lxc.ll
 
 subdirs: $(SUBDIRS)
 	$(QUIET) $(foreach TARGET,$(SUBDIRS), \
-		$(MAKE) $(SUBMAKEOPTS) -C $(TARGET))
+		$(MAKE) $(SUBMAKEOPTS) -C $(TARGET) &&) true
 
 else
 all: $(TARGET)
@@ -212,6 +212,6 @@ install:
 clean:
 	@$(ECHO_CLEAN)
 	$(QUIET) $(foreach TARGET,$(SUBDIRS), \
-		$(MAKE) $(SUBMAKEOPTS) -C $(TARGET) clean)
+		$(MAKE) $(SUBMAKEOPTS) -C $(TARGET) clean;)
 	$(QUIET)rm -fr *.o *.ll *.i *.s
 	$(QUIET)rm -f $(TARGET)

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -56,15 +56,15 @@ check: coccicheck checkpatch
 	$(QUIET) sparse -Wsparse-all ${FLAGS} $(ROOT_DIR)/$(RELATIVE_DIR)/*.c
 	$(QUIET) $(CLANG) ${CLANG_FLAGS} --analyze $(ROOT_DIR)/$(RELATIVE_DIR)/*.c
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
-		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@)
+		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@ &&) true
 
 preprocess: $(LIB)
 	$(QUIET) $(foreach TARGET,$(shell find $(ROOT_DIR)/$(RELATIVE_DIR)/ -name 'bpf_*.c'), \
 		echo "  GEN   $(patsubst %.c,%.i,${TARGET})"; \
 		${CLANG} $(FLAGS) -E -target bpf -c ${TARGET} -o $(patsubst %.c,%.i,${TARGET}); )
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
-		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@)
+		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@ &&) true
 
 assembly: $(BPF_C) $(LIB) $(BPF_ASM)
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
-		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@)
+		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@ &&) true

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -25,7 +25,6 @@
 # undef ENABLE_HOST_FIREWALL
 #endif
 
-#include "lib/utils.h"
 #include "lib/common.h"
 #include "lib/arp.h"
 #include "lib/maps.h"

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -12,7 +12,6 @@
 #define EVENT_SOURCE LXC_ID
 
 #include "lib/tailcall.h"
-#include "lib/utils.h"
 #include "lib/common.h"
 #include "lib/config.h"
 #include "lib/maps.h"

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -7,7 +7,6 @@
 #include <node_config.h>
 #include <netdev_config.h>
 
-#include "lib/utils.h"
 #include "lib/common.h"
 #include "lib/maps.h"
 #include "lib/ipv6.h"

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -10,7 +10,6 @@
 #define IS_BPF_OVERLAY 1
 
 #include "lib/tailcall.h"
-#include "lib/utils.h"
 #include "lib/common.h"
 #include "lib/maps.h"
 #include "lib/ipv6.h"

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -10,7 +10,6 @@
 #define SKIP_POLICY_MAP	1
 #define SKIP_CALLS_MAP	1
 
-#include "lib/utils.h"
 #include "lib/common.h"
 #include "lib/lb.h"
 #include "lib/eps.h"

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -10,7 +10,6 @@
 
 #define SKIP_POLICY_MAP 1
 
-#include "lib/utils.h"
 #include "lib/common.h"
 #include "lib/maps.h"
 #include "lib/eps.h"

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -11,6 +11,7 @@
 #include <linux/ipv6.h>
 #include <linux/in.h>
 
+#include "endian.h"
 #include "mono.h"
 
 /* FIXME: GH-3239 LRU logic is not handling timeouts gracefully enough

--- a/bpf/lib/static_data.h
+++ b/bpf/lib/static_data.h
@@ -7,6 +7,8 @@
 #include <bpf/ctx/ctx.h>
 #include <bpf/api.h>
 
+#include "endian.h"
+
 /* fetch_* macros assist in fetching variously sized static data */
 #define fetch_u32(x) __fetch(x)
 #define fetch_u32_i(x, i) __fetch(x ## _ ## i)

--- a/bpf/sockops/bpf_redir.c
+++ b/bpf/sockops/bpf_redir.c
@@ -13,7 +13,6 @@
 
 #define SOCKMAP 1
 
-#include "../lib/utils.h"
 #include "../lib/common.h"
 #include "../lib/maps.h"
 #include "../lib/lb.h"

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -13,7 +13,6 @@
 
 #define SOCKMAP 1
 
-#include "../lib/utils.h"
 #include "../lib/common.h"
 #include "../lib/maps.h"
 #include "../lib/lb.h"


### PR DESCRIPTION
These are two commits with minor fixes for `bpf/`.

- The first one fixes the `Makefile` so we can compile programs in multiple subdirectories instead of just one.

- The second adds includes for `endian.h` to `common.h` (and `static_data.h`) so we can skip including `utils.h` when this is otherwise unnecessary. More details in the commit log.
