### PR TITLE
v1.7 backports 2020-09-03

### DIFF
--- a/Documentation/gettingstarted/k8s-install-kops.rst
+++ b/Documentation/gettingstarted/k8s-install-kops.rst
@@ -82,7 +82,7 @@ you will be deploying the cluster.
 
 The above steps are sufficient for getting a working cluster installed. Please
 consult `kops aws documentation
-<https://github.com/kubernetes/kops/blob/master/docs/aws.md>`_ for more
+<https://github.com/kubernetes/kops/blob/master/docs/getting_started/aws.md>`_ for more
 detailed setup instructions.
 
 Cilium Prerequisites
@@ -134,13 +134,7 @@ You may be prompted to create a ssh public-private key pair.
 
 (Please see :ref:`appendix_kops`)
 
-Testing Cilium
-==============
-
-Follow the `Cilium getting started guide example
-<http://cilium.readthedocs.io/en/latest/gettingstarted/minikube/#step-2-deploy-the-demo-application>`_
-to test that the cluster is setup properly and that Cilium CNI and security
-policies are functional.
+.. include:: k8s-install-connectivity-test.rst
 
 .. _appendix_kops:
 

--- a/Documentation/gettingstarted/k8s-install-kops.rst
+++ b/Documentation/gettingstarted/k8s-install-kops.rst
@@ -108,7 +108,7 @@ in the command below.
 
 
 Creating a Cluster
-====================
+==================
 
 * Note that you will need to specify the ``--master-zones`` and ``--zones`` for
   creating the master and worker nodes. The number of master zones should be
@@ -139,7 +139,7 @@ You may be prompted to create a ssh public-private key pair.
 .. _appendix_kops:
 
 Deleting a Cluster
-===========================
+==================
 
 To undo the dependencies and other deployment features in AWS from the ``kops``
 cluster creation, use ``kops`` to destroy a cluster *immediately* with the

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -171,10 +171,7 @@ Execute the commands below from the bastion host. If ``kubectl`` isn't installed
 
 You should see that nodes are in ``Ready`` state and Cilium pods are in ``Running`` state
 
-Demo Application
-================
-
-Follow this `link <https://cilium.readthedocs.io/en/stable/gettingstarted/minikube/#step-2-deploy-the-demo-application>`__ to deploy a demo application and verify the correctness of the installation.
+.. include:: k8s-install-connectivity-test.rst
 
 Delete Cluster
 ==============

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -39,7 +39,6 @@ Infrastructure Provisioning
 
 We will use Terraform for provisioning AWS infrastructure.
 
--------------------------
 Configure AWS credentials
 -------------------------
 
@@ -52,7 +51,6 @@ Export the variables for your AWS credentials
   export AWS_SSH_KEY_NAME="yyy"
   export AWS_DEFAULT_REGION="zzz"
 
------------------------------
 Configure Terraform Variables
 -----------------------------
 
@@ -108,7 +106,6 @@ Example ``terraform.tfvars`` file:
   kube_insecure_apiserver_address = "0.0.0.0"
 
 
------------------------
 Apply the configuration
 -----------------------
 

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -73,6 +73,17 @@ func CurlFail(endpoint string, optionalValues ...interface{}) string {
 		CurlConnectTimeout, CurlMaxTimeout, endpoint, statsInfo)
 }
 
+// CurlFailNoStats does the same as CurlFail() except that it does not print
+// the stats info.
+func CurlFailNoStats(endpoint string, optionalValues ...interface{}) string {
+	if len(optionalValues) > 0 {
+		endpoint = fmt.Sprintf(endpoint, optionalValues...)
+	}
+	return fmt.Sprintf(
+		`curl --path-as-is -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[2]d %[3]s`,
+		CurlConnectTimeout, CurlMaxTimeout, endpoint)
+}
+
 // CurlWithHTTPCode retunrs the string representation of the curl command which
 // only outputs the HTTP code returned by its execution against the specified
 // endpoint. It takes a variadic optinalValues argument. This is passed on to

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -16,6 +16,7 @@ package k8sTest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"regexp"
@@ -1125,7 +1126,6 @@ var _ = Describe("K8sPolicyTest", func() {
 	Context("GuestBook Examples", func() {
 		var (
 			deployment                = "guestbook_deployment.yaml"
-			groupLabel                = "zgroup=guestbook"
 			redisPolicy               = "guestbook-policy-redis.json"
 			redisPolicyName           = "guestbook-policy-redis"
 			redisPolicyDeprecated     = "guestbook-policy-redis-deprecated.json"
@@ -1180,20 +1180,17 @@ var _ = Describe("K8sPolicyTest", func() {
 		})
 
 		waitforPods := func() {
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l tier=backend", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "Backend pods are not ready after timeout")
 
-			err = kubectl.WaitforPods(
-				helpers.DefaultNamespace,
-				fmt.Sprintf("-l %s", groupLabel), helpers.HelperTimeout)
-			ExpectWithOffset(1, err).Should(BeNil(), "Bookinfo pods are not ready after timeout")
+			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l tier=frontend", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "Frontend pods are not ready after timeout")
 
-			err := kubectl.WaitForServiceEndpoints(
-				helpers.DefaultNamespace, "", "redis-master", helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "error waiting for redis-master service to be ready")
+			err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", "redis-master", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "error waiting for redis-master service to be ready")
 
-			err = kubectl.WaitForServiceEndpoints(
-				helpers.DefaultNamespace, "", "redis-slave", helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "error waiting for redis-slave service to be ready")
-
+			err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", "redis-follower", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "error waiting for redis-follower service to be ready")
 		}
 
 		policyCheckStatus := func(policyCheck string) {
@@ -1204,27 +1201,18 @@ var _ = Describe("K8sPolicyTest", func() {
 		}
 
 		testConnectivitytoRedis := func() {
-			webPods, err := kubectl.GetPodsNodes(helpers.DefaultNamespace, "-l k8s-app.guestbook=web")
-			Expect(err).To(BeNil(), "Cannot get web pods")
+			webPods, err := kubectl.GetPodsNodes(helpers.DefaultNamespace, "-l app=guestbook")
+			ExpectWithOffset(1, err).To(BeNil(), "Error retrieving web pods")
+			ExpectWithOffset(1, webPods).ShouldNot(BeEmpty(), "Cannot retrieve web pods")
 
-			serviceIP, port, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, "redis-master")
-			Expect(err).To(BeNil(), "Cannot get hostPort of redis-master")
-
-			serviceName := "redis-master"
-			err = kubectl.WaitForKubeDNSEntry(serviceName, helpers.DefaultNamespace)
-			Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
-
+			cmd := helpers.CurlFailNoStats(`"127.0.0.1/guestbook.php?cmd=set&key=messages&value=Hello"`)
 			for pod := range webPods {
+				res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, cmd)
+				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Cannot curl webhook frontend of pod %q", pod)
 
-				redisMetadata := map[string]int{serviceIP: port, serviceName: port}
-				for k, v := range redisMetadata {
-					command := fmt.Sprintf(`nc %s %d <<EOF
-PING
-EOF`, k, v)
-					res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, command)
-					ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
-						"Web pod %q cannot connect to redis-master on '%s:%d'", pod, k, v)
-				}
+				var response map[string]interface{}
+				err := json.Unmarshal([]byte(res.GetStdOut()), &response)
+				ExpectWithOffset(1, err).To(BeNil(), fmt.Sprintf("Error parsing JSON response: %s", res.GetStdOut()))
 			}
 		}
 		It("checks policy example", func() {

--- a/test/k8sT/manifests/guestbook_deployment.yaml
+++ b/test/k8sT/manifests/guestbook_deployment.yaml
@@ -4,24 +4,24 @@ apiVersion: v1
 metadata:
   name: redis-master
   labels:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
+    role: leader
+    tier: backend
 spec:
   replicas: 1
   selector:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
   template:
     metadata:
       labels:
-        k8s-app.guestbook: redis
-        role: master
-        zgroup: guestbook
+        app: redis
+        role: leader
+        tier: backend
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - name: redis-master
-        image: docker.io/library/redis:4.0.11
+      - name: leader
+        image: "docker.io/library/redis:6.0.5"
         imagePullPolicy: IfNotPresent
         ports:
         - name: redis-server
@@ -34,40 +34,41 @@ apiVersion: v1
 metadata:
   name: redis-master
   labels:
-    k8s-app.guestbook: redis
-    role: master
-    zgroup: guestbook
+    app: redis
+    role: leader
+    tier: backend
 spec:
   ports:
   - port: 6379
     targetPort: redis-server
   selector:
-    k8s-app.guestbook: redis
-    role: master
+    app: redis
+    role: leader
+    tier: backend
 ---
 kind: ReplicationController
 apiVersion: v1
 metadata:
-  name: redis-slave
+  name: redis-follower
   labels:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 spec:
   replicas: 1
   selector:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
   template:
     metadata:
       labels:
-        k8s-app.guestbook: redis
-        role: slave
-        zgroup: guestbook
+        app: redis
+        role: follower
+        tier: backend
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - name: redis-slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+      - name: follower
+        image: gcr.io/google_samples/gb-redis-follower:v2
         imagePullPolicy: IfNotPresent
         ports:
         - name: redis-server
@@ -78,17 +79,19 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: redis-slave
+  name: redis-follower
   labels:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 spec:
   ports:
   - port: 6379
     targetPort: redis-server
   selector:
-    k8s-app.guestbook: redis
-    role: slave
+    app: redis
+    role: follower
+    tier: backend
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -108,7 +111,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: gcr.io/google-samples/gb-frontend:v6
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
v1.7 backports 2020-09-03
  
 * #13003 -- test: Fix guestbook test (@pchaigno)
 * #10576 -- docs: Fix multiple broken links (@errordeveloper)      --- added to have #12884 as clean backport
 * #12884 -- Update kops installation documentation (@olemarkus)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13003 10576 12884; do contrib/backporting/set-labels.py $pr done 1.7; done
```