### PR TITLE
datapath/maps: drop cilium_policy_reserved_* maps from to-be-removed maps

### DIFF
--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -169,15 +169,6 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 		maps = append(maps, "cilium_throttle")
 	}
 
-	// Can be removed with Cilium 1.8
-	maps = append(maps, []string{
-		"cilium_policy_reserved_1",
-		"cilium_policy_reserved_2",
-		"cilium_policy_reserved_3",
-		"cilium_policy_reserved_4",
-		"cilium_policy_reserved_5",
-	}...)
-
 	for _, m := range maps {
 		p := path.Join(bpf.MapPrefixPath(), m)
 		if _, err := os.Stat(p); !os.IsNotExist(err) {


### PR DESCRIPTION
Commit f3b3a7083b32 ("bpf: Remove POLICY_MAP from bpf_netdev and
bpf_overlay") removed these policy maps and marked their removal in
(*MapSweeper).Remove as deprecated with Cilium 1.8. They are no longer
created as of Cilium 1.7, so it is save to drop them from the list of
to-be-removed maps now.