### PR TITLE
pkg/k8s: set schema version to 1.22.1

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -31,7 +31,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.22.2"
+	CustomResourceDefinitionSchemaVersion = "1.22.1"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"


### PR DESCRIPTION
We don't need to update the schema version every time the schema is
changed, we only the to be sure the schema version is updated before a
release is done. Although the schema version was bumped 2 times in the
1.9 development cycle we only need to make sure it is set to 1.22.1
before we cut the first release candidate.

Signed-off-by: André Martins <andre@cilium.io>