### PR TITLE
fix endpoint selection for wildcard to/fromEndpoint in CCNP

### DIFF
--- a/Documentation/policy/kubernetes.rst
+++ b/Documentation/policy/kubernetes.rst
@@ -92,8 +92,8 @@ for a fully functional example including pods deployed to different namespaces.
 Example: Allow egress to kube-dns in kube-system namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example allows all pods in the namespace in which the policy is
-created to communicate with kube-dns on port 53/UDP in the ``kube-system``
+The following example allows all pods in the ``public`` namespace in which the
+policy is created to communicate with kube-dns on port 53/UDP in the ``kube-system``
 namespace.
 
 .. only:: html
@@ -202,3 +202,20 @@ namespace to pods matching the labels ``name=leia`` in any namespace.
 .. only:: epub or latex
 
         .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/clusterscope-policy.yaml
+
+Example: Allow all ingress to kube-dns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example allows all Cilium managed endpoints in the cluster to communicate
+with kube-dns on port 53/UDP in the ``kube-system`` namespace.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml

--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -151,11 +151,10 @@ func validateNPResources(
 				cnpName = cnp.GetName()
 			}
 			if err := validator(&cnp); err != nil {
-				log.Errorf("Validating %s '%s': unexpected validation error: %s",
-					shortName, cnpName, err)
+				log.WithField(shortName, cnpName).WithError(err).Error("Unexpected validation error")
 				policyErr = fmt.Errorf("Found invalid %s", shortName)
 			} else {
-				log.Infof("Validating %s '%s': OK!", shortName, cnpName)
+				log.WithField(shortName, cnpName).Info("Validation OK!")
 			}
 		}
 		if cnps.GetContinue() == "" {

--- a/examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+++ b/examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+description: "Policy for ingress allow to kube-dns from all Cilium managed endpoints in the cluster"
+metadata:
+  name: "wildcard-from-endpoints"
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: kube-system
+      k8s-app: kube-dns
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP

--- a/examples/policies/kubernetes/namespace/kubedns-policy.json
+++ b/examples/policies/kubernetes/namespace/kubedns-policy.json
@@ -1,8 +1,10 @@
 [
    {
-      "endpointSelector" : {
-         "matchLabels" : {}
-      },
+      "endpointSelector" :  {
+         "matchLabels": {
+            "k8s:io.kubernetes.pod.namespace": "public"
+         }
+     },
       "egress" : [
          {
             "toEndpoints" : [

--- a/examples/policies/kubernetes/namespace/kubedns-policy.yaml
+++ b/examples/policies/kubernetes/namespace/kubedns-policy.yaml
@@ -2,6 +2,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: "allow-to-kubedns"
+  namespace: public
 spec:
   endpointSelector:
     {}

--- a/pkg/k8s/apis/cilium.io/v2/validator/logfields.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/logfields.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "validator")

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -17,16 +17,21 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/go-openapi/validate"
+	"github.com/sirupsen/logrus"
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// NPValidator is a validator structure used to validate CNP.
+// NPValidator is a validator structure used to validate CNP and CCNP.
 type NPValidator struct {
 	cnpValidator  *validate.SchemaValidator
 	ccnpValidator *validate.SchemaValidator
@@ -105,10 +110,97 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 	return nil
 }
 
+var (
+	// We can remove the check for this warning once 1.9 is the oldest supported Cilium version.
+	warnWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
+		"with a wildcard to/from endpoint selector. The behavior of this selector has been " +
+		"changed. The selector now only allows traffic to/from Cilium managed K8s endpoints, " +
+		"instead of acting as a truly empty endpoint selector allowing all traffic. To " +
+		"ensure that the policy behavior does not affect your workloads, consider adding " +
+		"another policy that allows traffic to/from world and cluster entities. For a more " +
+		"detailed discussion on the topic, see https://github.com/cilium/cilium/issues/12844"
+
+	logOnce sync.Once
+)
+
 // ValidateCCNP validates the given CCNP accordingly the CCNP validation schema.
 func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 	if errs := validation.ValidateCustomResource(nil, &ccnp, n.ccnpValidator); len(errs) > 0 {
 		return errs.ToAggregate()
 	}
+
+	logger := log.WithFields(logrus.Fields{
+		logfields.CiliumClusterwideNetworkPolicyName: ccnp.GetName(),
+	})
+
+	// At this point we have validated the custom resource with the new CRV.
+	// We can try converting it to the new CCNP type.
+	// This should not fail, so we are not returning any errors, just logging
+	// a warning.
+	ccnpBytes, err := ccnp.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	resCCNP := cilium_v2.CiliumClusterwideNetworkPolicy{}
+	err = json.Unmarshal(ccnpBytes, &resCCNP)
+	if err != nil {
+		return err
+	}
+
+	// Print the warninig only once per CCNP.
+	if resCCNP.Spec != nil {
+		if containsWildcardToFromEndpoint(resCCNP.Spec) {
+			logOnce.Do(func() {
+				logger.Warning(warnWildcardToFromEndpointMessage)
+			})
+			return nil
+		}
+	}
+
+	if resCCNP.Specs != nil {
+		for _, rule := range resCCNP.Specs {
+			if containsWildcardToFromEndpoint(rule) {
+				logOnce.Do(func() {
+					logger.Warning(warnWildcardToFromEndpointMessage)
+				})
+				return nil
+			}
+		}
+	}
+
 	return nil
+}
+
+// containsWildcardToFromEndpoint returns true if a CCNP contains an empty endpoint selector
+// in ingress/egress rules.
+// For more information - https://github.com/cilium/cilium/issues/12844#issuecomment-672074170
+func containsWildcardToFromEndpoint(rule *api.Rule) bool {
+	if len(rule.Ingress) > 0 {
+		for _, r := range rule.Ingress {
+			// We only check for the presence of wildcard to/fromEndpoints
+			// in the network policy spec.
+			if len(r.FromEndpoints) > 0 {
+				for _, epSel := range r.FromEndpoints {
+					if epSel.IsWildcard() {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	if len(rule.Egress) > 0 {
+		for _, r := range rule.Egress {
+			if len(r.ToEndpoints) > 0 {
+				for _, epSel := range r.ToEndpoints {
+					if epSel.IsWildcard() {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -298,6 +298,20 @@ func (n *EndpointSelector) AddMatch(key, value string) {
 	n.CachedLabelSelectorString = n.LabelSelector.String()
 }
 
+// AddMatchExpression adds a match expression to label selector of the endpoint selector.
+func (n *EndpointSelector) AddMatchExpression(key string, op slim_metav1.LabelSelectorOperator, values []string) {
+	n.MatchExpressions = append(n.MatchExpressions, slim_metav1.LabelSelectorRequirement{
+		Key:      key,
+		Operator: op,
+		Values:   values,
+	})
+
+	// Update cache of the EndopintSelector from the embedded label selector.
+	// This is to make sure we have updates caches containing the required selectors.
+	n.Requirements = labelSelectorToRequirements(n.LabelSelector)
+	n.CachedLabelSelectorString = n.LabelSelector.String()
+}
+
 // Matches returns true if the endpoint selector Matches the `lblsToMatch`.
 // Returns always true if the endpoint selector contains the reserved label for
 // "all".


### PR DESCRIPTION
See individual commits for more details.

- [x] Fixes #12844 
- [x] Add unit tests.
- [x] Update pre-flight CCNP checks to check for possible required policy upgrade in cluster.

Example of preflight warning.
![image](https://user-images.githubusercontent.com/21292343/90757664-87b9f080-e2fb-11ea-959e-42476e024357.png)

```release-note
Fix endpoint selection for a wildcard to/fromEndpoints in CCNP.
Cilium will only allow access from Cilium-managed endpoints in such cases instead of allowing traffic from any source. Preflight checks, when following the upgrade guide, have been extended to warn users of the new behavior.
```