### PR TITLE
v1.7 backports 2020-08-13

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -29,20 +29,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.5.7 <https://github.com/cilium/istio/releases/tag/1.5.7>`_:
+Download the `cilium enhanced istioctl version 1.5.9 <https://github.com/cilium/istio/releases/tag/1.5.9>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-linux.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.9/cilium-istioctl-1.5.9-linux.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.9/cilium-istioctl-1.5.9-osx.tar.gz | tar xz
 
 .. note::
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -485,6 +485,10 @@ func init() {
 		option.KVStoreOpt, "Key-value store options")
 	option.BindEnv(option.KVStoreOpt)
 
+	flags.Duration(option.K8sSyncTimeoutName, defaults.K8sSyncTimeout, "Timeout for synchronizing k8s resources before exiting")
+	flags.MarkHidden(option.K8sSyncTimeoutName)
+	option.BindEnv(option.K8sSyncTimeoutName)
+
 	flags.Uint(option.K8sWatcherQueueSize, 1024, "Queue size used to serialize each k8s event type")
 	option.BindEnv(option.K8sWatcherQueueSize)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -220,6 +220,10 @@ const (
 	// invoked only for endpoints which are selected by policy changes.
 	SelectiveRegeneration = true
 
+	// K8sSyncTimeout specifies the standard time to allow for synchronizing
+	// local caches with Kubernetes state before exiting.
+	K8sSyncTimeout = 3 * time.Minute
+
 	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
 	// should watch for.
 	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager"

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -58,7 +58,6 @@ const (
 	k8sAPIGroupCiliumClusterwideNetworkPolicyV2 = "cilium/v2::CiliumClusterwideNetworkPolicy"
 	k8sAPIGroupCiliumNodeV2                     = "cilium/v2::CiliumNode"
 	k8sAPIGroupCiliumEndpointV2                 = "cilium/v2::CiliumEndpoint"
-	cacheSyncTimeout                            = 3 * time.Minute
 	K8sAPIGroupEndpointSliceV1Beta1Discovery    = "discovery/v1beta1::EndpointSlice"
 
 	metricCNP            = "CiliumNetworkPolicy"
@@ -389,7 +388,7 @@ func (k *K8sWatcher) InitK8sSubsystem() <-chan struct{} {
 		select {
 		case <-cachesSynced:
 			log.Info("All pre-existing resources related to policy have been received; continuing")
-		case <-time.After(cacheSyncTimeout):
+		case <-time.After(option.Config.K8sSyncTimeout):
 			log.Fatalf("Timed out waiting for pre-existing resources related to policy to be received; exiting")
 		}
 	}()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -216,6 +216,9 @@ const (
 	// K8sServiceCacheSize is service cache size for cilium k8s package.
 	K8sServiceCacheSize = "k8s-service-cache-size"
 
+	// K8sSyncTimeout is the timeout to synchronize all resources with k8s.
+	K8sSyncTimeoutName = "k8s-sync-timeout"
+
 	// K8sWatcherQueueSize is the queue size used to serialize each k8s event type
 	K8sWatcherQueueSize = "k8s-watcher-queue-size"
 
@@ -1154,6 +1157,7 @@ type DaemonConfig struct {
 	IPv6ServiceRange              string
 	K8sAPIServer                  string
 	K8sKubeConfigPath             string
+	K8sSyncTimeout                time.Duration
 	K8sWatcherEndpointSelector    string
 	KVStore                       string
 	KVStoreOpt                    map[string]string
@@ -1924,6 +1928,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sServiceCacheSize = uint(viper.GetInt(K8sServiceCacheSize))
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
+	c.K8sSyncTimeout = viper.GetDuration(K8sSyncTimeoutName)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
 	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -36,7 +36,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.5.7"
+		istioVersion = "1.5.9"
 
 		// Modifiers for pre-release testing, normally empty
 		prerelease     = "" // "-beta.1"
@@ -45,9 +45,9 @@ var _ = Describe("K8sIstioTest", func() {
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.7" +
-		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.7" +
-		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.7"
+		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.9" +
+		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.9" +
+		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.9"
 		ciliumOptions = map[string]string{
 			// "global.proxy.sidecarImageRegex": "jrajahalme/istio_proxy",
 		}


### PR DESCRIPTION
 * #12822 -- daemon: Add hidden --k8s-sync-timeout option (@joestringer)
   * Cherry-picking lead to a small, easy to resolve merge conflict in `pkg/option/config.go`.
 * #12861 -- Istio: Update to release 1.5.9 (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12822 12861; do contrib/backporting/set-labels.py $pr done 1.7; done
```
