### PR TITLE
[v1.7] Reduce operator memory usage when CNP status updates are disabled

### DIFF
--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -25,6 +25,7 @@ import (
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/groups"
 
 	v1 "k8s.io/api/core/v1"
@@ -44,7 +45,11 @@ var (
 // using CiliumNetworkPolicy itself, the entire implementation uses the methods
 // associcated with CiliumNetworkPolicy.
 func enableCCNPWatcher() error {
-	log.Info("Starting to garbage collect stale CiliumClusterwideNetworkPolicy status field entries...")
+	enableCNPStatusUpdates := kvstoreEnabled() && option.Config.K8sEventHandover && !option.Config.DisableCNPStatusUpdates
+	if enableCNPStatusUpdates {
+		log.Info("Starting a CCNP Status handover from etcd to k8s...")
+	}
+	log.Info("Starting CCNP derivative handler...")
 
 	var (
 		ccnpConverterFunc informer.ConvertFunc
@@ -61,7 +66,7 @@ func enableCCNPWatcher() error {
 		ccnpConverterFunc = k8s.ConvertToCCNPWithStatus
 	}
 
-	if kvstoreEnabled() {
+	if enableCNPStatusUpdates {
 		ccnpSharedStore, err := store.JoinSharedStore(store.Configuration{
 			Prefix: k8s.CCNPStatusesPath,
 			KeyCreator: func() store.Key {
@@ -87,7 +92,7 @@ func enableCCNPWatcher() error {
 				metrics.EventTSK8s.SetToCurrentTime()
 				if cnp := k8s.CopyObjToV2CNP(obj); cnp != nil {
 					groups.AddDerivativeCCNPIfNeeded(cnp.CiliumNetworkPolicy)
-					if kvstoreEnabled() {
+					if enableCNPStatusUpdates {
 						ccnpStatusMgr.StartStatusHandler(cnp)
 					}
 				}
@@ -122,7 +127,7 @@ func enableCCNPWatcher() error {
 				// The derivative policy will be deleted by the parent but need
 				// to delete the cnp from the pooling.
 				groups.DeleteDerivativeFromCache(cnp.CiliumNetworkPolicy)
-				if kvstoreEnabled() {
+				if enableCNPStatusUpdates {
 					ccnpStatusMgr.StopStatusHandler(cnp)
 				}
 			},

--- a/operator/main.go
+++ b/operator/main.go
@@ -207,9 +207,16 @@ func init() {
 	flags.MarkHidden(option.DisableCiliumEndpointCRDName)
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
 
+	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)`)
+	flags.MarkHidden(option.DisableCNPStatusUpdates)
+	option.BindEnv(option.DisableCNPStatusUpdates)
+
 	flags.BoolVar(&enableCNPNodeStatusGC, "cnp-node-status-gc", true, "Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
 	flags.BoolVar(&enableCCNPNodeStatusGC, "ccnp-node-status-gc", true, "Enable CiliumClusterwideNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
 	flags.DurationVar(&ciliumCNPNodeStatusGCInterval, "cnp-node-status-gc-interval", time.Minute*2, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
+
+	flags.Bool(option.K8sEventHandover, defaults.K8sEventHandover, "Enable k8s event handover to kvstore for improved scalability")
+	option.BindEnv(option.K8sEventHandover)
 
 	flags.DurationVar(&cnpStatusUpdateInterval, "cnp-status-update-interval", 1*time.Second, "interval between CNP status updates sent to the k8s-apiserver per-CNP")
 
@@ -252,7 +259,9 @@ func initConfig() {
 	option.Config.ClusterName = viper.GetString(option.ClusterName)
 	option.Config.ClusterID = viper.GetInt(option.ClusterIDName)
 	option.Config.DisableCiliumEndpointCRD = viper.GetBool(option.DisableCiliumEndpointCRDName)
+	option.Config.DisableCNPStatusUpdates = viper.GetBool(option.DisableCNPStatusUpdates)
 	option.Config.K8sNamespace = viper.GetString(option.K8sNamespaceName)
+	option.Config.K8sEventHandover = viper.GetBool(option.K8sEventHandover)
 	option.Config.AwsReleaseExcessIps = viper.GetBool(option.AwsReleaseExcessIps)
 	option.Config.EC2APIEndpoint = viper.GetString(option.EC2APIEndpoint)
 	option.Config.IdentityGCRateInterval = viper.GetDuration(option.IdentityGCRateInterval)


### PR DESCRIPTION
The code for handling CNP status updates from other nodes via the
kvstore was previously not covered by the same option that enables this
functionality in the cilium-agent daemon. As such, this could cause the
logic to run, including goroutines for each CNP, in scenarios where this
logic is not in use.

Improve memory usage by disabling this functionality when it is disabled.

Backports #13135 

```upstream-prs
$ for pr in 13135; do contrib/backporting/set-labels.py 13135 done 1.7; done
```