### PR TITLE
daemon: Disable BPF-masq if host-svc is disabled in tunnel mode

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -450,15 +450,23 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	detectNativeDevices(isKubeProxyReplacementStrict)
 	finishKubeProxyReplacementInit(isKubeProxyReplacementStrict)
 
-	// BPF masquerade depends on BPF NodePort, so the following checks should
+	// BPF masquerade depends on BPF NodePort and require host-reachable svc to
+	// be fully enabled in the tunneling mode, so the following checks should
 	// happen after invoking initKubeProxyReplacementOptions().
 	if option.Config.Masquerade && option.Config.EnableBPFMasquerade &&
-		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "") {
+		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "" ||
+			(option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices())) {
+
 		var msg string
-		if !option.Config.EnableNodePort {
+		switch {
+		case !option.Config.EnableNodePort:
 			msg = fmt.Sprintf("BPF masquerade requires NodePort (--%s=\"true\").",
 				option.EnableNodePort)
-		} else if option.Config.EgressMasqueradeInterfaces != "" {
+		// Remove the check after https://github.com/cilium/cilium/issues/12544 is fixed
+		case option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices():
+			msg = fmt.Sprintf("BPF masquerade requires --%s to be fully enabled (TCP and UDP).",
+				option.EnableHostReachableServices)
+		case option.Config.EgressMasqueradeInterfaces != "":
 			msg = fmt.Sprintf("BPF masquerade does not allow to specify devices via --%s (use --%s instead).",
 				option.EgressMasqueradeInterfaces, option.Devices)
 		}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -573,3 +573,9 @@ func checkNodePortAndEphemeralPortRanges() error {
 
 	return nil
 }
+
+func hasFullHostReachableServices() bool {
+	return option.Config.EnableHostReachableServices &&
+		option.Config.EnableHostServicesTCP &&
+		option.Config.EnableHostServicesUDP
+}


### PR DESCRIPTION
Currently, when running with `--enable-bpf-masquerade=true`, `--tunnel!=disabled` and `--enable-host-reachable-services=false`, accessing a remote backend from a host netns via ClusterIP is broken (reported in https://github.com/cilium/cilium/issues/12699).

This is because the DNAT is performed by an iptables rule installed by kube-proxy, which means that src IP addr is selected before the DNAT. So, the kernel picks the src IP addr of the iface with a IP default route, then does the DNAT, and finally sends the packet over the native device to the remote node. Everything is fine until a reply to the request is about to be sent by the remote backend. On the remote node, the reply (dst=the client node IP) gets masqueraded by the BPF-masq feature, because we masquerade pod -> remote host IP in the tunnel mode (see comment in the `snat_v4_needed()` for the reason), and currently we don't consult the CT map to see whether a packet is reply.

When the host-svc feature is enabled, the socket dst addr is rewritten before a related skb is even crafted. This makes the routing lookup to be performed with dst IP addr of the remote backend IP addr. So, in the tunnel mode the kernel will pick `cilium_host`'s IP addr as the src IP addr, and the packet will be sent over the tunnel (and a reply). Therefore, the troublesome masquerading is avoided.

Disable the BPF-masq feature if the conditions are not met until we add a lookup in CT map (https://github.com/cilium/cilium/issues/12544).

```release-note
Disable BPF masquerade if host reachable services is disabled in tunnel mode
```