### PR TITLE
test: Detect missed tail calls on upgrade/downgrade test

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -517,6 +517,10 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		validateEndpointsConnection()
 		checkNoInteruptsInSVCFlows()
 
+		nbMissedTailCalls, err := kubectl.CountMissedTailCalls()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed to retrieve number of missed tail calls")
+		ExpectWithOffset(1, nbMissedTailCalls).To(BeNumerically("==", 0))
+
 		By("Downgrading cilium to %s image", oldHelmChartVersion)
 		// rollback cilium 1 because it's the version that we have started
 		// cilium with in this updates test.
@@ -538,6 +542,10 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 
 		validateEndpointsConnection()
 		checkNoInteruptsInSVCFlows()
+
+		nbMissedTailCalls, err = kubectl.CountMissedTailCalls()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed to retrieve number of missed tail calls")
+		ExpectWithOffset(1, nbMissedTailCalls).To(BeNumerically("==", 0))
 	}
 	return testfunc, cleanupCallback
 }


### PR DESCRIPTION
Connectivity disruptions caused by missed tail calls were recently reported at #13015. It was caused by an incorrect handling of a call map rename. We didn't detect it because we don't have code to specifically detect missed tail calls during the upgrade/downgrade test; the test only fails if the connectivity is broken during a long enough period.

This pull request adds a new function to retrieve the sum of 'Missed tail calls' metrics across all Cilium pods. It is then used in the test after both the upgrade and the subsequent downgrade to check that no drops due to missed tail calls happened.

This new test was tested by:
- Backporting to v1.8 and checking that missed tail calls are indeed detected.
- Backporting the fixes on the v1.7 (#13052) and v1.8 (#13051) branches and checking that no more tail calls were detected.

We need to wait for both #13052 and #13051 to be merged and backported before we can backport this test to v1.8, as it will otherwise fail.

Related: #13015, #13051, #13052