### PR TITLE
test: fix build after merge of #13107 and #13036

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -664,7 +664,7 @@ func (kub *Kubectl) GetNumCiliumNodes() int {
 // CountMissedTailCalls returns the number of the sum of all drops due to
 // missed tail calls that happened on all Cilium-managed nodes.
 func (kub *Kubectl) CountMissedTailCalls() (int, error) {
-	ciliumPods, err := kub.GetCiliumPods(GetCiliumNamespace(GetCurrentIntegration()))
+	ciliumPods, err := kub.GetCiliumPods()
 	if err != nil {
 		return -1, err
 	}

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -354,7 +354,7 @@ var _ = Describe("K8sServicesTest", func() {
 		It("Checks service.kubernetes.io/service-proxy-name label implementation", func() {
 			serviceProxyLabelName := "service.kubernetes.io/service-proxy-name"
 
-			ciliumPods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
+			ciliumPods, err := kubectl.GetCiliumPods()
 			Expect(err).To(BeNil(), "Cannot get cilium pods")
 
 			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, echoServiceName)


### PR DESCRIPTION
Commit 61ebc232cb8c ("test: Use existing alias for Cilium namespace")
changes kubectl.GetCiliumPods to take no namespace argument anymore.
Commit 4f7fbaee92c5 ("test: add e2e tests to validate service-proxy-name
implmentation") introduced a new test and helpers which used
kubectl.GetCiliumPods in the old way, leading to a build failure in the
tests.