### PR TITLE
hubble-relay: add support for (m)TLS

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -323,6 +323,15 @@ Annotations:
 -----------------
 
 * Cilium has bumped the minimal kubernetes version supported to v1.12.0.
+* Connections between Hubble server and Hubble Relay instances is now secured
+  via mutual TLS (mTLS) by default. Users who have opted to enable Hubble Relay
+  in v1.8 (a beta feature) will experience disruptions of the Hubble Relay
+  service during the upgrade process.
+  Users may opt to disable mTLS by using the following Helm options when
+  upgrading (strongly discouraged):
+
+  - ``global.hubble.tls.enabled=false``
+  - ``global.hubble.tls.auto.enabled=false``
 
 Renamed Metrics
 ~~~~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -466,6 +466,7 @@ loopback
 lspci
 luke
 lwt
+mTLS
 macOS
 masq
 masqLinkLocal

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	v "github.com/cilium/cilium/pkg/version"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // New creates a new hubble-relay command.
@@ -32,11 +33,19 @@ func New() *cobra.Command {
 		SilenceUsage: true,
 		Version:      v.GetCiliumVersion().Version,
 	}
+	vp := newViper()
 	rootCmd.AddCommand(
 		completion.New(),
-		serve.New(),
+		serve.New(vp),
 		version.New(),
 	)
 	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\n")
 	return rootCmd
+}
+
+func newViper() *viper.Viper {
+	vp := viper.New()
+	vp.SetEnvPrefix("relay")
+	vp.AutomaticEnv()
+	return vp
 }

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -18,11 +18,16 @@ import (
 	"github.com/cilium/cilium/hubble-relay/cmd/completion"
 	"github.com/cilium/cilium/hubble-relay/cmd/serve"
 	"github.com/cilium/cilium/hubble-relay/cmd/version"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	v "github.com/cilium/cilium/pkg/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// configFilePath defines where the hubble-relay config file should be found.
+const configFilePath = "/etc/hubble-relay/config.yaml"
 
 // New creates a new hubble-relay command.
 func New() *cobra.Command {
@@ -33,7 +38,11 @@ func New() *cobra.Command {
 		SilenceUsage: true,
 		Version:      v.GetCiliumVersion().Version,
 	}
+	logger := logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay")
 	vp := newViper()
+	if err := vp.ReadInConfig(); err != nil {
+		logger.WithError(err).Warnf("Failed to read config from file '%s'", configFilePath)
+	}
 	rootCmd.AddCommand(
 		completion.New(),
 		serve.New(vp),
@@ -46,6 +55,7 @@ func New() *cobra.Command {
 func newViper() *viper.Viper {
 	vp := viper.New()
 	vp.SetEnvPrefix("relay")
+	vp.SetConfigFile(configFilePath)
 	vp.AutomaticEnv()
 	return vp
 }

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -98,7 +98,8 @@ func runServe(vp *viper.Viper) error {
 		server.WithRetryTimeout(vp.GetDuration(keyRetryTimeout)),
 		server.WithSortBufferMaxLen(vp.GetInt(keySortBufferMaxLen)),
 		server.WithSortBufferDrainTimeout(vp.GetDuration(keySortBufferDrainTimeout)),
-		server.WithInsecure(), //FIXME: add option to set server and client TLS settings
+		server.WithInsecureClient(), //FIXME: add option to set client TLS settings
+		server.WithInsecureServer(), //FIXME: add option to set server TLS settings
 	}
 	if vp.GetBool(keyDebug) {
 		opts = append(opts, server.WithDebug())

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -96,6 +96,7 @@ func runServe(f flags) error {
 		server.WithRetryTimeout(f.retryTimeout),
 		server.WithSortBufferMaxLen(f.sortBufferMaxLen),
 		server.WithSortBufferDrainTimeout(f.sortBufferDrainTimeout),
+		server.WithInsecure(), //FIXME: add option to set server and client TLS settings
 	}
 	if f.debug {
 		opts = append(opts, server.WithDebug())

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/configmap.yaml
@@ -23,3 +23,16 @@ data:
 {{- if .Values.sortBufferDrainTimeout }}
     sort-buffer-drain-timeout: {{ .Values.sortBufferDrainTimeout }}
 {{- end }}
+{{- if .Values.global.hubble.tls.enabled }}
+    tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
+    tls-client-key-file: /var/lib/hubble-relay/tls/client.key
+    tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
+{{- else }}
+    disable-client-tls: true
+{{- end}}
+{{- if .Values.global.hubble.relay.tls.enabled }}
+    tls-server-cert-file: /var/lib/hubble-relay/tls/server.crt
+    tls-server-key-file: /var/lib/hubble-relay/tls/server.key
+{{- else }}
+    disable-server-tls: true
+{{- end}}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/configmap.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-relay-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |
+    peer-service: unix://{{ .Values.global.hubble.socketPath }}
+    listen-address: {{ .Values.listenHost }}:{{ .Values.listenPort }}
+{{- if .Values.global.debug.enabled }}
+    debug: true
+{{- end }}
+{{- if .Values.dialTimeout }}
+    dial-timeout: {{ .Values.dialTimeout }}
+{{- end }}
+{{- if .Values.retryTimeout }}
+    retry-timeout: {{ .Values.retryTimeout }}
+{{- end }}
+{{- if .Values.sortBufferLenMax }}
+    sort-buffer-len-max: {{ .Values.sortBufferLenMax }}
+{{- end }}
+{{- if .Values.sortBufferDrainTimeout }}
+    sort-buffer-drain-timeout: {{ .Values.sortBufferDrainTimeout }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -39,23 +39,6 @@ spec:
             - "hubble-relay"
           args:
             - "serve"
-            - "--peer-service=unix://{{ .Values.global.hubble.socketPath }}"
-            - "--listen-address={{ .Values.listenHost }}:{{ .Values.listenPort }}"
-{{- if .Values.global.debug.enabled }}
-            - "--debug=true"
-{{- end }}
-{{- if .Values.dialTimeout }}
-            - "--dial-timeout={{ .Values.dialTimeout }}"
-{{- end }}
-{{- if .Values.retryTimeout }}
-            - "--retry-timeout={{ .Values.retryTimeout }}"
-{{- end }}
-{{- if .Values.sortBufferLenMax }}
-            - "--sort-buffer-len-max={{ .Values.sortBufferLenMax }}"
-{{- end }}
-{{- if .Values.sortBufferDrainTimeout }}
-            - "--sort-buffer-drain-timeout={{ .Values.sortBufferDrainTimeout }}"
-{{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.listenPort }}
@@ -73,11 +56,20 @@ spec:
           - mountPath: {{ dir .Values.global.hubble.socketPath }}
             name: hubble-sock-dir
             readOnly: true
+          - mountPath: /etc/hubble-relay
+            name: config
+            readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
       tolerations:
       - operator: Exists
       volumes:
+      - configMap:
+          name: hubble-relay-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+        name: config
       - hostPath:
           path: {{ dir .Values.global.hubble.socketPath }}
           type: Directory

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
           - mountPath: /etc/hubble-relay
             name: config
             readOnly: true
+{{- if or (.Values.global.hubble.tls.enabled) (.Values.global.hubble.relay.tls.enabled) }}
+          - mountPath: /var/lib/hubble-relay/tls
+            name: tls
+            readOnly: true
+{{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
       tolerations:
@@ -74,3 +79,31 @@ spec:
           path: {{ dir .Values.global.hubble.socketPath }}
           type: Directory
         name: hubble-sock-dir
+{{- if or (.Values.global.hubble.tls.enabled) (.Values.global.hubble.relay.tls.enabled) }}
+      - projected:
+          sources:
+{{- if .Values.global.hubble.tls.enabled }}
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+          - configMap:
+              name: hubble-ca-cert
+              items:
+                - key: ca.crt
+                  path: hubble-server-ca.crt
+{{- end }}
+{{- if .Values.global.hubble.relay.tls.enabled }}
+          - secret:
+              name: hubble-relay-server-certs
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.key
+                  path: server.key
+{{- end }}
+        name: tls
+{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/service.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
     k8s-app: {{ .Chart.Name }}
   ports:
   - protocol: TCP
+{{- if .Values.servicePort }}
     port: {{ .Values.servicePort }}
+{{- else if .Values.global.hubble.relay.tls.enabled }}
+    port: 443
+{{- else }}
+    port: 80
+{{- end }}
     targetPort: {{ .Values.listenPort }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -34,7 +34,9 @@ sortBufferLenMax: ~
 sortBufferDrainTimeout: ~
 
 # Port to use for the k8s service backed by hubble-relay pods.
-servicePort: 80
+# If not set, it is dynamically assigned to port 443 if TLS is enabled and to
+# port 80 if not.
+servicePort:
 
 # Specifies annotation for service accounts
 serviceAccount:

--- a/install/kubernetes/cilium/charts/hubble-tls/templates/secret.yaml
+++ b/install/kubernetes/cilium/charts/hubble-tls/templates/secret.yaml
@@ -45,15 +45,29 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: hubble-relay-certs
+  name: hubble-relay-client-certs
   namespace: {{ .Release.Namespace }}
 type: kubernetes.io/tls
 data:
 {{- if and (.Values.global.hubble.tls.auto.enabled) (eq .Values.global.hubble.tls.auto.method "helm") }}
 {{ include "relay.gen-certs" . | indent 2 }}
 {{- else }}
-  tls.crt: {{ .Values.relay.crt }}
-  tls.key: {{ .Values.relay.key }}
+  tls.crt: {{ .Values.relay.client.crt }}
+  tls.key: {{ .Values.relay.client.key }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubble-relay-server-certs
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/tls
+data:
+{{- if and (.Values.global.hubble.tls.auto.enabled) (eq .Values.global.hubble.tls.auto.method "helm") }}
+{{ include "relay.gen-certs" . | indent 2 }}
+{{- else }}
+  tls.crt: {{ .Values.relay.server.crt }}
+  tls.key: {{ .Values.relay.server.key }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/hubble-tls/templates/secret.yaml
+++ b/install/kubernetes/cilium/charts/hubble-tls/templates/secret.yaml
@@ -55,6 +55,8 @@ data:
   tls.crt: {{ .Values.relay.client.crt }}
   tls.key: {{ .Values.relay.client.key }}
 {{- end }}
+{{- end }}
+{{- if .Values.global.hubble.relay.tls.enabled }}
 ---
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/charts/hubble-tls/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-tls/values.yaml
@@ -8,5 +8,9 @@ server:
   key:
 # base64 encoded PEM values for hubble relay certificate and private key
 relay:
-  crt:
-  key:
+  client:
+    crt:
+    key:
+  server:
+    crt:
+    key:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -549,6 +549,9 @@ global:
     # Configures the hubble-relay subchart
     relay:
       enabled: false
+      tls:
+        # Enable TLS on the server address.
+        enabled: false
 
   # CI specific options: DO NOT USE IN PRODUCTION.
   ci:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -501,7 +501,7 @@ global:
       # Enable mutual TLS for listenAddress. Setting this value to false is
       # highly discouraged as the Hubble API provides access to potentially
       # sensitive network flow metadata and is exposed on the host network.
-      enabled: false
+      enabled: true
       # Configure automatic TLS certificates generation.
       auto:
         # When set to true, automatically generate a CA and certificates to

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -164,6 +164,19 @@ data:
   cluster-pool-ipv4-mask-size: "24"
   disable-cnp-status-updates: "true"
 ---
+# Source: cilium/charts/hubble-relay/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-relay-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    peer-service: unix:///var/run/cilium/hubble.sock
+    listen-address: :4245
+    disable-client-tls: true
+    disable-server-tls: true
+---
 # Source: cilium/charts/agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -739,8 +752,6 @@ spec:
             - "hubble-relay"
           args:
             - "serve"
-            - "--peer-service=unix:///var/run/cilium/hubble.sock"
-            - "--listen-address=:4245"
           ports:
             - name: grpc
               containerPort: 4245
@@ -754,11 +765,20 @@ spec:
           - mountPath: /var/run/cilium
             name: hubble-sock-dir
             readOnly: true
+          - mountPath: /etc/hubble-relay
+            name: config
+            readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
       tolerations:
       - operator: Exists
       volumes:
+      - configMap:
+          name: hubble-relay-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+        name: config
       - hostPath:
           path: /var/run/cilium
           type: Directory

--- a/pkg/hubble/peer/types/peer.go
+++ b/pkg/hubble/peer/types/peer.go
@@ -38,6 +38,13 @@ type Peer struct {
 
 	// Address is the address of the peer's gRPC service.
 	Address net.Addr
+
+	// TLSEnabled indicates whether the service offered by the peer has TLS
+	// enabled.
+	TLSEnabled bool
+
+	// TLSServerName is the name the TLS certificate should be matched to.
+	TLSServerName string
 }
 
 // FromChangeNotification creates a new Peer from a ChangeNotification.
@@ -84,9 +91,17 @@ func FromChangeNotification(cn *peerpb.ChangeNotification) *Peer {
 	if err != nil {
 		addr = (net.Addr)(nil)
 	}
+	var tlsEnabled bool
+	var tlsServerName string
+	if tls := cn.GetTls(); tls != nil {
+		tlsEnabled = true
+		tlsServerName = tls.GetServerName()
+	}
 	return &Peer{
-		Name:    cn.GetName(),
-		Address: addr,
+		Name:          cn.GetName(),
+		Address:       addr,
+		TLSEnabled:    tlsEnabled,
+		TLSServerName: tlsServerName,
 	}
 }
 

--- a/pkg/hubble/peer/types/peer_test.go
+++ b/pkg/hubble/peer/types/peer_test.go
@@ -149,6 +149,39 @@ func TestFromChangeNotification(t *testing.T) {
 					Net:  "unix",
 				},
 			},
+		}, {
+			name: "with an IPv4 address and port and TLS enabled",
+			arg: &peerpb.ChangeNotification{
+				Name:    "name",
+				Address: "192.0.2.1:4000",
+				Tls:     &peerpb.TLS{},
+			},
+			want: &Peer{
+				Name: "name",
+				Address: &net.TCPAddr{
+					IP:   net.ParseIP("192.0.2.1"),
+					Port: 4000,
+				},
+				TLSEnabled: true,
+			},
+		}, {
+			name: "with an IPv4 address and port and TLS enabled with server name",
+			arg: &peerpb.ChangeNotification{
+				Name:    "name",
+				Address: "192.0.2.1:4000",
+				Tls: &peerpb.TLS{
+					ServerName: "name.default.hubble-grpc.cilium.io",
+				},
+			},
+			want: &Peer{
+				Name: "name",
+				Address: &net.TCPAddr{
+					IP:   net.ParseIP("192.0.2.1"),
+					Port: 4000,
+				},
+				TLSEnabled:    true,
+				TLSServerName: "name.default.hubble-grpc.cilium.io",
+			},
 		},
 	}
 

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -319,8 +319,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 	m.opts.log.WithFields(logrus.Fields{
 		"address": p.Address,
 	}).Debugf("Connecting peer %s...", p.Name)
-	//FIXME: provide hostname to ClientConn
-	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), "")
+	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), p.TLSServerName)
 	if err != nil {
 		duration := m.opts.backoff.Duration(p.connAttempts)
 		p.nextConnAttempt = now.Add(duration)

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -317,7 +317,8 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 	m.opts.log.WithFields(logrus.Fields{
 		"address": p.Address,
 	}).Debugf("Connecting peer %s...", p.Name)
-	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String())
+	//FIXME: provide hostname to ClientConn
+	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), "")
 	if err != nil {
 		duration := m.opts.backoff.Duration(p.connAttempts)
 		p.nextConnAttempt = now.Add(duration)

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -210,8 +210,10 @@ func (m *PeerManager) List() []poolTypes.Peer {
 		// note: there shouldn't be null entries in the map
 		peers = append(peers, poolTypes.Peer{
 			Peer: peerTypes.Peer{
-				Name:    v.Name,
-				Address: v.Address,
+				Name:          v.Name,
+				Address:       v.Address,
+				TLSEnabled:    v.TLSEnabled,
+				TLSServerName: v.TLSServerName,
 			},
 			Conn: v.conn,
 		})

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -152,7 +152,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			ccBuilder: FakeClientConnBuilder{
-				OnClientConn: func(target string) (poolTypes.ClientConn, error) {
+				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					return nil, io.EOF
 				},
 			},
@@ -203,7 +203,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			ccBuilder: FakeClientConnBuilder{
-				OnClientConn: func(target string) (poolTypes.ClientConn, error) {
+				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					var once sync.Once
 					return testutils.FakeClientConn{
 						OnGetState: func() connectivity.State {
@@ -267,7 +267,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			ccBuilder: FakeClientConnBuilder{
-				OnClientConn: func(target string) (poolTypes.ClientConn, error) {
+				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					return testutils.FakeClientConn{
 						OnGetState: func() connectivity.State {
 							return connectivity.Ready
@@ -311,7 +311,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			ccBuilder: FakeClientConnBuilder{
-				OnClientConn: func(target string) (poolTypes.ClientConn, error) {
+				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					var once sync.Once
 					return testutils.FakeClientConn{
 						OnGetState: func() connectivity.State {
@@ -375,7 +375,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			ccBuilder: FakeClientConnBuilder{
-				OnClientConn: func(target string) (poolTypes.ClientConn, error) {
+				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					var i int
 					return testutils.FakeClientConn{
 						OnGetState: func() connectivity.State {
@@ -449,7 +449,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			ccBuilder: FakeClientConnBuilder{
-				OnClientConn: func(target string) (poolTypes.ClientConn, error) {
+				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					return nil, nil
 				},
 			},
@@ -508,7 +508,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			ccBuilder: FakeClientConnBuilder{
-				OnClientConn: func(target string) (poolTypes.ClientConn, error) {
+				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					close(done)
 					return nil, errors.New("Don't feel like workin' today")
 				},
@@ -630,12 +630,12 @@ func (n ByName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n ByName) Less(i, j int) bool { return n[i].Name < n[j].Name }
 
 type FakeClientConnBuilder struct {
-	OnClientConn func(target string) (poolTypes.ClientConn, error)
+	OnClientConn func(target, hostname string) (poolTypes.ClientConn, error)
 }
 
-func (b FakeClientConnBuilder) ClientConn(target string) (poolTypes.ClientConn, error) {
+func (b FakeClientConnBuilder) ClientConn(target, hostname string) (poolTypes.ClientConn, error) {
 	if b.OnClientConn != nil {
-		return b.OnClientConn(target)
+		return b.OnClientConn(target, hostname)
 	}
 	panic("OnClientConn not set")
 }

--- a/pkg/hubble/relay/pool/types/client.go
+++ b/pkg/hubble/relay/pool/types/client.go
@@ -43,6 +43,7 @@ var _ ClientConn = (*grpc.ClientConn)(nil)
 
 // ClientConnBuilder wraps the ClientConn method.
 type ClientConnBuilder interface {
-	// ClientConn creates a new ClientConn using target.
-	ClientConn(target string) (ClientConn, error)
+	// ClientConn creates a new ClientConn using target as the address and,
+	// optionally, hostname.
+	ClientConn(target, hostname string) (ClientConn, error)
 }


### PR DESCRIPTION
This PR adds support for TLS and mTLS to Hubble Relay. This allows to configure (m)TLS for the server as well as when establishing connections to peers in the cluster.

Note: This PR depends on #12906.

Ref: #11224