### PR TITLE
image/hubble-proto: Install bash in builder image

### DIFF
--- a/images/hubble-proto/Dockerfile
+++ b/images/hubble-proto/Dockerfile
@@ -2,6 +2,7 @@ FROM docker.io/library/golang:1.15-alpine3.12 as builder
 
 RUN apk add --no-cache \
     curl \
+    bash \
     make \
     && true
 


### PR DESCRIPTION
`install-protoplugins.sh` requires bash. This fixes the build error on DockerHub.