### PR TITLE
v1.8 backports 2020-09-02

### DIFF
--- a/Documentation/_static/copybutton.js
+++ b/Documentation/_static/copybutton.js
@@ -27,7 +27,7 @@ function addCopyButtonToCodeCells() {
     setTimeout(addCopyButtonToCodeCells, 1000);
     return;
   }
-  var codeCells = document.querySelectorAll("pre");
+  var codeCells = document.querySelectorAll(".rst-content pre");
   codeCells.forEach(function(codeCell, index) {
     var wrapper = document.createElement("div");
     wrapper.className = "code-wrapper";

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -36,6 +36,6 @@ If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
 in the respective namespace and see if the pod is listed.
 
 .. include:: k8s-install-azure-cni-validate.rst
-.. include:: namespace-kube-system.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -11,6 +11,12 @@ Calico
 This guide instructs how to install Cilium in chaining configuration on top of
 `Calico <https://github.com/projectcalico/calico>`_.
 
+.. note::
+
+   When running Cilium in chaining configuration on top of Calico, the L7
+   policies may not work because of conflicting packet mark usage. This
+   limitation is currently tracked at `#12454 <https://github.com/cilium/cilium/issues/12454>`_.
+
 Create a CNI configuration
 ==========================
 

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -83,6 +83,6 @@ To verify, you should see AKS in the name of the nodes when you run:
 .. include:: k8s-install-azure-cni-steps.rst
 
 .. include:: k8s-install-validate.rst
-.. include:: namespace-kube-system.rst
+.. include:: namespace-cilium.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -82,7 +82,7 @@ To verify, you should see AKS in the name of the nodes when you run:
 
 .. include:: k8s-install-azure-cni-steps.rst
 
-.. include:: k8s-install-validate.rst
+.. include:: k8s-install-azure-cni-validate.rst
 .. include:: namespace-cilium.rst
 .. include:: hubble-enable.rst
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1004,6 +1004,14 @@ Limitations
       setting will be ignored and a warning emitted to the Cilium agent log. Similarly,
       explicitly binding the ``hostIP`` to the loopback address in the host namespace is
       currently not supported and will log a warning to the Cilium agent log.
+    * When Cilium's kube-proxy replacement is used with Kubernetes versions(< 1.19) that have
+      support for ``EndpointSlices``, ``Services`` without selectors and backing ``Endpoints``
+      don't work. The reason is that Cilium only monitors changes made to ``EndpointSlices``
+      objects if support is available and ignores ``Endpoints`` in those cases. Kubernetes 1.19
+      release introduces ``EndpointSliceMirroring`` controller that mirrors custom ``Endpoints``
+      resources to corresponding ``EndpointSlices`` and thus allowing backing ``Endpoints``
+      to work. For a more detailed discussion see
+      `#12438 <https://github.com/cilium/cilium/issues/12438>`__.
 
 Further Readings
 ################

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,7 +20,7 @@ snowballstemmer==1.2.1
 Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
-git+git://github.com/cilium/sphinx_rtd_theme.git@v0.6
+git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -177,7 +177,6 @@ Vagrant.configure(2) do |config|
                 type: "shell",
                 run: "always",
                 inline: "ip -6 a a #{$master_ipv6}/16 dev enp0s9"
-            node_ip = "#{$nfs_ipv4_master_addr}"
             if ENV["IPV6_EXT"] then
                 node_ip = "#{$master_ipv6}"
             end
@@ -225,7 +224,6 @@ Vagrant.configure(2) do |config|
                 :libvirt__dhcp_enabled => false
             if ENV["NFS"] || ENV["IPV6_EXT"] then
                 nfs_ipv4_addr = $workers_ipv4_addrs_nfs[n]
-                node_ip = "#{nfs_ipv4_addr}"
                 ipv6_addr = $workers_ipv6_addrs[n]
                 node.vm.network "private_network", ip: "#{nfs_ipv4_addr}", bridge: "enp0s9"
                 # Add IPv6 address this way or we get hit by a virtualbox bug

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -574,3 +574,9 @@ func checkNodePortAndEphemeralPortRanges() error {
 
 	return nil
 }
+
+func hasFullHostReachableServices() bool {
+	return option.Config.EnableHostReachableServices &&
+		option.Config.EnableHostServicesTCP &&
+		option.Config.EnableHostServicesUDP
+}

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -260,9 +260,19 @@ func (c *clusterNodesClient) NodeAdd(newNode nodeTypes.Node) error {
 
 func (c *clusterNodesClient) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
 	c.Lock()
+	defer c.Unlock()
+
+	// If the node is on the added list, just update it
+	for i, added := range c.NodesAdded {
+		if added.Name == newNode.Fullname() {
+			c.NodesAdded[i] = newNode.GetModel()
+			return nil
+		}
+	}
+
+	// otherwise, add the new node and remove the old one
 	c.NodesAdded = append(c.NodesAdded, newNode.GetModel())
 	c.NodesRemoved = append(c.NodesRemoved, oldNode.GetModel())
-	c.Unlock()
 	return nil
 }
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1036,6 +1036,16 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		}
 	}
 
+	// AWS ENI requires to mark packets ingressing on the primary interface
+	// and route them back the same way even if the pod responding is using
+	// the IP of a different interface. Please see note in Reinitialize()
+	// in pkg/datapath/loader for more details.
+	if option.Config.IPAM == ipamOption.IPAMENI {
+		if err := m.addCiliumENIRules(); err != nil {
+			return fmt.Errorf("cannot install rules for ENI multi-node NodePort: %w", err)
+		}
+	}
+
 	if option.Config.EnableIPSec {
 		if err := m.addCiliumNoTrackXfrmRules(); err != nil {
 			return fmt.Errorf("cannot install xfrm rules: %s", err)
@@ -1139,4 +1149,28 @@ func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 		return m.ciliumNoTrackXfrmRules("iptables", "-I")
 	}
 	return nil
+}
+
+func (m *IptablesManager) addCiliumENIRules() error {
+	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
+	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+	if err := runProg("iptables", append(
+		m.waitArgs,
+		"-t", "mangle",
+		"-A", ciliumPreMangleChain,
+		"-i", "eth0",
+		"-m", "comment", "--comment", "cilium: primary ENI",
+		"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
+		"-j", "CONNMARK", "--set-xmark", nfmask+"/"+ctmask),
+		false); err != nil {
+		return err
+	}
+	return runProg("iptables", append(
+		m.waitArgs,
+		"-t", "mangle",
+		"-A", ciliumPreMangleChain,
+		"-i", "lxc+",
+		"-m", "comment", "--comment", "cilium: primary ENI",
+		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask),
+		false)
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -34,6 +34,15 @@ const (
 	// RouteMarkMask is the mask required for the route mark value
 	RouteMarkMask = 0xF00
 
+	// MarkMultinodeNodeport is used for AWS ENI to mark traffic from
+	// another node, so that it gets routed back through the relevant
+	// interface.
+	MarkMultinodeNodeport = 0x80
+
+	// MaskMultinodeNodeport is the mask associated with the
+	// RouterMarkNodePort
+	MaskMultinodeNodeport = 0x80
+
 	// IPSecProtocolID IP protocol ID for IPSec defined in RFC4303
 	RouteProtocolIPSec = 50
 
@@ -45,6 +54,13 @@ const (
 	// RulePriorityEgress is the priority of the rule used for egress routing
 	// of endpoints. This priority is after the local table priority.
 	RulePriorityEgress = 110
+
+	// RulePriorityNodeport is the priority of the rule used with AWS ENI to
+	// make sure that lookups for multi-node NodePort traffic are NOT done
+	// from the table for the VPC to which the endpoint's CIDR is
+	// associated, but from the main routing table instead.
+	// This priority is before the egress priority.
+	RulePriorityNodeport = RulePriorityEgress - 1
 
 	// TunnelDeviceName the default name of the tunnel device when using vxlan
 	TunnelDeviceName = "cilium_vxlan"

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,9 +30,12 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -296,6 +299,35 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	clockSource := []string{"ktime", "jiffies"}
 	log.Infof("Setting up base BPF datapath (BPF %s instruction set, %s clock source)",
 		args[initBPFCPU], clockSource[option.Config.ClockSource])
+
+	// AWS ENI mode requires symmetric routing, see
+	// iptables.addCiliumENIRules().
+	// The default AWS daemonset installs the following rules that are used
+	// for NodePort traffic between nodes:
+	//
+	// # sysctl -w net.ipv4.conf.eth0.rp_filter=2
+	// # iptables -t mangle -A PREROUTING -i eth0 -m comment --comment "AWS, primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
+	// # iptables -t mangle -A PREROUTING -i eni+ -m comment --comment "AWS, primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
+	// # ip rule add fwmark 0x80/0x80 lookup main
+	//
+	// It marks packets coming from another node through eth0, and restores
+	// the mark on the return path to force a lookup into the main routing
+	// table. Without these rules, the "ip rules" set by the cilium-cni
+	// plugin tell the host to lookup into the table related to the VPC for
+	// which the CIDR used by the endpoint has been configured.
+	//
+	// We want to reproduce equivalent rules to ensure correct routing.
+	if option.Config.IPAM == ipamOption.IPAMENI {
+		sysSettings = append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
+		if err := route.ReplaceRule(route.Rule{
+			Priority: linux_defaults.RulePriorityNodeport,
+			Mark:     linux_defaults.MarkMultinodeNodeport,
+			Mask:     linux_defaults.MaskMultinodeNodeport,
+			Table:    route.MainTable,
+		}); err != nil {
+			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+		}
+	}
 
 	for _, s := range sysSettings {
 		log.Infof("Setting sysctl %s=%s", s.name, s.val)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -236,13 +236,6 @@ func (e *etcdModule) newClient(ctx context.Context, opts *ExtraOptions) (Backend
 		e.config.Endpoints = []string{endpointsOpt.value}
 	}
 
-	// Shuffle the order of endpoints to avoid all agents connecting to the
-	// same etcd endpoint and to work around etcd client library failover
-	// bugs. (https://github.com/etcd-io/etcd/pull/9860)
-	if e.config.Endpoints != nil {
-		shuffleEndpoints(e.config.Endpoints)
-	}
-
 	for {
 		// connectEtcdClient will close errChan when the connection attempt has
 		// been successful
@@ -674,6 +667,13 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		}
 		cfg.DialOptions = append(cfg.DialOptions, config.DialOptions...)
 		config = cfg
+	}
+
+	// Shuffle the order of endpoints to avoid all agents connecting to the
+	// same etcd endpoint and to work around etcd client library failover
+	// bugs. (https://github.com/etcd-io/etcd/pull/9860)
+	if config.Endpoints != nil {
+		shuffleEndpoints(config.Endpoints)
 	}
 
 	// Set DialTimeout to 0, otherwise the creation of a new client will

--- a/test/k8sT/manifests/guestbook_deployment.yaml
+++ b/test/k8sT/manifests/guestbook_deployment.yaml
@@ -4,24 +4,24 @@ apiVersion: v1
 metadata:
   name: redis-master
   labels:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
+    role: leader
+    tier: backend
 spec:
   replicas: 1
   selector:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
   template:
     metadata:
       labels:
-        k8s-app.guestbook: redis
-        role: master
-        zgroup: guestbook
+        app: redis
+        role: leader
+        tier: backend
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - name: redis-master
-        image: docker.io/library/redis:4.0.11
+      - name: leader
+        image: "docker.io/library/redis:6.0.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: redis-server
@@ -34,40 +34,41 @@ apiVersion: v1
 metadata:
   name: redis-master
   labels:
-    k8s-app.guestbook: redis
-    role: master
-    zgroup: guestbook
+    app: redis
+    role: leader
+    tier: backend
 spec:
   ports:
   - port: 6379
     targetPort: redis-server
   selector:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
+    role: leader
+    tier: backend
 ---
 kind: ReplicationController
 apiVersion: v1
 metadata:
-  name: redis-slave
+  name: redis-follower
   labels:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 spec:
   replicas: 1
   selector:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
   template:
     metadata:
       labels:
-        k8s-app.guestbook: redis
-        role: slave
-        zgroup: guestbook
+        app: redis
+        role: follower
+        tier: backend
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - name: redis-slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+      - name: follower
+        image: gcr.io/google_samples/gb-redis-follower:v2
         imagePullPolicy: IfNotPresent
         ports:
         - name: redis-server
@@ -78,17 +79,19 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: redis-slave
+  name: redis-follower
   labels:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 spec:
   ports:
   - port: 6379
     targetPort: redis-server
   selector:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -108,7 +111,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: gcr.io/google-samples/gb-frontend:v6
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
* #12215 -- vagrant: Don't use the NFS device's IP as node IP (@pchaigno)
 * #12983 -- docs: update kubeproxy-free gsg to account for #12438 (@fristonio)
 * #12996 -- Upgrade Cilium docs theme version (@Neelajacques)
 * #12997 -- docs: limit copybutton to content area only (@genbit)
 * #12989 -- Fix bug where cilium-health reports connectivity failures to stale IPs (@kkourt)
 * #12770 -- iptables, loader: add rules for multi-node NodePort traffic on EKS (@qmonnet)
 * #13005 -- docs: Mention L7 limitation in Calico chaining GSG (@pchaigno)
 * #13006 -- daemon: Disable BPF-masq if host-svc is disabled in tunnel mode (@brb)
 * #12943 -- pkg/kvstore: set endpoint shuffle in etcd client connectivity (@aanm)
 * #12967 -- doc: cilium namespace fix (@kAworu)
 * #13003 -- test: Fix guestbook test (@pchaigno)
 * #12884 -- Update kops installation documentation (@olemarkus)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12215 12983 12996 12997 12989 12770 13005 13006 12943 12967 13003 12884; do contrib/backporting/set-labels.py $pr done 1.8; done
```