### PR TITLE
test/conformance: Disable pulling latest image in ipv6 test

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -60,6 +60,7 @@ jobs:
             --set global.nodeinit.enabled=true \
             --set global.kubeProxyReplacement=strict \
             --set config.ipam=kubernetes \
+            --set global.pullPolicy=Never \
             --set global.ipv6.enabled=true \
             --set global.ipv4.enabled=false \
             --set global.tunnel=disabled \


### PR DESCRIPTION
This PR is to update pullPolicy to Never, so that kind will use existing
loaded docker images.

This seems to be a miss in previous commit.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
test/conformance: Disable pulling latest image in ipv6 test
```
