### PR TITLE
v1.6 backports 2020-08-07

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -643,6 +643,10 @@ func init() {
 		option.KVStoreOpt, "Key-value store options")
 	option.BindEnv(option.KVStoreOpt)
 
+	flags.Duration(option.K8sSyncTimeoutName, defaults.K8sSyncTimeout, "Timeout for synchronizing k8s resources before exiting")
+	flags.MarkHidden(option.K8sSyncTimeoutName)
+	option.BindEnv(option.K8sSyncTimeoutName)
+
 	flags.Uint(option.K8sWatcherQueueSize, 1024, "Queue size used to serialize each k8s event type")
 	option.BindEnv(option.K8sWatcherQueueSize)
 

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -77,7 +77,6 @@ const (
 	k8sAPIGroupCiliumNetworkPolicyV2 = "cilium/v2::CiliumNetworkPolicy"
 	k8sAPIGroupCiliumNodeV2          = "cilium/v2::CiliumNode"
 	k8sAPIGroupCiliumEndpointV2      = "cilium/v2::CiliumEndpoint"
-	cacheSyncTimeout                 = time.Duration(3 * time.Minute)
 
 	metricCNP            = "CiliumNetworkPolicy"
 	metricEndpoint       = "Endpoint"
@@ -303,7 +302,7 @@ func (d *Daemon) initK8sSubsystem() <-chan struct{} {
 		select {
 		case <-cachesSynced:
 			log.Info("All pre-existing resources related to policy have been received; continuing")
-		case <-time.After(cacheSyncTimeout):
+		case <-time.After(option.Config.K8sSyncTimeout):
 			log.Fatalf("Timed out waiting for pre-existing resources related to policy to be received; exiting")
 		}
 	}()

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -204,6 +204,10 @@ const (
 	// invoked only for endpoints which are selected by policy changes.
 	SelectiveRegeneration = true
 
+	// K8sSyncTimeout specifies the standard time to allow for synchronizing
+	// local caches with Kubernetes state before exiting.
+	K8sSyncTimeout = 3 * time.Minute
+
 	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
 	// should watch for.
 	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -199,6 +199,9 @@ const (
 	// K8sServiceCacheSize is service cache size for cilium k8s package.
 	K8sServiceCacheSize = "k8s-service-cache-size"
 
+	// K8sSyncTimeout is the timeout to synchronize all resources with k8s.
+	K8sSyncTimeoutName = "k8s-sync-timeout"
+
 	// K8sWatcherQueueSize is the queue size used to serialize each k8s event type
 	K8sWatcherQueueSize = "k8s-watcher-queue-size"
 
@@ -1014,6 +1017,7 @@ type DaemonConfig struct {
 	IPv6ServiceRange              string
 	K8sAPIServer                  string
 	K8sKubeConfigPath             string
+	K8sSyncTimeout                time.Duration
 	K8sWatcherEndpointSelector    string
 	KVStore                       string
 	KVStoreOpt                    map[string]string
@@ -1635,6 +1639,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sServiceCacheSize = uint(viper.GetInt(K8sServiceCacheSize))
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
+	c.K8sSyncTimeout = viper.GetDuration(K8sSyncTimeoutName)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
 	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)


### PR DESCRIPTION
* #12822 -- daemon: Add hidden --k8s-sync-timeout option (@joestringer)
  * Had to tweak a few bits to cherry-pick against v1.6 branch. I manually validated the changes in a local cluster.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12822; do contrib/backporting/set-labels.py $pr done 1.6; done
```