### PR TITLE
github-workflow: Reduce scope of quick-install test

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -53,48 +53,6 @@ jobs:
           make -C install/kubernetes ${{ matrix.target.name }}
           git diff --exit-code
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-rc.1
-        with:
-          version: ${{ env.KIND_VERSION }}
-          config: ${{ env.KIND_CONFIG }}
-
-      - name: Run ${{ matrix.target.name }}
-        run: |
-          kubectl apply -f ${{ matrix.target.template }}
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=${{ env.TIMEOUT }}
-          # To make sure that cilium CRD is available (default timeout is 5m)
-          # https://github.com/cilium/cilium/blob/master/operator/crd.go#L34
-          kubectl wait --for condition=Established crd/ciliumnetworkpolicies.cilium.io --timeout=5m
-
-      - name: Run conformance test (e.g. connectivity check)
-        run: |
-          kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
-          kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
-
-      - name: Dump cilium related logs and events
-        if: ${{ failure() }}
-        run: |
-          kubectl -n kube-system describe daemonsets.apps cilium
-          kubectl -n kube-system logs daemonset/cilium --all-containers --since=${{ env.LOG_TIME }}
-
-      - name: Dump connectivity related logs and events
-        if: ${{ failure() }}
-        run: |
-          kubectl describe pods
-          kubectl describe deploy
-          for svc in $(make -C examples/kubernetes/connectivity-check/ list | grep Service | awk '{ print $4 }'); do kubectl describe service $svc; kubectl logs service/$svc --all-containers --since=${{ env.LOG_TIME }}; done
-
-      - name: Dump hubble related logs and events
-        if: ${{ failure() &&  matrix.target.name == 'experimental-install' }}
-        run: |
-          kubectl -n kube-system describe service hubble-metrics
-          kubectl -n kube-system logs service/hubble-metrics --all-containers --since=${{ env.LOG_TIME }}
-          kubectl -n kube-system describe service hubble-relay
-          kubectl -n kube-system logs service/hubble-relay --all-containers --since=${{ env.LOG_TIME }}
-          kubectl -n kube-system describe service hubble-ui
-          kubectl -n kube-system logs service/hubble-ui --all-containers --since=${{ env.LOG_TIME }}
-
   conformance-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The current quick-install tests deployment of the quickinstall yaml
without building new images and then runs the connectivity check. THis
is problematic as it means that no change will pass the test where a
helm template change depends on a code change.

The connectivity test is already being run in the "conformance-test"
test where images are being built properly.

There is a small diff in the options bein used in the "conformance-test"
and the default options in the quickinstall YAML but nothing that
wouldn't be covered by the overall CI anyway.

Reduce the scope of the quick-install test to validate that the
quickinstall YAML is not outdated.