### PR TITLE
Relay: handle peer without address

### DIFF
--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -96,7 +96,7 @@ func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, stream observerpb.Obs
 	for _, p := range peers {
 		p := p
 		if !isAvailable(p.Conn) {
-			s.opts.log.WithField("address", p.Address.String()).Infof(
+			s.opts.log.WithField("address", p.Address).Infof(
 				"No connection to peer %s, skipping", p.Name,
 			)
 			s.peers.ReportOffline(p.Name)
@@ -176,7 +176,7 @@ func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusR
 		p := p
 		if !isAvailable(p.Conn) {
 			numUnavailableNodes++
-			s.opts.log.WithField("address", p.Address.String()).Infof(
+			s.opts.log.WithField("address", p.Address).Infof(
 				"No connection to peer %s, skipping", p.Name,
 			)
 			s.peers.ReportOffline(p.Name)

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -297,7 +297,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	now := time.Now()
-	if p.nextConnAttempt.After(now) && !ignoreBackoff {
+	if p.Address == nil || (p.nextConnAttempt.After(now) && !ignoreBackoff) {
 		return
 	}
 	if p.conn != nil {


### PR DESCRIPTION
There are multiple cases where `pkg/hubble/peer/types/peer.FromChangeNotification` can return a non-nil `Peer`struct having a nil `Address` field. Notably, we could receive a `ChangeNotification` with an empty address from the peer service, see https://github.com/cilium/cilium/blob/85600be8c0d73ca564661979f37c37e63340cd2d/pkg/hubble/peer/handler.go#L133-L145

Codepath using the `pkg/hubble/peer/types/peer.Peer` struct assume that its `Address` field can not be nil.

I see two ways to address this: (1) modify `FromChangeNotification` to never return a `Peer` with a nil `Address` field (i.e. return nil instead) or (2) handle the nil `Address` case everywhere. The former is tempting because a simpler invariant yield simpler code, but since there are multiple cases where `Address` can be nil (amonst them DNS resolution failure) there is some value to have it reported as unreachable peer by status and `NodeState_NODE_UNAVAILABLE` by GetFlows. Thus, this PR implement the latter proposition.