### PR TITLE
test: Increase range of accepted values for bandwidth test

### DIFF
--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -31,7 +31,7 @@ var _ = Describe("K8sBandwidthTest", func() {
 		testClientPod  = "run=netperf-client-pod"
 		testClientHost = "run=netperf-client-host"
 
-		maxRateDeviation = 5
+		maxRateDeviation = 7
 	)
 
 	var (


### PR DESCRIPTION
The bandwidth test is failing in master and PRs because the measured rate-limited bandwidth sometimes falls outside the accepted range.

The accepted range is [20; 30] and values sampled from failing tests are 19.92, 19.73, 19.38, 19, 19.88, 19.94, etc. Thus, increasing the range to [18; 32] should be enough to prevent further flakes.

Fixes: #13062
