### PR TITLE
install/kubernetes: add disableEnvoyVersionCheck option

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -69,6 +69,10 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if hasKey .Values "disableEnvoyVersionCheck" }}
+  disable-envoy-version-check: {{ .Values.disableEnvoyVersionCheck }}
+{{- end }}
+
   # Identity allocation mode selects how identities are shared between cilium
   # nodes by setting how they are stored. The options are "crd" or "kvstore".
   # - "crd" stores identities in kubernetes as CRDs (custom resource definition).

--- a/install/kubernetes/cilium/charts/config/values.yaml
+++ b/install/kubernetes/cilium/charts/config/values.yaml
@@ -57,3 +57,6 @@
 
 # A list of labels to include or exclude from Cilium identity evaluation.
 #labels: "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
+
+#disableEnvoyVersionCheck: false
+


### PR DESCRIPTION
With this option users will be able to deploy Cilium without envoy
support which is helpful for arm64 clusters.

Signed-off-by: André Martins <andre@cilium.io>