### PR TITLE
Fix typo in UpdateEC2AdapterLimitViaAPI command line flag

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -69,7 +69,7 @@ cilium-operator-aws [flags]
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
       --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api          Use the EC2 API to update the instance type to adapter limits
+      --update-ec2-adapter-limit-via-api          Use the EC2 API to update the instance type to adapter limits
       --version                                   Print version information
 ```
 

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -73,7 +73,7 @@ cilium-operator [flags]
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
       --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api          Use the EC2 API to update the instance type to adapter limits
+      --update-ec2-adapter-limit-via-api          Use the EC2 API to update the instance type to adapter limits
       --version                                   Print version information
 ```
 

--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -384,8 +384,9 @@ hardcoded in the Cilium codebase for easy out-of-the box deployment and usage.
 The limits can be modified via the ``--aws-instance-limit-mapping`` CLI flag on
 the cilium-operator. This allows the user to supply a custom limit.
 
-Additionally the limits can be updated via the EC2 API
-by passing the ``--update-ec2-apdater-limit-via-api`` CLI flag. This will require an additional EC2 IAM permission:
+Additionally the limits can be updated via the EC2 API by passing the
+``--update-ec2-adapter-limit-via-api`` CLI flag.
+This will require an additional EC2 IAM permission:
 
  * ``DescribeInstanceTypes``
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -128,9 +128,13 @@ const (
 	// ParallelAllocWorkers specifies the number of parallel workers to be used for IPAM allocation
 	ParallelAllocWorkers = "parallel-alloc-workers"
 
+	// UpdateEC2AdapterLimitViaAPIDeprecated configures the operator to use the EC2
+	// API to fill out the instancetype to adapter limit mapping.
+	UpdateEC2AdapterLimitViaAPIDeprecated = "update-ec2-apdater-limit-via-api"
+
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2
 	// API to fill out the instancetype to adapter limit mapping.
-	UpdateEC2AdapterLimitViaAPI = "update-ec2-apdater-limit-via-api"
+	UpdateEC2AdapterLimitViaAPI = "update-ec2-adapter-limit-via-api"
 
 	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
 	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
@@ -335,7 +339,8 @@ func (c *OperatorConfig) Populate() {
 	// AWS options
 
 	c.AWSReleaseExcessIPs = viper.GetBool(AWSReleaseExcessIPs)
-	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
+	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPIDeprecated) ||
+		viper.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.EC2APIEndpoint = viper.GetString(EC2APIEndpoint)
 
 	// Azure options

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"fmt"
+
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/spf13/viper"
 
@@ -43,6 +45,9 @@ func init() {
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(operatorOption.ENITags)
 
+	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPIDeprecated, false, fmt.Sprintf("Use the EC2 API to update the instance type to adapter limits. Deprecated in favor of %s", operatorOption.UpdateEC2AdapterLimitViaAPI))
+	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPIDeprecated)
+	flags.MarkDeprecated(operatorOption.UpdateEC2AdapterLimitViaAPIDeprecated, "This option will be removed in v1.10")
 	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
 	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPI)
 


### PR DESCRIPTION
This PR fixes the typo in UpdateEC2AdapterLimitViaAPI command line
flag by introducing a new command line flag and deprecating the
old command line flag.

Fixes: #12396
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
