### PR TITLE
CNI configmap + dnsPolicy for operator in managed ETCd mode.

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -63,6 +63,33 @@ Deploy Cilium release via Helm:
    the security groups for pod ENIs are derived from the primary ENI
    (``eth0``).
 
+.. note::
+
+   For AWS managed cluster (EKS) Cilium in CNI mode uses by default interface (ENI)
+   starting from 1 for pods IP allocation so effectively excluding 1 ENI (index 0), 
+   hence reducing pods IP pool. This should be taken into account creating 
+   clusters / deploying Cilium. Without special K8s/EKS configuration pods may and will 
+   become unschedulable in some cases. 
+
+   If you don't want to change K8s cluster configuration for any reason - there is another way. 
+   You may use params:
+
+   .. parsed-literal::
+
+      --set global.cni.managedConfigmap=true \\
+      --set global.cni.eni.first_interface_index=0 \\
+      --set global.cni.configMap=cilium-cni-configuration
+
+
+   Additional params you may use to configure CNI:
+
+   .. parsed-literal::
+
+      --set global.cni.name=cilium \\
+      --set global.cni.version="0.3.1" \\
+      --set global.cni.type=cilium-cni \\
+      --set global.cni.debug=false
+
 .. include:: aws-create-nodegroup.rst
 .. include:: k8s-install-validate.rst
 .. include:: namespace-kube-system.rst

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -108,6 +108,34 @@ Deploy Cilium release via Helm:
    Excluding the lines for ``global.eni=true`` and ``global.tunnel=disabled`` from the
    helm command will configure Cilium to use overlay routing mode (which is the helm default).
 
+.. note::
+
+   For AWS managed cluster (EKS) Cilium in CNI mode uses by default interface (ENI)
+   starting from 1 for pods IP allocation so effectively excluding 1 ENI (index 0), 
+   hence reducing pods IP pool. This should be taken into account creating 
+   clusters / deploying Cilium. Without special K8s/EKS configuration pods may and will 
+   become unschedulable in some cases. 
+
+   If you don't want to change K8s cluster configuration for any reason - there is another way. 
+   You may use params:
+
+   .. parsed-literal::
+
+      --set global.cni.managedConfigmap=true \\
+      --set global.cni.eni.first_interface_index=0 \\
+      --set global.cni.configMap=cilium-cni-configuration
+
+
+   Additional params you may use to configure CNI:
+
+   .. parsed-literal::
+
+      --set global.cni.name=cilium \\
+      --set global.cni.version="0.3.1" \\
+      --set global.cni.type=cilium-cni \\
+      --set global.cni.debug=false
+
+
 .. include:: aws-create-nodegroup.rst
 .. include:: k8s-install-validate.rst
 .. include:: namespace-kube-system.rst

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -40,7 +40,8 @@ Deploy Cilium release via Helm:
    helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
       --set global.etcd.enabled=true \\
-      --set global.etcd.managed=true
+      --set global.etcd.managed=true \\
+      --set global.operator.dnsPolicy="Default"
 
 
 Validate the Installation

--- a/install/kubernetes/cilium/charts/config/templates/cni-configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/cni-configmap.yaml
@@ -1,0 +1,35 @@
+{{- $defaultCniVersion := "0.3.1" -}}
+{{- $defaultCniName := "cilium" -}}
+{{- $defaultCniType := "cilium-cni" -}}
+{{- $defaultCniDebug := false -}}
+{{- $defaultCniFirstInterfaceIndex := 1 -}}
+
+{{- if .Values.global.cni.managedConfigmap }}
+# if we want to customize CNI config we can do this in the following path: .global.cni.* after we define .global.cni.managedConfigmap
+# supported config params as of now:
+# .global.cni.version
+# .global.cni.name
+# .global.cni.type
+# .global.cni.debug
+# .global.cni.eni.first_interface_index
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-cni-configuration
+  namespace: {{ .Release.Namespace }}
+data:
+  cni-config: |
+    {
+      "cniVersion": {{ .Values.global.cni.version | default $defaultCniVersion }},
+      "name": {{ .Values.global.cni.name | default $defaultCniName }},
+      "type": {{ .Values.global.cni.type | default $defaultCniType }},
+      "enable-debug": {{ .Values.global.cni.debug | default $defaultCniDebug }},
+{{- if .Values.global.cni.eni }}
+      "eni": {
+        "first-instance-index": {{ .Values.global.cni.eni.first_interface_index | default $defaultCniFirstInterfaceIndex }}
+      }
+{{- end }}
+    }
+{{- end }}
+

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: {{ .Values.global.operator.dnsPolicy | default "ClusterFirstWithHostNet" }}
 {{- end }}
       restartPolicy: Always
 {{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")}}


### PR DESCRIPTION
Fixes: 
1. No Helm way to provide CNI config for cilium. So we introduce template to do this.
2. Introduce configurable dnsPolicy when managed ETCd is used.

Description:
1. if we want to customize CNI config we can do this in the following path: `.global.cni.*` after we define `.global.cni.managedConfigmap`. Before that the only way to customize CNI config was to manually create configmap and provide it as param `.global.cni.configMap` for the helm install. Usable in combination with `.global.cni.configMap=cilium-cni-configuration`

This is not breaking change for existing installations.

Supported config params as of now:
`.global.cni.version`
`.global.cni.name`
`.global.cni.type`
`.global.cni.debug`
`.global.cni.eni.first_interface_index`

2. In my case chart v1.8.2 wasn't able to provide functioning Cilium installation on clean EKS cluster if I tried to install Cilium with managed ETCd. So to fix the chicken-egg issue I introducing param `.global.operator.dnsPolicy` which is usable only if we enabled `.global.etcd.managed`. By default `.global.operator.dnsPolicy` is falling back to `ClusterFirstWithHostNet` and for me value `Default` is the fix. 

So this isn't a breaking change for existing installations.

Supported config params as of now:
`.global.operator.dnsPolicy`

