### PR TITLE
images/builder: bump protoc to 3.12.4

### DIFF
--- a/images/builder/install-protoc.sh
+++ b/images/builder/install-protoc.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-protoc_version="3.12.3"
+protoc_version="3.12.4"
 
 curl --fail --show-error --silent --location \
   "https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip" \

--- a/images/builder/test/spec.yaml
+++ b/images/builder/test/spec.yaml
@@ -22,4 +22,4 @@ commandTests:
   command: "protoc"
   args: ["--version"]
   expectedOutput:
-  - 'libprotoc\ 3\.12\.3'
+  - 'libprotoc\ 3\.12\.4'

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:7aa895373c377835481f2036a79d6a2119499560
+ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:8241b166e9576cb45990442509f2128ccbba1978
 ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:b8f4a74bd085c5d28795dbe658b3dca1bf0019d8
 
 FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:7aa895373c377835481f2036a79d6a2119499560
+ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:8241b166e9576cb45990442509f2128ccbba1978
 ARG CA_CERTIFICATES_IMAGE=docker.io/cilium/ca-certificates:69a9f5d66ff96bf97e8b9dc107e92aa9ddbdc9a8
 
 FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:7aa895373c377835481f2036a79d6a2119499560
+ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:8241b166e9576cb45990442509f2128ccbba1978
 ARG CA_CERTIFICATES_IMAGE=docker.io/cilium/ca-certificates:69a9f5d66ff96bf97e8b9dc107e92aa9ddbdc9a8
 
 FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder


### PR DESCRIPTION
protoc was bumped to 3.12.4 in #12808. Bump it in the images as well.