### PR TITLE
hubble, monitor: handle accesslog.DNSSourceProxy in log record parsers

### DIFF
--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -16,8 +16,6 @@ package seven
 
 import (
 	"fmt"
-	"github.com/cilium/cilium/pkg/hubble/parser/errors"
-	"github.com/cilium/cilium/pkg/monitor/api"
 	"net"
 	"net/url"
 	"sort"
@@ -25,8 +23,10 @@ import (
 	"time"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
+	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 
@@ -467,8 +467,11 @@ func dnsSummary(flowType accesslog.FlowType, dns *accesslog.LogRecordDNS) string
 		}
 
 		sourceType := "Query"
-		if dns.ObservationSource == accesslog.DNSSourceAgentPoller {
+		switch dns.ObservationSource {
+		case accesslog.DNSSourceAgentPoller:
 			sourceType = "Poll"
+		case accesslog.DNSSourceProxy:
+			sourceType = "Proxy"
 		}
 
 		return fmt.Sprintf("DNS Answer %s TTL: %d (%s %s %s)", answer, dns.TTL, sourceType, dns.Query, qTypeStr)

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -103,8 +103,11 @@ func (l *LogRecordNotify) DumpInfo() {
 
 		case l.Type == accesslog.TypeResponse:
 			sourceType := "Query"
-			if l.DNS.ObservationSource == accesslog.DNSSourceAgentPoller {
+			switch l.DNS.ObservationSource {
+			case accesslog.DNSSourceAgentPoller:
 				sourceType = "Poll"
+			case accesslog.DNSSourceProxy:
+				sourceType = "Proxy"
 			}
 
 			fmt.Printf(" DNS %s: %s %s", sourceType, l.DNS.Query, qTypeStr)


### PR DESCRIPTION
`dns.ObservationSource` is of type `accesslog.DNSDataSource` which could take the value `accesslog.DNSSourceProxy` as well. Account for that when constructing the DNS record string in Hubble and the Cilium monitor.
