### PR TITLE
Add config point to send bugtool to stdout

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -46,6 +46,6 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
       --pprof-port int            Port on which pprof server is exposed (default 6060)
       --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
-  -t, --tmp string                Path to store extracted files (default "/tmp")
+  -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```
 


### PR DESCRIPTION
<!-- Description of change -->

Add config point to send bugtool to stdout.

Currently, it's not possible to stream bugtool output to stdout. This makes it difficult to get a bugtool out of a container because it requires either host-mounting a location for the bugtool or `cat`'ing the bugtool after generating it.

This change allows you to specify `-` (which colloquially means stdout in this context) as the path to store extracted files, i.e. `cilium-bugtool -t -`. Note that I've also moved other stdout output (which currently outputs information such as `ARCHIVE at /tmp/...`) to stderr.
