### PR TITLE
pkg/datapath: Remove unused feature maps

### DIFF
--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/ipmasq"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
@@ -146,6 +147,8 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			"cilium_snat_v6_external",
 			"cilium_proxy6",
 			lbmap.MaglevOuter6MapName,
+			lbmap.Affinity6MapName,
+			lbmap.SourceRange6MapName,
 		}...)
 	}
 
@@ -163,6 +166,9 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			"cilium_snat_v4_external",
 			"cilium_proxy4",
 			lbmap.MaglevOuter4MapName,
+			lbmap.Affinity4MapName,
+			lbmap.SourceRange4MapName,
+			ipmasq.MapName,
 		}...)
 	}
 
@@ -176,6 +182,18 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 
 	if option.Config.NodePortAlg != option.NodePortAlgMaglev {
 		maps = append(maps, lbmap.MaglevOuter6MapName, lbmap.MaglevOuter4MapName)
+	}
+
+	if !option.Config.EnableSessionAffinity {
+		maps = append(maps, lbmap.Affinity6MapName, lbmap.Affinity4MapName, lbmap.AffinityMatchMapName)
+	}
+
+	if !option.Config.EnableSVCSourceRangeCheck {
+		maps = append(maps, lbmap.SourceRange6MapName, lbmap.SourceRange4MapName)
+	}
+
+	if !option.Config.EnableIPMasqAgent {
+		maps = append(maps, ipmasq.MapName)
 	}
 
 	for _, m := range maps {


### PR DESCRIPTION
Remove ipmasq, source range check and session affinity related maps if corresponding features are not enabled.

Fix #11085
Fix #12841
Fix #11267

