### PR TITLE
v1.7 backports 2020-08-28

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1062,6 +1062,16 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		}
 	}
 
+	// AWS ENI requires to mark packets ingressing on the primary interface
+	// and route them back the same way even if the pod responding is using
+	// the IP of a different interface. Please see note in Reinitialize()
+	// in pkg/datapath/loader for more details.
+	if option.Config.IPAM == option.IPAMENI {
+		if err := m.addCiliumENIRules(); err != nil {
+			return fmt.Errorf("cannot install rules for ENI multi-node NodePort: %w", err)
+		}
+	}
+
 	if option.Config.EnableIPSec {
 		if err := m.addCiliumNoTrackXfrmRules(); err != nil {
 			return fmt.Errorf("cannot install xfrm rules: %s", err)
@@ -1152,4 +1162,28 @@ func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 		return m.ciliumNoTrackXfrmRules("iptables", "-I")
 	}
 	return nil
+}
+
+func (m *IptablesManager) addCiliumENIRules() error {
+	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
+	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+	if err := runProg("iptables", append(
+		m.waitArgs,
+		"-t", "mangle",
+		"-A", ciliumPreMangleChain,
+		"-i", "eth0",
+		"-m", "comment", "--comment", "cilium: primary ENI",
+		"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
+		"-j", "CONNMARK", "--set-xmark", nfmask+"/"+ctmask),
+		false); err != nil {
+		return err
+	}
+	return runProg("iptables", append(
+		m.waitArgs,
+		"-t", "mangle",
+		"-A", ciliumPreMangleChain,
+		"-i", "lxc+",
+		"-m", "comment", "--comment", "cilium: primary ENI",
+		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask),
+		false)
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -34,6 +34,15 @@ const (
 	// RouteMarkMask is the mask required for the route mark value
 	RouteMarkMask = 0xF00
 
+	// MarkMultinodeNodeport is used for AWS ENI to mark traffic from
+	// another node, so that it gets routed back through the relevant
+	// interface.
+	MarkMultinodeNodeport = 0x80
+
+	// MaskMultinodeNodeport is the mask associated with the
+	// RouterMarkNodePort
+	MaskMultinodeNodeport = 0x80
+
 	// IPSecProtocolID IP protocol ID for IPSec defined in RFC4303
 	RouteProtocolIPSec = 50
 
@@ -45,6 +54,13 @@ const (
 	// RulePriorityEgress is the priority of the rule used for egress routing
 	// of endpoints. This priority is after the local table priority.
 	RulePriorityEgress = 110
+
+	// RulePriorityNodeport is the priority of the rule used with AWS ENI to
+	// make sure that lookups for multi-node NodePort traffic are NOT done
+	// from the table for the VPC to which the endpoint's CIDR is
+	// associated, but from the main routing table instead.
+	// This priority is before the egress priority.
+	RulePriorityNodeport = RulePriorityEgress - 1
 
 	// TunnelDeviceName the default name of the tunnel device when using vxlan
 	TunnelDeviceName = "cilium_vxlan"

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import (
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -263,6 +265,35 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgNrCPUs] = fmt.Sprintf("%d", common.GetNumPossibleCPUs(log))
 
 	log.Info("Setting up base BPF datapath")
+
+	// AWS ENI mode requires symmetric routing, see
+	// iptables.addCiliumENIRules().
+	// The default AWS daemonset installs the following rules that are used
+	// for NodePort traffic between nodes:
+	//
+	// # sysctl -w net.ipv4.conf.eth0.rp_filter=2
+	// # iptables -t mangle -A PREROUTING -i eth0 -m comment --comment "AWS, primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
+	// # iptables -t mangle -A PREROUTING -i eni+ -m comment --comment "AWS, primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
+	// # ip rule add fwmark 0x80/0x80 lookup main
+	//
+	// It marks packets coming from another node through eth0, and restores
+	// the mark on the return path to force a lookup into the main routing
+	// table. Without these rules, the "ip rules" set by the cilium-cni
+	// plugin tell the host to lookup into the table related to the VPC for
+	// which the CIDR used by the endpoint has been configured.
+	//
+	// We want to reproduce equivalent rules to ensure correct routing.
+	if option.Config.IPAM == option.IPAMENI {
+		sysSettings = append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
+		if err := route.ReplaceRule(route.Rule{
+			Priority: linux_defaults.RulePriorityNodeport,
+			Mark:     linux_defaults.MarkMultinodeNodeport,
+			Mask:     linux_defaults.MaskMultinodeNodeport,
+			Table:    route.MainTable,
+		}); err != nil {
+			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+		}
+	}
 
 	for _, s := range sysSettings {
 		log.Infof("Setting sysctl %s=%s", s.name, s.val)


### PR DESCRIPTION
 * #12770 -- iptables, loader: add rules for multi-node NodePort traffic on EKS (@qmonnet)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12770; do contrib/backporting/set-labels.py $pr done 1.7; done
```
