### PR TITLE
metrics: Deprecate non-conventional prometheus metrics

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -135,7 +135,11 @@ jobs:
              --set global.hostPort.enabled=true \
              --set config.bpfMasquerade=false \
              --set config.ipam=kubernetes \
-             --set global.pullPolicy=Never
+             --set global.pullPolicy=Never \
+             --set global.prometheus.enabled=true \
+             --set global.operatorPrometheus.enabled=true \
+             --set global.hubble.enabled=true \
+             --set global.hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}"
 
           kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
           # To make sure that cilium CRD is available (default timeout is 5m)
@@ -146,6 +150,19 @@ jobs:
         run: |
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
+
+      - name: Check prometheus metrics
+        if: ${{ success() }}
+        env:
+          DEPRECATED_METRICS: cilium_bpf_map_ops_total|cilium_endpoint_count|cilium_identity_count|cilium_endpoint_regenerations|cilium_k8s_client_api_calls_counter|cilium_nodes_all_events_received_total|cilium_policy_count|cilium_policy_import_errors
+        run: |
+          cd $HOME
+          cilium_pod=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].metadata.name}' )
+          kubectl -n kube-system exec $cilium_pod -- sh -c "apt update && apt install curl -y"
+          kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9090/metrics > metrics.prom
+          go get -u github.com/prometheus/prometheus/cmd/promtool
+          cat metrics.prom
+          cat metrics.prom | egrep -v "${{ env.DEPRECATED_METRICS }}" | $HOME/go/bin/promtool check metrics
 
       - name: Dump cilium related logs and events
         if: ${{ failure() }}

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -161,8 +161,7 @@ jobs:
           kubectl -n kube-system exec $cilium_pod -- sh -c "apt update && apt install curl -y"
           kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9090/metrics > metrics.prom
           go get -u github.com/prometheus/prometheus/cmd/promtool
-          cat metrics.prom
-          cat metrics.prom | egrep -v "${{ env.DEPRECATED_METRICS }}" | $HOME/go/bin/promtool check metrics
+          egrep -v "${{ env.DEPRECATED_METRICS }}" metrics.prom | $HOME/go/bin/promtool check metrics
 
       - name: Dump cilium related logs and events
         if: ${{ failure() }}

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -175,8 +175,10 @@ Endpoint
 ============================================ ================================================== ========================================================
 Name                                         Labels                                             Description
 ============================================ ================================================== ========================================================
-``endpoint_count``                                                                              Number of endpoints managed by this agent
-``endpoint_regenerations``                   ``outcome``                                        Count of all endpoint regenerations that have completed
+``endpoint``                                                                                    Number of endpoints managed by this agent
+``endpoint_count``                                                                              Number of endpoints managed by this agent (deprecated,  use ``endpoint``)
+``endpoint_regenerations``                   ``outcome``                                        Count of all endpoint regenerations that have completed (deprecated,  use ``endpoint_regenerations_total``)
+``endpoint_regenerations_total``             ``outcome``                                        Count of all endpoint regenerations that have completed
 ``endpoint_regeneration_time_stats_seconds`` ``scope``                                          Endpoint regeneration time stats
 ``endpoint_state``                           ``state``                                          Count of all endpoints
 ============================================ ================================================== ========================================================
@@ -206,14 +208,14 @@ Name                                          Labels                            
 eBPF
 ~~~~
 
-========================================== ================================================== ========================================================
-Name                                       Labels                                             Description
-========================================== ================================================== ========================================================
-``bpf_syscall_duration_seconds``           ``operation``, ``outcome``                         Duration of eBPF system call performed
-``bpf_map_ops_total``                      ``mapName``, ``operation``, ``outcome``            Number of eBPF map operations performed
-``bpf_maps_virtual_memory_max_bytes``                                                         Max memory used by eBPF maps installed in the system
-``bpf_progs_virtual_memory_max_bytes``                                                        Max memory used by eBPF programs installed in the system
-========================================== ================================================== ========================================================
+========================================== ===================================================================== ========================================================
+Name                                       Labels                                                                Description
+========================================== ===================================================================== ========================================================
+``bpf_syscall_duration_seconds``           ``operation``, ``outcome``                                            Duration of eBPF system call performed
+``bpf_map_ops_total``                      ``mapName`` (deprecated), ``map_name``, ``operation``, ``outcome``    Number of eBPF map operations performed. ``mapName`` is deprecated and will be removed in 1.10. Use ``map_name`` instead.
+``bpf_maps_virtual_memory_max_bytes``                                                                            Max memory used by eBPF maps installed in the system
+``bpf_progs_virtual_memory_max_bytes``                                                                           Max memory used by eBPF programs installed in the system
+========================================== ===================================================================== ========================================================
 
 Both ``bpf_maps_virtual_memory_max_bytes`` and ``bpf_progs_virtual_memory_max_bytes``
 are currently reporting the system-wide memory usage of eBPF that is directly
@@ -238,11 +240,13 @@ Policy
 ========================================== ================================================== ========================================================
 Name                                       Labels                                             Description
 ========================================== ================================================== ========================================================
-``policy_count``                                                                              Number of policies currently loaded
+``policy``                                                                                    Number of policies currently loaded
+``policy_count``                                                                              Number of policies currently loaded (deprecated, use ``policy``)
 ``policy_regeneration_total``                                                                 Total number of policies regenerated successfully
 ``policy_regeneration_time_stats_seconds`` ``scope``                                          Policy regeneration time stats labeled by the scope
 ``policy_max_revision``                                                                       Highest policy revision number in the agent
-``policy_import_errors``                                                                      Number of times a policy import has failed
+``policy_import_errors``                                                                      Number of times a policy import has failed (deprecated, use ``policy_import_errors_total``)
+``policy_import_errors_total``                                                                Number of times a policy import has failed
 ``policy_endpoint_enforcement_status``                                                        Number of endpoints labeled by policy enforcement status
 ========================================== ================================================== ========================================================
 
@@ -263,7 +267,8 @@ Identity
 ======================================== ================================================== ========================================================
 Name                                     Labels                                             Description
 ======================================== ================================================== ========================================================
-``identity_count``                                                                          Number of identities currently allocated
+``identity``                                                                                Number of identities currently allocated
+``identity_count``                                                                          Number of identities currently allocated (deprecated, use ``identity``)
 ======================================== ================================================== ========================================================
 
 Events external to Cilium
@@ -365,18 +370,18 @@ All metrics are exported under the ``cilium_operator_`` Prometheus namespace.
 IPAM
 ~~~~
 
-======================================== ================================ ========================================================
-Name                                     Labels                           Description
-======================================== ================================ ========================================================
-``ipam_ips``                             ``type``                         Number of IPs allocated
-``ipam_allocation_ops``                  ``subnetId``                     Number of IP allocation operations
-``ipam_interface_creation_ops``          ``subnetId``, ``status``         Number of interfaces creation operations
-``ipam_available``                                                        Number of interfaces with addresses available
-``ipam_nodes_at_capacity``                                                Number of nodes unable to allocate more addresses
-``ipam_resync_total``                                                     Number of synchronization operations with external IPAM API
-``ipam_api_duration_seconds``            ``operation``, ``responseCode``  Duration of interactions with external IPAM API
-``ipam_api_rate_limit_duration_seconds`` ``operation``                    Duration of rate limiting while accessing external IPAM API
-======================================== ================================ ========================================================
+======================================== ================================================================= ========================================================
+Name                                     Labels                                                            Description
+======================================== ================================================================= ========================================================
+``ipam_ips``                             ``type``                                                          Number of IPs allocated
+``ipam_allocation_ops``                  ``subnetId`` (deprecated), ``subnet_id``                          Number of IP allocation operations. ``subnetId`` is deprecated and will be removed in 1.10. Use ``subnet_id`` instead.
+``ipam_interface_creation_ops``          ``subnetId`` (deprecated), ``subnet_id``, ``status``              Number of interfaces creation operations. ``subnetId`` is deprecated and will be removed in 1.10. Use ``subnet_id`` instead.
+``ipam_available``                                                                                         Number of interfaces with addresses available
+``ipam_nodes_at_capacity``                                                                                 Number of nodes unable to allocate more addresses
+``ipam_resync_total``                                                                                      Number of synchronization operations with external IPAM API
+``ipam_api_duration_seconds``            ``operation``, ``responseCode`` (deprecated), ``response_code``   Duration of interactions with external IPAM API. ``responseCode`` is deprecated and will be removed in 1.10. Use ``response_code`` instead.
+``ipam_api_rate_limit_duration_seconds`` ``operation``                                                     Duration of rate limiting while accessing external IPAM API
+======================================== ================================================================= ========================================================
 
 Hubble
 ------

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -336,8 +336,30 @@ The following metrics have been renamed:
 New Metrics
 ~~~~~~~~~~~
 
+  * ``cilium_endpoint_regenerations_total`` counts of all endpoint regenerations that have completed, tagged by outcome.
+  * ``cilium_k8s_client_api_calls_total`` is number of API calls made to kube-apiserver labeled by host, method and return code.
   * ``cilium_kvstore_quorum_errors_total`` counts the number of kvstore quorum
     loss errors. The label ``error`` indicates the type of error.
+
+Deprecated Metrics/Labels
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  * ``cilium_endpoint_regenerations`` is deprecated and will be removed in 1.10. Please use ``cilium_endpoint_regenerations_total`` instead.
+  * ``cilium_k8s_client_api_calls_counter``is deprecated and will be removed in 1.10. Please use ``cilium_k8s_client_api_calls_total`` instead.
+  * ``cilium_identity_count`` is deprecated and will be removed in 1.10. Please use ``cilium_identity`` instead.
+  * ``cilium_policy_count`` is deprecated and will be removed in 1.10. Please use ``cilium_policy`` instead.
+  * ``cilium_policy_import_errors`` is deprecated and will be removed in 1.10. Please use ``cilium_policy_import_errors_total`` instead.
+  * Label ``mapName`` in ``cilium_bpf_map_ops_total`` is deprecated and will be removed in 1.10. Please use label ``map_name`` instead.
+  * Label ``eventType`` in ``cilium_nodes_all_events_received_total`` is deprecated and will be removed in 1.10. Please use
+    label ``event_type`` instead.
+  * Label ``responseCode`` in ``*api_duration_seconds`` is deprecated and will be removed in 1.10. Please use
+    label ``response_code`` instead.
+  * Label ``subnetId`` in ``cilium_operator_ipam_allocation_ops`` is deprecated and will be removed in 1.10. Please use
+    label ``subnet_id`` instead.
+  * Label ``subnetId`` in ``cilium_operator_ipam_release_ops`` is deprecated and will be removed in 1.10. Please use
+    label ``subnet_id`` instead.
+  * Label ``subnetId`` and ``availabilityZone`` in ``cilium_operator_ipam_available_ips_per_subnet`` are deprecated and will be removed in 1.10. Please use
+    label ``subnet_id`` and ``availability_zone`` instead.
 
 Removed options
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -295,11 +295,13 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	}
 
 	identity.IterateReservedIdentities(func(_ string, _ identity.NumericIdentity) {
+		metrics.Identity.Inc()
 		metrics.IdentityCount.Inc()
 	})
 	if option.Config.EnableWellKnownIdentities {
 		// Must be done before calling policy.NewPolicyRepository() below.
 		num := identity.InitWellKnownIdentities(option.Config)
+		metrics.Identity.Add(float64(num))
 		metrics.IdentityCount.Add(float64(num))
 	}
 

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -271,6 +271,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	newPrefixLengths, err := d.prefixLengths.Add(prefixes)
 	if err != nil {
 		metrics.PolicyImportErrors.Inc()
+		metrics.PolicyImportErrorsTotal.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to reference-count prefix lengths in CIDR policy")
 		resChan <- &PolicyAddResult{
@@ -285,6 +286,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy, d.ipam); err != nil {
 			_ = d.prefixLengths.Delete(prefixes)
 			metrics.PolicyImportErrors.Inc()
+			metrics.PolicyImportErrorsTotal.Inc()
 			err2 := fmt.Errorf("Unable to recompile base programs: %s", err)
 			logger.WithError(err2).WithField("prefixes", prefixes).Warn(
 				"Failed to recompile base programs due to prefix length count change")
@@ -299,6 +301,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	if _, err := ipcache.AllocateCIDRs(prefixes); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		metrics.PolicyImportErrors.Inc()
+		metrics.PolicyImportErrorsTotal.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to allocate identities for CIDRs during policy add")
 		resChan <- &PolicyAddResult{

--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
@@ -1866,10 +1866,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, mapName, operation))",
+          "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{mapName}} {{operation}}",
+          "legendFormat": "{{map_name}} {{operation}}",
           "refId": "A"
         }
       ],
@@ -1967,10 +1967,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, mapName, operation))",
+          "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{mapName}} {{operation}}",
+          "legendFormat": "{{map_name}} {{operation}}",
           "refId": "A"
         }
       ],
@@ -2068,10 +2068,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\"}[5m])) by (pod, mapName, operation)",
+          "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\"}[5m])) by (pod, map_name, operation)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{mapName}} {{operation}}",
+          "legendFormat": "{{map_name}} {{operation}}",
           "refId": "A"
         }
       ],
@@ -4120,7 +4120,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\"}[1m])) by (pod, eventType, source) * 60",
+          "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\"}[1m])) by (pod, event_type, source) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{eventType}} {{source}}",
@@ -5558,28 +5558,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_policy_count{k8s_app=\"cilium\"}) by(pod)",
+          "expr": "min(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_policy_count{k8s_app=\"cilium\"}) by(pod)",
+          "expr": "avg(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_policy_count{k8s_app=\"cilium\"}) by(pod)",
+          "expr": "max(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "sum(cilium_policy_import_errors{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "sum(cilium_policy_import_errors_total{k8s_app=\"cilium\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "policy import errors",
@@ -6143,7 +6143,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_endpoint_regenerations{k8s_app=\"cilium\"}[30s])) by(outcome)",
+          "expr": "sum(rate(cilium_endpoint_regenerations_total{k8s_app=\"cilium\"}[30s])) by(outcome)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -6928,7 +6928,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_k8s_client_api_calls_counter{k8s_app=\"cilium\"}[1m])) by (pod, method, return_code)",
+          "expr": "sum(rate(cilium_k8s_client_api_calls_total{k8s_app=\"cilium\"}[1m])) by (pod, method, return_code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{return_code}}",

--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-operator-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-operator-dashboard.json
@@ -425,7 +425,7 @@
           "expr": "rate(cilium_operator_eni_aws_api_duration_seconds_sum[1m])/rate(cilium_operator_eni_aws_api_duration_seconds_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{operation}} {{responseCode}}",
+          "legendFormat": "{{operation}} {{response_code}}",
           "refId": "A"
         }
       ],

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -2218,10 +2218,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, mapName, operation))",
+              "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{mapName}} {{operation}}",
+              "legendFormat": "{{map_name}} {{operation}}",
               "refId": "A"
             }
           ],
@@ -2319,10 +2319,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, mapName, operation))",
+              "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{mapName}} {{operation}}",
+              "legendFormat": "{{map_name}} {{operation}}",
               "refId": "A"
             }
           ],
@@ -2420,10 +2420,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\"}[5m])) by (pod, mapName, operation)",
+              "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\"}[5m])) by (pod, map_name, operation)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{mapName}} {{operation}}",
+              "legendFormat": "{{map_name}} {{operation}}",
               "refId": "A"
             }
           ],
@@ -4472,10 +4472,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\"}[1m])) by (pod, eventType, source) * 60",
+              "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\"}[1m])) by (pod, event_type, source) * 60",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{eventType}} {{source}}",
+              "legendFormat": "{{event_type}} {{source}}",
               "refId": "B"
             }
           ],
@@ -5910,28 +5910,28 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_policy_count{k8s_app=\"cilium\"}) by(pod)",
+              "expr": "min(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min",
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_policy_count{k8s_app=\"cilium\"}) by(pod)",
+              "expr": "avg(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_policy_count{k8s_app=\"cilium\"}) by(pod)",
+              "expr": "max(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
               "refId": "C"
             },
             {
-              "expr": "sum(cilium_policy_import_errors{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "sum(cilium_policy_import_errors_total{k8s_app=\"cilium\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "policy import errors",
@@ -6495,7 +6495,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_endpoint_regenerations{k8s_app=\"cilium\"}[30s])) by(outcome)",
+              "expr": "sum(rate(cilium_endpoint_regenerations_total{k8s_app=\"cilium\"}[30s])) by(outcome)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -7280,7 +7280,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_k8s_client_api_calls_counter{k8s_app=\"cilium\"}[1m])) by (pod, method, return_code)",
+              "expr": "sum(rate(cilium_k8s_client_api_calls_total{k8s_app=\"cilium\"}[1m])) by (pod, method, return_code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{return_code}}",
@@ -8936,7 +8936,7 @@ data:
               "expr": "rate(cilium_operator_eni_aws_api_duration_seconds_sum[1m])/rate(cilium_operator_eni_aws_api_duration_seconds_count[1m])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{operation}} {{responseCode}}",
+              "legendFormat": "{{operation}} {{response_code}}",
               "refId": "A"
             }
           ],

--- a/install/kubernetes/cilium/charts/prometheus-crd/crds/crd-servicemonitor.yaml
+++ b/install/kubernetes/cilium/charts/prometheus-crd/crds/crd-servicemonitor.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
     helm.sh/hook: crd-install
-  creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -38,7 +38,7 @@ func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Regi
 		Subsystem: subsystem,
 		Name:      "api_duration_seconds",
 		Help:      "Duration of interactions with API",
-	}, []string{"operation", "responseCode"})
+	}, []string{"operation", "responseCode", "response_code"}) //TODO(sayboras): Remove deprecated tag responseCode in 1.10
 
 	m.RateLimit = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
@@ -56,7 +56,8 @@ func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Regi
 // ObserveAPICall must be called on every API call made with the operation
 // performed, the status code received and the duration of the call
 func (p *PrometheusMetrics) ObserveAPICall(operation, status string, duration float64) {
-	p.ApiDuration.WithLabelValues(operation, status).Observe(duration)
+	//TODO(sayboras): Remove deprecated tag responseCode in 1.10
+	p.ApiDuration.WithLabelValues(operation, status, status).Observe(duration)
 }
 
 // ObserveRateLimit must be called in case an API call was subject to rate limiting

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -842,7 +842,8 @@ func (m *Map) Update(key MapKey, value MapValue) error {
 
 	err = UpdateElement(m.fd, key.GetKeyPtr(), value.GetValuePtr(), 0)
 	if option.Config.MetricsConfig.BPFMapOps {
-		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
+		//TODO(sayboras): Remove deprecated label in 1.10
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
 	}
 	return err
 }
@@ -890,7 +891,8 @@ func (m *Map) Delete(key MapKey) error {
 
 	_, errno := deleteElement(m.fd, key.GetKeyPtr())
 	if option.Config.MetricsConfig.BPFMapOps {
-		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Errno2Outcome(errno)).Inc()
+		//TODO(sayboras): Remove deprecated label in 1.10
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), m.commonName(), metricOpDelete, metrics.Errno2Outcome(errno)).Inc()
 	}
 	if errno != 0 {
 		err = fmt.Errorf("unable to delete element %s from map %s: %w", key, m.name, errno)

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -75,10 +75,12 @@ func (s *regenerationStatistics) SendMetrics() {
 	if !s.success {
 		// Endpoint regeneration failed, increase on failed metrics
 		metrics.EndpointRegenerationCount.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
+		metrics.EndpointRegenerationTotal.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
 		return
 	}
 
 	metrics.EndpointRegenerationCount.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
+	metrics.EndpointRegenerationTotal.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
 
 	sendMetrics(s, metrics.EndpointRegenerationTimeStats)
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -150,18 +150,29 @@ func (mgr *EndpointManager) InitMetrics() {
 	if option.Config.DryMode {
 		return
 	}
-	metricsOnce.Do(func() { // EndpointCount is a function used to collect this metric. We cannot
-		// increment/decrement a gauge since we invoke Remove gratuitiously and that
+	metricsOnce.Do(func() { // Endpoint is a function used to collect this metric. We cannot
+		// increment/decrement a gauge since we invoke Remove gratuitously and that
 		// would result in negative counts.
 		// It must be thread-safe.
+
+		//TODO(sayboras): Remove deprecated metric in 1.10
 		metrics.EndpointCount = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Name:      "endpoint_count",
-			Help:      "Number of endpoints managed by this agent",
+			Help:      "Number of endpoints managed by this agent (deprecated, use endpoint instead)",
 		},
 			func() float64 { return float64(len(mgr.GetEndpoints())) },
 		)
 		metrics.MustRegister(metrics.EndpointCount)
+
+		metrics.Endpoint = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Name:      "endpoint",
+			Help:      "Number of endpoints managed by this agent",
+		},
+			func() float64 { return float64(len(mgr.GetEndpoints())) },
+		)
+		metrics.MustRegister(metrics.Endpoint)
 	})
 }
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -308,6 +308,7 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 	defer func() {
 		if err == nil {
 			if allocated || isNewLocally {
+				metrics.Identity.Inc()
 				metrics.IdentityCount.Inc()
 			}
 
@@ -377,6 +378,7 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Identity) (released bool, err error) {
 	defer func() {
 		if released {
+			metrics.Identity.Dec()
 			metrics.IdentityCount.Dec()
 		}
 	}()

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -58,21 +58,21 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 		Subsystem: ipamSubsystem,
 		Name:      "allocation_ops",
 		Help:      "Number of IP allocation operations",
-	}, []string{"subnetId"})
+	}, []string{"subnetId", "subnet_id"}) //TODO(sayboras): Remove deprecated tag subnetId in 1.10
 
 	m.ReleaseIpOps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
 		Name:      "release_ops",
 		Help:      "Number of IP release operations",
-	}, []string{"subnetId"})
+	}, []string{"subnetId", "subnet_id"}) //TODO(sayboras): Remove deprecated tag subnetId in 1.10
 
 	m.AllocateInterfaceOps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
 		Name:      "interface_creation_ops",
 		Help:      "Number of interfaces allocated",
-	}, []string{"subnetId", "status"})
+	}, []string{"subnetId", "subnet_id", "status"}) //TODO(sayboras): Remove deprecated tag subnetId in 1.10
 
 	m.AvailableInterfaces = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -86,7 +86,9 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 		Subsystem: ipamSubsystem,
 		Name:      "available_ips_per_subnet",
 		Help:      "Number of available IPs per subnet ID",
-	}, []string{"subnetId", "availabilityZone"})
+	},
+		//TODO(sayboras): Remove deprecated tag subnetId, availabilityZone in 1.10
+		[]string{"subnetId", "subnet_id", "availabilityZone", "availability_zone"})
 
 	m.Nodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -136,15 +138,18 @@ func (p *prometheusMetrics) ResyncTrigger() trigger.MetricsObserver {
 }
 
 func (p *prometheusMetrics) IncAllocationAttempt(status, subnetID string) {
-	p.AllocateInterfaceOps.WithLabelValues(subnetID, status).Inc()
+	// TODO(sayboras): Remove deprecated tag subnetID in 1.10
+	p.AllocateInterfaceOps.WithLabelValues(subnetID, subnetID, status).Inc()
 }
 
 func (p *prometheusMetrics) AddIPAllocation(subnetID string, allocated int64) {
-	p.AllocateIpOps.WithLabelValues(subnetID).Add(float64(allocated))
+	// TODO(sayboras): Remove deprecated tag subnetID in 1.10
+	p.AllocateIpOps.WithLabelValues(subnetID, subnetID).Add(float64(allocated))
 }
 
 func (p *prometheusMetrics) AddIPRelease(subnetID string, released int64) {
-	p.ReleaseIpOps.WithLabelValues(subnetID).Add(float64(released))
+	// TODO(sayboras): Remove deprecated tag subnetID in 1.10
+	p.ReleaseIpOps.WithLabelValues(subnetID, subnetID).Add(float64(released))
 }
 
 func (p *prometheusMetrics) SetAllocatedIPs(typ string, allocated int) {
@@ -156,7 +161,8 @@ func (p *prometheusMetrics) SetAvailableInterfaces(available int) {
 }
 
 func (p *prometheusMetrics) SetAvailableIPsPerSubnet(subnetID string, availabilityZone string, available int) {
-	p.AvailableIPsPerSubnet.WithLabelValues(subnetID, availabilityZone).Set(float64(available))
+	// TODO(sayboras): Remove deprecated tag subnetID and availabilityZone in 1.10
+	p.AvailableIPsPerSubnet.WithLabelValues(subnetID, subnetID, availabilityZone, availabilityZone).Set(float64(available))
 }
 
 func (p *prometheusMetrics) SetNodes(label string, nodes int) {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -241,7 +241,8 @@ func (*k8sMetrics) Observe(verb string, u url.URL, latency time.Duration) {
 }
 
 func (*k8sMetrics) Increment(code string, method string, host string) {
-	metrics.KubernetesAPICalls.WithLabelValues(host, method, code).Inc()
+	metrics.KubernetesAPICalls.WithLabelValues(host, method, code).Inc() //TODO(sayboras): Remove deprecated metric in 1.10
+	metrics.KubernetesAPICallsTotal.WithLabelValues(host, method, code).Inc()
 	// The 'code' is set to '<error>' in case an error is returned from k8s
 	// more info:
 	// https://github.com/kubernetes/client-go/blob/v0.18.0-rc.1/rest/request.go#L700-L703

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -193,7 +193,7 @@ func updateMetric(getCounter func() (prometheus.Counter, error), newValue float6
 
 	oldValue := metrics.GetCounterValue(counter)
 	if newValue > oldValue {
-		counter.Add((newValue - oldValue))
+		counter.Add(newValue - oldValue)
 	}
 }
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -62,12 +62,12 @@ type Configuration interface {
 	NodeEncryptionEnabled() bool
 }
 
-// Notifier is the interaface the wraps Subscribe and Unsubscribe. An
+// Notifier is the interface the wraps Subscribe and Unsubscribe. An
 // implementation of this interface notifies subscribers of nodes being added,
 // updated or deleted.
 type Notifier interface {
 	// Subscribe adds the given NodeHandler to the list of subscribers that are
-	// notified of node changes. Upcon call to this method, the NodeHandler is
+	// notified of node changes. Upon call to this method, the NodeHandler is
 	// being notified of all nodes that are already in the cluster by calling
 	// the NodeHandler's NodeAdd callback.
 	Subscribe(datapath.NodeHandler)
@@ -183,7 +183,7 @@ func NewManager(name string, dp datapath.NodeHandler, ipcache IPCache, c Configu
 		Subsystem: "nodes",
 		Name:      name + "_events_received_total",
 		Help:      "Number of node events received",
-	}, []string{"eventType", "source"})
+	}, []string{"eventType", "event_type", "source"}) //TODO(sayboras): Remove deprecated tag eventType in 1.10
 
 	m.metricNumNodes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.Namespace,
@@ -196,7 +196,7 @@ func NewManager(name string, dp datapath.NodeHandler, ipcache IPCache, c Configu
 		Namespace: metrics.Namespace,
 		Subsystem: "nodes",
 		Name:      name + "_datapath_validations_total",
-		Help:      "Number of validation calls to implement the datapath implemention of a node",
+		Help:      "Number of validation calls to implement the datapath implementation of a node",
 	})
 
 	err := metrics.RegisterList([]prometheus.Collector{m.metricDatapathValidations, m.metricEventsReceived, m.metricNumNodes})
@@ -382,7 +382,8 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	m.mutex.Lock()
 	entry, oldNodeExists := m.nodes[nodeIdentity]
 	if oldNodeExists {
-		m.metricEventsReceived.WithLabelValues("update", string(n.Source)).Inc()
+		//TODO(sayboras): Remove deprecated metric in 1.10
+		m.metricEventsReceived.WithLabelValues("update", "update", string(n.Source)).Inc()
 
 		if !source.AllowOverwrite(entry.node.Source, n.Source) {
 			m.mutex.Unlock()
@@ -400,7 +401,8 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		}
 		entry.mutex.Unlock()
 	} else {
-		m.metricEventsReceived.WithLabelValues("add", string(n.Source)).Inc()
+		//TODO(sayboras): Remove deprecated metric in 1.10
+		m.metricEventsReceived.WithLabelValues("add", "add", string(n.Source)).Inc()
 		m.metricNumNodes.Inc()
 
 		entry = &nodeEntry{node: n}
@@ -418,10 +420,11 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 
 // NodeDeleted is called after a node has been deleted. It removes the node
 // from the manager if the node is still owned by the source of which the event
-// orgins from. If the node was removed, NodeDelete() is invoked of the
+// origins from. If the node was removed, NodeDelete() is invoked of the
 // datapath interface.
 func (m *Manager) NodeDeleted(n nodeTypes.Node) {
-	m.metricEventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
+	//TODO(sayboras): Remove deprecated metric in 1.10
+	m.metricEventsReceived.WithLabelValues("delete", "delete", string(n.Source)).Inc()
 
 	log.Debugf("Received node delete event from %s", n.Source)
 
@@ -511,7 +514,7 @@ func (m *Manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 	return nodes
 }
 
-// DeleteAllNodes deletes all nodes from the node maanger.
+// DeleteAllNodes deletes all nodes from the node manager.
 func (m *Manager) DeleteAllNodes() {
 	m.mutex.Lock()
 	for _, entry := range m.nodes {

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -185,6 +185,7 @@ func labelSelectorToRequirements(labelSelector *slim_metav1.LabelSelector) *k8sL
 	selector, err := slim_metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
 		metrics.PolicyImportErrors.Inc()
+		metrics.PolicyImportErrorsTotal.Inc()
 		log.WithError(err).WithField(logfields.EndpointLabelSelector,
 			logfields.Repr(labelSelector)).Error("unable to construct selector in label selector")
 		return nil

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -151,6 +151,7 @@ func addDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) e
 			break
 		}
 		metrics.PolicyImportErrors.Inc()
+		metrics.PolicyImportErrorsTotal.Inc()
 		scopedLog.WithError(derivativeErr).Error("Cannot create derivative rule. Installing deny-all rule.")
 		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, derivativeErr)
 		if statusErr != nil {
@@ -164,6 +165,7 @@ func addDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) e
 		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, err)
 		if statusErr != nil {
 			metrics.PolicyImportErrors.Inc()
+			metrics.PolicyImportErrorsTotal.Inc()
 			scopedLog.WithError(err).Error("Cannot update CNP status for derivative policy")
 		}
 		return statusErr

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -345,8 +345,8 @@ func (p *Repository) AddListLocked(rules api.Rules) (ruleSlice, uint64) {
 
 	p.rules = append(p.rules, newList...)
 	p.BumpRevision()
+	metrics.Policy.Add(float64(len(newList)))
 	metrics.PolicyCount.Add(float64(len(newList)))
-
 	return newList, p.GetRevision()
 }
 
@@ -448,6 +448,7 @@ func (p *Repository) DeleteByLabelsLocked(lbls labels.LabelArray) (ruleSlice, ui
 	if deleted > 0 {
 		p.BumpRevision()
 		p.rules = new
+		metrics.Policy.Sub(float64(deleted))
 		metrics.PolicyCount.Sub(float64(deleted))
 	}
 


### PR DESCRIPTION
metrics: Add new prometheus metrics and related label

This PR is to add new metrics and labels as per the check done
by official tool promtool.

Summary of the changes can be found as below:
- Deprecate eventType, mapName labels in favour of event_type and map_name
- Add _total suffix for counter metrics (cilium_endpoint_regenerations,
cilium_k8s_client_api_calls_counter, cilium_policy_import_errors)
- Add _count suffix for non-histogram and non-summary metrics
(cilium_identity_count, cilium_policy_count)

Fixes: #11743
Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
metrics: Deprecate non-conventional prometheus metrics
```
