### PR TITLE
smoketest: Set liveness and readiness timeout in connectivity check

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -26,6 +26,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -37,6 +38,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -81,6 +83,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -92,6 +95,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -134,6 +138,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -145,6 +150,7 @@ spec:
             - /dev/null
             - localhost:41000
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -199,6 +205,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -210,6 +217,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -252,6 +260,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -263,6 +272,7 @@ spec:
             - /dev/null
             - localhost:41001
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -316,6 +326,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -327,6 +338,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -370,6 +382,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -381,6 +394,7 @@ spec:
             - /dev/null
             - 1.1.1.1
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -470,6 +484,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -481,6 +496,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -524,6 +540,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -535,6 +552,7 @@ spec:
             - /dev/null
             - www.google.com
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1052,6 +1070,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1063,6 +1082,7 @@ spec:
             - /dev/null
             - echo-b:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1116,6 +1136,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1127,6 +1148,7 @@ spec:
             - /dev/null
             - echo-b-headless:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1180,6 +1202,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1191,6 +1214,7 @@ spec:
             - /dev/null
             - echo-b:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1245,6 +1269,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1256,6 +1281,7 @@ spec:
             - /dev/null
             - echo-b-headless:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1310,6 +1336,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1321,6 +1348,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:40000/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1374,6 +1402,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1385,6 +1414,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:40000/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1438,6 +1468,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1449,6 +1480,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:31313/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1502,6 +1534,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1513,6 +1546,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:31313/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -26,6 +26,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -37,6 +38,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -81,6 +83,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -92,6 +95,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -134,6 +138,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -145,6 +150,7 @@ spec:
             - /dev/null
             - localhost:41000
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -198,6 +204,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -209,6 +216,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -298,6 +306,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -309,6 +318,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -352,6 +362,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -363,6 +374,7 @@ spec:
             - /dev/null
             - echo-b:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -416,6 +428,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -427,6 +440,7 @@ spec:
             - /dev/null
             - echo-b-headless:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -480,6 +494,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -491,6 +506,7 @@ spec:
             - /dev/null
             - echo-b:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -545,6 +561,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -556,6 +573,7 @@ spec:
             - /dev/null
             - echo-b-headless:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -610,6 +628,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -621,6 +640,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:31313/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -674,6 +694,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -685,6 +706,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:31313/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -27,6 +27,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -38,6 +39,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -80,6 +82,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -91,6 +94,7 @@ spec:
             - /dev/null
             - localhost:41001
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -878,6 +882,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -889,6 +894,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -953,6 +959,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -964,6 +971,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1027,6 +1035,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -1038,6 +1047,7 @@ spec:
             - /dev/null
             - localhost:41000
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -666,6 +666,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -677,6 +678,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -741,6 +743,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -752,6 +755,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -815,6 +819,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -826,6 +831,7 @@ spec:
             - /dev/null
             - localhost:41000
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -26,6 +26,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -37,6 +38,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -81,6 +83,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -92,6 +95,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -134,6 +138,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -145,6 +150,7 @@ spec:
             - /dev/null
             - localhost:41000
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -198,6 +204,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -209,6 +216,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -252,6 +260,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -263,6 +272,7 @@ spec:
             - /dev/null
             - 1.1.1.1
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -352,6 +362,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -363,6 +374,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -406,6 +418,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -417,6 +430,7 @@ spec:
             - /dev/null
             - www.google.com
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -460,6 +474,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -471,6 +486,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:31313/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -26,6 +26,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -37,6 +38,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -81,6 +83,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -92,6 +95,7 @@ spec:
             - /dev/null
             - localhost:8080
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -134,6 +138,7 @@ spec:
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -145,6 +150,7 @@ spec:
             - /dev/null
             - localhost:41000
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -198,6 +204,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -209,6 +216,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -252,6 +260,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -263,6 +272,7 @@ spec:
             - /dev/null
             - 1.1.1.1
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -352,6 +362,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -363,6 +374,7 @@ spec:
             - /dev/null
             - echo-a:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -406,6 +418,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -417,6 +430,7 @@ spec:
             - /dev/null
             - www.google.com
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -460,6 +474,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -471,6 +486,7 @@ spec:
             - /dev/null
             - echo-b:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -524,6 +540,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -535,6 +552,7 @@ spec:
             - /dev/null
             - echo-b-headless:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -588,6 +606,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -599,6 +618,7 @@ spec:
             - /dev/null
             - echo-b:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -653,6 +673,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -664,6 +685,7 @@ spec:
             - /dev/null
             - echo-b-headless:8080/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -718,6 +740,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -729,6 +752,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:31313/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -782,6 +806,7 @@ spec:
         - -c
         - sleep 1000000000
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl
@@ -793,6 +818,7 @@ spec:
             - /dev/null
             - echo-b-host-headless:31313/public
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - curl

--- a/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
@@ -27,10 +27,12 @@ spec:
         - while true; do dig +noall +question +answer +timeout=1 +tries=1 www.google.com
           && sleep 1 ; done
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - "true"
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command:
             - "true"

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -15,7 +15,7 @@ _echoDeploymentWithHostPort: _echoDeployment & {
 
 // Regular service exposed via ClusterIP.
 deployment: "echo-a": _echoDeployment & {
-	_serverPort: "8080"
+	_serverPort:      "8080"
 	_exposeClusterIP: true
 	metadata: labels: component: "network-check"
 	spec: template: spec: containers: [{ports: [{_expose: true, containerPort: 8080, _portName: "http"}]}]
@@ -23,7 +23,7 @@ deployment: "echo-a": _echoDeployment & {
 
 // Service exposed via NodePort + headless svc.
 deployment: "echo-b": _echoDeployment & {
-	_serverPort: "8080"
+	_serverPort:     "8080"
 	_exposeNodePort: true
 	_exposeHeadless: true
 	_nodePort:       31313
@@ -61,7 +61,7 @@ ingressL7Policy: {
 
 // Service with policy applied.
 deployment: "echo-c": _echoDeployment & {
-	_serverPort: "8080"
+	_serverPort:      "8080"
 	_exposeClusterIP: true
 	_exposeHeadless:  true
 

--- a/examples/kubernetes/connectivity-check/resources.cue
+++ b/examples/kubernetes/connectivity-check/resources.cue
@@ -58,8 +58,14 @@ _spec: {
 				}
 			}
 			if !_probeExpectFail {
-				readinessProbe: exec: command: _allowProbe
-				livenessProbe: exec: command:  _allowProbe
+				readinessProbe: {
+					timeoutSeconds: _probeFailureTimeout + 2
+					exec: command: _allowProbe
+				}
+				livenessProbe: {
+					timeoutSeconds: _probeFailureTimeout + 2
+					exec: command: _allowProbe
+				}
 			}
 		}
 		_containers: [_c1]


### PR DESCRIPTION
The default value for these two fields is only 1 second. This PR is to
update values to 7 seconds, which is 5 (curl connection timeout) + 2
(some buffer)

Relates: #12279
Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
test(smoketest): Set liveness and readiness timeout in connectivity check
```
