### PR TITLE
envoy: Optimize list of allowed remote security IDs

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -11,7 +11,7 @@ env:
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
-  TIMEOUT: 2m
+  TIMEOUT: 5m
   LOG_TIME: 30m
 
 jobs:

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -353,8 +353,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						RemotePolicies: expectedRemotePolicies,
-						L7:             &PNPAllowGETbar,
+						L7: &PNPAllowGETbar,
 					},
 				},
 			},
@@ -378,12 +377,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	sort.Slice(expectedRemotePolicies, func(i, j int) bool {
 		return expectedRemotePolicies[i] < expectedRemotePolicies[j]
 	})
-	expectedRemotePolicies2 := []uint64{
-		uint64(prodFooJoeSecLblsCtx.ID),
-	}
-	sort.Slice(expectedRemotePolicies2, func(i, j int) bool {
-		return expectedRemotePolicies2[i] < expectedRemotePolicies2[j]
-	})
 
 	expectedNetworkPolicy = &cilium.NetworkPolicy{
 		Name:             ProdIPv4Addr.String(),
@@ -404,8 +397,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						RemotePolicies: expectedRemotePolicies,
-						L7:             &PNPAllowGETbar,
+						L7: &PNPAllowGETbar,
 					},
 				},
 			},
@@ -660,8 +652,7 @@ func (ds *DaemonSuite) TestL3_dependent_L7(c *C) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						RemotePolicies: []uint64{uint64(qaFooSecLblsCtx.ID)},
-						L7:             &PNPAllowGETbar,
+						L7: &PNPAllowGETbar,
 					},
 				},
 			},
@@ -898,7 +889,18 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	qaBarNetworkPolicy := networkPolicies[QAIPv4Addr.String()]
 	c.Assert(qaBarNetworkPolicy, Not(IsNil))
 
-	c.Assert(qaBarNetworkPolicy.IngressPerPortPolicies, HasLen, 0)
+	c.Assert(qaBarNetworkPolicy.IngressPerPortPolicies, HasLen, 1)
+
+	expectedIngressPolicy := &cilium.PortNetworkPolicy{
+		Port:     80,
+		Protocol: envoy_config_core.SocketAddress_TCP,
+		Rules: []*cilium.PortNetworkPolicyRule{
+			{
+				L7: &PNPAllowGETbar,
+			},
+		},
+	}
+	c.Assert(qaBarNetworkPolicy.IngressPerPortPolicies[0], checker.Equals, expectedIngressPolicy)
 
 	// Allocate identities needed for this test
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
@@ -941,8 +943,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						RemotePolicies: []uint64{uint64(qaFooID.ID)},
-						L7:             &PNPAllowGETbar,
+						L7: &PNPAllowGETbar,
 					},
 				},
 			},

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -360,7 +360,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 		},
 		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
 			{Protocol: envoy_config_core.SocketAddress_TCP},
-			{Protocol: envoy_config_core.SocketAddress_UDP},
 		},
 	}
 	c.Assert(qaBarNetworkPolicy, checker.Equals, expectedNetworkPolicy)
@@ -404,7 +403,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 		},
 		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
 			{Protocol: envoy_config_core.SocketAddress_TCP},
-			{Protocol: envoy_config_core.SocketAddress_UDP},
 		},
 	}
 	c.Assert(prodBarNetworkPolicy, checker.Equals, expectedNetworkPolicy)
@@ -484,7 +482,6 @@ func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
 		},
 		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
 			{Protocol: envoy_config_core.SocketAddress_TCP},
-			{Protocol: envoy_config_core.SocketAddress_UDP},
 		},
 	}
 	c.Assert(qaBarNetworkPolicy, checker.Equals, expectedNetworkPolicy)
@@ -561,7 +558,6 @@ func (ds *DaemonSuite) TestL4_L7_ShadowingShortCircuit(c *C) {
 		},
 		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
 			{Protocol: envoy_config_core.SocketAddress_TCP},
-			{Protocol: envoy_config_core.SocketAddress_UDP},
 		},
 	}
 	c.Assert(qaBarNetworkPolicy, checker.Equals, expectedNetworkPolicy)
@@ -659,7 +655,6 @@ func (ds *DaemonSuite) TestL3_dependent_L7(c *C) {
 		},
 		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
 			{Protocol: envoy_config_core.SocketAddress_TCP},
-			{Protocol: envoy_config_core.SocketAddress_UDP},
 		},
 	}
 	c.Assert(qaBarNetworkPolicy, checker.Equals, expectedNetworkPolicy)
@@ -881,7 +876,6 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 
 	// Create the endpoint and generate its policy.
 	e := ds.prepareEndpoint(c, qaBarSecLblsCtx, true)
-
 	// Check that the policy has been updated in the xDS cache for the L7
 	// proxies.
 	networkPolicies := ds.getXDSNetworkPolicies(c, nil)
@@ -950,7 +944,6 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 		},
 		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
 			{Protocol: envoy_config_core.SocketAddress_TCP},
-			{Protocol: envoy_config_core.SocketAddress_UDP},
 		},
 	})
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1068,8 +1068,6 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 	}
 
 	PerPortPolicies := make([]*cilium.PortNetworkPolicy, 0, len(l4Policy))
-	// map to locate entries already on the same port
-	pnps := make(map[string]*cilium.PortNetworkPolicy, len(l4Policy))
 	for _, l4 := range l4Policy {
 		var protocol envoy_config_core.SocketAddress_Protocol
 		switch l4.Protocol {
@@ -1144,30 +1142,18 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 			continue
 		}
 
-		// Add rules to a new or existing entry for this port
-		key := fmt.Sprintf("%d/%s", port, l4.Protocol)
-		pnp, exists := pnps[key]
-		if !exists {
-			pnp = &cilium.PortNetworkPolicy{
-				Port:     uint32(port),
-				Protocol: protocol,
-				Rules:    rules,
-			}
-			pnps[key] = pnp
-			PerPortPolicies = append(PerPortPolicies, pnp)
-		} else {
-			pnp.Rules = append(pnp.Rules, rules...)
-		}
-		SortPortNetworkPolicyRules(pnp.Rules)
+		PerPortPolicies = append(PerPortPolicies, &cilium.PortNetworkPolicy{
+			Port:     uint32(port),
+			Protocol: protocol,
+			Rules:    SortPortNetworkPolicyRules(rules),
+		})
 	}
 
 	if len(PerPortPolicies) == 0 {
 		return nil
 	}
 
-	SortPortNetworkPolicies(PerPortPolicies)
-
-	return PerPortPolicies
+	return SortPortNetworkPolicies(PerPortPolicies)
 }
 
 // getNetworkPolicy converts a network policy into a cilium.NetworkPolicy.

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -63,7 +63,8 @@ var (
 		// Allow all TCP traffic to any port.
 		{Protocol: envoy_config_core.SocketAddress_TCP},
 		// Allow all UDP traffic to any port.
-		{Protocol: envoy_config_core.SocketAddress_UDP},
+		// UDP rules not sent to Envoy for now.
+		// {Protocol: envoy_config_core.SocketAddress_UDP},
 	}
 )
 
@@ -1074,7 +1075,8 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 		case api.ProtoTCP:
 			protocol = envoy_config_core.SocketAddress_TCP
 		case api.ProtoUDP:
-			protocol = envoy_config_core.SocketAddress_UDP
+			// UDP rules not sent to Envoy for now.
+			continue
 		}
 
 		port := uint16(l4.Port)

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -913,31 +913,24 @@ func GetEnvoyHTTPRules(certManager policy.CertificateManager, l7Rules *api.L7Rul
 	return nil, true
 }
 
-func getPortNetworkPolicyRule(sel policy.CachedSelector, l7Parser policy.L7ParserType, l7Rules *policy.PerSelectorPolicy) (*cilium.PortNetworkPolicyRule, bool) {
+func getPortNetworkPolicyRule(sel policy.CachedSelector, wildcard bool, l7Parser policy.L7ParserType, l7Rules *policy.PerSelectorPolicy) (*cilium.PortNetworkPolicyRule, bool) {
+	r := &cilium.PortNetworkPolicyRule{}
+
 	// Optimize the policy if the endpoint selector is a wildcard by
 	// keeping remote policies list empty to match all remote policies.
-	var remotePolicies []uint64
-	if !sel.IsWildcard() {
+	if !wildcard {
 		for _, id := range sel.GetSelections() {
-			remotePolicies = append(remotePolicies, uint64(id))
+			r.RemotePolicies = append(r.RemotePolicies, uint64(id))
 		}
 
 		// No remote policies would match this rule. Discard it.
-		if len(remotePolicies) == 0 {
+		if len(r.RemotePolicies) == 0 {
 			return nil, true
 		}
-
-		sort.Slice(remotePolicies, func(i, j int) bool {
-			return remotePolicies[i] < remotePolicies[j]
-		})
-	}
-
-	r := &cilium.PortNetworkPolicyRule{
-		RemotePolicies: remotePolicies,
 	}
 
 	if l7Rules == nil {
-		// L3/L4 only rule, everything in L7 is allowed
+		// L3/L4 only rule, everything in L7 is allowed && no TLS
 		return r, true
 	}
 
@@ -1092,8 +1085,14 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 				rules = append(rules, rule)
 			}
 		} else {
+			nSelectors := len(l4.L7RulesPerSelector)
 			for sel, l7 := range l4.L7RulesPerSelector {
-				rule, cs := getPortNetworkPolicyRule(sel, l4.L7Parser, l7)
+				// A single selector is effectively a wildcard, as bpf passes through
+				// only allowed l3. If there are multiple selectors for this l4-filter
+				// then the proxy may need to drop some allowed l3 due to l7 rules potentially
+				// being different between the selectors.
+				wildcard := nSelectors == 1 || sel.IsWildcard()
+				rule, cs := getPortNetworkPolicyRule(sel, wildcard, l4.L7Parser, l7)
 				if rule != nil {
 					if !cs {
 						canShortCircuit = false

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -208,85 +208,55 @@ var (
 	cachedRequiresV2Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, RequiresV2Selector)
 )
 
-var L7Rules1 = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1, *PortRuleHTTP2}}}
+var L7Rules12 = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1, *PortRuleHTTP2}}}
 
-var L7Rules1HeaderMatch = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1, *PortRuleHTTP2HeaderMatch}}}
+var L7Rules12HeaderMatch = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1, *PortRuleHTTP2HeaderMatch}}}
 
-var L7Rules2 = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1}}}
+var L7Rules1 = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1}}}
+
+var ExpectedHttpRule1 = &cilium.PortNetworkPolicyRule_HttpRules{
+	HttpRules: &cilium.HttpNetworkPolicyRules{
+		HttpRules: []*cilium.HttpNetworkPolicyRule{
+			{Headers: ExpectedHeaders1},
+		},
+	},
+}
+
+var ExpectedHttpRule12 = &cilium.PortNetworkPolicyRule_HttpRules{
+	HttpRules: &cilium.HttpNetworkPolicyRules{
+		HttpRules: []*cilium.HttpNetworkPolicyRule{
+			{Headers: ExpectedHeaders2},
+			{Headers: ExpectedHeaders1},
+		},
+	},
+}
+
+var ExpectedHttpRule122HeaderMatch = &cilium.PortNetworkPolicyRule_HttpRules{
+	HttpRules: &cilium.HttpNetworkPolicyRules{
+		HttpRules: []*cilium.HttpNetworkPolicyRule{
+			{Headers: ExpectedHeaders2, HeaderMatches: ExpectedHeaderMatches2},
+			{Headers: ExpectedHeaders1},
+		},
+	},
+}
+
+var ExpectedPortNetworkPolicyRule12 = &cilium.PortNetworkPolicyRule{
+	RemotePolicies: []uint64{1001, 1002},
+	L7:             ExpectedHttpRule12,
+}
+
+var ExpectedPortNetworkPolicyRule12Wildcard = &cilium.PortNetworkPolicyRule{
+	L7: ExpectedHttpRule12,
+}
+
+var ExpectedPortNetworkPolicyRule122HeaderMatch = &cilium.PortNetworkPolicyRule{
+	RemotePolicies: []uint64{1001, 1002},
+	L7:             ExpectedHttpRule122HeaderMatch,
+}
 
 var ExpectedPortNetworkPolicyRule1 = &cilium.PortNetworkPolicyRule{
-	RemotePolicies: []uint64{1001, 1002},
-	L7: &cilium.PortNetworkPolicyRule_HttpRules{
-		HttpRules: &cilium.HttpNetworkPolicyRules{
-			HttpRules: []*cilium.HttpNetworkPolicyRule{
-				{Headers: ExpectedHeaders2},
-				{Headers: ExpectedHeaders1},
-			},
-		},
-	},
-}
-
-var ExpectedPortNetworkPolicyRule1HeaderMatch = &cilium.PortNetworkPolicyRule{
-	RemotePolicies: []uint64{1001, 1002},
-	L7: &cilium.PortNetworkPolicyRule_HttpRules{
-		HttpRules: &cilium.HttpNetworkPolicyRules{
-			HttpRules: []*cilium.HttpNetworkPolicyRule{
-				{Headers: ExpectedHeaders2, HeaderMatches: ExpectedHeaderMatches2},
-				{Headers: ExpectedHeaders1},
-			},
-		},
-	},
-}
-
-var ExpectedPortNetworkPolicyRule2 = &cilium.PortNetworkPolicyRule{
 	RemotePolicies: []uint64{1001, 1003},
-	L7: &cilium.PortNetworkPolicyRule_HttpRules{
-		HttpRules: &cilium.HttpNetworkPolicyRules{
-			HttpRules: []*cilium.HttpNetworkPolicyRule{
-				{Headers: ExpectedHeaders1},
-			},
-		},
-	},
-}
-
-var ExpectedPortNetworkPolicyRule3 = &cilium.PortNetworkPolicyRule{
-	RemotePolicies: nil, // Wildcard. Select all.
-	L7: &cilium.PortNetworkPolicyRule_HttpRules{
-		HttpRules: &cilium.HttpNetworkPolicyRules{
-			HttpRules: []*cilium.HttpNetworkPolicyRule{
-				{Headers: ExpectedHeaders2},
-				{Headers: ExpectedHeaders1},
-			},
-		},
-	},
-}
-
-var ExpectedPortNetworkPolicyRule4RequiresV2 = &cilium.PortNetworkPolicyRule{
-	RemotePolicies: []uint64{1002}, // Like ExpectedPortNetworkPolicyRule1 but "k8s:version=v2" is required.
-	L7: &cilium.PortNetworkPolicyRule_HttpRules{
-		HttpRules: &cilium.HttpNetworkPolicyRules{
-			HttpRules: []*cilium.HttpNetworkPolicyRule{
-				{Headers: ExpectedHeaders2},
-				{Headers: ExpectedHeaders1},
-			},
-		},
-	},
-}
-
-var ExpectedPortNetworkPolicyRule5RequiresV2 = &cilium.PortNetworkPolicyRule{
-	RemotePolicies: []uint64{1002}, // Wildcard, but "k8s:version=v2" required
-	L7: &cilium.PortNetworkPolicyRule_HttpRules{
-		HttpRules: &cilium.HttpNetworkPolicyRules{
-			HttpRules: []*cilium.HttpNetworkPolicyRule{
-				{Headers: ExpectedHeaders2},
-				{Headers: ExpectedHeaders1},
-			},
-		},
-	},
-}
-
-var ExpectedPortNetworkPolicyRule6 = &cilium.PortNetworkPolicyRule{
-	RemotePolicies: []uint64{1001, 1002},
+	L7:             ExpectedHttpRule1,
 }
 
 var L4PolicyMap1 = map[string]*policy.L4Filter{
@@ -295,7 +265,7 @@ var L4PolicyMap1 = map[string]*policy.L4Filter{
 		Protocol: api.ProtoTCP,
 		L7Parser: policy.ParserTypeHTTP,
 		L7RulesPerSelector: policy.L7DataMap{
-			cachedSelector1: L7Rules1,
+			cachedSelector1: L7Rules12,
 		},
 	},
 }
@@ -306,7 +276,7 @@ var L4PolicyMap1HeaderMatch = map[string]*policy.L4Filter{
 		Protocol: api.ProtoTCP,
 		L7Parser: policy.ParserTypeHTTP,
 		L7RulesPerSelector: policy.L7DataMap{
-			cachedSelector1: L7Rules1HeaderMatch,
+			cachedSelector1: L7Rules12HeaderMatch,
 		},
 	},
 }
@@ -317,7 +287,7 @@ var L4PolicyMap1RequiresV2 = map[string]*policy.L4Filter{
 		Protocol: api.ProtoTCP,
 		L7Parser: policy.ParserTypeHTTP,
 		L7RulesPerSelector: policy.L7DataMap{
-			cachedRequiresV2Selector1: L7Rules1,
+			cachedRequiresV2Selector1: L7Rules12,
 		},
 	},
 }
@@ -328,7 +298,7 @@ var L4PolicyMap2 = map[string]*policy.L4Filter{
 		Protocol: api.ProtoTCP,
 		L7Parser: policy.ParserTypeHTTP,
 		L7RulesPerSelector: policy.L7DataMap{
-			cachedSelector2: L7Rules2,
+			cachedSelector2: L7Rules1,
 		},
 	},
 }
@@ -339,7 +309,7 @@ var L4PolicyMap3 = map[string]*policy.L4Filter{
 		Protocol: api.ProtoTCP,
 		L7Parser: policy.ParserTypeHTTP,
 		L7RulesPerSelector: policy.L7DataMap{
-			wildcardCachedSelector: L7Rules1,
+			wildcardCachedSelector: L7Rules12,
 		},
 	},
 }
@@ -350,7 +320,7 @@ var L4PolicyMap3RequiresV2 = map[string]*policy.L4Filter{
 		Protocol: api.ProtoTCP,
 		L7Parser: policy.ParserTypeHTTP,
 		L7RulesPerSelector: policy.L7DataMap{
-			cachedRequiresV2Selector: L7Rules1,
+			cachedRequiresV2Selector: L7Rules12,
 		},
 	},
 }
@@ -379,7 +349,7 @@ var L4PolicyMap5 = map[string]*policy.L4Filter{
 
 var ExpectedPerPortPolicies1 = []*cilium.PortNetworkPolicy{
 	{
-		Port:     80,
+		Port:     8080,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{
 			ExpectedPortNetworkPolicyRule1,
@@ -387,67 +357,58 @@ var ExpectedPerPortPolicies1 = []*cilium.PortNetworkPolicy{
 	},
 }
 
-var ExpectedPerPortPolicies1HeaderMatch = []*cilium.PortNetworkPolicy{
+var ExpectedPerPortPolicies122HeaderMatch = []*cilium.PortNetworkPolicy{
 	{
 		Port:     80,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{
-			ExpectedPortNetworkPolicyRule1HeaderMatch,
+			ExpectedPortNetworkPolicyRule122HeaderMatch,
 		},
 	},
 }
 
-var ExpectedPerPortPolicies2 = []*cilium.PortNetworkPolicy{
-	{
-		Port:     8080,
-		Protocol: envoy_config_core.SocketAddress_TCP,
-		Rules: []*cilium.PortNetworkPolicyRule{
-			ExpectedPortNetworkPolicyRule2,
-		},
-	},
-}
-
-var ExpectedPerPortPolicies3 = []*cilium.PortNetworkPolicy{
+var ExpectedPerPortPolicies12 = []*cilium.PortNetworkPolicy{
 	{
 		Port:     80,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{
-			ExpectedPortNetworkPolicyRule3,
+			ExpectedPortNetworkPolicyRule12,
 		},
 	},
 }
 
-var ExpectedPerPortPolicies4RequiresV2 = []*cilium.PortNetworkPolicy{
+var ExpectedPerPortPolicies12Wildcard = []*cilium.PortNetworkPolicy{
 	{
 		Port:     80,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{
-			ExpectedPortNetworkPolicyRule4RequiresV2,
+			ExpectedPortNetworkPolicyRule12Wildcard,
 		},
 	},
 }
 
-var ExpectedPerPortPolicies5RequiresV2 = []*cilium.PortNetworkPolicy{
+var ExpectedPerPortPolicies12RequiresV2 = []*cilium.PortNetworkPolicy{
 	{
 		Port:     80,
 		Protocol: envoy_config_core.SocketAddress_TCP,
-		Rules: []*cilium.PortNetworkPolicyRule{
-			ExpectedPortNetworkPolicyRule5RequiresV2,
-		},
+		Rules: []*cilium.PortNetworkPolicyRule{{
+			RemotePolicies: []uint64{1002},
+			L7:             ExpectedHttpRule12,
+		}},
 	},
 }
 
-var ExpectedPerPortPolicies6 = []*cilium.PortNetworkPolicy{
+var ExpectedPerPortPoliciesL3_12 = []*cilium.PortNetworkPolicy{
 	{
 		Port:     80,
 		Protocol: envoy_config_core.SocketAddress_TCP,
-		Rules: []*cilium.PortNetworkPolicyRule{
-			ExpectedPortNetworkPolicyRule6,
-		},
+		Rules: []*cilium.PortNetworkPolicyRule{{
+			RemotePolicies: []uint64{1001, 1002},
+		}},
 	},
 }
 
-var ExpectedPerPortPolicies7 = []*cilium.PortNetworkPolicy{
+var ExpectedPerPortPoliciesWildcard = []*cilium.PortNetworkPolicy{
 	{
 		Port:     80,
 		Protocol: envoy_config_core.SocketAddress_TCP,
@@ -481,39 +442,39 @@ func (s *ServerSuite) TestGetHTTPRule(c *C) {
 }
 
 func (s *ServerSuite) TestGetPortNetworkPolicyRule(c *C) {
-	obtained, canShortCircuit := getPortNetworkPolicyRule(cachedSelector1, policy.ParserTypeHTTP, L7Rules1)
-	c.Assert(obtained, checker.Equals, ExpectedPortNetworkPolicyRule1)
+	obtained, canShortCircuit := getPortNetworkPolicyRule(cachedSelector1, policy.ParserTypeHTTP, L7Rules12)
+	c.Assert(obtained, checker.Equals, ExpectedPortNetworkPolicyRule12)
 	c.Assert(canShortCircuit, checker.Equals, true)
 
-	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector1, policy.ParserTypeHTTP, L7Rules1HeaderMatch)
-	c.Assert(obtained, checker.Equals, ExpectedPortNetworkPolicyRule1HeaderMatch)
+	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector1, policy.ParserTypeHTTP, L7Rules12HeaderMatch)
+	c.Assert(obtained, checker.Equals, ExpectedPortNetworkPolicyRule122HeaderMatch)
 	c.Assert(canShortCircuit, checker.Equals, false)
 
-	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector2, policy.ParserTypeHTTP, L7Rules2)
-	c.Assert(obtained, checker.Equals, ExpectedPortNetworkPolicyRule2)
+	obtained, canShortCircuit = getPortNetworkPolicyRule(cachedSelector2, policy.ParserTypeHTTP, L7Rules1)
+	c.Assert(obtained, checker.Equals, ExpectedPortNetworkPolicyRule1)
 	c.Assert(canShortCircuit, checker.Equals, true)
 }
 
 func (s *ServerSuite) TestGetDirectionNetworkPolicy(c *C) {
 	// L4+L7
 	obtained := getDirectionNetworkPolicy(ep, L4PolicyMap1, true)
-	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies1)
+	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies12)
 
 	// L4+L7 with header mods
 	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap1HeaderMatch, true)
-	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies1HeaderMatch)
+	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies122HeaderMatch)
 
 	// L4+L7
 	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap2, true)
-	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies2)
+	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies1)
 
 	// L4-only
 	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap4, true)
-	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies6)
+	c.Assert(obtained, checker.Equals, ExpectedPerPortPoliciesL3_12)
 
 	// L4-only
 	obtained = getDirectionNetworkPolicy(ep, L4PolicyMap5, true)
-	c.Assert(obtained, checker.Equals, ExpectedPerPortPolicies7)
+	c.Assert(obtained, checker.Equals, ExpectedPerPortPoliciesWildcard)
 }
 
 func (s *ServerSuite) TestGetNetworkPolicy(c *C) {
@@ -521,8 +482,8 @@ func (s *ServerSuite) TestGetNetworkPolicy(c *C) {
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
-		IngressPerPortPolicies: ExpectedPerPortPolicies1,
-		EgressPerPortPolicies:  ExpectedPerPortPolicies2,
+		IngressPerPortPolicies: ExpectedPerPortPolicies12,
+		EgressPerPortPolicies:  ExpectedPerPortPolicies1,
 		ConntrackMapName:       "global",
 	}
 	c.Assert(obtained, checker.Equals, expected)
@@ -533,8 +494,8 @@ func (s *ServerSuite) TestGetNetworkPolicyWildcard(c *C) {
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
-		IngressPerPortPolicies: ExpectedPerPortPolicies3,
-		EgressPerPortPolicies:  ExpectedPerPortPolicies2,
+		IngressPerPortPolicies: ExpectedPerPortPolicies12Wildcard,
+		EgressPerPortPolicies:  ExpectedPerPortPolicies1,
 		ConntrackMapName:       "global",
 	}
 	c.Assert(obtained, checker.Equals, expected)
@@ -545,8 +506,8 @@ func (s *ServerSuite) TestGetNetworkPolicyDeny(c *C) {
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
-		IngressPerPortPolicies: ExpectedPerPortPolicies4RequiresV2,
-		EgressPerPortPolicies:  ExpectedPerPortPolicies2,
+		IngressPerPortPolicies: ExpectedPerPortPolicies12RequiresV2,
+		EgressPerPortPolicies:  ExpectedPerPortPolicies1,
 		ConntrackMapName:       "global",
 	}
 	c.Assert(obtained, checker.Equals, expected)
@@ -557,8 +518,8 @@ func (s *ServerSuite) TestGetNetworkPolicyWildcardDeny(c *C) {
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
-		IngressPerPortPolicies: ExpectedPerPortPolicies5RequiresV2,
-		EgressPerPortPolicies:  ExpectedPerPortPolicies2,
+		IngressPerPortPolicies: ExpectedPerPortPolicies12RequiresV2,
+		EgressPerPortPolicies:  ExpectedPerPortPolicies1,
 		ConntrackMapName:       "global",
 	}
 	c.Assert(obtained, checker.Equals, expected)
@@ -582,7 +543,7 @@ func (s *ServerSuite) TestGetNetworkPolicyIngressNotEnforced(c *C) {
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
 		IngressPerPortPolicies: allowAllPortNetworkPolicy,
-		EgressPerPortPolicies:  ExpectedPerPortPolicies2,
+		EgressPerPortPolicies:  ExpectedPerPortPolicies1,
 		ConntrackMapName:       "global",
 	}
 	c.Assert(obtained, checker.Equals, expected)
@@ -593,7 +554,7 @@ func (s *ServerSuite) TestGetNetworkPolicyEgressNotEnforced(c *C) {
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
-		IngressPerPortPolicies: ExpectedPerPortPolicies5RequiresV2,
+		IngressPerPortPolicies: ExpectedPerPortPolicies12RequiresV2,
 		EgressPerPortPolicies:  allowAllPortNetworkPolicy,
 		ConntrackMapName:       "global",
 	}

--- a/pkg/envoy/sort.go
+++ b/pkg/envoy/sort.go
@@ -72,9 +72,11 @@ func (s PortNetworkPolicySlice) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// SortPortNetworkPolicies sorts the given slice.
-func SortPortNetworkPolicies(policies []*cilium.PortNetworkPolicy) {
+// SortPortNetworkPolicies sorts the given slice in place and returns
+// the sorted slice for convenience.
+func SortPortNetworkPolicies(policies []*cilium.PortNetworkPolicy) []*cilium.PortNetworkPolicy {
 	sort.Sort(PortNetworkPolicySlice(policies))
+	return policies
 }
 
 // PortNetworkPolicyRuleSlice implements sort.Interface to sort a slice of
@@ -149,9 +151,11 @@ func (s PortNetworkPolicyRuleSlice) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// SortPortNetworkPolicyRules sorts the given slice.
-func SortPortNetworkPolicyRules(rules []*cilium.PortNetworkPolicyRule) {
+// SortPortNetworkPolicyRules sorts the given slice in place
+// and returns the sorted slice for convenience.
+func SortPortNetworkPolicyRules(rules []*cilium.PortNetworkPolicyRule) []*cilium.PortNetworkPolicyRule {
 	sort.Sort(PortNetworkPolicyRuleSlice(rules))
+	return rules
 }
 
 // HTTPNetworkPolicyRuleSlice implements sort.Interface to sort a slice of


### PR DESCRIPTION
We already omit explicit listing of allowed remote security IDs when they are
for a wildcard selector. Do the same if there is only one selector for
the port, as bpf l3/l4 will pass only allowed lDs through. Only if there
are multiple selectors, then we need to differentiate between remotes
based on the L7 rules, so we must explicitly list the allowed remotes
for non-wildcard selectors in that case.

1st commit contains only test refactoring to ease reviewing of the test changes in the 2nd commit.