### PR TITLE
hubble/relay: fix warning about missing config file

### DIFF
--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	v "github.com/cilium/cilium/pkg/version"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -40,9 +41,17 @@ func New() *cobra.Command {
 	}
 	logger := logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay")
 	vp := newViper()
+	flags := rootCmd.PersistentFlags()
+	flags.BoolP("debug", "D", false, "Enable debug messages")
+	vp.BindPFlags(flags)
+
+	if vp.GetBool("debug") {
+		logging.SetLogLevel(logrus.DebugLevel)
+	}
 	if err := vp.ReadInConfig(); err != nil {
 		logger.WithError(err).Warnf("Failed to read config from file '%s'", configFilePath)
 	}
+
 	rootCmd.AddCommand(
 		completion.New(),
 		serve.New(vp),

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -34,7 +34,6 @@ import (
 )
 
 const (
-	keyDebug                  = "debug"
 	keyPprof                  = "pprof"
 	keyGops                   = "gops"
 	keyDialTimeout            = "dial-timeout"
@@ -63,9 +62,6 @@ func New(vp *viper.Viper) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolP(
-		keyDebug, "D", false, "Run in debug mode",
-	)
 	flags.Bool(
 		keyPprof, false, "Enable serving the pprof debugging API",
 	)
@@ -157,7 +153,7 @@ func runServe(vp *viper.Viper) error {
 	}
 	opts = append(opts, serverTLSOption)
 
-	if vp.GetBool(keyDebug) {
+	if vp.GetBool("debug") {
 		opts = append(opts, server.WithDebug())
 	}
 	if vp.GetBool(keyPprof) {

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/configmap.yaml
@@ -8,9 +8,6 @@ data:
   config.yaml: |
     peer-service: unix://{{ .Values.global.hubble.socketPath }}
     listen-address: {{ .Values.listenHost }}:{{ .Values.listenPort }}
-{{- if .Values.global.debug.enabled }}
-    debug: true
-{{- end }}
 {{- if .Values.dialTimeout }}
     dial-timeout: {{ .Values.dialTimeout }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - "hubble-relay"
           args:
             - "serve"
+{{- if .Values.global.debug.enabled }}
+            - "--debug"
+{{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.listenPort }}


### PR DESCRIPTION
Before this patch, hubble-relay would complain when its config file was missing. This patch make it so the error message is only shown at the debug level.

Before this patch:
```
% ./hubble-relay version
level=warning msg="Failed to read config from file '/etc/hubble-relay/config.yaml'" error="open /etc/hubble-relay/config.yaml: no such file or directory" subsys=hubble-relay
Hubble-relay: 1.8.90 b13dcfb3f 2020-08-21T15:53:46+05:30 go version go1.15 linux/amd64
```
After this patch:
```
% ./hubble-relay version
Hubble-relay: 1.8.90 6c4963ab6 2020-09-07T19:07:01+02:00 go version go1.15 linux/amd64
```
and
```
% ./hubble-relay version --debug
level=debug msg="os.Hostname() returned" nodeName=shelob subsys=node
level=debug msg="Failed to read config from file '/etc/hubble-relay/config.yaml'" error="open /etc/hubble-relay/config.yaml: no such file or directory" subsys=hubble-relay
Hubble-relay: 1.8.90 6c4963ab6 2020-09-07T19:07:01+02:00 go version go1.15 linux/amd64
% RELAY_DEBUG=true ./hubble-relay version
level=debug msg="Failed to read config from file '/etc/hubble-relay/config.yaml'" error="open /etc/hubble-relay/config.yaml: no such file or directory" subsys=hubble-relay
Hubble-relay: 1.8.90 6c4963ab6 2020-09-07T19:07:01+02:00 go version go1.15 linux/amd64
```

Fixes #13104