### PR TITLE
Add a `node` label to agent metrics.

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
@@ -41,5 +41,10 @@ spec:
     interval: 10s
     honorLabels: true
     path: /metrics
+    relabelings:
+    - replacement: ${1}
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
 {{- end }}
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Exposing node name allows correlating Cilium metrics to node metrics for
more advanced recording rules/alerts, for example: ignore endpoint
health on nodes aged less than 2 minutes.

