### PR TITLE
Add detection of unknown fields for policies (CNP & CCNP) in preflight

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.1
 	// must be bound to this old version not to break libnetwork
 	github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed // indirect
+	github.com/jeremywohl/flatten v1.0.1
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
 	github.com/kr/pretty v0.2.0
 	github.com/mattn/go-shellwords v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -111,4 +111,8 @@ replace (
 	// Using private fork of controller-tools. See commit msg for more context
 	// as to why we are using a private fork.
 	sigs.k8s.io/controller-tools => github.com/christarazi/controller-tools v0.3.1-0.20200911184030-7e668c1fb4c2
+
+	// Fork until
+	// https://github.com/kubernetes-sigs/structured-merge-diff/issues/172 is fixed.
+	sigs.k8s.io/structured-merge-diff/v4 => github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc601931628
 )

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed h1:3MJOWnAfq3T9eoCQTarEY2DMlUWYcBkBLf03dAMvEb8=
 github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
+github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/christarazi/controller-tools v0.3.1-0.20200911184030-7e668c1fb4c2 h1:e8rUgm4lkgItm5/qX43VmvtRkxaOhLIPP6gWjP9Eib4=
 github.com/christarazi/controller-tools v0.3.1-0.20200911184030-7e668c1fb4c2/go.mod h1:hJyC9ybFldjAq/sR0x8jwbV9g0uPxjl8fqBa+mVa3DE=
+github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc601931628 h1:Ftn36pj7se79iQy2/HEqzQFh2fqV/OPjDs69io6J3CE=
+github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc601931628/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -1014,8 +1016,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
-sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
-sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields.go
@@ -1,0 +1,271 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jeremywohl/flatten"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// detectUnknownFields will check the given policy against the expected policy
+// for any unknown fields that were found. The expected policy is retrieved by
+// taking the given policy, marshalling it into its Golang type (CNP or CCNP),
+// and unmarshalling it back into bytes. We can rely on this process to strip
+// away "unknown" fields (specifically, fields that don't have a `json:...`
+// annotation), hence it is expected. Once it's in bytes, we convert it to an
+// unstructured.Unstructured type so that it matches with the given policy. A
+// diff is performed between the two to uncover any differences.
+//
+// Special treatment is given if a top-level description field is found, and
+// returns ErrTopLevelDescriptionFound if so. This is likely to be the most
+// common path of this function as we can usually rely on the validation of the
+// CRDs themselves, however the top-level description field has been widely
+// used incorrectly (see https://github.com/cilium/cilium/issues/13155).
+//
+// This function returns the following possible errors:
+//   - ErrTopLevelDescriptionFound
+//   - ErrUnknownFields
+//   - ErrUnknownKind
+//   - Other marshalling / unmarshalling errors
+func detectUnknownFields(policy *unstructured.Unstructured) error {
+	kind := policy.GetKind()
+
+	scopedLog := log
+	switch kind {
+	case cilium_v2.CNPKindDefinition:
+		scopedLog = scopedLog.WithField(logfields.CiliumNetworkPolicyName,
+			policy.GetName())
+	case cilium_v2.CCNPKindDefinition:
+		scopedLog = scopedLog.WithField(logfields.CiliumClusterwideNetworkPolicyName,
+			policy.GetName())
+	default:
+		return ErrUnknownKind{
+			kind: kind,
+		}
+	}
+
+	if _, ok := policy.Object["description"]; ok {
+		scopedLog.Warn(warnTopLevelDescriptionField)
+		return ErrTopLevelDescriptionFound
+	}
+
+	policyBytes, err := policy.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	var filtered map[string]interface{}
+	switch kind {
+	case cilium_v2.CNPKindDefinition:
+		cnp := new(cilium_v2.CiliumNetworkPolicy)
+		if err := json.Unmarshal(policyBytes, cnp); err != nil {
+			return err
+		}
+		filtered, err = runtime.DefaultUnstructuredConverter.ToUnstructured(cnp)
+	case cilium_v2.CCNPKindDefinition:
+		ccnp := new(cilium_v2.CiliumClusterwideNetworkPolicy)
+		if err := json.Unmarshal(policyBytes, ccnp); err != nil {
+			return err
+		}
+		filtered, err = runtime.DefaultUnstructuredConverter.ToUnstructured(ccnp)
+	default:
+		// We've already validated above that there can only be two kinds: CNP
+		// & CCNP. This is likely to be a developer error if hit, so fatal.
+		scopedLog.WithField("kind", kind).Fatal("Unexpected kind found when processing policy")
+	}
+	if err != nil {
+		return err
+	}
+
+	given, err := getFields(policy.Object)
+	if err != nil {
+		return err
+	}
+
+	expected, err := getFields(filtered)
+	if err != nil {
+		return err
+	}
+
+	// Compare the expected policy with the given policy to find all unknown
+	// fields.
+	var r reporter
+	if !cmp.Equal(
+		expected,
+		given,
+		cmp.Reporter(&r),
+		cmpopts.SortSlices(func(o, n string) bool {
+			return o < n
+		}),
+	) {
+		scopedLog.Warn(warnUnknownFields)
+		return ErrUnknownFields{
+			extras: r.extras,
+		}
+	}
+
+	return nil
+}
+
+const (
+	warnTopLevelDescriptionField = "It seems you have a policy with a " +
+		"top-level description. This field is no longer supported. Please migrate " +
+		"your policy's description field under `spec` or `specs`."
+
+	warnUnknownFields = "It seems you have a policy with extra unknown fields. " +
+		"Consider removing these fields, as they have no effect. The presence " +
+		"of these fields may have introduced a false sense security, so please " +
+		"check whether your policy is actually behaving as you expect."
+)
+
+// ErrTopLevelDescriptionFound is the error returned if a policy contains a
+// top-level description field. Instead this field should be moved to under
+// (Rule).Description.
+var ErrTopLevelDescriptionFound = errors.New("top-level description field found")
+
+// ErrUnknownFields is an error representing the condition where unknown fields
+// were found within a policy during validation. Fields that are not expected
+// to be in the policy will be put inside the "extras" slice.
+type ErrUnknownFields struct {
+	extras []string
+}
+
+func (e ErrUnknownFields) Error() string {
+	return fmt.Sprintf("unknown fields found, extra:%v", e.extras)
+}
+
+// ErrUnknownKind is an error representing an unknown Kubernetes object kind
+// that is passed to the validator.
+type ErrUnknownKind struct {
+	kind string
+}
+
+func (e ErrUnknownKind) Error() string {
+	return fmt.Sprintf("unknown kind %q", e.kind)
+}
+
+func getFields(u map[string]interface{}) ([]string, error) {
+	flat, err := flattenObject(u)
+	if err != nil {
+		return nil, err
+	}
+
+	// set is used as a lookup for whether we've already seen the field path.
+	// This is useful to dedup entries that match the "matchLabels" or
+	// "matchExpressions" field path. Without this lookup, we will return a
+	// slice containing duplicate entries. See example below.
+	//   {
+	//     "spec": {
+	//       "endpointSelector": {
+	//         "matchLabels": {
+	//           "app": "",
+	//           "key": "",
+	//           "operator": ""
+	//         }
+	//       }
+	//     }
+	//   }
+	// => []string{"spec.endpointSelector.matchLabels",
+	//             "spec.endpointSelector.matchLabels",
+	//             "spec.endpointSelector.matchLabels"}
+	// Here we get an entry for each label inside "matchLabels". What we want
+	// is []string{"spec.endpointSelector.matchLabels"}. See comment inside the
+	// for-loop below for why we have to truncate the labels.
+	set := make(map[string]struct{})
+
+	fields := make([]string, 0, len(flat))
+	for f := range flat {
+		// Due to converting to Unstructured (same issue as ignoring fields
+		// below), we need to truncate any label under "matchLabels" or
+		// "matchExpressions", to effectively ignore the labels. This is
+		// because they are arbitrary as the user can specify anything they
+		// want. We will strip off the label, and keep the entire field path up
+		// to and including "matchLabels" or "matchExpressions", which we
+		// insert to the "fields" slice.
+		if matches := arbitraryLabelRegex.FindStringSubmatch(f); len(matches) > 1 {
+			m := matches[1] // matches[0] contains the full match
+
+			if _, seen := set[m]; !seen {
+				set[m] = struct{}{} // Mark as seen
+				fields = append(fields, m)
+			}
+		} else if !isIgnoredField(f) {
+			fields = append(fields, f)
+		}
+	}
+
+	return fields, nil
+}
+
+// arbitraryLabelRegex matches any field path that includes "matchLabels" or
+// "matchExpressions". For example, it matches the following:
+//  - spec.endpointSelector.matchLabels.*
+//  - specs.0.ingress.0.fromEndpoints.0.matchLabels.*
+//  - specs.0.ingress.0.fromEndpoints.0.matchExpressions.*
+var arbitraryLabelRegex = regexp.MustCompile(`^(.+\.(matchLabels|matchExpressions))\..+$`)
+
+func flattenObject(obj map[string]interface{}) (map[string]interface{}, error) {
+	return flatten.Flatten(obj, "", flatten.DotStyle)
+}
+
+func isIgnoredField(f string) bool {
+	// We ignore the creation timestamp and the name because when marshalling
+	// and unmarshalling happens when converting to Unstructured, these fields
+	// are added in the "expected" policy.  These fields missing should not be
+	// warned about. Specifically for "metadata.name", a CRD cannot be created
+	// without it, so in reality, we can rely on the CRD validation, hence it
+	// is safe to ignore at this level of the code.
+	return f == "metadata.creationTimestamp" || f == "metadata.name"
+}
+
+// reporter is a custom reporter adhering to the cmp.Reporter interface.
+type reporter struct {
+	path   cmp.Path
+	extras []string
+}
+
+func (r *reporter) PushStep(ps cmp.PathStep) {
+	r.path = append(r.path, ps)
+}
+
+func (r *reporter) Report(rs cmp.Result) {
+	if !rs.Equal() {
+		// The below call returns two values of the diff, vx & xy. In our case,
+		// vx represents a "missing" value (-) in the diff, and vy represents
+		// an "extra" value (+) in the diff. We ignore vx because it is not
+		// possible to have "missing" values, because the validator will catch
+		// "missing" or "required" values earlier on. We only care about
+		// "extra" values here.
+		_, vy := r.path.Last().Values()
+		if vy.IsValid() {
+			r.extras = append(r.extras, vy.String())
+		}
+	}
+}
+
+func (r *reporter) PopStep() {
+	r.path = r.path[:len(r.path)-1]
+}

--- a/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields_test.go
@@ -1,0 +1,198 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package validator
+
+import (
+	"sort"
+
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *CNPValidationSuite) Test_getFields(c *C) {
+	tests := []struct {
+		name      string
+		structure map[string]interface{}
+		expected  []string
+		err       error
+	}{
+		{
+			name:      "nil structure",
+			structure: nil,
+			expected:  []string{},
+			err:       nil,
+		},
+		{
+			name: "empty structure",
+			structure: map[string]interface{}{
+				"": "",
+			},
+			expected: []string{""},
+			err:      nil,
+		},
+		{
+			name: "simple structure",
+			structure: map[string]interface{}{
+				"spec": "",
+			},
+			expected: []string{"spec"},
+			err:      nil,
+		},
+		{
+			name: "nested structure",
+			structure: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"more":   "",
+					"fields": "",
+					"another": map[string]interface{}{
+						"field": "",
+					},
+				},
+			},
+			expected: []string{"spec.more", "spec.fields", "spec.another.field"},
+			err:      nil,
+		},
+		{
+			name: `contains "matchLabels"`,
+			structure: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"endpointSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app": "",
+						},
+					},
+				},
+			},
+			expected: []string{"spec.endpointSelector.matchLabels"},
+			err:      nil,
+		},
+		{
+			name: `contains multiple labels inside multiple "matchLabels"`,
+			structure: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"endpointSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"app":      "",
+							"key":      "",
+							"operator": "",
+						},
+					},
+				},
+			},
+			expected: []string{"spec.endpointSelector.matchLabels"},
+			err:      nil,
+		},
+		{
+			name: `contains multiple labels inside "matchLabels" based on real policy`,
+			structure: map[string]interface{}{
+				"specs": []interface{}{
+					map[string]interface{}{
+						"description": "Policy to test multiple rules in a single file",
+						"endpointSelector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"app":     "",
+								"version": "",
+							},
+						},
+						"ingress": []interface{}{
+							map[string]interface{}{
+								"fromEndpoints": []interface{}{
+									map[string]interface{}{
+										"matchLabels": map[string]interface{}{
+											"app":     "",
+											"track":   "",
+											"version": "",
+										},
+									},
+								},
+							},
+						},
+					},
+					map[string]interface{}{
+						"endpointSelector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"app":     "details",
+								"track":   "stable",
+								"version": "v1",
+							},
+						},
+						"ingress": []interface{}{
+							map[string]interface{}{
+								"fromEndpoints": []interface{}{
+									map[string]interface{}{
+										"matchLabels": map[string]interface{}{
+											"app":     "productpage",
+											"track":   "stable",
+											"version": "v1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"specs.0.description",
+				"specs.0.endpointSelector.matchLabels",
+				"specs.1.endpointSelector.matchLabels",
+				"specs.0.ingress.0.fromEndpoints.0.matchLabels",
+				"specs.1.ingress.0.fromEndpoints.0.matchLabels"},
+			err: nil,
+		},
+		{
+			name: `contains "matchLabels" and "matchExpressions" based on real policy`,
+			structure: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"description": "Policy to test matchExpressions key",
+					"endpointSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"id": "app1",
+						},
+					},
+					"ingress": []interface{}{
+						map[string]interface{}{
+							"fromEndpoints": []interface{}{
+								map[string]interface{}{
+									"matchExpressions": []interface{}{
+										map[string]interface{}{
+											"key":      "",
+											"operator": "Exists",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"spec.description", "spec.endpointSelector.matchLabels",
+				"spec.ingress.0.fromEndpoints.0.matchExpressions"},
+			err: nil,
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+
+		got, err := getFields(tt.structure)
+		c.Assert(tt.err, checker.DeepEquals, err)
+
+		sort.Strings(tt.expected) // Must sort to check slice equality
+		sort.Strings(got)
+		c.Assert(tt.expected, checker.DeepEquals, got)
+	}
+}

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -108,6 +108,11 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 	if errs := validation.ValidateCustomResource(nil, &cnp, n.cnpValidator); len(errs) > 0 {
 		return errs.ToAggregate()
 	}
+
+	if err := detectUnknownFields(cnp); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -128,6 +133,10 @@ var (
 func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 	if errs := validation.ValidateCustomResource(nil, &ccnp, n.ccnpValidator); len(errs) > 0 {
 		return errs.ToAggregate()
+	}
+
+	if err := detectUnknownFields(ccnp); err != nil {
+		return err
 	}
 
 	if err := checkWildCardToFromEndpoint(ccnp); err != nil {

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
+
 	"github.com/go-openapi/validate"
 	"github.com/sirupsen/logrus"
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -129,6 +130,14 @@ func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 		return errs.ToAggregate()
 	}
 
+	if err := checkWildCardToFromEndpoint(ccnp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkWildCardToFromEndpoint(ccnp *unstructured.Unstructured) error {
 	logger := log.WithFields(logrus.Fields{
 		logfields.CiliumClusterwideNetworkPolicyName: ccnp.GetName(),
 	})

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -221,4 +223,186 @@ spec:
 	err = validator.ValidateCCNP(&us)
 	// Err can't be nil since validation should detect the policy is not correct.
 	c.Assert(err, Not(IsNil))
+}
+
+func (s *CNPValidationSuite) Test_UnknownFieldDetection(c *C) {
+	tests := []struct {
+		name        string
+		policy      []byte
+		clusterwide bool
+		err         error
+	}{
+		{
+			name: "neither a cnp or ccnp",
+			policy: []byte(`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: app1-account
+`),
+			clusterwide: false,
+			err: ErrUnknownKind{
+				kind: "ServiceAccount",
+			},
+		},
+
+		{
+			name: "cnp top-level description exists",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+description: "default deny policy"
+metadata:
+  name: cnp-test-1
+spec:
+  endpointSelector: {}
+`),
+			clusterwide: false,
+			err:         ErrTopLevelDescriptionFound,
+		},
+		{
+			name: "cnp top-level description does not exist",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-test-1
+spec:
+  endpointSelector: {}
+`),
+			clusterwide: false,
+			err:         nil,
+		},
+		{
+			name: "ccnp top-level description exists",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+description: "default deny policy"
+metadata:
+  name: ccnp-test-1
+spec:
+  nodeSelector: {}
+`),
+			clusterwide: true,
+			err:         ErrTopLevelDescriptionFound,
+		},
+		{
+			name: "ccnp top-level description does not exist",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: ccnp-test-1
+spec:
+  nodeSelector: {}
+`),
+			clusterwide: true,
+			err:         nil,
+		},
+
+		{
+			name: "cnp extra unknown fields",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+foo: bar
+metadata:
+  name: ccnp-test-1
+spec:
+  endpointSelector: {}
+  bar: baz
+`),
+			clusterwide: false,
+			err: ErrUnknownFields{
+				extras: []string{"foo", "spec.bar"},
+			},
+		},
+		{
+			name: "ccnp extra unknown fields",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+foo: bar
+metadata:
+  name: ccnp-test-1
+spec:
+  nodeSelector: {}
+  bar: baz
+`),
+			clusterwide: true,
+			err: ErrUnknownFields{
+				extras: []string{"foo", "spec.bar"},
+			},
+		},
+		{
+			name: "cnp specs",
+			policy: []byte(`
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cnp-specs"
+specs:
+  - description: "Policy to test multiple rules in a single file"
+    endpointSelector:
+      matchLabels:
+        app: ratings
+        version: v1
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: reviews
+          track: stable
+          version: v1
+      toPorts:
+      - ports:
+        - port: "9080"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/health"
+  - endpointSelector:
+      matchLabels:
+        app: details
+        track: stable
+        version: v1
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: productpage
+          track: stable
+          version: v1
+      toPorts:
+      - ports:
+        - port: "9080"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/.*"
+`),
+			clusterwide: false,
+			err:         nil,
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+
+		jsnByte, err := yaml.YAMLToJSON(tt.policy)
+		c.Assert(err, IsNil)
+
+		us := unstructured.Unstructured{}
+		err = json.Unmarshal(jsnByte, &us)
+		c.Assert(err, IsNil)
+
+		validator, err := NewNPValidator()
+		c.Assert(err, IsNil)
+
+		if tt.clusterwide {
+			c.Assert(validator.ValidateCCNP(&us), checker.DeepEquals, tt.err)
+		} else {
+			c.Assert(validator.ValidateCNP(&us), checker.DeepEquals, tt.err)
+		}
+	}
 }

--- a/vendor/github.com/jeremywohl/flatten/.gitignore
+++ b/vendor/github.com/jeremywohl/flatten/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/jeremywohl/flatten/.travis.yml
+++ b/vendor/github.com/jeremywohl/flatten/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/jeremywohl/flatten/LICENSE
+++ b/vendor/github.com/jeremywohl/flatten/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Jeremy Wohl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jeremywohl/flatten/README.md
+++ b/vendor/github.com/jeremywohl/flatten/README.md
@@ -1,0 +1,65 @@
+flatten
+=======
+
+[![GoDoc](https://godoc.org/github.com/jeremywohl/flatten?status.png)](https://godoc.org/github.com/jeremywohl/flatten)
+[![Build Status](https://travis-ci.org/jeremywohl/flatten.svg?branch=master)](https://travis-ci.org/jeremywohl/flatten)
+
+Flatten makes flat, one-dimensional maps from arbitrarily nested ones.
+
+It turns map keys into compound
+names, in four default styles: dotted (`a.b.1.c`), path-like (`a/b/1/c`), Rails (`a[b][1][c]`), or with underscores (`a_b_1_c`).  Alternatively, you can pass a custom style.
+
+It takes input as either JSON strings or
+Go structures.  It knows how to traverse these JSON types: objects/maps, arrays and scalars.
+
+You can flatten JSON strings.
+
+```go
+nested := `{
+  "one": {
+    "two": [
+      "2a",
+      "2b"
+    ]
+  },
+  "side": "value"
+}`
+
+flat, err := flatten.FlattenString(nested, "", flatten.DotStyle)
+
+// output: `{ "one.two.0": "2a", "one.two.1": "2b", "side": "value" }`
+```
+
+Or Go maps directly.
+
+```go
+nested := map[string]interface{}{
+   "a": "b",
+   "c": map[string]interface{}{
+       "d": "e",
+       "f": "g",
+   },
+   "z": 1.4567,
+}
+
+flat, err := flatten.Flatten(nested, "", flatten.RailsStyle)
+
+// output:
+// map[string]interface{}{
+//  "a":    "b",
+//  "c[d]": "e",
+//  "c[f]": "g",
+//  "z":    1.4567,
+// }
+```
+
+Let's try a custom style, with the first example above.
+
+```go
+emdash := flatten.SeparatorStyle{Middle: "--"}
+flat, err := flatten.FlattenString(nested, "", emdash)
+
+// output: `{ "one--two--0": "2a", "one--two--1": "2b", "side": "value" }`
+```
+
+See [godoc](https://godoc.org/github.com/jeremywohl/flatten) for API.

--- a/vendor/github.com/jeremywohl/flatten/TODO
+++ b/vendor/github.com/jeremywohl/flatten/TODO
@@ -1,0 +1,4 @@
+test: all Go scalar types
+todo: initial list vs map
+todo: fail properly with alternate types
+todo: support structs and pointers?

--- a/vendor/github.com/jeremywohl/flatten/doc.go
+++ b/vendor/github.com/jeremywohl/flatten/doc.go
@@ -1,0 +1,54 @@
+// Flatten makes flat, one-dimensional maps from arbitrarily nested ones.
+//
+// It turns map keys into compound
+// names, in four default styles: dotted (`a.b.1.c`), path-like (`a/b/1/c`), Rails (`a[b][1][c]`),
+// or with underscores (`a_b_1_c`).  Alternatively, you can pass a custom style.
+//
+// It takes input as either JSON strings or
+// Go structures.  It knows how to traverse these JSON types: objects/maps, arrays and scalars.
+//
+// You can flatten JSON strings.
+//
+//	nested := `{
+//	  "one": {
+//	    "two": [
+//	      "2a",
+//	      "2b"
+//	    ]
+//	  },
+//	  "side": "value"
+//	}`
+//
+//	flat, err := flatten.FlattenString(nested, "", flatten.DotStyle)
+//
+//	// output: `{ "one.two.0": "2a", "one.two.1": "2b", "side": "value" }`
+//
+// Or Go maps directly.
+//
+//	nested := map[string]interface{}{
+//		"a": "b",
+//		"c": map[string]interface{}{
+//			"d": "e",
+//			"f": "g",
+//		},
+//		"z": 1.4567,
+//	}
+//
+//	flat, err := flatten.Flatten(nested, "", flatten.RailsStyle)
+//
+//	// output:
+//	// map[string]interface{}{
+//	//	"a":    "b",
+//	//	"c[d]": "e",
+//	//	"c[f]": "g",
+//	//	"z":    1.4567,
+//	// }
+//
+// Let's try a custom style, with the first example above.
+//
+//	emdash := flatten.SeparatorStyle{Middle: "--"}
+//	flat, err := flatten.FlattenString(nested, "", emdash)
+//
+//	// output: `{ "one--two--0": "2a", "one--two--1": "2b", "side": "value" }`
+//
+package flatten

--- a/vendor/github.com/jeremywohl/flatten/flatten.go
+++ b/vendor/github.com/jeremywohl/flatten/flatten.go
@@ -1,0 +1,130 @@
+package flatten
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+)
+
+// The style of keys.  If there is an input with two
+// nested keys "f" and "g", with "f" at the root,
+//    { "f": { "g": ... } }
+// the output will be the concatenation
+//    f{Middle}{Before}g{After}...
+// Any struct element may be blank.
+// If you use Middle, you will probably leave Before & After blank, and vice-versa.
+// See examples in flatten_test.go and the "Default styles" here.
+type SeparatorStyle struct {
+	Before string // Prepend to key
+	Middle string // Add between keys
+	After  string // Append to key
+}
+
+// Default styles
+var (
+	// Separate nested key components with dots, e.g. "a.b.1.c.d"
+	DotStyle = SeparatorStyle{Middle: "."}
+
+	// Separate with path-like slashes, e.g. a/b/1/c/d
+	PathStyle = SeparatorStyle{Middle: "/"}
+
+	// Separate ala Rails, e.g. "a[b][c][1][d]"
+	RailsStyle = SeparatorStyle{Before: "[", After: "]"}
+
+	// Separate with underscores, e.g. "a_b_1_c_d"
+	UnderscoreStyle = SeparatorStyle{Middle: "_"}
+)
+
+// Nested input must be a map or slice
+var NotValidInputError = errors.New("Not a valid input: map or slice")
+
+// Flatten generates a flat map from a nested one.  The original may include values of type map, slice and scalar,
+// but not struct.  Keys in the flat map will be a compound of descending map keys and slice iterations.
+// The presentation of keys is set by style.  A prefix is joined to each key.
+func Flatten(nested map[string]interface{}, prefix string, style SeparatorStyle) (map[string]interface{}, error) {
+	flatmap := make(map[string]interface{})
+
+	err := flatten(true, flatmap, nested, prefix, style)
+	if err != nil {
+		return nil, err
+	}
+
+	return flatmap, nil
+}
+
+// JSON nested input must be a map
+var NotValidJsonInputError = errors.New("Not a valid input, must be a map")
+
+var isJsonMap = regexp.MustCompile(`^\s*\{`)
+
+// FlattenString generates a flat JSON map from a nested one.  Keys in the flat map will be a compound of
+// descending map keys and slice iterations.  The presentation of keys is set by style.  A prefix is joined
+// to each key.
+func FlattenString(nestedstr, prefix string, style SeparatorStyle) (string, error) {
+	if !isJsonMap.MatchString(nestedstr) {
+		return "", NotValidJsonInputError
+	}
+
+	var nested map[string]interface{}
+	err := json.Unmarshal([]byte(nestedstr), &nested)
+	if err != nil {
+		return "", err
+	}
+
+	flatmap, err := Flatten(nested, prefix, style)
+	if err != nil {
+		return "", err
+	}
+
+	flatb, err := json.Marshal(&flatmap)
+	if err != nil {
+		return "", err
+	}
+
+	return string(flatb), nil
+}
+
+func flatten(top bool, flatMap map[string]interface{}, nested interface{}, prefix string, style SeparatorStyle) error {
+	assign := func(newKey string, v interface{}) error {
+		switch v.(type) {
+		case map[string]interface{}, []interface{}:
+			if err := flatten(false, flatMap, v, newKey, style); err != nil {
+				return err
+			}
+		default:
+			flatMap[newKey] = v
+		}
+
+		return nil
+	}
+
+	switch nested.(type) {
+	case map[string]interface{}:
+		for k, v := range nested.(map[string]interface{}) {
+			newKey := enkey(top, prefix, k, style)
+			assign(newKey, v)
+		}
+	case []interface{}:
+		for i, v := range nested.([]interface{}) {
+			newKey := enkey(top, prefix, strconv.Itoa(i), style)
+			assign(newKey, v)
+		}
+	default:
+		return NotValidInputError
+	}
+
+	return nil
+}
+
+func enkey(top bool, prefix, subkey string, style SeparatorStyle) string {
+	key := prefix
+
+	if top {
+		key += subkey
+	} else {
+		key += style.Before + style.Middle + subkey + style.After
+	}
+
+	return key
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -376,6 +376,9 @@ github.com/inconshreveable/mousetrap
 # github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed
 ## explicit
 github.com/ishidawataru/sctp
+# github.com/jeremywohl/flatten v1.0.1
+## explicit
+github.com/jeremywohl/flatten
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
 # github.com/json-iterator/go v1.1.10

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1124,7 +1124,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/structured-merge-diff/v4 v4.0.1
+# sigs.k8s.io/structured-merge-diff/v4 v4.0.1 => github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc601931628
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit
@@ -1133,3 +1133,4 @@ sigs.k8s.io/yaml
 # github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 # k8s.io/client-go => github.com/cilium/client-go v0.0.0-20200917084247-85ed8d558b9c
 # sigs.k8s.io/controller-tools => github.com/christarazi/controller-tools v0.3.1-0.20200911184030-7e668c1fb4c2
+# sigs.k8s.io/structured-merge-diff/v4 => github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc601931628

--- a/vendor/sigs.k8s.io/structured-merge-diff/v4/value/reflectcache.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v4/value/reflectcache.go
@@ -150,7 +150,11 @@ func buildStructCacheEntry(t reflect.Type, infos map[string]*FieldCacheEntry, fi
 			continue
 		}
 		if isInline {
-			buildStructCacheEntry(field.Type, infos, append(fieldPath, field.Index))
+			e := field.Type
+			if field.Type.Kind() == reflect.Ptr {
+				e = field.Type.Elem()
+			}
+			buildStructCacheEntry(e, infos, append(fieldPath, field.Index))
 			continue
 		}
 		info := &FieldCacheEntry{JsonName: jsonName, isOmitEmpty: isOmitempty, fieldPath: append(fieldPath, field.Index), fieldType: field.Type}


### PR DESCRIPTION
~Please only pay attention to the three most recent commits. This PR depends on
https://github.com/cilium/cilium/pull/11477 and includes commits from it (until it's merged.)~ See commit msgs.

Example output of "unknown fields found":
```
$ kubectl get cnp cnp-update -o yaml
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
...
  name: cnp-update
...
spec:
  endpointSelector: {}
  wrong: foo

$ kubectl -n cilium exec -it cilium-ffdz4 -- bash
root@gke-chris-cluster-default-pool-d04d0083-8xx4:/home/cilium# cilium preflight validate-cnp
INFO[0000] Setting up Kubernetes client
INFO[0000] Establishing connection to apiserver          host="https://10.47.240.1:443" subsys=k8s
INFO[0000] Connected to apiserver                        subsys=k8s
INFO[0000] Unable to retrieve EndpointSlices for default/kubernetes. Disabling EndpointSlices  error="the server could not find the requested resource (get endpointslices.discovery.k8s.io kubernetes)" subsys=k8s
WARN[0000] It seems you have a policy with extra unknown fields. Consider removing these fields, as they have no effect. The presence of these fields may have introduced a false sense security, so please check whether your policy is actually behaving as you expect.  ciliumNetworkPolicyName=cnp-update subsys=validator
ERRO[0000] Unexpected validation error                   CiliumNetworkPolicy=default/cnp-update error="unknown fields found, extra:[spec.wrong]"
ERRO[0000] Found invalid CiliumNetworkPolicy
```

Example output of "top-level description field found":
```
$ kubectl get cnp cnp-update -o yaml
apiVersion: cilium.io/v2
description: Policy with the same name as cnp-update-deny-ingress to test CNP update
kind: CiliumNetworkPolicy
metadata:
...
  name: cnp-update
...
spec:
  endpointSelector: {}

$ kubectl -n cilium exec -it cilium-ffdz4 -- bash
root@gke-chris-cluster-default-pool-d04d0083-8xx4:/home/cilium# cilium preflight validate-cnp
INFO[0000] Setting up Kubernetes client
INFO[0000] Establishing connection to apiserver          host="https://10.47.240.1:443" subsys=k8s
INFO[0000] Connected to apiserver                        subsys=k8s
INFO[0000] Unable to retrieve EndpointSlices for default/kubernetes. Disabling EndpointSlices  error="the server could not find the requested resource (get endpointslices.discovery.k8s.io kubernetes)" subsys=k8s
WARN[0000] It seems you have a policy with a top-level description. This field is no longer supported. Please migrate your policy's description field under `spec` or `specs`.  ciliumNetworkPolicyName=cnp-update subsys=validator
ERRO[0000] Unexpected validation error                   CiliumNetworkPolicy=default/cnp-update error="top-level description field found"
ERRO[0000] Found invalid CiliumNetworkPolicy
```

Updates: https://github.com/cilium/cilium/issues/12737