### PR TITLE
v1.8 backports 2020-09-07

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -66,7 +66,7 @@ Deploy Cilium release via Helm:
      --set global.cni.chainingMode=generic-veth \\
      --set global.cni.customConf=true \\
      --set global.nodeinit.enabled=true \\
-     --set global.azure.enabled=true \\
+     --set nodeinit.expectAzureVnet=true \\
      --set global.cni.configMap=cni-configuration \\
      --set global.tunnel=disabled \\
      --set global.masquerade=false

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -340,11 +340,11 @@ IMPORTANT: Changes required before upgrading to 1.8.0
   by Kubernetes does not remove the old probe when replacing with a new one.
   This causes ``kubectl apply`` command to return an error such as:
 
-::
+  ::
 
-  The DaemonSet "cilium" is invalid:
-  * spec.template.spec.containers[0].livenessProbe.httpGet: Forbidden: may not specify more than 1 handler type
-  * spec.template.spec.containers[0].readinessProbe.httpGet: Forbidden: may not specify more than 1 handler type
+    The DaemonSet "cilium" is invalid:
+    * spec.template.spec.containers[0].livenessProbe.httpGet: Forbidden: may not specify more than 1 handler type
+    * spec.template.spec.containers[0].readinessProbe.httpGet: Forbidden: may not specify more than 1 handler type
 
   Existing users must either choose to keep the ``exec`` probe in the
   `DaemonSet` specification to safely upgrade or re-create the Cilium `DaemonSet`
@@ -354,7 +354,8 @@ IMPORTANT: Changes required before upgrading to 1.8.0
   upgrade.
 
   The helm option ``agent.keepDeprecatedProbes=true`` will keep the
-  ``exec`` probe in the new `DaemonSet`:
+  ``exec`` probe in the new `DaemonSet`. Add this option along with any
+  other options you would otherwise specify to Helm:
 
 .. tabs::
   .. group-tab:: kubectl

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -155,7 +155,7 @@ spec:
               ip -4 a
               ip -6 a
 
-{{- if .Values.global.azure.enabled }}
+{{- if or .Values.expectAzureVnet .Values.global.azure.enabled }}
               # Azure specific: Transparent bridge mode is required in order
               # for proxy-redirection to work
               until [ -f /var/run/azure-vnet.json ]; do

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -11,5 +11,9 @@ reconfigureKubelet: false
 # Delete the cbr0 bridge if it exists (GKE)
 removeCbrBridge: false
 
+# Wait for the /var/run/azure-vnet.json file to be created before continuing the script
+# This must be set as true explicitly if Azure AKS with CNI chaining is used.
+expectAzureVnet: false
+
 # Revert nodeinit changes via preStop container lifecycle hook
 revertReconfigureKubelet: false


### PR DESCRIPTION
* #13058 -- docs: Fix up upgrade sample indentation (@joestringer)
 * #13024 -- helm/azure: Fatal error for CNI Azure installation (@sayboras)
 * #13051 -- daemon: Fix handling of policy call map on upgrades (@pchaigno)

Not included due to non-trivial conflicts:

 * #12920 -- pkg/policy: fix toGroups derivative policy for clusterwide policies (@fristonio)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13058 13024 13051; do contrib/backporting/set-labels.py $pr done 1.8; done
```