### PR TITLE
test: Quarantine K8sIstioTest while flaky

### DIFF
--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -29,7 +29,9 @@ import (
 // This tests the Istio integration, following the configuration
 // instructions specified in the Istio Getting Started Guide in
 // Documentation/gettingstarted/istio.rst.
-var _ = Describe("K8sIstioTest", func() {
+var _ = SkipContextIf(func() bool {
+	return helpers.SkipQuarantined() && helpers.GetCurrentK8SEnv() == "1.19"
+}, "K8sIstioTest", func() {
 
 	var (
 		// istioSystemNamespace is the default namespace into which Istio is


### PR DESCRIPTION
This commit quarantines the Istio test on K8s 1.19 as it is currently flaky and makes subsequent tests fail.

Related: #12993