### PR TITLE
v1.8 backports 2020-08-14

### DIFF
--- a/Documentation/gettingstarted/ipam-crd.rst
+++ b/Documentation/gettingstarted/ipam-crd.rst
@@ -50,10 +50,11 @@ Create a CiliumNode CR
              name: "k8s1"
            spec:
              ipam:
-               192.168.1.1: {}
-               192.168.1.2: {}
-               192.168.1.3: {}
-               192.168.1.4: {}
+               pool:
+                 192.168.1.1: {}
+                 192.168.1.2: {}
+                 192.168.1.3: {}
+                 192.168.1.4: {}
 
 #. Validate that Cilium has started up correctly
 
@@ -79,10 +80,11 @@ Create a CiliumNode CR
          [...]
        spec:
          ipam:
-           192.168.1.1: {}
-           192.168.1.2: {}
-           192.168.1.3: {}
-           192.168.1.4: {}
+           pool:
+             192.168.1.1: {}
+             192.168.1.2: {}
+             192.168.1.3: {}
+             192.168.1.4: {}
        status:
          ipam:
            used:
@@ -90,3 +92,7 @@ Create a CiliumNode CR
                owner: router
              192.168.1.3:
                owner: health
+
+.. note::
+
+    At the moment only single IP addresses are allowed. CIDR's are not supported.

--- a/Documentation/gettingstarted/ipam-crd.rst
+++ b/Documentation/gettingstarted/ipam-crd.rst
@@ -40,7 +40,7 @@ Enable CRD IPAM mode
 Create a CiliumNode CR
 ======================
 
-#. Import the following custom resource to make t
+#. Import the following custom resource to make IPs available in the Cilium agent.
 
    .. code-block:: yaml
 

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -29,20 +29,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.5.7 <https://github.com/cilium/istio/releases/tag/1.5.7>`_:
+Download the `cilium enhanced istioctl version 1.5.9 <https://github.com/cilium/istio/releases/tag/1.5.9>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-linux.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.9/cilium-istioctl-1.5.9-linux.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.7/cilium-istioctl-1.5.7-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.9/cilium-istioctl-1.5.9-osx.tar.gz | tar xz
 
 .. note::
 

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/spf13/viper"
 
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -41,4 +42,6 @@ func init() {
 	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(operatorOption.ENITags)
+
+	viper.BindPFlags(flags)
 }

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/spf13/viper"
 
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -30,4 +31,6 @@ func init() {
 
 	flags.String(operatorOption.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
+
+	viper.BindPFlags(flags)
 }

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -158,8 +158,8 @@ func (s *SSHMeta) SetAndWaitForEndpointConfiguration(endpointID, optionName, exp
 // is exceeded, false otherwise.
 func (s *SSHMeta) WaitEndpointsDeleted() bool {
 	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsDeleted"})
-	// cilium-health endpoint is always running.
-	desiredState := "1"
+	// cilium-health endpoint is always running, as is the host endpoint.
+	desiredState := "2"
 	body := func() bool {
 		cmd := `cilium endpoint list -o json | jq '. | length'`
 		res := s.Exec(cmd)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -36,7 +36,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.5.7"
+		istioVersion = "1.5.9"
 
 		// Modifiers for pre-release testing, normally empty
 		prerelease     = "" // "-beta.1"
@@ -45,9 +45,9 @@ var _ = Describe("K8sIstioTest", func() {
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.7" +
-		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.7" +
-		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.7"
+		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.9" +
+		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.9" +
+		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.9"
 		ciliumOptions = map[string]string{
 			// "global.proxy.sidecarImageRegex": "jrajahalme/istio_proxy",
 		}


### PR DESCRIPTION
* #12861 -- Istio: Update to release 1.5.9 (@jrajahalme)
 * #12864 -- Speed up runtime CI cleanup in AfterAll function (@joestringer)
 * #12860 -- Fix docs on ipam-crd (@mmack)
 * #12874 -- docs: fix incomplete statement ipam-crd docs (@fristonio)
 * #12871 -- operator: bind provider-specific flags (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12861 12864 12860 12874 12871; do contrib/backporting/set-labels.py $pr done 1.8; done
```