### PR TITLE
contrib: Add release helper scripts for preparing micro releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -27,16 +27,15 @@ assignees: ''
 - [ ] Move any unresolved issues/PRs from old release project into the newly
       created release project
 - [ ] Push a PR including the changes necessary for the new release:
-  - [ ] Update the VERSION file to represent X.Y.Z
-  - [ ] Update helm charts via `make -C install/kubernetes`
+  - [ ] Pull latest branch
+  - [ ] Run `contrib/release/start-release.sh'
   - [ ] (If applicable) Update the `cilium_version` and `cilium_tag` in
         `examples/getting-started/Vagrantfile`
-  - [ ] Update `AUTHORS` via `make update-authors`
-  - [ ] Use [Cilium release-notes tool] to generate `CHANGELOG.md`
-  - [ ] Point `.github/cilium-actions.yml` to the newly created project
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
+  - [ ] Submit PR (`contrib/release/submit-release.sh`)
 - [ ] Merge PR
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
+  - Pull latest branch locally and run `contrib/release/tag-release.sh`
 - [ ] Wait for docker builds to complete
   - [cilium](https://hub.docker.com/repository/docker/cilium/cilium/builds)
   - [operator](https://hub.docker.com/repository/docker/cilium/operator/builds)
@@ -46,8 +45,7 @@ assignees: ''
       & push to repository
 - [ ] Run sanity check of Helm install using connectivity-check script.
       Suggested approach: Follow the full [GKE getting started guide].
-- [ ] [Create a release] for the new tag `vX.Y.Z`, using the release notes
-      from above
+- [ ] Check draft release from [releases] page and publish the release
 - [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
 
 ## Post-release
@@ -65,7 +63,7 @@ assignees: ''
 [Cilium release-notes tool]: https://github.com/cilium/release
 [Docker Hub]: https://hub.docker.com/orgs/cilium/repositories
 [Cilium charts]: https://github.com/cilium/charts
-[Create a release]: https://github.com/cilium/cilium/releases/new
+[releases]: https://github.com/cilium/cilium/releases
 [Stable releases]: https://github.com/cilium/cilium#stable-releases
 [kops]: https://github.com/kubernetes/kops/
 [kubespray]: https://github.com/kubernetes-sigs/kubespray/

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -20,6 +20,17 @@ If you intent to release a new feature release, see the
           used in the Cilium development process. See :ref:`dev_env` for
           detailed instructions about setting up said VM.
 
+GitHub template process
+~~~~~~~~~~~~~~~~~~~~~~~
+
+#. File a `new release issue <https://github.com/cilium/cilium/issues/new?assignees=&labels=kind%2Frelease&template=release_template.md&title=vX.Y.Z+release>`_
+   on GitHub, updating the title to reflect the version that will be released.
+
+#. Follow the steps in the issue template to prepare the release.
+
+Reference steps for the template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 #. Ensure that the necessary backports have been completed and merged. See
    :ref:`backport_process`.
 
@@ -27,62 +38,38 @@ If you intent to release a new feature release, see the
    #. Update PRs / issues that were added to the ``vX.Y.Z`` project, but didn't
       make it into this release into the ``vX.Y.Z+1`` project.
 
+#. Create a new project named "X.Y.Z+1" to automatically track the backports
+   for that particular release. `Direct Link: <https://github.com/cilium/cilium/projects/new>`_
+
 #. Checkout the desired stable branch and pull it:
 
    ::
 
        git checkout v1.0; git pull
 
-#. Create a branch for the release pull request:
+#. Run the release preparation script:
 
    ::
 
-       git checkout -b pr/prepare-v1.0.3
+       contrib/release/start-release.sh
 
-#. Update the ``VERSION`` file to represent ``X.Y.Z+1``
-
-#. Update the image tag versions and pullPolicy in the examples:
-
-   ::
-
-       make -C install/kubernetes clean all
-
-#. Update the ``cilium_version`` and ``cilium_tag`` variables in
-   ``examples/getting-started/Vagrantfile``
-
-#. Update the ``AUTHORS file``
-
-   ::
-
-       make update-authors
-
-
-   .. note::
+  .. note::
 
        Check to see if the ``AUTHORS`` file has any formatting errors (for
        instance, indentation mismatches) as well as duplicate contributor
        names, and correct them accordingly.
 
+#. Update the ``cilium_version`` and ``cilium_tag`` variables in
+   ``examples/getting-started/Vagrantfile``
 
-#. Generate the release notes by running the instructions provided in github.com/cilium/release
+#. Add all modified files using ``git add`` and create a commit with the
+   title ``Prepare for release v1.0.3``.
 
-#. Add the generated release notes in the ``CHANGELOG.md`` file
+#. Prepare a pull request for the changes:
 
-#. Create a new project named "X.Y.Z+1" to automatically track the backports
-   for that particular release. `Direct Link: <https://github.com/cilium/cilium/projects/new>`_
+   ::
 
-#. Update the project URL for the respective release in file ``.github/cilium-actions.yml``
-
-#. Add all modified files using ``git add`` and create a pull request with the
-   title ``Prepare for release v1.0.3``. Add the backport label to the PR which
-   corresponds to the branch for which the release is being performed, e.g.
-   ``backport/1.0``.
-
-   .. note::
-
-       Make sure to create the PR against the desired stable branch. In this
-       case ``v1.0``
-
+      contrib/release/submit-release.sh
 
 #. Follow standard procedures to get the aforementioned PR merged into the
    desired stable branch. See :ref:`submit_pr` for more information about this
@@ -94,26 +81,11 @@ If you intent to release a new feature release, see the
 
        git checkout v1.0; git pull
 
-#. Build the container images and push them
+#. Create and push release tags to GitHub:
 
    ::
 
-      DOCKER_IMAGE_TAG=v1.0.3 make docker-images-all
-      docker push cilium/cilium:v1.0.3
-
-   .. note:
-
-      This step requires you to login with ``docker login`` first and it will
-      require your Docker hub ID to have access to the ``Cilium`` organization.
-      You can alternatively trigger a build on DockerHub directly if you have
-      credentials to do so.
-
-#. Create release tags:
-
-   ::
-
-       git tag -a v1.0.3 -m 'Release v1.0.3'
-       git tag -a 1.0.3 -m 'Release 1.0.3'
+      contrib/release/tag-release.sh
 
    .. note::
 
@@ -123,24 +95,14 @@ If you intent to release a new feature release, see the
        ``x.y.z`` For more information about how ReadTheDocs does versioning, you can
        read their `Versions Documentation <https://docs.readthedocs.io/en/latest/versions.html>`_.
 
-#. Push the git release tag
+#. Wait for DockerHub to prepare all docker images.
 
-   ::
+#. `Publish a GitHub release <https://github.com/cilium/cilium/releases/>`_:
 
-       git push --tags
+   Following the steps above, the release draft will already be prepared.
+   Preview the description and then publish the release.
 
-#. `Create a GitHub release <https://github.com/cilium/cilium/releases/new>`_:
-
-   #. Choose the correct target branch, e.g. ``v1.0``
-   #. Choose the correct target tag, e.g. ``v1.0.3``
-   #. Title: ``1.0.3``
-   #. Check the ``This is a pre-release`` box if you are releasing a release
-      candidate.
-   #. Fill in the release description with the output generated by github.com/cilium/release
-
-   #. Preview the description and then publish the release
-
-#. Prepare Helm changes using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
+#. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    and push the changes into that repository (not the main cilium repository):
 
    ::
@@ -148,7 +110,7 @@ If you intent to release a new feature release, see the
       ./prepare_artifacts.sh /path/to/cilium/repository/checked/out/to/release/commit
       git push
 
-#. Prepare Helm changes using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
+#. Prepare Helm changes for the dev version of the branch using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    for the vX.Y helm charts, and push the changes into that repository (not the main cilium repository):
 
    In the ``cilium/cilium`` repository:

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+RELEASE_TOOL_PATH="${RELEASE_TOOL_PATH:-$GOPATH/src/github.com/cilium/release}"
+RELNOTES="$RELEASE_TOOL_PATH/release"
+RELNOTESCACHE="release-state.json"
+
+usage() {
+    logecho "usage: $0 <OLD-VERSION> <NEW-VERSION>"
+    logecho "OLD-VERSION    Previous release version for comparison"
+    logecho "NEW-VERSION    Target release version"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+[-rc0-9]*"; then
+        usage 2>&1
+        common::exit 1 "Invalid NEW-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(echo $1 | sed 's/^v//')"
+    local ersion="$(echo $2 | sed 's/^v//')"
+    local version="v$ersion"
+
+    logecho "Generating CHANGELOG.md"
+    rm -f $RELNOTESCACHE
+    echo -e "# Changelog\n\n## $version" > $version-changes.txt
+    $RELNOTES --base $old_version --head $(git rev-parse HEAD) >> $version-changes.txt
+    cp $version-changes.txt CHANGELOG-new.md
+    if [[ -e CHANGELOG.md ]]; then
+        tail -n+2 CHANGELOG.md >> CHANGELOG-new.md
+    fi
+    mv CHANGELOG-new.md CHANGELOG.md
+    logecho "Generated CHANGELOG.md"
+}
+
+main "$@"

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+ACTS_YAML=".github/cilium-actions.yml"
+
+usage() {
+    logecho "usage: $0 <VERSION> <GH-PROJECT>"
+    logecho "VERSION    Target release version"
+    logecho "GH-PROJECT Project ID for next release"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "^[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid GH-PROJECT ID argument. Expected [0-9]+"
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ "$(git status -s | grep -v "^??" | wc -l)" -gt 0 ]]; then
+        git status -s | grep -v "^??"
+        common::exit 1 "Unmerged changes in tree prevent preparing release PR."
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(cat VERSION)"
+    local ersion="$(echo $1 | sed 's/^v//')"
+    local version="v$ersion"
+    local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
+    local remote="origin"
+    local new_proj="$2"
+
+    git fetch $remote
+    git checkout -b pr/prepare-$version $remote/v$branch
+
+    logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
+    echo $ersion > VERSION
+    logrun make -C install/kubernetes all
+    logrun make update-authors
+    old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
+    sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+
+    $DIR/prep-changelog.sh "$old_version" "$version"
+
+    logecho "Next steps:"
+    logecho "* Check all changes and add to a new commit"
+    logecho "* Push the PR to Github for review"
+    logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
+    logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
+
+    # Leave $version-changes.txt around for prep-release.sh usage later
+}
+
+main "$@"

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+BRANCH="${1:-""}"
+if [ "$BRANCH" = "" ]; then
+    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
+fi
+BRANCH=$(echo "$BRANCH" | sed 's/^v//')
+
+RELEASE="v$(cat VERSION)"
+SUMMARY=${2:-}
+GENERATE_SUMMARY=false
+if [ "$SUMMARY" = "" ]; then
+    SUMMARY="$RELEASE-changes.txt"
+    GENERATE_SUMMARY=true
+fi
+
+if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+    echo "usage: $0 [branch version] [release-summary]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
+    exit 1
+fi
+
+if ! hub help | grep -q "pull-request"; then
+    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+    echo "Please install this tool first." 1>&2
+    exit 1
+fi
+
+if ! git diff --quiet; then
+    echo "Local changes found in git tree. Exiting release process..." 1>&2
+    exit 1
+fi
+
+if ! git log --oneline | grep -q $RELEASE; then
+    echo "Latest commit does not match commit title for release:" 1>&2
+    git log -1
+    exit 1
+fi
+
+if $GENERATE_SUMMARY; then
+    CHANGELOG=$SUMMARY
+    SUMMARY="$RELEASE-pr-$(date --rfc-3339=date).txt"
+    echo "Prepare for release $RELEASE" > $SUMMARY
+    tail -n+4 $CHANGELOG >> $SUMMARY
+fi
+
+echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+cat $SUMMARY 1>&2
+echo -e "\nSending pull request..." 2>&1
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git push origin "$PR_BRANCH"
+hub pull-request -b "v$BRANCH" -l kind/release,backport/$BRANCH -F $SUMMARY

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+REMOTE="$(get_remote)"
+CHARTS_PATH="${CHARTS_PATH:-$GOPATH/src/github.com/cilium/charts}"
+CHARTS_TOOL="prepare_artifacts.sh"
+RELEASES_URL="https://github.com/cilium/cilium/releases"
+VERSION=""
+
+usage() {
+    echo "usage: $0 [VERSION]"
+    echo "CHARTS_REPO Path to local copy of github.com/cilium/charts"
+    echo
+    echo "--help     Print this help message"
+}
+
+handle_args() {
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 1
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ ! -e "$CHARTS_PATH/$CHARTS_TOOL" ]]; then
+        usage
+        common::exit 1 "CHARTS_PATH='$CHARTS_PATH' invalid. Clone from github.com/cilium/charts"
+    fi
+
+    if ! which hub >/dev/null; then
+        echo "This tool relies on 'hub' from https://github.com/github/hub ." 1>&2
+        common::exit 1 "Please install this tool first."
+    fi
+
+    if [[ $# -ge 1 ]]; then
+        VERSION="$1"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local ersion="$(cat VERSION)"
+    if [[ "$VERSION" != "" ]]; then
+        ersion="$(echo $VERSION | sed 's/^v//')"
+    fi
+    local version="v$ersion"
+
+    if [[ ! -e $version-changes.txt ]]; then
+        common::exit 1 "Generate release notes via contrib/release/start-release.sh"
+    fi
+
+    echo "Current HEAD is:"
+    git log --oneline -1 $(git rev-parse HEAD)
+    echo "Create git tags for $version with this commit"
+    if ! common::askyorn ; then
+        common::exit 0 "Aborting release preparation."
+    fi
+
+    logrun -s git tag -a $ersion -s -m "Release $version"
+    logrun -s git tag -a $version -s -m "Release $version"
+    logrun -s git push $REMOTE $version $ersion
+
+    # Leave $version-changes.txt around so we can generate release notes later
+    echo -e "$ersion\n" > $version-release-summary.txt
+    echo "We are pleased to release Cilium $version." >>  $version-release-summary.txt
+    tail -n+4 $version-changes.txt >> $version-release-summary.txt
+    logecho "Creating Github draft release"
+    logrun hub release create -d -F $version-release-summary.txt $version
+    logecho "Browse to $RELEASES_URL to see the draft release"
+
+    logecho
+    logecho "Next steps:"
+    logecho "* Wait for cilium docker images to be prepared"
+    logecho "* Prepare the helm template changes"
+    logecho "* When docker images are available, test deployment of new version"
+    logecho "* Push templates and announce release on GitHub / Slack"
+}
+
+main "$@"


### PR DESCRIPTION
Automate the preparation of micro releases via a set of scripts. Steps in this PR:

* Run `start-release.sh` to generate helm charts, authors, changelogs, etc. Provide target release version and GH project number for N+1 version.
* Inspect changes and create commit with name "Prepare for release vX.Y.Z".
* Run `submit-release.sh` to send PR for this commit
* Manually close the old GH project
* Review & merge PR
* Pull release branch for true version of release commit
* `tag-release.sh` to tag current release & push releases (requires GPG key)
* Continue other steps from templates

### Backporting
For backports, the docs and GH issue template changes can be dropped, it's only useful to have the scripts.