### PR TITLE
Fix render-docs build again

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -42,7 +42,6 @@ endif
 copy-api:
 	@$(ECHO_GEN)_api
 	$(QUIET)cp -r ../api _api
-	$(QUIET)rm _api/v1/docker/README.md
 
 epub latex html: builder-image copy-api
 	@$(ECHO_GEN)_build/$@


### PR DESCRIPTION
This reverts commit c3251bc8262129e9c8b32565edb2775bb24dceec.

Originally commit 98aeaf05d39a ("api/v1: Compile hubble proto in
docker") broke the docs build by adding a documentation file to the api
directory that wasn't included in the documentation. Commit c3251bc82621
("docs: Fix build") fixed this with a quick hack to remove the file.
Commit eb6bd759f518 ("api/v1: Include Makefile in the hubble proto
image") subsequently removed the original file again, causing the fix
commit to break the build due to:

  rm: cannot remove ‘_api/v1/docker/README.md’: No such file or directory

Fix it by removing the previous hacky fix.

Related: https://github.com/cilium/cilium/issues/13057