### PR TITLE
v1.8 backport 2020-09-16

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -35,6 +35,7 @@ cilium-operator-aws [flags]
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
   -h, --help                                      help for cilium-operator-aws

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -34,6 +34,7 @@ cilium-operator-azure [flags]
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
   -h, --help                                      help for cilium-operator-azure
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -32,6 +32,7 @@ cilium-operator-generic [flags]
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
   -h, --help                                      help for cilium-operator-generic
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -37,6 +37,7 @@ cilium-operator [flags]
       --enable-ipv6                               Enable IPv6 support (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
   -h, --help                                      help for cilium-operator

--- a/Documentation/concepts/networking/ipam/azure.rst
+++ b/Documentation/concepts/networking/ipam/azure.rst
@@ -62,10 +62,6 @@ Configuration
   ``--auto-create-cilium-node-resource`` or  set
   ``auto-create-cilium-node-resource: "true"`` in the ConfigMap.
 
-* If IPs are limited, run the Operator with option
-  ``--aws-release-excess-ips=true``. When enabled, operator checks the number
-  of IPs regularly and attempts to release excess free IPs from ENI.
-
 * It is generally a good idea to enable metrics in the Operator as well with
   the option ``--enable-metrics``. See the section :ref:`install_metrics` for
   additional information how to install and run Prometheus including the
@@ -134,9 +130,6 @@ addresses. The check to recognize a deficit is performed on two occasions:
 
  * When a ``CiliumNode`` custom resource is updated
  * All nodes are scanned in a regular interval (once per minute)
-
-If ``--aws-release-excess-ips`` is enabled, the check to recognize IP excess
-is performed at the interval based scan.
 
 When determining whether a node has a deficit in IP addresses, the following
 calculation is performed:

--- a/Documentation/gettingstarted/host-firewall.rst
+++ b/Documentation/gettingstarted/host-firewall.rst
@@ -26,7 +26,6 @@ Deploy Cilium release via Helm:
 
     helm install cilium |CHART_RELEASE|        \\
       --namespace kube-system                  \\
-      --set global.kubeProxyReplacement=strict \\
       --set global.hostFirewall=true           \\
       --set global.devices=ethX,ethY
 

--- a/Documentation/gettingstarted/minikube-install.rst
+++ b/Documentation/gettingstarted/minikube-install.rst
@@ -22,7 +22,19 @@
 
      minikube start --network-plugin=cni --memory=4096
 
-4. Mount the BPF filesystem
+::
+
+     # Only available for minikube >= v1.12.1
+     minikube start --network-plugin=cilium --memory=4096
+
+.. note::
+
+   From minikube v1.12.1+, cilium networking plugin can be enabled directly with
+   ``--network-plugin=cilium`` parameter in ``minikube start`` command. With this
+   flag enabled, ``minikube`` will not only mount eBPF file system but also
+   deploy ``quick-install.yaml`` automatically.
+
+4. Mount the eBPF filesystem
 
 ::
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell echo $(GOFILES) | \
 	grep -v '/api/v1\|/vendor\|/contrib\|/$(BUILD_DIR)/' | \
 	grep -v -P 'test(?!/helpers/logutils)'))
 TESTPKGS ?= $(TESTPKGS_EVAL)
-GOLANGVERSION := $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES := $(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor | sort | uniq)
 
 SWAGGER_VERSION := v0.20.1

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -61,8 +61,8 @@ ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
 else
 	GIT_VERSION = $(shell cat $(ROOT_DIR)/GIT_VERSION)
 endif
-FULL_BUILD_VERSION = $(VERSION) $(GIT_VERSION) $(shell $(GO) version)
-GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/version.Version=$(FULL_BUILD_VERSION)"
+FULL_BUILD_VERSION = $(VERSION) $(GIT_VERSION)
+GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/version.ciliumVersion=$(FULL_BUILD_VERSION)"
 
 ifeq ($(NOSTRIP),)
 	# Note: these options will not remove annotations needed for stack

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -363,7 +363,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPV4
 static __always_inline __u32
 resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
-		   const bool from_host)
+		   __u32 *sec_label, const bool from_host)
 {
 	__u32 src_id = WORLD_ID, srcid_from_ipcache = srcid_from_proxy;
 	struct remote_endpoint_info *info = NULL;
@@ -382,9 +382,9 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	if (identity_is_reserved(srcid_from_ipcache)) {
 		info = lookup_ip4_remote_endpoint(ip4->saddr);
 		if (info != NULL) {
-			__u32 sec_label = info->sec_label;
+			*sec_label = info->sec_label;
 
-			if (sec_label) {
+			if (*sec_label) {
 				/* When SNAT is enabled on traffic ingressing
 				 * into Cilium, all traffic from the world will
 				 * have a source IP of the host. It will only
@@ -395,9 +395,9 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 				 * source as HOST_ID.
 				 */
 #ifndef ENABLE_EXTRA_HOST_DEV
-				if (from_host && sec_label != HOST_ID)
+				if (from_host && *sec_label != HOST_ID)
 #endif
-					srcid_from_ipcache = sec_label;
+					srcid_from_ipcache = *sec_label;
 			}
 		}
 		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
@@ -419,7 +419,8 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 }
 
 static __always_inline int
-handle_ipv4(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
+handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
+	    __u32 ipcache_srcid __maybe_unused, const bool from_host)
 {
 	struct remote_endpoint_info *info = NULL;
 	__u32 __maybe_unused remoteID = 0;
@@ -459,7 +460,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {
 		/* We're on the egress path of cilium_host. */
-		ret = ipv4_host_policy_egress(ctx, secctx);
+		ret = ipv4_host_policy_egress(ctx, secctx, ipcache_srcid);
 		if (IS_ERR(ret))
 			return ret;
 	} else if (!ctx_skip_host_fw(ctx)) {
@@ -567,14 +568,14 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
 }
 
 static __always_inline int
-tail_handle_ipv4(struct __ctx_buff *ctx, const bool from_host)
+tail_handle_ipv4(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_host)
 {
 	__u32 proxy_identity = ctx_load_meta(ctx, CB_SRC_IDENTITY);
 	int ret;
 
 	ctx_store_meta(ctx, CB_SRC_IDENTITY, 0);
 
-	ret = handle_ipv4(ctx, proxy_identity, from_host);
+	ret = handle_ipv4(ctx, proxy_identity, ipcache_srcid, from_host);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, proxy_identity,
 					      ret, CTX_ACT_DROP, METRIC_INGRESS);
@@ -584,13 +585,20 @@ tail_handle_ipv4(struct __ctx_buff *ctx, const bool from_host)
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_HOST)
 int tail_handle_ipv4_from_host(struct __ctx_buff *ctx)
 {
-	return tail_handle_ipv4(ctx, true);
+	__u32 ipcache_srcid = 0;
+
+#if defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE)
+	ipcache_srcid = ctx_load_meta(ctx, CB_IPCACHE_SRC_LABEL);
+	ctx_store_meta(ctx, CB_IPCACHE_SRC_LABEL, 0);
+#endif
+
+	return tail_handle_ipv4(ctx, ipcache_srcid, true);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC)
 int tail_handle_ipv4_from_netdev(struct __ctx_buff *ctx)
 {
-	return tail_handle_ipv4(ctx, false);
+	return tail_handle_ipv4(ctx, 0, false);
 }
 #endif /* ENABLE_IPV4 */
 
@@ -755,6 +763,7 @@ static __always_inline int
 do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 {
 	__u32 __maybe_unused identity = 0;
+	__u32 __maybe_unused ipcache_srcid = 0;
 	int ret;
 
 #ifdef ENABLE_IPSEC
@@ -818,12 +827,21 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 #endif
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		identity = resolve_srcid_ipv4(ctx, identity, from_host);
+		identity = resolve_srcid_ipv4(ctx, identity, &ipcache_srcid,
+					      from_host);
 		ctx_store_meta(ctx, CB_SRC_IDENTITY, identity);
-		if (from_host)
+		if (from_host) {
+# if defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE)
+			/* If we don't rely on BPF-based masquerading, we need
+			 * to pass the srcid from ipcache to host firewall. See
+			 * comment in ipv4_host_policy_egress() for details.
+			 */
+			ctx_store_meta(ctx, CB_IPCACHE_SRC_LABEL, ipcache_srcid);
+# endif
 			ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_HOST);
-		else
+		} else {
 			ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
+		}
 		/* We are not returning an error here to always allow traffic to
 		 * the stack in case maps have become unavailable.
 		 *
@@ -914,15 +932,27 @@ int to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		break;
 # endif
 # ifdef ENABLE_IPV4
-	case bpf_htons(ETH_P_IP):
+	case bpf_htons(ETH_P_IP): {
+		void *data, *data_end;
+		struct iphdr *ip4;
+		__u32 ipcache_srcid = 0;
+
 		/* to-netdev is attached to the egress path of the native
 		 * device.
 		 */
 		if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
 			src_id = HOST_ID;
-		src_id = resolve_srcid_ipv4(ctx, src_id, true);
-		ret = ipv4_host_policy_egress(ctx, src_id);
+		src_id = resolve_srcid_ipv4(ctx, src_id, &ipcache_srcid, true);
+
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
+			return DROP_INVALID;
+
+		/* We need to pass the srcid from ipcache to host firewall. See
+		 * comment in ipv4_host_policy_egress() for details.
+		 */
+		ret = ipv4_host_policy_egress(ctx, src_id, ipcache_srcid);
 		break;
+	}
 # endif
 	default:
 		ret = DROP_UNKNOWN_L3;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -487,6 +487,7 @@ enum {
 #define	CB_SVC_ADDR_V4		CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_SVC_ADDR_V6_1	CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_ENCRYPT_IDENTITY	CB_IFINDEX	/* Alias, non-overlapping */
+#define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
 	CB_POLICY,
 #define	CB_SVC_ADDR_V6_2	CB_POLICY	/* Alias, non-overlapping */
 	CB_NAT46_STATE,

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -86,7 +86,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	ctx->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
+	ctk->mark |= MARK_MAGIC_IDENTITY;
+	set_identity_mark(ctx, seclabel)
 	return redirect_peer(ep->ifindex, 0);
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
@@ -126,7 +127,8 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	ctx->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
+	ctk->mark |= MARK_MAGIC_IDENTITY;
+	set_identity_mark(ctx, seclabel)
 	return redirect_peer(ep->ifindex, 0);
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);

--- a/examples/policies/host/lock-down-dev-vms.yaml
+++ b/examples/policies/host/lock-down-dev-vms.yaml
@@ -53,6 +53,25 @@ spec:
       - port: "4240"
         protocol: TCP
 
+  # NodePort
+  # These two rules are only needed when kube-proxy is used.
+  # They should be removed when running in kube-proxy-free mode.
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-intra-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-multi-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+
+
   egress:
   # Only ICMP echo/reply messages should be drop if this is commented.
   - toEntities:

--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -26,6 +26,7 @@ import (
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/groups"
 
 	"k8s.io/api/core/v1"
@@ -39,7 +40,11 @@ import (
 // using CiliumNetworkPolicy itself, the entire implementation uses the methods
 // associcated with CiliumNetworkPolicy.
 func enableCCNPWatcher() error {
-	log.Info("Starting to garbage collect stale CiliumClusterwideNetworkPolicy status field entries...")
+	enableCNPStatusUpdates := kvstoreEnabled() && option.Config.K8sEventHandover && !option.Config.DisableCNPStatusUpdates
+	if enableCNPStatusUpdates {
+		log.Info("Starting a CCNP Status handover from kvstore to k8s...")
+	}
+	log.Info("Starting CCNP derivative handler...")
 
 	var (
 		ccnpConverterFunc informer.ConvertFunc
@@ -56,7 +61,7 @@ func enableCCNPWatcher() error {
 		ccnpConverterFunc = k8s.ConvertToCCNPWithStatus
 	}
 
-	if kvstoreEnabled() {
+	if enableCNPStatusUpdates {
 		ccnpSharedStore, err := store.JoinSharedStore(store.Configuration{
 			Prefix: k8s.CCNPStatusesPath,
 			KeyCreator: func() store.Key {
@@ -88,7 +93,7 @@ func enableCCNPWatcher() error {
 					cnpCpy := cnp.DeepCopy()
 
 					groups.AddDerivativeCCNPIfNeeded(cnpCpy.CiliumNetworkPolicy)
-					if kvstoreEnabled() {
+					if enableCNPStatusUpdates {
 						ccnpStatusMgr.StartStatusHandler(cnpCpy)
 					}
 				}
@@ -120,7 +125,7 @@ func enableCCNPWatcher() error {
 				// The derivative policy will be deleted by the parent but need
 				// to delete the cnp from the pooling.
 				groups.DeleteDerivativeFromCache(cnp.CiliumNetworkPolicy)
-				if kvstoreEnabled() {
+				if enableCNPStatusUpdates {
 					ccnpStatusMgr.StopStatusHandler(cnp)
 				}
 			},

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -87,6 +87,13 @@ func init() {
 	option.BindEnv(operatorOption.EnableCNPNodeStatusGC)
 	flags.MarkDeprecated(operatorOption.EnableCNPNodeStatusGC, fmt.Sprintf("Please use %s=0 to disable CNP Status GC", operatorOption.CNPNodeStatusGCInterval))
 
+	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)`)
+	flags.MarkHidden(option.DisableCNPStatusUpdates)
+	option.BindEnv(option.DisableCNPStatusUpdates)
+
+	flags.Bool(option.K8sEventHandover, defaults.K8sEventHandover, "Enable k8s event handover to kvstore for improved scalability")
+	option.BindEnv(option.K8sEventHandover)
+
 	flags.Duration(operatorOption.CNPNodeStatusGCInterval, 2*time.Minute, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
 	option.BindEnv(operatorOption.CNPNodeStatusGCInterval)
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -254,7 +254,10 @@ func runOperator() {
 				if identity == operatorID {
 					log.Info("Leading the operator HA deployment")
 				} else {
-					log.WithField("operator-id", operatorID).Infof("Operator with ID %q elected as new leader", identity)
+					log.WithFields(logrus.Fields{
+						"newLeader": operatorID,
+						"identity":  identity,
+					})
 				}
 			},
 		},

--- a/operator/main.go
+++ b/operator/main.go
@@ -257,7 +257,7 @@ func runOperator() {
 					log.WithFields(logrus.Fields{
 						"newLeader": operatorID,
 						"identity":  identity,
-					})
+					}).Info("Leader re-election complete")
 				}
 			},
 		},

--- a/operator/main.go
+++ b/operator/main.go
@@ -255,8 +255,8 @@ func runOperator() {
 					log.Info("Leading the operator HA deployment")
 				} else {
 					log.WithFields(logrus.Fields{
-						"newLeader": operatorID,
-						"identity":  identity,
+						"newLeader":  identity,
+						"operatorID": operatorID,
 					}).Info("Leader re-election complete")
 				}
 			},

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -27,6 +27,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/ipmasq"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -143,7 +145,10 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			"cilium_lb6_backends",
 			"cilium_lb6_reverse_sk",
 			"cilium_snat_v6_external",
-			"cilium_proxy6"}...)
+			"cilium_proxy6",
+			lbmap.Affinity6MapName,
+			lbmap.SourceRange6MapName,
+		}...)
 	}
 
 	if !option.Config.EnableIPv4 {
@@ -158,7 +163,11 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			"cilium_lb4_backends",
 			"cilium_lb4_reverse_sk",
 			"cilium_snat_v4_external",
-			"cilium_proxy4"}...)
+			"cilium_proxy4",
+			lbmap.Affinity4MapName,
+			lbmap.SourceRange4MapName,
+			ipmasq.MapName,
+		}...)
 	}
 
 	if !option.Config.EnableIPv4FragmentsTracking {
@@ -173,6 +182,18 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 		"cilium_policy_reserved_4",
 		"cilium_policy_reserved_5",
 	}...)
+
+	if !option.Config.EnableSessionAffinity {
+		maps = append(maps, lbmap.Affinity6MapName, lbmap.Affinity4MapName, lbmap.AffinityMatchMapName)
+	}
+
+	if !option.Config.EnableSVCSourceRangeCheck {
+		maps = append(maps, lbmap.SourceRange6MapName, lbmap.SourceRange4MapName)
+	}
+
+	if !option.Config.EnableIPMasqAgent {
+		maps = append(maps, ipmasq.MapName)
+	}
 
 	for _, m := range maps {
 		p := path.Join(bpf.MapPrefixPath(), m)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,8 @@ package version
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -34,8 +36,18 @@ type CiliumVersion struct {
 	AuthorDate string
 }
 
-// Version is set during build
+// ciliumVersion is set to Cilium's version, revision and git author time reference during build.
+var ciliumVersion string
+
+// Version is the complete Cilium version string including Go version.
 var Version string
+
+func init() {
+	// Mimic the output of `go version` and append it to ciliumVersion.
+	// Report GOOS/GOARCH of the actual binary, not the system it was built on, in case it was
+	// cross-compiled. See #13122
+	Version = fmt.Sprintf("%s go version %s %s/%s", ciliumVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}
 
 // FromString converts a version string into struct
 func FromString(versionString string) CiliumVersion {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -17,6 +17,7 @@
 package version
 
 import (
+	"runtime"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -96,4 +97,10 @@ func (vs *VersionSuite) TestStructIsSet(c *C) {
 		c.Assert(cver.Arch, Equals, tt.out.Arch)
 		c.Assert(cver.AuthorDate, Equals, tt.out.AuthorDate)
 	}
+}
+
+func (vs *VersionSuite) TestVersionArchMatchesGOARCH(c *C) {
+	// var ciliumVersion is not set in tests, thus Version does not contain the cilium version,
+	// just check that GOOS/GOARCH are reported correctly, see #13122.
+	c.Assert(Version, Matches, ".* "+runtime.GOOS+"/"+runtime.GOARCH)
 }

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1278,7 +1278,7 @@ var _ = Describe("K8sPolicyTest", func() {
 					"Monitor output does not show traffic as allowed")
 			})
 
-			SkipContextIf(helpers.RunsWithKubeProxy, "With host policy", func() {
+			Context("With host policy", func() {
 				BeforeAll(func() {
 					// Deploy echoserver pods in host namespace.
 					echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-cilium-hostnetns.yaml")


### PR DESCRIPTION
v1.8 backports 2020-09-16

There were some conflicts, so please have a look. Notes below.

 * #13120 -- logging_fix: Adding logs in a structured way (@chowmean)
 * #12694 -- Fix clustermesh policy with endpoint-routes mode (@joestringer)
 * #13135 -- Reduce operator memory usage when CNP status updates are disabled (@joestringer)
   - had to resolve some conflicts since files have diverged between the two versions
 * #13153 -- Report correct target system architecture in Cilium version (@tklauser)
 * ~~#13141 -- operator: fix invocation with `--help` option (@tklauser)~~
   - ~~conflict on original commit d570daaf06075d1d599bdbd061d22a3be7a08bbc resolved by omitting change in `daemon/cmd/daemon_main.go` since the corresponding line does not exist (_edit_: moved on the correct PR)~~ NOTE: The changes of #13141 were dropped from this backport PR to be picked up later.
 * #13095 -- docs: Removing wrong options from azure IPAM documentation.  (@chowmean)
 * #13159 -- docs/minikube: Update the step for minikube 1.12.1+ (@sayboras)
   - conflict on bb9411bdc264dc435e90c87f12106c67babcfbf6 resolved by changing BPF to eBPF since #12836 was not backported.
 * #13150 -- pkg/datapath: Remove unused feature maps (@brb)
   - conflict on f191f9eed4b9ab1d09c4bd8a6bf2456011acea52 resolved by including `lbmap package` and ignoring lines added by #13131 which was not backported (CC: @borkmann @joestringer @pchaigno)
 * #13049 -- bpf: Fix host firewall in presence of kube-proxy masquerading (@pchaigno)
    - conflicts on 31357599ff3486b6d9b1164485f2a86ac1603bd2 resolved by including changes in `lock-down-dev-vms.yaml` and omitting changes in `examples/policies/host/lock-down-gke.yaml` since file does not exist in v1.8.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13120 12694 13135 13153 13095 13159 13150 13049; do contrib/backporting/set-labels.py $pr done 1.8; done
```
