### PR TITLE
docs: Mention L7 limitation in Calico chaining GSG

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -11,6 +11,12 @@ Calico
 This guide instructs how to install Cilium in chaining configuration on top of
 `Calico <https://github.com/projectcalico/calico>`_.
 
+.. note::
+
+   When running Cilium in chaining configuration on top of Calico, the L7
+   policies may not work because of conflicting packet mark usage. This
+   limitation is currently tracked at `#12454 <https://github.com/cilium/cilium/issues/12454>`_.
+
 Create a CNI configuration
 ==========================
 


### PR DESCRIPTION
Several users have reported issues with L7 policies when running Cilium in chaining configuration on top of Calico. The long-term solution to this issue is well known (BPF TPROXY), but we should add a note to the documentation in the meantime to warn users.

I'm happy to change the wording or the position of this note in the guide of course (or bump it to a warning).

----

![calico-chaining-note](https://user-images.githubusercontent.com/1764210/91564941-afcfd200-e941-11ea-86cf-ec1fb313ee12.png)

---

Related: https://github.com/cilium/cilium/issues/12454