### PR TITLE
smoke-test: Additional logs in case of error

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -83,6 +83,6 @@ jobs:
       - name: Dump connectivity related logs and events
         if: ${{ failure() }}
         run: |
-          kubectl get pods -o wide
-          kubectl get deploy -o wide
+          kubectl describe pods
+          kubectl describe deploy
           for svc in $(make -C examples/kubernetes/connectivity-check/ list | grep Service | awk '{ print $4 }'); do kubectl describe service $svc; kubectl logs service/$svc --all-containers --since=${{ env.LOG_TIME }}; done

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -81,8 +81,8 @@ jobs:
       - name: Dump connectivity related logs and events
         if: ${{ failure() }}
         run: |
-          kubectl get pods -o wide
-          kubectl get deploy -o wide
+          kubectl describe pods
+          kubectl describe deploy
           for svc in $(make -C examples/kubernetes/connectivity-check/ list | grep Service | awk '{ print $4 }'); do kubectl describe service $svc; kubectl logs service/$svc --all-containers --since=${{ env.LOG_TIME }}; done
 
       - name: Dump hubble related logs and events
@@ -172,6 +172,6 @@ jobs:
       - name: Dump connectivity related logs and events
         if: ${{ failure() }}
         run: |
-          kubectl get pods -o wide
-          kubectl get deploy -o wide
+          kubectl describe pods
+          kubectl describe deploy
           for svc in $(make -C examples/kubernetes/connectivity-check/ list | grep Service | awk '{ print $4 }'); do kubectl describe service $svc; kubectl logs service/$svc --all-containers --since=${{ env.LOG_TIME }}; done


### PR DESCRIPTION
This commit adds additional logs in the smoke test by switching `kubectl get xxx` to `kubectl describe xxx`, which should help debug #12279 in particular.

Related: #12279