### PR TITLE
v1.8 backports 2020-08-27

### DIFF
--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -49,6 +49,7 @@ Then, install Cilium release via Helm:
       --set global.externalIPs.enabled=true \\
       --set global.nodePort.enabled=true \\
       --set global.hostPort.enabled=true \\
+      --set config.bpfMasquerade=false \\
       --set global.pullPolicy=IfNotPresent \\
       --set config.ipam=kubernetes
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -530,18 +530,11 @@ support on the ena driver. The latter is needed to configure channel parameters 
 
   for ip in $IPS ; do ssh ec2-user@$ip "sudo amazon-linux-extras install -y kernel-ng && sudo yum install -y ethtool && sudo reboot"; done
 
-Once the nodes come back up their kernel version should say ``5.4.50-25.83.amzn2.x86_64`` or
+Once the nodes come back up their kernel version should say ``5.4.58-27.104.amzn2.x86_64`` or
 similar through ``uname -r``. In order to run XDP on ena, make sure the driver version is at
 least `2.2.8 <https://github.com/amzn/amzn-drivers/commit/ccbb1fe2c2f2ab3fc6d7827b012ba8ec06f32c39>`__.
-The driver version can be inspected through ``ethtool -i eth0``.
-
-.. note::
-
-  If the reported driver version is <2.2.8, a new version of the ena driver needs to be built
-  and installed according to the instructions given `here <https://github.com/amzn/amzn-drivers/blob/master/kernel/linux/rpm/README-rpm.txt>`__.
-  For kernel-ng version ``5.4.50-25.83.amzn2.x86_64`` a prebuild rpm of ena driver version
-  2.2.10g can be downloaded `here <https://gist.github.com/tklauser/268641aea4fced9e8c3b4a2f7536661b#file-kmod-ena-2-2-10-1-amzn2-26-x86_64-rpm>`__
-  for testing purposes.
+The driver version can be inspected through ``ethtool -i eth0``. For the given kernel version
+the driver version should be reported as ``2.2.10g``.
 
 Before Cilium's XDP acceleration can be deployed, there are two settings needed on the
 network adapter side, that is, MTU needs to be lowered in order to be able to operate

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
-{{- if .Values.global.gke.enabled }}
+{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
                     # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
@@ -183,13 +183,16 @@ spec:
               systemctl restart kubelet
 {{- end }}
 
-{{- if .Values.global.gke.enabled }}
-              # If Cilium is installed, it would be expected that it would be solely responsible
-              # for the networking configuration on that node.
-              # In GKE, even if the IP masquerade agent is not enabled, the instance
-              # configure script adds some default masquerade rules anyway.
-              # If we remove the jump to that ip-masq chain, then we ensure masquerade configuration
-              # is managed by Cilium.
+{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
+              # If Cilium is configured to manage masquerading of traffic leaving the node,
+              # we need to disable the IP-MASQ chain because even if ip-masq-agent
+              # is not installed, the node init script installs some default rules into
+              # the IP-MASQ chain.
+              # If we remove the jump to that ip-masq chain, then we ensure the ip masquerade
+              # configuration is solely managed by Cilium.
+              # Also, if Cilium is installed, it may be expected that it would be solely responsible
+              # for the networking configuration on that node. So provide the same functionality
+              # as the --disable-snat-flag for existing GKE clusters.
               iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ || true
 {{- end }}
 

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
-{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
+{{- if (and .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat))}}
                     # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
@@ -183,7 +183,7 @@ spec:
               systemctl restart kubelet
 {{- end }}
 
-{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
+{{- if (and .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat))}}
               # If Cilium is configured to manage masquerading of traffic leaving the node,
               # we need to disable the IP-MASQ chain because even if ip-masq-agent
               # is not installed, the node init script installs some default rules into

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
                     fi
 
                     echo "Waiting on pods to stop..."
-                    if grep -q 'docker' /etc/crictl.yaml; then
+                    if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
                       # Works for COS, ubuntu
                       while docker ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     else
@@ -199,7 +199,7 @@ spec:
 
 {{- if .Values.restartPods }}
               echo "Restarting kubenet managed pods"
-              if grep -q 'docker' /etc/crictl.yaml; then
+              if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
                 # Works for COS, ubuntu
                 # Note the first line is the containerID with a trailing \r
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f "$(sed 's/\r//;1q' $f)" || true; done

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
                     systemctl restart kubelet
 {{- end }}
 
-{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
+{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
                     # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
                     if iptables -w -t nat -L IP-MASQ > /dev/null; then
                       iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
@@ -183,7 +183,7 @@ spec:
               systemctl restart kubelet
 {{- end }}
 
-{{- if (or (and .Values.global.gke.enabled .Values.global.masquerade) (and .Values.global.gke.enabled .Values.global.gke.disableDefaultSnat))}}
+{{- if (and ( .Values.global.gke.enabled (or .Values.global.masquerade .Values.global.gke.disableDefaultSnat)))}}
               # If Cilium is configured to manage masquerading of traffic leaving the node,
               # we need to disable the IP-MASQ chain because even if ip-masq-agent
               # is not installed, the node init script installs some default rules into

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -430,6 +430,9 @@ global:
   # Google Kubernetes Engine
   gke:
     enabled: false
+    # Provide the same functionality as the --disable-default-snat flag
+    # for existing GKE clusters that want to disable masquerade
+    disableDefaultSnat: false
 
   azure:
     enabled: false

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -201,6 +201,7 @@ pipeline {
                 KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
+                HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
 
                 // We need to define all ${KERNEL}-dependent env vars in stage instead of top environment block
                 // because jenkins doesn't initialize these values sequentially within one block

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -246,6 +246,7 @@ pipeline {
                         K8S_NODES="3"
                         KUBEPROXY="0"
                         NO_CILIUM_ON_NODE="k8s3"
+                        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
                     }
                     steps {
                         sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s/" | sed "s/Runtime.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'
@@ -274,6 +275,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                         K8S_VERSION="1.18"
+                        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
                     }
                     steps {
                         sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s/" | sed "s/Runtime.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -260,6 +260,9 @@ var (
 const (
 	// ReservedIdentityHealth is equivalent to pkg/identity.ReservedIdentityHealth
 	ReservedIdentityHealth = 4
+
+	// ReservedIdentityHost is equivalent to pkg/identity.ReservedIdentityHost
+	ReservedIdentityHost = 1
 )
 
 // NightlyStableUpgradesFrom maps the cilium image versions to the helm charts

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -116,7 +116,6 @@ var (
 		// We need CNP node status to know when a policy is being enforced
 		"config.enableCnpStatusUpdates": "true",
 
-		"global.hostFirewall":      "true",
 		"global.nativeRoutingCIDR": "10.0.0.0/8",
 	}
 
@@ -2171,18 +2170,6 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 	}
 
-	// Set devices
-	privateIface, err := kub.GetPrivateIface()
-	if err != nil {
-		return err
-	}
-	defaultIface, err := kub.GetDefaultIface()
-	if err != nil {
-		return err
-	}
-	devices := fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface)
-	addIfNotOverwritten(options, "global.devices", devices)
-
 	if !RunsWithKubeProxy() {
 		nodeIP, err := kub.GetNodeIPByLabel(K8s1, false)
 		if err != nil {
@@ -2202,6 +2189,24 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		for key, value := range opts {
 			options = addIfNotOverwritten(options, key, value)
 		}
+	}
+
+	if RunsWithHostFirewall() {
+		addIfNotOverwritten(options, "global.hostFirewall", "true")
+	}
+
+	if !RunsWithKubeProxy() || options["global.hostFirewall"] == "true" {
+		// Set devices
+		privateIface, err := kub.GetPrivateIface()
+		if err != nil {
+			return err
+		}
+		defaultIface, err := kub.GetDefaultIface()
+		if err != nil {
+			return err
+		}
+		devices := fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface)
+		addIfNotOverwritten(options, "global.devices", devices)
 	}
 
 	return nil

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -532,6 +532,11 @@ func DoesNotHaveHosts(count int) func() bool {
 	}
 }
 
+// RunsWithHostFirewall returns true is Cilium runs with the host firewall enabled.
+func RunsWithHostFirewall() bool {
+	return os.Getenv("HOST_FIREWALL") != "0"
+}
+
 // RunsWithKubeProxy returns true if cilium runs together with k8s' kube-proxy.
 func RunsWithKubeProxy() bool {
 	return os.Getenv("KUBEPROXY") != "0"

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1364,6 +1364,35 @@ var _ = Describe("K8sServicesTest", func() {
 						testExternalIPs()
 					})
 
+					Context("With host policy", func() {
+						var ccnpHostPolicy string
+
+						BeforeAll(func() {
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+								"global.hostFirewall": "true",
+							})
+
+							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlApply, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be applied", ccnpHostPolicy)
+						})
+
+						AfterAll(func() {
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlDelete, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be deleted", ccnpHostPolicy)
+
+							DeployCiliumAndDNS(kubectl, ciliumFilename)
+						})
+
+						It("Tests NodePort", func() {
+							testNodePort(true, false, helpers.ExistNodeWithoutCilium(), 0)
+						})
+					})
+
 					SkipItIf(func() bool { return helpers.GetCurrentIntegration() != "" },
 						"Tests with secondary NodePort device", func() {
 							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
@@ -1412,6 +1441,40 @@ var _ = Describe("K8sServicesTest", func() {
 
 					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests externalIPs", func() {
 						testExternalIPs()
+					})
+
+					Context("With host policy", func() {
+						var ccnpHostPolicy string
+
+						BeforeAll(func() {
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+								"global.tunnel":               "disabled",
+								"global.autoDirectNodeRoutes": "true",
+								"global.hostFirewall":         "true",
+							})
+
+							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlApply, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be applied", ccnpHostPolicy)
+						})
+
+						AfterAll(func() {
+							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+								helpers.KubectlDelete, helpers.HelperTimeout)
+							Expect(err).Should(BeNil(),
+								"Policy %s cannot be deleted", ccnpHostPolicy)
+
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+								"global.tunnel":               "disabled",
+								"global.autoDirectNodeRoutes": "true",
+							})
+						})
+
+						It("Tests NodePort", func() {
+							testNodePort(true, false, helpers.ExistNodeWithoutCilium(), 0)
+						})
 					})
 
 					SkipItIf(func() bool { return helpers.GetCurrentIntegration() != "" },

--- a/test/k8sT/manifests/ccnp-default-deny-host-ingress.yaml
+++ b/test/k8sT/manifests/ccnp-default-deny-host-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "default-deny-host-ingress"
+spec:
+  nodeSelector: {}
+  ingress:
+  - fromEntities:
+    - cluster
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "22"
+        protocol: TCP
+      - port: "6443"
+        protocol: TCP

--- a/test/k8sT/manifests/ccnp-host-ingress-from-cidr-to-ports.yaml
+++ b/test/k8sT/manifests/ccnp-host-ingress-from-cidr-to-ports.yaml
@@ -1,0 +1,14 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+description: "Host policy to allow traffic external to cluster inwards via CIDR and port"
+metadata:
+  name: "host-ingress-from-cidr-to-ports"
+spec:
+  nodeSelector: {}
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+    fromCIDR:
+      - 192.168.36.13/32

--- a/test/k8sT/manifests/ccnp-host-policy-nodeport-tests.yaml
+++ b/test/k8sT/manifests/ccnp-host-policy-nodeport-tests.yaml
@@ -1,0 +1,41 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-policy-nodeport-tests"
+spec:
+  nodeSelector: {}
+  ingress:
+  # Access from outside world
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "22"
+        protocol: TCP
+      - port: "6443"
+        protocol: TCP
+  # VXLAN tunnels and ICMP echos
+  - fromEntities:
+    - remote-node
+
+  egress:
+  # VXLAN tunnels, kubelet, and ICMP echos
+  - toEntities:
+    - remote-node
+  # Kubelet to node without Cilium
+  - toCIDR:
+    - 192.168.36.13/32
+    toPorts:
+    - ports:
+      - port: "10250"
+        protocol: TCP
+  # NodePort test from host namespace
+  - toEndpoints:
+    - matchLabels:
+        zgroup: testDS
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      - port: "69"
+        protocol: UDP

--- a/test/k8sT/manifests/echoserver-cilium-hostnetns.yaml
+++ b/test/k8sT/manifests/echoserver-cilium-hostnetns.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: echoserver
+  labels:
+    k8s-app: echoserver-hostnetns
+spec:
+  selector:
+    matchLabels:
+      name: echoserver-hostnetns
+  template:
+    metadata:
+      labels:
+        name: echoserver-hostnetns
+    spec:
+      containers:
+      - name: web
+        image: docker.io/cilium/echoserver:1.10.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+      hostNetwork: true
+      tolerations:
+      - operator: Exists


### PR DESCRIPTION
 * #12894 -- fix: node-init restartPods should use docker if /etc/crictl.yaml not found (@UnwashedMeme)
 * #12621 -- Host firewall tests (@pchaigno)
 * #12973 -- docs: Disable BPF-masq in KIND GSG (@brb)
 * #12977 -- docs: bump kernel and ena driver version, drop custom prebuilt driver in EKS XDP GSG (@tklauser)
 * #12952 -- nodeinit: only bypass IP-MASQ chain if Cilium manages masquerade (@dctrwatson)

**NOT INCLUDED DUE TO MERGE CONFLICTS**

 * #12948 -- connectivity-check: Use unprivileged ports (@tgraf)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12894 12621 12973 12977 12952; do contrib/backporting/set-labels.py $pr done 1.8; done
```