### PR TITLE
Azure IPAM: don't install PodCIDR route by default

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -68,7 +68,10 @@ type NodeDiscovery struct {
 }
 
 func enableLocalNodeRoute() bool {
-	return option.Config.EnableLocalNodeRoute && !option.Config.IsFlannelMasterDeviceSet() && option.Config.IPAM != ipamOption.IPAMENI
+	return option.Config.EnableLocalNodeRoute &&
+		!option.Config.IsFlannelMasterDeviceSet() &&
+		option.Config.IPAM != ipamOption.IPAMENI &&
+		option.Config.IPAM != ipamOption.IPAMAzure
 }
 
 func getInt(i int) *int {


### PR DESCRIPTION
In Azure IPAM mode, nodes don't get assigned real PodCIDRs ranges
(instead ciliumnodes are provided with random prefixes).

Installing a PodCIDR route through `cilium_host` interface might
remains unnoticed until a node have several interfaces and its
random PodCIDR range shadows traffic that should be routed otherwise.
Having that route injection enabled by default isn't ideal on Azure.

Please ensure your pull request adheres to the following guidelines:

```release-note
Azure IPAM: don't install bogus "PodCIDR via cilium_host" route by default
```
