### PR TITLE
bpf: edt support for traffic egressing l7 proxy

### DIFF
--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -24,18 +24,10 @@ based on TBF (Token Bucket Filter) instead of EDT.
 Cilium's bandwidth manager supports the ``kubernetes.io/egress-bandwidth`` Pod
 annotation which is enforced on egress at the native host networking devices.
 The bandwidth enforcement is supported for direct routing as well as tunneling
-mode in Cilium.
+mode in Cilium, and also works in combination with L7 proxies.
 
-The ``kubernetes.io/ingress-bandwidth`` annotation is not supported and also not
-recommended to use. Limiting bandwidth happens natively at the egress point of
-networking devices in order to reduce or pace bandwidth usage on the wire.
-Enforcing at ingress would add yet another layer of buffer queueing right in the
-critical fast-path of a node via ``ifb`` device where ingress traffic first needs
-to be redirected to the ``ifb``'s egress point in order to perform shaping before
-traffic can go up the stack. At this point traffic has already occupied the
-bandwidth usage on the wire, and the node has already spent resources on
-processing the packet. ``kubernetes.io/ingress-bandwidth`` annotation is ignored
-by Cilium's bandwidth manager.
+The ``kubernetes.io/ingress-bandwidth`` annotation is not supported and therefore
+ignored by Cilium's bandwidth manager.
 
 .. note::
 
@@ -139,6 +131,12 @@ identity can then be correlated with the ``cilium endpoint list`` command.
 Limitations
 ###########
 
-    * Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
-      In case they select the Pod at egress, then the bandwidth enforcement will be disabled for
-      those Pods.
+    * The ``kubernetes.io/ingress-bandwidth`` annotation is not supported and also not
+      recommended to use. Limiting bandwidth happens natively at the egress point of
+      networking devices in order to reduce or pace bandwidth usage on the wire.
+      Enforcing at ingress would add yet another layer of buffer queueing right in the
+      critical fast-path of a node via ``ifb`` device where ingress traffic first needs
+      to be redirected to the ``ifb``'s egress point in order to perform shaping before
+      traffic can go up the stack. At this point traffic has already occupied the
+      bandwidth usage on the wire, and the node has already spent resources on processing
+      the packet.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -783,13 +783,14 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 					   BPF_F_INGRESS);
 		}
 #endif
-
 		int trace = TRACE_FROM_HOST;
 		bool from_proxy;
 
 		from_proxy = inherit_identity_from_host(ctx, &identity);
-		if (from_proxy)
+		if (from_proxy) {
+			edt_set_aggregate_from_proxy(ctx);
 			trace = TRACE_FROM_PROXY;
+		}
 		send_trace_notify(ctx, trace, identity, 0, 0,
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
 	} else {

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -10,7 +10,7 @@
 #include "maps.h"
 
 static __always_inline __maybe_unused struct endpoint_info *
-lookup_ip6_endpoint_from_daddr(const union v6addr *ip6)
+__lookup_ip6_endpoint(const union v6addr *ip6)
 {
 	struct endpoint_key key = {};
 
@@ -23,7 +23,7 @@ lookup_ip6_endpoint_from_daddr(const union v6addr *ip6)
 static __always_inline __maybe_unused struct endpoint_info *
 lookup_ip6_endpoint(struct ipv6hdr *ip6)
 {
-	return lookup_ip6_endpoint_from_daddr((union v6addr *)&ip6->daddr);
+	return __lookup_ip6_endpoint((union v6addr *)&ip6->daddr);
 }
 
 static __always_inline __maybe_unused struct endpoint_info *

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -382,7 +382,7 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 		return send_icmp6_ndisc_adv(ctx, nh_off, &router_mac, true);
 	}
 
-	ep = lookup_ip6_endpoint_from_daddr(&target);
+	ep = __lookup_ip6_endpoint(&target);
 	if (ep) {
 		union macaddr router_mac = NODE_MAC;
 


### PR DESCRIPTION
WIP (not tested yet), setting release blocker to pick this up later but in scope for 1.9

TODO:
 - [ ] Waiting to rebase on top of https://github.com/cilium/cilium/pull/12976
 - [ ] CI tests for proxy
 - [ ] UDP specific drop horizon (SO_TXTIME)
 - [ ] Adjust readme graphic