### PR TITLE
agent: fix panic when clustermesh not set and cluster-id is non-zero

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -341,7 +341,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 			if k8s.IsEnabled() {
 				// Also wait for all cluster mesh to be synchronized with the
 				// datapath before proceeding.
-				if option.Config.ClusterID != 0 {
+				if d.clustermesh != nil {
 					err := d.clustermesh.ClustersSynced(context.Background())
 					if err != nil {
 						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")


### PR DESCRIPTION
Currently, `d.clustermesh` is initialized if (in `bootstrapClusterMesh()`)

1. `clustermesh-config` is set to a non-empty dir, AND then
2. `cluster-id` is set to non-zero

So if `clustermesh-config` is set empty, `d.clustermesh` will not be
initialized.

The reported code determines whether clustermesh is enabled by only
`ClusterID == 0`, which is not sufficient and will cause panic when
`clustermesh-config == "" && cluster-id != 0`.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>