### PR TITLE
v1.8 backports 2020-08-11

### DIFF
--- a/operator/api.go
+++ b/operator/api.go
@@ -113,10 +113,17 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 // k8s apiserver and returns an error if any of them is unhealthy
 func checkStatus() error {
 	if kvstoreEnabled() {
-		if client := kvstore.Client(); client == nil {
-			return fmt.Errorf("kvstore client not configured")
-		} else if _, err := client.Status(); err != nil {
-			return err
+		// We check if we are the leader here because only the leader has
+		// access to the kvstore client. Otherwise, the kvstore client check
+		// will block. It is safe for a non-leader to skip this check, as the
+		// it is the leader's responsibility to report the status of the
+		// kvstore client.
+		if leader, ok := isLeader.Load().(bool); ok && leader {
+			if client := kvstore.Client(); client == nil {
+				return fmt.Errorf("kvstore client not configured")
+			} else if _, err := client.Status(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
* #12825 -- operator: Fix non-leader crashing with kvstore (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12825; do contrib/backporting/set-labels.py $pr done 1.8; done
```