### PR TITLE
envoy: Add Prometheus metrics listener

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -177,6 +177,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                       Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                  IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                    Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-prometheus-port int                     Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                          Read to the CNI configuration at specified path to extract per node configuration
       --restore                                       Restores state, if possible, from previous daemon (default true)
       --sidecar-istio-proxy-image string              Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -23,18 +23,20 @@ Cilium Metrics
 ==============
 
 Cilium metrics provide insights into the state of Cilium itself, namely
-of the ``cilium-agent`` and ``cilium-operator`` processes. To run Cilium with
-Prometheus metrics enabled, deploy it with the
+of the ``cilium-agent``, ``cilium-envoy``, and ``cilium-operator`` processes.
+To run Cilium with Prometheus metrics enabled, deploy it with the
 ``global.prometheus.enabled=true`` Helm value set.
 
-Cilium metrics are exported under the ``cilium_`` Prometheus namespace.
+Cilium metrics are exported under the ``cilium_`` Prometheus namespace. Envoy
+metrics are exported under the ``envoy_`` Prometheus namespace, of which the
+Cilium-defined metrics are exported under the ``envoy_cilium_`` namespace.
 When running and collecting in Kubernetes they will be tagged with a pod name
 and namespace.
 
 Installation
 ------------
 
-You can enable metrics for ``cilium-agent`` with the Helm value
+You can enable metrics for ``cilium-agent`` (including Envoy) with the Helm value
 ``global.prometheus.enabled=true``. To enable metrics for ``cilium-operator``,
 use ``global.operatorPrometheus.enabled=true``.
 
@@ -45,8 +47,8 @@ use ``global.operatorPrometheus.enabled=true``.
      --set global.prometheus.enabled=true \\
      --set global.operatorPrometheus.enabled=true
 
-The ports can be configured via
-``global.prometheus.port`` or ``global.operatorPrometheus.port`` respectively.
+The ports can be configured via ``global.prometheus.port``,
+``global.proxy.prometheus.port``, or ``global.operatorPrometheus.port`` respectively.
 
 When metrics are enabled, all Cilium components will have the following
 annotations. They can be used to signal Prometheus whether to scrape metrics:
@@ -56,7 +58,18 @@ annotations. They can be used to signal Prometheus whether to scrape metrics:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
 
-Prometheus will pick up the Cilium metrics automatically if the following
+To collect Envoy metrics the Cilium chart will create a Kubernetes headless
+service named ``cilium-agent`` with the ``prometheus.io/scrape:'true'`` annotation set:
+
+.. code-block:: yaml
+
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9095"
+
+This additional headless service in addition to the other Cilium components is needed
+as each component can only have one Prometheus scrape and port annotation.
+
+Prometheus will pick up the Cilium and Envoy metrics automatically if the following
 option is set in the ``scrape_configs`` section:
 
 .. code-block:: yaml

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -404,6 +404,9 @@ func init() {
 	flags.Uint(option.ProxyConnectTimeout, 1, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
 	option.BindEnv(option.ProxyConnectTimeout)
 
+	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
+	option.BindEnv(option.ProxyPrometheusPort)
+
 	flags.Bool(option.DisableEnvoyVersionCheck, false, "Do not perform Envoy binary version check on startup")
 	flags.MarkHidden(option.DisableEnvoyVersionCheck)
 	// Disable version check if Envoy build is disabled

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -177,10 +177,14 @@ spec:
         name: cilium-agent
 {{- if or .Values.global.prometheus.enabled .Values.global.hubble.metrics.enabled }}
         ports:
-{{- if .Values.global.prometheus.enabled }}                
+{{- if .Values.global.prometheus.enabled }}
         - containerPort: {{ .Values.global.prometheus.port }}
           hostPort: {{ .Values.global.prometheus.port }}
           name: prometheus
+          protocol: TCP
+        - containerPort: {{ .Values.global.proxy.prometheus.port }}
+          hostPort: {{ .Values.global.proxy.prometheus.port }}
+          name: envoy-metrics
           protocol: TCP
 {{- end }}
 {{- if .Values.global.hubble.metrics.enabled }}

--- a/install/kubernetes/cilium/charts/agent/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/svc.yaml
@@ -14,6 +14,31 @@ spec:
     port: {{ .Values.global.prometheus.port }}
     protocol: TCP
     targetPort: prometheus
+  - name: envoy-metrics
+    port: {{ .Values.global.proxy.prometheus.port }}
+    protocol: TCP
+    targetPort: envoy-metrics
+  selector:
+    k8s-app: cilium
+{{- else if .Values.global.prometheus.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: cilium-agent
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: {{ .Values.global.proxy.prometheus.port | quote }}
+  labels:
+    k8s-app: cilium
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: envoy-metrics
+    port: {{ .Values.global.proxy.prometheus.port }}
+    protocol: TCP
+    targetPort: envoy-metrics
   selector:
     k8s-app: cilium
 {{- end }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -133,6 +133,9 @@ data:
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
   prometheus-serve-addr: ":{{ .Values.global.prometheus.port }}"
+  # Port to expose Envoy metrics (e.g. "9095"). Envoy metrics listener will be disabled if this
+  # field is not set.
+  proxy-prometheus-port: "{{ .Values.global.proxy.prometheus.port }}"
 {{- end }}
 
 {{- if .Values.global.operatorPrometheus.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -543,6 +543,10 @@ global:
     # container image names
     sidecarImageRegex: "cilium/istio_proxy"
 
+    prometheus:
+      # Port to expose Envoy metrics on (e.g. "9095"). Prometheus metrics will be exposed on "/metrics".
+      port: "9095"
+
   endpointHealthChecking:
     enabled: true
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -154,6 +154,9 @@ const (
 	// EnvoyLog sets the path to a separate Envoy log file, if any
 	EnvoyLog = "envoy-log"
 
+	// ProxyPrometheusPort specifies the port to serve Cilium host proxy metrics on.
+	ProxyPrometheusPort = "proxy-prometheus-port"
+
 	// FixedIdentityMapping is the key-value for the fixed identity mapping
 	// which allows to use reserved label for fixed identities
 	FixedIdentityMapping = "fixed-identity-mapping"
@@ -913,6 +916,7 @@ var HelpFlagSections = []FlagsSection{
 			HTTPRetryCount,
 			HTTPRetryTimeout,
 			ProxyConnectTimeout,
+			ProxyPrometheusPort,
 			SidecarIstioProxyImage,
 		},
 	},
@@ -1438,6 +1442,9 @@ type DaemonConfig struct {
 	// ProxyConnectTimeout is the time in seconds after which Envoy considers a TCP
 	// connection attempt to have timed out.
 	ProxyConnectTimeout int
+
+	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
+	ProxyPrometheusPort int
 
 	// BPFCompilationDebug specifies whether to compile BPF programs compilation
 	// debugging enabled.
@@ -2404,6 +2411,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
+	c.ProxyPrometheusPort = viper.GetInt(ProxyPrometheusPort)
 	c.BlacklistConflictingRoutes = viper.GetBool(BlacklistConflictingRoutes)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
 	c.RestoreState = viper.GetBool(Restore)


### PR DESCRIPTION
Add Envoy listener for prometheus metrics at port cunfigured via command line option
'--proxy-prometheus-port'. Default 0 (== disabled).

The corresponding Helm value 'global.proxy.prometheus.port' defaults to 9095, but is
only configured if 'global.prometheus.enabled' is set to 'true'.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy metrics from the Cilium host proxy are exported via a prometheus port.
```
