### PR TITLE
k8s: Fix parsing of CCNPs

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -218,6 +218,18 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	}
 
 	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
+	// Temporary fix for CCNPs. See #12834.
+	// TL;DR. CCNPs are converted into SlimCNPs and end up here so we need to
+	// convert them back to CCNPs to allow proper parsing.
+	if namespace == "" {
+		ccnp := CiliumClusterwideNetworkPolicy{
+			TypeMeta:            r.TypeMeta,
+			ObjectMeta:          r.ObjectMeta,
+			CiliumNetworkPolicy: r,
+			Status:              r.Status,
+		}
+		return ccnp.Parse()
+	}
 	name := r.ObjectMeta.Name
 	uid := r.ObjectMeta.UID
 

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -466,13 +466,26 @@ func (s *CiliumV2Suite) TestParseWithNodeSelector(c *C) {
 	// CCNP parse is allowed to have a NodeSelector.
 	ccnpl := CiliumClusterwideNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
+			Namespace: "",
 			Name:      "rule",
 			UID:       uuidRule,
 		},
 		CiliumNetworkPolicy: &cnpl,
 	}
 	_, err = ccnpl.Parse()
+	c.Assert(err, IsNil)
+
+	// CCNPs are received as CNP and initially parsed as CNP. Create a CNP with
+	// an empty namespace to test this case. See #12834 for details.
+	ccnplAsCNP := CiliumNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "",
+			Name:      "rule",
+			UID:       uuidRule,
+		},
+		Spec: &rule,
+	}
+	_, err = ccnplAsCNP.Parse()
 	c.Assert(err, IsNil)
 
 	// Now test a CNP and CCNP with an EndpointSelector only.
@@ -482,9 +495,9 @@ func (s *CiliumV2Suite) TestParseWithNodeSelector(c *C) {
 	// CNP and CCNP parse is allowed to have an EndpointSelector.
 	_, err = cnpl.Parse()
 	c.Assert(err, IsNil)
-
-	// CNP and CCNP parse is allowed to have an EndpointSelector.
 	_, err = ccnpl.Parse()
+	c.Assert(err, IsNil)
+	_, err = ccnplAsCNP.Parse()
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
Host policies are rejected on master with the following error:

    $ kubectl describe ccnp | tail -n9
    Status:
      Nodes:
        k8s1:
          Error:         Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector
          Last Updated:  2020-08-10T12:52:51Z
        k8s2:
          Error:         Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector
          Last Updated:  2020-08-10T12:52:48Z
    Events:              <none>

This error is printed because `CiliumNetworkPolicy.Parse()` has some new checks to prevent using `NodeSelector` in CNPs. It assumes `CiliumClusterwideNetworkPolicy.Parse()` will be called in the case of CCNPs with `NodeSelectors`. However, the k8s watcher for CCNPs calls `addCiliumNetworkPolicyV2` which takes a `types.SlimCNP` and therefore calls `CiliumNetworkPolicy.Parse()`.

This commit implements a temporary fix for this regression by manually construction a CCNP object from `CiliumNetworkPolicy.Parse()` when the namespace is empty (CNP is actually a CCNP) and parsing that instead of the CNP object. It also adds a new unit test to check this behavior.

Fixes: #12834
Fixes: #11607

@christarazi Should we leave #12834 open until this is properly fixed, or is it okay to close it with this PR?