### PR TITLE
Use net.JoinHostPort to construct network address strings

### DIFF
--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -78,7 +78,7 @@ func (k EndpointKey) ToIP() net.IP {
 // String provides a string representation of the EndpointKey.
 func (k EndpointKey) String() string {
 	if ip := k.ToIP(); ip != nil {
-		return fmt.Sprintf("%s:%d", ip.String(), k.Key)
+		return net.JoinHostPort(ip.String(), fmt.Sprintf("%d", k.Key))
 	}
 	return "nil"
 }

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -134,7 +134,7 @@ func (v *RevNat4Value) ToNetwork() RevNatValue {
 }
 
 func (v *RevNat4Value) String() string {
-	return fmt.Sprintf("%s:%d", v.Address, v.Port)
+	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
 }
 
 type pad2uint8 [2]uint8
@@ -171,11 +171,11 @@ func NewService4Key(ip net.IP, port uint16, proto u8proto.U8proto, scope uint8, 
 }
 
 func (k *Service4Key) String() string {
+	addr := net.JoinHostPort(k.Address.String(), fmt.Sprintf("%d", k.Port))
 	if k.Scope == loadbalancer.ScopeInternal {
-		return fmt.Sprintf("%s:%d/i", k.Address, k.Port)
-	} else {
-		return fmt.Sprintf("%s:%d", k.Address, k.Port)
+		addr += "/i"
 	}
+	return addr
 }
 
 func (k *Service4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -126,7 +126,10 @@ type RevNat6Value struct {
 }
 
 func (v *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
-func (v *RevNat6Value) String() string              { return fmt.Sprintf("%s:%d", v.Address, v.Port) }
+
+func (v *RevNat6Value) String() string {
+	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+}
 
 // ToNetwork converts RevNat6Value to network byte order.
 func (v *RevNat6Value) ToNetwork() RevNatValue {

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -16,6 +16,7 @@ package proxy
 
 import (
 	"fmt"
+	"net"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -46,7 +47,7 @@ func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServe
 	l := r.listener
 	if envoyProxy != nil {
 		redir := &envoyRedirect{
-			listenerName: fmt.Sprintf("%s:%d", l.name, l.proxyPort),
+			listenerName: net.JoinHostPort(l.name, fmt.Sprintf("%d", l.proxyPort)),
 			xdsServer:    xdsServer,
 		}
 		// Only use original source address for egress

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1681,7 +1681,7 @@ func (kub *Kubectl) validateServicePlumbingInCiliumPod(fullName, ciliumPod strin
 				port.Port, fullName, serviceObj.Spec.ClusterIP, ciliumPod)
 		}
 
-		if _, ok := lbMap[fmt.Sprintf("%s:%d", serviceObj.Spec.ClusterIP, port.Port)]; !ok {
+		if _, ok := lbMap[net.JoinHostPort(serviceObj.Spec.ClusterIP, fmt.Sprintf("%d", port.Port))]; !ok {
 			return fmt.Errorf("port %d of service %s (%s) not found in cilium bpf lb list of pod %s",
 				port.Port, fullName, serviceObj.Spec.ClusterIP, ciliumPod)
 		}
@@ -1693,13 +1693,13 @@ func (kub *Kubectl) validateServicePlumbingInCiliumPod(fullName, ciliumPod strin
 				foundBackend, foundBackendLB := false, false
 				for _, realizedService := range realizedServices {
 					frontEnd := realizedService.FrontendAddress
-					lb := lbMap[fmt.Sprintf("%s:%d", frontEnd.IP, frontEnd.Port)]
+					lb := lbMap[net.JoinHostPort(frontEnd.IP, fmt.Sprintf("%d", frontEnd.Port))]
 
 					for _, backAddr := range realizedService.BackendAddresses {
 						if addr.IP == *backAddr.IP && uint16(port.Port) == backAddr.Port {
 							foundBackend = true
 							for _, backend := range lb {
-								if strings.Contains(backend, fmt.Sprintf("%s:%d", *backAddr.IP, port.Port)) {
+								if strings.Contains(backend, net.JoinHostPort(*backAddr.IP, fmt.Sprintf("%d", port.Port))) {
 									foundBackendLB = true
 								}
 							}
@@ -1707,13 +1707,13 @@ func (kub *Kubectl) validateServicePlumbingInCiliumPod(fullName, ciliumPod strin
 					}
 				}
 				if !foundBackend {
-					return fmt.Errorf("unable to find service backend %s:%d in cilium pod %s",
-						addr.IP, port.Port, ciliumPod)
+					return fmt.Errorf("unable to find service backend %s in cilium pod %s",
+						net.JoinHostPort(addr.IP, fmt.Sprintf("%d", port.Port)), ciliumPod)
 				}
 
 				if !foundBackendLB {
-					return fmt.Errorf("unable to find service backend %s:%d in datapath of cilium pod %s",
-						addr.IP, port.Port, ciliumPod)
+					return fmt.Errorf("unable to find service backend %s in datapath of cilium pod %s",
+						net.JoinHostPort(addr.IP, fmt.Sprintf("%d", port.Port)), ciliumPod)
 				}
 			}
 		}

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -303,7 +303,7 @@ func (client *SSHClient) newSession() (*ssh.Session, error) {
 	} else {
 		connection, err = ssh.Dial(
 			"tcp",
-			fmt.Sprintf("%s:%d", client.Host, client.Port),
+			net.JoinHostPort(client.Host, fmt.Sprintf("%d", client.Port)),
 			client.Config)
 
 		if err != nil {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -530,13 +530,13 @@ var _ = Describe("K8sServicesTest", func() {
 			// Field #7 is "RxPackets=<n>"
 			cmdIn := "cilium bpf ct list global | awk '/%s/ { sub(\".*=\",\"\", $7); print $7 }'"
 
-			endpointK8s1 := fmt.Sprintf("%s:%d", dstPodIPK8s1, dstPodPort)
+			endpointK8s1 := net.JoinHostPort(dstPodIPK8s1, fmt.Sprintf("%d", dstPodPort))
 			patternInK8s1 := fmt.Sprintf("UDP IN [^:]+:%d -> %s", srcPort, endpointK8s1)
 			cmdInK8s1 := fmt.Sprintf(cmdIn, patternInK8s1)
 			res := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdInK8s1)
 			countInK8s1, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 
-			endpointK8s2 := fmt.Sprintf("%s:%d", dstPodIPK8s2, dstPodPort)
+			endpointK8s2 := net.JoinHostPort(dstPodIPK8s2, fmt.Sprintf("%d", dstPodPort))
 			patternInK8s2 := fmt.Sprintf("UDP IN [^:]+:%d -> %s", srcPort, endpointK8s2)
 			cmdInK8s2 := fmt.Sprintf(cmdIn, patternInK8s2)
 			res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s2, cmdInK8s2)
@@ -549,7 +549,7 @@ var _ = Describe("K8sServicesTest", func() {
 				// If kube-proxy is enabled, we see packets in ctmap with the
 				// service's IP address and port, not backend's.
 				dstIPv4 := strings.Replace(dstIP, "::ffff:", "", 1)
-				endpointK8s1 = fmt.Sprintf("%s:%d", dstIPv4, dstPort)
+				endpointK8s1 = net.JoinHostPort(dstIPv4, fmt.Sprintf("%d", dstPort))
 				endpointK8s2 = endpointK8s1
 			}
 			patternOutK8s1 := fmt.Sprintf("UDP OUT [^:]+:%d -> %s", srcPort, endpointK8s1)
@@ -568,7 +568,7 @@ var _ = Describe("K8sServicesTest", func() {
 			}
 
 			// Send datagram
-			By("Sending a fragmented packet from %s to endpoint %s:%d", srcPod, dstIP, dstPort)
+			By("Sending a fragmented packet from %s to endpoint %s", srcPod, net.JoinHostPort(dstIP, fmt.Sprintf("%d", dstPort)))
 			cmd := fmt.Sprintf("bash -c 'dd if=/dev/zero bs=%d count=%d | nc -u -w 1 -p %d %s %d'", blockSize, blockCount, srcPort, dstIP, dstPort)
 			res = kubectl.ExecPodCmd(helpers.DefaultNamespace, srcPod, cmd)
 			res.ExpectSuccess("Cannot send fragmented datagram: %s", res.CombineOutput())

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -16,6 +16,7 @@ package RuntimeTest
 
 import (
 	"fmt"
+	"net"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -161,8 +162,8 @@ var _ = Describe("RuntimeLB", func() {
 			Expect(err).Should(BeNil())
 
 			status := vm.ServiceAdd(svcID, service, []string{
-				fmt.Sprintf("%s:80", httpd1["IPv4"]),
-				fmt.Sprintf("%s:80", httpd2["IPv4"])})
+				net.JoinHostPort(httpd1["IPv4"], "80"),
+				net.JoinHostPort(httpd2["IPv4"], "80")})
 			status.ExpectSuccess("failed to create service %s=>{httpd1,httpd2}", service)
 
 			By("Making HTTP request via the service before restart")
@@ -238,13 +239,13 @@ var _ = Describe("RuntimeLB", func() {
 
 			By("Configuring services")
 
-			service1 := fmt.Sprintf("2.2.2.100:%d", svcPort)
-			service2 := fmt.Sprintf("[f00d::1:1]:%d", svcPort)
-			service3 := fmt.Sprintf("2.2.2.101:%d", svcPort)
+			service1 := net.JoinHostPort("2.2.2.100", fmt.Sprintf("%d", svcPort))
+			service2 := net.JoinHostPort("f00d::1:1", fmt.Sprintf("%d", svcPort))
+			service3 := net.JoinHostPort("2.2.2.101", fmt.Sprintf("%d", svcPort))
 			services := map[string]string{
-				service1: fmt.Sprintf("%s:80", httpd1[helpers.IPv4]),
-				service2: fmt.Sprintf("[%s]:80", httpd2[helpers.IPv6]),
-				service3: fmt.Sprintf("%s:80", httpd2[helpers.IPv4]),
+				service1: net.JoinHostPort(httpd1[helpers.IPv4], "80"),
+				service2: net.JoinHostPort(httpd2[helpers.IPv6], "80"),
+				service3: net.JoinHostPort(httpd2[helpers.IPv4], "80"),
 			}
 			svc := 100
 			for fe, be := range services {


### PR DESCRIPTION
Using fmt.Sprintf("%s:%d", host, port) or similar to construct network
address strings can to problems when dealing with IPv6 addresses.
However, net.JoinHostPort formats IPv6 in the correct [host]:port
notation, for example [fe80::a46c:bcff:feed:a481]:8080

For consistency, also use the same function in places where it's obvious
we're dealing with IPv4 addresses.

Also see golang/go#28308

Found using semgrep using the hostport.yml rule from
https://github.com/dgryski/semgrep-go