### PR TITLE
operator: bind provider-specific flags

### DIFF
--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/spf13/viper"
 
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -44,4 +45,6 @@ func init() {
 
 	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
 	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPI)
+
+	viper.BindPFlags(flags)
 }

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/spf13/viper"
 
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -30,4 +31,6 @@ func init() {
 
 	flags.String(operatorOption.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
+
+	viper.BindPFlags(flags)
 }


### PR DESCRIPTION
Provider specific options passed as command line flags are currently
ignore because the flags are not bound. Add the missing viper.BindPFlags
to fix this.

Fixes: #12870
Fixes: 053fc866ab53 ("operator: Build 3 new slimmer binaries")

```release-note
Cilium Operator: bind provider-specific flags for `operator-aws` and `operator-aks`
```