### PR TITLE
datapath: Pull skb data in to-netdev path

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -118,7 +118,7 @@ resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	union v6addr *src;
 	int ret;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip6, !from_host))
 		return DROP_INVALID;
 
 	if (!from_host) {
@@ -336,7 +336,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx)
 	__u32 srcID = 0;
 	__u8 nexthdr;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	nexthdr = ip6->nexthdr;
@@ -369,7 +369,12 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	void *data, *data_end;
 	struct iphdr *ip4;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+	/* This is the first time revalidate_data() is going to be called in
+	 * the "to-netdev" path. Make sure that we don't legitimately drop
+	 * the packet if the skb arrived with the header not being not in the
+	 * linear data.
+	 */
+	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip4, !from_host))
 		return DROP_INVALID;
 
 	/* Packets from the proxy will already have a real identity. */

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -25,7 +25,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx)
 	bool decrypted;
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	if (!decrypted) {
@@ -63,7 +63,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx)
 	bool decrypted;
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	if (!decrypted) {

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -33,7 +33,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	bool decrypted;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
 	if (!bpf_skip_nodeport(ctx)) {
@@ -156,7 +156,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 	bool decrypted;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
 	if (!bpf_skip_nodeport(ctx)) {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -114,8 +114,8 @@ static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,
 }
 
 static __always_inline __maybe_unused bool
-__revalidate_data(struct __ctx_buff *ctx, void **data_, void **data_end_,
-		  void **l3, const __u32 l3_len, const bool pull)
+__revalidate_data_pull(struct __ctx_buff *ctx, void **data_, void **data_end_,
+		       void **l3, const __u32 l3_len, const bool pull)
 {
 	const __u32 tot_len = ETH_HLEN + l3_len;
 	void *data_end;
@@ -137,22 +137,29 @@ __revalidate_data(struct __ctx_buff *ctx, void **data_, void **data_end_,
 	return true;
 }
 
-/* revalidate_data_first() initializes the provided pointers from the ctx and
+/* revalidate_data_pull() initializes the provided pointers from the ctx and
  * ensures that the data is pulled in for access. Should be used the first
  * time that the ctx data is accessed, subsequent calls can be made to
  * revalidate_data() which is cheaper.
  * Returns true if 'ctx' is long enough for an IP header of the provided type,
  * false otherwise.
  */
-#define revalidate_data_first(ctx, data, data_end, ip)			\
-	__revalidate_data(ctx, data, data_end, (void **)ip, sizeof(**ip), true)
+#define revalidate_data_pull(ctx, data, data_end, ip)			\
+	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), true)
+
+/* revalidate_data_maybe_pull() does the same as revalidate_data_maybe_pull()
+ * except that the skb data pull is controlled by the "pull" argument.
+ */
+#define revalidate_data_maybe_pull(ctx, data, data_end, ip, pull)	\
+	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), pull)
+
 
 /* revalidate_data() initializes the provided pointers from the ctx.
  * Returns true if 'ctx' is long enough for an IP header of the provided type,
  * false otherwise.
  */
 #define revalidate_data(ctx, data, data_end, ip)			\
-	__revalidate_data(ctx, data, data_end, (void **)ip, sizeof(**ip), false)
+	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), false)
 
 /* Macros for working with L3 cilium defined IPV6 addresses */
 #define BPF_V6(dst, ...)	BPF_V6_1(dst, fetch_ipv6(__VA_ARGS__))


### PR DESCRIPTION
It has been reported \[1\]\[2\] that ICMP packets are being dropped by a
receiving node due to `DROP_INVALID` when bpf_host was attached to the
receiving iface. Further look into the issue revealed that the drops
were happening because IP headers were not in the skb linear data
(unsuccessful `revalidate_data()` caused the `DROP_INVALID` return).

Fix this by making sure that the first invocation of `revalidate_data()`
in the `to-netdev` path will always do `skb_data_pull()` before deciding
that the packet is invalid.

Manually tested by the user who reported \[2\]: https://github.com/cilium/cilium/issues/12854#issuecomment-675569188.

\[1\]: https://github.com/cilium/cilium/issues/11802
\[2\]: https://github.com/cilium/cilium/issues/12854

Fix #11802 
Fix #12854 

Reported-by: Andrei Kvapil (@kvaps)
