### PR TITLE
test: Quarantine flaky GuestBook test

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1604,7 +1604,7 @@ EOF`, k, v)
 				}
 			}
 		}
-		It("checks policy example", func() {
+		SkipItIf(helpers.SkipQuarantined, "checks policy example", func() {
 
 			waitforPods()
 


### PR DESCRIPTION
That test has been failing a lot across v1.7, v1.8 and master. Let's disable until we find a proper fix.

Related: #12994