### PR TITLE
v1.7 backports 2020-09-17

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -32,6 +32,7 @@ cilium-operator [flags]
       --ec2-api-endpoint string                   AWS API endpoint for the EC2 service
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
       --eni-parallel-workers int                  Maximum number of parallel workers used by ENI allocator (default 50)
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+RELEASE_TOOL_PATH="${RELEASE_TOOL_PATH:-$GOPATH/src/github.com/cilium/release}"
+RELNOTES="$RELEASE_TOOL_PATH/release"
+RELNOTESCACHE="release-state.json"
+
+usage() {
+    logecho "usage: $0 <OLD-VERSION> <NEW-VERSION>"
+    logecho "OLD-VERSION    Previous release version for comparison"
+    logecho "NEW-VERSION    Target release version"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+[-rc0-9]*"; then
+        usage 2>&1
+        common::exit 1 "Invalid NEW-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(echo $1 | sed 's/^v//')"
+    local ersion="$(echo $2 | sed 's/^v//')"
+    local version="v$ersion"
+
+    logecho "Generating CHANGELOG.md"
+    rm -f $RELNOTESCACHE
+    echo -e "# Changelog\n\n## $version" > $version-changes.txt
+    $RELNOTES --base $old_version --head $(git rev-parse HEAD) >> $version-changes.txt
+    cp $version-changes.txt CHANGELOG-new.md
+    if [[ -e CHANGELOG.md ]]; then
+        tail -n+2 CHANGELOG.md >> CHANGELOG-new.md
+    fi
+    mv CHANGELOG-new.md CHANGELOG.md
+    logecho "Generated CHANGELOG.md"
+}
+
+main "$@"

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+ACTS_YAML=".github/cilium-actions.yml"
+
+usage() {
+    logecho "usage: $0 <VERSION> <GH-PROJECT>"
+    logecho "VERSION    Target release version"
+    logecho "GH-PROJECT Project ID for next release"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "^[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid GH-PROJECT ID argument. Expected [0-9]+"
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ "$(git status -s | grep -v "^??" | wc -l)" -gt 0 ]]; then
+        git status -s | grep -v "^??"
+        common::exit 1 "Unmerged changes in tree prevent preparing release PR."
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(cat VERSION)"
+    local ersion="$(echo $1 | sed 's/^v//')"
+    local version="v$ersion"
+    local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
+    local remote="origin"
+    local new_proj="$2"
+
+    git fetch $remote
+    git checkout -b pr/prepare-$version $remote/v$branch
+
+    logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
+    echo $ersion > VERSION
+    logrun make -C install/kubernetes all
+    logrun make update-authors
+    old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
+    sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+
+    $DIR/prep-changelog.sh "$old_version" "$version"
+
+    logecho "Next steps:"
+    logecho "* Check all changes and add to a new commit"
+    logecho "* Push the PR to Github for review"
+    logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
+    logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
+
+    # Leave $version-changes.txt around for prep-release.sh usage later
+}
+
+main "$@"

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+BRANCH="${1:-""}"
+if [ "$BRANCH" = "" ]; then
+    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
+fi
+BRANCH=$(echo "$BRANCH" | sed 's/^v//')
+
+RELEASE="v$(cat VERSION)"
+SUMMARY=${2:-}
+GENERATE_SUMMARY=false
+if [ "$SUMMARY" = "" ]; then
+    SUMMARY="$RELEASE-changes.txt"
+    GENERATE_SUMMARY=true
+fi
+
+if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+    echo "usage: $0 [branch version] [release-summary]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
+    exit 1
+fi
+
+if ! hub help | grep -q "pull-request"; then
+    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+    echo "Please install this tool first." 1>&2
+    exit 1
+fi
+
+if ! git diff --quiet; then
+    echo "Local changes found in git tree. Exiting release process..." 1>&2
+    exit 1
+fi
+
+if ! git log --oneline | grep -q $RELEASE; then
+    echo "Latest commit does not match commit title for release:" 1>&2
+    git log -1
+    exit 1
+fi
+
+if $GENERATE_SUMMARY; then
+    CHANGELOG=$SUMMARY
+    SUMMARY="$RELEASE-pr-$(date --rfc-3339=date).txt"
+    echo "Prepare for release $RELEASE" > $SUMMARY
+    tail -n+4 $CHANGELOG >> $SUMMARY
+fi
+
+echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+cat $SUMMARY 1>&2
+echo -e "\nSending pull request..." 2>&1
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git push origin "$PR_BRANCH"
+hub pull-request -b "v$BRANCH" -l kind/release,backport/$BRANCH -F $SUMMARY

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+REMOTE="$(get_remote)"
+CHARTS_PATH="${CHARTS_PATH:-$GOPATH/src/github.com/cilium/charts}"
+CHARTS_TOOL="prepare_artifacts.sh"
+RELEASES_URL="https://github.com/cilium/cilium/releases"
+VERSION=""
+
+usage() {
+    echo "usage: $0 [VERSION]"
+    echo "CHARTS_REPO Path to local copy of github.com/cilium/charts"
+    echo
+    echo "--help     Print this help message"
+}
+
+handle_args() {
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 1
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ ! -e "$CHARTS_PATH/$CHARTS_TOOL" ]]; then
+        usage
+        common::exit 1 "CHARTS_PATH='$CHARTS_PATH' invalid. Clone from github.com/cilium/charts"
+    fi
+
+    if ! which hub >/dev/null; then
+        echo "This tool relies on 'hub' from https://github.com/github/hub ." 1>&2
+        common::exit 1 "Please install this tool first."
+    fi
+
+    if [[ $# -ge 1 ]]; then
+        VERSION="$1"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local ersion="$(cat VERSION)"
+    if [[ "$VERSION" != "" ]]; then
+        ersion="$(echo $VERSION | sed 's/^v//')"
+    fi
+    local version="v$ersion"
+
+    if [[ ! -e $version-changes.txt ]]; then
+        common::exit 1 "Generate release notes via contrib/release/start-release.sh"
+    fi
+
+    echo "Current HEAD is:"
+    git log --oneline -1 $(git rev-parse HEAD)
+    echo "Create git tags for $version with this commit"
+    if ! common::askyorn ; then
+        common::exit 0 "Aborting release preparation."
+    fi
+
+    logrun -s git tag -a $ersion -s -m "Release $version"
+    logrun -s git tag -a $version -s -m "Release $version"
+    logrun -s git push $REMOTE $version $ersion
+
+    # Leave $version-changes.txt around so we can generate release notes later
+    echo -e "$ersion\n" > $version-release-summary.txt
+    echo "We are pleased to release Cilium $version." >>  $version-release-summary.txt
+    tail -n+4 $version-changes.txt >> $version-release-summary.txt
+    logecho "Creating Github draft release"
+    logrun hub release create -d -F $version-release-summary.txt $version
+    logecho "Browse to $RELEASES_URL to see the draft release"
+
+    logecho
+    logecho "Next steps:"
+    logecho "* Wait for cilium docker images to be prepared"
+    logecho "* Prepare the helm template changes"
+    logecho "* When docker images are available, test deployment of new version"
+    logecho "* Push templates and announce release on GitHub / Slack"
+}
+
+main "$@"

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -99,8 +99,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			// Open socket for using gops to get stacktraces of the agent.
 			if err := gops.Listen(gops.Options{}); err != nil {
-				errorString := fmt.Sprintf("unable to start gops: %s", err)
-				fmt.Println(errorString)
+				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 				os.Exit(-1)
 			}
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -97,6 +97,13 @@ var (
 		Use:   "cilium-agent",
 		Short: "Run the cilium agent",
 		Run: func(cmd *cobra.Command, args []string) {
+			// Open socket for using gops to get stacktraces of the agent.
+			if err := gops.Listen(gops.Options{}); err != nil {
+				errorString := fmt.Sprintf("unable to start gops: %s", err)
+				fmt.Println(errorString)
+				os.Exit(-1)
+			}
+
 			bootstrapStats.earlyInit.Start()
 			initEnv(cmd)
 			bootstrapStats.earlyInit.End(true)
@@ -121,12 +128,6 @@ func init() {
 func daemonMain() {
 	bootstrapStats.overall.Start()
 
-	// Open socket for using gops to get stacktraces of the agent.
-	if err := gops.Listen(gops.Options{}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
-		os.Exit(-1)
-	}
 	interruptCh := cleaner.registerSigHandler()
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/operator/main.go
+++ b/operator/main.go
@@ -396,7 +396,10 @@ func runOperator(cmd *cobra.Command) {
 				if identity == operatorID {
 					log.Info("Leading the operator HA deployment")
 				} else {
-					log.WithField("operator-id", operatorID).Infof("Operator with ID %q elected as new leader", identity)
+					log.WithFields(logrus.Fields{
+						"newLeader": operatorID,
+						"identity":  identity,
+					})
 				}
 			},
 		},

--- a/operator/main.go
+++ b/operator/main.go
@@ -60,6 +60,12 @@ var (
 		Use:   "cilium-operator",
 		Short: "Run the cilium-operator",
 		Run: func(cmd *cobra.Command, args []string) {
+			// Open socket for using gops to get stacktraces of the operator.
+			if err := gops.Listen(gops.Options{}); err != nil {
+				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
+				os.Exit(-1)
+			}
+
 			runOperator(cmd)
 		},
 	}
@@ -123,12 +129,6 @@ func main() {
 		<-signals
 		doCleanup()
 	}()
-
-	// Open socket for using gops to get stacktraces of the operator.
-	if err := gops.Listen(gops.Options{}); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
-		os.Exit(-1)
-	}
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/operator/main.go
+++ b/operator/main.go
@@ -397,8 +397,8 @@ func runOperator(cmd *cobra.Command) {
 					log.Info("Leading the operator HA deployment")
 				} else {
 					log.WithFields(logrus.Fields{
-						"newLeader": operatorID,
-						"identity":  identity,
+						"newLeader":  identity,
+						"operatorID": operatorID,
 					}).Info("Leader re-election complete")
 				}
 			},

--- a/operator/main.go
+++ b/operator/main.go
@@ -124,10 +124,9 @@ func main() {
 		doCleanup()
 	}()
 
-	// Open socket for using gops to get stacktraces of the agent.
+	// Open socket for using gops to get stacktraces of the operator.
 	if err := gops.Listen(gops.Options{}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
+		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 		os.Exit(-1)
 	}
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -399,7 +399,7 @@ func runOperator(cmd *cobra.Command) {
 					log.WithFields(logrus.Fields{
 						"newLeader": operatorID,
 						"identity":  identity,
-					})
+					}).Info("Leader re-election complete")
 				}
 			},
 		},

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -692,6 +692,68 @@ func (a *Allocator) GetByID(ctx context.Context, id idpool.ID) (AllocatorKey, er
 	return a.backend.GetByID(ctx, id)
 }
 
+// GetIncludeRemoteCaches returns the ID which is allocated to a key. Includes the
+// caches of watched remote kvstores in the query. Returns an ID of NoID if no
+// ID has been allocated in any remote kvstore to this key yet.
+func (a *Allocator) GetIncludeRemoteCaches(ctx context.Context, key AllocatorKey) (idpool.ID, error) {
+	encoded := a.encodeKey(key)
+
+	// check main cache first
+	if id := a.mainCache.get(encoded); id != idpool.NoID {
+		return id, nil
+	}
+
+	// check remote caches
+	a.remoteCachesMutex.RLock()
+	for rc := range a.remoteCaches {
+		if id := rc.cache.get(encoded); id != idpool.NoID {
+			a.remoteCachesMutex.RUnlock()
+			return id, nil
+		}
+	}
+	a.remoteCachesMutex.RUnlock()
+
+	// check main backend
+	if id, err := a.backend.Get(ctx, key); id != idpool.NoID || err != nil {
+		return id, err
+	}
+
+	// we skip checking remote backends explicitly here, to avoid
+	// accidentally overloading them in case of lookups for invalid identities
+
+	return idpool.NoID, nil
+}
+
+// GetByIDIncludeRemoteCaches returns the key associated with an ID. Includes
+// the caches of watched remote kvstores in the query.
+// Returns nil if no key is associated with the ID.
+func (a *Allocator) GetByIDIncludeRemoteCaches(ctx context.Context, id idpool.ID) (AllocatorKey, error) {
+	// check main cache first
+	if key := a.mainCache.getByID(id); key != nil {
+		return key, nil
+	}
+
+	// check remote caches
+	a.remoteCachesMutex.RLock()
+	for rc := range a.remoteCaches {
+		if key := rc.cache.getByID(id); key != nil {
+			a.remoteCachesMutex.RUnlock()
+			return key, nil
+		}
+	}
+	a.remoteCachesMutex.RUnlock()
+
+	// check main backend
+	if key, err := a.backend.GetByID(ctx, id); key != nil || err != nil {
+		return key, err
+	}
+
+	// we skip checking remote backends explicitly here, to avoid
+	// accidentally overloading them in case of lookups for invalid identities
+
+	return nil, nil
+}
+
 // Release releases the use of an ID associated with the provided key. After
 // the last user has released the ID, the key is removed in the KVstore and
 // the returned lastUse value is true.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -767,17 +767,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
-		// Configure the new network policy with the proxies.
-		// Do this before updating the bpf policy maps, so that the proxy listeners have a chance to be
-		// ready when new traffic is redirected to them.
-		stats.proxyPolicyCalculation.Start()
-		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
-		stats.proxyPolicyCalculation.End(err == nil)
-		if err != nil {
-			return false, err
-		}
-		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
-
 		// Walk the L4Policy to add new redirects and update the desired policy for existing redirects.
 		// Do this before updating the bpf policy maps, so that the proxies are ready when new traffic
 		// is redirected to them.
@@ -796,6 +785,21 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 			datapathRegenCtxt.finalizeList.Append(finalizeFunc)
 			datapathRegenCtxt.revertStack.Push(revertFunc)
 		}
+
+		// Configure the new network policy with the proxies.
+		//
+		// This must be done after adding new redirects above, as waiting for policy update ACKs is
+		// disabled when there are no listeners, which is the case before the first redirect is added.
+		//
+		// Do this before updating the bpf policy maps below, so that the proxy listeners have a chance to be
+		// ready when new traffic is redirected to them.
+		stats.proxyPolicyCalculation.Start()
+		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
+		stats.proxyPolicyCalculation.End(err == nil)
+		if err != nil {
+			return false, err
+		}
+		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
 
 		// Synchronously try to update PolicyMap for this endpoint. If any
 		// part of updating the PolicyMap fails, bail out and do not generate

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -242,17 +242,17 @@ func (s *Service) UpsertService(
 
 	// Only add a HealthCheckNodePort server if this is a service which may
 	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
-	if onlyLocalBackends {
-		localBackendCount := len(backendsCopy)
-		if option.Config.EnableHealthCheckNodePort {
+	if option.Config.EnableHealthCheckNodePort {
+		if onlyLocalBackends {
+			localBackendCount := len(backendsCopy)
 			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
 				localBackendCount, svc.svcHealthCheckNodePort)
+		} else if svc.svcHealthCheckNodePort == 0 {
+			// Remove the health check server in case this service used to have
+			// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
+			// version, but not anymore.
+			s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 		}
-	} else if svc.svcHealthCheckNodePort == 0 {
-		// Remove the health check server in case this service used to have
-		// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
-		// version, but not anymore.
-		s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 	}
 
 	if new {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -49,8 +49,7 @@ func init() {
 
 	// Open socket for using gops to get stacktraces in case the tests deadlock.
 	if err := gops.Listen(gops.Options{ShutdownCleanup: true}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
+		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 		os.Exit(-1)
 	}
 


### PR DESCRIPTION
* #12675 -- fix(12664): initialize gops in RootCmd execution function (@fristonio)
   * Minor conflict due to cmdref not being present. Easily resolved.
 * #13120 -- logging_fix: Adding logs in a structured way (@chowmean)
 * #13141 -- operator: fix invocation with `--help` option (@tklauser)
   * Minor conflict due to cmdref not being present. Easily resolved.
 * #13044 -- contrib: Add release helper scripts for preparing micro releases (@joestringer)
   * Dropped docs / gh template changes from this commit.
 * #13190 -- service: Fix panic when restoring services with enable-health-check-nodeport: false (@gandro)
   * Minor conflict in the first patch as v1.7 didn't have backend filtering.
   * Second patch in pkg/service/service_test.go had several conflicts, reworked the tests against v1.7 APIs and dropped test code that attempts to reference variables or functions that don't exist
 * #12925 -- endpoint: Update proxy policy after adding redirects (@jrajahalme)
   * Skipped backporting commit a57e2aad56eedb69079f94c8e1829486623ff9ce as
     there was some dependency on sql proxy tests which is not present in v1.7.
 * #13205 -- identity: Fix user-space security identity lookup in cluster mesh (@gandro)

Extra commit at end to fix the cmdref from previous backports breaking it.

Skipped:
 * #13101 -- docs: Document restart-ginkgo CI-trigger phrase (@pchaigno)
   * I'm not sure which things we're trying to document in the older branch
     there, there's lots of changes to these phrases. Updating v1.8 makes
     sense to me, but I'm less sure about v1.6/v1.7. Do backporters often
     refer to these docs on the older branches?
 * #13159 -- docs/minikube: Update the step for minikube 1.12.1+ (@sayboras)
   * The doc doesn't exist in the v1.7 tree. Do we need to backport this PR
     to v1.7?

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12675 13120 13141 13044 13190 12925 13205; do contrib/backporting/set-labels.py $pr done 1.7; done
```