### PR TITLE
bpf: fix nodeport ipv6 services

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -698,6 +698,8 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 			return DROP_INVALID;
 
 		bpf_mark_snat_done(ctx);
+
+		*ifindex = ct_state.ifindex;
 #ifdef ENCAP_IFINDEX
 		{
 			union v6addr *dst = (union v6addr *)&ip6->daddr;


### PR DESCRIPTION
See commit messages for more details

- [x] Fixes IPv6 NodePort service handling - Fixes #13047 
- [x] Add test to validate the behavior in tests.

```release-note
Fix issue in NodePort service revnat handling where the interface index was not properly restored from the conntrack state leading to packet redirects to an invalid interface.
```