### PR TITLE
v1.8 backports 2020-08-20

### DIFF
--- a/Documentation/gettingstarted/bird.rst
+++ b/Documentation/gettingstarted/bird.rst
@@ -15,6 +15,12 @@ If you are not familiar with it, you had best have a glance at the `User's Guide
 
 .. _`User's Guide`: https://bird.network.cz/?get_doc&f=bird.html&v=20
 
+BIRD provides a way to advertise routes using traditional networking protocols
+to allow Cilium-managed endpoints to be accessible outside the cluster. This
+guide assumes that Cilium is already deployed in the cluster, and that the
+remaining piece is how to ensure that the pod CIDR ranges are externally
+routable.
+
 `BIRD <https://bird.network.cz>`_ maintains two release families at present:
 ``1.x`` and ``2.x``, and the configuration format varies a lot between them.
 Unless you have already deployed the ``1.x``, we suggest using ``2.x``

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -119,7 +119,7 @@ resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	union v6addr *src;
 	int ret;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip6, !from_host))
 		return DROP_INVALID;
 
 	if (!from_host) {
@@ -337,7 +337,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx)
 	__u32 srcID = 0;
 	__u8 nexthdr;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	nexthdr = ip6->nexthdr;
@@ -370,7 +370,12 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	void *data, *data_end;
 	struct iphdr *ip4;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+	/* This is the first time revalidate_data() is going to be called in
+	 * the "to-netdev" path. Make sure that we don't legitimately drop
+	 * the packet if the skb arrived with the header not being not in the
+	 * linear data.
+	 */
+	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip4, !from_host))
 		return DROP_INVALID;
 
 	/* Packets from the proxy will already have a real identity. */

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -26,7 +26,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx)
 	bool decrypted;
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	if (!decrypted) {
@@ -64,7 +64,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx)
 	bool decrypted;
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	if (!decrypted) {

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -34,7 +34,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	bool decrypted;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
 	if (!bpf_skip_nodeport(ctx)) {
@@ -157,7 +157,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 	bool decrypted;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
 	if (!bpf_skip_nodeport(ctx)) {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -113,8 +113,8 @@ static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,
 }
 
 static __always_inline __maybe_unused bool
-__revalidate_data(struct __ctx_buff *ctx, void **data_, void **data_end_,
-		  void **l3, const __u32 l3_len, const bool pull)
+__revalidate_data_pull(struct __ctx_buff *ctx, void **data_, void **data_end_,
+		       void **l3, const __u32 l3_len, const bool pull)
 {
 	const __u32 tot_len = ETH_HLEN + l3_len;
 	void *data_end;
@@ -136,22 +136,29 @@ __revalidate_data(struct __ctx_buff *ctx, void **data_, void **data_end_,
 	return true;
 }
 
-/* revalidate_data_first() initializes the provided pointers from the ctx and
+/* revalidate_data_pull() initializes the provided pointers from the ctx and
  * ensures that the data is pulled in for access. Should be used the first
  * time that the ctx data is accessed, subsequent calls can be made to
  * revalidate_data() which is cheaper.
  * Returns true if 'ctx' is long enough for an IP header of the provided type,
  * false otherwise.
  */
-#define revalidate_data_first(ctx, data, data_end, ip)			\
-	__revalidate_data(ctx, data, data_end, (void **)ip, sizeof(**ip), true)
+#define revalidate_data_pull(ctx, data, data_end, ip)			\
+	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), true)
+
+/* revalidate_data_maybe_pull() does the same as revalidate_data_maybe_pull()
+ * except that the skb data pull is controlled by the "pull" argument.
+ */
+#define revalidate_data_maybe_pull(ctx, data, data_end, ip, pull)	\
+	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), pull)
+
 
 /* revalidate_data() initializes the provided pointers from the ctx.
  * Returns true if 'ctx' is long enough for an IP header of the provided type,
  * false otherwise.
  */
 #define revalidate_data(ctx, data, data_end, ip)			\
-	__revalidate_data(ctx, data, data_end, (void **)ip, sizeof(**ip), false)
+	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), false)
 
 /* Macros for working with L3 cilium defined IPV6 addresses */
 #define BPF_V6(dst, ...)	BPF_V6_1(dst, fetch_ipv6(__VA_ARGS__))

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -200,6 +200,8 @@ spec:
 {{- end }}
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+      tolerations:
+        - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -904,6 +904,8 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+      tolerations:
+        - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -650,6 +650,8 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+      tolerations:
+        - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -96,7 +96,7 @@ func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, stream observerpb.Obs
 	for _, p := range peers {
 		p := p
 		if !isAvailable(p.Conn) {
-			s.opts.log.WithField("address", p.Address.String()).Infof(
+			s.opts.log.WithField("address", p.Address).Infof(
 				"No connection to peer %s, skipping", p.Name,
 			)
 			s.peers.ReportOffline(p.Name)
@@ -176,7 +176,7 @@ func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusR
 		p := p
 		if !isAvailable(p.Conn) {
 			numUnavailableNodes++
-			s.opts.log.WithField("address", p.Address.String()).Infof(
+			s.opts.log.WithField("address", p.Address).Infof(
 				"No connection to peer %s, skipping", p.Name,
 			)
 			s.peers.ReportOffline(p.Name)

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -297,7 +297,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	now := time.Now()
-	if p.nextConnAttempt.After(now) && !ignoreBackoff {
+	if p.Address == nil || (p.nextConnAttempt.After(now) && !ignoreBackoff) {
 		return
 	}
 	if p.conn != nil {


### PR DESCRIPTION
v1.8 backports 2020-08-20

 * #12916 -- install/kubernetes: add permissive tolerations to cilium operator (@aanm)
 * #12907 -- Relay: handle peer without address (@kAworu)
 * #12917 -- datapath: Pull skb data in to-netdev path (@brb)
 * #12930 -- docs: Add summary of bird integration (@joestringer)


Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12916 12907 12917 12930; do contrib/backporting/set-labels.py $pr done 1.8; done
```

--- 

Skipped due non-trivial conflicts:

 * #12841 -- datapath,daemon: Add check for loadBalancerSourceRanges (@brb) (depends on #12809)

Dropped as requested by @brb (doesn't make sense without backporting the above first):

 * #12940 -- helm,docs: Add section about (LB) source range check (@brb)