### PR TITLE
nodeinit: only bypass IP-MASQ chain if Cilium manages masquerade

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
-{{- if .Values.global.gke.enabled }}
+{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
                     # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
@@ -183,13 +183,16 @@ spec:
               systemctl restart kubelet
 {{- end }}
 
-{{- if .Values.global.gke.enabled }}
-              # If Cilium is installed, it would be expected that it would be solely responsible
-              # for the networking configuration on that node.
-              # In GKE, even if the IP masquerade agent is not enabled, the instance
-              # configure script adds some default masquerade rules anyway.
-              # If we remove the jump to that ip-masq chain, then we ensure masquerade configuration
-              # is managed by Cilium.
+{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
+              # If Cilium is configured to manage masquerading of traffic leaving the node,
+              # we need to disable the IP-MASQ chain because even if ip-masq-agent
+              # is not installed, the node init script installs some default rules into
+              # the IP-MASQ chain.
+              # If we remove the jump to that ip-masq chain, then we ensure the ip masquerade
+              # configuration is solely managed by Cilium.
+              # Also, if Cilium is installed, it may be expected that it would be solely responsible
+              # for the networking configuration on that node. So provide the same functionality
+              # as the --disable-snat-flag for existing GKE clusters.
               iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ || true
 {{- end }}
 

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
-{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
+{{- if (and .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat))}}
                     # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
@@ -183,7 +183,7 @@ spec:
               systemctl restart kubelet
 {{- end }}
 
-{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
+{{- if (and .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat))}}
               # If Cilium is configured to manage masquerading of traffic leaving the node,
               # we need to disable the IP-MASQ chain because even if ip-masq-agent
               # is not installed, the node init script installs some default rules into

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
-{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
+{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
                     # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
@@ -183,7 +183,7 @@ spec:
               systemctl restart kubelet
 {{- end }}
 
-{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
+{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
               # If Cilium is configured to manage masquerading of traffic leaving the node,
               # we need to disable the IP-MASQ chain because even if ip-masq-agent
               # is not installed, the node init script installs some default rules into

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -434,6 +434,9 @@ global:
   # Google Kubernetes Engine
   gke:
     enabled: false
+    # Provide the same functionality as the --disable-default-snat flag
+    # for existing GKE clusters that want to disable masquerade
+    disableDefaultSnat: false
 
   azure:
     enabled: false


### PR DESCRIPTION
#11782 introduced unexpected behavior of outright disabling ip-masquerade-agent functionality in GKE clusters with Cilium installed.

See: https://github.com/cilium/cilium/pull/11782#issuecomment-676508941

Instead of always bypassing the IP-MASQ chain managed by GKE nodeinit and the ip-masquerade-agent, only bypass it if the user wants Cilium to manage masquerading (`global.masquerade=true`) or if they want to explicitly disable masquerade (`global.gke.disableDefaultSnat`)
