### PR TITLE
k8s: honor the service.kubernetes.io/service-proxy-name label

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -146,6 +146,7 @@ cilium-agent [flags]
       --k8s-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in
       --k8s-require-ipv4-pod-cidr                     Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                     Require IPv6 PodCIDR to be specified in node resource
+      --k8s-service-proxy-name string                 Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --k8s-watcher-endpoint-selector string          K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
       --k8s-watcher-queue-size uint                   Queue size used to serialize each k8s event type (default 1024)
       --keep-config                                   When restoring state, keeps containers' configuration in place

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -50,6 +50,7 @@ cilium-operator-aws [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -48,6 +48,7 @@ cilium-operator-azure [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -46,6 +46,7 @@ cilium-operator-generic [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -52,6 +52,7 @@ cilium-operator [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1001,6 +1001,25 @@ Meanwhile `GKE internal TCP/UDP load balancer
 <https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#lb_source_ranges>`__
 does not, so the feature must be kept enabled in order to restrict the access.
 
+Service Proxy Name Configuration
+********************************
+
+Like kube-proxy, Cilium also honors the ``service.kubernetes.io/service-proxy-name`` service annotation
+and only manages services that contain a matching service-proxy-name label. This name can be configured
+by setting ``global.k8s.serviceProxyName`` option and the behavior is identical to that of
+kube-proxy. The service proxy name defaults to an empty string which instructs Cilium to
+only manage services not having ``service.kubernetes.io/service-proxy-name`` label.
+
+For more details on the usage of ``service.kubernetes.io/service-proxy-name`` label and its
+working, take a look at `this KEP
+<https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0031-20181017-kube-proxy-services-optional.md>`__.
+
+.. note::
+
+    If Cilium with a non-empty service proxy name is meant to manage all services in kube-proxy
+    free mode, make sure that default Kubernetes services like ``kube-dns`` and ``kubernetes``
+    have the required label value.
+
 Limitations
 ###########
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -844,6 +844,9 @@ func init() {
 	flags.Int(option.LBMapEntriesName, lbmap.MaxEntries, "Maximum number of entries in Cilium BPF lbmap")
 	option.BindEnv(option.LBMapEntriesName)
 
+	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
+	option.BindEnv(option.K8sServiceProxyName)
+
 	viper.BindPFlags(flags)
 
 	CustomCommandHelpFormat(RootCmd, option.HelpFlagSections)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -621,3 +621,8 @@ data:
 {{- if hasKey .Values "enableK8sEndpointSlice" }}
   enable-k8s-endpoint-slice: {{ .Values.enableK8sEndpointSlice | quote }}
 {{- end }}
+
+{{- if and .Values.global.k8s .Values.global.k8s.serviceProxyName }}
+  # Configure service proxy name for Cilium.
+  k8s-service-proxy-name: {{ .Values.global.k8s.serviceProxyName | quote }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -432,6 +432,13 @@ global:
     # range via the Kubernetes node resource
     requireIPv4PodCIDR: false
 
+    # Service proxy name to use for Cilium components. This name makes sure
+    # that Cilium only manages service objects that contains the matching
+    # service.kubernetes.io/service-proxy-name label value.
+    # Defaults to empty string, in which case Cilium manages all services
+    # without the mentioned label.
+    serviceProxyName: ""
+
   # ENI mode configures the options required to run with ENI
   eni: false
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -275,5 +275,8 @@ func init() {
 		"Duration that LeaderElector clients should wait between retries of the actions")
 	option.BindEnv(operatorOption.LeaderElectionRetryPeriod)
 
+	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
+	option.BindEnv(option.K8sServiceProxyName)
+
 	viper.BindPFlags(flags)
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -21,17 +21,16 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) servicesInit(k8sClient kubernetes.Interface, swgSvcs *lock.StoppableWaitGroup) {
-
+func (k *K8sWatcher) servicesInit(k8sClient kubernetes.Interface, swgSvcs *lock.StoppableWaitGroup, optsModifier func(*v1meta.ListOptions)) {
 	_, svcController := informer.NewInformer(
-		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
-			"services", v1.NamespaceAll, fields.Everything()),
+		cache.NewFilteredListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+			"services", v1.NamespaceAll, optsModifier),
 		&slim_corev1.Service{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -829,11 +829,15 @@ const (
 	// tracking map.
 	FragmentsMapEntriesName = "bpf-fragments-map-max"
 
-	// K8sEnableAPIDiscovery
+	// K8sEnableAPIDiscovery enables Kubernetes API discovery
 	K8sEnableAPIDiscovery = "enable-k8s-api-discovery"
 
 	// LBMapEntriesName configures max entries for BPF lbmap.
 	LBMapEntriesName = "bpf-lb-map-max"
+
+	// K8sServiceProxyName instructs Cilium to handle service objects only when
+	// service.kubernetes.io/service-proxy-name label equals the provided value.
+	K8sServiceProxyName = "k8s-service-proxy-name"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -910,6 +914,7 @@ var HelpFlagSections = []FlagsSection{
 			FlannelMasterDevice,
 			FlannelUninstallOnExit,
 			EnableWellKnownIdentities,
+			K8sServiceProxyName,
 		},
 	},
 	{
@@ -1953,6 +1958,13 @@ type DaemonConfig struct {
 
 	// LBMapEntries is the maximum number of entries allowed in BPF lbmap.
 	LBMapEntries int
+
+	// K8sServiceProxyName is the value of service.kubernetes.io/service-proxy-name label,
+	// that identifies the service objects Cilium should handle.
+	// If the provided value is an empty string, Cilium will manage service objects when
+	// the label is not present. For more details -
+	// https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0031-20181017-kube-proxy-services-optional.md
+	K8sServiceProxyName string
 }
 
 var (
@@ -2474,6 +2486,7 @@ func (c *DaemonConfig) Populate() {
 	c.PolicyAuditMode = viper.GetBool(PolicyAuditModeArg)
 	c.EnableIPv4FragmentsTracking = viper.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = viper.GetInt(FragmentsMapEntriesName)
+	c.K8sServiceProxyName = viper.GetString(K8sServiceProxyName)
 
 	c.populateDevices()
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -352,6 +352,66 @@ var _ = Describe("K8sServicesTest", func() {
 				testCurlFromPods(echoPodLabel, url, 10, 0)
 			})
 		})
+
+		It("Checks service.kubernetes.io/service-proxy-name label implementation", func() {
+			serviceProxyLabelName := "service.kubernetes.io/service-proxy-name"
+
+			ciliumPods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
+			Expect(err).To(BeNil(), "Cannot get cilium pods")
+
+			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, echoServiceName)
+			Expect(err).Should(BeNil(), "Cannot get service %q ClusterIP", echoServiceName)
+			Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+
+			By("Labelling echo service with dummy service-proxy-name")
+			res := kubectl.Exec(fmt.Sprintf("kubectl label services/%s %s=%s", echoServiceName, serviceProxyLabelName, "dummy-lb"))
+			res.ExpectSuccess("cannot label service")
+
+			// Wait for all cilium pods to remove the serivce from its list.
+			By("Validating that Cilium is not handling the service")
+			Eventually(func() int {
+				validPods := 0
+				for _, pod := range ciliumPods {
+					serviceRes := kubectl.CiliumExecMustSucceed(
+						context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
+
+					if !strings.Contains(serviceRes.Stdout(), clusterIP) {
+						validPods++
+					}
+				}
+
+				return validPods
+			}, 30*time.Second, 2*time.Second).
+				Should(Equal(len(ciliumPods)), "All Cilium pods should remove the service from its services list")
+
+			url := fmt.Sprintf("http://%s/", clusterIP)
+
+			By("Checking that service should not be reachable with dummy service-proxy-name")
+			testCurlFromPods(echoPodLabel, url, 5, 5)
+
+			By("Removing echo service service-proxy-name label")
+			res = kubectl.Exec(fmt.Sprintf("kubectl label services/%s %s-", echoServiceName, serviceProxyLabelName))
+			res.ExpectSuccess("cannot remove label from service")
+
+			By("Validating that Cilium is handling the service")
+			Eventually(func() int {
+				validPods := 0
+				for _, pod := range ciliumPods {
+					serviceRes := kubectl.CiliumExecMustSucceed(
+						context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
+
+					if strings.Contains(serviceRes.Stdout(), clusterIP) {
+						validPods++
+					}
+				}
+
+				return validPods
+			}, 30*time.Second, 2*time.Second).
+				Should(Equal(len(ciliumPods)), "All Cilium pods must have the service in its services list")
+
+			By("Checking that service should be reachable with no service-proxy-name")
+			testCurlFromPods(echoPodLabel, url, 5, 0)
+		})
 	})
 
 	Context("Checks service across nodes", func() {


### PR DESCRIPTION
See commit messages for detailed info.

- [x] Add support for service.kubernetes.io/service-proxy-name label
- [x] Add e2e tests to check for required service behavior.
- [x] Add helm option to configure service proxy name for Cilium
- [x] Update Cilium kube-proxy-free GSG to include usage and changes.
- [x] Fix K8s E2E tests failure in #13018 

Fixes #13019 
Fixes #13018 