### PR TITLE
test: Update coredns image tag from 1.2.2 to 1.2.6 for k8s 1.12

### DIFF
--- a/test/provision/manifest/1.12/coredns_deployment.yaml
+++ b/test/provision/manifest/1.12/coredns_deployment.yaml
@@ -1,5 +1,7 @@
 # File source
 # https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.12/cluster/addons/dns/coredns/coredns.yaml.base
+# Local changes:
+# 8/13/2020: coredns image updated to 1.2.6 to fix #6307 (jrajahalme)
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -111,7 +113,7 @@ spec:
         operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.2.2
+        image: k8s.gcr.io/coredns:1.2.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Update k8s 1.12 coredns deployment to image tag 1.2.6 to get the bug
fix for loop detection getting confused due to retries
(https://github.com/coredns/coredns/issues/2391).

Fixes: #6307
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
