### PR TITLE
Use existing consts for Cilium CRD names

### DIFF
--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -77,7 +77,7 @@ func enableCCNPWatcher() error {
 
 	ciliumV2Controller := informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(k8s.CiliumClient().CiliumV2().RESTClient(),
-			"ciliumclusterwidenetworkpolicies", v1.NamespaceAll, fields.Everything()),
+			cilium_v2.CCNPPluralName, v1.NamespaceAll, fields.Everything()),
 		&cilium_v2.CiliumClusterwideNetworkPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -57,7 +57,7 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 
 	k8sNodeStore, nodeController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.CiliumClient().CiliumV2().RESTClient(),
-			"ciliumnodes", v1.NamespaceAll, fields.Everything()),
+			cilium_v2.CNPluralName, v1.NamespaceAll, fields.Everything()),
 		&cilium_v2.CiliumNode{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -73,7 +73,7 @@ func CiliumEndpointsInit(ciliumNPClient cilium_cli.CiliumV2Interface) {
 
 		ciliumEndpointInformer := informer.NewInformerWithStore(
 			cache.NewListWatchFromClient(ciliumNPClient.RESTClient(),
-				"ciliumendpoints", v1.NamespaceAll, fields.Everything()),
+				cilium_api_v2.CEPPluralName, v1.NamespaceAll, fields.Everything()),
 			&cilium_api_v2.CiliumEndpoint{},
 			0,
 			cache.ResourceEventHandlerFuncs{},

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -115,7 +115,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 	ciliumNodeStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	ciliumNodeInformer := informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(ciliumClient.CiliumV2().RESTClient(),
-			"ciliumnodes", corev1.NamespaceAll, ciliumNodeSelector),
+			ciliumv2.CNPluralName, corev1.NamespaceAll, ciliumNodeSelector),
 		&ciliumv2.CiliumNode{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -284,7 +284,7 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 	c.Store = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	identityInformer := informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(c.Client.CiliumV2().RESTClient(),
-			"ciliumidentities", v1.NamespaceAll, fields.Everything()),
+			v2.CIDPluralName, v1.NamespaceAll, fields.Everything()),
 		&v2.CiliumIdentity{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
@@ -44,7 +44,7 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 
 	ciliumV2ClusterwidePolicyController := informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
-			"ciliumclusterwidenetworkpolicies", v1.NamespaceAll, fields.Everything()),
+			cilium_v2.CCNPPluralName, v1.NamespaceAll, fields.Everything()),
 		&cilium_v2.CiliumClusterwideNetworkPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -42,7 +42,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, as
 	for {
 		_, ciliumEndpointInformer := informer.NewInformer(
 			cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
-				"ciliumendpoints", v1.NamespaceAll, fields.Everything()),
+				cilium_v2.CEPPluralName, v1.NamespaceAll, fields.Everything()),
 			&cilium_v2.CiliumEndpoint{},
 			0,
 			cache.ResourceEventHandlerFuncs{

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -110,7 +110,7 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClie
 
 	ciliumV2Controller := informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
-			"ciliumnetworkpolicies", v1.NamespaceAll, fields.Everything()),
+			cilium_v2.CNPPluralName, v1.NamespaceAll, fields.Everything()),
 		&cilium_v2.CiliumNetworkPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -38,7 +38,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 		swgNodes := lock.NewStoppableWaitGroup()
 		_, ciliumNodeInformer := informer.NewInformer(
 			cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
-				"ciliumnodes", v1.NamespaceAll, fields.Everything()),
+				cilium_v2.CNPluralName, v1.NamespaceAll, fields.Everything()),
 			&cilium_v2.CiliumNode{},
 			0,
 			cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
Use the existing `*{Plural,Singular}Name` consts already defined in pkg/k8s/apis/cilium.io/v2 instead of duplicating strings for the Cilium CRD names.