### PR TITLE
docs: Update kernel requirements for advanced features

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1071,6 +1071,8 @@ The current Cilium kube-proxy replacement mode can also be introspected through 
     kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep KubeProxyReplacement
     KubeProxyReplacement:   Strict	[eth0 (DR)]
 
+.. _session-affinity:
+
 Session Affinity
 ****************
 

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -159,14 +159,17 @@ additional kernel features continues to progress in the Linux community. Some
 of Cilium's features are dependent on newer kernel versions and are thus
 enabled by upgrading to more recent kernel versions as detailed below.
 
-======================= ===============================
-Cilium Feature          Minimum Kernel Version
-======================= ===============================
-IPv4 fragment tracking  >= 4.10
-:ref:`cidr_limitations` >= 4.11
-:ref:`host-services`    >= 4.19.57, >= 5.1.16,  >= 5.2
-:ref:`kubeproxy-free`   >= 4.19.57, >= 5.1.16,  >= 5.2
-======================= ===============================
+============================= ===============================
+Cilium Feature                Minimum Kernel Version
+============================= ===============================
+:ref:`concepts_fragmentation` >= 4.10
+:ref:`cidr_limitations`       >= 4.11
+:ref:`host-services`          >= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`kubeproxy-free`         >= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`bandwidth-manager`      >= 5.1
+:ref:`session-affinity`       >= 5.7
+BPF-based proxy redirection   >= 5.7
+============================= ===============================
 
 .. _req_kvstore:
 

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -151,13 +151,13 @@ by adding the following to the helm configuration command line:
 
 .. _features_kernel_matrix:
 
-Advanced Features and Required Kernel Version
-=============================================
-Cilium requires Linux kernel 4.9.17 or higher, however development on additional
-kernel features and functionality continues to progress in the Linux community.
-Some Cilium features and functionality are dependent on newer kernel versions.
-These additional Cilium features and functionality are enabled by upgrading to
-a later kernel version as detailed below:
+Required Kernel Versions for Advanced Features
+==============================================
+
+Cilium requires Linux kernel 4.9.17 or higher; however, development on
+additional kernel features continues to progress in the Linux community. Some
+of Cilium's features are dependent on newer kernel versions and are thus
+enabled by upgrading to more recent kernel versions as detailed below.
 
 ======================= ===============================
 Cilium Feature          Minimum Kernel Version


### PR DESCRIPTION
The first commit rewords a bit the paragraph and title. The second adds three missing advanced features (BPF-based TProxy, bandwidth manager, and session affinity) and updates the IPv4 fragment tracking entry with a link.