### PR TITLE
bpf: configure mtu for the created $ENCAP_DEV

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -518,8 +518,9 @@ fi
 if [ "$MODE" = "vxlan" -o "$MODE" = "geneve" ]; then
 	ENCAP_DEV="cilium_${MODE}"
 	ip link show $ENCAP_DEV || {
-		ip link add name $ENCAP_DEV address $(rnd_mac_addr) mtu $MTU type $MODE external || encap_fail
+		ip link add name $ENCAP_DEV address $(rnd_mac_addr) type $MODE external || encap_fail
 	}
+	ip link set $ENCAP_DEV mtu $MTU || encap_fail
 
 	setup_dev $ENCAP_DEV
 	ip link set $ENCAP_DEV up || encap_fail


### PR DESCRIPTION
In the case that the $ENCAP_DEV already exists, the new $MTU is not
configured to $ENCAP_DEV

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

