### PR TITLE
.gitattributes: Mark cmdref files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 go.sum linguist-generated
 examples/kubernetes/connectivity-check/connectivity-*.yaml linguist-generated
 examples/crds/*.yaml linguist-generated
+Documentation/cmdref/** linguist-generated


### PR DESCRIPTION
This commit tells [Linguist](https://github.com/github/linguist) that files in `Documentation/cmdref/` are generated and can therefore be hidden by default in pull requests.