### PR TITLE
helm: allow setting conntrack-gc-interval in cilium-config cm

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -79,6 +79,10 @@ data:
   disable-envoy-version-check: {{ .Values.disableEnvoyVersionCheck | quote }}
 {{- end }}
 
+{{- if hasKey .Values "conntrackGCInterval" }}
+  conntrack-gc-interval: {{ .Values.conntrackGCInterval | quote }}
+{{- end }}
+
   # Identity allocation mode selects how identities are shared between cilium
   # nodes by setting how they are stored. The options are "crd" or "kvstore".
   # - "crd" stores identities in kubernetes as CRDs (custom resource definition).

--- a/install/kubernetes/cilium/charts/config/values.yaml
+++ b/install/kubernetes/cilium/charts/config/values.yaml
@@ -64,3 +64,6 @@
 
 #disableEnvoyVersionCheck: false
 
+# Set the connection-tracking garbage collection interval. If not set, the value will be
+# calculated automatically on startup of cilium-agent. A low value will consume more CPU cycles.
+#conntrackGCInterval: "0s"


### PR DESCRIPTION
We need to set conntrack-gc-interval to a custom value (as discussed with @brb in slack) because of an issue where the CT map filled up.

PR allows the set the value by helm.