### PR TITLE
connectivity-check: Check cue file formatting in Github Action

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Precheck generated connectivity manifest files
         run: |
+          make -C examples/kubernetes/connectivity-check fmt
           make -C examples/kubernetes/connectivity-check all
           git diff --exit-code
 

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Precheck generated connectivity manifest files
         run: |
+          make -C examples/kubernetes/connectivity-check fmt
           make -C examples/kubernetes/connectivity-check all
           git diff --exit-code
 

--- a/examples/kubernetes/connectivity-check/Makefile
+++ b/examples/kubernetes/connectivity-check/Makefile
@@ -92,10 +92,13 @@ help:
 list:
 	$(QUIET)$(CUE) cmd ls
 
+fmt:
+	$(QUIET)$(CUE) fmt
+
 $(SERVERS_OUT): $(SRC)
 	@echo > $(SERVERS_OUT)
 	@for name in $(SERVERS_NAME); do \
 		$(CUE) cmd -t component=all -t name=$$name dump >> $@; \
 	done
 
-.PHONY: all clean deploy eval generate_all help inspect list $(ALL_TARGETS)
+.PHONY: all clean deploy eval fmt generate_all help inspect list $(ALL_TARGETS)


### PR DESCRIPTION
This PR is to add one simple make target `make fmt` to auto-format cue
files, and run this check in related Github Action step as well

Related to https://github.com/cilium/cilium/pull/13067#discussion_r482930334

```release-note
connectivity-check: Check cue file formatting in Github Action
```
