### PR TITLE
daemon: Fix handling of policy call map on downgrades

### DIFF
--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -301,6 +301,17 @@ func (d *Daemon) initMaps() error {
 		return nil
 	}
 
+	// Rename new policy call map from 1.8 to avoid packet drops during
+	// downgrades.
+	policyMapPath18 := bpf.MapPath("cilium_call_policy")
+	if _, err := os.Stat(policyMapPath18); err == nil {
+		policyMapPath17 := bpf.MapPath(policymap.CallMapName)
+		if err = os.Rename(policyMapPath18, policyMapPath17); err != nil {
+			log.WithError(err).Fatalf("Failed to rename policy call map from %s to %s",
+				policyMapPath18, policyMapPath17)
+		}
+	}
+
 	// Delete old proxymaps if left over from an upgrade.
 	// TODO: Remove this code when Cilium 1.6 is the oldest supported release
 	for _, name := range []string{"cilium_proxy4", "cilium_proxy6"} {


### PR DESCRIPTION
The name of the policy call map on the bpffs was changed between 1.7 and 1.8 by commit 5d6b669. Commit 6bada02 then added code to delete the old map name on initialization of the agent.

We cannot simply delete the old policy call map because it might still be used by endpoints (until they are regenerated) and the base programs (until they are reloaded). However, if we rename the map in the bpffs, it shouldn't affect BPF programs that are using it and they will then pick up the new name on reload.

The reverse renaming operation is needed in 1.7 to allow for downgrades from 1.8.

Updates: #13015
Fixes: #10626
Fixes: #10845