### PR TITLE
test: Add nightly policy stress test

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -161,7 +161,7 @@ be scraped by Prometheus. You can then expose Grafana to access it via your brow
 
 .. code:: bash
 
-    kubectl -n cilium-monitoring port-forward service/grafana 3000:3000
+    kubectl -n cilium-monitoring port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000
 
 Open your browser and access http://localhost:3000/
 

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -89,7 +89,7 @@ Expose the port on your local machine
 
 .. code:: bash
 
-    kubectl -n cilium-monitoring port-forward service/grafana 3000:3000
+    kubectl -n cilium-monitoring port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000
 
 Access it via your browser: http://localhost:3000
 
@@ -100,7 +100,7 @@ Expose the port on your local machine
 
 .. code:: bash
 
-    kubectl -n cilium-monitoring port-forward service/prometheus 9090:9090
+    kubectl -n cilium-monitoring port-forward service/prometheus --address 0.0.0.0 --address :: 9090:9090
 
 Access it via your browser: http://localhost:9090
 

--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -74,7 +74,7 @@ networking infrastructure in a completely transparent manner.
 
   .. parsed-literal::
 
-      kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-relay 4245:80
+      kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-relay --address 0.0.0.0 --address :: 4245:80
       hubble observe --server localhost:4245
 
   (**For Linux / MacOS**) For convenience, you may set and export the ``HUBBLE_DEFAULT_SOCKET_PATH``
@@ -92,6 +92,6 @@ networking infrastructure in a completely transparent manner.
 
   .. parsed-literal::
 
-      kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-ui 12000:80
+      kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-ui --address 0.0.0.0 --address :: 12000:80
 
   and then open http://localhost:12000/.

--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -182,7 +182,7 @@ your service dependencies. To access **Hubble UI**, you can use the following
 command to forward the port of the web frontend to your local machine:
 
 .. parsed-literal::
-   kubectl port-forward -n kube-system svc/hubble-ui 12000:80
+   kubectl port-forward -n kube-system svc/hubble-ui --address 0.0.0.0 --address :: 12000:80
 
 Open http://localhost:12000 in your browser. You should
 see a screen with an invitation to select a namespace, use the namespace
@@ -230,7 +230,7 @@ port-forward the Hubble Relay service locally:
 
 .. parsed-literal::
 
-   $ kubectl port-forward -n kube-system svc/hubble-relay 4245:80
+   $ kubectl port-forward -n kube-system svc/hubble-relay --address 0.0.0.0 --address :: 4245:80
 
 .. note::
    This terminal window needs to be remain open to keep port-forwarding in

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -275,11 +275,11 @@ service by port-forwarding it:
 
 .. code:: bash
 
-    $ kubectl -n kube-system port-forward service/hubble-relay 4245:80
+    $ kubectl -n kube-system port-forward service/hubble-relay --address 0.0.0.0 --address :: 4245:80
 
 This will forward the Hubble Relay service port (``80``) to your local machine
-on port ``4245``. The next step consists of downloading the latest binary
-release of Hubble CLI from the
+on port ``4245`` on all of it's IP addresses. The next step consists of
+downloading the latest binary release of Hubble CLI from the
 `GitHub release page <https://github.com/cilium/hubble/releases>`_. Make sure to
 download the tarball for your platform, verify the checksum and extract the
 ``hubble`` binary from the tarball. Optionally, add the binary to your

--- a/examples/kubernetes/addons/prometheus/README.md
+++ b/examples/kubernetes/addons/prometheus/README.md
@@ -45,7 +45,7 @@ job.batch/grafana-dashboards-import created
 Expose the port on your local machine
 
 ```
-kubectl -n cilium-monitoring port-forward service/grafana 3000:3000
+kubectl -n cilium-monitoring port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000
 ```
 
 Access it via your browser: `https://localhost:3000`
@@ -55,7 +55,7 @@ Access it via your browser: `https://localhost:3000`
 Expose the port on your local machine
 
 ```
-kubectl -n cilium-monitoring port-forward service/prometheus 9090:9090
+kubectl -n cilium-monitoring port-forward service/prometheus --address 0.0.0.0 --address :: 9090:9090
 ```
 
 Access it via your browser: `https://localhost:9090`

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -116,6 +116,8 @@ Vagrant.configure("2") do |config|
             server.vm.hostname = "k8s#{i}"
             server.vm.boot_timeout = 600
             if i == 1 then
+                # grafana
+                server.vm.network "forwarded_port", guest: 3000, host: 3000
                 server.vm.network "forwarded_port", guest: 6443, host: 9443,
                   auto_correct: true
             end

--- a/test/k8sT/StressPolicy.go
+++ b/test/k8sT/StressPolicy.go
@@ -1,0 +1,107 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NightlyPolicyStress", func() {
+
+	var (
+		kubectl          *helpers.Kubectl
+		backgroundCancel context.CancelFunc = func() {}
+		backgroundError  error
+	)
+
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		deploymentManager.SetKubectl(kubectl)
+	})
+
+	JustBeforeEach(func() {
+		backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
+		Expect(backgroundError).To(BeNil(), "Cannot start background report process")
+	})
+
+	JustAfterEach(func() {
+		blacklist := helpers.GetBadLogMessages()
+		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
+		backgroundCancel()
+	})
+
+	AfterEach(func() {
+		deploymentManager.DeleteAll()
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.CiliumNamespace,
+			"cilium endpoint list")
+	})
+
+	AfterAll(func() {
+		deploymentManager.DeleteCilium()
+		kubectl.CloseSSHClient()
+	})
+
+	// Return a command string for bash loop.
+	loopCommand := func(cmd, namespace string, count int) string {
+		// Repeat 'cmd' 'count' times.
+		// '${namespace} in 'cmd' will be replaced by 'namespace'.
+		// '$i' in 'cmd' will be replaced by the loop counter, starting from 1.
+		return fmt.Sprintf(`/bin/bash -c 'namespace=%s; for i in $(seq 1 %d); do %s; done'`,
+			namespace, count, cmd)
+	}
+
+	Context("Identity Churn", func() {
+		It("Run policy-stress-test manifest with identity churn", func() {
+			deploymentManager.Deploy(helpers.CiliumNamespace, StatelessEtcd)
+			deploymentManager.WaitUntilReady()
+
+			host, port, err := kubectl.GetServiceHostPort(helpers.CiliumNamespace, "stateless-etcd")
+			Expect(err).Should(BeNil(), "Unable to retrieve ClusterIP and port for stateless-etcd service")
+
+			etcdService := fmt.Sprintf("http://%s:%d", host, port)
+			opts := map[string]string{
+				"global.etcd.enabled":           "true",
+				"global.etcd.endpoints[0]":      etcdService,
+				"global.identityAllocationMode": "kvstore",
+				"global.prometheus.enabled":     "true",
+			}
+			if helpers.ExistNodeWithoutCilium() {
+				opts["config.synchronizeK8sNodes"] = "false"
+			}
+			deploymentManager.DeployCilium(opts, DeployCiliumOptionsAndDNS)
+
+			randomNamespace := deploymentManager.DeployRandomNamespace(ConnectivityCheck)
+			deploymentManager.WaitUntilReady()
+
+			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			Expect(err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
+
+			By("Stressing Cilium policy engine by inserting 20000 identities into kvstore...")
+			kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, loopCommand(
+				`cilium kvstore set --key "cilium/state/identities/v1/id/$((65535+$i))" --value "k8s:test-id=$((65535+$i));k8s:io.kubernetes.pod.namespace=default;"; `+
+					`cilium kvstore set --key "cilium/state/identities/v1/id/$((75535+$i))" --value "k8s:manifest=policy-stress-test;k8s:test-id=$((75535+$i));k8s:io.kubernetes.pod.namespace=${namespace};"`,
+				randomNamespace, 10000))
+		})
+	})
+})

--- a/test/k8sT/manifests.go
+++ b/test/k8sT/manifests.go
@@ -57,4 +57,11 @@ var (
 		NumPods:       1,
 		LabelSelector: "name=stateless-etcd",
 	}
+
+	ConnectivityCheck = helpers.Manifest{
+		Filename:      "policy-stress-test.yaml",
+		NumPods:       14,
+		LabelSelector: "manifest=policy-stress-test",
+		Singleton:     true,
+	}
 )

--- a/test/k8sT/manifests/etcd-deployment.yaml
+++ b/test/k8sT/manifests/etcd-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "stateless-etcd"
 spec:
   ports:
-  - port: 2379
+  - port: 4379
     name: api
   type: ClusterIP
   selector:
@@ -41,8 +41,8 @@ spec:
           - "/usr/local/bin/etcd"
         args:
           - --name=clustermesh-apiserver
-          - --listen-client-urls=http://0.0.0.0:2379
-          - --advertise-client-urls=http://$(HOSTNAME_IP):2379
+          - --listen-client-urls=http://0.0.0.0:4379
+          - --advertise-client-urls=http://$(HOSTNAME_IP):4379
           - --initial-cluster-token=clustermesh-apiserver
           - --initial-cluster-state=new
           - --auto-compaction-retention=1

--- a/test/k8sT/manifests/policy-stress-test.yaml
+++ b/test/k8sT/manifests/policy-stress-test.yaml
@@ -1,0 +1,1066 @@
+# Based on an automatically generated connectivity-check.
+# Edited manually.
+---
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+    topology: any
+    component: network-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-a
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-a-container
+        ports:
+        - containerPort: 80
+        image: docker.io/cilium/json-mock:1.2
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+  selector:
+    matchLabels:
+      name: echo-a
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+    topology: any
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-b
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: echo-b-container
+        ports:
+        - containerPort: 80
+          hostPort: 40000
+        image: docker.io/cilium/json-mock:1.2
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost
+  selector:
+    matchLabels:
+      name: echo-b
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: echo-b-host
+  labels:
+    name: echo-b-host
+    topology: any
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: echo-b-host
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-b-host-container
+        env:
+        - name: PORT
+          value: "41000"
+        ports: []
+        image: docker.io/cilium/json-mock:1.2
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:41000
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - localhost:41000
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: echo-b-host
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-a
+  labels:
+    name: pod-to-a
+    topology: any
+    component: network-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a/public
+  selector:
+    matchLabels:
+      name: pod-to-a
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-external-1111
+  labels:
+    name: pod-to-external-1111
+    topology: any
+    component: network-check
+    traffic: external
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-external-1111
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-external-1111-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - 1.0.0.1
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - 1.0.0.1
+  selector:
+    matchLabels:
+      name: pod-to-external-1111
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-a-denied-cnp
+  labels:
+    name: pod-to-a-denied-cnp
+    topology: any
+    component: policy-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-denied-cnp
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-denied-cnp-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - ash
+            - -c
+            - '! curl -s --fail --connect-timeout 5 -o /dev/null echo-a/private'
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - ash
+            - -c
+            - '! curl -s --fail --connect-timeout 5 -o /dev/null echo-a/private'
+  selector:
+    matchLabels:
+      name: pod-to-a-denied-cnp
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-a-allowed-cnp
+  labels:
+    name: pod-to-a-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-allowed-cnp
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-a-allowed-cnp-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-a/public
+  selector:
+    matchLabels:
+      name: pod-to-a-allowed-cnp
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-external-fqdn-allow-google-cnp
+  labels:
+    name: pod-to-external-fqdn-allow-google-cnp
+    topology: any
+    component: policy-check
+    traffic: external
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-external-fqdn-allow-google-cnp
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-external-fqdn-allow-google-cnp-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - www.google.com
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - www.google.com
+  selector:
+    matchLabels:
+      name: pod-to-external-fqdn-allow-google-cnp
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-b-multi-node-clusterip
+  labels:
+    name: pod-to-b-multi-node-clusterip
+    topology: multi-node
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-clusterip
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-clusterip-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-clusterip
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-b-multi-node-headless
+  labels:
+    name: pod-to-b-multi-node-headless
+    topology: multi-node
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-headless
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-headless-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-headless
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: host-to-b-multi-node-clusterip
+  labels:
+    name: host-to-b-multi-node-clusterip
+    topology: multi-node
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-clusterip
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: true
+      containers:
+      - name: host-to-b-multi-node-clusterip-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      dnsPolicy: ClusterFirstWithHostNet
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-clusterip
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: host-to-b-multi-node-headless
+  labels:
+    name: host-to-b-multi-node-headless
+    topology: multi-node
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-headless
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: true
+      containers:
+      - name: host-to-b-multi-node-headless-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-headless/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      dnsPolicy: ClusterFirstWithHostNet
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-headless
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-b-multi-node-nodeport
+  labels:
+    name: pod-to-b-multi-node-nodeport
+    topology: multi-node
+    component: nodeport-check
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-nodeport
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-multi-node-nodeport-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31313/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31313/public
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-nodeport
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: pod-to-b-intra-node-nodeport
+  labels:
+    name: pod-to-b-intra-node-nodeport
+    topology: intra-node
+    component: nodeport-check
+    quarantine: "false"
+    type: autocheck
+spec:
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-intra-node-nodeport
+        manifest: policy-stress-test
+    spec:
+      hostNetwork: false
+      containers:
+      - name: pod-to-b-intra-node-nodeport-container
+        ports: []
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31313/public
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - echo-b-host-headless:31313/public
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+  selector:
+    matchLabels:
+      name: pod-to-b-intra-node-nodeport
+  replicas: 1
+apiVersion: apps/v1
+kind: Deployment
+---
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+    topology: any
+    component: network-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - port: 80
+  type: ClusterIP
+  selector:
+    name: echo-a
+apiVersion: v1
+kind: Service
+---
+metadata:
+  name: echo-a-allowed-cnp
+  labels:
+    name: echo-a-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: echo-a
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        manifest: policy-stress-test
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http: [{}]
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+---
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+    topology: any
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - port: 80
+    nodePort: 31313
+  type: NodePort
+  selector:
+    name: echo-b
+apiVersion: v1
+kind: Service
+---
+metadata:
+  name: echo-b-allowed-cnp
+  labels:
+    name: echo-b-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: echo-b
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http: [{}]
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+---
+metadata:
+  name: echo-b-headless
+  labels:
+    name: echo-b-headless
+    topology: any
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports:
+  - port: 80
+  type: ClusterIP
+  selector:
+    name: echo-b
+  clusterIP: None
+apiVersion: v1
+kind: Service
+---
+metadata:
+  name: echo-b-host-headless
+  labels:
+    name: echo-b-host-headless
+    topology: any
+    component: services-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  ports: []
+  type: ClusterIP
+  selector:
+    name: echo-b-host
+  clusterIP: None
+apiVersion: v1
+kind: Service
+---
+metadata:
+  name: pod-to-a-denied-cnp
+  labels:
+    name: pod-to-a-denied-cnp
+    topology: any
+    component: policy-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: pod-to-a-denied-cnp
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: openshift-dns
+        k8s:dns.operator.openshift.io/daemonset-dns: default
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+---
+metadata:
+  name: pod-to-a-allowed-cnp
+  labels:
+    name: pod-to-a-allowed-cnp
+    topology: any
+    component: policy-check
+    traffic: any
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: pod-to-a-allowed-cnp
+  egress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        name: echo-a
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: openshift-dns
+        k8s:dns.operator.openshift.io/daemonset-dns: default
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+---
+metadata:
+  name: pod-to-external-fqdn-allow-google-cnp
+  labels:
+    name: pod-to-external-fqdn-allow-google-cnp
+    topology: any
+    component: policy-check
+    traffic: external
+    quarantine: "false"
+    type: autocheck
+spec:
+  endpointSelector:
+    matchLabels:
+      name: pod-to-external-fqdn-allow-google-cnp
+  egress:
+  - toFQDNs:
+    - matchPattern: '*.google.com'
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: openshift-dns
+        k8s:dns.operator.openshift.io/daemonset-dns: default
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+


### PR DESCRIPTION
Add a nightly policy stress test using the connectivity-check as the
base deployment, but using CNPs that exercise the policy computation
while thousands of security identitites are added to the cluster via
`cilium kvstore` commands.

Currently kubectl port-forward must be manually run to forward the Grafana port from the test cluster:

      kubectl -n cilium-monitoring port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000

Related: #11197 
