### PR TITLE
pkg/kvstore: set endpoint shuffle in etcd client connectivity

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -201,13 +201,6 @@ func (e *etcdModule) newClient(ctx context.Context, opts *ExtraOptions) (Backend
 		e.config.Endpoints = []string{endpointsOpt.value}
 	}
 
-	// Shuffle the order of endpoints to avoid all agents connecting to the
-	// same etcd endpoint and to work around etcd client library failover
-	// bugs. (https://github.com/etcd-io/etcd/pull/9860)
-	if e.config.Endpoints != nil {
-		shuffleEndpoints(e.config.Endpoints)
-	}
-
 	for {
 		// connectEtcdClient will close errChan when the connection attempt has
 		// been successful
@@ -639,6 +632,13 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		}
 		cfg.DialOptions = append(cfg.DialOptions, config.DialOptions...)
 		config = cfg
+	}
+
+	// Shuffle the order of endpoints to avoid all agents connecting to the
+	// same etcd endpoint and to work around etcd client library failover
+	// bugs. (https://github.com/etcd-io/etcd/pull/9860)
+	if config.Endpoints != nil {
+		shuffleEndpoints(config.Endpoints)
 	}
 
 	// Set DialTimeout to 0, otherwise the creation of a new client will


### PR DESCRIPTION
The endpoint shuffle was happening before loading the etcd
configuration. To have the endpoints shuffled we should do it after
loading the configuration from disk.

Fixes: b95650b30b46 ("etcd: Shuffle list of etcd endpoints")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Shuffle etcd endpoints before making initial connectivity to etcd servers
```