### PR TITLE
v1.8 backports 2020-09-09

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -137,6 +137,7 @@ cilium-agent [flags]
       --k8s-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in
       --k8s-require-ipv4-pod-cidr                     Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                     Require IPv6 PodCIDR to be specified in node resource
+      --k8s-service-proxy-name string                 Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --k8s-watcher-endpoint-selector string          K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
       --k8s-watcher-queue-size uint                   Queue size used to serialize each k8s event type (default 1024)
       --keep-config                                   When restoring state, keeps containers' configuration in place

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -50,6 +50,7 @@ cilium-operator-aws [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -48,6 +48,7 @@ cilium-operator-azure [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -46,6 +46,7 @@ cilium-operator-generic [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -52,6 +52,7 @@ cilium-operator [flags]
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
       --kvstore-opt map                           Key-value store options (default map[])
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -981,6 +981,25 @@ Meanwhile `GKE internal TCP/UDP load balancer
 <https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#lb_source_ranges>`__
 does not, so the feature must be kept enabled in order to restrict the access.
 
+Service Proxy Name Configuration
+********************************
+
+Like kube-proxy, Cilium also honors the ``service.kubernetes.io/service-proxy-name`` service annotation
+and only manages services that contain a matching service-proxy-name label. This name can be configured
+by setting ``global.k8s.serviceProxyName`` option and the behavior is identical to that of
+kube-proxy. The service proxy name defaults to an empty string which instructs Cilium to
+only manage services not having ``service.kubernetes.io/service-proxy-name`` label.
+
+For more details on the usage of ``service.kubernetes.io/service-proxy-name`` label and its
+working, take a look at `this KEP
+<https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0031-20181017-kube-proxy-services-optional.md>`__.
+
+.. note::
+
+    If Cilium with a non-empty service proxy name is meant to manage all services in kube-proxy
+    free mode, make sure that default Kubernetes services like ``kube-dns`` and ``kubernetes``
+    have the required label value.
+
 Limitations
 ###########
 

--- a/Documentation/policy/kubernetes.rst
+++ b/Documentation/policy/kubernetes.rst
@@ -92,8 +92,8 @@ for a fully functional example including pods deployed to different namespaces.
 Example: Allow egress to kube-dns in kube-system namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example allows all pods in the namespace in which the policy is
-created to communicate with kube-dns on port 53/UDP in the ``kube-system``
+The following example allows all pods in the ``public`` namespace in which the
+policy is created to communicate with kube-dns on port 53/UDP in the ``kube-system``
 namespace.
 
 .. only:: html
@@ -202,3 +202,20 @@ namespace to pods matching the labels ``name=leia`` in any namespace.
 .. only:: epub or latex
 
         .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/clusterscope-policy.yaml
+
+Example: Allow all ingress to kube-dns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example allows all Cilium managed endpoints in the cluster to communicate
+with kube-dns on port 53/UDP in the ``kube-system`` namespace.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml

--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -151,11 +151,10 @@ func validateNPResources(
 				cnpName = cnp.GetName()
 			}
 			if err := validator(&cnp); err != nil {
-				log.Errorf("Validating %s '%s': unexpected validation error: %s",
-					shortName, cnpName, err)
+				log.WithField(shortName, cnpName).WithError(err).Error("Unexpected validation error")
 				policyErr = fmt.Errorf("Found invalid %s", shortName)
 			} else {
-				log.Infof("Validating %s '%s': OK!", shortName, cnpName)
+				log.WithField(shortName, cnpName).Info("Validation OK!")
 			}
 		}
 		if cnps.GetContinue() == "" {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -820,6 +820,9 @@ func init() {
 	flags.Int(option.FragmentsMapEntriesName, defaults.FragmentsMapEntries, "Maximum number of entries in fragments tracking map")
 	option.BindEnv(option.FragmentsMapEntriesName)
 
+	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
+	option.BindEnv(option.K8sServiceProxyName)
+
 	viper.BindPFlags(flags)
 
 	CustomCommandHelpFormat(RootCmd, option.HelpFlagSections)

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -29,10 +29,12 @@ import (
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/status"
+	"github.com/sirupsen/logrus"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
@@ -733,5 +735,20 @@ func (d *Daemon) startStatusCollector() {
 
 	d.statusCollector = status.NewCollector(probes, status.Config{})
 
+	// Set up a signal handler function which prints out logs related to daemon status.
+	cleaner.cleanupFuncs.Add(func() {
+		// If the KVstore state is not OK, print help for user.
+		if d.statusResponse.Kvstore != nil &&
+			d.statusResponse.Kvstore.State != models.StatusStateOk {
+			helpMsg := "cilium-agent depends on the availability of cilium-operator/etcd-cluster. " +
+				"Check if the cilium-operator pod and etcd-cluster are running and do not have any " +
+				"warnings or error messages."
+			log.WithFields(logrus.Fields{
+				"status":              d.statusResponse.Kvstore.Msg,
+				logfields.HelpMessage: helpMsg,
+			}).Error("KVStore state not OK")
+
+		}
+	})
 	return
 }

--- a/examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+++ b/examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+description: "Policy for ingress allow to kube-dns from all Cilium managed endpoints in the cluster"
+metadata:
+  name: "wildcard-from-endpoints"
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: kube-system
+      k8s-app: kube-dns
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP

--- a/examples/policies/kubernetes/namespace/kubedns-policy.json
+++ b/examples/policies/kubernetes/namespace/kubedns-policy.json
@@ -1,8 +1,10 @@
 [
    {
-      "endpointSelector" : {
-         "matchLabels" : {}
-      },
+      "endpointSelector" :  {
+         "matchLabels": {
+            "k8s:io.kubernetes.pod.namespace": "public"
+         }
+     },
       "egress" : [
          {
             "toEndpoints" : [

--- a/examples/policies/kubernetes/namespace/kubedns-policy.yaml
+++ b/examples/policies/kubernetes/namespace/kubedns-policy.yaml
@@ -2,6 +2,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: "allow-to-kubedns"
+  namespace: public
 spec:
   endpointSelector:
     {}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -582,3 +582,8 @@ data:
 {{- else if ( ne $crdWaitTimeout "5m" ) }}
   crd-wait-timeout: {{ $crdWaitTimeout | quote }}
 {{- end }}
+
+{{- if and .Values.global.k8s .Values.global.k8s.serviceProxyName }}
+  # Configure service proxy name for Cilium.
+  k8s-service-proxy-name: {{ .Values.global.k8s.serviceProxyName | quote }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -424,6 +424,13 @@ global:
     # range via the Kubernetes node resource
     requireIPv4PodCIDR: false
 
+    # Service proxy name to use for Cilium components. This name makes sure
+    # that Cilium only manages service objects that contains the matching
+    # service.kubernetes.io/service-proxy-name label value.
+    # Defaults to empty string, in which case Cilium manages all services
+    # without the mentioned label.
+    serviceProxyName: ""
+
   # ENI mode configures the options required to run with ENI
   eni: false
 

--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -87,7 +87,7 @@ func enableCCNPWatcher() error {
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
 					cnpCpy := cnp.DeepCopy()
 
-					groups.AddDerivativeCNPIfNeeded(cnpCpy.CiliumNetworkPolicy)
+					groups.AddDerivativeCCNPIfNeeded(cnpCpy.CiliumNetworkPolicy)
 					if kvstoreEnabled() {
 						ccnpStatusMgr.StartStatusHandler(cnpCpy)
 					}
@@ -107,7 +107,7 @@ func enableCCNPWatcher() error {
 						newCNPCpy := newCNP.DeepCopy()
 						oldCNPCpy := oldCNP.DeepCopy()
 
-						groups.UpdateDerivativeCNPIfNeeded(newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy)
+						groups.UpdateDerivativeCCNPIfNeeded(newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy)
 					}
 				}
 			},

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -316,5 +316,8 @@ func init() {
 		"Duration that LeaderElector clients should wait between retries of the actions")
 	option.BindEnv(operatorOption.LeaderElectionRetryPeriod)
 
+	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
+	option.BindEnv(option.K8sServiceProxyName)
+
 	viper.BindPFlags(flags)
 }

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -186,7 +187,10 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 			break
 		}
 
-		log.WithFields(logFields).Info("Waiting for IPs to become available in CRD-backed allocation pool")
+		log.WithFields(logFields).WithField(
+			logfields.HelpMessage,
+			"Check if cilium-operator pod is running and does not have any warnings or error messages.",
+		).Info("Waiting for IPs to become available in CRD-backed allocation pool")
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/k8s/apis/cilium.io/v2/validator/logfields.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/logfields.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "validator")

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -17,17 +17,21 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
-
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/go-openapi/validate"
+	"github.com/sirupsen/logrus"
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// NPValidator is a validator structure used to validate CNP.
+// NPValidator is a validator structure used to validate CNP and CCNP.
 type NPValidator struct {
 	cnpValidator  *validate.SchemaValidator
 	ccnpValidator *validate.SchemaValidator
@@ -102,10 +106,97 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 	return nil
 }
 
+var (
+	// We can remove the check for this warning once 1.9 is the oldest supported Cilium version.
+	warnWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
+		"with a wildcard to/from endpoint selector. The behavior of this selector has been " +
+		"changed. The selector now only allows traffic to/from Cilium managed K8s endpoints, " +
+		"instead of acting as a truly empty endpoint selector allowing all traffic. To " +
+		"ensure that the policy behavior does not affect your workloads, consider adding " +
+		"another policy that allows traffic to/from world and cluster entities. For a more " +
+		"detailed discussion on the topic, see https://github.com/cilium/cilium/issues/12844"
+
+	logOnce sync.Once
+)
+
 // ValidateCCNP validates the given CCNP accordingly the CCNP validation schema.
 func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 	if errs := validation.ValidateCustomResource(nil, &ccnp, n.ccnpValidator); len(errs) > 0 {
 		return errs.ToAggregate()
 	}
+
+	logger := log.WithFields(logrus.Fields{
+		logfields.CiliumClusterwideNetworkPolicyName: ccnp.GetName(),
+	})
+
+	// At this point we have validated the custom resource with the new CRV.
+	// We can try converting it to the new CCNP type.
+	// This should not fail, so we are not returning any errors, just logging
+	// a warning.
+	ccnpBytes, err := ccnp.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	resCCNP := cilium_v2.CiliumClusterwideNetworkPolicy{}
+	err = json.Unmarshal(ccnpBytes, &resCCNP)
+	if err != nil {
+		return err
+	}
+
+	// Print the warninig only once per CCNP.
+	if resCCNP.Spec != nil {
+		if containsWildcardToFromEndpoint(resCCNP.Spec) {
+			logOnce.Do(func() {
+				logger.Warning(warnWildcardToFromEndpointMessage)
+			})
+			return nil
+		}
+	}
+
+	if resCCNP.Specs != nil {
+		for _, rule := range resCCNP.Specs {
+			if containsWildcardToFromEndpoint(rule) {
+				logOnce.Do(func() {
+					logger.Warning(warnWildcardToFromEndpointMessage)
+				})
+				return nil
+			}
+		}
+	}
+
 	return nil
+}
+
+// containsWildcardToFromEndpoint returns true if a CCNP contains an empty endpoint selector
+// in ingress/egress rules.
+// For more information - https://github.com/cilium/cilium/issues/12844#issuecomment-672074170
+func containsWildcardToFromEndpoint(rule *api.Rule) bool {
+	if len(rule.Ingress) > 0 {
+		for _, r := range rule.Ingress {
+			// We only check for the presence of wildcard to/fromEndpoints
+			// in the network policy spec.
+			if len(r.FromEndpoints) > 0 {
+				for _, epSel := range r.FromEndpoints {
+					if epSel.IsWildcard() {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	if len(rule.Egress) > 0 {
+		for _, r := range rule.Egress {
+			if len(r.ToEndpoints) > 0 {
+				for _, epSel := range r.ToEndpoints {
+					if epSel.IsWildcard() {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -21,17 +21,16 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) servicesInit(k8sClient kubernetes.Interface, swgSvcs *lock.StoppableWaitGroup) {
-
+func (k *K8sWatcher) servicesInit(k8sClient kubernetes.Interface, swgSvcs *lock.StoppableWaitGroup, optsModifier func(*v1meta.ListOptions)) {
 	_, svcController := informer.NewInformer(
-		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
-			"services", v1.NamespaceAll, fields.Everything()),
+		cache.NewFilteredListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+			"services", v1.NamespaceAll, optsModifier),
 		&slim_corev1.Service{},
 		0,
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
+	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -353,7 +354,7 @@ func (k *K8sWatcher) WaitForCacheSync(resourceNames ...string) {
 // caches essential for daemon are synchronized.
 func (k *K8sWatcher) InitK8sSubsystem() <-chan struct{} {
 	if err := k.EnableK8sWatcher(option.Config.K8sWatcherQueueSize); err != nil {
-		log.WithError(err).Fatal("Unable to establish connection to Kubernetes apiserver")
+		log.WithError(err).Fatal("Unable to start K8s watchers for Cilium")
 	}
 
 	cachesSynced := make(chan struct{})
@@ -428,9 +429,14 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	swgKNP := lock.NewStoppableWaitGroup()
 	k.networkPoliciesInit(k8s.WatcherCli(), swgKNP)
 
+	serviceOptModifier, err := utils.GetServiceListOptionsModifier()
+	if err != nil {
+		return fmt.Errorf("error creating service list option modifier: %w", err)
+	}
+
 	// kubernetes services
 	swgSvcs := lock.NewStoppableWaitGroup()
-	k.servicesInit(k8s.WatcherCli(), swgSvcs)
+	k.servicesInit(k8s.WatcherCli(), swgSvcs, serviceOptModifier)
 
 	// kubernetes endpoints
 	swgEps := lock.NewStoppableWaitGroup()
@@ -438,14 +444,16 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	// We only enable either "Endpoints" or "EndpointSlice"
 	switch {
 	case k8s.SupportsEndpointSlice():
+		// We don't add the service option modifier here, as endpointslices do not
+		// mirror service proxy name label present in the corresponding service.
 		connected := k.endpointSlicesInit(k8s.WatcherCli(), swgEps)
-		// the cluster has endpoint slices so we should not check for v1.Endpoints
+		// The cluster has endpoint slices so we should not check for v1.Endpoints
 		if connected {
 			break
 		}
 		fallthrough
 	default:
-		k.endpointsInit(k8s.WatcherCli(), swgEps)
+		k.endpointsInit(k8s.WatcherCli(), swgEps, serviceOptModifier)
 	}
 
 	// cilium network policies

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -250,6 +250,9 @@ const (
 	// CiliumNetworkPolicyName is the name of a CiliumNetworkPolicy
 	CiliumNetworkPolicyName = "ciliumNetworkPolicyName"
 
+	// CiliumClusterwideNetworkPolicyName is the name of the CiliumClusterWideNetworkPolicy
+	CiliumClusterwideNetworkPolicyName = "ciliumClusterwideNetworkPolicyName"
+
 	// BPFMapKey is a key from a BPF map
 	BPFMapKey = "bpfMapKey"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -441,4 +441,8 @@ const (
 
 	// SysParamValue is the value of the kernel parameter (sysctl)
 	SysParamValue = "sysParamValue"
+
+	// HelpMessage is the help message corresponding to a log message.
+	// This is to make sure we keep separate contexts for logs and help messages.
+	HelpMessage = "helpMessage"
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -809,8 +809,12 @@ const (
 	// tracking map.
 	FragmentsMapEntriesName = "bpf-fragments-map-max"
 
-	// K8sEnableAPIDiscovery
+	// K8sEnableAPIDiscovery enables Kubernetes API discovery
 	K8sEnableAPIDiscovery = "enable-k8s-api-discovery"
+
+	// K8sServiceProxyName instructs Cilium to handle service objects only when
+	// service.kubernetes.io/service-proxy-name label equals the provided value.
+	K8sServiceProxyName = "k8s-service-proxy-name"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -887,6 +891,7 @@ var HelpFlagSections = []FlagsSection{
 			FlannelMasterDevice,
 			FlannelUninstallOnExit,
 			EnableWellKnownIdentities,
+			K8sServiceProxyName,
 		},
 	},
 	{
@@ -1886,6 +1891,13 @@ type DaemonConfig struct {
 	// election purposes in HA mode.
 	// This is only enabled for cilium-operator
 	k8sEnableLeasesFallbackDiscovery bool
+
+	// K8sServiceProxyName is the value of service.kubernetes.io/service-proxy-name label,
+	// that identifies the service objects Cilium should handle.
+	// If the provided value is an empty string, Cilium will manage service objects when
+	// the label is not present. For more details -
+	// https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0031-20181017-kube-proxy-services-optional.md
+	K8sServiceProxyName string
 }
 
 var (
@@ -2394,6 +2406,7 @@ func (c *DaemonConfig) Populate() {
 	c.PolicyAuditMode = viper.GetBool(PolicyAuditModeArg)
 	c.EnableIPv4FragmentsTracking = viper.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = viper.GetInt(FragmentsMapEntriesName)
+	c.K8sServiceProxyName = viper.GetString(K8sServiceProxyName)
 
 	c.populateDevices()
 

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -110,6 +110,8 @@ type EgressRule struct {
 
 	// ToServices is a list of services to which the endpoint subject
 	// to the rule is allowed to initiate connections.
+	// Currently Cilium only supports toServices for K8s services without
+	// selectors.
 	//
 	// Example:
 	// Any endpoint with the label "app=backend-app" is allowed to

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -287,6 +287,20 @@ func (n *EndpointSelector) AddMatch(key, value string) {
 	n.cachedLabelSelectorString = n.LabelSelector.String()
 }
 
+// AddMatchExpression adds a match expression to label selector of the endpoint selector.
+func (n *EndpointSelector) AddMatchExpression(key string, op slim_metav1.LabelSelectorOperator, values []string) {
+	n.MatchExpressions = append(n.MatchExpressions, slim_metav1.LabelSelectorRequirement{
+		Key:      key,
+		Operator: op,
+		Values:   values,
+	})
+
+	// Update cache of the EndopintSelector from the embedded label selector.
+	// This is to make sure we have updates caches containing the required selectors.
+	n.requirements = labelSelectorToRequirements(n.LabelSelector)
+	n.cachedLabelSelectorString = n.LabelSelector.String()
+}
+
 // Matches returns true if the endpoint selector Matches the `lblsToMatch`.
 // Returns always true if the endpoint selector contains the reserved label for
 // "all".

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -40,10 +40,10 @@ var (
 	controllerManager = controller.NewManager()
 )
 
-// AddDerivativeCNPIfNeeded will create a new CNP if the given CNP has any rule
+// AddDerivativeCNPIfNeeded will create a new CNP if the given CNP has any rules
 // that need to create a new derivative policy.
 // It returns a boolean, true in case that all actions are correct, false if
-// something fails
+// something fails.
 func AddDerivativeCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
 	if !cnp.RequiresDerivative() {
 		log.WithFields(logrus.Fields{
@@ -55,7 +55,27 @@ func AddDerivativeCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
 	controllerManager.UpdateController(fmt.Sprintf("add-derivative-cnp-%s", cnp.ObjectMeta.Name),
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return addDerivativeCNP(ctx, cnp)
+				return addDerivativePolicy(ctx, cnp, false)
+			},
+		})
+	return true
+}
+
+// AddDerivativeCCNPIfNeeded will create a new CCNP if the given NetworkPolicy has any rules
+// that need to create a new derivative policy.
+// It returns a boolean, true in case that all actions are correct, false if
+// something fails.
+func AddDerivativeCCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
+	if !cnp.RequiresDerivative() {
+		log.WithFields(logrus.Fields{
+			logfields.CiliumClusterwideNetworkPolicyName: cnp.ObjectMeta.Name,
+		}).Debug("CCNP does not have derivative policies, skipped")
+		return true
+	}
+	controllerManager.UpdateController(fmt.Sprintf("add-derivative-ccnp-%s", cnp.ObjectMeta.Name),
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				return addDerivativePolicy(ctx, cnp, true)
 			},
 		})
 	return true
@@ -65,14 +85,16 @@ func AddDerivativeCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
 // any rule that needs to create a new derivative policy(eg: ToGroups). In case
 // that the new CNP does not have any derivative policy and the old one had
 // one, it will delete the old policy.
+// The function returns true if an update is required for the derivative policy
+// and false otherwise.
 func UpdateDerivativeCNPIfNeeded(newCNP *cilium_v2.CiliumNetworkPolicy, oldCNP *cilium_v2.CiliumNetworkPolicy) bool {
 	if !newCNP.RequiresDerivative() && oldCNP.RequiresDerivative() {
 		log.WithFields(logrus.Fields{
 			logfields.CiliumNetworkPolicyName: newCNP.ObjectMeta.Name,
 			logfields.K8sNamespace:            newCNP.ObjectMeta.Namespace,
-		}).Info("New CNP does not have derivative policy, but old had. Deleted old policies")
+		}).Info("New CNP does not have derivative policy, but old had. Deleting old policies")
 
-		controllerManager.UpdateController(fmt.Sprintf("delete-derivatve-cnp-%s", oldCNP.ObjectMeta.Name),
+		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-cnp-%s", oldCNP.ObjectMeta.Name),
 			controller.ControllerParams{
 				DoFunc: func(ctx context.Context) error {
 					return DeleteDerivativeCNP(oldCNP)
@@ -85,10 +107,44 @@ func UpdateDerivativeCNPIfNeeded(newCNP *cilium_v2.CiliumNetworkPolicy, oldCNP *
 		return false
 	}
 
-	controllerManager.UpdateController(fmt.Sprintf("CNP-Derivative-update-%s", newCNP.ObjectMeta.Name),
+	controllerManager.UpdateController(fmt.Sprintf("update-derivative-cnp-%s", newCNP.ObjectMeta.Name),
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return addDerivativeCNP(ctx, newCNP)
+				return addDerivativePolicy(ctx, newCNP, false)
+			},
+		})
+	return true
+}
+
+// UpdateDerivativeCCNPIfNeeded updates or creates a CCNP if the given CCNP has
+// any rule that needs to create a new derivative policy(eg: ToGroups). In case
+// that the new CCNP does not have any derivative policy and the old one had
+// one, it will delete the old policy.
+// The function returns true if an update is required for the derivative policy
+// and false otherwise.
+func UpdateDerivativeCCNPIfNeeded(newCCNP *cilium_v2.CiliumNetworkPolicy, oldCCNP *cilium_v2.CiliumNetworkPolicy) bool {
+	if !newCCNP.RequiresDerivative() && oldCCNP.RequiresDerivative() {
+		log.WithFields(logrus.Fields{
+			logfields.CiliumClusterwideNetworkPolicyName: newCCNP.ObjectMeta.Name,
+		}).Info("New CCNP does not have derivative policy, but old had. Deleting old policies")
+
+		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-ccnp-%s", oldCCNP.ObjectMeta.Name),
+			controller.ControllerParams{
+				DoFunc: func(ctx context.Context) error {
+					return DeleteDerivativeCCNP(oldCCNP)
+				},
+			})
+		return false
+	}
+
+	if !newCCNP.RequiresDerivative() {
+		return false
+	}
+
+	controllerManager.UpdateController(fmt.Sprintf("update-derivative-ccnp-%s", newCCNP.ObjectMeta.Name),
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				return addDerivativePolicy(ctx, newCCNP, true)
 			},
 		})
 	return true
@@ -103,7 +159,6 @@ func DeleteDerivativeFromCache(cnp *cilium_v2.CiliumNetworkPolicy) {
 // DeleteDerivativeCNP if the given policy has a derivative constraint,the
 // given CNP will be deleted from store and the cache.
 func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
-
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
@@ -127,15 +182,48 @@ func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
 	return nil
 }
 
-func addDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) error {
-
+// DeleteDerivativeCCNP if the given policy has a derivative constraint, the
+// given CCNP will be deleted from store and the cache.
+func DeleteDerivativeCCNP(ccnp *cilium_v2.CiliumNetworkPolicy) error {
 	scopedLog := log.WithFields(logrus.Fields{
-		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
-		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
+		logfields.CiliumClusterwideNetworkPolicyName: ccnp.ObjectMeta.Name,
 	})
 
-	var derivativeCNP *cilium_v2.CiliumNetworkPolicy
-	var derivativeErr error
+	if !ccnp.RequiresDerivative() {
+		scopedLog.Debug("CCNP does not have derivative policies, skipped")
+		return nil
+	}
+
+	err := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().DeleteCollection(
+		context.TODO(),
+		v1.DeleteOptions{},
+		v1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", parentCNP, ccnp.ObjectMeta.UID)})
+	if err != nil {
+		return err
+	}
+
+	DeleteDerivativeFromCache(ccnp)
+	return nil
+}
+
+func addDerivativePolicy(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy, clusterScoped bool) error {
+	var (
+		scopedLog          *logrus.Entry
+		derivativePolicy   v1.Object
+		derivativeCNP      *cilium_v2.CiliumNetworkPolicy
+		derivativeCCNP     *cilium_v2.CiliumClusterwideNetworkPolicy
+		derivativeErr, err error
+	)
+	if clusterScoped {
+		scopedLog = log.WithFields(logrus.Fields{
+			logfields.CiliumClusterwideNetworkPolicyName: cnp.ObjectMeta.Name,
+		})
+	} else {
+		scopedLog = log.WithFields(logrus.Fields{
+			logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
+			logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
+		})
+	}
 
 	// The maxNumberOfAttempts is to not hit the limits of cloud providers API.
 	// Also, the derivativeErr is never returned, if not the controller will
@@ -146,32 +234,45 @@ func addDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) e
 	// the derivative status in the parent policy  will be updated with the
 	// error.
 	for numAttempts := 0; numAttempts <= maxNumberOfAttempts; numAttempts++ {
-		derivativeCNP, derivativeErr = createDerivativeCNP(ctx, cnp)
+		if clusterScoped {
+			derivativeCCNP, derivativeErr = createDerivativeCCNP(ctx, cnp)
+			derivativePolicy = derivativeCCNP
+		} else {
+			derivativeCNP, derivativeErr = createDerivativeCNP(ctx, cnp)
+			derivativePolicy = derivativeCNP
+		}
+
 		if derivativeErr == nil {
 			break
 		}
 		metrics.PolicyImportErrors.Inc()
 		scopedLog.WithError(derivativeErr).Error("Cannot create derivative rule. Installing deny-all rule.")
-		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, derivativeErr)
+		statusErr := updateDerivativeStatus(cnp, derivativePolicy.GetName(), derivativeErr, clusterScoped)
 		if statusErr != nil {
-			scopedLog.WithError(statusErr).Error("Cannot update CNP status for derivative policy")
+			scopedLog.WithError(statusErr).Error("Cannot update status for derivative policy")
 		}
 		time.Sleep(sleepDuration)
 	}
+
 	groupsCNPCache.UpdateCNP(cnp)
-	_, err := updateOrCreateCNP(derivativeCNP)
+	if clusterScoped {
+		_, err = updateOrCreateCCNP(derivativeCCNP)
+	} else {
+		_, err = updateOrCreateCNP(derivativeCNP)
+	}
+
 	if err != nil {
-		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, err)
+		statusErr := updateDerivativeStatus(cnp, derivativePolicy.GetName(), err, clusterScoped)
 		if statusErr != nil {
 			metrics.PolicyImportErrors.Inc()
-			scopedLog.WithError(err).Error("Cannot update CNP status for derivative policy")
+			scopedLog.WithError(err).Error("Cannot update status for derivative policy")
 		}
 		return statusErr
 	}
 
-	err = updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, nil)
+	err = updateDerivativeStatus(cnp, derivativePolicy.GetName(), nil, clusterScoped)
 	if err != nil {
-		scopedLog.WithError(err).Error("Cannot update CNP status for derivative policy")
+		scopedLog.WithError(err).Error("Cannot update status for derivative policy")
 	}
 	return err
 }

--- a/pkg/policy/groups/helpers.go
+++ b/pkg/policy/groups/helpers.go
@@ -22,7 +22,7 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -35,11 +35,10 @@ var (
 	blockOwnerDeletionPtr = true
 )
 
-func getDerivativeName(cnp *cilium_v2.CiliumNetworkPolicy) string {
-	return fmt.Sprintf(
-		"%s-togroups-%s",
-		cnp.GetObjectMeta().GetName(),
-		cnp.GetObjectMeta().GetUID())
+func getDerivativeName(obj v1.Object) string {
+	return fmt.Sprintf("%s-togroups-%s",
+		obj.GetName(),
+		obj.GetUID())
 }
 
 // createDerivativeCNP will return a new CNP based on the given rule.
@@ -64,9 +63,18 @@ func createDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 		},
 	}
 
-	rules, err := cnp.Parse()
+	var (
+		rules api.Rules
+		err   error
+	)
+
+	rules, err = cnp.Parse()
+
 	if err != nil {
-		return nil, fmt.Errorf("Cannot parse policies: %s", err)
+		// We return a valid pointer for derivative policy here instead of nil.
+		// This object is used to get generated name for the derivative policy
+		// when updating the status of the network policy.
+		return derivativeCNP, fmt.Errorf("cannot parse CNP: %v", err)
 	}
 
 	derivativeCNP.Specs = make(api.Rules, len(rules))
@@ -90,6 +98,70 @@ func createDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 	return derivativeCNP, nil
 }
 
+// createDerivativeCCNP will return a new CCNP based on the given rule.
+func createDerivativeCCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumClusterwideNetworkPolicy, error) {
+	ccnp := &cilium_v2.CiliumClusterwideNetworkPolicy{
+		CiliumNetworkPolicy: cnp,
+		Status:              cnp.Status,
+	}
+
+	// CCNP informer may provide a CCNP object without APIVersion or Kind.
+	// Setting manually to make sure that the derivative policy works ok.
+	derivativeCCNP := &cilium_v2.CiliumClusterwideNetworkPolicy{
+		CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      getDerivativeName(ccnp),
+				Namespace: ccnp.ObjectMeta.Namespace,
+				OwnerReferences: []v1.OwnerReference{{
+					APIVersion:         cilium_v2.SchemeGroupVersion.String(),
+					Kind:               cilium_v2.CCNPKindDefinition,
+					Name:               ccnp.ObjectMeta.Name,
+					UID:                ccnp.ObjectMeta.UID,
+					BlockOwnerDeletion: &blockOwnerDeletionPtr,
+				}},
+				Labels: map[string]string{
+					parentCNP:  string(ccnp.ObjectMeta.UID),
+					cnpKindKey: cnpKindName,
+				},
+			},
+		},
+	}
+
+	var (
+		rules api.Rules
+		err   error
+	)
+
+	rules, err = ccnp.Parse()
+
+	if err != nil {
+		// We return a valid pointer for derivative policy here instead of nil.
+		// This object is used to get generated name for the derivative policy
+		// when updating the status of the network policy.
+		return derivativeCCNP, fmt.Errorf("cannot parse CCNP: %v", err)
+	}
+
+	derivativeCCNP.Specs = make(api.Rules, len(rules))
+	for i, rule := range rules {
+		if rule.RequiresDerivative() {
+			derivativeCCNP.Specs[i] = denyEgressRule()
+		}
+	}
+
+	for i, rule := range rules {
+		if !rule.RequiresDerivative() {
+			derivativeCCNP.Specs[i] = rule
+			continue
+		}
+		newRule, err := rule.CreateDerivative(ctx)
+		if err != nil {
+			return derivativeCCNP, err
+		}
+		derivativeCCNP.Specs[i] = newRule
+	}
+	return derivativeCCNP, nil
+}
+
 func denyEgressRule() *api.Rule {
 	return &api.Rule{
 		Egress: []api.EgressRule{},
@@ -109,7 +181,23 @@ func updateOrCreateCNP(cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumNet
 	return k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).Create(context.TODO(), cnp, v1.CreateOptions{})
 }
 
-func updateDerivativeStatus(cnp *cilium_v2.CiliumNetworkPolicy, derivativeName string, err error) error {
+func updateOrCreateCCNP(ccnp *cilium_v2.CiliumClusterwideNetworkPolicy) (*cilium_v2.CiliumClusterwideNetworkPolicy, error) {
+	k8sCCNP, err := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().
+		Get(context.TODO(), ccnp.ObjectMeta.Name, v1.GetOptions{})
+	if err == nil {
+		k8sCCNP.ObjectMeta.Labels = ccnp.ObjectMeta.Labels
+		k8sCCNP.Spec = ccnp.Spec
+		k8sCCNP.Specs = ccnp.Specs
+		k8sCCNP.Status = cilium_v2.CiliumNetworkPolicyStatus{}
+
+		return k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().Update(context.TODO(), k8sCCNP, v1.UpdateOptions{})
+	}
+
+	return k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().
+		Create(context.TODO(), ccnp, v1.CreateOptions{})
+}
+
+func updateDerivativeStatus(cnp *cilium_v2.CiliumNetworkPolicy, derivativeName string, err error, clusterScoped bool) error {
 	status := cilium_v2.CiliumNetworkPolicyNodeStatus{
 		LastUpdated: cilium_v2.NewTimestamp(),
 		Enforcing:   false,
@@ -122,24 +210,74 @@ func updateDerivativeStatus(cnp *cilium_v2.CiliumNetworkPolicy, derivativeName s
 		status.OK = true
 	}
 
+	if clusterScoped {
+		return updateDerivativeCCNPStatus(cnp, status, derivativeName)
+	}
+
+	return updateDerivativeCNPStatus(cnp, status, derivativeName)
+}
+
+func updateDerivativeCNPStatus(cnp *cilium_v2.CiliumNetworkPolicy, status cilium_v2.CiliumNetworkPolicyNodeStatus,
+	derivativeName string) error {
 	// This CNP can be modified by cilium agent or operator. To be able to push
 	// the status correctly fetch the last version to avoid updates issues.
-	k8sCNPStatus, clientErr := k8s.CiliumClient().CiliumV2().
-		CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).
+	k8sCNP, clientErr := k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).
 		Get(context.TODO(), cnp.ObjectMeta.Name, v1.GetOptions{})
+
 	if clientErr != nil {
-		return fmt.Errorf("Cannot get Kubernetes policy: %s", clientErr)
+		return fmt.Errorf("cannot get Kubernetes policy: %v", clientErr)
 	}
-	if k8sCNPStatus.ObjectMeta.UID != cnp.ObjectMeta.UID {
+
+	if k8sCNP.ObjectMeta.UID != cnp.ObjectMeta.UID {
 		// This case should not happen, but if the UID does not match make sure
 		// that the new policy is not in the cache to not loop over it. The
 		// kubernetes watcher should take care about that.
-		groupsCNPCache.DeleteCNP(k8sCNPStatus)
-		return fmt.Errorf("Policy UID mistmatch")
+		groupsCNPCache.DeleteCNP(k8sCNP)
+		return fmt.Errorf("policy UID mistmatch")
 	}
-	k8sCNPStatus.SetDerivedPolicyStatus(derivativeName, status)
-	groupsCNPCache.UpdateCNP(k8sCNPStatus)
-	// TODO: switch to JSON Patch
-	_, err = k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).UpdateStatus(context.TODO(), cnp, v1.UpdateOptions{})
+
+	k8sCNP.SetDerivedPolicyStatus(derivativeName, status)
+	groupsCNPCache.UpdateCNP(k8sCNP)
+
+	// TODO: Switch to JSON patch.
+	_, err := k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).
+		UpdateStatus(context.TODO(), k8sCNP, v1.UpdateOptions{})
+
 	return err
+}
+
+func updateDerivativeCCNPStatus(cnp *cilium_v2.CiliumNetworkPolicy, status cilium_v2.CiliumNetworkPolicyNodeStatus,
+	derivativeName string) error {
+	k8sCCNP, clientErr := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().
+		Get(context.TODO(), cnp.ObjectMeta.Name, v1.GetOptions{})
+
+	if clientErr != nil {
+		return fmt.Errorf("cannot get Kubernetes policy: %v", clientErr)
+	}
+
+	if k8sCCNP.ObjectMeta.UID != cnp.ObjectMeta.UID {
+		// This case should not happen, but if the UID does not match make sure
+		// that the new policy is not in the cache to not loop over it. The
+		// kubernetes watcher should take care of that.
+		groupsCNPCache.DeleteCNP(&cilium_v2.CiliumNetworkPolicy{
+			ObjectMeta: k8sCCNP.ObjectMeta,
+		})
+		return fmt.Errorf("policy UID mistmatch")
+	}
+
+	k8sCCNP.SetDerivedPolicyStatus(derivativeName, status)
+	groupsCNPCache.UpdateCNP(&cilium_v2.CiliumNetworkPolicy{
+		TypeMeta:   k8sCCNP.TypeMeta,
+		ObjectMeta: k8sCCNP.ObjectMeta,
+		Spec:       k8sCCNP.Spec,
+		Specs:      k8sCCNP.Specs,
+		Status:     k8sCCNP.Status,
+	})
+
+	// TODO: Switch to JSON patch
+	_, err := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().
+		UpdateStatus(context.TODO(), k8sCCNP, v1.UpdateOptions{})
+
+	return err
+
 }

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -51,10 +51,10 @@ func getSamplePolicy(name, ns string) *cilium_v2.CiliumNetworkPolicy {
 func (s *GroupsTestSuite) TestCorrectDerivativeName(c *C) {
 	name := "test"
 	cnp := getSamplePolicy(name, "testns")
-	DerivativeCNP, err := createDerivativeCNP(context.TODO(), cnp)
+	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
 	c.Assert(err, IsNil)
 	c.Assert(
-		DerivativeCNP.ObjectMeta.Name,
+		derivativeCNP.ObjectMeta.Name,
 		Equals,
 		fmt.Sprintf("%s-togroups-%s", name, cnp.ObjectMeta.UID))
 }
@@ -75,14 +75,13 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
 		},
 	}
 
-	DerivativeCNP, err := createDerivativeCNP(context.TODO(), cnp)
+	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
 	c.Assert(err, IsNil)
-	c.Assert(DerivativeCNP.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
-	c.Assert(len(DerivativeCNP.Specs), Equals, 1)
+	c.Assert(derivativeCNP.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
+	c.Assert(len(derivativeCNP.Specs), Equals, 1)
 }
 
 func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
-
 	cb := func(ctx context.Context, group *api.ToGroups) ([]net.IP, error) {
 		return []net.IP{net.ParseIP("192.168.1.1")}, nil
 	}
@@ -113,10 +112,10 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
 		},
 	}
 
-	DerivativeCNP, err := createDerivativeCNP(context.TODO(), cnp)
+	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
 	c.Assert(err, IsNil)
-	c.Assert(DerivativeCNP.Spec, IsNil)
-	c.Assert(len(DerivativeCNP.Specs), Equals, 1)
-	c.Assert(DerivativeCNP.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
-	c.Assert(len(DerivativeCNP.Specs[0].Egress[0].ToGroups), Equals, 0)
+	c.Assert(derivativeCNP.Spec, IsNil)
+	c.Assert(len(derivativeCNP.Specs), Equals, 1)
+	c.Assert(derivativeCNP.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
+	c.Assert(len(derivativeCNP.Specs[0].Egress[0].ToGroups), Equals, 0)
 }

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -51,19 +51,28 @@ func getSamplePolicy(name, ns string) *cilium_v2.CiliumNetworkPolicy {
 func (s *GroupsTestSuite) TestCorrectDerivativeName(c *C) {
 	name := "test"
 	cnp := getSamplePolicy(name, "testns")
-	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), cnp)
 	c.Assert(err, IsNil)
 	c.Assert(
-		derivativeCNP.ObjectMeta.Name,
+		cnpDerivedPolicy.ObjectMeta.Name,
 		Equals,
 		fmt.Sprintf("%s-togroups-%s", name, cnp.ObjectMeta.UID))
+
+	// Test clusterwide policy helper functions
+	ccnpName := "ccnp-test"
+	ccnp := getSamplePolicy(ccnpName, "")
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), ccnp)
+
+	c.Assert(err, IsNil)
+	c.Assert(
+		ccnpDerivedPolicy.ObjectMeta.Name,
+		Equals,
+		fmt.Sprintf("%s-togroups-%s", ccnpName, ccnp.ObjectMeta.UID),
+	)
 }
 
 func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
-	name := "test"
-	cnp := getSamplePolicy(name, "testns")
-
-	cnp.Spec.Egress = []api.EgressRule{
+	egressRule := []api.EgressRule{
 		{
 			ToPorts: []api.PortRule{
 				{
@@ -75,10 +84,25 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
 		},
 	}
 
-	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
+	name := "test"
+	cnp := getSamplePolicy(name, "testns")
+
+	cnp.Spec.Egress = egressRule
+
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), cnp)
 	c.Assert(err, IsNil)
-	c.Assert(derivativeCNP.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
-	c.Assert(len(derivativeCNP.Specs), Equals, 1)
+	c.Assert(cnpDerivedPolicy.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
+	c.Assert(len(cnpDerivedPolicy.Specs), Equals, 1)
+
+	// Clusterwide policies
+	ccnpName := "ccnp-test"
+	ccnp := getSamplePolicy(ccnpName, "")
+	ccnp.Spec.Egress = egressRule
+
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), ccnp)
+	c.Assert(err, IsNil)
+	c.Assert(ccnpDerivedPolicy.Specs[0].Egress, checker.DeepEquals, ccnp.Spec.Egress)
+	c.Assert(len(ccnpDerivedPolicy.Specs), Equals, 1)
 }
 
 func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
@@ -86,12 +110,7 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
 		return []net.IP{net.ParseIP("192.168.1.1")}, nil
 	}
 
-	api.RegisterToGroupsProvider(api.AWSProvider, cb)
-
-	name := "test"
-	cnp := getSamplePolicy(name, "testns")
-
-	cnp.Spec.Egress = []api.EgressRule{
+	egressRule := []api.EgressRule{
 		{
 			ToPorts: []api.PortRule{
 				{
@@ -112,10 +131,29 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
 		},
 	}
 
-	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
+	api.RegisterToGroupsProvider(api.AWSProvider, cb)
+
+	name := "test"
+	cnp := getSamplePolicy(name, "testns")
+
+	cnp.Spec.Egress = egressRule
+
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), cnp)
 	c.Assert(err, IsNil)
-	c.Assert(derivativeCNP.Spec, IsNil)
-	c.Assert(len(derivativeCNP.Specs), Equals, 1)
-	c.Assert(derivativeCNP.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
-	c.Assert(len(derivativeCNP.Specs[0].Egress[0].ToGroups), Equals, 0)
+	c.Assert(cnpDerivedPolicy.Spec, IsNil)
+	c.Assert(len(cnpDerivedPolicy.Specs), Equals, 1)
+	c.Assert(cnpDerivedPolicy.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
+	c.Assert(len(cnpDerivedPolicy.Specs[0].Egress[0].ToGroups), Equals, 0)
+
+	// Clusterwide policies
+	ccnpName := "ccnp-test"
+	ccnp := getSamplePolicy(ccnpName, "")
+	ccnp.Spec.Egress = egressRule
+
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), ccnp)
+	c.Assert(err, IsNil)
+	c.Assert(ccnpDerivedPolicy.Spec, IsNil)
+	c.Assert(len(ccnpDerivedPolicy.Specs), Equals, 1)
+	c.Assert(ccnpDerivedPolicy.Specs[0].Egress[0].ToPorts, checker.DeepEquals, ccnp.Spec.Egress[0].ToPorts)
+	c.Assert(len(ccnpDerivedPolicy.Specs[0].Egress[0].ToGroups), Equals, 0)
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -662,6 +662,37 @@ func (kub *Kubectl) GetNumCiliumNodes() int {
 	return len(strings.Split(res.SingleOut(), " ")) - sub
 }
 
+// CountMissedTailCalls returns the number of the sum of all drops due to
+// missed tail calls that happened on all Cilium-managed nodes.
+func (kub *Kubectl) CountMissedTailCalls() (int, error) {
+	ciliumPods, err := kub.GetCiliumPods(GetCiliumNamespace(GetCurrentIntegration()))
+	if err != nil {
+		return -1, err
+	}
+
+	totalMissedTailCalls := 0
+	for _, ciliumPod := range ciliumPods {
+		cmd := "cilium metrics list -o json | jq '.[] | select( .name == \"cilium_drop_count_total\" and .labels.reason == \"Missed tail call\" ).value'"
+		res := kub.CiliumExecContext(context.Background(), ciliumPod, cmd)
+		if !res.WasSuccessful() {
+			return -1, fmt.Errorf("Failed to run %s in pod %s: %s", cmd, ciliumPod, res.CombineOutput())
+		}
+		if res.Stdout() == "" {
+			return 0, nil
+		}
+
+		for _, cnt := range res.ByLines() {
+			nbMissedTailCalls, err := strconv.Atoi(cnt)
+			if err != nil {
+				return -1, err
+			}
+			totalMissedTailCalls += nbMissedTailCalls
+		}
+	}
+
+	return totalMissedTailCalls, nil
+}
+
 // CreateSecret is a wrapper around `kubernetes create secret
 // <resourceName>.
 func (kub *Kubectl) CreateSecret(secretType, name, namespace, args string) *CmdRes {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -495,6 +495,10 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		validateEndpointsConnection()
 		checkNoInteruptsInSVCFlows()
 
+		nbMissedTailCalls, err := kubectl.CountMissedTailCalls()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed to retrieve number of missed tail calls")
+		ExpectWithOffset(1, nbMissedTailCalls).To(BeNumerically("==", 0))
+
 		By("Downgrading cilium to %s image", oldHelmChartVersion)
 		// rollback cilium 1 because it's the version that we have started
 		// cilium with in this updates test.
@@ -516,6 +520,10 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 
 		validateEndpointsConnection()
 		checkNoInteruptsInSVCFlows()
+
+		nbMissedTailCalls, err = kubectl.CountMissedTailCalls()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed to retrieve number of missed tail calls")
+		ExpectWithOffset(1, nbMissedTailCalls).To(BeNumerically("==", 0))
 	}
 	return testfunc, cleanupCallback
 }


### PR DESCRIPTION
v1.8 backports 2020-09-09

 * #12920 -- pkg/policy: fix toGroups derivative policy for clusterwide policies (@fristonio)
 * #12946 -- pkg/logging: add a logfield to embed help messages when logging (@fristonio)
 * #13097 -- test: Detect missed tail calls on upgrade/downgrade test (@pchaigno)
 * #13036 -- k8s: honor the service.kubernetes.io/service-proxy-name label (@fristonio)
 * #12890 -- fix endpoint selection for wildcard to/fromEndpoint in CCNP (@fristonio)

Not included due to non-trivial conflicts. @tklauser will be doing a round of backports later to pick this up.

 * #12283 -- vendor: update github.com/google/gops to v0.3.10 (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12920 12946 13097 13036 12890; do contrib/backporting/set-labels.py $pr done 1.8; done
```