### PR TITLE
operator: fix invocation with `--help` option

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -113,8 +113,7 @@ var (
 
 			// Open socket for using gops to get stacktraces of the agent.
 			if err := gops.Listen(gops.Options{}); err != nil {
-				errorString := fmt.Sprintf("unable to start gops: %s", err)
-				fmt.Println(errorString)
+				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 				os.Exit(-1)
 			}
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -134,10 +134,9 @@ func main() {
 		doCleanup()
 	}()
 
-	// Open socket for using gops to get stacktraces of the agent.
+	// Open socket for using gops to get stacktraces of the operator.
 	if err := gops.Listen(gops.Options{}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
+		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 		os.Exit(-1)
 	}
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -69,6 +69,13 @@ var (
 				genMarkdown(cmd, cmdRefDir)
 				os.Exit(0)
 			}
+
+			// Open socket for using gops to get stacktraces of the operator.
+			if err := gops.Listen(gops.Options{}); err != nil {
+				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
+				os.Exit(-1)
+			}
+
 			initEnv()
 			runOperator()
 		},
@@ -133,12 +140,6 @@ func main() {
 		<-signals
 		doCleanup()
 	}()
-
-	// Open socket for using gops to get stacktraces of the operator.
-	if err := gops.Listen(gops.Options{}); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
-		os.Exit(-1)
-	}
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -48,8 +48,7 @@ var (
 func init() {
 	// Open socket for using gops to get stacktraces in case the tests deadlock.
 	if err := gops.Listen(gops.Options{ShutdownCleanup: true}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
+		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 		os.Exit(-1)
 	}
 


### PR DESCRIPTION
Fix the invocation of `cilium-operator --help` by initializing `gops` in the root command function and print the `gops` start failure messages to `stderr` instead of `stdout`.

See individual commit messages for details.