### PR TITLE
Hubble-Relay: proxy context from originating client

### DIFF
--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -78,7 +78,7 @@ func NewServer(peers PeerListReporter, options ...Option) (*Server, error) {
 // GetFlows implements observerpb.ObserverServer.GetFlows by proxying requests to
 // the hubble instance the proxy is connected to.
 func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, stream observerpb.Observer_GetFlowsServer) error {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 
 	peers := s.peers.List()
@@ -164,9 +164,13 @@ sortedFlowsLoop:
 // ServerStatus implements observerpb.ObserverServer.ServerStatus by aggregating
 // the ServerStatus answer of all hubble peers.
 func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusRequest) (*observerpb.ServerStatusResponse, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	var (
+		cancel context.CancelFunc
+		g      *errgroup.Group
+	)
+	ctx, cancel = context.WithCancel(ctx)
 	defer cancel()
-	g, ctx := errgroup.WithContext(ctx)
+	g, ctx = errgroup.WithContext(ctx)
 
 	peers := s.peers.List()
 	var numConnectedNodes, numUnavailableNodes uint32

--- a/pkg/hubble/relay/observer/server_test.go
+++ b/pkg/hubble/relay/observer/server_test.go
@@ -54,6 +54,9 @@ func TestGetFlows(t *testing.T) {
 		err          error
 		log          []string
 	}
+	fss := &testutils.FakeGRPCServerStream{
+		OnContext: context.TODO,
+	}
 	done := make(chan struct{})
 	tests := []struct {
 		name   string
@@ -125,6 +128,7 @@ func TestGetFlows(t *testing.T) {
 			},
 			req: &observerpb.GetFlowsRequest{Number: 2},
 			stream: &testutils.FakeGetFlowsServer{
+				FakeGRPCServerStream: fss,
 				OnSend: func(resp *observerpb.GetFlowsResponse) error {
 					if resp == nil {
 						return nil
@@ -222,6 +226,7 @@ func TestGetFlows(t *testing.T) {
 			},
 			req: &observerpb.GetFlowsRequest{Number: 2},
 			stream: &testutils.FakeGetFlowsServer{
+				FakeGRPCServerStream: fss,
 				OnSend: func(resp *observerpb.GetFlowsResponse) error {
 					if resp == nil {
 						return nil


### PR DESCRIPTION
The context that comes with the GRPC request has valuable
metadata information in it that is useful for things like
authentication and authorization for downstream servers.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->


```release-note
Hubble-relay now proxies the GRPC context to its servers.
```
