### PR TITLE
pkg/kvstore: add gRPC keep alives for etcd connectivity

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -645,6 +645,11 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	// block until DialTimeout is reached or a connection to the server
 	// is made.
 	config.DialTimeout = 0
+	// Ping the server to verify if the server connection is still valid
+	config.DialKeepAliveTime = 15 * time.Second
+	// Timeout if the server does not reply within 15 seconds and close the
+	// connection. Ideally it should be lower than staleLockTimeout
+	config.DialKeepAliveTimeout = 25 * time.Second
 	c, err := client.New(*config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If the client does not receive a keep alive from the server, that
connection should be closed so the etcd client library does proper
round robin for the other available endpoints.

This might be a little bit aggressive in a larger environment if all
clients perform a keep alive requests to the etcd servers. Some
testing could be done to verify if there is a large overhead of
doing these keep alive requests.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/12945

**TODO** Perhaps it would also be a good idea to do have a hidden flag to configure this timeouts? Or even disable them?

```release-note
Improved reliability of etcd connectivity by adding gRPC keep alives
```