### PR TITLE
Provide option to avoid DROP_INVALID_IDENTITY during upgrade from v1.6 to later Cilium versions

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -58,12 +58,14 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 			return DROP_NO_TUNNEL_KEY;
 		*identity = key.tunnel_id;
 
+#ifdef ALLOW_HOST_SRC
 		/* Any node encapsulating will map any HOST_ID source to be
 		 * presented as REMOTE_NODE_ID, therefore any attempt to signal
 		 * HOST_ID as source from a remote node can be dropped.
 		 */
 		if (*identity == HOST_ID)
 			return DROP_INVALID_IDENTITY;
+#endif /* ALLOW_HOST_SRC */
 	}
 
 	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
@@ -179,8 +181,10 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 			return DROP_NO_TUNNEL_KEY;
 		*identity = key.tunnel_id;
 
+#ifdef ALLOW_HOST_SRC
 		if (*identity == HOST_ID)
 			return DROP_INVALID_IDENTITY;
+#endif /* ALLOW_HOST_SRC */
 	}
 
 	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -557,6 +557,10 @@ func init() {
 	flags.Bool(option.EnableHostFirewall, false, "Enable host network policies (beta)")
 	option.BindEnv(option.EnableHostFirewall)
 
+	flags.String(option.AllowHostSrc, "auto", "Accept traffic from remote nodes with source identity \"host\"")
+	flags.MarkHidden(option.AllowHostSrc)
+	option.BindEnv(option.AllowHostSrc)
+
 	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.")
 	option.BindEnv(option.IPv4NativeRoutingCIDR)
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -391,6 +391,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_IDENTITY_MARK"] = "1"
 	}
 
+	if !option.Config.EnableRemoteNodeIdentity {
+		cDefinesMap["ALLOW_HOST_SRC"] = "1"
+	}
+
 	// Since golang maps are unordered, we sort the keys in the map
 	// to get a consistent writtern format to the writer. This maintains
 	// the consistency when we try to calculate hash for a datapath after

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -391,7 +391,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_IDENTITY_MARK"] = "1"
 	}
 
-	if !option.Config.EnableRemoteNodeIdentity {
+	if !option.Config.AllowHostSrc {
 		cDefinesMap["ALLOW_HOST_SRC"] = "1"
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -272,6 +272,11 @@ const (
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager = "enable-bandwidth-manager"
 
+	// AllowHostSrc enables nodes to receive traffic from other nodes with
+	// the source identity "host". Useful for dropless upgrades from v1.6
+	// to later versions.
+	AllowHostSrc = "allow-host-src"
+
 	// LibDir enables the directory path to store runtime build environment
 	LibDir = "lib-dir"
 
@@ -1794,6 +1799,11 @@ type DaemonConfig struct {
 	// KernelHz is the HZ rate the kernel is operating in
 	KernelHz int
 
+	// AllowHostSrc enables nodes to receive traffic from other nodes with
+	// the source identity "host". Useful for dropless upgrades from v1.6
+	// to later versions.
+	AllowHostSrc bool
+
 	// excludeLocalAddresses excludes certain addresses to be recognized as
 	// a local address
 	excludeLocalAddresses []*net.IPNet
@@ -2462,6 +2472,15 @@ func (c *DaemonConfig) Populate() {
 
 	c.ClockSource = ClockSourceKtime
 	c.EnableIdentityMark = viper.GetBool(EnableIdentityMark)
+
+	switch viper.GetString(AllowHostSrc) {
+	case "auto":
+		c.AllowHostSrc = !c.EnableRemoteNodeIdentity
+	case "true":
+		c.AllowHostSrc = true
+	default:
+		c.AllowHostSrc = false
+	}
 
 	// toFQDNs options
 	// When the poller is enabled, the default MinTTL is lowered. This is to


### PR DESCRIPTION
*  Allow tunnel traffic "from host" with remote-node-identity=false

    According to the documentation:

        One can set enable-remote-node-identity=false in the ConfigMap to
        retain the Cilium 1.6.x behavior.

    The above is true when evaluating policy, but not true from the
    DROP_INVALID_IDENTITY perspective as during an upgrade from v1.6 to
    v1.7, v1.6 nodes may send traffic to v1.7 nodes with the "host" identity
    and the v1.7 nodes will drop such traffic with this error code. Mitigate
    this by also covering this datapath case with the
    `EnableRemoteNodeIdentity` flag check.

* Add hidden `allow-remote-src` flag

    This flag allows to override the default setting for whether to accept
    traffic into a node if the source node reports the source identity as
    "host". Default is "auto" - to allow if enableRemoteNodeIdentity is
    disabled; deny if enableRemoteNodeIdentity is enabled. If specified
    directly, it will take on the configured behaviour (allow such traffic
    if true, otherwise drop it).