### PR TITLE
envoy: use errors.Is(..., net.ErrClosed) instead of string matching

### DIFF
--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -15,11 +15,12 @@
 package envoy
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
+	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -72,8 +73,7 @@ func StartAccessLogServer(stateDir string, xdsServer *XDSServer, endpointInfoReg
 			uc, err := accessLogListener.AcceptUnix()
 			if err != nil {
 				// These errors are expected when we are closing down
-				if strings.Contains(err.Error(), "closed network connection") ||
-					strings.Contains(err.Error(), "invalid argument") {
+				if errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.EINVAL) {
 					break
 				}
 				log.WithError(err).Warn("Envoy: Failed to accept access log connection")

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/cilium/cilium/pkg/envoy/xds"
@@ -60,7 +59,7 @@ func startXDSGRPCServer(listener net.Listener, ldsConfig, npdsConfig, nphdsConfi
 
 	go func() {
 		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener.Addr())
-		if err := grpcServer.Serve(listener); err != nil && !strings.Contains(err.Error(), "closed network connection") {
+		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, net.ErrClosed) {
 			log.WithError(err).Fatal("Envoy: Failed to serve xDS gRPC API")
 		}
 	}()


### PR DESCRIPTION
Use errors.Is to check whether err (or some error that it wraps) is
net.ErrClosed instead of comparing error strings.

Same for syscall.EINVAL.