### PR TITLE
v1.7 backports 2020 09 09

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1202,8 +1202,8 @@ for a fully functional example including pods deployed to different namespaces.
 Example: Allow egress to kube-dns in kube-system namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example allows all pods in the namespace in which the policy is
-created to communicate with kube-dns on port 53/UDP in the ``kube-system``
+The following example allows all pods in the ``public`` namespace in which the
+policy is created to communicate with kube-dns on port 53/UDP in the ``kube-system``
 namespace.
 
 .. only:: html
@@ -1312,3 +1312,20 @@ namespace to pods matching the labels ``name=leia`` in any namespace.
 .. only:: epub or latex
 
         .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/clusterscope-policy.yaml
+
+Example: Allow all ingress to kube-dns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example allows all Cilium managed endpoints in the cluster to communicate
+with kube-dns on port 53/UDP in the ``kube-system`` namespace.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml

--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -151,11 +151,10 @@ func validateNPResources(
 				cnpName = cnp.GetName()
 			}
 			if err := validator(&cnp); err != nil {
-				log.Errorf("Validating %s '%s': unexpected validation error: %s",
-					shortName, cnpName, err)
+				log.WithField(shortName, cnpName).WithError(err).Error("Unexpected validation error")
 				policyErr = fmt.Errorf("Found invalid %s", shortName)
 			} else {
-				log.Infof("Validating %s '%s': OK!", shortName, cnpName)
+				log.WithField(shortName, cnpName).Info("Validation OK!")
 			}
 		}
 		if cnps.GetContinue() == "" {

--- a/examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+++ b/examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+description: "Policy for ingress allow to kube-dns from all Cilium managed endpoints in the cluster"
+metadata:
+  name: "wildcard-from-endpoints"
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: kube-system
+      k8s-app: kube-dns
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP

--- a/examples/policies/kubernetes/namespace/kubedns-policy.json
+++ b/examples/policies/kubernetes/namespace/kubedns-policy.json
@@ -1,8 +1,10 @@
 [
    {
-      "endpointSelector" : {
-         "matchLabels" : {}
-      },
+      "endpointSelector" :  {
+         "matchLabels": {
+            "k8s:io.kubernetes.pod.namespace": "public"
+         }
+     },
       "egress" : [
          {
             "toEndpoints" : [

--- a/examples/policies/kubernetes/namespace/kubedns-policy.yaml
+++ b/examples/policies/kubernetes/namespace/kubedns-policy.yaml
@@ -2,6 +2,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: "allow-to-kubedns"
+  namespace: public
 spec:
   endpointSelector:
     {}

--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy/groups"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -86,7 +86,7 @@ func enableCCNPWatcher() error {
 			AddFunc: func(obj interface{}) {
 				metrics.EventTSK8s.SetToCurrentTime()
 				if cnp := k8s.CopyObjToV2CNP(obj); cnp != nil {
-					groups.AddDerivativeCNPIfNeeded(cnp.CiliumNetworkPolicy)
+					groups.AddDerivativeCCNPIfNeeded(cnp.CiliumNetworkPolicy)
 					if kvstoreEnabled() {
 						ccnpStatusMgr.StartStatusHandler(cnp)
 					}
@@ -99,7 +99,7 @@ func enableCCNPWatcher() error {
 						if k8s.EqualV2CNP(oldCNP, newCNP) {
 							return
 						}
-						groups.UpdateDerivativeCNPIfNeeded(newCNP.CiliumNetworkPolicy, oldCNP.CiliumNetworkPolicy)
+						groups.UpdateDerivativeCCNPIfNeeded(newCNP.CiliumNetworkPolicy, oldCNP.CiliumNetworkPolicy)
 					}
 				}
 			},

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -93,8 +93,17 @@ func getEndpointSelector(namespace string, labelSelector *metav1.LabelSelector, 
 	// Those pods don't have any labels, so they don't have a namespace label either.
 	// Don't add a namespace label to those endpoint selectors, or we wouldn't be
 	// able to match on those pods.
-	if !matchesInit && !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) && namespace != "" {
-		es.AddMatch(podPrefixLbl, namespace)
+	if !matchesInit && !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) {
+		if namespace == "" {
+			// For a clusterwide policy if a namespace is not specified in the labels we add
+			// a selector to only match endpoints that contains a namespace label.
+			// This is to make sure that we are only allowing traffic for cilium managed k8s endpoints
+			// and even if a wildcard is provided in the selector we don't proceed with a truly
+			// empty(allow all) endpoint selector for the policy.
+			es.AddMatchExpression(podPrefixLbl, metav1.LabelSelectorOpExists, []string{})
+		} else {
+			es.AddMatch(podPrefixLbl, namespace)
+		}
 	}
 
 	return es

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -286,6 +286,78 @@ func Test_ParseToCiliumRule(t *testing.T) {
 				},
 			),
 		},
+		{
+			// For a clusterwide policy the namespace is empty but when a to/fromEndpoint
+			// rule is added that represents a wildcard we add a match expression
+			// to account only for endpoints managed by cilium.
+			name: "wildcard-to-from-endpoints-with-ccnp",
+			args: args{
+				// Empty namespace for Clusterwide policy
+				namespace: "",
+				uid:       uuid,
+				rule: &api.Rule{
+					EndpointSelector: api.NewESFromMatchRequirements(
+						map[string]string{
+							role: "backend",
+						},
+						nil,
+					),
+					Ingress: []api.IngressRule{
+						{
+							FromEndpoints: []api.EndpointSelector{
+								{
+									LabelSelector: &metav1.LabelSelector{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: api.NewRule().WithEndpointSelector(
+				api.NewESFromMatchRequirements(
+					map[string]string{
+						role: "backend",
+					},
+					nil,
+				),
+			).WithIngressRules(
+				[]api.IngressRule{
+					{
+						FromEndpoints: []api.EndpointSelector{
+							api.NewESFromK8sLabelSelector(
+								labels.LabelSourceK8sKeyPrefix,
+								&metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      k8sConst.PodNamespaceLabel,
+											Operator: metav1.LabelSelectorOpExists,
+											Values:   []string{},
+										},
+									},
+								}),
+						},
+					},
+				},
+			).WithLabels(
+				labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumClusterwideNetworkPolicy",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "wildcard-to-from-endpoints-with-ccnp",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/k8s/apis/cilium.io/v2/validator/logfields.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/logfields.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "validator")

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -17,17 +17,21 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/go-openapi/validate"
+	"github.com/sirupsen/logrus"
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// NPValidator is a validator structure used to validate CNP.
+// NPValidator is a validator structure used to validate CNP and CCNP.
 type NPValidator struct {
 	cnpValidator  *validate.SchemaValidator
 	ccnpValidator *validate.SchemaValidator
@@ -102,10 +106,97 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 	return nil
 }
 
+var (
+	// We can remove the check for this warning once 1.9 is the oldest supported Cilium version.
+	warnWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
+		"with a wildcard to/from endpoint selector. The behavior of this selector has been " +
+		"changed. The selector now only allows traffic to/from Cilium managed K8s endpoints, " +
+		"instead of acting as a truly empty endpoint selector allowing all traffic. To " +
+		"ensure that the policy behavior does not affect your workloads, consider adding " +
+		"another policy that allows traffic to/from world and cluster entities. For a more " +
+		"detailed discussion on the topic, see https://github.com/cilium/cilium/issues/12844"
+
+	logOnce sync.Once
+)
+
 // ValidateCCNP validates the given CCNP accordingly the CCNP validation schema.
 func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 	if errs := validation.ValidateCustomResource(nil, &ccnp, n.ccnpValidator); len(errs) > 0 {
 		return errs.ToAggregate()
 	}
+
+	logger := log.WithFields(logrus.Fields{
+		logfields.CiliumClusterwideNetworkPolicyName: ccnp.GetName(),
+	})
+
+	// At this point we have validated the custom resource with the new CRV.
+	// We can try converting it to the new CCNP type.
+	// This should not fail, so we are not returning any errors, just logging
+	// a warning.
+	ccnpBytes, err := ccnp.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	resCCNP := cilium_v2.CiliumClusterwideNetworkPolicy{}
+	err = json.Unmarshal(ccnpBytes, &resCCNP)
+	if err != nil {
+		return err
+	}
+
+	// Print the warninig only once per CCNP.
+	if resCCNP.Spec != nil {
+		if containsWildcardToFromEndpoint(resCCNP.Spec) {
+			logOnce.Do(func() {
+				logger.Warning(warnWildcardToFromEndpointMessage)
+			})
+			return nil
+		}
+	}
+
+	if resCCNP.Specs != nil {
+		for _, rule := range resCCNP.Specs {
+			if containsWildcardToFromEndpoint(rule) {
+				logOnce.Do(func() {
+					logger.Warning(warnWildcardToFromEndpointMessage)
+				})
+				return nil
+			}
+		}
+	}
+
 	return nil
+}
+
+// containsWildcardToFromEndpoint returns true if a CCNP contains an empty endpoint selector
+// in ingress/egress rules.
+// For more information - https://github.com/cilium/cilium/issues/12844#issuecomment-672074170
+func containsWildcardToFromEndpoint(rule *api.Rule) bool {
+	if len(rule.Ingress) > 0 {
+		for _, r := range rule.Ingress {
+			// We only check for the presence of wildcard to/fromEndpoints
+			// in the network policy spec.
+			if len(r.FromEndpoints) > 0 {
+				for _, epSel := range r.FromEndpoints {
+					if epSel.IsWildcard() {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	if len(rule.Egress) > 0 {
+		for _, r := range rule.Egress {
+			if len(r.ToEndpoints) > 0 {
+				for _, epSel := range r.ToEndpoints {
+					if epSel.IsWildcard() {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -228,6 +228,9 @@ const (
 	// CiliumNetworkPolicyName is the name of a CiliumNetworkPolicy
 	CiliumNetworkPolicyName = "ciliumNetworkPolicyName"
 
+	// CiliumClusterwideNetworkPolicyName is the name of the CiliumClusterWideNetworkPolicy
+	CiliumClusterwideNetworkPolicyName = "ciliumClusterwideNetworkPolicyName"
+
 	// BPFMapKey is a key from a BPF map
 	BPFMapKey = "bpfMapKey"
 

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -110,6 +110,8 @@ type EgressRule struct {
 
 	// ToServices is a list of services to which the endpoint subject
 	// to the rule is allowed to initiate connections.
+	// Currently Cilium only supports toServices for K8s services without
+	// selectors.
 	//
 	// Example:
 	// Any endpoint with the label "app=backend-app" is allowed to

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -287,6 +287,20 @@ func (n *EndpointSelector) AddMatch(key, value string) {
 	n.cachedLabelSelectorString = n.LabelSelector.String()
 }
 
+// AddMatchExpression adds a match expression to label selector of the endpoint selector.
+func (n *EndpointSelector) AddMatchExpression(key string, op metav1.LabelSelectorOperator, values []string) {
+	n.MatchExpressions = append(n.MatchExpressions, metav1.LabelSelectorRequirement{
+		Key:      key,
+		Operator: op,
+		Values:   values,
+	})
+
+	// Update cache of the EndopintSelector from the embedded label selector.
+	// This is to make sure we have updates caches containing the required selectors.
+	n.requirements = labelSelectorToRequirements(n.LabelSelector)
+	n.cachedLabelSelectorString = n.LabelSelector.String()
+}
+
 // Matches returns true if the endpoint selector Matches the `lblsToMatch`.
 // Returns always true if the endpoint selector contains the reserved label for
 // "all".

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -40,10 +40,10 @@ var (
 	controllerManager = controller.NewManager()
 )
 
-// AddDerivativeCNPIfNeeded will create a new CNP if the given CNP has any rule
+// AddDerivativeCNPIfNeeded will create a new CNP if the given CNP has any rules
 // that need to create a new derivative policy.
 // It returns a boolean, true in case that all actions are correct, false if
-// something fails
+// something fails.
 func AddDerivativeCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
 	if !cnp.RequiresDerivative() {
 		log.WithFields(logrus.Fields{
@@ -55,7 +55,27 @@ func AddDerivativeCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
 	controllerManager.UpdateController(fmt.Sprintf("add-derivative-cnp-%s", cnp.ObjectMeta.Name),
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return addDerivativeCNP(ctx, cnp)
+				return addDerivativePolicy(ctx, cnp, false)
+			},
+		})
+	return true
+}
+
+// AddDerivativeCCNPIfNeeded will create a new CCNP if the given NetworkPolicy has any rules
+// that need to create a new derivative policy.
+// It returns a boolean, true in case that all actions are correct, false if
+// something fails.
+func AddDerivativeCCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
+	if !cnp.RequiresDerivative() {
+		log.WithFields(logrus.Fields{
+			logfields.CiliumClusterwideNetworkPolicyName: cnp.ObjectMeta.Name,
+		}).Debug("CCNP does not have derivative policies, skipped")
+		return true
+	}
+	controllerManager.UpdateController(fmt.Sprintf("add-derivative-ccnp-%s", cnp.ObjectMeta.Name),
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				return addDerivativePolicy(ctx, cnp, true)
 			},
 		})
 	return true
@@ -65,14 +85,16 @@ func AddDerivativeCNPIfNeeded(cnp *cilium_v2.CiliumNetworkPolicy) bool {
 // any rule that needs to create a new derivative policy(eg: ToGroups). In case
 // that the new CNP does not have any derivative policy and the old one had
 // one, it will delete the old policy.
+// The function returns true if an update is required for the derivative policy
+// and false otherwise.
 func UpdateDerivativeCNPIfNeeded(newCNP *cilium_v2.CiliumNetworkPolicy, oldCNP *cilium_v2.CiliumNetworkPolicy) bool {
 	if !newCNP.RequiresDerivative() && oldCNP.RequiresDerivative() {
 		log.WithFields(logrus.Fields{
 			logfields.CiliumNetworkPolicyName: newCNP.ObjectMeta.Name,
 			logfields.K8sNamespace:            newCNP.ObjectMeta.Namespace,
-		}).Info("New CNP does not have derivative policy, but old had. Deleted old policies")
+		}).Info("New CNP does not have derivative policy, but old had. Deleting old policies")
 
-		controllerManager.UpdateController(fmt.Sprintf("delete-derivatve-cnp-%s", oldCNP.ObjectMeta.Name),
+		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-cnp-%s", oldCNP.ObjectMeta.Name),
 			controller.ControllerParams{
 				DoFunc: func(ctx context.Context) error {
 					return DeleteDerivativeCNP(oldCNP)
@@ -85,10 +107,44 @@ func UpdateDerivativeCNPIfNeeded(newCNP *cilium_v2.CiliumNetworkPolicy, oldCNP *
 		return false
 	}
 
-	controllerManager.UpdateController(fmt.Sprintf("CNP-Derivative-update-%s", newCNP.ObjectMeta.Name),
+	controllerManager.UpdateController(fmt.Sprintf("update-derivative-cnp-%s", newCNP.ObjectMeta.Name),
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return addDerivativeCNP(ctx, newCNP)
+				return addDerivativePolicy(ctx, newCNP, false)
+			},
+		})
+	return true
+}
+
+// UpdateDerivativeCCNPIfNeeded updates or creates a CCNP if the given CCNP has
+// any rule that needs to create a new derivative policy(eg: ToGroups). In case
+// that the new CCNP does not have any derivative policy and the old one had
+// one, it will delete the old policy.
+// The function returns true if an update is required for the derivative policy
+// and false otherwise.
+func UpdateDerivativeCCNPIfNeeded(newCCNP *cilium_v2.CiliumNetworkPolicy, oldCCNP *cilium_v2.CiliumNetworkPolicy) bool {
+	if !newCCNP.RequiresDerivative() && oldCCNP.RequiresDerivative() {
+		log.WithFields(logrus.Fields{
+			logfields.CiliumClusterwideNetworkPolicyName: newCCNP.ObjectMeta.Name,
+		}).Info("New CCNP does not have derivative policy, but old had. Deleting old policies")
+
+		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-ccnp-%s", oldCCNP.ObjectMeta.Name),
+			controller.ControllerParams{
+				DoFunc: func(ctx context.Context) error {
+					return DeleteDerivativeCCNP(oldCCNP)
+				},
+			})
+		return false
+	}
+
+	if !newCCNP.RequiresDerivative() {
+		return false
+	}
+
+	controllerManager.UpdateController(fmt.Sprintf("update-derivative-ccnp-%s", newCCNP.ObjectMeta.Name),
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				return addDerivativePolicy(ctx, newCCNP, true)
 			},
 		})
 	return true
@@ -103,7 +159,6 @@ func DeleteDerivativeFromCache(cnp *cilium_v2.CiliumNetworkPolicy) {
 // DeleteDerivativeCNP if the given policy has a derivative constraint,the
 // given CNP will be deleted from store and the cache.
 func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
-
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
@@ -126,15 +181,47 @@ func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
 	return nil
 }
 
-func addDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) error {
-
+// DeleteDerivativeCCNP if the given policy has a derivative constraint, the
+// given CCNP will be deleted from store and the cache.
+func DeleteDerivativeCCNP(ccnp *cilium_v2.CiliumNetworkPolicy) error {
 	scopedLog := log.WithFields(logrus.Fields{
-		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
-		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
+		logfields.CiliumClusterwideNetworkPolicyName: ccnp.ObjectMeta.Name,
 	})
 
-	var derivativeCNP *cilium_v2.CiliumNetworkPolicy
-	var derivativeErr error
+	if !ccnp.RequiresDerivative() {
+		scopedLog.Debug("CCNP does not have derivative policies, skipped")
+		return nil
+	}
+
+	err := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().DeleteCollection(
+		&v1.DeleteOptions{},
+		v1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", parentCNP, ccnp.ObjectMeta.UID)})
+	if err != nil {
+		return err
+	}
+
+	DeleteDerivativeFromCache(ccnp)
+	return nil
+}
+
+func addDerivativePolicy(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy, clusterScoped bool) error {
+	var (
+		scopedLog          *logrus.Entry
+		derivativePolicy   v1.Object
+		derivativeCNP      *cilium_v2.CiliumNetworkPolicy
+		derivativeCCNP     *cilium_v2.CiliumClusterwideNetworkPolicy
+		derivativeErr, err error
+	)
+	if clusterScoped {
+		scopedLog = log.WithFields(logrus.Fields{
+			logfields.CiliumClusterwideNetworkPolicyName: cnp.ObjectMeta.Name,
+		})
+	} else {
+		scopedLog = log.WithFields(logrus.Fields{
+			logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
+			logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
+		})
+	}
 
 	// The maxNumberOfAttempts is to not hit the limits of cloud providers API.
 	// Also, the derivativeErr is never returned, if not the controller will
@@ -145,32 +232,45 @@ func addDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) e
 	// the derivative status in the parent policy  will be updated with the
 	// error.
 	for numAttempts := 0; numAttempts <= maxNumberOfAttempts; numAttempts++ {
-		derivativeCNP, derivativeErr = createDerivativeCNP(ctx, cnp)
+		if clusterScoped {
+			derivativeCCNP, derivativeErr = createDerivativeCCNP(ctx, cnp)
+			derivativePolicy = derivativeCCNP
+		} else {
+			derivativeCNP, derivativeErr = createDerivativeCNP(ctx, cnp)
+			derivativePolicy = derivativeCNP
+		}
+
 		if derivativeErr == nil {
 			break
 		}
 		metrics.PolicyImportErrors.Inc()
 		scopedLog.WithError(derivativeErr).Error("Cannot create derivative rule. Installing deny-all rule.")
-		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, derivativeErr)
+		statusErr := updateDerivativeStatus(cnp, derivativePolicy.GetName(), derivativeErr, clusterScoped)
 		if statusErr != nil {
-			scopedLog.WithError(statusErr).Error("Cannot update CNP status for derivative policy")
+			scopedLog.WithError(statusErr).Error("Cannot update status for derivative policy")
 		}
 		time.Sleep(sleepDuration)
 	}
+
 	groupsCNPCache.UpdateCNP(cnp)
-	_, err := updateOrCreateCNP(derivativeCNP)
+	if clusterScoped {
+		_, err = updateOrCreateCCNP(derivativeCCNP)
+	} else {
+		_, err = updateOrCreateCNP(derivativeCNP)
+	}
+
 	if err != nil {
-		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, err)
+		statusErr := updateDerivativeStatus(cnp, derivativePolicy.GetName(), err, clusterScoped)
 		if statusErr != nil {
 			metrics.PolicyImportErrors.Inc()
-			scopedLog.WithError(err).Error("Cannot update CNP status for derivative policy")
+			scopedLog.WithError(err).Error("Cannot update status for derivative policy")
 		}
 		return statusErr
 	}
 
-	err = updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, nil)
+	err = updateDerivativeStatus(cnp, derivativePolicy.GetName(), nil, clusterScoped)
 	if err != nil {
-		scopedLog.WithError(err).Error("Cannot update CNP status for derivative policy")
+		scopedLog.WithError(err).Error("Cannot update status for derivative policy")
 	}
 	return err
 }

--- a/pkg/policy/groups/helpers.go
+++ b/pkg/policy/groups/helpers.go
@@ -22,7 +22,7 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -35,11 +35,10 @@ var (
 	blockOwnerDeletionPtr = true
 )
 
-func getDerivativeName(cnp *cilium_v2.CiliumNetworkPolicy) string {
-	return fmt.Sprintf(
-		"%s-togroups-%s",
-		cnp.GetObjectMeta().GetName(),
-		cnp.GetObjectMeta().GetUID())
+func getDerivativeName(obj v1.Object) string {
+	return fmt.Sprintf("%s-togroups-%s",
+		obj.GetName(),
+		obj.GetUID())
 }
 
 // createDerivativeCNP will return a new CNP based on the given rule.
@@ -64,9 +63,18 @@ func createDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 		},
 	}
 
-	rules, err := cnp.Parse()
+	var (
+		rules api.Rules
+		err   error
+	)
+
+	rules, err = cnp.Parse()
+
 	if err != nil {
-		return nil, fmt.Errorf("Cannot parse policies: %s", err)
+		// We return a valid pointer for derivative policy here instead of nil.
+		// This object is used to get generated name for the derivative policy
+		// when updating the status of the network policy.
+		return derivativeCNP, fmt.Errorf("cannot parse CNP: %v", err)
 	}
 
 	derivativeCNP.Specs = make(api.Rules, len(rules))
@@ -90,6 +98,70 @@ func createDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 	return derivativeCNP, nil
 }
 
+// createDerivativeCCNP will return a new CCNP based on the given rule.
+func createDerivativeCCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumClusterwideNetworkPolicy, error) {
+	ccnp := &cilium_v2.CiliumClusterwideNetworkPolicy{
+		CiliumNetworkPolicy: cnp,
+		Status:              cnp.Status,
+	}
+
+	// CCNP informer may provide a CCNP object without APIVersion or Kind.
+	// Setting manually to make sure that the derivative policy works ok.
+	derivativeCCNP := &cilium_v2.CiliumClusterwideNetworkPolicy{
+		CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      getDerivativeName(ccnp),
+				Namespace: ccnp.ObjectMeta.Namespace,
+				OwnerReferences: []v1.OwnerReference{{
+					APIVersion:         cilium_v2.SchemeGroupVersion.String(),
+					Kind:               cilium_v2.CCNPKindDefinition,
+					Name:               ccnp.ObjectMeta.Name,
+					UID:                ccnp.ObjectMeta.UID,
+					BlockOwnerDeletion: &blockOwnerDeletionPtr,
+				}},
+				Labels: map[string]string{
+					parentCNP:  string(ccnp.ObjectMeta.UID),
+					cnpKindKey: cnpKindName,
+				},
+			},
+		},
+	}
+
+	var (
+		rules api.Rules
+		err   error
+	)
+
+	rules, err = ccnp.Parse()
+
+	if err != nil {
+		// We return a valid pointer for derivative policy here instead of nil.
+		// This object is used to get generated name for the derivative policy
+		// when updating the status of the network policy.
+		return derivativeCCNP, fmt.Errorf("cannot parse CCNP: %v", err)
+	}
+
+	derivativeCCNP.Specs = make(api.Rules, len(rules))
+	for i, rule := range rules {
+		if rule.RequiresDerivative() {
+			derivativeCCNP.Specs[i] = denyEgressRule()
+		}
+	}
+
+	for i, rule := range rules {
+		if !rule.RequiresDerivative() {
+			derivativeCCNP.Specs[i] = rule
+			continue
+		}
+		newRule, err := rule.CreateDerivative(ctx)
+		if err != nil {
+			return derivativeCCNP, err
+		}
+		derivativeCCNP.Specs[i] = newRule
+	}
+	return derivativeCCNP, nil
+}
+
 func denyEgressRule() *api.Rule {
 	return &api.Rule{
 		Egress: []api.EgressRule{},
@@ -109,7 +181,22 @@ func updateOrCreateCNP(cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumNet
 	return k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).Create(cnp)
 }
 
-func updateDerivativeStatus(cnp *cilium_v2.CiliumNetworkPolicy, derivativeName string, err error) error {
+func updateOrCreateCCNP(ccnp *cilium_v2.CiliumClusterwideNetworkPolicy) (*cilium_v2.CiliumClusterwideNetworkPolicy, error) {
+	k8sCCNP, err := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().
+		Get(ccnp.ObjectMeta.Name, v1.GetOptions{})
+	if err == nil {
+		k8sCCNP.ObjectMeta.Labels = ccnp.ObjectMeta.Labels
+		k8sCCNP.Spec = ccnp.Spec
+		k8sCCNP.Specs = ccnp.Specs
+		k8sCCNP.Status = cilium_v2.CiliumNetworkPolicyStatus{}
+
+		return k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().Update(k8sCCNP)
+	}
+
+	return k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().Create(ccnp)
+}
+
+func updateDerivativeStatus(cnp *cilium_v2.CiliumNetworkPolicy, derivativeName string, err error, clusterScoped bool) error {
 	status := cilium_v2.CiliumNetworkPolicyNodeStatus{
 		LastUpdated: cilium_v2.NewTimestamp(),
 		Enforcing:   false,
@@ -122,24 +209,73 @@ func updateDerivativeStatus(cnp *cilium_v2.CiliumNetworkPolicy, derivativeName s
 		status.OK = true
 	}
 
+	if clusterScoped {
+		return updateDerivativeCCNPStatus(cnp, status, derivativeName)
+	}
+
+	return updateDerivativeCNPStatus(cnp, status, derivativeName)
+}
+
+func updateDerivativeCNPStatus(cnp *cilium_v2.CiliumNetworkPolicy, status cilium_v2.CiliumNetworkPolicyNodeStatus,
+	derivativeName string) error {
 	// This CNP can be modified by cilium agent or operator. To be able to push
 	// the status correctly fetch the last version to avoid updates issues.
-	k8sCNPStatus, clientErr := k8s.CiliumClient().CiliumV2().
+	k8sCNP, clientErr := k8s.CiliumClient().CiliumV2().
 		CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).
 		Get(cnp.ObjectMeta.Name, v1.GetOptions{})
+
 	if clientErr != nil {
-		return fmt.Errorf("Cannot get Kubernetes policy: %s", clientErr)
+		return fmt.Errorf("cannot get Kubernetes policy: %v", clientErr)
 	}
-	if k8sCNPStatus.ObjectMeta.UID != cnp.ObjectMeta.UID {
+
+	if k8sCNP.ObjectMeta.UID != cnp.ObjectMeta.UID {
 		// This case should not happen, but if the UID does not match make sure
 		// that the new policy is not in the cache to not loop over it. The
 		// kubernetes watcher should take care about that.
-		groupsCNPCache.DeleteCNP(k8sCNPStatus)
-		return fmt.Errorf("Policy UID mistmatch")
+		groupsCNPCache.DeleteCNP(k8sCNP)
+		return fmt.Errorf("policy UID mistmatch")
 	}
-	k8sCNPStatus.SetDerivedPolicyStatus(derivativeName, status)
-	groupsCNPCache.UpdateCNP(k8sCNPStatus)
-	// TODO: switch to JSON Patch
-	_, err = k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).UpdateStatus(cnp)
+
+	k8sCNP.SetDerivedPolicyStatus(derivativeName, status)
+	groupsCNPCache.UpdateCNP(k8sCNP)
+
+	// TODO: Switch to JSON patch.
+	_, err := k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).UpdateStatus(k8sCNP)
+
 	return err
+}
+
+func updateDerivativeCCNPStatus(cnp *cilium_v2.CiliumNetworkPolicy, status cilium_v2.CiliumNetworkPolicyNodeStatus,
+	derivativeName string) error {
+	k8sCCNP, clientErr := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().
+		Get(cnp.ObjectMeta.Name, v1.GetOptions{})
+
+	if clientErr != nil {
+		return fmt.Errorf("cannot get Kubernetes policy: %v", clientErr)
+	}
+
+	if k8sCCNP.ObjectMeta.UID != cnp.ObjectMeta.UID {
+		// This case should not happen, but if the UID does not match make sure
+		// that the new policy is not in the cache to not loop over it. The
+		// kubernetes watcher should take care of that.
+		groupsCNPCache.DeleteCNP(&cilium_v2.CiliumNetworkPolicy{
+			ObjectMeta: k8sCCNP.ObjectMeta,
+		})
+		return fmt.Errorf("policy UID mistmatch")
+	}
+
+	k8sCCNP.SetDerivedPolicyStatus(derivativeName, status)
+	groupsCNPCache.UpdateCNP(&cilium_v2.CiliumNetworkPolicy{
+		TypeMeta:   k8sCCNP.TypeMeta,
+		ObjectMeta: k8sCCNP.ObjectMeta,
+		Spec:       k8sCCNP.Spec,
+		Specs:      k8sCCNP.Specs,
+		Status:     k8sCCNP.Status,
+	})
+
+	// TODO: Switch to JSON patch
+	_, err := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().UpdateStatus(k8sCCNP)
+
+	return err
+
 }

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -51,10 +51,10 @@ func getSamplePolicy(name, ns string) *cilium_v2.CiliumNetworkPolicy {
 func (s *GroupsTestSuite) TestCorrectDerivativeName(c *C) {
 	name := "test"
 	cnp := getSamplePolicy(name, "testns")
-	DerivativeCNP, err := createDerivativeCNP(context.TODO(), cnp)
+	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
 	c.Assert(err, IsNil)
 	c.Assert(
-		DerivativeCNP.ObjectMeta.Name,
+		derivativeCNP.ObjectMeta.Name,
 		Equals,
 		fmt.Sprintf("%s-togroups-%s", name, cnp.ObjectMeta.UID))
 }
@@ -75,14 +75,13 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
 		},
 	}
 
-	DerivativeCNP, err := createDerivativeCNP(context.TODO(), cnp)
+	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
 	c.Assert(err, IsNil)
-	c.Assert(DerivativeCNP.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
-	c.Assert(len(DerivativeCNP.Specs), Equals, 1)
+	c.Assert(derivativeCNP.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
+	c.Assert(len(derivativeCNP.Specs), Equals, 1)
 }
 
 func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
-
 	cb := func(ctx context.Context, group *api.ToGroups) ([]net.IP, error) {
 		return []net.IP{net.ParseIP("192.168.1.1")}, nil
 	}
@@ -113,10 +112,10 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
 		},
 	}
 
-	DerivativeCNP, err := createDerivativeCNP(context.TODO(), cnp)
+	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
 	c.Assert(err, IsNil)
-	c.Assert(DerivativeCNP.Spec, IsNil)
-	c.Assert(len(DerivativeCNP.Specs), Equals, 1)
-	c.Assert(DerivativeCNP.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
-	c.Assert(len(DerivativeCNP.Specs[0].Egress[0].ToGroups), Equals, 0)
+	c.Assert(derivativeCNP.Spec, IsNil)
+	c.Assert(len(derivativeCNP.Specs), Equals, 1)
+	c.Assert(derivativeCNP.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
+	c.Assert(len(derivativeCNP.Specs[0].Egress[0].ToGroups), Equals, 0)
 }

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -51,19 +51,28 @@ func getSamplePolicy(name, ns string) *cilium_v2.CiliumNetworkPolicy {
 func (s *GroupsTestSuite) TestCorrectDerivativeName(c *C) {
 	name := "test"
 	cnp := getSamplePolicy(name, "testns")
-	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), cnp)
 	c.Assert(err, IsNil)
 	c.Assert(
-		derivativeCNP.ObjectMeta.Name,
+		cnpDerivedPolicy.ObjectMeta.Name,
 		Equals,
 		fmt.Sprintf("%s-togroups-%s", name, cnp.ObjectMeta.UID))
+
+	// Test clusterwide policy helper functions
+	ccnpName := "ccnp-test"
+	ccnp := getSamplePolicy(ccnpName, "")
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), ccnp)
+
+	c.Assert(err, IsNil)
+	c.Assert(
+		ccnpDerivedPolicy.ObjectMeta.Name,
+		Equals,
+		fmt.Sprintf("%s-togroups-%s", ccnpName, ccnp.ObjectMeta.UID),
+	)
 }
 
 func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
-	name := "test"
-	cnp := getSamplePolicy(name, "testns")
-
-	cnp.Spec.Egress = []api.EgressRule{
+	egressRule := []api.EgressRule{
 		{
 			ToPorts: []api.PortRule{
 				{
@@ -75,10 +84,25 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
 		},
 	}
 
-	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
+	name := "test"
+	cnp := getSamplePolicy(name, "testns")
+
+	cnp.Spec.Egress = egressRule
+
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), cnp)
 	c.Assert(err, IsNil)
-	c.Assert(derivativeCNP.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
-	c.Assert(len(derivativeCNP.Specs), Equals, 1)
+	c.Assert(cnpDerivedPolicy.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
+	c.Assert(len(cnpDerivedPolicy.Specs), Equals, 1)
+
+	// Clusterwide policies
+	ccnpName := "ccnp-test"
+	ccnp := getSamplePolicy(ccnpName, "")
+	ccnp.Spec.Egress = egressRule
+
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), ccnp)
+	c.Assert(err, IsNil)
+	c.Assert(ccnpDerivedPolicy.Specs[0].Egress, checker.DeepEquals, ccnp.Spec.Egress)
+	c.Assert(len(ccnpDerivedPolicy.Specs), Equals, 1)
 }
 
 func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
@@ -86,12 +110,7 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
 		return []net.IP{net.ParseIP("192.168.1.1")}, nil
 	}
 
-	api.RegisterToGroupsProvider(api.AWSProvider, cb)
-
-	name := "test"
-	cnp := getSamplePolicy(name, "testns")
-
-	cnp.Spec.Egress = []api.EgressRule{
+	egressRule := []api.EgressRule{
 		{
 			ToPorts: []api.PortRule{
 				{
@@ -112,10 +131,29 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
 		},
 	}
 
-	derivativeCNP, err := createDerivativeCNP(context.TODO(), cnp, false)
+	api.RegisterToGroupsProvider(api.AWSProvider, cb)
+
+	name := "test"
+	cnp := getSamplePolicy(name, "testns")
+
+	cnp.Spec.Egress = egressRule
+
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), cnp)
 	c.Assert(err, IsNil)
-	c.Assert(derivativeCNP.Spec, IsNil)
-	c.Assert(len(derivativeCNP.Specs), Equals, 1)
-	c.Assert(derivativeCNP.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
-	c.Assert(len(derivativeCNP.Specs[0].Egress[0].ToGroups), Equals, 0)
+	c.Assert(cnpDerivedPolicy.Spec, IsNil)
+	c.Assert(len(cnpDerivedPolicy.Specs), Equals, 1)
+	c.Assert(cnpDerivedPolicy.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
+	c.Assert(len(cnpDerivedPolicy.Specs[0].Egress[0].ToGroups), Equals, 0)
+
+	// Clusterwide policies
+	ccnpName := "ccnp-test"
+	ccnp := getSamplePolicy(ccnpName, "")
+	ccnp.Spec.Egress = egressRule
+
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), ccnp)
+	c.Assert(err, IsNil)
+	c.Assert(ccnpDerivedPolicy.Spec, IsNil)
+	c.Assert(len(ccnpDerivedPolicy.Specs), Equals, 1)
+	c.Assert(ccnpDerivedPolicy.Specs[0].Egress[0].ToPorts, checker.DeepEquals, ccnp.Spec.Egress[0].ToPorts)
+	c.Assert(len(ccnpDerivedPolicy.Specs[0].Egress[0].ToGroups), Equals, 0)
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -332,6 +332,37 @@ func (kub *Kubectl) GetNumCiliumNodes() int {
 	return len(strings.Split(res.SingleOut(), " ")) - sub
 }
 
+// CountMissedTailCalls returns the number of the sum of all drops due to
+// missed tail calls that happened on all Cilium-managed nodes.
+func (kub *Kubectl) CountMissedTailCalls() (int, error) {
+	ciliumPods, err := kub.GetCiliumPods(GetCiliumNamespace(GetCurrentIntegration()))
+	if err != nil {
+		return -1, err
+	}
+
+	totalMissedTailCalls := 0
+	for _, ciliumPod := range ciliumPods {
+		cmd := "cilium metrics list -o json | jq '.[] | select( .name == \"cilium_drop_count_total\" and .labels.reason == \"Missed tail call\" ).value'"
+		res := kub.CiliumExecContext(context.Background(), ciliumPod, cmd)
+		if !res.WasSuccessful() {
+			return -1, fmt.Errorf("Failed to run %s in pod %s: %s", cmd, ciliumPod, res.CombineOutput())
+		}
+		if res.GetStdOut() == "" {
+			return 0, nil
+		}
+
+		for _, cnt := range res.ByLines() {
+			nbMissedTailCalls, err := strconv.Atoi(cnt)
+			if err != nil {
+				return -1, err
+			}
+			totalMissedTailCalls += nbMissedTailCalls
+		}
+	}
+
+	return totalMissedTailCalls, nil
+}
+
 // CreateSecret is a wrapper around `kubernetes create secret
 // <resourceName>.
 func (kub *Kubectl) CreateSecret(secretType, name, namespace, args string) *CmdRes {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -443,6 +443,10 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		validateEndpointsConnection()
 		checkNoInteruptsInSVCFlows()
 
+		nbMissedTailCalls, err := kubectl.CountMissedTailCalls()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed to retrieve number of missed tail calls")
+		ExpectWithOffset(1, nbMissedTailCalls).To(BeNumerically("==", 0))
+
 		By("Downgrading cilium to %s image", oldHelmChartVersion)
 		// rollback cilium 1 because it's the version that we have started
 		// cilium with in this updates test.
@@ -464,6 +468,10 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 
 		validateEndpointsConnection()
 		checkNoInteruptsInSVCFlows()
+
+		nbMissedTailCalls, err = kubectl.CountMissedTailCalls()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed to retrieve number of missed tail calls")
+		ExpectWithOffset(1, nbMissedTailCalls).To(BeNumerically("==", 0))
 	}
 	return testfunc, cleanupCallback
 }


### PR DESCRIPTION
v1.7 backports 2020-09-09

 * #12920 -- pkg/policy: fix toGroups derivative policy for clusterwide policies (@fristonio)
 * #13097 -- test: Detect missed tail calls on upgrade/downgrade test (@pchaigno)
 * #12890 -- fix endpoint selection for wildcard to/fromEndpoint in CCNP (@fristonio)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12920 13097 12890; do contrib/backporting/set-labels.py $pr done 1.7; done
```