### PR TITLE
Enable host firewall without remote-node identity

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1142,9 +1142,6 @@ func initEnv(cmd *cobra.Command) {
 		if option.Config.EnableIPSec {
 			log.Fatal("IPSec cannot be used with the host firewall.")
 		}
-		if !option.Config.EnableRemoteNodeIdentity {
-			log.Fatalf("%s must be enabled to use the host firewall.", option.EnableRemoteNodeIdentity)
-		}
 		if option.Config.EnableEndpointRoutes {
 			log.Fatalf("%s cannot be used with the host firewall. Packets must be routed through the host device.", option.EnableEndpointRoutes)
 		}

--- a/examples/policies/host/lock-down-dev-vms.yaml
+++ b/examples/policies/host/lock-down-dev-vms.yaml
@@ -10,7 +10,11 @@ spec:
   # Only ICMP echo/reply messages should be drop if this is commented.
   - fromEntities:
     - remote-node
-    - host
+    - health
+  # Same as above, but for when remote-node identities are disabled.
+  - fromCIDR:
+    - 192.168.33.0/24
+
   # SSH access to the VMs
   - fromEntities:
     - world
@@ -18,9 +22,9 @@ spec:
     - ports:
       - port: "22"
         protocol: TCP
+
   - fromEntities:
     - remote-node
-    - host
     toPorts:
     - ports:
       # VXLAN tunnels between nodes
@@ -34,6 +38,23 @@ spec:
       # kube-api server
       - port: "6443"
         protocol: TCP
+  # Same as above, but for when remote-node identities are disabled.
+  - fromCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      # VXLAN tunnels between nodes
+      - port: "8472"
+        protocol: UDP
+      # etcd connections
+      - port: "2379"
+        protocol: TCP
+      - port: "2380"
+        protocol: TCP
+      # kube-api server
+      - port: "6443"
+        protocol: TCP
+
   # kube-api server access for kube-dns
   - fromEndpoints:
     - matchLabels:
@@ -43,22 +64,33 @@ spec:
     - ports:
       - port: "6443"
         protocol: TCP
+
   # Health checks
   - fromEntities:
     - remote-node
     - health
-    - host
     toPorts:
     - ports:
       - port: "4240"
         protocol: TCP
+  # Same as above, but for when remote-node identities are disabled.
+  - fromCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      - port: "4240"
+        protocol: TCP
+
 
   egress:
   # Only ICMP echo/reply messages should be drop if this is commented.
   - toEntities:
     - remote-node
     - health
-    - host
+  # Same as above, but for when remote-node identities are disabled.
+  - toCIDR:
+    - 192.168.33.0/24
+
   # DNS traffic to kube-dns
   - toEndpoints:
     - matchLabels:
@@ -70,9 +102,9 @@ spec:
         protocol: TCP
       - port: "53"
         protocol: UDP
+
   - toEntities:
     - remote-node
-    - host
     toPorts:
     - ports:
       # VXLAN tunnels between nodes
@@ -86,15 +118,39 @@ spec:
       # kube-api server
       - port: "6443"
         protocol: TCP
+  # Same as above, but for when remote-node identities are disabled.
+  - toCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      # VXLAN tunnels between nodes
+      - port: "8472"
+        protocol: UDP
+      # etcd connections
+      - port: "2379"
+        protocol: TCP
+      - port: "2380"
+        protocol: TCP
+      # kube-api server
+      - port: "6443"
+        protocol: TCP
+
   # Health checks
   - toEntities:
     - remote-node
     - health
-    - host
     toPorts:
     - ports:
       - port: "4240"
         protocol: TCP
+  # Same as above, but for when remote-node identities are disabled.
+  - toCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      - port: "4240"
+        protocol: TCP
+
   # NTP queries
   - toEntities:
     - world
@@ -109,6 +165,7 @@ spec:
     - ports:
       - port: "53"
         protocol: UDP
+
   # Required for host-networking pods of the connectivity-check
   - toEndpoints:
     - matchLabels:

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1353,7 +1353,6 @@ var _ = Describe("K8sPolicyTest", func() {
 					RedeployCiliumWithMerge(kubectl, ciliumFilename, daemonCfg,
 						map[string]string{
 							"global.remoteNodeIdentity": "false",
-							"global.hostFirewall":       "false",
 						})
 				})
 


### PR DESCRIPTION
In 9654cb4, the Cilium agent was made to fatal if the host firewall was enabled while the `remote-node` identity was disabled. This was based on tests using existing policy examples during which the connectivity check was failing.

It turns out the host firewall works fine without the `remote-node` identity. The policy just needs to be adapted to take that into account, by using the node CIDR in place of the `remote-node` identity. This commit thus reverts 9654cb4.

Fixes: #12495