### PR TITLE
test: Simplify Cilium namespace handling

### DIFF
--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -56,9 +56,7 @@ var _ = Describe("K8sBandwidthTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium bpf bandwidth list",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium bpf bandwidth list", "cilium endpoint list")
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -42,9 +42,7 @@ var _ = Describe("K8sChaosTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium service list",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
 
 	JustAfterEach(func() {

--- a/test/k8sT/Conformance.go
+++ b/test/k8sT/Conformance.go
@@ -61,8 +61,7 @@ var _ = Describe("K8sConformance", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium endpoint list")
 	})
 
 	AfterAll(func() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -49,9 +49,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium status",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium status", "cilium endpoint list")
 	})
 
 	AfterAll(func() {
@@ -191,7 +189,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		validateBPFTunnelMap := func() {
 			By("Checking that BPF tunnels are in place")
-			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
+			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
 			ExpectWithOffset(1, err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
 			status := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, "cilium bpf tunnel list | wc -l")
 
@@ -813,11 +811,11 @@ func monitorConnectivityAcrossNodes(kubectl *helpers.Kubectl) (monitorRes *helpe
 		By("Performing multinode connectivity check within a single node")
 	}
 
-	ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
+	ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 
 	By(fmt.Sprintf("Launching cilium monitor on %q", ciliumPodK8s1))
-	monitorRes, monitorCancel = kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s1)
+	monitorRes, monitorCancel = kubectl.MonitorStart(ciliumPodK8s1)
 	result, targetIP := testPodConnectivityAndReturnIP(kubectl, requireMultinode, 2)
 	ExpectWithOffset(1, result).Should(BeTrue(), "Connectivity test between nodes failed")
 

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -39,8 +39,7 @@ var _ = Describe("K8sHealthTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium endpoint list")
 	})
 
 	JustAfterEach(func() {
@@ -57,7 +56,7 @@ var _ = Describe("K8sHealthTest", func() {
 	})
 
 	getCilium := func(node string) (pod, ip string) {
-		pod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, node)
+		pod, err := kubectl.GetCiliumPodOnNodeWithLabel(node)
 		Expect(err).Should(BeNil())
 
 		res, err := kubectl.Get(

--- a/test/k8sT/Identity.go
+++ b/test/k8sT/Identity.go
@@ -47,8 +47,7 @@ var _ = Describe("K8sIdentity", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium endpoint list")
 	})
 
 	AfterAll(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -56,9 +56,7 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 	)
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium service list",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
 
 	AfterAll(func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -78,9 +78,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium service list",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
 
 	JustAfterEach(func() {
@@ -134,7 +132,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		log.WithFields(logrus.Fields{"pod creation time": waitForPodsTime}).Info("")
 
-		ciliumPods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
+		ciliumPods, err := kubectl.GetCiliumPods()
 		Expect(err).To(BeNil(), "Cannot retrieve cilium pods")
 
 		runtime := b.Time("Endpoint creation", func() {
@@ -349,9 +347,7 @@ var _ = Describe("NightlyExamples", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium service list",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
 
 	JustAfterEach(func() {
@@ -411,7 +407,7 @@ var _ = Describe("NightlyExamples", func() {
 		})
 
 		AfterFailed(func() {
-			kubectl.CiliumReport(helpers.CiliumNamespace, "cilium endpoint list")
+			kubectl.CiliumReport("cilium endpoint list")
 		})
 
 		JustAfterEach(func() {

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -39,9 +39,7 @@ var _ = Describe("NightlyPolicies", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium endpoint list",
-			"cilium service list")
+		kubectl.CiliumReport("cilium endpoint list", "cilium service list")
 	})
 
 	JustAfterEach(func() {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -92,7 +92,7 @@ var _ = Describe("K8sUpdates", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace, "cilium endpoint list")
+		kubectl.CiliumReport("cilium endpoint list")
 	})
 
 	JustAfterEach(func() {
@@ -402,7 +402,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 
 		waitForUpdateImage := func(image string) func() bool {
 			return func() bool {
-				pods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
+				pods, err := kubectl.GetCiliumPods()
 				if err != nil {
 					return false
 				}

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -49,9 +49,7 @@ var _ = Describe("K8sDemosTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium endpoint list",
-			"cilium service list")
+		kubectl.CiliumReport("cilium endpoint list", "cilium service list")
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -181,9 +181,7 @@ var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 		if !helpers.RunsOnNetNextOr419Kernel() {
 			return
 		}
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium service list",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
 
 	AfterAll(func() {

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -87,9 +87,7 @@ var _ = Describe("K8sFQDNTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace,
-			"cilium service list",
-			"cilium endpoint list")
+		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
 
 	AfterAll(func() {
@@ -126,12 +124,12 @@ var _ = Describe("K8sFQDNTest", func() {
 		// On restart) Cilium will restore the IPS that were white-listted in
 		// the FQDN and connection will work as normal.
 
-		ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
+		ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
-		monitorRes1, monitorCancel1 := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s1)
-		ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s2)
+		monitorRes1, monitorCancel1 := kubectl.MonitorStart(ciliumPodK8s1)
+		ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s2")
-		monitorRes2, monitorCancel2 := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s2)
+		monitorRes2, monitorCancel2 := kubectl.MonitorStart(ciliumPodK8s2)
 		defer func() {
 			monitorCancel1()
 			monitorCancel2()
@@ -212,8 +210,8 @@ var _ = Describe("K8sFQDNTest", func() {
 		ExpectCiliumReady(kubectl)
 
 		// Restart monitoring after Cilium restart
-		monitorRes1After, monitorCancel1After := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s1)
-		monitorRes2After, monitorCancel2After := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s2)
+		monitorRes1After, monitorCancel1After := kubectl.MonitorStart(ciliumPodK8s1)
+		monitorRes2After, monitorCancel2After := kubectl.MonitorStart(ciliumPodK8s2)
 		defer func() {
 			monitorCancel1After()
 			monitorCancel2After()

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -142,7 +142,7 @@ var _ = SkipContextIf(func() bool {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.CiliumNamespace, "cilium endpoint list")
+		kubectl.CiliumReport("cilium endpoint list")
 	})
 
 	// This is defined as a separate function to be called from the test below


### PR DESCRIPTION
Remove unneeded passing of Cilium namespace as argument to helper functions and use `helpers.CiliumNamespace = GetCiliumNamespace(GetCurrentIntegration())` everywhere.