### PR TITLE
test: auto correct grafana port in test vagrant vms

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -117,7 +117,8 @@ Vagrant.configure("2") do |config|
             server.vm.boot_timeout = 600
             if i == 1 then
                 # grafana
-                server.vm.network "forwarded_port", guest: 3000, host: 3000
+                server.vm.network "forwarded_port", guest: 3000, host: 3000,
+                  auto_correct: true
                 server.vm.network "forwarded_port", guest: 6443, host: 9443,
                   auto_correct: true
             end


### PR DESCRIPTION
Not having auto_correct set to true caused concurrent vagrant envs
to conflict on host port 3000 which caused builds to fail