### PR TITLE
ci/gke: Fix Hubble Relay on GKE

### DIFF
--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -167,6 +167,7 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationGKE:
 		vm.RestartUnmanagedPodsInNamespace(helpers.KubeSystemNamespace)
+		vm.RestartUnmanagedPodsInNamespace(helpers.CiliumNamespace)
 	}
 
 	switch helpers.GetCurrentIntegration() {

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -105,167 +105,164 @@ var _ = Describe("K8sHubbleTest", func() {
 			"hubble observe: filter %q never matched expected string %q", filter, expected)
 	}
 
-	// Skipping on GKE due to hubble-relay not getting ready
-	SkipContextIf(helpers.SkipGKEQuarantined, "All Hubble Tests", func() {
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		k8s1NodeName, _ = kubectl.GetNodeInfo(helpers.K8s1)
+
+		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+			"global.hubble.metrics.enabled": `"{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"`,
+			"global.hubble.relay.enabled":   "true",
+		})
+
+		var err error
+		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
+		Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
+
+		ExpectHubbleRelayReady(kubectl, hubbleRelayNamespace)
+		hubbleRelayIP, hubbleRelayPort, err := kubectl.GetServiceHostPort(hubbleRelayNamespace, hubbleRelayService)
+		Expect(err).Should(BeNil(), "Cannot get service %s", hubbleRelayService)
+		Expect(govalidator.IsIP(hubbleRelayIP)).Should(BeTrue(), "hubbleRelayIP is not an IP")
+		hubbleRelayAddress = net.JoinHostPort(hubbleRelayIP, strconv.Itoa(hubbleRelayPort))
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.CiliumNamespace,
+			"cilium endpoint list")
+	})
+
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterEach(func() {
+		ExpectAllPodsTerminated(kubectl)
+	})
+
+	AfterAll(func() {
+		kubectl.DeleteHubbleRelay(hubbleRelayNamespace)
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
+		kubectl.CloseSSHClient()
+	})
+
+	Context("Hubble Observe", func() {
+		var (
+			namespaceForTest string
+			appPods          map[string]string
+			app1ClusterIP    string
+			app1Port         int
+		)
+
 		BeforeAll(func() {
-			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-			k8s1NodeName, _ = kubectl.GetNodeInfo(helpers.K8s1)
+			namespaceForTest = helpers.GenerateNamespaceForTest("")
+			kubectl.NamespaceDelete(namespaceForTest)
+			res := kubectl.NamespaceCreate(namespaceForTest)
+			res.ExpectSuccess("could not create namespace")
 
-			demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+			res = kubectl.Apply(helpers.ApplyOptions{FilePath: demoPath, Namespace: namespaceForTest})
+			res.ExpectSuccess("could not create resource")
 
-			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"global.hubble.metrics.enabled": `"{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"`,
-				"global.hubble.relay.enabled":   "true",
-			})
+			err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
+			Expect(err).Should(BeNil(), "test pods are not ready after timeout")
 
-			var err error
-			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
-			Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
-
-			ExpectHubbleRelayReady(kubectl, hubbleRelayNamespace)
-			hubbleRelayIP, hubbleRelayPort, err := kubectl.GetServiceHostPort(hubbleRelayNamespace, hubbleRelayService)
-			Expect(err).Should(BeNil(), "Cannot get service %s", hubbleRelayService)
-			Expect(govalidator.IsIP(hubbleRelayIP)).Should(BeTrue(), "hubbleRelayIP is not an IP")
-			hubbleRelayAddress = net.JoinHostPort(hubbleRelayIP, strconv.Itoa(hubbleRelayPort))
-		})
-
-		AfterFailed(func() {
-			kubectl.CiliumReport(helpers.CiliumNamespace,
-				"cilium endpoint list")
-		})
-
-		JustAfterEach(func() {
-			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-		})
-
-		AfterEach(func() {
-			ExpectAllPodsTerminated(kubectl)
+			appPods = helpers.GetAppPods(apps, namespaceForTest, kubectl, "id")
+			app1ClusterIP, app1Port, err = kubectl.GetServiceHostPort(namespaceForTest, app1Service)
+			Expect(err).To(BeNil(), "unable to find service in %q namespace", namespaceForTest)
 		})
 
 		AfterAll(func() {
-			kubectl.DeleteHubbleRelay(hubbleRelayNamespace)
-			UninstallCiliumFromManifest(kubectl, ciliumFilename)
-			kubectl.CloseSSHClient()
+			kubectl.Delete(demoPath)
+			kubectl.NamespaceDelete(namespaceForTest)
 		})
 
-		Context("Hubble Observe", func() {
-			var (
-				namespaceForTest string
-				appPods          map[string]string
-				app1ClusterIP    string
-				app1Port         int
+		It("Test L3/L4 Flow", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
+			defer cancel()
+			follow := kubectl.HubbleObserveFollow(ctx, helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
+				"--last 1 --type trace --from-pod %s/%s --to-namespace %s --to-label %s --to-port %d",
+				namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels, app1Port))
+
+			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
+				helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
+
+			err := follow.WaitUntilMatchFilterLineTimeout(`{$.Type}`, "L3_L4", helpers.ShortCommandTimeout)
+			Expect(err).To(BeNil(), fmt.Sprintf("hubble observe query timed out on %q", follow.OutputPrettyPrint()))
+
+			// Basic check for L4 Prometheus metrics.
+			_, nodeIP := kubectl.GetNodeInfo(helpers.K8s1)
+			metricsUrl := fmt.Sprintf("%s/metrics", net.JoinHostPort(nodeIP, prometheusPort))
+			res = kubectl.ExecInHostNetNS(ctx, k8s1NodeName, helpers.CurlFail(metricsUrl))
+			res.ExpectSuccess("%s/%s cannot curl metrics %q", helpers.CiliumNamespace, ciliumPodK8s1, app1ClusterIP)
+			res.ExpectContains(`hubble_flows_processed_total{protocol="TCP",subtype="to-endpoint",type="Trace",verdict="FORWARDED"}`)
+		})
+
+		It("Test L3/L4 Flow with hubble-relay", func() {
+			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
+				helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
+
+			// In case a node was temporarily unavailable, hubble-relay will
+			// reconnect once it receives a new request. Therefore we retry
+			// in a 5 second interval.
+			hubbleObserveUntilMatch(helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
+				"--server %s --last 1 --type trace --from-pod %s/%s --to-namespace %s --to-label %s --to-port %d",
+				hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels, app1Port),
+				`{$.Type}`, "L3_L4",
+				&helpers.TimeoutConfig{
+					Ticker:  5 * time.Second,
+					Timeout: helpers.MidCommandTimeout,
+				},
 			)
+		})
 
-			BeforeAll(func() {
-				namespaceForTest = helpers.GenerateNamespaceForTest("")
-				kubectl.NamespaceDelete(namespaceForTest)
-				res := kubectl.NamespaceCreate(namespaceForTest)
-				res.ExpectSuccess("could not create namespace")
+		It("Test L7 Flow", func() {
+			addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
+			defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
 
-				res = kubectl.Apply(helpers.ApplyOptions{FilePath: demoPath, Namespace: namespaceForTest})
-				res.ExpectSuccess("could not create resource")
+			ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
+			defer cancel()
+			follow := kubectl.HubbleObserveFollow(ctx, helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
+				"--last 1 --type l7 --from-pod %s/%s --to-namespace %s --to-label %s --protocol http",
+				namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels))
 
-				err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "test pods are not ready after timeout")
+			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
+				helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
 
-				appPods = helpers.GetAppPods(apps, namespaceForTest, kubectl, "id")
-				app1ClusterIP, app1Port, err = kubectl.GetServiceHostPort(namespaceForTest, app1Service)
-				Expect(err).To(BeNil(), "unable to find service in %q namespace", namespaceForTest)
-			})
+			err := follow.WaitUntilMatchFilterLineTimeout(`{$.Type}`, "L7", helpers.ShortCommandTimeout)
+			Expect(err).To(BeNil(), fmt.Sprintf("hubble observe query timed out on %q", follow.OutputPrettyPrint()))
 
-			AfterAll(func() {
-				kubectl.Delete(demoPath)
-				kubectl.NamespaceDelete(namespaceForTest)
-			})
+			// Basic check for L7 Prometheus metrics.
+			_, nodeIP := kubectl.GetNodeInfo(helpers.K8s1)
+			metricsUrl := fmt.Sprintf("%s/metrics", net.JoinHostPort(nodeIP, prometheusPort))
+			res = kubectl.ExecInHostNetNS(ctx, k8s1NodeName, helpers.CurlFail(metricsUrl))
+			res.ExpectSuccess("%s/%s cannot curl metrics %q", helpers.CiliumNamespace, ciliumPodK8s1, app1ClusterIP)
+			res.ExpectContains(`hubble_flows_processed_total{protocol="HTTP",subtype="HTTP",type="L7",verdict="FORWARDED"}`)
+		})
 
-			It("Test L3/L4 Flow", func() {
-				ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
-				defer cancel()
-				follow := kubectl.HubbleObserveFollow(ctx, helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
-					"--last 1 --type trace --from-pod %s/%s --to-namespace %s --to-label %s --to-port %d",
-					namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels, app1Port))
+		It("Test L7 Flow with hubble-relay", func() {
+			addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
+			defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
 
-				res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
-					helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
-				res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
+			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
+				helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
 
-				err := follow.WaitUntilMatchFilterLineTimeout(`{$.Type}`, "L3_L4", helpers.ShortCommandTimeout)
-				Expect(err).To(BeNil(), fmt.Sprintf("hubble observe query timed out on %q", follow.OutputPrettyPrint()))
-
-				// Basic check for L4 Prometheus metrics.
-				_, nodeIP := kubectl.GetNodeInfo(helpers.K8s1)
-				metricsUrl := fmt.Sprintf("%s/metrics", net.JoinHostPort(nodeIP, prometheusPort))
-				res = kubectl.ExecInHostNetNS(ctx, k8s1NodeName, helpers.CurlFail(metricsUrl))
-				res.ExpectSuccess("%s/%s cannot curl metrics %q", helpers.CiliumNamespace, ciliumPodK8s1, app1ClusterIP)
-				res.ExpectContains(`hubble_flows_processed_total{protocol="TCP",subtype="to-endpoint",type="Trace",verdict="FORWARDED"}`)
-			})
-
-			It("Test L3/L4 Flow with hubble-relay", func() {
-				res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
-					helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
-				res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
-
-				// In case a node was temporarily unavailable, hubble-relay will
-				// reconnect once it receives a new request. Therefore we retry
-				// in a 5 second interval.
-				hubbleObserveUntilMatch(helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
-					"--server %s --last 1 --type trace --from-pod %s/%s --to-namespace %s --to-label %s --to-port %d",
-					hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels, app1Port),
-					`{$.Type}`, "L3_L4",
-					&helpers.TimeoutConfig{
-						Ticker:  5 * time.Second,
-						Timeout: helpers.MidCommandTimeout,
-					},
-				)
-			})
-
-			It("Test L7 Flow", func() {
-				addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
-				defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
-
-				ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
-				defer cancel()
-				follow := kubectl.HubbleObserveFollow(ctx, helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
-					"--last 1 --type l7 --from-pod %s/%s --to-namespace %s --to-label %s --protocol http",
-					namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels))
-
-				res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
-					helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
-				res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
-
-				err := follow.WaitUntilMatchFilterLineTimeout(`{$.Type}`, "L7", helpers.ShortCommandTimeout)
-				Expect(err).To(BeNil(), fmt.Sprintf("hubble observe query timed out on %q", follow.OutputPrettyPrint()))
-
-				// Basic check for L7 Prometheus metrics.
-				_, nodeIP := kubectl.GetNodeInfo(helpers.K8s1)
-				metricsUrl := fmt.Sprintf("%s/metrics", net.JoinHostPort(nodeIP, prometheusPort))
-				res = kubectl.ExecInHostNetNS(ctx, k8s1NodeName, helpers.CurlFail(metricsUrl))
-				res.ExpectSuccess("%s/%s cannot curl metrics %q", helpers.CiliumNamespace, ciliumPodK8s1, app1ClusterIP)
-				res.ExpectContains(`hubble_flows_processed_total{protocol="HTTP",subtype="HTTP",type="L7",verdict="FORWARDED"}`)
-			})
-
-			It("Test L7 Flow with hubble-relay", func() {
-				addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
-				defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
-
-				res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
-					helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
-				res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
-
-				// In case a node was temporarily unavailable, hubble-relay will
-				// reconnect once it receives a new request. Therefore we retry
-				// in a 5 second interval.
-				hubbleObserveUntilMatch(helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
-					"--server %s --last 1 --type l7 --from-pod %s/%s --to-namespace %s --to-label %s --protocol http",
-					hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels),
-					`{$.Type}`, "L7",
-					&helpers.TimeoutConfig{
-						Ticker:  5 * time.Second,
-						Timeout: helpers.MidCommandTimeout,
-					},
-				)
-			})
+			// In case a node was temporarily unavailable, hubble-relay will
+			// reconnect once it receives a new request. Therefore we retry
+			// in a 5 second interval.
+			hubbleObserveUntilMatch(helpers.CiliumNamespace, ciliumPodK8s1, fmt.Sprintf(
+				"--server %s --last 1 --type l7 --from-pod %s/%s --to-namespace %s --to-label %s --protocol http",
+				hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels),
+				`{$.Type}`, "L7",
+				&helpers.TimeoutConfig{
+					Ticker:  5 * time.Second,
+					Timeout: helpers.MidCommandTimeout,
+				},
+			)
 		})
 	})
 })


### PR DESCRIPTION
As our [documentation states](https://docs.cilium.io/en/v1.8/gettingstarted/k8s-install-gke/), GKE requires unmanaged pods to be restarted after Cilium is deployed. Because Hubble Relay is deployed together with Cilium, it can end up being an unmanaged pod depending on when it is scheduled, so has to be restarted.

This PR adds an additional step to the GKE setup where we also restart all unmanaged (non-hostNetwork) pods in the `cilium` namespace.

I have manually verified that when the `hubble-relay` pod enters a `CrashLoopBackoff` with the same logs output described in #12452, that it is indeed not managed (i.e. it did not show up in `cilium endpoint list`). Deleting the pod made the pod managed and fixed the connectivity issue immediately

Fixes #12452