### PR TITLE
operator: Fix non-leader crashing with kvstore

### DIFF
--- a/operator/api.go
+++ b/operator/api.go
@@ -113,10 +113,17 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 // k8s apiserver and returns an error if any of them is unhealthy
 func checkStatus() error {
 	if kvstoreEnabled() {
-		if client := kvstore.Client(); client == nil {
-			return fmt.Errorf("kvstore client not configured")
-		} else if _, err := client.Status(); err != nil {
-			return err
+		// We check if we are the leader here because only the leader has
+		// access to the kvstore client. Otherwise, the kvstore client check
+		// will block. It is safe for a non-leader to skip this check, as the
+		// it is the leader's responsibility to report the status of the
+		// kvstore client.
+		if leader, ok := isLeader.Load().(bool); ok && leader {
+			if client := kvstore.Client(); client == nil {
+				return fmt.Errorf("kvstore client not configured")
+			} else if _, err := client.Status(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
A non-leader operator will hang during its healthcheck report as it
tries to check the status of the kvstore. The reason it hangs is because
the leader operator is the only one that has access to the client. This
hang causes an HTTP level timeout on the kubetlet liveness check. The
timeout then causes kubelet to roll the pod, eventually into
CrashLoopBackOff.

```
Warning  Unhealthy         8m17s (x19 over 17m)   kubelet, ip-10-0-12-239.us-west-2.compute.internal
                                                  Liveness probe failed:
                                                  Get http://127.0.0.1:9234/healthz:
                                                  net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

Fixes: https://github.com/cilium/cilium/pull/12409