### PR TITLE
travis: remove Arm64 jobs from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ jobs:
     - arch: arm64-graviton2
       virt: vm
       group: edge
-  allow_failures:
-    - arch: arm64-graviton2
 
 if: branch = master OR type = pull_request
 


### PR DESCRIPTION
VM jobs make the test on Arm64 more stable and efficient
and no abnormal interruption of jobs was observed.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>