### PR TITLE
docs/minikube: Update the step for minikube 1.12.1+

### DIFF
--- a/Documentation/gettingstarted/minikube-install.rst
+++ b/Documentation/gettingstarted/minikube-install.rst
@@ -22,6 +22,19 @@
 
      minikube start --network-plugin=cni --memory=4096
 
+
+::
+
+     # Only available for minikube >= v1.12.1
+     minikube start --network-plugin=cilium --memory=4096
+
+.. note::
+
+   From minikube v1.12.1+, cilium networking plugin can be enabled directly with
+   ``--network-plugin=cilium`` parameter in ``minikube start`` command. With this
+   flag enabled, ``minikube`` will not only mount eBPF file system but also
+   deploy ``quick-install.yaml`` automatically.
+
 4. Mount the eBPF filesystem
 
 ::


### PR DESCRIPTION
From minikube 1.12.1+, cilium quick install can be enabled by passing flag
--network-cni=cilium

Related release in minikube project https://github.com/kubernetes/minikube/releases/tag/v1.12.1

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
docs/minikube: Update the step for minikube 1.12.1+
```
