### PR TITLE
daemon: Fatal if IPSec and Devices are used together

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1163,6 +1163,10 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
+	if len(option.Config.Devices) != 0 && option.Config.EnableIPSec {
+		log.Fatalf("--%s cannot be used with IPSec.", option.Devices)
+	}
+
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
 	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)


### PR DESCRIPTION
If a device list is specified the bpf_host program gets hooked
into the kernel. This overwrites bpf_network program which
is needed for IPSec. In order to avoid misconfigurations cilium
should fatal if both options are used together.

Fixes: #13027

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>

```release-note
Fail to start if IPSec and devices are used together
```