### PR TITLE
v1.8: Make EC2 AWS API endpoint configurable in operator

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -30,6 +30,7 @@ cilium-operator-aws [flags]
       --config-dir string                         Configuration directory that contains a file for each option
       --crd-wait-timeout duration                 Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                     Enable debugging mode
+      --ec2-api-endpoint string                   AWS API endpoint for the EC2 service
       --enable-ipv4                               Enable IPv4 support (default true)
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -32,6 +32,7 @@ cilium-operator [flags]
       --config-dir string                         Configuration directory that contains a file for each option
       --crd-wait-timeout duration                 Operator will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                     Enable debugging mode
+      --ec2-api-endpoint string                   AWS API endpoint for the EC2 service
       --enable-ipv4                               Enable IPv4 support (default true)
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -156,6 +156,10 @@ const (
 	// API to fill out the instnacetype to adapter limit mapping.
 	UpdateEC2AdapterLimitViaAPI = "update-ec2-apdater-limit-via-api"
 
+	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
+	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
+	EC2APIEndpoint = "ec2-api-endpoint"
+
 	// Azure options
 
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
@@ -297,6 +301,10 @@ type OperatorConfig struct {
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2 API to fill out the instnacetype to adapter limit mapping
 	UpdateEC2AdapterLimitViaAPI bool
 
+	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
+	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
+	EC2APIEndpoint string
+
 	// Azure options
 
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
@@ -354,6 +362,7 @@ func (c *OperatorConfig) Populate() {
 
 	c.AWSReleaseExcessIPs = viper.GetBool(AWSReleaseExcessIPs)
 	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
+	c.EC2APIEndpoint = viper.GetString(EC2APIEndpoint)
 
 	// Azure options
 

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -43,5 +43,8 @@ func init() {
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(operatorOption.ENITags)
 
+	flags.String(operatorOption.EC2APIEndpoint, "", "AWS API endpoint for the EC2 service")
+	option.BindEnv(operatorOption.EC2APIEndpoint)
+
 	viper.BindPFlags(flags)
 }

--- a/pkg/aws/endpoints/resolver.go
+++ b/pkg/aws/endpoints/resolver.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "aws-endpoints")
+
+	defaultResolver = endpoints.NewDefaultResolver()
+)
+
+func Resolver(service, region string) (aws.Endpoint, error) {
+	if ep := operatorOption.Config.EC2APIEndpoint; len(ep) > 0 && service == "ec2" {
+		log.Debugf("Using custom API endpoint %s for service %s in region %s", ep, service, region)
+		// See https://docs.aws.amazon.com/sdk-for-go/v2/api/aws/endpoints/#hdr-Using_Custom_Endpoints
+		return aws.Endpoint{
+			URL: "https://" + ep,
+		}, nil
+	}
+	return defaultResolver.ResolveEndpoint(service, region)
+}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -22,6 +22,7 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
+	"github.com/cilium/cilium/pkg/aws/endpoints"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
@@ -29,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -82,6 +84,7 @@ func (*AllocatorAWS) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (allocato
 	}).Info("Connected to EC2 metadata server")
 
 	cfg.Region = instance.Region
+	cfg.EndpointResolver = aws.EndpointResolverFunc(endpoints.Resolver)
 
 	if operatorOption.Config.EnableMetrics {
 		aMetrics = apiMetrics.NewPrometheusMetrics("ipam", operatorMetrics.Namespace, operatorMetrics.Registry)

--- a/pkg/policy/groups/aws/aws.go
+++ b/pkg/policy/groups/aws/aws.go
@@ -20,10 +20,12 @@ import (
 	"net"
 	"os"
 
+	"github.com/cilium/cilium/pkg/aws/endpoints"
+	"github.com/cilium/cilium/pkg/policy/api"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 const (
@@ -60,6 +62,7 @@ func initializeAWSAccount(region string) (*aws.Config, error) {
 	}
 	cfg.Region = region
 	cfg.LogLevel = awsLogLevel
+	cfg.EndpointResolver = aws.EndpointResolverFunc(endpoints.Resolver)
 	return &cfg, nil
 }
 


### PR DESCRIPTION
Manual backport of #12835 to 1.8 for #12620

[ upstream commit f0e584d92b4799a48b83c1d1a4758541c0033ac2 ]

Add a new --ec2-api-endpoint operator option which allows to specify
a custom AWS API endpoints for the EC2 service. One possible use-case
for this is the usage of FIPS endpoints, see
https://aws.amazon.com/compliance/fips/. For example, to use API
endpoint ec2-fips.us-west-1.amazonaws.com, the AWS operator can be
called using:

    cilium-operator-aws --ec2-api-endpoint=ec2-fips.us-west-1.amazonaws.com

Updates #12620

```upstream-prs
$ for pr in 12835; do contrib/backporting/set-labels.py $pr done 1.8; done
```