### PR TITLE
Speed up runtime CI cleanup in AfterAll function

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -158,8 +158,8 @@ func (s *SSHMeta) SetAndWaitForEndpointConfiguration(endpointID, optionName, exp
 // is exceeded, false otherwise.
 func (s *SSHMeta) WaitEndpointsDeleted() bool {
 	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsDeleted"})
-	// cilium-health endpoint is always running.
-	desiredState := "1"
+	// cilium-health endpoint is always running, as is the host endpoint.
+	desiredState := "2"
 	body := func() bool {
 		cmd := `cilium endpoint list -o json | jq '. | length'`
 		res := s.Exec(cmd)


### PR DESCRIPTION
Since Cilium v1.8.0, there is typically two endpoints remaining after
all cleanup: One for the health endpoint and one for the host. This code
was assuming there should only be one, failing for 4 minutes, then
giving up. This just wastes time unnecessarily.

Fix it by correcting the number of endpoints expected after test run.

Fixes: #12863