### PR TITLE
[v1.8] k8s: Fix non-structural schema with CiliumNode

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -260,6 +260,9 @@ func createNodeCRD(clientset apiextensionsclient.Interface) error {
 	res := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: k8sconstv2.CNName,
+			Labels: map[string]string{
+				k8sconstv2.CustomResourceDefinitionSchemaVersionKey: k8sconstv2.CustomResourceDefinitionSchemaVersion,
+			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   k8sconstv2.CustomResourceDefinitionGroup,

--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"time"
 
 	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -28,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
+	"golang.org/x/sync/errgroup"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -279,6 +279,7 @@ func createNodeCRD(clientset apiextensionsclient.Interface) error {
 					Description: "CiliumNode represents the k8s node from the view of Cilium.",
 					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 						"spec": {
+							Type: "object",
 							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 								"azure": {
 									Type: "object",

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -31,7 +31,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.21.1"
+	CustomResourceDefinitionSchemaVersion = "1.21.2"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"


### PR DESCRIPTION
This is a direct backport to 1.8.

Fixes: https://github.com/cilium/cilium/issues/13192

```release-note
Fix bug in EKS environments where Cilium agents never become ready due to a missing CiliumNode CRD schema property
```