### PR TITLE
test: add services conformance test to kubernetes upstream suite

### DIFF
--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -36,7 +36,8 @@ pipeline {
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
         VM_MEMORY = "5120"
         K8S_VERSION="1.19"
-        SERVER_BOX = "cilium/ubuntu"
+        KERNEL="419"
+        SERVER_BOX = "cilium/ubuntu-4-19"
         CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
         RACE="""${sh(
                 returnStdout: true,
@@ -104,7 +105,7 @@ pipeline {
 
         stage('BDD-tests'){
             options {
-                timeout(time: 90, unit: 'MINUTES')
+                timeout(time: 150, unit: 'MINUTES')
             }
 
             steps {

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -73,6 +73,10 @@ export KUBE_MASTER=192.168.36.11
 export KUBE_MASTER_IP=192.168.36.11
 export KUBE_MASTER_URL="https://192.168.36.11:6443"
 
+echo "Running upstream services conformance tests"
+${HOME}/go/bin/kubetest --provider=local --test \
+  --test_args="--ginkgo.focus=Services.*\[Conformance\].* --e2e-verify-service-account=false --host ${KUBE_MASTER_URL}"
+
 # We currently skip the following tests:
 # should not allow access by TCP when a policy specifies only SCTP
 #  - Cilium does not support SCTP yet
@@ -81,4 +85,6 @@ export KUBE_MASTER_URL="https://192.168.36.11:6443"
 #  - TL;DR Cilium does not allow to specify pod CIDRs as part of the policy
 #    because it conflicts with the pod's security identity.
 #  - More info at https://github.com/cilium/cilium/issues/9209
-${HOME}/go/bin/kubetest --provider=local --test --test_args="--ginkgo.focus=NetworkPolicy.* --e2e-verify-service-account=false --host ${KUBE_MASTER_URL} --ginkgo.skip=(should.ensure.an.IP.overlapping.both.IPBlock.CIDR.and.IPBlock.Except.is.allowed)|(should.allow.egress.access.to.server.in.CIDR.block)|(should.not.allow.access.by.TCP.when.a.policy.specifies.only.SCTP)"
+echo "Running upstream NetworkPolicy tests"
+${HOME}/go/bin/kubetest --provider=local --test \
+  --test_args="--ginkgo.focus=NetworkPolicy.* --e2e-verify-service-account=false --host ${KUBE_MASTER_URL} --ginkgo.skip=(should.ensure.an.IP.overlapping.both.IPBlock.CIDR.and.IPBlock.Except.is.allowed)|(should.allow.egress.access.to.server.in.CIDR.block)|(should.not.allow.access.by.TCP.when.a.policy.specifies.only.SCTP)"

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -77,13 +77,14 @@ data:
         ready
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
-            ttl 0
             fallthrough in-addr.arpa ip6.arpa
-        }
-        forward . /etc/resolv.conf {
-            max_fails 0
+            ttl 30
         }
         prometheus :9153
+        forward . /etc/resolv.conf {
+            max_concurrent 1000
+        }
+        cache 30
         loop
         reload
         loadbalance


### PR DESCRIPTION
Read commit messages for more details.

To reproduce the issue with CoreDNS manifest for K8s 1.19. Deploy the test VM with 4.19 kernel
```
cd test && KERNEL=419 K8S_VERSION=1.19 vagrant up
```
SSH inside the VM and apply the below manifest:

```
apiVersion: v1
kind: Namespace
metadata:
  name: test-namespace
---
apiVersion: v1
kind: Pod
metadata:
  name: client
  namespace: test-namespace
spec:
  containers:
  restartPolicy: Always
  - command:
    - sleep
    - "36000"
    image: docker.io/library/busybox:1.29
    imagePullPolicy: IfNotPresent
    name: client
---
apiVersion: v1
kind: Pod
metadata:
  name: dnsutils
  namespace: test-namespace
spec:
  containers:
  - name: dnsutils
    image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
    command:
      - sleep
      - "3600"
    imagePullPolicy: IfNotPresent
  restartPolicy: Always
```

From each of the pod try to connect to `kuberentes.default` service.

`nc -vz kubernetes.default 443`
You will find that the DNS cannot be resolved for the client pod but the same works with dnsutils pod.

Apply the patched coredns manifest from the PR and see that you can now connect from the both the pods.