### PR TITLE
doc: cilium namespace fix

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -36,6 +36,6 @@ If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
 in the respective namespace and see if the pod is listed.
 
 .. include:: k8s-install-azure-cni-validate.rst
-.. include:: namespace-kube-system.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -83,6 +83,6 @@ To verify, you should see AKS in the name of the nodes when you run:
 .. include:: k8s-install-azure-cni-steps.rst
 
 .. include:: k8s-install-validate.rst
-.. include:: namespace-kube-system.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -82,7 +82,7 @@ To verify, you should see AKS in the name of the nodes when you run:
 
 .. include:: k8s-install-azure-cni-steps.rst
 
-.. include:: k8s-install-validate.rst
+.. include:: k8s-install-azure-cni-validate.rst
 .. include:: namespace-cilium.rst
 .. include:: hubble-enable.rst
 


### PR DESCRIPTION
fix some typo related to the cilium namespace for AKS and Azure CNI chaining.