### PR TITLE
Report correct target system architecture in Cilium version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell echo $(GOFILES) | \
 	grep -v '/api/v1\|/vendor\|/contrib\|/$(BUILD_DIR)/' | \
 	grep -v -P 'test(?!/helpers/logutils)'))
 TESTPKGS ?= $(TESTPKGS_EVAL)
-GOLANGVERSION := $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES := $(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor | sort | uniq)
 K8S_CRD_EVAL := $(addprefix $(ROOT_DIR)/,$(shell git ls-files $(ROOT_DIR)/examples/crds | grep -v .gitignore | tr "\n" ' '))
 K8S_CRD_FILES ?= $(K8S_CRD_EVAL)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -69,8 +69,8 @@ ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
 else
 	GIT_VERSION = $(shell cat $(ROOT_DIR)/GIT_VERSION)
 endif
-FULL_BUILD_VERSION = $(VERSION) $(GIT_VERSION) $(shell $(GO) version)
-GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/version.Version=$(FULL_BUILD_VERSION)"
+FULL_BUILD_VERSION = $(VERSION) $(GIT_VERSION)
+GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/version.ciliumVersion=$(FULL_BUILD_VERSION)"
 
 ifeq ($(NOSTRIP),)
 	# Note: these options will not remove annotations needed for stack

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,8 @@ package version
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -34,8 +36,18 @@ type CiliumVersion struct {
 	AuthorDate string
 }
 
-// Version is set during build
+// ciliumVersion is set to Cilium's version, revision and git author time reference during build.
+var ciliumVersion string
+
+// Version is the complete Cilium version string including Go version.
 var Version string
+
+func init() {
+	// Mimic the output of `go version` and append it to ciliumVersion.
+	// Report GOOS/GOARCH of the actual binary, not the system it was built on, in case it was
+	// cross-compiled. See #13122
+	Version = fmt.Sprintf("%s go version %s %s/%s", ciliumVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}
 
 // FromString converts a version string into struct
 func FromString(versionString string) CiliumVersion {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -17,6 +17,7 @@
 package version
 
 import (
+	"runtime"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -96,4 +97,10 @@ func (vs *VersionSuite) TestStructIsSet(c *C) {
 		c.Assert(cver.Arch, Equals, tt.out.Arch)
 		c.Assert(cver.AuthorDate, Equals, tt.out.AuthorDate)
 	}
+}
+
+func (vs *VersionSuite) TestVersionArchMatchesGOARCH(c *C) {
+	// var ciliumVersion is not set in tests, thus Version does not contain the cilium version,
+	// just check that GOOS/GOARCH are reported correctly, see #13122.
+	c.Assert(Version, Matches, ".* "+runtime.GOOS+"/"+runtime.GOARCH)
 }


### PR DESCRIPTION
The first commit removes the unused `GOLANGVERSION` make variable.

The second commit fixes Cilium to report `GOOS`/`GOARCH` of the target, not the build system. Quoting its commit message:

When cross-building Cilium, like we do for the ARM64 image,
version.Version reports the `GOOS`/`GOARCH` of the build system (i.e.
`linux/amd64`) because it is set to the value of `go version` as run on
the build system.
    
Instead, report the Go version properties of the proper target system by
using the corresponding information from Go's `runtime` package. Mimic the
`go version` format to keep Cilium's version format backwards-compatible.
    
Fixes #13122

Marking for backport to 1.8 since this is the first Cilium version that we support ARM64.