### PR TITLE
bpf: clean up .PHONY targets for Makefiles

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-.PHONY: all build_all subdirs check force preprocess assembly install clean $(BUILD_PERMUTATIONS_DEP)
+.PHONY: all build_all subdirs install clean
 
 SUBDIRS = sockops
 

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -30,6 +30,7 @@ HOST_STRIP ?= strip
 # the 'all' target first (which we expect to be overridden by the includer).
 all:
 
+.PHONY: $(BUILD_PERMUTATIONS_DEP)
 $(BUILD_PERMUTATIONS_DEP):
 	@touch $(BUILD_PERMUTATIONS_DEP)
 
@@ -68,3 +69,5 @@ preprocess: $(LIB)
 assembly: $(BPF_C) $(LIB) $(BPF_ASM)
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
 		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@ &&) true
+
+.PHONY: all force checkpatch coccicheck check preprocess assembly

--- a/bpf/sockops/Makefile
+++ b/bpf/sockops/Makefile
@@ -3,7 +3,7 @@
 
 include ../../Makefile.defs
 
-.PHONY: all assembly check preprocess clean
+.PHONY: all clean
 
 BPF = bpf_sockops.o bpf_redir.o
 


### PR DESCRIPTION
Some targets have been moved between the different `Makefile`s in use for eBPF code over time. The corresponding `.PHONY` declarations have not always followed or been updated appropriately. Let's clean it up.
