### PR TITLE
Reduce operator memory usage when CNP status updates are disabled

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -35,6 +35,7 @@ cilium-operator-aws [flags]
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
   -h, --help                                      help for cilium-operator-aws

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -36,6 +36,7 @@ cilium-operator-azure [flags]
       --enable-ipv6                                Enable IPv6 support (default true)
       --enable-k8s-api-discovery                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                  Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                  Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                             Enable Prometheus metrics
   -h, --help                                       help for cilium-operator-azure
       --identity-allocation-mode string            Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -32,6 +32,7 @@ cilium-operator-generic [flags]
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
   -h, --help                                      help for cilium-operator-generic
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -39,6 +39,7 @@ cilium-operator [flags]
       --enable-ipv6                                Enable IPv6 support (default true)
       --enable-k8s-api-discovery                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                  Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                  Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                             Enable Prometheus metrics
       --eni-tags map                               ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
   -h, --help                                       help for cilium-operator

--- a/operator/cnp_event.go
+++ b/operator/cnp_event.go
@@ -26,6 +26,7 @@ import (
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/groups"
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -50,7 +51,11 @@ func init() {
 // enableCNPWatcher waits for the CiliumNetowrkPolicy CRD availability and then
 // garbage collects stale CiliumNetowrkPolicy status field entries.
 func enableCNPWatcher(apiextensionsK8sClient apiextensionsclientset.Interface) error {
-	log.Info("Starting to garbage collect stale CiliumNetworkPolicy status field entries...")
+	enableCNPStatusUpdates := kvstoreEnabled() && option.Config.K8sEventHandover && !option.Config.DisableCNPStatusUpdates
+	if enableCNPStatusUpdates {
+		log.Info("Starting a CNP Status handover from kvstore to k8s...")
+	}
+	log.Info("Starting CNP derivative handler...")
 
 	var (
 		cnpConverterFunc informer.ConvertFunc
@@ -67,7 +72,7 @@ func enableCNPWatcher(apiextensionsK8sClient apiextensionsclientset.Interface) e
 		cnpConverterFunc = k8s.ConvertToCNPWithStatus
 	}
 
-	if kvstoreEnabled() {
+	if enableCNPStatusUpdates {
 		cnpStatusMgr = k8s.NewCNPStatusEventHandler(cnpStore, cnpStatusUpdateInterval)
 		cnpSharedStore, err := store.JoinSharedStore(store.Configuration{
 			Prefix: k8s.CNPStatusesPath,
@@ -102,7 +107,7 @@ func enableCNPWatcher(apiextensionsK8sClient apiextensionsclientset.Interface) e
 					cnpCpy := cnp.DeepCopy()
 
 					groups.AddDerivativeCNPIfNeeded(cnpCpy.CiliumNetworkPolicy)
-					if kvstoreEnabled() {
+					if enableCNPStatusUpdates {
 						cnpStatusMgr.StartStatusHandler(cnpCpy)
 					}
 				}
@@ -134,7 +139,7 @@ func enableCNPWatcher(apiextensionsK8sClient apiextensionsclientset.Interface) e
 				// The derivative policy will be deleted by the parent but need
 				// to delete the cnp from the pooling.
 				groups.DeleteDerivativeFromCache(cnp.CiliumNetworkPolicy)
-				if kvstoreEnabled() {
+				if enableCNPStatusUpdates {
 					cnpStatusMgr.StopStatusHandler(cnp)
 				}
 			},

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -63,6 +63,13 @@ func init() {
 	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
 	option.BindEnv(option.ConfigDir)
 
+	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)`)
+	flags.MarkHidden(option.DisableCNPStatusUpdates)
+	option.BindEnv(option.DisableCNPStatusUpdates)
+
+	flags.Bool(option.K8sEventHandover, defaults.K8sEventHandover, "Enable k8s event handover to kvstore for improved scalability")
+	option.BindEnv(option.K8sEventHandover)
+
 	flags.Duration(operatorOption.CNPNodeStatusGCInterval, 2*time.Minute, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
 	option.BindEnv(operatorOption.CNPNodeStatusGCInterval)
 


### PR DESCRIPTION
The code for handling CNP status updates from other nodes via the
kvstore was previously not covered by the same option that enables this
functionality in the cilium-agent daemon. As such, this could cause the
logic to run, including goroutines for each CNP, in scenarios where this
logic is not in use.

Improve memory usage by disabling this functionality when it is disabled.

Backporters: The daemon option is not included in this patch as the
latest operator code seems to inherit all cilium-agent options automatically.
This is not the case for v1.7 at least so the option will need to be
added to the operator arguments.