### PR TITLE
helm/azure: Fatal error for CNI Azure installation

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -66,7 +66,7 @@ Deploy Cilium release via Helm:
      --set global.cni.chainingMode=generic-veth \\
      --set global.cni.customConf=true \\
      --set global.nodeinit.enabled=true \\
-     --set global.azure.enabled=true \\
+     --set nodeinit.expectAzureVnet=true \\
      --set global.cni.configMap=cni-configuration \\
      --set global.tunnel=disabled \\
      --set global.masquerade=false

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -155,7 +155,7 @@ spec:
               ip -4 a
               ip -6 a
 
-{{- if .Values.global.azure.enabled }}
+{{- if or .Values.expectAzureVnet .Values.global.azure.enabled }}
               # Azure specific: Transparent bridge mode is required in order
               # for proxy-redirection to work
               until [ -f /var/run/azure-vnet.json ]; do

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -11,5 +11,9 @@ reconfigureKubelet: false
 # Delete the cbr0 bridge if it exists (GKE)
 removeCbrBridge: false
 
+# Wait for the /var/run/azure-vnet.json file to be created before continuing the script
+# This must be set as true explicitly if Azure AKS with CNI chaining is used.
+expectAzureVnet: false
+
 # Revert nodeinit changes via preStop container lifecycle hook
 revertReconfigureKubelet: false


### PR DESCRIPTION
Setting `global.azure.enabled` will change operator image to
`operator-azure`, which only accepts azure IPAM, and throw
fatal error for `cluster-pool`.

This PR is to enable node init azure step for both cases (e.g. CNI
and Azure IPAM)

Closes #13023

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
helm/azure: Fix fatal error for CNI Azure installation
```

TODO
- [x] Follow GSG for azure one more time

<details>
<summary>Testing Azure CNI Chaining</summary>

```bash
$ helm install cilium install/kubernetes/cilium \
  --namespace cilium \
  --set global.cni.chainingMode=generic-veth \
  --set global.cni.customConf=true \
  --set global.nodeinit.enabled=true \
  --set nodeinit.azure=true \
  --set global.cni.configMap=cni-configuration \
  --set global.tunnel=disabled \
  --set global.masquerade=false
NAME: cilium
LAST DEPLOYED: Mon Aug 31 22:45:39 2020
NAMESPACE: cilium
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
You have successfully installed Cilium.

Your release version is 1.8.90.

For any further help, visit https://docs.cilium.io/en/v1.8/gettinghelp

$ kgpoowiden cilium                                                  
NAME                               READY   STATUS    RESTARTS   AGE     IP            NODE                                NOMINATED NODE   READINESS GATES
cilium-5hwmr                       1/1     Running   0          2m29s   10.240.0.35   aks-nodepool1-14356785-vmss000001   <none>           <none>
cilium-lj9fw                       1/1     Running   0          2m29s   10.240.0.4    aks-nodepool1-14356785-vmss000000   <none>           <none>
cilium-node-init-b28ts             1/1     Running   0          2m29s   10.240.0.4    aks-nodepool1-14356785-vmss000000   <none>           <none>
cilium-node-init-brjrn             1/1     Running   0          2m29s   10.240.0.35   aks-nodepool1-14356785-vmss000001   <none>           <none>
cilium-operator-65456488b8-74p79   1/1     Running   0          2m29s   10.240.0.35   aks-nodepool1-14356785-vmss000001   <none>           <none>
cilium-operator-65456488b8-z645x   1/1     Running   0          2m29s   10.240.0.4    aks-nodepool1-14356785-vmss000000   <none>           <none>

```

</details>