### PR TITLE
Add NodePortAddresses as KP-free command line option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -173,6 +173,7 @@ cilium-agent [flags]
       --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
       --native-routing-cidr string                    Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
       --node-port-acceleration string                 BPF NodePort acceleration via XDP ("native", "disabled") (default "disabled")
+      --node-port-addresses strings                   A list of values which specify the addresses to use for NodePorts. Values must be valid IP blocks (e.g. 1.2.3.0/24, ::1/128). The default is to use all local addresses.
       --node-port-algorithm string                    BPF load balancing algorithm ("random", "maglev") (default "random")
       --node-port-bind-protection                     Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -550,6 +550,9 @@ func init() {
 	flags.StringSlice(option.NodePortRange, []string{fmt.Sprintf("%d", option.NodePortMinDefault), fmt.Sprintf("%d", option.NodePortMaxDefault)}, "Set the min/max NodePort port range")
 	option.BindEnv(option.NodePortRange)
 
+	flags.StringSlice(option.NodePortAddresses, nil, "A list of values which specify the addresses to use for NodePorts. Values must be valid IP blocks (e.g. 1.2.3.0/24, ::1/128). The default is to use all local addresses.")
+	option.BindEnv(option.NodePortAddresses)
+
 	flags.Bool(option.NodePortBindProtection, true, "Reject application bind(2) requests to service ports in the NodePort range")
 	option.BindEnv(option.NodePortBindProtection)
 
@@ -1290,8 +1293,9 @@ func (d *Daemon) initKVStore() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice:       option.Config.HostDevice,
-		EncryptInterface: option.Config.EncryptInterface,
+		HostDevice:        option.Config.HostDevice,
+		EncryptInterface:  option.Config.EncryptInterface,
+		NodePortAddresses: option.Config.NodePortAddresses,
 	}
 
 	log.Info("Initializing daemon")

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -281,14 +281,10 @@ func (d *Daemon) allocateIPs() error {
 	if option.Config.EnableIPv6 {
 		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
 		log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
-
-		if addrs, err := d.datapath.LocalNodeAddressing().IPv6().LocalAddresses(); err != nil {
+		log.Info("  Local IPv6 addresses:")
+		err := d.datapath.LocalNodeAddressing().IPv6().MapLocalAddresses(logIPAddress)
+		if err != nil {
 			log.WithError(err).Fatal("Unable to list local IPv6 addresses")
-		} else {
-			log.Info("  Local IPv6 addresses:")
-			for _, ip := range addrs {
-				log.Infof("  - %s", ip)
-			}
 		}
 	}
 
@@ -309,14 +305,11 @@ func (d *Daemon) allocateIPs() error {
 		}
 		node.SetIPv4Loopback(loopbackIPv4)
 		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())
+		log.Info("  Local IPv4 addresses:")
 
-		if addrs, err := d.datapath.LocalNodeAddressing().IPv4().LocalAddresses(); err != nil {
+		err := d.datapath.LocalNodeAddressing().IPv4().MapLocalAddresses(logIPAddress)
+		if err != nil {
 			log.WithError(err).Fatal("Unable to list local IPv4 addresses")
-		} else {
-			log.Info("  Local IPv4 addresses:")
-			for _, ip := range addrs {
-				log.Infof("  - %s", ip)
-			}
 		}
 	}
 
@@ -373,4 +366,9 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 		result.Master,
 		option.Config.Masquerade)
 	return err
+}
+
+func logIPAddress(ip net.IP) error {
+	log.Infof("  - %s", ip)
+	return nil
 }

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -471,6 +471,9 @@ data:
 {{- if .Values.global.nodePort.range }}
   node-port-range: {{ .Values.global.nodePort.range | quote }}
 {{- end }}
+{{- if .Values.global.nodePort.addresses }}
+  node-port-addresses: {{ .Values.global.nodePort.addresses | quote }}
+{{- end }}
 {{- if .Values.global.nodePort.directRoutingDevice }}
   direct-routing-device: {{ .Values.global.nodePort.directRoutingDevice | quote }}
 {{- end }}

--- a/pkg/datapath/fake/datapath_test.go
+++ b/pkg/datapath/fake/datapath_test.go
@@ -17,6 +17,7 @@
 package fake
 
 import (
+	"net"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/datapath"
@@ -46,10 +47,19 @@ func (s *fakeTestSuite) TestNewDatapath(c *check.C) {
 	c.Assert(dp.LocalNodeAddressing().IPv4().Router(), check.Not(check.IsNil))
 	c.Assert(dp.LocalNodeAddressing().IPv4().AllocationCIDR(), check.Not(check.IsNil))
 
-	list, err := dp.LocalNodeAddressing().IPv4().LocalAddresses()
-	c.Assert(len(list), check.Not(check.Equals), 0)
+	var list []net.IP
+	err := dp.LocalNodeAddressing().IPv4().MapLocalAddresses(func(ip net.IP) error {
+		list = append(list, ip)
+		return nil
+	})
 	c.Assert(err, check.IsNil)
-	list, err = dp.LocalNodeAddressing().IPv6().LocalAddresses()
 	c.Assert(len(list), check.Not(check.Equals), 0)
+
+	var list2 []net.IP
+	err = dp.LocalNodeAddressing().IPv6().MapLocalAddresses(func(ip net.IP) error {
+		list2 = append(list2, ip)
+		return nil
+	})
 	c.Assert(err, check.IsNil)
+	c.Assert(len(list2), check.Not(check.Equals), 0)
 }

--- a/pkg/datapath/fake/node_addressing.go
+++ b/pkg/datapath/fake/node_addressing.go
@@ -104,8 +104,18 @@ func (a *addressFamily) AllocationCIDR() *cidr.CIDR {
 	return a.allocCIDR
 }
 
-func (a *addressFamily) LocalAddresses() ([]net.IP, error) {
-	return a.localAddresses, nil
+func (a *addressFamily) MapLocalAddresses(f func(net.IP) error) error {
+	for _, addr := range a.localAddresses {
+		err := f(addr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *addressFamily) SubnetOverride() []net.IPNet {
+	return nil
 }
 
 func (a *addressFamily) LoadBalancerNodeAddresses() []net.IP {

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -15,6 +15,8 @@
 package linux
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
@@ -29,6 +31,8 @@ type DatapathConfiguration struct {
 	HostDevice string
 	// EncryptInterface is the name of the device to be used for direct ruoting encryption
 	EncryptInterface string
+	// NodePortAddresses is a set of IP blocks that should be considered local to the node
+	NodePortAddresses []net.IPNet
 }
 
 type linuxDatapath struct {
@@ -45,7 +49,7 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 	dp := &linuxDatapath{
 		ConfigWriter:    &config.HeaderfileWriter{},
 		IptablesManager: ruleManager,
-		nodeAddressing:  NewNodeAddressing(),
+		nodeAddressing:  NewNodeAddressing(cfg.NodePortAddresses),
 		config:          cfg,
 		loader:          loader.NewLoader(canDisableDwarfRelocations),
 	}

--- a/pkg/datapath/linux/node_addressing_test.go
+++ b/pkg/datapath/linux/node_addressing_test.go
@@ -1,0 +1,135 @@
+// Copyright 2018-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package linux
+
+import (
+	"net"
+
+	"gopkg.in/check.v1"
+)
+
+func (s *linuxTestSuite) TestMapSubnetAddresses(c *check.C) {
+	tests := []struct {
+		name        string
+		subnets     []net.IPNet
+		expectedIPs []net.IP
+	}{
+		{
+			name: "one ipv4 ip",
+			subnets: []net.IPNet{
+				{
+					IP:   net.IPv4(127, 0, 0, 1),
+					Mask: net.IPv4Mask(255, 255, 255, 255),
+				},
+			},
+			expectedIPs: []net.IP{
+				net.IPv4(127, 0, 0, 1),
+			},
+		},
+		{
+			name: "one ipv4 subnet",
+			subnets: []net.IPNet{
+				{
+					IP:   net.IPv4(127, 0, 0, 1),
+					Mask: net.IPv4Mask(255, 255, 255, 254),
+				},
+			},
+			expectedIPs: []net.IP{
+				net.IPv4(127, 0, 0, 0),
+				net.IPv4(127, 0, 0, 1),
+			},
+		},
+		{
+			name: "two ipv4 subnets",
+			subnets: []net.IPNet{
+				{
+					IP:   net.IPv4(127, 0, 0, 2),
+					Mask: net.IPv4Mask(255, 255, 255, 254),
+				},
+				{
+					IP:   net.IPv4(127, 0, 0, 4),
+					Mask: net.IPv4Mask(255, 255, 255, 254),
+				},
+			},
+			expectedIPs: []net.IP{
+				net.IPv4(127, 0, 0, 2),
+				net.IPv4(127, 0, 0, 3),
+				net.IPv4(127, 0, 0, 4),
+				net.IPv4(127, 0, 0, 5),
+			},
+		},
+		{
+			name: "one ipv6",
+			subnets: []net.IPNet{
+				{
+					IP:   net.IPv6zero,
+					Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				},
+			},
+			expectedIPs: []net.IP{
+				net.IPv6zero,
+			},
+		},
+		{
+			name: "one ipv6 subnet",
+			subnets: []net.IPNet{
+				{
+					IP:   net.IPv6loopback,
+					Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe},
+				},
+			},
+			expectedIPs: []net.IP{
+				net.IPv6zero,
+				net.IPv6loopback,
+			},
+		},
+		{
+			name: "two ipv6 subnets",
+			subnets: []net.IPNet{
+				{
+					IP:   net.IPv6loopback,
+					Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe},
+				},
+				{
+					IP:   net.IPv6linklocalallnodes,
+					Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe},
+				},
+			},
+			expectedIPs: []net.IP{
+				net.IPv6zero,
+				net.IPv6loopback,
+				{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				net.IPv6linklocalallnodes,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Logf("running %q", tt.name)
+		var got []net.IP
+		err := mapSubnetAddresses(tt.subnets, func(ip net.IP) error {
+			got = append(got, ip)
+			return nil
+		})
+		c.Assert(err, check.IsNil)
+		le := len(tt.expectedIPs)
+		c.Assert(le, check.Equals, len(got))
+		for i := 0; i < le; i++ {
+			c.Assert(tt.expectedIPs[i].Equal(got[i]), check.Equals, true)
+		}
+	}
+}

--- a/pkg/datapath/node_addressing.go
+++ b/pkg/datapath/node_addressing.go
@@ -36,12 +36,16 @@ type NodeAddressingFamily interface {
 	// on the node
 	AllocationCIDR() *cidr.CIDR
 
-	// LocalAddresses lists all local addresses
-	LocalAddresses() ([]net.IP, error)
+	// MapLocalAddresses applies a function to each local address.
+	MapLocalAddresses(func(net.IP) error) error
 
 	// LoadBalancerNodeAddresses lists all addresses on which HostPort and
 	// NodePort services should be responded to
 	LoadBalancerNodeAddresses() []net.IP
+
+	// SubnetOverride returns a set of IP blocks that override local ip addresses
+	// if they are present
+	SubnetOverride() []net.IPNet
 }
 
 // NodeAddressing implements addressing of a node


### PR DESCRIPTION
Add --node-port-addresses as a command line option that
sets specific IP blocks that node ports will utilize
on the individual hosts

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #12508
```release-note
Add the `--node-port-addresses` command line flag so that specific IP blocks will be used for node-ports when cilium is running in "kube-proxy free" mode.
```
