### PR TITLE
travis: enable vm jobs of aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 
+dist: focal
 sudo: required
 
 go: "1.15"
@@ -8,9 +9,7 @@ go: "1.15"
 jobs:
   include:
     - arch: amd64
-      dist: bionic
     - arch: arm64-graviton2
-      dist: focal
       virt: vm
       group: edge
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: go
 
-dist: bionic
 sudo: required
 
 go: "1.15"
 
-arch:
-  - amd64
-  - arm64
 
 jobs:
+  include:
+    - arch: amd64
+      dist: bionic
+    - arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
   allow_failures:
-  - arch: arm64
+    - arch: arm64-graviton2
 
 if: branch = master OR type = pull_request
 
@@ -21,6 +24,7 @@ addons:
       - kernel-package
       - gnupg
       - libelf-dev
+      - libncurses5
 
 before_install: ./.travis/prepare.sh
 


### PR DESCRIPTION
Current Arm64 job often gets the following issue:
    "No output has been received in the last 10m0s"
Perhaps it can be avoided by enabling the VM job of arm64.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

