### PR TITLE
datapath: Reimplement init.sh in Go

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -209,9 +209,9 @@ func (d *Daemon) init() error {
 	if !option.Config.DryMode {
 		bandwidth.InitBandwidthManager()
 
-		if err := d.createNodeConfigHeaderfile(); err != nil {
-			return err
-		}
+		// if err := d.createNodeConfigHeaderfile(); err != nil {
+		// 	return err
+		// }
 
 		if option.Config.SockopsEnable {
 			eppolicymap.CreateEPPolicyMap()
@@ -225,6 +225,10 @@ func (d *Daemon) init() error {
 		}
 
 		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+			return err
+		}
+
+		if err := d.createNodeConfigHeaderfile(); err != nil {
 			return err
 		}
 	}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -532,21 +532,9 @@ func detectNodeDevice(ifidxByAddr map[string]int) (string, error) {
 // Otherwise, if EnableAutoProtectNodePortRange == true, then append the nodeport
 // range to ip_local_reserved_ports.
 func checkNodePortAndEphemeralPortRanges() error {
-	ephemeralPortRangeStr, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	ephemeralPortRangeStr, ephemeralPortMin, ephemeralPortMax, err := node.EphemeralPortRange()
 	if err != nil {
-		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
-	}
-	ephemeralPortRange := strings.Split(ephemeralPortRangeStr, "\t")
-	if len(ephemeralPortRange) != 2 {
-		return fmt.Errorf("Invalid ephemeral port range: %s", ephemeralPortRangeStr)
-	}
-	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
-	if err != nil {
-		return fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
-	}
-	ephemeralPortMax, err := strconv.Atoi(ephemeralPortRange[1])
-	if err != nil {
-		return fmt.Errorf("Unable to parse max port value %s for ephemeral range", ephemeralPortRange[1])
+		return err
 	}
 
 	if option.Config.NodePortMax < ephemeralPortMin {

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -17,11 +17,16 @@ package loader
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -150,4 +155,426 @@ func RemoveTCFilters(ifName string, tcDir uint32) error {
 	}
 
 	return nil
+}
+
+func setupDev(link netlink.Link) error {
+	ifName := link.Attrs().Name
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		log.WithError(err).WithField("device", ifName).Warn("Could not set up the link")
+		return err
+	}
+
+	sysSettings := make([]sysctl.Setting, 0, 5)
+	if option.Config.EnableIPv6 {
+		sysctl.Enable(fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName))
+		sysSettings = append(sysSettings, sysctl.Setting{
+			Name: fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName), Val: "1", IgnoreErr: false})
+	}
+	if option.Config.EnableIPv4 {
+		sysSettings = append(sysSettings, []sysctl.Setting{
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.forwarding", ifName), Val: "1", IgnoreErr: false},
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName), Val: "0", IgnoreErr: false},
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.accept_local", ifName), Val: "1", IgnoreErr: false},
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.send_redirects", ifName), Val: "0", IgnoreErr: false},
+		}...)
+	}
+	if err := sysctl.ApplySettings(sysSettings); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupDevs(links ...netlink.Link) error {
+	for _, link := range links {
+		if err := setupDev(link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setupVethPair(name, peerName string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		hostMac, err := mac.GenerateRandMAC()
+		if err != nil {
+			return err
+		}
+		peerMac, err := mac.GenerateRandMAC()
+		if err != nil {
+			return err
+		}
+
+		// Ignore the error.
+		netlink.LinkDel(link)
+
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         name,
+				HardwareAddr: net.HardwareAddr(hostMac),
+			},
+			PeerName:         peerName,
+			PeerHardwareAddr: net.HardwareAddr(peerMac),
+		}
+		if err := netlink.LinkAdd(veth); err != nil {
+			return err
+		}
+	}
+
+	// for _, iface := range ifaces {
+	// 	if err := setupDev(link); err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	return nil
+}
+
+func setupIpvlanSlave(name string, nativeLink netlink.Link) (*netlink.IPVlan, error) {
+	hostLink, err := netlink.LinkByName(name)
+	if err == nil {
+		// Ignore the error.
+		netlink.LinkDel(hostLink)
+	}
+
+	ipvlan := &netlink.IPVlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        name,
+			ParentIndex: nativeLink.Attrs().Index,
+		},
+		Mode: netlink.IPVLAN_MODE_L3,
+	}
+	if err := netlink.LinkAdd(ipvlan); err != nil {
+		return nil, err
+	}
+
+	if err := setupDev(ipvlan); err != nil {
+		return nil, err
+	}
+
+	return ipvlan, nil
+}
+
+func setupBaseDevice(nativeDevs []netlink.Link, mode string, mtu int) error {
+	switch mode {
+	case "flannel":
+		if err := setupDevs(nativeDevs...); err != nil {
+			return err
+		}
+	case "ipvlan":
+		ciliumHostlink, err := netlink.LinkByName("cilium_host")
+		if err != nil {
+			return err
+		}
+
+		ipvlan, err := setupIpvlanSlave("cilium_host", nativeDevs[0])
+		if err != nil {
+			return err
+		}
+		if err := netlink.LinkSetMTU(ipvlan, mtu); err != nil {
+			return err
+		}
+	default:
+		if err := setupVethPair("cilium_host", "cilium_net"); err != nil {
+			return err
+		}
+
+		link1, err := netlink.LinkByName("cilium_host")
+		if err != nil {
+			return err
+		}
+		link2, err := netlink.LinkByName("cilium_net")
+		if err != nil {
+			return err
+		}
+
+		if err := netlink.LinkSetARPOff(link1); err != nil {
+			return err
+		}
+		if err := netlink.LinkSetARPOff(link2); err != nil {
+			return err
+		}
+
+		if err := netlink.LinkSetMTU(link1, mtu); err != nil {
+			return err
+		}
+		if err := netlink.LinkSetMTU(link2, mtu); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// moveLocalRulesAf moves the local table lookup rule from priority 0 to 100 so
+// we can insert the cilium ip rules before the local table. It is strictly
+// required to add the new local rule before deleting the old one as otherwise
+// local addresses will not be reachable for a short period of time.
+func moveLocalRulesAf(family int) error {
+	filter1 := netlink.NewRule()
+	filter1.Priority = 100
+	filter1.Table = unix.RT_TABLE_LOCAL
+
+	rules1, err := netlink.RuleListFiltered(family, filter1, 0)
+	if err != nil {
+		return err
+	}
+
+	if len(rules1) == 0 {
+		rule := netlink.NewRule()
+		rule.Priority = 100
+		rule.Table = unix.RT_TABLE_LOCAL
+
+		if err := netlink.RuleAdd(rule); err != nil {
+			return err
+		}
+	}
+
+	filter2 := netlink.NewRule()
+	filter2.Priority = 0
+	filter2.Table = unix.RT_TABLE_LOCAL
+
+	rules2, err := netlink.RuleListFiltered(family, filter2, 0)
+	if err != nil {
+		return err
+	}
+
+	for _, ruleToDel := range rules2 {
+		// Ignore the error.
+		netlink.RuleDel(&ruleToDel)
+	}
+
+	// Check if the move of the local table move was successful and restore
+	// it otherwise.
+	filter3 := netlink.NewRule()
+	filter3.Table = unix.RT_TABLE_LOCAL
+
+	rules3, err := netlink.RuleListFiltered(family, filter3, 0)
+	if err != nil {
+		return err
+	}
+
+	if len(rules3) == 0 {
+		rule := netlink.NewRule()
+		rule.Priority = 0
+		rule.Table = unix.RT_TABLE_LOCAL
+
+		if err := netlink.RuleAdd(rule); err != nil {
+			return err
+		}
+
+		filter4 := netlink.NewRule()
+		filter4.Priority = 100
+		filter4.Table = unix.RT_TABLE_LOCAL
+
+		rules4, err := netlink.RuleListFiltered(family, filter4, 0)
+		if err != nil {
+			return err
+		}
+
+		for _, ruleToDel := range rules4 {
+			if err := netlink.RuleDel(&ruleToDel); err != nil {
+				return err
+			}
+		}
+
+		return fmt.Errorf("")
+	}
+
+	return nil
+}
+
+func moveLocalRules() error {
+	if option.Config.EnableIPv4 {
+		if err := moveLocalRulesAf(4); err != nil {
+			return err
+		}
+	}
+	if option.Config.EnableIPv6 {
+		if err := moveLocalRulesAf(6); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+const (
+	ProxyRtTable   = 2005
+	ToProxyRtTable = 2004
+)
+
+func setupProxyRules(mode, hostDev1, hostDev2 string) error {
+	switch mode {
+	case "ipvlan":
+		return nil
+	}
+
+	ruleFromIngress := netlink.NewRule()
+	ruleFromIngress.Priority = 10
+	ruleFromIngress.Table = ProxyRtTable
+	ruleFromIngress.Mark = 0xA00
+	ruleFromIngress.Mask = 0xF00
+
+	ruleToProxy := netlink.NewRule()
+	ruleToProxy.Priority = 9
+	ruleToProxy.Table = ToProxyRtTable
+	ruleToProxy.Mark = 0x200
+	ruleToProxy.Mask = 0xF00
+
+	if option.Config.EnableIPv4 {
+		rules, err := netlink.RuleListFiltered(4, ruleToProxy, 0)
+		if err != nil {
+			return err
+		}
+
+		if len(rules) == 0 {
+			if err := netlink.RuleAdd(ruleToProxy); err != nil {
+				return err
+			}
+		}
+
+		switch mode {
+		case "routed":
+			rules2, err := netlink.RuleListFiltered(4, ruleFromIngress, 0)
+			if err != nil {
+				return err
+			}
+
+			if len(rules2) > 0 {
+				if err := netlink.RuleDel(ruleFromIngress); err != nil {
+					return err
+				}
+			}
+		default:
+			rules2, err := netlink.RuleListFiltered(4, ruleToProxy, 0)
+			if err != nil {
+				return err
+			}
+
+			if len(rules2) == 0 {
+				if err := netlink.RuleDel(ruleToProxy); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		// Ignore errors.
+		netlink.RuleDel(ruleToProxy)
+		netlink.RuleDel(ruleFromIngress)
+	}
+
+	// flannel might not have an IPv6 address.
+	switch mode {
+	case "flannel":
+	default:
+		if option.Config.EnableIPv6 {
+			rules, err := netlink.RuleListFiltered(6, ruleToProxy, 0)
+			if err != nil {
+				return err
+			}
+
+			if len(rules) == 0 {
+				if err := netlink.RuleAdd(ruleToProxy); err != nil {
+					return err
+				}
+
+				switch mode {
+				case "routed":
+					rules2, err := netlink.RuleListFiltered(6, ruleFromIngress, 0)
+					if err != nil {
+						return err
+					}
+
+					if len(rules2) > 0 {
+						if err := netlink.RuleDel(ruleFromIngress); err != nil {
+							return err
+						}
+					}
+				default:
+					rules2, err := netlink.RuleListFiltered(6, ruleFromIngress, 0)
+					if err != nil {
+						return err
+					}
+
+					if len(rules2) == 0 {
+						if err := netlink.RuleAdd(ruleFromIngress); err != nil {
+							return err
+						}
+					}
+				}
+			}
+
+			hostLink1, err := netlink.LinkByName(hostDev1)
+			if err != nil {
+				return err
+			}
+			hostLink2, err := netlink.LinkByName(hostDev2)
+			if err != nil {
+				return err
+			}
+			addrs, err := netlink.AddrList(hostLink2, 6)
+			if err != nil {
+				return err
+			}
+
+			if len(addrs) > 0 {
+				route := netlink.Route{
+					LinkIndex: hostLink2.Attrs().Index,
+					Table:     ToProxyRtTable,
+					Type:      unix.RTN_LOCAL,
+				}
+				netlink.RouteReplace(&route)
+
+				switch mode {
+				case "routed":
+					route2 := netlink.Route{
+						LinkIndex: hostLink1.Attrs().Index,
+						Dst:       addrs[0].IPNet, // TODO: /128
+						Table:     ProxyRtTable,
+					}
+					route3 := netlink.Route{
+						LinkIndex: hostLink1.Attrs().Index,
+						Dst:       addrs[0].IPNet, // via?
+						Table:     ProxyRtTable,
+					}
+					// Ignore errors.
+					netlink.RouteDel(&route2)
+					netlink.RouteDel(&route3)
+				default:
+					route2 := netlink.Route{
+						LinkIndex: hostLink1.Attrs().Index,
+						Dst:       addrs[0].IPNet, // TODO: /128
+						Table:     ProxyRtTable,
+					}
+					route3 := netlink.Route{
+						LinkIndex: hostLink1.Attrs().Index,
+						Dst:       addrs[0].IPNet, // via?
+						Table:     ProxyRtTable,
+					}
+					netlink.RouteReplace(&route2)
+					netlink.RouteReplace(&route3)
+				}
+			}
+		} else {
+			// Ignore errors.
+			netlink.RuleDel(ruleToProxy)
+			netlink.RuleDel(ruleFromIngress)
+		}
+	}
+
+	return nil
+}
+
+func mac2array(mac net.HardwareAddr) string {
+	s := "{"
+	s += fmt.Sprintf("0x%x", mac[0])
+	for _, b := range mac[1:] {
+		s += ","
+		s += fmt.Sprintf("0x%x", b)
+	}
+	s += "}"
+
+	return s
 }

--- a/pkg/datapath/loader/netlink_bpf.go
+++ b/pkg/datapath/loader/netlink_bpf.go
@@ -1,0 +1,205 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loader
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	stdlibExec "os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/command/exec"
+
+	"github.com/cilium/ebpf"
+	"github.com/vishvananda/netlink"
+)
+
+func bpfCompileProg(src, dst string, extraCFlags []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 100)
+	defer cancel()
+
+	if err := Compile(ctx, src, dst, extraCFlags); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func xdpLoad(ifName, mode, src, dst, sec, cidrMap string, extraCFlags []string) error {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return err
+	}
+	mac := mac2array(link.Attrs().HardwareAddr)
+
+	extraCFlags = append(extraCFlags, fmt.Sprintf("-DNODE_MAC=%s", mac))
+
+	if err := bpfCompileProg(src, dst, extraCFlags); err != nil {
+		return err
+	}
+
+	collection, err := ebpf.LoadCollectionSpec(dst)
+	if err != nil {
+		return err
+	}
+
+	var retCode int64
+	for _, progSpec := range collection.Programs {
+		prog, err := ebpf.NewProgram(progSpec)
+		if err != nil {
+			return err
+		}
+
+		// TODO: mode?
+		if err := netlink.LinkSetXdpFd(link, prog.FD()); err != nil {
+			// return err
+			retCode = 1
+		}
+	}
+
+	args := []string{"-e", dst, "-r", strconv.FormatInt(retCode, 10)}
+	cmd := exec.CommandContext(context.Background(), "cilium-map-migrate", args...)
+	cmd.Env = bpf.Environment()
+	// Ignore errors.
+	cmd.CombinedOutput(log, true)
+
+	return nil
+}
+
+func xdpUnload(ifName, mode string) error {
+	// TODO
+	return nil
+}
+
+func bpfLoad(ifName, where, src, dst, sec, callsMap string, extraCFlags []string) error {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return err
+	}
+	mac := mac2array(link.Attrs().HardwareAddr)
+
+	extraCFlags = append(extraCFlags, fmt.Sprintf("-DNODE_MAC=%s", mac))
+	extraCFlags = append(extraCFlags, fmt.Sprintf("-DCALLS_MAP=%s", callsMap))
+
+	if err := bpfCompileProg(src, dst, extraCFlags); err != nil {
+		return err
+	}
+
+	qdisc := &netlink.Htb{
+		QdiscAttrs: netlink.QdiscAttrs{
+			LinkIndex: link.Attrs().Index,
+		},
+	}
+	// Ignore error.
+	netlink.QdiscReplace(qdisc)
+
+	// [ -z "$(tc filter show dev $DEV $WHERE | grep -v 'pref 1 bpf chain 0 $\|pref 1 bpf chain 0 handle 0x1')" ] || tc filter del dev $DEV $WHERE
+	// filters, err := netlink.FilterList(link, 0)
+	// if err != nil {
+	// 	return err
+	// }
+	// ffilters := make([]netlink.Filter, 0)
+	// for _, filter := range filters {
+	// }
+
+	// tc filter replace dev $DEV $WHERE prio 1 handle 1 bpf da obj $OUT sec $SEC
+
+	args := []string{"-s", dst}
+	cmd := exec.CommandContext(context.Background(), "cilium-map-migrate", args...)
+	cmd.Env = bpf.Environment()
+	if _, err := cmd.CombinedOutput(log, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func bpdLoadCgroups(src, dst, progType, where, callsMap, cgroup, bpfMount string, extraCFlags []string) error {
+	extraCFlags = append(extraCFlags, fmt.Sprintf("-DCALLS_MAP=%s", callsMap))
+
+	if err := bpfCompileProg(src, dst, extraCFlags); err != nil {
+		return err
+	}
+
+	tmpFile := fmt.Sprintf("%s/tc/globals/cilium_cgroups_%s", bpfMount, where)
+	os.Remove(tmpFile)
+
+	cmd := exec.CommandContext(context.Background(), "cilium-map-migrate", "-s", dst)
+	cmd.Env = bpf.Environment()
+	if _, err := cmd.CombinedOutput(log, true); err != nil {
+		return err
+	}
+
+	retCode := 0
+	cmd2 := exec.CommandContext(context.Background(), "tc", "exec", "bpf", "pin", tmpFile, "obj", dst, "type", progType, "attach_type", where, "sec", where)
+	cmd.Env = bpf.Environment()
+	if _, err := cmd2.CombinedOutput(log, true); err != nil {
+		if exitErr, ok := err.(*stdlibExec.ExitError); ok {
+			retCode = exitErr.ExitCode()
+		}
+	}
+
+	cmd3 := exec.CommandContext(context.Background(), "cilium-map-migrate", "-e", out, "-r", retCode)
+	cmd.Env = bpf.Environment()
+	if _, err := cmd3.CombinedOutput(log, true); err != nil {
+		return err
+	}
+
+	if retCode != 0 {
+		return fmt.Errorf("tc return code: %d", retCode)
+	}
+
+	cmd4 := exec.CommandContext(context.Background(), "bpftool", "cgroup", "attach", cgroup, where, "pinned", tmpFile)
+	if _, err := cmd4.CombinedOutput(log, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func bpfClearCgroups(cgroup, hook string) error {
+	cmd := exec.CommandContext(context.Background(), "bpftool", "cgroup", "show", cgroup)
+	cmd.Env = bpf.Environment()
+	out, err := cmd.CombinedOutput(log, true)
+	if err != nil {
+		if _, ok := err.(*stdlibExec.ExitError); ok {
+			// No cgroups to clean.
+			return nil
+		}
+		return err
+	}
+
+	var cgID string
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, hook) {
+			id := strings.Split(line, " ")[0]
+			break
+		}
+	}
+
+	cmd2 := exec.CommandContext(context.Background(), "bpftool", "cgroup", "detach", cgroup, hook, "id", cgID)
+	cmd2.Env() = bpf.Environment()
+	if _, err := cmd2.CombinedOutput(log, true); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/node/port_range.go
+++ b/pkg/node/port_range.go
@@ -1,0 +1,45 @@
+// Copyright 2019-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+// EphemeralPortRange returns the minimal and maximal ports from the ephemeral
+// port range.
+func EphemeralPortRange() (string, int, int, error) {
+	ephemeralPortRangeStr, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
+	}
+	ephemeralPortRange := strings.Split(ephemeralPortRangeStr, "\t")
+	if len(ephemeralPortRange) != 2 {
+		return "", 0, 0, fmt.Errorf("Invalid ephemeral port range: %s", ephemeralPortRangeStr)
+	}
+	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
+	}
+	ephemeralPortMax, err := strconv.Atoi(ephemeralPortRange[1])
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("Unable to parse max port value %s for ephemeral range", ephemeralPortRange[1])
+	}
+	return ephemeralPortRangeStr, ephemeralPortMin, ephemeralPortMax, nil
+}

--- a/pkg/node/port_range_test.go
+++ b/pkg/node/port_range_test.go
@@ -1,0 +1,74 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package node
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+type PortRangeSuite struct {
+	prevEphemeralPortRange string
+}
+
+var _ = Suite(&PortRangeSuite{})
+
+func (s *PortRangeSuite) SetUpTest(c *C) {
+	prevEphemeralPortRange, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	c.Assert(err, IsNil)
+	s.prevEphemeralPortRange = prevEphemeralPortRange
+}
+
+func (s *PortRangeSuite) TearDownTest(c *C) {
+	err := sysctl.Write("net.ipv4.ip_local_port_range", s.prevEphemeralPortRange)
+	c.Assert(err, IsNil)
+}
+
+func (s *PortRangeSuite) TestEphemeralPortRangeDefault(c *C) {
+	_, _, _, err := EphemeralPortRange()
+	c.Assert(err, IsNil)
+}
+
+func (s *PortRangeSuite) TestEphemralPortRangeCustom(c *C) {
+	tests := []struct {
+		epRange string
+		expMin  int
+		expMax  int
+	}{
+		{
+			"32000\t32999",
+			32000,
+			32999,
+		},
+		{
+			"32768\t60999",
+			32768,
+			60999,
+		},
+	}
+
+	for _, test := range tests {
+		err := sysctl.Write("net.ipv4.ip_local_port_range", test.epRange)
+		c.Assert(err, IsNil)
+
+		epRange, epMin, epMax, err := EphemeralPortRange()
+		c.Assert(epRange, Equals, test.epRange)
+		c.Assert(epMin, Equals, test.expMin)
+		c.Assert(epMax, Equals, test.expMax)
+	}
+}

--- a/pkg/sockops/sockops.go
+++ b/pkg/sockops/sockops.go
@@ -266,7 +266,7 @@ func bpfCompileProg(src string, dst string) error {
 	srcpath := filepath.Join("sockops", src)
 	outpath := filepath.Join(dst)
 
-	err := loader.Compile(ctx, srcpath, outpath)
+	err := loader.Compile(ctx, srcpath, outpath, nil)
 	if err != nil {
 		return fmt.Errorf("failed compile %s: %s", srcpath, err)
 	}


### PR DESCRIPTION
This change reimplements the datapath initialization logic in Go with
netlink and ebpf libraries and replaces the init.sh script.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

```release-note
Datapath initialization logic in Go
```
