### PR TITLE
pkg/option: add option to configure BPF lbmap size

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -33,6 +33,7 @@ cilium-agent [flags]
       --bpf-ct-timeout-service-any duration           Timeout for service entries in non-TCP CT table (default 1m0s)
       --bpf-ct-timeout-service-tcp duration           Timeout for established service entries in TCP CT table (default 6h0m0s)
       --bpf-fragments-map-max int                     Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-lb-map-max int                            Maximum number of entries in Cilium BPF lbmap (default 65536)
       --bpf-map-dynamic-size-ratio float              Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
       --bpf-nat-global-max int                        Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-neigh-global-max int                      Maximum number of entries for the global BPF neighbor table (default 524288)

--- a/Documentation/concepts/ebpf/maps.rst
+++ b/Documentation/concepts/ebpf/maps.rst
@@ -34,7 +34,7 @@ For some BPF maps, the upper capacity limit can be overridden using command
 line options for ``cilium-agent``. A given capacity can be set using
 ``--bpf-ct-global-tcp-max``, ``--bpf-ct-global-any-max``,
 ``--bpf-nat-global-max``, ``--bpf-neigh-global-max``, ``--bpf-policy-map-max``,
-and ``--bpf-fragments-map-max``.
+``--bpf-fragments-map-max`` and ``--bpf-lb-map-max``.
 
 Using the ``--bpf-map-dynamic-size-ratio`` flag, the upper capacity limits of
 several large BPF maps are determined at agent startup based on the given ratio

--- a/Documentation/concepts/scalability/report.rst
+++ b/Documentation/concepts/scalability/report.rst
@@ -184,7 +184,7 @@ documentation the maximum recommended number of pods per node is 100.
 Having 5 namespaces with 50 deployments means that we have 250 different unique
 security identities. Having a low cardinality in the labels selected by Cilium
 helps scale the cluster. By default, Cilium has a limit of 16k security
-identities, but it can be increase with ``bpf-policy-map-max`` in the Cilium
+identities, but it can be increased with ``bpf-policy-map-max`` in the Cilium
 ``ConfigMap``.
 
 .. figure:: images/image_7_01.png

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -706,6 +706,26 @@ and therefore not affecting any application pod ``bind(2)`` requests anymore. In
 order to opt-out from this behavior in general, this setting can be changed for
 expert users by switching ``global.nodePort.bindProtection`` to ``false``.
 
+.. _Configuring Maps:
+
+Configuring BPF map sizes
+*************************
+
+For high-scale environments, Cilium's BPF maps can be configured to have higher
+limits on the number of entries. Overriding helm options can be used to tweak
+these limits.
+
+To increase the number of entries in Cilium's BPF LB service, backend and
+affinity maps consider overriding ``global.bpf.lbMapMax`` helm option.
+The default value of this LB map size is 65536.
+
+.. parsed-literal::
+
+    helm install cilium |CHART_RELEASE| \\
+        --namespace kube-system \\
+        --set global.kubeProxyReplacement=strict \\
+        --set global.bpf.lbMapMax=131072
+
 .. _kubeproxyfree_hostport:
 
 Container hostPort support

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -268,7 +268,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		option.Config.EnableIPv4, option.Config.EnableIPv6,
 	)
 	policymap.InitMapInfo(option.Config.PolicyMapEntries)
-	lbmap.InitMapInfo(option.Config.SockRevNatEntries)
+	lbmap.InitMapInfo(option.Config.SockRevNatEntries, option.Config.LBMapEntries)
 
 	if option.Config.DryMode == false {
 		if err := bpf.ConfigureResourceLimits(); err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
@@ -711,7 +712,7 @@ func init() {
 	flags.Int(option.NeighMapEntriesGlobalName, option.NATMapEntriesGlobalDefault, "Maximum number of entries for the global BPF neighbor table")
 	option.BindEnv(option.NeighMapEntriesGlobalName)
 
-	flags.Int(option.PolicyMapEntriesName, defaults.PolicyMapEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
+	flags.Int(option.PolicyMapEntriesName, policymap.MaxEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
 	option.BindEnv(option.PolicyMapEntriesName)
 
 	flags.Int(option.SockRevNatEntriesName, option.SockRevNATMapEntriesDefault, "Maximum number of entries for the SockRevNAT BPF map")
@@ -814,6 +815,9 @@ func init() {
 
 	flags.Int(option.FragmentsMapEntriesName, defaults.FragmentsMapEntries, "Maximum number of entries in fragments tracking map")
 	option.BindEnv(option.FragmentsMapEntriesName)
+
+	flags.Int(option.LBMapEntriesName, lbmap.MaxEntries, "Maximum number of entries in Cilium BPF lbmap")
+	option.BindEnv(option.LBMapEntriesName)
 
 	viper.BindPFlags(flags)
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -234,10 +234,17 @@ data:
 {{- end }}
 
 {{- if .Values.global.bpf.policyMapMax }}
-  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
   bpf-policy-map-max: "{{ .Values.global.bpf.policyMapMax }}"
 {{- end }}
+
+{{- if .Values.global.bpf.lbMapMax }}
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+  bpf-lb-map-max: "{{ .Values.global.bpf.lbMapMax }}"
+{{- end }}
+
 
 {{- if hasKey .Values "bpfMapDynamicSizeRatio" }}
   bpf-map-dynamic-size-ratio: {{ .Values.bpfMapDynamicSizeRatio | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -292,6 +292,10 @@ global:
     # policyMapMax is the maximum number of entries in endpoint policy map (per endpoint)
     policyMapMax: 16384
 
+    # lbMapMax is the maximum number of entries in cilium lb service, backend and affinity
+    # maps.
+    lbMapMax: 65536
+
     # monitorAggregation is the level of aggregation for datapath trace events
     monitorAggregation: medium
 

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -75,9 +75,12 @@ data:
   #
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: all
-  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
   bpf-policy-map-max: "16384"
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+  bpf-lb-map-max: "65536"
   # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: "0.0025"

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -61,9 +61,12 @@ data:
   #
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: all
-  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
   bpf-policy-map-max: "16384"
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+  bpf-lb-map-max: "65536"
   # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: "0.0025"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -255,11 +255,6 @@ const (
 	// connection tracking garbage collection
 	ConntrackGCStartingInterval = 5 * time.Minute
 
-	// PolicyMapEntries is the default number of entries allowed in an
-	// endpoint's policymap, ie the maximum number of peer identities that
-	// the endpoint could send/receive traffic to/from.
-	PolicyMapEntries = 16384 // Cilium 1.5 and earlier value
-
 	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
 	// event handling by listening for k8s events in the operator and
 	// mirroring it into the kvstore for reduced overhead in large

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -390,9 +390,3 @@ func CreateSockRevNat4Map() error {
 	_, err := sockRevNat4Map.Create()
 	return err
 }
-
-// InitMapInfo updates the map info defaults for sock rev nat {4,6} maps.
-func InitMapInfo(maxSockRevNatEntries int) {
-	MaxSockRevNat4MapEntries = maxSockRevNatEntries
-	MaxSockRevNat6MapEntries = maxSockRevNatEntries
-}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -31,8 +31,9 @@ import (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-lb")
 
-const (
-	// Maximum number of entries in each hashtable
+var (
+	// MaxEntries contains the maximum number of entries that are allowed in cilium
+	// LB service, backend and affinity maps.
 	MaxEntries = 65536
 )
 
@@ -469,4 +470,12 @@ func (svcs svcMap) addFEnBE(fe *loadbalancer.L3n4AddrID, be *loadbalancer.Backen
 
 	svcs[hash] = lbsvc
 	return &lbsvc
+}
+
+// InitMapInfo updates the map info defaults for sock rev nat {4,6} and lb maps.
+func InitMapInfo(maxSockRevNatEntries, lbMapMaxEntries int) {
+	MaxSockRevNat4MapEntries = maxSockRevNatEntries
+	MaxSockRevNat6MapEntries = maxSockRevNatEntries
+
+	MaxEntries = lbMapMaxEntries
 }

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -50,9 +49,11 @@ const (
 
 var (
 	// MaxEntries is the upper limit of entries in the per endpoint policy
-	// table. It is set by InitMapInfo(), but unit tests use the initial
-	// value below.
-	MaxEntries = defaults.PolicyMapEntries
+	// table ie the maximum number of peer identities that the endpoint could
+	// send/receive traffic to/from.. It is set by InitMapInfo(), but unit
+	// tests use the initial value below.
+	// The default value of this upper limit is 16384.
+	MaxEntries = 16384
 )
 
 type PolicyMap struct {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -802,6 +802,9 @@ const (
 
 	// K8sEnableAPIDiscovery
 	K8sEnableAPIDiscovery = "enable-k8s-api-discovery"
+
+	// LBMapEntriesName configures max entries for BPF lbmap.
+	LBMapEntriesName = "bpf-lb-map-max"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -831,6 +834,7 @@ var HelpFlagSections = []FlagsSection{
 			EnableBPFClockProbe,
 			EnableBPFMasquerade,
 			EnableIdentityMark,
+			LBMapEntriesName,
 		},
 	},
 	{
@@ -1886,6 +1890,9 @@ type DaemonConfig struct {
 	// election purposes in HA mode.
 	// This is only enabled for cilium-operator
 	k8sEnableLeasesFallbackDiscovery bool
+
+	// LBMapEntries is the maximum number of entries allowed in BPF lbmap.
+	LBMapEntries int
 }
 
 var (
@@ -2742,6 +2749,10 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 			c.FragmentsMapEntries, FragmentsMapMax)
 	}
 
+	if c.LBMapEntries <= 0 {
+		return fmt.Errorf("specified LBMap max entries %d must be a value greater than 0", c.LBMapEntries)
+	}
+
 	return nil
 }
 
@@ -2768,6 +2779,7 @@ func (c *DaemonConfig) calculateBPFMapSizes() error {
 	c.NeighMapEntriesGlobal = viper.GetInt(NeighMapEntriesGlobalName)
 	c.PolicyMapEntries = viper.GetInt(PolicyMapEntriesName)
 	c.SockRevNatEntries = viper.GetInt(SockRevNatEntriesName)
+	c.LBMapEntries = viper.GetInt(LBMapEntriesName)
 
 	// Don't attempt dynamic sizing if any of the sizeof members was not
 	// populated by the daemon (or any other caller).

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -268,6 +268,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		CTMapEntriesGlobalAny int
 		NATMapEntriesGlobal   int
 		PolicyMapEntries      int
+		LBMapEntries          int
 		FragmentsMapEntries   int
 		NeighMapEntriesGlobal int
 		SockRevNatEntries     int
@@ -284,7 +285,8 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalTCP: CTMapEntriesGlobalTCPDefault,
 				CTMapEntriesGlobalAny: CTMapEntriesGlobalAnyDefault,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
-				PolicyMapEntries:      defaults.PolicyMapEntries,
+				PolicyMapEntries:      16384,
+				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				NeighMapEntriesGlobal: NATMapEntriesGlobalDefault,
 				SockRevNatEntries:     SockRevNATMapEntriesDefault,
@@ -293,7 +295,8 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalTCP: CTMapEntriesGlobalTCPDefault,
 				CTMapEntriesGlobalAny: CTMapEntriesGlobalAnyDefault,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
-				PolicyMapEntries:      defaults.PolicyMapEntries,
+				PolicyMapEntries:      16384,
+				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				NeighMapEntriesGlobal: NATMapEntriesGlobalDefault,
 				SockRevNatEntries:     SockRevNATMapEntriesDefault,
@@ -307,6 +310,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 18000,
 				NATMapEntriesGlobal:   2048,
 				PolicyMapEntries:      512,
+				LBMapEntries:          1 << 14,
 				SockRevNatEntries:     18000,
 				FragmentsMapEntries:   2 << 14,
 			},
@@ -315,6 +319,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 18000,
 				NATMapEntriesGlobal:   2048,
 				PolicyMapEntries:      512,
+				LBMapEntries:          1 << 14,
 				SockRevNatEntries:     18000,
 				FragmentsMapEntries:   2 << 14,
 				WantErr:               false,
@@ -387,15 +392,17 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 4096,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
 				SockRevNatEntries:     4096,
-				PolicyMapEntries:      defaults.PolicyMapEntries,
+				PolicyMapEntries:      16384,
+				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 			},
 			want: sizes{
 				CTMapEntriesGlobalTCP: 2048,
 				CTMapEntriesGlobalAny: 4096,
 				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
-				PolicyMapEntries:      defaults.PolicyMapEntries,
 				SockRevNatEntries:     4096,
+				PolicyMapEntries:      16384,
+				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				WantErr:               false,
 			},
@@ -464,6 +471,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: tt.d.CTMapEntriesGlobalAny,
 				NATMapEntriesGlobal:   tt.d.NATMapEntriesGlobal,
 				PolicyMapEntries:      tt.d.PolicyMapEntries,
+				LBMapEntries:          tt.d.LBMapEntries,
 				FragmentsMapEntries:   tt.d.FragmentsMapEntries,
 				NeighMapEntriesGlobal: tt.d.NeighMapEntriesGlobal,
 				SockRevNatEntries:     tt.d.SockRevNatEntries,


### PR DESCRIPTION
Add a command-line flag to cilium-agent to configure BPF lbmap size
with a user-provided value. This commit adds a new flag called
`bpf-lb-map-max` for this. The default value of max entries in BPF lbmap is 65536.

Running cilium-agent with `--bpf-lb-map-max 131072` gives the maps with the following sizes.

![image](https://user-images.githubusercontent.com/21292343/89995787-9b37dc80-dca7-11ea-876c-119b1ea54707.png)

FIxes #12815