### PR TITLE
v1.8 backports 2020-08-12

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -493,6 +493,10 @@ func init() {
 		option.KVStoreOpt, "Key-value store options")
 	option.BindEnv(option.KVStoreOpt)
 
+	flags.Duration(option.K8sSyncTimeoutName, defaults.K8sSyncTimeout, "Timeout for synchronizing k8s resources before exiting")
+	flags.MarkHidden(option.K8sSyncTimeoutName)
+	option.BindEnv(option.K8sSyncTimeoutName)
+
 	flags.Uint(option.K8sWatcherQueueSize, 1024, "Queue size used to serialize each k8s event type")
 	option.BindEnv(option.K8sWatcherQueueSize)
 

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
             - "serve"
             - "--peer-service=unix://{{ .Values.global.hubble.socketPath }}"
             - "--listen-address={{ .Values.listenHost }}:{{ .Values.listenPort }}"
+{{- if .Values.global.debug.enabled }}
+            - "--debug=true"
+{{- end }}
 {{- if .Values.dialTimeout }}
             - "--dial-timeout={{ .Values.dialTimeout }}"
 {{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -1,4 +1,4 @@
-# Configuration for the Hubble CLI
+# Configuration for Hubble Relay
 image:
   # repository of the docker image
   repository: hubble-relay

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -85,6 +85,19 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
+{{- if .Values.global.gke.enabled }}
+                    # If the IP-MASQ chain exists, add back jump rule
+                    if iptables -w -t nat -L IP-MASQ > /dev/null; then
+                      iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
+                    fi
+{{- end }}
+{{- if .Values.azure }}
+                    # If the IP-MASQ-AGENT chain exists, add back jump rule
+                    if iptables -w -t nat -L IP-MASQ-AGENT > /dev/null; then
+                      iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT
+                    fi
+{{- end }}
+
                     echo "Node de-initialization complete"
 {{- end }}
           env:
@@ -158,6 +171,8 @@ spec:
               if [ -f /var/run/azure-vnet.json ]; then
                 sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
               fi
+              # Disable jumping to ip-masq chain
+              iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT || true
 {{- end }}
 
 {{- if .Values.removeCbrBridge }}
@@ -174,6 +189,11 @@ spec:
               sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.global.cni.binPath }}:g" /etc/default/kubelet
               echo "Restarting kubelet..."
               systemctl restart kubelet
+{{- end }}
+
+{{- if .Values.global.gke.enabled }}
+              # Disable jumping to ip-masq chain
+              iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ || true
 {{- end }}
 
 {{- if not (eq .Values.global.nodeinit.bootstrapFile "") }}

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -91,12 +91,6 @@ spec:
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
                     fi
 {{- end }}
-{{- if .Values.azure }}
-                    # If the IP-MASQ-AGENT chain exists, add back jump rule
-                    if iptables -w -t nat -L IP-MASQ-AGENT > /dev/null; then
-                      iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT
-                    fi
-{{- end }}
 
                     echo "Node de-initialization complete"
 {{- end }}
@@ -171,8 +165,6 @@ spec:
               if [ -f /var/run/azure-vnet.json ]; then
                 sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
               fi
-              # Disable jumping to ip-masq chain
-              iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq-agent: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ-AGENT chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ-AGENT || true
 {{- end }}
 
 {{- if .Values.removeCbrBridge }}

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -86,7 +86,7 @@ spec:
 {{- end }}
 
 {{- if .Values.global.gke.enabled }}
-                    # If the IP-MASQ chain exists, add back jump rule
+                    # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
                     fi
@@ -184,7 +184,12 @@ spec:
 {{- end }}
 
 {{- if .Values.global.gke.enabled }}
-              # Disable jumping to ip-masq chain
+              # If Cilium is installed, it would be expected that it would be solely responsible
+              # for the networking configuration on that node.
+              # In GKE, even if the IP masquerade agent is not enabled, the instance
+              # configure script adds some default masquerade rules anyway.
+              # If we remove the jump to that ip-masq chain, then we ensure masquerade configuration
+              # is managed by Cilium.
               iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ || true
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -38,7 +38,7 @@ hubble-relay:
   # # TODO: Develop a plan to migrate global.hubble.relay.enabled and other
   # # global values
   #
-  # # Configuration for the Hubble CLI
+  # # Configuration for Hubble Relay
   # image:
   #   # repository of the docker image
   #   name: hubble-relay
@@ -78,7 +78,7 @@ hubble-relay:
 
 # global groups all configuration options that have effect on all sub-charts
 global:
-  # registry is the address of the registry and orgnization for all container images
+  # registry is the address of the registry and organization for all container images
   registry: docker.io/cilium
 
   # tag is the container image tag to use

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -231,6 +231,10 @@ const (
 	// invoked only for endpoints which are selected by policy changes.
 	SelectiveRegeneration = true
 
+	// K8sSyncTimeout specifies the standard time to allow for synchronizing
+	// local caches with Kubernetes state before exiting.
+	K8sSyncTimeout = 3 * time.Minute
+
 	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
 	// should watch for.
 	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager"

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -58,7 +58,6 @@ const (
 	k8sAPIGroupCiliumClusterwideNetworkPolicyV2 = "cilium/v2::CiliumClusterwideNetworkPolicy"
 	k8sAPIGroupCiliumNodeV2                     = "cilium/v2::CiliumNode"
 	k8sAPIGroupCiliumEndpointV2                 = "cilium/v2::CiliumEndpoint"
-	cacheSyncTimeout                            = 3 * time.Minute
 	K8sAPIGroupEndpointSliceV1Beta1Discovery    = "discovery/v1beta1::EndpointSlice"
 
 	metricCNP            = "CiliumNetworkPolicy"
@@ -404,7 +403,7 @@ func (k *K8sWatcher) InitK8sSubsystem() <-chan struct{} {
 		select {
 		case <-cachesSynced:
 			log.Info("All pre-existing resources related to policy have been received; continuing")
-		case <-time.After(cacheSyncTimeout):
+		case <-time.After(option.Config.K8sSyncTimeout):
 			log.Fatalf("Timed out waiting for pre-existing resources related to policy to be received; exiting")
 		}
 	}()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -205,6 +205,9 @@ const (
 	// K8sServiceCacheSize is service cache size for cilium k8s package.
 	K8sServiceCacheSize = "k8s-service-cache-size"
 
+	// K8sSyncTimeout is the timeout to synchronize all resources with k8s.
+	K8sSyncTimeoutName = "k8s-sync-timeout"
+
 	// K8sWatcherQueueSize is the queue size used to serialize each k8s event type
 	K8sWatcherQueueSize = "k8s-watcher-queue-size"
 
@@ -860,6 +863,7 @@ var HelpFlagSections = []FlagsSection{
 			K8sNamespaceName,
 			K8sRequireIPv4PodCIDRName,
 			K8sRequireIPv6PodCIDRName,
+			K8sSyncTimeoutName,
 			K8sWatcherEndpointSelector,
 			K8sWatcherQueueSize,
 			K8sEventHandover,
@@ -1496,6 +1500,7 @@ type DaemonConfig struct {
 	K8sKubeConfigPath             string
 	K8sClientBurst                int
 	K8sClientQPSLimit             float64
+	K8sSyncTimeout                time.Duration
 	K8sWatcherEndpointSelector    string
 	KVStore                       string
 	KVStoreOpt                    map[string]string
@@ -2321,6 +2326,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sServiceCacheSize = uint(viper.GetInt(K8sServiceCacheSize))
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
+	c.K8sSyncTimeout = viper.GetDuration(K8sSyncTimeoutName)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
 	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepConfig = viper.GetBool(KeepConfig)


### PR DESCRIPTION
* #12741 -- helm: run relay in debug mode when debug is globally enabled (@kAworu)
 * #12822 -- daemon: Add hidden --k8s-sync-timeout option (@joestringer)
 * #11782 -- nodeinit: Disable default ip-masq-agent jumps (@dctrwatson)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12741 12822 11782; do contrib/backporting/set-labels.py $pr done 1.8; done
```