### PR TITLE
v1.6 backports 2020-09-02

### DIFF
--- a/Documentation/_static/copybutton.js
+++ b/Documentation/_static/copybutton.js
@@ -27,7 +27,7 @@ function addCopyButtonToCodeCells() {
     setTimeout(addCopyButtonToCodeCells, 1000);
     return;
   }
-  var codeCells = document.querySelectorAll("pre");
+  var codeCells = document.querySelectorAll(".rst-content pre");
   codeCells.forEach(function(codeCell, index) {
     var wrapper = document.createElement("div");
     wrapper.className = "code-wrapper";

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -192,7 +192,7 @@ Kubernetes
 ======================================== ================================================== ========================================================
 Name                                     Labels                                             Description
 ======================================== ================================================== ========================================================
-``kubernetes_events_received_total``     ``scope``, ``action``, ``validity``, ``equiality`` Number of Kubernetes events received
+``kubernetes_events_received_total``     ``scope``, ``action``, ``validity``, ``equal``     Number of Kubernetes events received
 ``kubernetes_events_total``              ``scope``, ``action``, ``outcome``                 Number of Kubernetes events processed
 ``k8s_cnp_status_completion_seconds``    ``attempts``, ``outcome``                          Duration in seconds in how long it took to complete a CNP status update
 ======================================== ================================================== ========================================================

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -17,7 +17,7 @@ six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.8.1
 # forked read the docs themez
-git+git://github.com/cilium/sphinx_rtd_theme.git@v0.6
+git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-websupport==1.1.0

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -103,7 +103,7 @@ spec:
 
 {{- if .Values.restartPods }}
               echo "Restarting kubenet managed pods"
-              if grep -q 'docker' /etc/crictl.yaml; then
+              if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
                 # Works for COS, ubuntu
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f $(cat $f) || true; done
               else


### PR DESCRIPTION
* #12901 -- docs/metrics: Correct label typos in metrics.rst (@sayboras)
 * #12894 -- fix: node-init restartPods should use docker if /etc/crictl.yaml not found (@UnwashedMeme)
   * Note for conflict resolution: see commit for backport notes
 * #12996 -- Upgrade Cilium docs theme version (@Neelajacques)
 * #12997 -- docs: limit copybutton to content area only (@genbit)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12901 12894 12996 12997; do contrib/backporting/set-labels.py $pr done 1.6; done
```