### PR TITLE
chore(ci): Correct indentation for github action workflows

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -7,22 +7,22 @@ on:
       - master
 
 jobs:
-    checkpatch:
-        name: checkpatch
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0
-            - name: Run checkpatch.pl
-              run:
-                  make -C bpf checkpatch
-    coccicheck:
-        name: coccicheck
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: docker://cilium/coccicheck:1.0
-              with:
-                entrypoint: ./contrib/coccinelle/check-cocci.sh
+  checkpatch:
+    name: checkpatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run checkpatch.pl
+        run:
+          make -C bpf checkpatch
+  coccicheck:
+    name: coccicheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker://cilium/coccicheck:1.0
+        with:
+          entrypoint: ./contrib/coccinelle/check-cocci.sh

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,12 +7,12 @@ on:
       - master
 
 jobs:
-    build-html:
-        name: Validate & Build HTML
-        runs-on: ubuntu-18.04
-        steps:
-            - uses: actions/checkout@v1
-            - uses: docker://cilium/docs-builder:latest
-              with:
-                entrypoint: ./Documentation/check-build.sh
-                args: html
+  build-html:
+    name: Validate & Build HTML
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: docker://cilium/docs-builder:latest
+        with:
+          entrypoint: ./Documentation/check-build.sh
+          args: html

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -38,7 +38,7 @@ jobs:
         name: Register binfmt from multi-platform builds
         with:
           entrypoint: docker
-          args: run --privileged linuxkit/binfmt:5d33e7346e79f9c13a73c6952669e47a53b063d4 
+          args: run --privileged linuxkit/binfmt:5d33e7346e79f9c13a73c6952669e47a53b063d4
       - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
         name: Run make lint
         with:


### PR DESCRIPTION
This PR is just to make indentation consistent in these github action
workflows.

Remove one extra space in images.yaml

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
chore(ci): Correct indentation for github action workflows
```
