### PR TITLE
v1.7 backports 2020-09-01

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -11,6 +11,12 @@ Calico
 This guide instructs how to install Cilium in chaining configuration on top of
 `Calico <https://github.com/projectcalico/calico>`_.
 
+.. note::
+
+   When running Cilium in chaining configuration on top of Calico, the L7
+   policies may not work because of conflicting packet mark usage. This
+   limitation is currently tracked at `#12454 <https://github.com/cilium/cilium/issues/12454>`_.
+
 Create a CNI configuration
 ==========================
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -248,13 +248,6 @@ func (e *etcdModule) newClient(ctx context.Context, opts *ExtraOptions) (Backend
 		e.config.Endpoints = []string{endpointsOpt.value}
 	}
 
-	// Shuffle the order of endpoints to avoid all agents connecting to the
-	// same etcd endpoint and to work around etcd client library failover
-	// bugs. (https://github.com/etcd-io/etcd/pull/9860)
-	if e.config.Endpoints != nil {
-		shuffleEndpoints(e.config.Endpoints)
-	}
-
 	for {
 		// connectEtcdClient will close errChan when the connection attempt has
 		// been successful
@@ -681,6 +674,13 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		}
 		cfg.DialOptions = append(cfg.DialOptions, config.DialOptions...)
 		config = cfg
+	}
+
+	// Shuffle the order of endpoints to avoid all agents connecting to the
+	// same etcd endpoint and to work around etcd client library failover
+	// bugs. (https://github.com/etcd-io/etcd/pull/9860)
+	if config.Endpoints != nil {
+		shuffleEndpoints(config.Endpoints)
 	}
 
 	// Set DialTimeout to 0, otherwise the creation of a new client will


### PR DESCRIPTION
* #13005 -- docs: Mention L7 limitation in Calico chaining GSG (@pchaigno)
 * #12943 -- pkg/kvstore: set endpoint shuffle in etcd client connectivity (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13005 12943; do contrib/backporting/set-labels.py $pr done 1.7; done
```