### PR TITLE
v1.7 doc: hubble namespace fix for GKE

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -64,6 +64,7 @@ Deploy Cilium release via Helm:
 
 .. include:: aws-scale-up-cluster.rst
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -60,6 +60,7 @@ If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
 in the respective namespace and see if the pod is listed.
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -36,6 +36,7 @@ If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
 in the respective namespace and see if the pod is listed.
 
 .. include:: k8s-install-azure-cni-validate.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -92,6 +92,7 @@ Deploy Cilium release via Helm:
    them.
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -81,6 +81,7 @@ Deploy Cilium release via Helm:
    them.
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -14,7 +14,7 @@ Generate the deployment files using Helm and deploy it:
     cd hubble/install/kubernetes
 
     helm template hubble \
-        --namespace kube-system \
+        --namespace $CILIUM_NAMESPACE \
         --set metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}" \
         --set ui.enabled=true \
     > hubble.yaml

--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -66,6 +66,7 @@ Install Cilium
 
 .. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/k8s-install-aks-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-aks-validate.rst
@@ -1,0 +1,24 @@
+Validate the Installation
+=========================
+
+You can monitor as Cilium and all required components are being installed:
+
+.. parsed-literal::
+
+    kubectl -n cilium get pods --watch
+    NAME                                    READY   STATUS              RESTARTS   AGE
+    cilium-operator-cb4578bc5-q52qk         0/1     Pending             0          8s
+    cilium-s8w5m                            0/1     PodInitializing     0          7s
+    coredns-86c58d9df4-4g7dd                0/1     ContainerCreating   0          8m57s
+    coredns-86c58d9df4-4l6b2                0/1     ContainerCreating   0          8m57s
+
+It may take a couple of minutes for all components to come up:
+
+.. parsed-literal::
+
+    cilium-operator-cb4578bc5-q52qk         1/1     Running   0          4m13s
+    cilium-s8w5m                            1/1     Running   0          4m12s
+    coredns-86c58d9df4-4g7dd                1/1     Running   0          13m
+    coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
+
+.. include:: k8s-install-connectivity-test.rst

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -86,6 +86,7 @@ To verify, you should see AKS in the name of the nodes when you run:
 .. include:: k8s-install-azure-cni-steps.rst
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -85,7 +85,7 @@ To verify, you should see AKS in the name of the nodes when you run:
 
 .. include:: k8s-install-azure-cni-steps.rst
 
-.. include:: k8s-install-validate.rst
+.. include:: k8s-install-aks-validate.rst
 .. include:: namespace-cilium.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -34,6 +34,7 @@ Install Cilium
     kubectl create -f \ |SCM_WEB|\/install/kubernetes/quick-install.yaml
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -106,6 +106,7 @@ Deploy Cilium release via Helm:
 
 .. include:: aws-scale-up-cluster.rst
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -88,6 +88,7 @@ to the cluster. The NodeInit DaemonSet will perform the following actions:
 
 .. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-gke-validate.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -94,6 +94,7 @@ Install Cilium release via Helm:
       --set global.pullPolicy=IfNotPresent
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 
 Next steps

--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -66,6 +66,7 @@ Kubernetes CNI plugin.
     kubectl create -f \ |SCM_WEB|\/install/kubernetes/quick-install.yaml
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/namespace-cilium.rst
+++ b/Documentation/gettingstarted/namespace-cilium.rst
@@ -1,0 +1,9 @@
+Specify Environment Variables
+=============================
+
+Specify the namespace in which Cilium is installed as ``CILIUM_NAMESPACE``
+environment variable. Subsequent commands reference this environment variable.
+
+.. parsed-literal::
+
+   export CILIUM_NAMESPACE=cilium

--- a/Documentation/gettingstarted/namespace-kube-system.rst
+++ b/Documentation/gettingstarted/namespace-kube-system.rst
@@ -1,0 +1,9 @@
+Specify Environment Variables
+=============================
+
+Specify the namespace in which Cilium is installed as ``CILIUM_NAMESPACE``
+environment variable. Subsequent commands reference this environment variable.
+
+.. parsed-literal::
+
+   export CILIUM_NAMESPACE=kube-system


### PR DESCRIPTION
_**NOTE**: This PR is against v1.7_

This is basically a backport of 575bff841b3f796d255e009da74944e4b7166b3a which intend to fix the Hubble installation doc for GKE and AKS as they install cilium in the `cilium` namespace (i.e. not in `kube-system`).

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 12149; do contrib/backporting/set-labels.py $pr done 1.7; done
```