### PR TITLE
contrib: provision cilium-operator before cilium

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -325,6 +325,8 @@ function write_cilium_cfg() {
         cilium_operator_options+=" --k8s-kubeconfig-path /var/lib/cilium/cilium.kubeconfig"
         cilium_operator_options+=" --kvstore etcd"
         cilium_operator_options+=" --kvstore-opt etcd.config=/var/lib/cilium/etcd-config.yml"
+        cilium_operator_options+=" --cluster-pool-ipv4-cidr=10.${master_ipv4_suffix}.0.0/16"
+        cilium_operator_options+=" --cluster-pool-ipv6-cidr=fd00::/104"
     else
         if [[ "${IPV4}" -eq "1" ]]; then
             cilium_options+=" --kvstore-opt consul.address=${MASTER_IPV4}:8500"
@@ -378,8 +380,8 @@ function create_master(){
         write_nodes_routes 1 "${MASTER_IPV4}" "${output_file}"
     fi
 
-    write_cilium_cfg 1 "${ipv4_array[3]}" "${master_cilium_ipv6}" "${output_file}"
     echo "service cilium-operator restart" >> ${output_file}
+    write_cilium_cfg 1 "${ipv4_array[3]}" "${master_cilium_ipv6}" "${output_file}"
 }
 
 function create_workers(){


### PR DESCRIPTION
Since Cilium depends on a podCIDR from cluster-pool, cilium-operator
needs to be run first. On other option would have been to start cilium
with `--ipam=kubernetes` and `--enable-ipv6=false` but this would then
mean that the developer would never been testing / developing on a IPv6
environment.

Fixes: 175bd96bff1c ("cleanup/ipam: Remove hostscope-legacy IPAM option")
Signed-off-by: André Martins <andre@cilium.io>