### PR TITLE
v1.7: Make EC2 AWS API endpoint configurable in operator

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -29,6 +29,7 @@ cilium-operator [flags]
       --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
       --cnp-status-update-interval duration       interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
   -D, --debug                                     Enable debugging mode
+      --ec2-api-endpoint string                   AWS API endpoint for the EC2 service
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-metrics                            Enable Prometheus metrics

--- a/operator/eni.go
+++ b/operator/eni.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
+	"github.com/cilium/cilium/pkg/aws/endpoints"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/aws/eni/metrics"
 	"github.com/cilium/cilium/pkg/controller"
@@ -28,6 +29,7 @@ import (
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/trigger"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -114,6 +116,7 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags ma
 	}).Info("Connected to EC2 metadata server")
 
 	cfg.Region = instance.Region
+	cfg.EndpointResolver = aws.EndpointResolverFunc(endpoints.Resolver)
 
 	var (
 		ec2Client *ec2shim.Client

--- a/operator/main.go
+++ b/operator/main.go
@@ -193,6 +193,9 @@ func init() {
 	option.BindEnv(option.AwsInstanceLimitMapping)
 	flags.Bool(option.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
 
+	flags.String(option.EC2APIEndpoint, "", "AWS API endpoint for the EC2 service")
+	option.BindEnv(option.EC2APIEndpoint)
+
 	flags.Float32(option.K8sClientQPSLimit, defaults.K8sClientQPSLimit, "Queries per second limit for the K8s client")
 	flags.Int(option.K8sClientBurst, defaults.K8sClientBurst, "Burst value allowed for the K8s client")
 
@@ -251,6 +254,7 @@ func initConfig() {
 	option.Config.DisableCiliumEndpointCRD = viper.GetBool(option.DisableCiliumEndpointCRDName)
 	option.Config.K8sNamespace = viper.GetString(option.K8sNamespaceName)
 	option.Config.AwsReleaseExcessIps = viper.GetBool(option.AwsReleaseExcessIps)
+	option.Config.EC2APIEndpoint = viper.GetString(option.EC2APIEndpoint)
 	option.Config.IdentityGCRateInterval = viper.GetDuration(option.IdentityGCRateInterval)
 	option.Config.IdentityGCRateLimit = viper.GetInt64(option.IdentityGCRateLimit)
 	option.Config.LeaderElectionLeaseDuration = viper.GetDuration(option.LeaderElectionLeaseDuration)

--- a/pkg/aws/endpoints/resolver.go
+++ b/pkg/aws/endpoints/resolver.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "aws-endpoints")
+
+	defaultResolver = endpoints.NewDefaultResolver()
+)
+
+func Resolver(service, region string) (aws.Endpoint, error) {
+	if ep := option.Config.EC2APIEndpoint; len(ep) > 0 && service == "ec2" {
+		log.Debugf("Using custom API endpoint %s for service %s in region %s", ep, service, region)
+		// See https://docs.aws.amazon.com/sdk-for-go/v2/api/aws/endpoints/#hdr-Using_Custom_Endpoints
+		return aws.Endpoint{
+			URL: "https://" + ep,
+		}, nil
+	}
+	return defaultResolver.ResolveEndpoint(service, region)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -646,6 +646,10 @@ const (
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2 API to fill out the instnacetype to adapter limit mapping
 	UpdateEC2AdapterLimitViaAPI = "update-ec2-apdater-limit-via-api"
 
+	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
+	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
+	EC2APIEndpoint = "ec2-api-endpoint"
+
 	// K8sClientQPSLimit is the queries per second limit for the K8s client. Defaults to k8s client defaults.
 	K8sClientQPSLimit = "k8s-client-qps"
 
@@ -1438,6 +1442,10 @@ type DaemonConfig struct {
 	// Enabling this option reduces waste of IP addresses but may increase
 	// the number of API calls to AWS EC2 service.
 	AwsReleaseExcessIps bool
+
+	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
+	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
+	EC2APIEndpoint string
 
 	// EnableWellKnownIdentities enables the use of well-known identities.
 	// This is requires if identiy resolution is required to bring up the

--- a/pkg/policy/groups/aws/aws.go
+++ b/pkg/policy/groups/aws/aws.go
@@ -20,10 +20,12 @@ import (
 	"net"
 	"os"
 
+	"github.com/cilium/cilium/pkg/aws/endpoints"
+	"github.com/cilium/cilium/pkg/policy/api"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 const (
@@ -60,6 +62,7 @@ func initializeAWSAccount(region string) (*aws.Config, error) {
 	}
 	cfg.Region = region
 	cfg.LogLevel = awsLogLevel
+	cfg.EndpointResolver = aws.EndpointResolverFunc(endpoints.Resolver)
 	return &cfg, nil
 }
 


### PR DESCRIPTION
Manual backport of #12835 to 1.7 for #12620

Add a new --ec2-api-endpoint operator option which allows to specify
a custom AWS API endpoints for the EC2 service. One possible use-case
for this is the usage of FIPS endpoints, see
https://aws.amazon.com/compliance/fips/. For example, to use API
endpoint ec2-fips.us-west-1.amazonaws.com, the AWS operator can be
called using:

    cilium-operator --ec2-api-endpoint=ec2-fips.us-west-1.amazonaws.com