### PR TITLE
CNI configmap + dnsPolicy for operator in managed ETCd mode.

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/cni-configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/cni-configmap.yaml
@@ -1,0 +1,35 @@
+{{- $defaultCniVersion := "0.3.1" -}}
+{{- $defaultCniName := "cilium" -}}
+{{- $defaultCniType := "cilium-cni" -}}
+{{- $defaultCniDebug := false -}}
+{{- $defaultCniFirstInterfaceIndex := 1 -}}
+
+{{- if .Values.global.cni.managedConfigmap }}
+# if we want to customize CNI config we can do this in the following path: .global.cni.* after we define .global.cni.managedConfigmap
+# supported config params as of now:
+# .global.cni.version
+# .global.cni.name
+# .global.cni.type
+# .global.cni.debug
+# .global.cni.eni.first-interface-index
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-cni-configuration
+  namespace: {{ .Release.Namespace }}
+data:
+  cni-config: |
+    {
+      "cniVersion": {{ .Values.global.cni.version | default $defaultCniVersion }},
+      "name": {{ .Values.global.cni.name | default $defaultCniName }},
+      "type": {{ .Values.global.cni.type | default $defaultCniType }},
+      "enable-debug": {{ .Values.global.cni.debug | default $defaultCniDebug }},
+{{- if .Values.global.cni.eni }}
+      "eni": {
+        "first-instance-index": {{ .Values.global.cni.eni.first-interface-index | default $defaultCniFirstInterfaceIndex }}
+      }
+{{- end }}
+    }
+{{- end }}
+

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -7,14 +7,7 @@ metadata:
   name: cilium-operator
   namespace: {{ .Release.Namespace }}
 spec:
-  # We support HA mode only for Kubernetes version > 1.14
-  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
-  # for more details.
-{{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
-  replicas: {{ .Values.numReplicas }}
-{{- else }}
   replicas: 1
-{{- end }}
   selector:
     matchLabels:
       io.cilium/app: operator
@@ -31,25 +24,10 @@ spec:
         prometheus.io/port: {{ .Values.global.operatorPrometheus.port | quote }}
         prometheus.io/scrape: "true"
 {{- end }}
-{{- with .Values.podsAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
       labels:
         io.cilium/app: operator
         name: cilium-operator
     spec:
-{{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
-      # In HA mode, cilium-operator pods must not be scheduled on the same
-      # node as they will clash with each other.
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: io.cilium/app
-                operator: In
-                values:
-                - operator
-            topologyKey: "kubernetes.io/hostname"
-{{- end }}
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -85,7 +63,6 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-{{- if .Values.global.eni }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -104,7 +81,6 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-{{- end }}
 {{- if .Values.global.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.global.k8sServiceHost | quote }}
@@ -195,7 +171,7 @@ spec:
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: {{ .Values.global.operator.dnsPolicy | default "ClusterFirstWithHostNet" }}
 {{- end }}
       restartPolicy: Always
 {{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")}}


### PR DESCRIPTION
Bump chart version to 1.8.3
Fixes: 
1. No Helm way to provide CNI config for cilium. So we introduce template to do this.
2. Introduce configurable dnsPolicy when managed ETCd is used.

Description:
1. if we want to customize CNI config we can do this in the following path: `.global.cni.*` after we define `.global.cni.managedConfigmap`. Before that the only way to customize CNI config was to manually create configmap and provide it as param `.global.cni.configMap` for the helm install. Usable in combination with `.global.cni.configMap=cilium-cni-configuration`

This is not breaking change for existing installations.

Supported config params as of now:
`.global.cni.version`
`.global.cni.name`
`.global.cni.type`
`.global.cni.debug`
`.global.cni.eni.first-interface-index`

2. In my case chart v1.8.2 wasn't able to provide functioning Cilium installation on clean EKS cluster if I tried to install Cilium with managed ETCd. So to fix the chicken-egg issue I introducing param `.global.operator.dnsPolicy` which is usable only if we enabled `.global.etcd.managed`. By default `.global.operator.dnsPolicy` is falling back to `ClusterFirstWithHostNet` and for me value `Default` is the fix. 

So this isn't a breaking change for existing installations.

Supported config params as of now:
`.global.operator.dnsPolicy`

