### PR TITLE
daemon: report HTTP service unavailable (503) in unhealthy state

### DIFF
--- a/daemon/cmd/agenthealth.go
+++ b/daemon/cmd/agenthealth.go
@@ -69,7 +69,7 @@ func (d *Daemon) startAgentHealthHTTPService(addr string) {
 		statusCode := http.StatusOK
 		sr := d.getStatus(true)
 		if isUnhealthy(&sr) {
-			statusCode = http.StatusInternalServerError
+			statusCode = http.StatusServiceUnavailable
 		}
 		w.WriteHeader(statusCode)
 	}))


### PR DESCRIPTION
Report HTTP status "service unavailable" (503) instead of "internal
server error" (500) on liveness/readiness probs in case the agent is
unhealthy.

Fixes: efffbdbebdbf ("daemon: expose HTTP endpoint on localhost for health checks")
Reported-by: André Martins <andre@cilium.io>

```release-note
Report HTTP "service unavailable" (503) instead of "internal
server error" (500) in unhealthy state, commonly used in Kubernetes liveness and readiness probes.
```