### PR TITLE
CODEOWNERS: Update Kubernetes owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -71,6 +71,7 @@ Dockerfile* @cilium/build
 /Documentation/envoy/ @cilium/proxy
 /envoy/ @cilium/proxy
 /examples/ @cilium/docs
+/examples/crds/ @cilium/kubernetes
 /examples/kubernetes/ @cilium/kubernetes
 /examples/minikube/ @cilium/kubernetes
 *.Jenkinsfile @cilium/ci
@@ -112,7 +113,7 @@ Jenkinsfile.nightly @cilium/ci
 /pkg/ipcache/ @cilium/ipcache
 /pkg/ipmasq @cilium/agent
 /pkg/k8s/ @cilium/kubernetes
-/pkg/k8s/apis/cilium.io/v2/ @cilium/api
+/pkg/k8s/apis/cilium.io/v2/ @cilium/api @cilium/kubernetes
 /pkg/k8s/client/clientset/versioned/ @cilium/api
 /pkg/k8s/client/informers/ @cilium/api
 /pkg/kafka/ @cilium/proxy

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -119,9 +119,9 @@ Jenkinsfile.nightly @cilium/ci
 /pkg/kafka/ @cilium/proxy
 /pkg/kvstore/ @cilium/kvstore
 /pkg/labels @cilium/policy @cilium/api
-/pkg/launcher @pkg/agent
+/pkg/launcher @cilium/agent
 /pkg/loadbalancer @cilium/loadbalancer
-/pkg/lock @pkg/agent
+/pkg/lock @cilium/agent
 /pkg/logging/ @cilium/cli
 /pkg/mac @cilium/bpf
 /pkg/maps/ @cilium/bpf


### PR DESCRIPTION
- examples/crds/ are where generated CRDs are kept.
- pkg/k8s/apis/cilium.io/v2 contains Kubernetes related code especially
  inside `validator`.

Also fix a few typos.