### PR TITLE
docs: Disable BPF-masq in KIND GSG

### DIFF
--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -49,6 +49,7 @@ Then, install Cilium release via Helm:
       --set global.externalIPs.enabled=true \\
       --set global.nodePort.enabled=true \\
       --set global.hostPort.enabled=true \\
+      --set config.bpfMasquerade=false \\
       --set global.pullPolicy=IfNotPresent \\
       --set config.ipam=kubernetes
 


### PR DESCRIPTION
Disable BPF-masq when deploying in KIND until https://github.com/cilium/cilium/issues/12699 has been fixed.

```release-note
Disable BPF-masq in KIND getting started guide
```