### PR TITLE
v1.7 backports 2020-08-28

### DIFF
--- a/Documentation/_static/copybutton.js
+++ b/Documentation/_static/copybutton.js
@@ -27,7 +27,7 @@ function addCopyButtonToCodeCells() {
     setTimeout(addCopyButtonToCodeCells, 1000);
     return;
   }
-  var codeCells = document.querySelectorAll("pre");
+  var codeCells = document.querySelectorAll(".rst-content pre");
   codeCells.forEach(function(codeCell, index) {
     var wrapper = document.createElement("div");
     wrapper.className = "code-wrapper";

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -17,7 +17,7 @@ six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.8.1
 # forked read the docs themez
-git+git://github.com/cilium/sphinx_rtd_theme.git@v0.6
+git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-websupport==1.1.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -147,7 +147,6 @@ Vagrant.configure(2) do |config|
                 type: "shell",
                 run: "always",
                 inline: "ip -6 a a #{$master_ipv6}/16 dev enp0s9"
-            node_ip = "#{$nfs_ipv4_master_addr}"
             if ENV["IPV6_EXT"] then
                 node_ip = "#{$master_ipv6}"
             end
@@ -195,7 +194,6 @@ Vagrant.configure(2) do |config|
                 :libvirt__dhcp_enabled => false
             if ENV["NFS"] || ENV["IPV6_EXT"] then
                 nfs_ipv4_addr = $workers_ipv4_addrs_nfs[n]
-                node_ip = "#{nfs_ipv4_addr}"
                 ipv6_addr = $workers_ipv6_addrs[n]
                 node.vm.network "private_network", ip: "#{nfs_ipv4_addr}", bridge: "enp0s9"
                 # Add IPv6 address this way or we get hit by a virtualbox bug

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -228,9 +228,19 @@ func (c *clusterNodesClient) NodeAdd(newNode node.Node) error {
 
 func (c *clusterNodesClient) NodeUpdate(oldNode, newNode node.Node) error {
 	c.Lock()
+	defer c.Unlock()
+
+	// If the node is on the added list, just update it
+	for i, added := range c.NodesAdded {
+		if added.Name == newNode.Fullname() {
+			c.NodesAdded[i] = newNode.GetModel()
+			return nil
+		}
+	}
+
+	// otherwise, add the new node and remove the old one
 	c.NodesAdded = append(c.NodesAdded, newNode.GetModel())
 	c.NodesRemoved = append(c.NodesRemoved, oldNode.GetModel())
-	c.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
* #12215 -- vagrant: Don't use the NFS device's IP as node IP (@pchaigno)
 * #12996 -- Upgrade Cilium docs theme version (@Neelajacques)
 * #12997 -- docs: limit copybutton to content area only (@genbit)
 * #12989 -- Fix bug where cilium-health reports connectivity failures to stale IPs (@kkourt)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12215 12996 12997 12989; do contrib/backporting/set-labels.py $pr done 1.7; done
```