### PR TITLE
fix: node-init restartPods should use docker if /etc/crictl.yaml not found

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
                     fi
 
                     echo "Waiting on pods to stop..."
-                    if grep -q 'docker' /etc/crictl.yaml; then
+                    if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
                       # Works for COS, ubuntu
                       while docker ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     else
@@ -199,7 +199,7 @@ spec:
 
 {{- if .Values.restartPods }}
               echo "Restarting kubenet managed pods"
-              if grep -q 'docker' /etc/crictl.yaml; then
+              if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
                 # Works for COS, ubuntu
                 # Note the first line is the containerID with a trailing \r
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f "$(sed 's/\r//;1q' $f)" || true; done


### PR DESCRIPTION
This script has several tests for what the container runtime situation
looks like to determine how best to restart the underlying containers
(going around the kubelet) so that the new networking configuration
can take effect.

The first test looks to see if the crictl config file is configured to use
docker, but if that file doesn't exist then it fails. I believe docker
is the default if this hasn't been configured at all so if that file
doesn't exist then use docker.

Fixes #12850

```release-note
node-init restartPods should use docker if /etc/crictl.yaml not found
```

Signed-off-by: Nathan Bird <njbird@infiniteenergy.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
   * not sure where we would test this, open to ideas
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
   * happy to clarify if there are questions, I think I wrote it up well
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
   * happy to clarify if there are questions, I think I wrote it up well
- [x] Thanks for contributing!
  
