### PR TITLE
identity: Fix user-space security identity lookup in cluster mesh

### DIFF
--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -200,8 +200,8 @@ func (w *identityWatcher) stop() {
 }
 
 // LookupIdentity looks up the identity by its labels but does not create it.
-// This function will first search through the local cache and fall back to
-// querying the kvstore.
+// This function will first search through the local cache, then the caches for
+// remote kvstores and finally fall back to the main kvstore
 func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labels.Labels) *identity.Identity {
 	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
 		return reservedIdentity
@@ -216,7 +216,7 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 	}
 
 	lblArray := lbls.LabelArray()
-	id, err := m.IdentityAllocator.Get(ctx, GlobalIdentity{lblArray})
+	id, err := m.IdentityAllocator.GetIncludeRemoteCaches(ctx, GlobalIdentity{lblArray})
 	if err != nil {
 		return nil
 	}
@@ -231,7 +231,8 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 var unknownIdentity = identity.NewIdentity(identity.IdentityUnknown, labels.Labels{labels.IDNameUnknown: labels.NewLabel(labels.IDNameUnknown, "", labels.LabelSourceReserved)})
 
 // LookupIdentityByID returns the identity by ID. This function will first
-// search through the local cache and fall back to querying the kvstore.
+// search through the local cache, then the caches for remote kvstores and
+// finally fall back to the main kvstore
 func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id identity.NumericIdentity) *identity.Identity {
 	if id == identity.IdentityUnknown {
 		return unknownIdentity
@@ -249,7 +250,7 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return identity
 	}
 
-	allocatorKey, err := m.IdentityAllocator.GetByID(ctx, idpool.ID(id))
+	allocatorKey, err := m.IdentityAllocator.GetByIDIncludeRemoteCaches(ctx, idpool.ID(id))
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
When looking up a security identity (either by its numeric id or by
labels) in user-space (e.g. in Hubble or the API), we want to ensure to
also include identities owned by remote clusters in cluster mesh too.

Before this commit, `GetIdentities` function of the identity allocator
(e.g. used for `cilium identity list`) would return all global
identities (i.e. including the ones from remote clusters as well), while
`LookupIdentity{,ByID}` would only return identitiies found the main
kvstore, ignoring any attached remote kvstores. This commit

This fixes multiple missed annotations which can occur in cluster-mesh
setups:

  - Hubble failed to annotate identities from remote clusters (#13076).

  - While the API would list remote identities in `/v1/identities`,
    performing a lookup on identities from remote clusters via API would
    fail with a "not found error". This 404 could be observed in
    `cilium identity get <remote-id>` or in `cilium bpf policy get`.

  - DNS proxy logrecords would not have the destination endpoint labels
    populated.

  - The `CiliumEndpoint.Status.Policy` CRD field would not contain
    labels for identities for remote clusters (if CEP status updates
    were enabled).

Fixes: #13076

```release-note
Fix bug where Hubble and the Cilium CLI would fail to resolve security identities across a cluster mesh.
```
