### PR TITLE
daemon: Start DNS proxy before k8s with restored rules

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -409,6 +409,39 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	treatRemoteNodeAsHost := option.Config.AlwaysAllowLocalhost() && !option.Config.EnableRemoteNodeIdentity
 	policyApi.InitEntities(option.Config.ClusterName, treatRemoteNodeAsHost)
 
+	// Start the proxy before we restore endpoints so that we can inject the
+	// daemon's proxy into each endpoint.
+	bootstrapStats.proxyStart.Start()
+	// FIXME: Make the port range configurable.
+	if option.Config.EnableL7Proxy {
+		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
+			&d, option.Config.AgentLabels, d.datapath, d.endpointManager)
+	} else {
+		log.Info("L7 proxies are disabled")
+	}
+	bootstrapStats.proxyStart.End(true)
+
+	bootstrapStats.restore.Start()
+	// fetch old endpoints before k8s is configured.
+	restoredEndpoints, err := d.fetchOldEndpoints(option.Config.StateDir)
+	if err != nil {
+		log.WithError(err).Error("Unable to read existing endpoints")
+	}
+	bootstrapStats.restore.End(true)
+
+	bootstrapStats.fqdn.Start()
+	if err := fqdn.ConfigFromResolvConf(); err != nil {
+		bootstrapStats.fqdn.EndError(err)
+		return nil, nil, err
+	}
+
+	err = d.bootstrapFQDN(restoredEndpoints.possible, option.Config.ToFQDNsPreCache)
+	if err != nil {
+		bootstrapStats.fqdn.EndError(err)
+		return nil, restoredEndpoints, err
+	}
+	bootstrapStats.fqdn.End(true)
+
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 		if err := k8s.RegisterCRDs(); err != nil {
@@ -513,23 +546,10 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 
 	d.bootstrapIPAM()
 
-	// Start the proxy before we restore endpoints so that we can inject the
-	// daemon's proxy into each endpoint.
-	bootstrapStats.proxyStart.Start()
-	// FIXME: Make the port range configurable.
-	if option.Config.EnableL7Proxy {
-		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
-			&d, option.Config.AgentLabels, d.datapath, d.endpointManager)
-	} else {
-		log.Info("L7 proxies are disabled")
-	}
-	bootstrapStats.proxyStart.End(true)
-
-	bootstrapStats.restore.Start()
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.
-	restoredEndpoints, err := d.restoreOldEndpoints(option.Config.StateDir, true)
+	err = d.restoreOldEndpoints(restoredEndpoints, true)
 	if err != nil {
 		log.WithError(err).Error("Unable to restore existing endpoints")
 	}
@@ -595,6 +615,12 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		return nil, restoredEndpoints, err
 	}
 
+	// iptables rules can be updated only after d.init() intializes the iptables above.
+	err = d.updateDNSDatapathRules()
+	if err != nil {
+		return nil, restoredEndpoints, err
+	}
+
 	// We can only start monitor agent once cilium_event has been set up.
 	if option.Config.RunMonitorAgent {
 		monitorAgent, err := monitoragent.NewAgent(d.ctx, defaults.MonitorBufferPages)
@@ -636,19 +662,6 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	// we populate the IPCache with the host's IP(s).
 	ipcache.InitIPIdentityWatcher()
 	identitymanager.Subscribe(d.policy)
-
-	bootstrapStats.fqdn.Start()
-	if err := fqdn.ConfigFromResolvConf(); err != nil {
-		bootstrapStats.fqdn.EndError(err)
-		return nil, nil, err
-	}
-
-	err = d.bootstrapFQDN(restoredEndpoints, option.Config.ToFQDNsPreCache)
-	if err != nil {
-		bootstrapStats.fqdn.EndError(err)
-		return nil, restoredEndpoints, err
-	}
-	bootstrapStats.fqdn.End(true)
 
 	return &d, restoredEndpoints, nil
 }

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -277,6 +277,9 @@ func (ds *DaemonSuite) GetDNSRules(epID uint16) restore.DNSRules {
 	return nil
 }
 
+func (ds *DaemonSuite) RemoveRestoredDNSRules(epID uint16) {
+}
+
 func (ds *DaemonSuite) GetNodeSuffix() string {
 	return ds.d.GetNodeSuffix()
 }

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath"
 	fakedatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -270,6 +271,10 @@ func (ds *DaemonSuite) GetCIDRPrefixLengths() ([]int, []int) {
 
 func (ds *DaemonSuite) Datapath() datapath.Datapath {
 	return ds.d.datapath
+}
+
+func (ds *DaemonSuite) GetDNSRules(epID uint16) restore.DNSRules {
+	return nil
 }
 
 func (ds *DaemonSuite) GetNodeSuffix() string {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
@@ -39,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/proxy"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
@@ -934,4 +936,8 @@ func (d *Daemon) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), e
 		})
 	}
 	return doneFunc, nil
+}
+
+func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
+	return proxy.DefaultDNSProxy.GetRules(epID)
 }

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -939,5 +939,17 @@ func (d *Daemon) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), e
 }
 
 func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
+	// Many unit tests do not initialize the DNS proxy
+	if proxy.DefaultDNSProxy == nil {
+		return nil
+	}
 	return proxy.DefaultDNSProxy.GetRules(epID)
+}
+
+func (d *Daemon) RemoveRestoredDNSRules(epID uint16) {
+	// Many unit tests do not initialize the DNS proxy
+	if proxy.DefaultDNSProxy == nil {
+		return
+	}
+	proxy.DefaultDNSProxy.RemoveRestoredRules(epID)
 }

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -316,7 +316,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		for _, possibleEP := range possibleEndpoints {
 			// Upgrades from old ciliums have this nil
 			if possibleEP.DNSRules != nil {
-				proxy.DefaultDNSProxy.RestoreRules(possibleEP.ID, possibleEP.DNSRules)
+				proxy.DefaultDNSProxy.RestoreRules(possibleEP)
 			}
 		}
 	}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -136,7 +136,7 @@ func (d *Daemon) updateSelectorCacheFQDNs(ctx context.Context, selectors map[pol
 // dnsNameManager and DNSPoller will use the default resolver and, implicitly, the
 // default DNS cache. The proxy binds to all interfaces, and uses the
 // configured DNS proxy port (this may be 0 and so OS-assigned).
-func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCachePath string) (err error) {
+func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, preCachePath string) (err error) {
 	cfg := fqdn.Config{
 		MinTTL:               option.Config.ToFQDNsMinTTL,
 		OverLimit:            option.Config.ToFQDNsMaxIPsPerHost,
@@ -263,20 +263,20 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 	// restoring after a long delay).
 	globalCache := d.dnsNameManager.GetDNSCache()
 	now := time.Now()
-	for _, restoredEP := range restoredEndpoints.restored {
+	for _, possibleEP := range possibleEndpoints {
 		// Upgrades from old ciliums have this nil
-		if restoredEP.DNSHistory != nil {
-			globalCache.UpdateFromCache(restoredEP.DNSHistory, []string{})
+		if possibleEP.DNSHistory != nil {
+			globalCache.UpdateFromCache(possibleEP.DNSHistory, []string{})
 
 			// GC any connections that have expired, but propagate it to the zombies
 			// list. DNSCache.GC can handle a nil DNSZombies parameter. We use the
 			// actual now time because we are checkpointing at restore time.
-			restoredEP.DNSHistory.GC(now, restoredEP.DNSZombies)
+			possibleEP.DNSHistory.GC(now, possibleEP.DNSZombies)
 		}
 
-		if restoredEP.DNSZombies != nil {
+		if possibleEP.DNSZombies != nil {
 			lookupTime := time.Now()
-			alive, _ := restoredEP.DNSZombies.GC()
+			alive, _ := possibleEP.DNSZombies.GC()
 			for _, zombie := range alive {
 				for _, name := range zombie.Names {
 					globalCache.Update(lookupTime, name, []net.IP{zombie.IP}, int(2*dnsGCJobInterval.Seconds()))
@@ -297,6 +297,9 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 	port, listenerName, err := proxy.GetProxyPort(policy.ParserTypeDNS, false)
 	if option.Config.ToFQDNsProxyPort != 0 {
 		port = uint16(option.Config.ToFQDNsProxyPort)
+	} else if port == 0 {
+		// Try locate old DNS proxy port number from the datapath
+		port = d.datapath.GetProxyPort(listenerName)
 	}
 	if err != nil {
 		return err
@@ -305,10 +308,19 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)
-
+		if err == nil && port == proxy.DefaultDNSProxy.BindPort {
+			log.Infof("Reusing previous DNS proxy port: %d", port)
+		}
 		proxy.DefaultDNSProxy.SetRejectReply(option.Config.FQDNRejectResponse)
 	}
 	return err // filled by StartDNSProxy
+}
+
+// updateDNSDatapathRules updates the DNS proxy iptables rules. Must be
+// called after iptables has been initailized, and only after
+// successful bootstrapFQDN().
+func (d *Daemon) updateDNSDatapathRules() error {
+	return d.l7Proxy.AckProxyPort(policy.ParserTypeDNS, false)
 }
 
 // updateSelectors propagates the mapping of FQDNSelector to identity, as well

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -38,6 +38,7 @@ import (
 )
 
 type endpointRestoreState struct {
+	possible map[uint16]*endpoint.Endpoint
 	restored []*endpoint.Endpoint
 	toClean  []*endpoint.Endpoint
 }
@@ -90,7 +91,40 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 	return true, nil
 }
 
-// restoreOldEndpoints reads the list of existing endpoints previously managed by
+// fetchOldEndpoints reads the list of existing endpoints previously managed by Cilium when it was
+// last run and associated it with container workloads. This function performs the first step in
+// restoring the endpoint structure.  It needs to be followed by a call to restoreOldEndpoints()
+// once k8s has been initialized and regenerateRestoredEndpoints() once the endpoint builder is
+// ready.
+func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
+	state := &endpointRestoreState{
+		possible: nil,
+		restored: []*endpoint.Endpoint{},
+		toClean:  []*endpoint.Endpoint{},
+	}
+
+	if !option.Config.RestoreState {
+		log.Info("Endpoint restore is disabled, skipping restore step")
+		return state, nil
+	}
+
+	log.Info("Reading old endpoints...")
+
+	dirFiles, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return state, err
+	}
+	eptsID := endpoint.FilterEPDir(dirFiles)
+
+	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d, dir, eptsID)
+
+	if len(state.possible) == 0 {
+		log.Info("No old endpoints found.")
+	}
+	return state, nil
+}
+
+// restoreOldEndpoints reads the list of existing endpoints previously managed
 // Cilium when it was last run and associated it with container workloads. This
 // function performs the first step in restoring the endpoint structure,
 // allocating their existing IPs out of the CIDR block and then inserting the
@@ -99,16 +133,15 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 //
 // If clean is true, endpoints which cannot be associated with a container
 // workloads are deleted.
-func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreState, error) {
+func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) error {
 	failed := 0
-	state := &endpointRestoreState{
-		restored: []*endpoint.Endpoint{},
-		toClean:  []*endpoint.Endpoint{},
-	}
+	defer func() {
+		state.possible = nil
+	}()
 
 	if !option.Config.RestoreState {
 		log.Info("Endpoint restore is disabled, skipping restore step")
-		return state, nil
+		return nil
 	}
 
 	log.Info("Restoring endpoints...")
@@ -125,20 +158,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 		}
 	}
 
-	dirFiles, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return state, err
-	}
-	eptsID := endpoint.FilterEPDir(dirFiles)
-
-	possibleEPs := endpoint.ReadEPsFromDirNames(d.ctx, d, dir, eptsID)
-
-	if len(possibleEPs) == 0 {
-		log.Info("No old endpoints found.")
-		return state, nil
-	}
-
-	for _, ep := range possibleEPs {
+	for _, ep := range state.possible {
 		scopedLog := log.WithField(logfields.EndpointID, ep.ID)
 		if k8s.IsEnabled() {
 			scopedLog = scopedLog.WithField("k8sPodName", ep.GetK8sNamespaceAndPodName())
@@ -202,7 +222,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 		}
 	}
 
-	return state, nil
+	return nil
 }
 
 func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (restoreComplete chan struct{}) {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/proxy"
 
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -280,8 +279,6 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 				epRegenerated <- false
 				return
 			}
-			// Remove restored rules after successful initial regeneration
-			proxy.DefaultDNSProxy.RemoveRestoredRules(ep.ID)
 			epRegenerated <- true
 		}(ep, epRegenerated)
 	}

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -92,6 +92,10 @@ func (f *fakeDatapath) TransientRulesEnd(quiet bool) {
 	return
 }
 
+func (m *fakeDatapath) GetProxyPort(name string) uint16 {
+	return 0
+}
+
 func (f *fakeDatapath) Loader() datapath.Loader {
 	return f.loader
 }

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -76,4 +76,8 @@ type IptablesManager interface {
 	InstallRules(ifName string) error
 	TransientRulesStart(ifName string) error
 	TransientRulesEnd(quiet bool)
+
+	// GetProxyPort fetches the existing proxy port configured for the
+	// specified listener. Used early in bootstrap to reopen proxy ports.
+	GetProxyPort(listener string) uint16
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -148,6 +148,18 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	}
 	defer f.Cleanup()
 
+	// Update DNSRules if any. This is needed because DNSRules also encode allowed destination IPs
+	// and those can change anytime we have identity updates in the cluster. If there are no
+	// DNSRules (== nil) we don't need to update here, as in that case there are no allowed
+	// destinations either.
+	if e.DNSRules != nil {
+		e.OnDNSPolicyUpdateLocked(e.owner.GetDNSRules(e.ID))
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.Path: headerPath,
+			"DNSRules":     e.DNSRules,
+		}).Debug("writing header file with DNSRules")
+	}
+
 	if err = e.writeInformationalComments(f); err != nil {
 		return err
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1048,6 +1048,9 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		e.owner.Datapath().Loader().Unload(e.createEpInfoCache(""))
 	}
 
+	// Remove restored rules of cleaned endpoint
+	e.owner.RemoveRestoredDNSRules(e.ID)
+
 	if e.SecurityIdentity != nil && len(e.realizedRedirects) > 0 {
 		// Passing a new map of nil will purge all redirects
 		finalize, _ := e.removeOldRedirects(nil, proxyWaitGroup)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1560,7 +1560,7 @@ func (e *Endpoint) UpdateProxyStatistics(l4Protocol string, port uint16, ingress
 	key := policy.ProxyID(e.ID, ingress, l4Protocol, port)
 	proxyStats, ok := e.proxyStatistics[key]
 	if !ok {
-		e.getLogger().WithField(logfields.L4PolicyID, key).Warn("Proxy stats not found when updating")
+		e.getLogger().WithField(logfields.L4PolicyID, key).Debug("Proxy stats not found when updating")
 		return
 	}
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -116,6 +117,10 @@ func (s *EndpointSuite) SendNotification(msg monitorAPI.AgentNotifyMessage) erro
 
 func (s *EndpointSuite) Datapath() datapath.Datapath {
 	return s.datapath
+}
+
+func (s *EndpointSuite) GetDNSRules(epID uint16) restore.DNSRules {
+	return nil
 }
 
 func (s *EndpointSuite) SetUpTest(c *C) {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -123,6 +123,9 @@ func (s *EndpointSuite) GetDNSRules(epID uint16) restore.DNSRules {
 	return nil
 }
 
+func (s *EndpointSuite) RemoveRestoredDNSRules(epID uint16) {
+}
+
 func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */
 	kvstore.SetupDummy("etcd")

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -465,6 +465,9 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 	// compiled for
 	e.setPolicyRevision(revision)
 
+	// Remove restored rules after successful regeneration
+	e.owner.RemoveRestoredDNSRules(e.ID)
+
 	return nil
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -128,6 +128,9 @@ func (s *DummyOwner) GetDNSRules(epID uint16) restore.DNSRules {
 	return nil
 }
 
+func (s *DummyOwner) RemoveRestoredDNSRules(epID uint16) {
+}
+
 // GetNodeSuffix does nothing.
 func (d *DummyOwner) GetNodeSuffix() string {
 	return ""

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -120,6 +121,10 @@ func (d *DummyOwner) SendNotification(msg monitorAPI.AgentNotifyMessage) error {
 
 // Datapath returns a nil datapath.
 func (d *DummyOwner) Datapath() datapath.Datapath {
+	return nil
+}
+
+func (s *DummyOwner) GetDNSRules(epID uint16) restore.DNSRules {
 	return nil
 }
 

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -48,8 +48,13 @@ type Owner interface {
 	// Datapath returns a reference to the datapath implementation.
 	Datapath() datapath.Datapath
 
-	// GetDNSRules()
+	// GetDNSRules creates a fresh copy of DNS rules that can be used when
+	// endpoint is restored on a restart.
 	GetDNSRules(epID uint16) restore.DNSRules
+
+	// RemoveRestoredDNSRules removes any restored DNS rules for
+	// this endpoint from the DNS proxy.
+	RemoveRestoredDNSRules(epID uint16)
 }
 
 // EndpointInfoSource returns information about an endpoint being proxied.

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -46,6 +47,9 @@ type Owner interface {
 
 	// Datapath returns a reference to the datapath implementation.
 	Datapath() datapath.Datapath
+
+	// GetDNSRules()
+	GetDNSRules(epID uint16) restore.DNSRules
 }
 
 // EndpointInfoSource returns information about an endpoint being proxied.

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -403,6 +404,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		NodeMAC:               e.nodeMAC,
 		SecurityIdentity:      e.SecurityIdentity,
 		Options:               e.Options,
+		DNSRules:              e.DNSRules,
 		DNSHistory:            e.DNSHistory,
 		DNSZombies:            e.DNSZombies,
 		K8sPodName:            e.K8sPodName,
@@ -477,6 +479,9 @@ type serializableEndpoint struct {
 	// Options determine the datapath configuration of the endpoint.
 	Options *option.IntOptions
 
+	// DNSRules is the collection of current DNS rules for this endpoint.
+	DNSRules restore.DNSRules
+
 	// DNSHistory is the collection of still-valid DNS responses intercepted for
 	// this endpoint.
 	DNSHistory *fqdn.DNSCache
@@ -536,6 +541,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.IPv4 = r.IPv4
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
+	ep.DNSRules = r.DNSRules
 	ep.DNSHistory = r.DNSHistory
 	ep.DNSZombies = r.DNSZombies
 	ep.K8sPodName = r.K8sPodName

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -88,6 +89,10 @@ func (s *EndpointManagerSuite) SendNotification(msg monitorAPI.AgentNotifyMessag
 }
 
 func (s *EndpointManagerSuite) Datapath() datapath.Datapath {
+	return nil
+}
+
+func (s *EndpointManagerSuite) GetDNSRules(epID uint16) restore.DNSRules {
 	return nil
 }
 

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -96,6 +96,9 @@ func (s *EndpointManagerSuite) GetDNSRules(epID uint16) restore.DNSRules {
 	return nil
 }
 
+func (s *EndpointManagerSuite) RemoveRestoredDNSRules(epID uint16) {
+}
+
 type DummyRuleCacheOwner struct{}
 
 func (d *DummyRuleCacheOwner) ClearPolicyConsumers(id uint16) *sync.WaitGroup {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -232,7 +232,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 }
 
 // 'p' must be locked
-func (p *DNSProxy) removeRestoredRules(endpointID uint64) {
+func (p *DNSProxy) removeRestoredRulesLocked(endpointID uint64) {
 	if _, exists := p.restored[endpointID]; exists {
 		// Remove IP->ID mappings for the restored EP
 		for ip, ep := range p.restoredEPs {
@@ -248,7 +248,7 @@ func (p *DNSProxy) removeRestoredRules(endpointID uint64) {
 func (p *DNSProxy) RemoveRestoredRules(endpointID uint16) {
 	p.Lock()
 	defer p.Unlock()
-	p.removeRestoredRules(uint64(endpointID))
+	p.removeRestoredRulesLocked(uint64(endpointID))
 }
 
 // setPortRulesForID sets the matching rules for endpointID and destPort for
@@ -451,7 +451,7 @@ func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules po
 	err := p.allowed.setPortRulesForID(endpointID, destPort, newRules)
 	if err == nil {
 		// Rules were updated based on policy, remove restored rules
-		p.removeRestoredRules(endpointID)
+		p.removeRestoredRulesLocked(endpointID)
 	}
 	return err
 }

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
@@ -84,6 +85,10 @@ type DNSProxy struct {
 	// design now.
 	LookupSecIDByIP LookupSecIDByIPFunc
 
+	// LookupIPsBySecID is a provided callback that returns the IPs by security ID
+	// from the ipcache.
+	LookupIPsBySecID LookupIPsBySecIDFunc
+
 	// NotifyOnDNSMsg is a provided callback by which the proxy can emit DNS
 	// response data. It is intended to wire into a DNS cache and a
 	// fqdn.NameManager.
@@ -123,6 +128,11 @@ type DNSProxy struct {
 	// Note: Simple DNS names, e.g. bar.foo.com, will treat the "." as a literal.
 	allowed perEPAllow
 
+	// restored is a set of rules restored from a previous instance that can be
+	// used until 'allowed' rules for an endpoint are first initialized after
+	// a restart
+	restored perEPRestored
+
 	// rejectReply is the OPCode send from the DNS-proxy to the endpoint if the
 	// DNS request is invalid
 	rejectReply int
@@ -137,6 +147,74 @@ type portToSelectorAllow map[uint16]cachedSelectorREEntry
 // cachedSelectorREEntry maps port numbers to selectors to rules, mirroring
 // policy.L7DataMap but the DNS rules are compiled into a single regexp
 type cachedSelectorREEntry map[policy.CachedSelector]*regexp.Regexp
+
+// structure for restored rules that can be used while Cilium agent is restoring endpoints
+type perEPRestored map[uint64]restore.DNSRules
+
+// CheckRestored checks endpointID, destPort, destIP, and name against the restored rules,
+// and only returns true if a restored rule matches.
+func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP string, name string) bool {
+	ipRules, exists := p.restored[endpointID][destPort]
+	if !exists {
+		return false
+	}
+
+	for i := range ipRules {
+		if _, exists := ipRules[i].IPs[destIP]; (exists || ipRules[i].IPs == nil) && ipRules[i].Re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetRules creates a fresh copy of EP's DNS rules to be stored
+// for later restoration.
+func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
+	p.Lock()
+	defer p.Unlock()
+
+	restored := make(restore.DNSRules)
+	for port, entries := range p.allowed[uint64(endpointID)] {
+		var ipRules restore.IPRules
+		for cs, regex := range entries {
+			var IPs map[string]struct{}
+			if !cs.IsWildcard() {
+				IPs = make(map[string]struct{})
+				for _, nid := range cs.GetSelections() {
+					for _, ip := range p.LookupIPsBySecID(nid) {
+						IPs[ip] = struct{}{}
+					}
+				}
+			}
+			ipRules = append(ipRules, restore.IPRule{IPs: IPs, Re: restore.RuleRegex{Regexp: regex}})
+		}
+		restored[port] = ipRules
+	}
+	return restored
+}
+
+// RestoreRules is used in the beginning of endpoint restoration to
+// install rules saved before the restart to be used before the endpoint
+// is regenerated.
+func (p *DNSProxy) RestoreRules(endpointID uint16, rules restore.DNSRules) {
+	p.Lock()
+	defer p.Unlock()
+	p.restored[uint64(endpointID)] = rules
+
+	log.Debugf("Restored rules for endpoint %d: %v", endpointID, rules)
+}
+
+// 'p' must be locked
+func (p *DNSProxy) removeRestoredRules(endpointID uint64) {
+	delete(p.restored, endpointID)
+}
+
+// RemoveRestoredRules removes all restored rules for 'endpointID'.
+func (p *DNSProxy) RemoveRestoredRules(endpointID uint16) {
+	p.Lock()
+	defer p.Unlock()
+	p.removeRestoredRules(uint64(endpointID))
+}
 
 // setPortRulesForID sets the matching rules for endpointID and destPort for
 // later lookups. It converts newRules into a unified regexp that can be reused
@@ -203,6 +281,10 @@ type LookupEndpointIDByIPFunc func(ip net.IP) (endpoint *endpoint.Endpoint, err 
 // See DNSProxy.LookupSecIDByIP for usage.
 type LookupSecIDByIPFunc func(ip net.IP) (secID ipcache.Identity, exists bool)
 
+// LookupIPsBySecIDFunc Func wraps logic to lookup an IPs by security ID from the
+// ipcache.
+type LookupIPsBySecIDFunc func(nid identity.NumericIdentity) []string
+
 // NotifyOnDNSMsgFunc handles propagating DNS response data
 // See DNSProxy.LookupEndpointIDByIP for usage.
 type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error
@@ -237,7 +319,7 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 // notifyFunc will be called with DNS response data that is returned to a
 // requesting endpoint. Note that denied requests will not trigger this
 // callback.
-func StartDNSProxy(address string, port uint16, enableDNSCompression bool, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
+func StartDNSProxy(address string, port uint16, enableDNSCompression bool, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
 	if port == 0 {
 		log.Debug("DNS Proxy port is configured to 0. A random port will be assigned by the OS.")
 	}
@@ -249,9 +331,11 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, looku
 	p := &DNSProxy{
 		LookupEndpointIDByIP:  lookupEPFunc,
 		LookupSecIDByIP:       lookupSecIDFunc,
+		LookupIPsBySecID:      lookupIPsFunc,
 		NotifyOnDNSMsg:        notifyFunc,
 		lookupTargetDNSServer: lookupTargetDNSServer,
 		allowed:               make(perEPAllow),
+		restored:              make(perEPRestored),
 		rejectReply:           dns.RcodeRefused,
 		EnableDNSCompression:  enableDNSCompression,
 	}
@@ -315,20 +399,25 @@ func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules po
 	p.Lock()
 	defer p.Unlock()
 
-	return p.allowed.setPortRulesForID(endpointID, destPort, newRules)
+	err := p.allowed.setPortRulesForID(endpointID, destPort, newRules)
+	if err == nil {
+		// Rules were updated based on policy, remove restored rules
+		p.removeRestoredRules(endpointID)
+	}
+	return err
 }
 
-// CheckAllowed checks endpointID, destPort, destID, and name against the rules
-// added to the proxy, and only returns true if this all match something that
-// was added (via SetAllowed) previously.
-func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID identity.NumericIdentity, name string) (allowed bool, err error) {
+// CheckAllowed checks endpointID, destPort, destID, destIP, and name against the rules
+// added to the proxy or restored during restart, and only returns true if this all match
+// something that was added (via UpdateAllowed or RestoreRules) previously.
+func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
 	name = strings.ToLower(dns.Fqdn(name))
 	p.Lock()
 	defer p.Unlock()
 
 	epAllow, exists := p.allowed.getPortRulesForID(endpointID, destPort)
 	if !exists {
-		return false, nil
+		return p.checkRestored(endpointID, destPort, destIP.String(), name), nil
 	}
 
 	for selector, re := range epAllow {
@@ -412,7 +501,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	// Note: The cache doesn't know about the source of the DNS data (yet) and so
 	// it won't enforce any separation between results from different endpoints.
 	// This isn't ideal but we are trusting the DNS responses anyway.
-	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, serverSecID.ID, qname)
+	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, serverSecID.ID, targetServerIP, qname)
 	switch {
 	case err != nil:
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -71,12 +71,12 @@ type DNSProxy struct {
 	// BindPort is the port in BindAddr.
 	BindPort uint16
 
-	// LookupEndpointIDByIP is a provided callback that returns the endpoint ID
+	// LookupRegisteredEndpoint is a provided callback that returns the endpoint ID
 	// as a uint16.
 	// Note: this is a little pointless since this proxy is in-process but it is
 	// intended to allow us to switch to an external proxy process by forcing the
 	// design now.
-	LookupEndpointIDByIP LookupEndpointIDByIPFunc
+	LookupRegisteredEndpoint LookupEndpointIDByIPFunc
 
 	// LookupSecIDByIP is a provided callback that returns the IP's security ID
 	// from the ipcache.
@@ -133,6 +133,9 @@ type DNSProxy struct {
 	// a restart
 	restored perEPRestored
 
+	// mapping restored endpoint IP (both IPv4 and IPv6) to *Endpoint
+	restoredEPs restoredEPs
+
 	// rejectReply is the OPCode send from the DNS-proxy to the endpoint if the
 	// DNS request is invalid
 	rejectReply int
@@ -150,6 +153,9 @@ type cachedSelectorREEntry map[policy.CachedSelector]*regexp.Regexp
 
 // structure for restored rules that can be used while Cilium agent is restoring endpoints
 type perEPRestored map[uint64]restore.DNSRules
+
+// map from EP IPs to *Endpoint
+type restoredEPs map[string]*endpoint.Endpoint
 
 // CheckRestored checks endpointID, destPort, destIP, and name against the restored rules,
 // and only returns true if a restored rule matches.
@@ -210,17 +216,32 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 // RestoreRules is used in the beginning of endpoint restoration to
 // install rules saved before the restart to be used before the endpoint
 // is regenerated.
-func (p *DNSProxy) RestoreRules(endpointID uint16, rules restore.DNSRules) {
+// 'ep' passed in is not fully functional yet, but just unmarshaled from JSON!
+func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	p.Lock()
 	defer p.Unlock()
-	p.restored[uint64(endpointID)] = rules
+	if ep.IPv4.IsSet() {
+		p.restoredEPs[ep.IPv4.String()] = ep
+	}
+	if ep.IPv6.IsSet() {
+		p.restoredEPs[ep.IPv6.String()] = ep
+	}
+	p.restored[uint64(ep.ID)] = ep.DNSRules
 
-	log.Debugf("Restored rules for endpoint %d: %v", endpointID, rules)
+	log.Debugf("Restored rules for endpoint %d: %v", ep.ID, ep.DNSRules)
 }
 
 // 'p' must be locked
 func (p *DNSProxy) removeRestoredRules(endpointID uint64) {
-	delete(p.restored, endpointID)
+	if _, exists := p.restored[endpointID]; exists {
+		// Remove IP->ID mappings for the restored EP
+		for ip, ep := range p.restoredEPs {
+			if ep.ID == uint16(endpointID) {
+				delete(p.restoredEPs, ip)
+			}
+		}
+		delete(p.restored, endpointID)
+	}
 }
 
 // RemoveRestoredRules removes all restored rules for 'endpointID'.
@@ -287,7 +308,7 @@ func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPort uint16) (r
 }
 
 // LookupEndpointIDByIPFunc wraps logic to lookup an endpoint with any backend.
-// See DNSProxy.LookupEndpointIDByIP for usage.
+// See DNSProxy.LookupRegisteredEndpoint for usage.
 type LookupEndpointIDByIPFunc func(ip net.IP) (endpoint *endpoint.Endpoint, err error)
 
 // LookupSecIDByIPFunc Func wraps logic to lookup an IP's security ID from the
@@ -343,15 +364,16 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, looku
 	}
 
 	p := &DNSProxy{
-		LookupEndpointIDByIP:  lookupEPFunc,
-		LookupSecIDByIP:       lookupSecIDFunc,
-		LookupIPsBySecID:      lookupIPsFunc,
-		NotifyOnDNSMsg:        notifyFunc,
-		lookupTargetDNSServer: lookupTargetDNSServer,
-		allowed:               make(perEPAllow),
-		restored:              make(perEPRestored),
-		rejectReply:           dns.RcodeRefused,
-		EnableDNSCompression:  enableDNSCompression,
+		LookupRegisteredEndpoint: lookupEPFunc,
+		LookupSecIDByIP:          lookupSecIDFunc,
+		LookupIPsBySecID:         lookupIPsFunc,
+		NotifyOnDNSMsg:           notifyFunc,
+		lookupTargetDNSServer:    lookupTargetDNSServer,
+		allowed:                  make(perEPAllow),
+		restored:                 make(perEPRestored),
+		restoredEPs:              make(restoredEPs),
+		rejectReply:              dns.RcodeRefused,
+		EnableDNSCompression:     enableDNSCompression,
 	}
 
 	// Start the DNS listeners on UDP and TCP
@@ -407,6 +429,19 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, looku
 	return p, nil
 }
 
+// LookupEndpointByIP wraps LookupRegisteredEndpoint by falling back to an restored EP, if available
+func (p *DNSProxy) LookupEndpointByIP(ip net.IP) (endpoint *endpoint.Endpoint, err error) {
+	endpoint, err = p.LookupRegisteredEndpoint(ip)
+	if err != nil {
+		// Check restored endpoints
+		endpoint, found := p.restoredEPs[ip.String()]
+		if found {
+			return endpoint, nil
+		}
+	}
+	return endpoint, err
+}
+
 // UpdateAllowed sets newRules for endpointID and destPort. It compiles the DNS
 // rules into regexes that are then used in CheckAllowed.
 func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
@@ -447,7 +482,7 @@ func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID ident
 // ServeDNS handles individual DNS requests forwarded to the proxy, and meets
 // the dns.Handler interface.
 // It will:
-//  - Look up the endpoint that sent the request by IP, via LookupEndpointIDByIP.
+//  - Look up the endpoint that sent the request by IP, via LookupEndpointByIP.
 //  - Look up the Sec ID of the destination server, via LookupSecIDByIP.
 //  - Check that the endpoint ID, destination Sec ID, destination port and the
 //  qname all match a rule. If not, the request is dropped.
@@ -477,7 +512,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
-	ep, err := p.LookupEndpointIDByIP(net.ParseIP(addr))
+	ep, err := p.LookupEndpointByIP(net.ParseIP(addr))
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %s", err)
@@ -499,23 +534,20 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 
-	serverSecID, exists := p.LookupSecIDByIP(targetServerIP)
-	if !exists {
-		scopedLog.WithField("server", targetServerAddr).Debug("cannot find server ip in ipcache")
-		stat.Err = fmt.Errorf("cannot find security identity for server ip=%s", targetServerIP)
-		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
-		p.sendRefused(scopedLog, w, request)
-		return
+	targetServerID := identity.ReservedIdentityWorld
+	if serverSecID, exists := p.LookupSecIDByIP(targetServerIP); !exists {
+		scopedLog.WithField("server", targetServerAddr).Debug("cannot find server ip in ipcache, defaulting to WORLD")
+	} else {
+		targetServerID = serverSecID.ID
+		scopedLog.WithField("server", targetServerAddr).Debugf("Found target server to of DNS request secID %+v", serverSecID)
 	}
-	scopedLog.WithField("server", targetServerAddr).Debugf("Found target server to of DNS request secID %+v", serverSecID)
 
 	// The allowed check is first because we don't want to use DNS responses that
 	// endpoints are not allowed to see.
 	// Note: The cache doesn't know about the source of the DNS data (yet) and so
 	// it won't enforce any separation between results from different endpoints.
 	// This isn't ideal but we are trusting the DNS responses anyway.
-	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, serverSecID.ID, targetServerIP, qname)
+	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, targetServerID, targetServerIP, qname)
 	switch {
 	case err != nil:
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -17,15 +17,19 @@
 package dnsproxy
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -153,6 +157,8 @@ var (
 	DstID4Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst4=test"))
 	cachedDstID4Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, DstID4Selector)
 
+	cachedWildcardSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
+
 	epID1   = uint64(111)
 	epID2   = uint64(222)
 	epID3   = uint64(333)
@@ -198,6 +204,18 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 				return ident, true
 			}
 		},
+		// LookupIPsBySecID
+		func(nid identity.NumericIdentity) []string {
+			DNSServerListenerAddr := (s.dnsServer.Listener.Addr()).(*net.TCPAddr)
+			switch nid {
+			case dstID1:
+				return []string{DNSServerListenerAddr.IP.String()}
+			case dstID2:
+				return []string{"127.0.0.1", "127.0.0.2"}
+			default:
+				return nil
+			}
+		},
 		// NotifyOnDNSMsg
 		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
@@ -241,7 +259,7 @@ func (s *DNSProxyTestSuite) TestRejectFromDifferentEndpoint(c *C) {
 	// Reject a query from not endpoint 1
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID2, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID2, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 }
@@ -260,7 +278,7 @@ func (s *DNSProxyTestSuite) TestAcceptFromMatchingEndpoint(c *C) {
 	// accept a query that matches from endpoint1
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
@@ -279,7 +297,7 @@ func (s *DNSProxyTestSuite) TestAcceptNonRegex(c *C) {
 	// accept a query that matches from endpoint1
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
@@ -298,7 +316,7 @@ func (s *DNSProxyTestSuite) TestRejectNonRegex(c *C) {
 	// reject a query for a non-regex where a . is different (i.e. ensure simple FQDNs treat . as .)
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 }
@@ -316,7 +334,7 @@ func (s *DNSProxyTestSuite) TestRejectNonMatchingRefusedResponse(c *C) {
 
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was not rejected when it should be blocked"))
 
@@ -354,7 +372,7 @@ func (s *DNSProxyTestSuite) TestRespondViaCorrectProtocol(c *C) {
 
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
@@ -383,7 +401,7 @@ func (s *DNSProxyTestSuite) TestRespondMixedCaseInRequestResponse(c *C) {
 
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
@@ -417,21 +435,21 @@ func (s *DNSProxyTestSuite) TestCheckAllowedTwiceRemovedOnce(c *C) {
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
 	err = s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Delete once, it should reject
 	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Delete once, it should reject and not crash
 	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, query)
+	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 }
@@ -447,7 +465,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	// | EP1  | DstID1 |      53 | *.ubuntu.com   |
 	// | EP1  | DstID1 |      53 | aws.amazon.com |
 	// | EP1  | DstID2 |      53 | cilium.io      |
-	// | EP1  | DstID1 |      54 | example.com    |
+	// | EP1  | *      |      54 | example.com    |
 	// | EP3  | DstID1 |      53 | example.com    |
 	// | EP3  | DstID3 |      53 | *              |
 	// | EP3  | DstID4 |      53 | nil            |
@@ -496,7 +514,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	//	| EP1  | DstID1 |      54 | example.com    |
 	err = s.proxy.UpdateAllowed(epID1, 54, policy.L7DataMap{
-		cachedDstID1Selector: &policy.PerSelectorPolicy{
+		cachedWildcardSelector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
 					{MatchPattern: "example.com."},
@@ -530,62 +548,314 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Test cases
 	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Allowed
-	allowed, err := s.proxy.CheckAllowed(epID1, 53, dstID1, "www.ubuntu.com")
+	allowed, err := s.proxy.CheckAllowed(epID1, 53, dstID1, nil, "www.ubuntu.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, "cilium.io")
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, "cilium.io")
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, "aws.amazon.com")
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, nil, "aws.amazon.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, "example.com")
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, nil, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 6 | EPID2 | DstID1 |   53 | cilium.io      | Rejected | EPID2 is not allowed as a source by any policy
-	allowed, err = s.proxy.CheckAllowed(epID2, 53, dstID1, "cilium.io")
+	allowed, err = s.proxy.CheckAllowed(epID2, 53, dstID1, nil, "cilium.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 7 | EPID3 | DstID1 |   53 | example.com    | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, "example.com")
+	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 8 | EPID3 | DstID1 |   53 | aws.amazon.com | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, "aws.amazon.io")
+	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID1, nil, "aws.amazon.io")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 8 | EPID3 | DstID1 |   54 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 54, dstID1, "example.com")
+	allowed, err = s.proxy.CheckAllowed(epID3, 54, dstID1, nil, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 9 | EPID3 | DstID2 |   53 | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID2, "example.com")
+	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID2, nil, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Case 10 | EPID3 | DstID3 |   53 | example.com    | Allowed due to wildcard match pattern
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID3, "example.com")
+	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID3, nil, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Case 11 | EPID3 | DstID4 |   53 | example.com    | Allowed due to a nil rule
-	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID4, "example.com")
+	allowed, err = s.proxy.CheckAllowed(epID3, 53, dstID4, nil, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Get rules for restoration
+	expected1 := restore.DNSRules{
+		53: restore.IPRules{{
+			IPs: map[string]struct{}{"::": {}},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID1Selector]},
+		}, {
+			IPs: map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID2Selector]},
+		}}.Sort(),
+		54: restore.IPRules{{
+			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
+		}},
+	}
+	restored1 := s.proxy.GetRules(uint16(epID1)).Sort()
+	c.Assert(restored1, checker.DeepEquals, expected1)
+
+	expected2 := restore.DNSRules{}
+	restored2 := s.proxy.GetRules(uint16(epID2)).Sort()
+	c.Assert(restored2, checker.DeepEquals, expected2)
+
+	expected3 := restore.DNSRules{
+		53: restore.IPRules{{
+			IPs: map[string]struct{}{"::": {}},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID1Selector]},
+		}, {
+			IPs: map[string]struct{}{},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID3Selector]},
+		}, {
+			IPs: map[string]struct{}{},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID4Selector]},
+		}}.Sort(),
+	}
+	restored3 := s.proxy.GetRules(uint16(epID3)).Sort()
+	c.Assert(restored3, checker.DeepEquals, expected3)
+
+	s.proxy.UpdateAllowed(epID1, 53, nil)
+	s.proxy.UpdateAllowed(epID1, 54, nil)
+	_, exists := s.proxy.allowed[epID1]
+	c.Assert(exists, Equals, false)
+
+	_, exists = s.proxy.allowed[epID2]
+	c.Assert(exists, Equals, false)
+
+	s.proxy.UpdateAllowed(epID3, 53, nil)
+	_, exists = s.proxy.allowed[epID3]
+	c.Assert(exists, Equals, false)
+
+	dstIP1 := (s.dnsServer.Listener.Addr()).(*net.TCPAddr).IP
+	dstIP2a := net.ParseIP("127.0.0.1")
+	dstIP2b := net.ParseIP("127.0.0.2")
+	dstIPrandom := net.ParseIP("127.0.0.42")
+
+	// Before restore: all rules removed above, everything is dropped
+	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Restore rules
+	s.proxy.RestoreRules(uint16(epID1), restored1)
+	_, exists = s.proxy.restored[epID1]
+	c.Assert(exists, Equals, true)
+
+	// Same tests with 2 (WORLD) dstID to make sure it is not used, but with correct destination IP
+
+	// Case 1 | EPID1 | dstIP1 |   53 | www.ubuntu.com | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Case 2 | EPID1 | dstIP1 |   54 | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 3 | EPID1 | dstIP2a |   53 | cilium.io      | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Case 4 | EPID1 | dstIP2b |   53 | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 5 | EPID1 | dstIP1 |   54 | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// make sure random IP is not allowed
+	// Case 5 | EPID1 | random IP |   53 | example.com    | Rejected due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// make sure random destination IP is allowed in a wildcard selector
+	// Case 5 | EPID1 | random IP |   54 | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Restore rules for epID3
+	s.proxy.RestoreRules(uint16(epID3), restored3)
+	_, exists = s.proxy.restored[epID3]
+	c.Assert(exists, Equals, true)
+
+	// Set empty ruleset, check that restored rules were deleted in epID3
+	err = s.proxy.UpdateAllowed(epID3, 53, nil)
+	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
+
+	_, exists = s.proxy.restored[epID3]
+	c.Assert(exists, Equals, false)
+
+	// epID1 still has restored rules
+	_, exists = s.proxy.restored[epID1]
+	c.Assert(exists, Equals, true)
+
+	// Marshal restored rules to JSON
+	jsn, err := json.Marshal(s.proxy.restored[epID1])
+	c.Assert(err, Equals, nil, Commentf("Could not marshal restored rules to json"))
+
+	expected := `
+	{
+		"53": [{
+			"Re":  "(^[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]$)|(^aws[.]amazon[.]com[.]$)",
+			"IPs": {"::": {}}
+		}, {
+			"Re":  "(^cilium[.]io[.]$)",
+			"IPs": {"127.0.0.1": {}, "127.0.0.2": {}}
+		}],
+		"54": [{
+			"Re":  "(^example[.]com[.]$)",
+			"IPs": null
+		}]
+	}`
+	pretty := new(bytes.Buffer)
+	err = json.Compact(pretty, []byte(expected))
+	c.Assert(err, Equals, nil, Commentf("Could not compact expected json"))
+	c.Assert(string(jsn), Equals, pretty.String())
+
+	s.proxy.RemoveRestoredRules(uint16(epID1))
+	_, exists = s.proxy.restored[epID1]
+	c.Assert(exists, Equals, false)
+
+	// Before restore after marshal: previous restored rules are removed, everything is dropped
+	// Case 1 | EPID1 | DstID1 |   53 | www.ubuntu.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID1, dstIP1, "www.ubuntu.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 2 | EPID1 | DstID1 |   54 | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 3 | EPID1 | DstID2 |   53 | cilium.io      | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2a, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 4 | EPID1 | DstID2 |   53 | aws.amazon.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, dstID2, dstIP2b, "aws.amazon.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 5 | EPID1 | DstID1 |   54 | example.com    | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, dstID1, dstIP1, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 5 | EPID1 | random IP |   54 | example.com    | Rejected
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Restore Unmarshaled rules
+	var rules restore.DNSRules
+	err = json.Unmarshal(jsn, &rules)
+	rules = rules.Sort()
+	c.Assert(err, Equals, nil, Commentf("Could not unmarshal restored rules from json"))
+	c.Assert(rules, checker.DeepEquals, expected1)
+
+	// Marshal again & compare
+	// Marshal restored rules to JSON
+	jsn2, err := json.Marshal(rules)
+	c.Assert(err, Equals, nil, Commentf("Could not marshal restored rules to json"))
+	c.Assert(string(jsn2), Equals, pretty.String())
+
+	s.proxy.RestoreRules(uint16(epID1), rules)
+	_, exists = s.proxy.restored[epID1]
+	c.Assert(exists, Equals, true)
+
+	// After restoration of JSON marshaled/unmarshaled rules
+
+	// Case 1 | EPID1 | dstIP1 |   53 | www.ubuntu.com | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP1, "www.ubuntu.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Case 2 | EPID1 | dstIP1 |   54 | cilium.io      | Rejected due to restored rules | Port 54 only allows example.com
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 3 | EPID1 | dstIP2a |   53 | cilium.io      | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2a, "cilium.io")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// Case 4 | EPID1 | dstIP2b |   53 | aws.amazon.com | Rejected due to restored rules | Only cilium.io is allowed with DstID2
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIP2b, "aws.amazon.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// Case 5 | EPID1 | dstIP1 |   54 | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIP1, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	// make sure random IP is not allowed
+	// Case 5 | EPID1 | random IP |   53 | example.com    | Rejected due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 53, 2, dstIPrandom, "example.com")
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
+
+	// make sure random IP is allowed on a wildcard
+	// Case 5 | EPID1 | random IP |   54 | example.com    | Allowed due to restored rules
+	allowed, err = s.proxy.CheckAllowed(epID1, 54, 2, dstIPrandom, "example.com")
 	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -106,6 +106,9 @@ func (s *DNSProxyTestSuite) GetDNSRules(epID uint16) restore.DNSRules {
 	return nil
 }
 
+func (s *DNSProxyTestSuite) RemoveRestoredDNSRules(epID uint16) {
+}
+
 var _ = Suite(&DNSProxyTestSuite{})
 
 func setupServer(c *C) (dnsServer *dns.Server) {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -102,6 +102,10 @@ func (s *DNSProxyTestSuite) Datapath() datapath.Datapath {
 	return nil
 }
 
+func (s *DNSProxyTestSuite) GetDNSRules(epID uint16) restore.DNSRules {
+	return nil
+}
+
 var _ = Suite(&DNSProxyTestSuite{})
 
 func setupServer(c *C) (dnsServer *dns.Server) {

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -1,0 +1,82 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The restore package provides data structures important to restoring
+// DNS proxy rules. This package serves as a central source for these
+// structures.
+// Note that these are marshaled as JSON and any changes need to be compatible
+// across an upgrade!
+package restore
+
+import (
+	"regexp"
+	"sort"
+)
+
+// DNSRules contains IP-based DNS rules for a set of ports (e.g., 53)
+type DNSRules map[uint16]IPRules
+
+// IPRules is an unsorted collection of IPrules
+type IPRules []IPRule
+
+// IPRule stores the allowed destination IPs for a DNS names matching a regex
+type IPRule struct {
+	Re  RuleRegex
+	IPs map[string]struct{} // IPs, nil set is wildcard and allows all IPs!
+}
+
+// RuleRegex is a wrapper for *regexp.Regexp so that we can define marshalers for it.
+type RuleRegex struct {
+	*regexp.Regexp
+}
+
+// Sort is only used for testing
+// Sorts in place, but returns IPRules for convenience
+func (r IPRules) Sort() IPRules {
+	sort.SliceStable(r, func(i, j int) bool {
+		return r[i].Re.String() < r[j].Re.String()
+	})
+	return r
+}
+
+// Sort is only used for testing
+// Sorts in place, but returns DNSRules for convenience
+func (r DNSRules) Sort() DNSRules {
+	for port, ipRules := range r {
+		if len(ipRules) > 0 {
+			ipRules = ipRules.Sort()
+			r[port] = ipRules
+		}
+	}
+	return r
+}
+
+// UnmarshalText unmarshals json into a RuleRegex
+// This must have a pointer receiver, otherwise the RuleRegex remains empty.
+func (r *RuleRegex) UnmarshalText(b []byte) error {
+	regex, err := regexp.Compile(string(b))
+	if err != nil {
+		return err
+	}
+	r.Regexp = regex
+	return nil
+}
+
+// MarshalText marshals RuleRegex as string
+func (r RuleRegex) MarshalText() ([]byte, error) {
+	if r.Regexp != nil {
+		return []byte(r.Regexp.String()), nil
+	}
+	return nil, nil
+}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -554,13 +554,20 @@ func (ipc *IPCache) LookupByPrefix(IP string) (Identity, bool) {
 }
 
 // LookupByIdentity returns the set of IPs (endpoint or CIDR prefix) that have
-// security identity ID, as well as whether the corresponding entry exists in
-// the IPCache.
-func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (map[string]struct{}, bool) {
+// security identity ID, or nil if the entry does not exist.
+func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (ips []string) {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
-	ips, exists := ipc.identityToIPCache[id]
-	return ips, exists
+	// Can't return the internal map as it may be modified at any time when the
+	// lock is not held, so return a slice of strings instead
+	length := len(ipc.identityToIPCache[id])
+	if length > 0 {
+		ips = make([]string, 0, length)
+		for ip := range ipc.identityToIPCache[id] {
+			ips = append(ips, ip)
+		}
+	}
+	return ips
 }
 
 // GetIPIdentityMapModel returns all known endpoint IP to security identity mappings

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -50,6 +50,7 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 	if err := DefaultDNSProxy.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, newRules); err != nil {
 		return err
 	}
+	dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(DefaultDNSProxy.GetRules(uint16(dr.redirect.endpointID)))
 	dr.currentRules = copyRules(dr.redirect.rules)
 
 	return nil
@@ -71,6 +72,7 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc,
 func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
 	return func() {
 		DefaultDNSProxy.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, nil)
+		dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
 		dr.currentRules = nil
 	}, nil
 }

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -17,6 +17,7 @@ package logger
 import (
 	"net"
 
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
@@ -70,6 +71,10 @@ type EndpointUpdater interface {
 	// UpdateProxyStatistics updates the Endpoint's proxy statistics to account
 	// for a new observed flow with the given characteristics.
 	UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool, verdict accesslog.FlowVerdict)
+
+	// OnDNSPolicyUpdateLocked is called when the Endpoint's DNS policy has been updated.
+	// 'rules' is a fresh copy of the DNS rules passed to the callee.
+	OnDNSPolicyUpdateLocked(rules restore.DNSRules)
 }
 
 // EndpointInfoRegistry provides endpoint information lookup by endpoint IP

--- a/pkg/proxy/logger/test/epinfo.go
+++ b/pkg/proxy/logger/test/epinfo.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -59,3 +60,4 @@ func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
 func (m *ProxyUpdaterMock) UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool,
 	verdict accesslog.FlowVerdict) {
 }
+func (m *ProxyUpdaterMock) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -399,6 +399,7 @@ func (p *Proxy) ReinstallRules() {
 // Caller must call exactly one of the returned functions:
 // - finalizeFunc to make the changes stick, or
 // - revertFunc to cancel the changes.
+// Called with 'localEndpoint' locked!
 func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater,
 	wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -118,10 +118,10 @@ var _ = Describe("K8sFQDNTest", func() {
 		// connect to DNS because dns-proxy filter the DNS request. If the
 		// connection is made correctly the IP is whitelisted by the FQDN rule
 		// until the DNS TTL expires.
-		// When Cilium is not running) The DNS-proxy is not working, so the IP
+		// - When Cilium is not running) The DNS-proxy is not working, so the IP
 		// connectivity to an existing IP that was queried before will work,
 		// meanwhile connections using new DNS request will fail.
-		// On restart) Cilium will restore the IPS that were white-listted in
+		// - On restart) Cilium will restore the IPS that were white-listted in
 		// the FQDN and connection will work as normal.
 
 		ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
@@ -202,6 +202,10 @@ var _ = Describe("K8sFQDNTest", func() {
 			helpers.DefaultNamespace, appPods[helpers.App2],
 			helpers.CurlFail(worldInvalidTargetIP))
 		res.ExpectFail("%q can connect when it should not work", helpers.App2)
+
+		// Re-run connectivity test while Cilium is still restarting. This should succeed as the same
+		// DNS names were used in a connectivity test before the restart.
+		connectivityTest()
 
 		channelClosed = true
 		close(quit)


### PR DESCRIPTION
**Note: This is a forward-port of #12718 and #12731, which were developed on v1.7 branch.**

Split the endpoint restoration process into more stages so that the saved endpoint DNS history can be used earlier in the bootstrap to start the DNS proxy. This helps ensure that the first regeneration of an Endpoint does not (temporarily) remove the policy keys needed to keep old traffic flowing.

TPROXY rules for the DNS proxy can only be installed couple of seconds later in the bootstrap process. To mitigate this and allow the DNS proxy start serving traffic sooner, it now reads the old TPROXY rule, if available, and tries to re-use the same proxy port number as before the restart. This allows the old datapath config to start feeding traffic to the new proxy instance even before the datapath config can be rewritten.

DNS proxy starts with restored DNS rules based on allowed IP addresses. These rules are removed for each endpoint as soon as the first regeneration completes. Such restored rules should allow DNS requests to be served, but for new DNS resolutions to be added to the Endpoint's policy the restored endpoint's must still have their first regeneration completed.

Fixes: #11004

```release-note
DNS Proxy is started earlier in the Cilium agent bootstrap to make it available to running endpoints sooner.
```
