### PR TITLE
docs/metrics: Correct label typos in metrics.rst

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -300,7 +300,7 @@ Kubernetes
 ======================================== ================================================== ========================================================
 Name                                     Labels                                             Description
 ======================================== ================================================== ========================================================
-``kubernetes_events_received_total``     ``scope``, ``action``, ``validity``, ``equiality`` Number of Kubernetes events received
+``kubernetes_events_received_total``     ``scope``, ``action``, ``validity``, ``equal``     Number of Kubernetes events received
 ``kubernetes_events_total``              ``scope``, ``action``, ``outcome``                 Number of Kubernetes events processed
 ``k8s_cnp_status_completion_seconds``    ``attempts``, ``outcome``                          Duration in seconds in how long it took to complete a CNP status update
 ======================================== ================================================== ========================================================


### PR DESCRIPTION
This PR is to correct simple typos in metrics.rst

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Saw this while working on #12826 

```release-note
docs/metrics: Correct label typos in metrics.rst
```
