### PR TITLE
bpf: Fix host firewall in presence of kube-proxy masquerading

### DIFF
--- a/Documentation/gettingstarted/host-firewall.rst
+++ b/Documentation/gettingstarted/host-firewall.rst
@@ -26,7 +26,6 @@ Deploy Cilium release via Helm:
 
     helm install cilium |CHART_RELEASE|        \\
       --namespace kube-system                  \\
-      --set global.kubeProxyReplacement=strict \\
       --set global.hostFirewall=true           \\
       --set global.devices=ethX,ethY
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -502,6 +502,7 @@ enum {
 #define	CB_SVC_ADDR_V4		CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_SVC_ADDR_V6_1	CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_ENCRYPT_IDENTITY	CB_IFINDEX	/* Alias, non-overlapping */
+#define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
 	CB_POLICY,
 #define	CB_SVC_ADDR_V6_2	CB_POLICY	/* Alias, non-overlapping */
 	CB_NAT46_STATE,

--- a/examples/policies/host/lock-down-dev-vms.yaml
+++ b/examples/policies/host/lock-down-dev-vms.yaml
@@ -81,6 +81,24 @@ spec:
       - port: "4240"
         protocol: TCP
 
+  # NodePort
+  # These two rules are only needed when kube-proxy is used.
+  # They should be removed when running in kube-proxy-free mode.
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-intra-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-multi-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+
 
   egress:
   # Only ICMP echo/reply messages should be drop if this is commented.

--- a/examples/policies/host/lock-down-gke.yaml
+++ b/examples/policies/host/lock-down-gke.yaml
@@ -59,6 +59,34 @@ spec:
       - port: "4240"
         protocol: TCP
 
+  # Requests from Heapster service to kube-proxy.
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s-app: heapster
+    toPorts:
+    - ports:
+      - port: "10255"
+        protocol: TCP
+
+  # NodePort
+  # These two rules are only needed when kube-proxy is used.
+  # They should be removed when running in kube-proxy-free mode.
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-intra-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-multi-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+
 
   egress:
   # Only ICMP echo/reply messages should be dropped if this is commented.
@@ -132,6 +160,16 @@ spec:
     toPorts:
     - ports:
       - port: "443"
+        protocol: TCP
+
+  # K8s Heapster service.
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s-app: heapster
+    toPorts:
+    - ports:
+      - port: "8082"
         protocol: TCP
 
   - toEntities:

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1282,7 +1282,7 @@ var _ = Describe("K8sPolicyTest", func() {
 					"Monitor output does not show traffic as allowed")
 			})
 
-			SkipContextIf(helpers.RunsWithKubeProxy, "With host policy", func() {
+			Context("With host policy", func() {
 				BeforeAll(func() {
 					// Deploy echoserver pods in host namespace.
 					echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-cilium-hostnetns.yaml")


### PR DESCRIPTION
If kube-proxy is in use (no BPF-based masquerading), packets from pods may be SNATed. The response packet will therefore have a host IP as the destination IP. For example, if a pod connects to 1.1.1.1:

    # Pod sends a SYN.
    from-lxc: 10.8.0.1 -> 1.1.1.1
    # Src IP gets masqueraded to 192.168.33.11. We skip the host firewall because
    # the packet mark tells us this is not coming from hostns.
    to-netdev: 192.168.33.11 -> 1.1.1.1
    ...
    # SYN+ACK is sent to 192.168.33.11. This IP belongs to the host endpoints, so
    # we incorrectly enforce host policy on this packet.
    from-netdev: 1.1.1.1 -> 192.168.33.11

To avoid enforcing host policies for response packets to pods, we need to create a CT entry for the forward, SNATed packet from the pod. Response packets will thus match this CT entry and bypass host policies.

I tested this change by deploying the connectivity checks in the dev. VM with kube-proxy and the `lock-down-dev-vms.yaml` host policy. The second commit also updates the CIDR+toPorts host policy test to run it when kube-proxy is used. Finally, the pull request has label `ci/host-firewall` to run all e2e CI tests on Jenkins with the host firewall enabled by default.

**RFC.** I've marked this pull request as RFC because of the performance concern. With this PR, when the host firewall and kube-proxy are enabled, we will perform a CT lookup (+ some CT updates) for each packet ingressing or egressing on the native devices. The only alternative I found so far is to restrict the host firewall to kube-proxy-free mode :frowning_face: 

Fixes: #11507