### PR TITLE
smoke-test: Capture sysdump details for troubleshooting

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -73,16 +73,15 @@ jobs:
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
 
-      - name: Dump cilium related logs and events
+      - name: Capture cilium-sysdump
         if: ${{ failure() }}
         run: |
-          kubectl -n kube-system describe daemonsets.apps cilium
-          kubectl -n kube-system logs daemonset/cilium --all-containers --since=${{ env.LOG_TIME }}
-          kubectl -n kube-system logs service/kube-dns --all-containers --since=${{ env.LOG_TIME }}
+          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
+          python cilium-sysdump.zip --output cilium-sysdump-out
 
-      - name: Dump connectivity related logs and events
+      - name: Upload cilium-sysdump
+        uses: actions/upload-artifact@v2
         if: ${{ failure() }}
-        run: |
-          kubectl describe pods
-          kubectl describe deploy
-          for svc in $(make -C examples/kubernetes/connectivity-check/ list | grep Service | awk '{ print $4 }'); do kubectl describe service $svc; kubectl logs service/$svc --all-containers --since=${{ env.LOG_TIME }}; done
+        with:
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -121,15 +121,15 @@ jobs:
           go get -u github.com/prometheus/prometheus/cmd/promtool
           egrep -v "${{ env.DEPRECATED_METRICS }}" metrics.prom | $HOME/go/bin/promtool check metrics
 
-      - name: Dump cilium related logs and events
+      - name: Capture cilium-sysdump
         if: ${{ failure() }}
         run: |
-          kubectl -n kube-system describe daemonsets.apps cilium
-          kubectl -n kube-system logs daemonset/cilium --all-containers --since=${{ env.LOG_TIME }}
+          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
+          python cilium-sysdump.zip --output cilium-sysdump-out
 
-      - name: Dump connectivity related logs and events
+      - name: Upload cilium-sysdump
+        uses: actions/upload-artifact@v2
         if: ${{ failure() }}
-        run: |
-          kubectl describe pods
-          kubectl describe deploy
-          for svc in $(make -C examples/kubernetes/connectivity-check/ list | grep Service | awk '{ print $4 }'); do kubectl describe service $svc; kubectl logs service/$svc --all-containers --since=${{ env.LOG_TIME }}; done
+        with:
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip


### PR DESCRIPTION
Relates: #12279

Testing was done in https://github.com/cilium/cilium/runs/1083962399

<details>
<summary>Always run sysdump (testing purpose only)</summary>

```
Run actions/upload-artifact@v2
  with:
    name: cilium-sysdump-out.zip
    path: cilium-sysdump-out.zip
    if-no-files-found: warn
  env:
    KIND_VERSION: v0.8.1
    KIND_CONFIG: .github/kind-config-ipv6.yaml
    CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
    TIMEOUT: 2m
    LOG_TIME: 30m
With the provided path, there will be 1 file(s) uploaded
Total size of all the files uploaded is 3514594 bytes
Finished uploading artifact cilium-sysdump-out.zip. Reported size is 3514594 bytes. There were 0 items that failed to upload
Artifact cilium-sysdump-out.zip has been successfully uploaded!
```

</details>

```release-note
smoke-test: Capture sysdump details for troubleshooting
```
