### PR TITLE
install/kubernetes: add permissive tolerations to cilium operator

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -203,6 +203,8 @@ spec:
 {{- end }}
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+      tolerations:
+        - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -888,6 +888,8 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+      tolerations:
+        - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -633,6 +633,8 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+      tolerations:
+        - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:


### PR DESCRIPTION
Since Cilium agents depend on the operator to be up and running, it is
better to have some permissive tolerations in the Cilium Operator
deployment spec. This will allow Cilium operator to be deployed in the
cluster in similar tolerations as the Cilium agent daemonset.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Add permissive tolerations to Cilium Operator deployment
```
