### PR TITLE
test: Remove incorrect comment on flakyness

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -575,7 +575,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("Etcd", func() {
-		// Flaky on pipelines other than K8s 1.11/Linux net-next.
 		It("Check connectivity", func() {
 			deploymentManager.Deploy(helpers.CiliumNamespace, StatelessEtcd)
 			deploymentManager.WaitUntilReady()


### PR DESCRIPTION
This comment was added in #11772 when the test was disabled, but it wasn't removed once the test was fixed and reenabled in #11818.

Fixes: #11818
