### PR TITLE
install/kubernetes: quote disableEnvoyVersionCheck when option is set

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -70,7 +70,7 @@ data:
 {{- end }}
 
 {{- if hasKey .Values "disableEnvoyVersionCheck" }}
-  disable-envoy-version-check: {{ .Values.disableEnvoyVersionCheck }}
+  disable-envoy-version-check: {{ .Values.disableEnvoyVersionCheck | quote }}
 {{- end }}
 
   # Identity allocation mode selects how identities are shared between cilium


### PR DESCRIPTION
The option needs to be quoted as this should be treated as a string.

Fixes: c1d63f79e31e ("pkg/k8s: set schema version to 1.22.1")
Signed-off-by: André Martins <andre@cilium.io>