### PR TITLE
daemon: Disable bandwidth manager if IPSec is enabled

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1176,6 +1176,11 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
+	if option.Config.EnableBandwidthManager && option.Config.EnableIPSec {
+		log.Warning("The bandwidth manager cannot be used with IPSec. Disabling the bandwidth manager.")
+		option.Config.EnableBandwidthManager = false
+	}
+
 	if len(option.Config.Devices) != 0 && option.Config.EnableIPSec {
 		log.Fatalf("--%s cannot be used with IPSec.", option.Devices)
 	}


### PR DESCRIPTION
Both features are not supported at the same time, because they both attach BPF programs to the same native devices.

This commit disables the bandwidth manager on daemon startup if IPSec is also enabled. Another approach could be to fatal if both features are enabled, to ensure users notice the lack of bandwidth rate-limiting. I went for the warning because the bandwdith manager is enabled by default in Helm charts and want to avoid a fatal for all IPSec users.