### PR TITLE
docs: Fix build

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -42,6 +42,7 @@ endif
 copy-api:
 	@$(ECHO_GEN)_api
 	$(QUIET)cp -r ../api _api
+	$(QUIET)rm _api/v1/docker/README.md
 
 epub latex html: builder-image copy-api
 	@$(ECHO_GEN)_build/$@


### PR DESCRIPTION
Commit 98aeaf05d39a ("api/v1: Compile hubble proto in docker") broke the
docs build by introducing a documentation file under the `api/`
directory without adding it to the toctree.

As it turns out, this file is not documentation for the API but just for
anyone browsing the directory wondering how a particular makefile should
be invoked.

Remove it from the docs build to prevent the docs warnings.