### PR TITLE
images/{Dockerfile.dockerignore}: do not ignore .git

### DIFF
--- a/images/cilium/Dockerfile.dockerignore
+++ b/images/cilium/Dockerfile.dockerignore
@@ -16,6 +16,7 @@
 !/Dockerfile
 
 # directories
+!/.git
 !/api
 !/bpf
 !/bugtool

--- a/images/hubble-relay/Dockerfile.dockerignore
+++ b/images/hubble-relay/Dockerfile.dockerignore
@@ -16,6 +16,7 @@
 !/Dockerfile
 
 # directories
+!/.git
 !/api
 !/pkg
 !/vendor

--- a/images/operator/Dockerfile.dockerignore
+++ b/images/operator/Dockerfile.dockerignore
@@ -16,6 +16,7 @@
 !/Dockerfile
 
 # directories
+!/.git
 !/api
 !/pkg
 !/vendor


### PR DESCRIPTION
The .git directory is important to detect the git commit SHA. This
commit SHA is then used to present as part of the `cilium --version`
command.

Signed-off-by: André Martins <andre@cilium.io>