### PR TITLE
hubble/peer: always generate tls ServerName at the same DNS domain level

### DIFF
--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -163,17 +163,21 @@ func nodeAddress(n types.Node) string {
 //
 //     moseisley.tatooine.hubble-grpc.cilium.io
 //
-// If nodeName is not provided, an empty string is returned. If clusterName is
-// not provided, it defaults to the default cluster name.
+// When nodeName is not provided, an empty string is returned. All Dot (.) in
+// nodeName are replaced by Hyphen (-). When clusterName is not provided, it
+// defaults to the default cluster name.
 func tlsServerName(nodeName, clusterName string) string {
 	if nodeName == "" {
 		return ""
 	}
+	// To ensure that each node's ServerName is at the same DNS domain level,
+	// we have to lookout for Dot (.) as Kubernetes allows them in Node names.
+	nn := strings.ReplaceAll(nodeName, ".", "-")
 	if clusterName == "" {
 		clusterName = ciliumDefaults.ClusterName
 	}
 	return strings.Join([]string{
-		nodeName,
+		nn,
 		clusterName,
 		defaults.GRPCServiceName,
 		defaults.DomainName,

--- a/pkg/hubble/peer/handler_test.go
+++ b/pkg/hubble/peer/handler_test.go
@@ -121,6 +121,20 @@ func TestNodeAdd(t *testing.T) {
 					ServerName: "name.cluster.hubble-grpc.cilium.io",
 				},
 			},
+		}, {
+			name: "node name with dots",
+			arg: types.Node{
+				Name:    "my.very.long.node.name",
+				Cluster: "cluster",
+			},
+			want: &peerpb.ChangeNotification{
+				Name:    "cluster/my.very.long.node.name",
+				Address: "",
+				Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+				Tls: &peerpb.TLS{
+					ServerName: "my-very-long-node-name.cluster.hubble-grpc.cilium.io",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Before this patch, when a Node name contained one or more Dot (`.`), its Hubble ServerName would not match the TLS certificate.

Because [Kubernetes Node names may contains dots][1], and the way [HTTPS wildcard certificate Server Identity matching is specified][2], Hubble Relay would fail to connect to Hubble instances running on a Node with one or more dot in their name.

Note that Node name part in the returned ServerName doesn't matter as long as we're using a wildcard certificate. This patch replace all the dots in the generated ServerName by Hyphen (`-`) to preserve readability for humans.

[1]: https://kubernetes.io/docs/concepts/architecture/nodes/
[2]: https://tools.ietf.org/html/rfc2818#section-3.1

Fix #13080