### PR TITLE
test: Fix guestbook test

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -16,6 +16,7 @@ package k8sTest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"time"
@@ -1502,7 +1503,6 @@ var _ = Describe("K8sPolicyTest", func() {
 	Context("GuestBook Examples", func() {
 		var (
 			deployment                = "guestbook_deployment.yaml"
-			groupLabel                = "zgroup=guestbook"
 			redisPolicy               = "guestbook-policy-redis.json"
 			redisPolicyName           = "guestbook-policy-redis"
 			redisPolicyDeprecated     = "guestbook-policy-redis-deprecated.json"
@@ -1557,20 +1557,17 @@ var _ = Describe("K8sPolicyTest", func() {
 		})
 
 		waitforPods := func() {
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l tier=backend", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "Backend pods are not ready after timeout")
 
-			err = kubectl.WaitforPods(
-				helpers.DefaultNamespace,
-				fmt.Sprintf("-l %s", groupLabel), helpers.HelperTimeout)
-			ExpectWithOffset(1, err).Should(BeNil(), "Bookinfo pods are not ready after timeout")
+			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l tier=frontend", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "Frontend pods are not ready after timeout")
 
-			err := kubectl.WaitForServiceEndpoints(
-				helpers.DefaultNamespace, "", "redis-master", helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "error waiting for redis-master service to be ready")
+			err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", "redis-master", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "error waiting for redis-master service to be ready")
 
-			err = kubectl.WaitForServiceEndpoints(
-				helpers.DefaultNamespace, "", "redis-slave", helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "error waiting for redis-slave service to be ready")
-
+			err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", "redis-follower", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "error waiting for redis-follower service to be ready")
 		}
 
 		policyCheckStatus := func(policyCheck string) {
@@ -1581,27 +1578,18 @@ var _ = Describe("K8sPolicyTest", func() {
 		}
 
 		testConnectivitytoRedis := func() {
-			webPods, err := kubectl.GetPodsNodes(helpers.DefaultNamespace, "-l k8s-app.guestbook=web")
-			Expect(err).To(BeNil(), "Cannot get web pods")
+			webPods, err := kubectl.GetPodsNodes(helpers.DefaultNamespace, "-l app=guestbook")
+			ExpectWithOffset(1, err).To(BeNil(), "Error retrieving web pods")
+			ExpectWithOffset(1, webPods).ShouldNot(BeEmpty(), "Cannot retrieve web pods")
 
-			serviceIP, port, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, "redis-master")
-			Expect(err).To(BeNil(), "Cannot get hostPort of redis-master")
-
-			serviceName := "redis-master"
-			err = kubectl.WaitForKubeDNSEntry(serviceName, helpers.DefaultNamespace)
-			Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
-
+			cmd := helpers.CurlFailNoStats(`"127.0.0.1/guestbook.php?cmd=set&key=messages&value=Hello"`)
 			for pod := range webPods {
+				res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, cmd)
+				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Cannot curl webhook frontend of pod %q", pod)
 
-				redisMetadata := map[string]int{serviceIP: port, serviceName: port}
-				for k, v := range redisMetadata {
-					command := fmt.Sprintf(`nc %s %d <<EOF
-PING
-EOF`, k, v)
-					res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, command)
-					ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
-						"Web pod %q cannot connect to redis-master on '%s:%d'", pod, k, v)
-				}
+				var response map[string]interface{}
+				err := json.Unmarshal([]byte(res.Stdout()), &response)
+				ExpectWithOffset(1, err).To(BeNil(), fmt.Sprintf("Error parsing JSON response: %s", res.Stdout()))
 			}
 		}
 		SkipItIf(helpers.SkipQuarantined, "checks policy example", func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1592,7 +1592,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				ExpectWithOffset(1, err).To(BeNil(), fmt.Sprintf("Error parsing JSON response: %s", res.Stdout()))
 			}
 		}
-		SkipItIf(helpers.SkipQuarantined, "checks policy example", func() {
+		It("checks policy example", func() {
 
 			waitforPods()
 

--- a/test/k8sT/manifests/guestbook_deployment.yaml
+++ b/test/k8sT/manifests/guestbook_deployment.yaml
@@ -4,24 +4,24 @@ apiVersion: v1
 metadata:
   name: redis-master
   labels:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
+    role: leader
+    tier: backend
 spec:
   replicas: 1
   selector:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
   template:
     metadata:
       labels:
-        k8s-app.guestbook: redis
-        role: master
-        zgroup: guestbook
+        app: redis
+        role: leader
+        tier: backend
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - name: redis-master
-        image: docker.io/library/redis:4.0.11
+      - name: leader
+        image: "docker.io/library/redis:6.0.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: redis-server
@@ -34,40 +34,41 @@ apiVersion: v1
 metadata:
   name: redis-master
   labels:
-    k8s-app.guestbook: redis
-    role: master
-    zgroup: guestbook
+    app: redis
+    role: leader
+    tier: backend
 spec:
   ports:
   - port: 6379
     targetPort: redis-server
   selector:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
+    role: leader
+    tier: backend
 ---
 kind: ReplicationController
 apiVersion: v1
 metadata:
-  name: redis-slave
+  name: redis-follower
   labels:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 spec:
   replicas: 1
   selector:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
   template:
     metadata:
       labels:
-        k8s-app.guestbook: redis
-        role: slave
-        zgroup: guestbook
+        app: redis
+        role: follower
+        tier: backend
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - name: redis-slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+      - name: follower
+        image: gcr.io/google_samples/gb-redis-follower:v2
         imagePullPolicy: IfNotPresent
         ports:
         - name: redis-server
@@ -78,17 +79,19 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: redis-slave
+  name: redis-follower
   labels:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 spec:
   ports:
   - port: 6379
     targetPort: redis-server
   selector:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
#7955 updated the GuestBook images and labels, but failed to make the same label update in the test itself. Thus, since then, we have not been running any connectivity check in the GuestBook test. That went unnoticed because we didn't check that the set of pods returned (from which we run connectivity checks) was not empty.

This commit fixes it by:

1. Updating the label in the test itself to app=guestbook.
2. Adding a check that the set of pods selected isn't empty.

However, the `nc` utility we were using to check connectivity from the frontend pods to the Redis backend isn't available in the new images. Therefore, we also need to:

3. Use curl instead inside the frontend pods to check that the PHP frontend works as expected and is able to contact the Redis backend.

That's it? No. Turns out some of the pod labels and names are also hardcoded in the Docker images and have been updated (mostly to use more neutral terms).

4. Update the YAML file to better match [1]. We however can't update the 'redis-master' name because our v6 frontend image has it hardcoded. The v5 frontend image at [1] has 'redis-leader' as the name, but somehow not the v6. We want to use the v6 image because it is a lot smaller (cf. dffb450).
5. And finally, Bob's our uncle!

1 - https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook
Fixes: #12994
Fixes: #7955
/cc @aanm 
Signed-off-by: Paul Chaignon <paul@cilium.io>