### PR TITLE
service: Fix panic when restoring services with enable-health-check-nodeport: false

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -276,17 +276,17 @@ func (s *Service) UpsertService(params *lb.SVC) (bool, lb.ID, error) {
 
 	// Only add a HealthCheckNodePort server if this is a service which may
 	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
-	if onlyLocalBackends && filterBackends {
-		localBackendCount := len(backendsCopy)
-		if option.Config.EnableHealthCheckNodePort {
+	if option.Config.EnableHealthCheckNodePort {
+		if onlyLocalBackends && filterBackends {
+			localBackendCount := len(backendsCopy)
 			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
 				localBackendCount, svc.svcHealthCheckNodePort)
+		} else if svc.svcHealthCheckNodePort == 0 {
+			// Remove the health check server in case this service used to have
+			// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
+			// version, but not anymore.
+			s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 		}
-	} else if svc.svcHealthCheckNodePort == 0 {
-		// Remove the health check server in case this service used to have
-		// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
-		// version, but not anymore.
-		s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 	}
 
 	if new {


### PR DESCRIPTION
We do not instantiate the service health server if `HealthCheckNodePort`
support is disabled in our kube-proxy replacement. This means that we
need to check the `EnableHealthCheckNodePort` flag before accessing the
service health server to avoid a nil pointer panic.

This PR also adds a unit test to catch potential regressions.
    
Fixes: edff374340cb ("agent: Add an option to cilium-agent for disabling 'HealthCheckNodePort'")
Fixes: #13178

**Note to backporters**: The unit test (second commit) may be skipped for backports if it causes non-trivial conflicts.

```release-note
Fix panic when restoring services with enable-health-check-nodeport: false
```
