### PR TITLE
docs: limit copybutton to content area only

### DIFF
--- a/Documentation/_static/copybutton.js
+++ b/Documentation/_static/copybutton.js
@@ -27,7 +27,7 @@ function addCopyButtonToCodeCells() {
     setTimeout(addCopyButtonToCodeCells, 1000);
     return;
   }
-  var codeCells = document.querySelectorAll("pre");
+  var codeCells = document.querySelectorAll(".rst-content pre");
   codeCells.forEach(function(codeCell, index) {
     var wrapper = document.createElement("div");
     wrapper.className = "code-wrapper";


### PR DESCRIPTION
Fixes copybutton plugin to not conflict with the search

Signed-off-by: Sergey Generalov <sergey@genbit.ru>