### PR TITLE
v1.8 backport 2020-09-18

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -27,16 +27,15 @@ assignees: ''
 - [ ] Move any unresolved issues/PRs from old release project into the newly
       created release project
 - [ ] Push a PR including the changes necessary for the new release:
-  - [ ] Update the VERSION file to represent X.Y.Z
-  - [ ] Update helm charts via `make -C install/kubernetes`
+  - [ ] Pull latest branch
+  - [ ] Run `contrib/release/start-release.sh'
   - [ ] (If applicable) Update the `cilium_version` and `cilium_tag` in
         `examples/getting-started/Vagrantfile`
-  - [ ] Update `AUTHORS` via `make update-authors`
-  - [ ] Use [Cilium release-notes tool] to generate `CHANGELOG.md`
-  - [ ] Point `.github/cilium-actions.yml` to the newly created project
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
+  - [ ] Submit PR (`contrib/release/submit-release.sh`)
 - [ ] Merge PR
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
+  - Pull latest branch locally and run `contrib/release/tag-release.sh`
 - [ ] Wait for docker builds to complete
   - [cilium](https://hub.docker.com/repository/docker/cilium/cilium/builds)
   - [operator](https://hub.docker.com/repository/docker/cilium/operator/builds)
@@ -46,8 +45,7 @@ assignees: ''
       & push to repository
 - [ ] Run sanity check of Helm install using connectivity-check script.
       Suggested approach: Follow the full [GKE getting started guide].
-- [ ] [Create a release] for the new tag `vX.Y.Z`, using the release notes
-      from above
+- [ ] Check draft release from [releases] page and publish the release
 - [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
 
 ## Post-release
@@ -65,7 +63,7 @@ assignees: ''
 [Cilium release-notes tool]: https://github.com/cilium/release
 [Docker Hub]: https://hub.docker.com/orgs/cilium/repositories
 [Cilium charts]: https://github.com/cilium/charts
-[Create a release]: https://github.com/cilium/cilium/releases/new
+[releases]: https://github.com/cilium/cilium/releases
 [Stable releases]: https://github.com/cilium/cilium#stable-releases
 [kops]: https://github.com/kubernetes/kops/
 [kubespray]: https://github.com/kubernetes-sigs/kubespray/

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -20,6 +20,17 @@ If you intent to release a new feature release, see the
           used in the Cilium development process. See :ref:`dev_env` for
           detailed instructions about setting up said VM.
 
+GitHub template process
+~~~~~~~~~~~~~~~~~~~~~~~
+
+#. File a `new release issue <https://github.com/cilium/cilium/issues/new?assignees=&labels=kind%2Frelease&template=release_template.md&title=vX.Y.Z+release>`_
+   on GitHub, updating the title to reflect the version that will be released.
+
+#. Follow the steps in the issue template to prepare the release.
+
+Reference steps for the template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 #. Ensure that the necessary backports have been completed and merged. See
    :ref:`backport_process`.
 
@@ -27,62 +38,38 @@ If you intent to release a new feature release, see the
    #. Update PRs / issues that were added to the ``vX.Y.Z`` project, but didn't
       make it into this release into the ``vX.Y.Z+1`` project.
 
+#. Create a new project named "X.Y.Z+1" to automatically track the backports
+   for that particular release. `Direct Link: <https://github.com/cilium/cilium/projects/new>`_
+
 #. Checkout the desired stable branch and pull it:
 
    ::
 
        git checkout v1.0; git pull
 
-#. Create a branch for the release pull request:
+#. Run the release preparation script:
 
    ::
 
-       git checkout -b pr/prepare-v1.0.3
+       contrib/release/start-release.sh
 
-#. Update the ``VERSION`` file to represent ``X.Y.Z+1``
-
-#. Update the image tag versions and pullPolicy in the examples:
-
-   ::
-
-       make -C install/kubernetes clean all
-
-#. Update the ``cilium_version`` and ``cilium_tag`` variables in
-   ``examples/getting-started/Vagrantfile``
-
-#. Update the ``AUTHORS file``
-
-   ::
-
-       make update-authors
-
-
-   .. note::
+  .. note::
 
        Check to see if the ``AUTHORS`` file has any formatting errors (for
        instance, indentation mismatches) as well as duplicate contributor
        names, and correct them accordingly.
 
+#. Update the ``cilium_version`` and ``cilium_tag`` variables in
+   ``examples/getting-started/Vagrantfile``
 
-#. Generate the release notes by running the instructions provided in github.com/cilium/release
+#. Add all modified files using ``git add`` and create a commit with the
+   title ``Prepare for release v1.0.3``.
 
-#. Add the generated release notes in the ``CHANGELOG.md`` file
+#. Prepare a pull request for the changes:
 
-#. Create a new project named "X.Y.Z+1" to automatically track the backports
-   for that particular release. `Direct Link: <https://github.com/cilium/cilium/projects/new>`_
+   ::
 
-#. Update the project URL for the respective release in file ``.github/cilium-actions.yml``
-
-#. Add all modified files using ``git add`` and create a pull request with the
-   title ``Prepare for release v1.0.3``. Add the backport label to the PR which
-   corresponds to the branch for which the release is being performed, e.g.
-   ``backport/1.0``.
-
-   .. note::
-
-       Make sure to create the PR against the desired stable branch. In this
-       case ``v1.0``
-
+      contrib/release/submit-release.sh
 
 #. Follow standard procedures to get the aforementioned PR merged into the
    desired stable branch. See :ref:`submit_pr` for more information about this
@@ -94,26 +81,11 @@ If you intent to release a new feature release, see the
 
        git checkout v1.0; git pull
 
-#. Build the container images and push them
+#. Create and push release tags to GitHub:
 
    ::
 
-      DOCKER_IMAGE_TAG=v1.0.3 make docker-image
-      docker push cilium/cilium:v1.0.3
-
-   .. note:
-
-      This step requires you to login with ``docker login`` first and it will
-      require your Docker hub ID to have access to the ``Cilium`` organization.
-      You can alternatively trigger a build on DockerHub directly if you have
-      credentials to do so.
-
-#. Create release tags:
-
-   ::
-
-       git tag -a v1.0.3 -m 'Release v1.0.3'
-       git tag -a 1.0.3 -m 'Release 1.0.3'
+      contrib/release/tag-release.sh
 
    .. note::
 
@@ -123,24 +95,14 @@ If you intent to release a new feature release, see the
        ``x.y.z`` For more information about how ReadTheDocs does versioning, you can
        read their `Versions Documentation <https://docs.readthedocs.io/en/latest/versions.html>`_.
 
-#. Push the git release tag
+#. Wait for DockerHub to prepare all docker images.
 
-   ::
+#. `Publish a GitHub release <https://github.com/cilium/cilium/releases/>`_:
 
-       git push --tags
+   Following the steps above, the release draft will already be prepared.
+   Preview the description and then publish the release.
 
-#. `Create a GitHub release <https://github.com/cilium/cilium/releases/new>`_:
-
-   #. Choose the correct target branch, e.g. ``v1.0``
-   #. Choose the correct target tag, e.g. ``v1.0.3``
-   #. Title: ``1.0.3``
-   #. Check the ``This is a pre-release`` box if you are releasing a release
-      candidate.
-   #. Fill in the release description with the output generated by github.com/cilium/release
-
-   #. Preview the description and then publish the release
-
-#. Prepare Helm changes using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
+#. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    and push the changes into that repository (not the main cilium repository):
 
    ::
@@ -148,7 +110,7 @@ If you intent to release a new feature release, see the
       ./prepare_artifacts.sh /path/to/cilium/repository/checked/out/to/release/commit
       git push
 
-#. Prepare Helm changes using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
+#. Prepare Helm changes for the dev version of the branch using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    for the vX.Y helm charts, and push the changes into that repository (not the main cilium repository):
 
    In the ``cilium/cilium`` repository:

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -226,6 +226,8 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Ginkgo-Tests-k8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-k8s/>`_                      | test-missed-k8s   | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
+| `Cilium-PR-Ginkgo-Tests-Validated <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/>`_          | restart-ginkgo    | Yes                |
++----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-Nightly-Tests-PR <https://jenkins.cilium.io/job/Cilium-PR-Nightly-Tests-All/>`_                        | test-nightly      | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Kubernetes-Upstream <https://jenkins.cilium.io/view/PR/job/Cilium-PR-Kubernetes-Upstream/>`_        | test-upstream-k8s | No                 |

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -935,6 +935,8 @@ The current Cilium kube-proxy replacement mode can also be introspected through 
     kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep KubeProxyReplacement
     KubeProxyReplacement:   Strict	[eth0 (DR)]	[NodePort (SNAT, 30000-32767, XDP: NONE), HostPort, ExternalIPs, HostReachableServices (TCP, UDP)]
 
+.. _session-affinity:
+
 Session Affinity
 ****************
 

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -151,13 +151,13 @@ by adding the following to the helm configuration command line:
 
 .. _features_kernel_matrix:
 
-Advanced Features and Required Kernel Version
-=============================================
-Cilium requires Linux kernel 4.9.17 or higher, however development on additional
-kernel features and functionality continues to progress in the Linux community.
-Some Cilium features and functionality are dependent on newer kernel versions.
-These additional Cilium features and functionality are enabled by upgrading to
-a later kernel version as detailed below:
+Required Kernel Versions for Advanced Features
+==============================================
+
+Cilium requires Linux kernel 4.9.17 or higher; however, development on
+additional kernel features continues to progress in the Linux community. Some
+of Cilium's features are dependent on newer kernel versions and are thus
+enabled by upgrading to more recent kernel versions as detailed below.
 
 ======================= ===============================
 Cilium Feature          Minimum Kernel Version

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -159,14 +159,15 @@ additional kernel features continues to progress in the Linux community. Some
 of Cilium's features are dependent on newer kernel versions and are thus
 enabled by upgrading to more recent kernel versions as detailed below.
 
-======================= ===============================
-Cilium Feature          Minimum Kernel Version
-======================= ===============================
-IPv4 fragment tracking  >= 4.10
-:ref:`cidr_limitations` >= 4.11
-:ref:`host-services`    >= 4.19.57, >= 5.1.16,  >= 5.2
-:ref:`kubeproxy-free`   >= 4.19.57, >= 5.1.16,  >= 5.2
-======================= ===============================
+============================= ===============================
+Cilium Feature                Minimum Kernel Version
+============================= ===============================
+:ref:`concepts_fragmentation` >= 4.10
+:ref:`cidr_limitations`       >= 4.11
+:ref:`host-services`          >= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`kubeproxy-free`         >= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`session-affinity`       >= 5.7
+============================= ===============================
 
 .. _req_kvstore:
 

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+RELEASE_TOOL_PATH="${RELEASE_TOOL_PATH:-$GOPATH/src/github.com/cilium/release}"
+RELNOTES="$RELEASE_TOOL_PATH/release"
+RELNOTESCACHE="release-state.json"
+
+usage() {
+    logecho "usage: $0 <OLD-VERSION> <NEW-VERSION>"
+    logecho "OLD-VERSION    Previous release version for comparison"
+    logecho "NEW-VERSION    Target release version"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+[-rc0-9]*"; then
+        usage 2>&1
+        common::exit 1 "Invalid NEW-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(echo $1 | sed 's/^v//')"
+    local ersion="$(echo $2 | sed 's/^v//')"
+    local version="v$ersion"
+
+    logecho "Generating CHANGELOG.md"
+    rm -f $RELNOTESCACHE
+    echo -e "# Changelog\n\n## $version" > $version-changes.txt
+    $RELNOTES --base $old_version --head $(git rev-parse HEAD) >> $version-changes.txt
+    cp $version-changes.txt CHANGELOG-new.md
+    if [[ -e CHANGELOG.md ]]; then
+        tail -n+2 CHANGELOG.md >> CHANGELOG-new.md
+    fi
+    mv CHANGELOG-new.md CHANGELOG.md
+    logecho "Generated CHANGELOG.md"
+}
+
+main "$@"

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+ACTS_YAML=".github/cilium-actions.yml"
+
+usage() {
+    logecho "usage: $0 <VERSION> <GH-PROJECT>"
+    logecho "VERSION    Target release version"
+    logecho "GH-PROJECT Project ID for next release"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "^[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid GH-PROJECT ID argument. Expected [0-9]+"
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ "$(git status -s | grep -v "^??" | wc -l)" -gt 0 ]]; then
+        git status -s | grep -v "^??"
+        common::exit 1 "Unmerged changes in tree prevent preparing release PR."
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(cat VERSION)"
+    local ersion="$(echo $1 | sed 's/^v//')"
+    local version="v$ersion"
+    local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
+    local remote="origin"
+    local new_proj="$2"
+
+    git fetch $remote
+    git checkout -b pr/prepare-$version $remote/v$branch
+
+    logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
+    echo $ersion > VERSION
+    logrun make -C install/kubernetes all
+    logrun make update-authors
+    old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
+    sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+
+    $DIR/prep-changelog.sh "$old_version" "$version"
+
+    logecho "Next steps:"
+    logecho "* Check all changes and add to a new commit"
+    logecho "* Push the PR to Github for review"
+    logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
+    logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
+
+    # Leave $version-changes.txt around for prep-release.sh usage later
+}
+
+main "$@"

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+BRANCH="${1:-""}"
+if [ "$BRANCH" = "" ]; then
+    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
+fi
+BRANCH=$(echo "$BRANCH" | sed 's/^v//')
+
+RELEASE="v$(cat VERSION)"
+SUMMARY=${2:-}
+GENERATE_SUMMARY=false
+if [ "$SUMMARY" = "" ]; then
+    SUMMARY="$RELEASE-changes.txt"
+    GENERATE_SUMMARY=true
+fi
+
+if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+    echo "usage: $0 [branch version] [release-summary]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
+    exit 1
+fi
+
+if ! hub help | grep -q "pull-request"; then
+    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+    echo "Please install this tool first." 1>&2
+    exit 1
+fi
+
+if ! git diff --quiet; then
+    echo "Local changes found in git tree. Exiting release process..." 1>&2
+    exit 1
+fi
+
+if ! git log --oneline | grep -q $RELEASE; then
+    echo "Latest commit does not match commit title for release:" 1>&2
+    git log -1
+    exit 1
+fi
+
+if $GENERATE_SUMMARY; then
+    CHANGELOG=$SUMMARY
+    SUMMARY="$RELEASE-pr-$(date --rfc-3339=date).txt"
+    echo "Prepare for release $RELEASE" > $SUMMARY
+    tail -n+4 $CHANGELOG >> $SUMMARY
+fi
+
+echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+cat $SUMMARY 1>&2
+echo -e "\nSending pull request..." 2>&1
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git push origin "$PR_BRANCH"
+hub pull-request -b "v$BRANCH" -l kind/release,backport/$BRANCH -F $SUMMARY

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+REMOTE="$(get_remote)"
+CHARTS_PATH="${CHARTS_PATH:-$GOPATH/src/github.com/cilium/charts}"
+CHARTS_TOOL="prepare_artifacts.sh"
+RELEASES_URL="https://github.com/cilium/cilium/releases"
+VERSION=""
+
+usage() {
+    echo "usage: $0 [VERSION]"
+    echo "CHARTS_REPO Path to local copy of github.com/cilium/charts"
+    echo
+    echo "--help     Print this help message"
+}
+
+handle_args() {
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 1
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ ! -e "$CHARTS_PATH/$CHARTS_TOOL" ]]; then
+        usage
+        common::exit 1 "CHARTS_PATH='$CHARTS_PATH' invalid. Clone from github.com/cilium/charts"
+    fi
+
+    if ! which hub >/dev/null; then
+        echo "This tool relies on 'hub' from https://github.com/github/hub ." 1>&2
+        common::exit 1 "Please install this tool first."
+    fi
+
+    if [[ $# -ge 1 ]]; then
+        VERSION="$1"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local ersion="$(cat VERSION)"
+    if [[ "$VERSION" != "" ]]; then
+        ersion="$(echo $VERSION | sed 's/^v//')"
+    fi
+    local version="v$ersion"
+
+    if [[ ! -e $version-changes.txt ]]; then
+        common::exit 1 "Generate release notes via contrib/release/start-release.sh"
+    fi
+
+    echo "Current HEAD is:"
+    git log --oneline -1 $(git rev-parse HEAD)
+    echo "Create git tags for $version with this commit"
+    if ! common::askyorn ; then
+        common::exit 0 "Aborting release preparation."
+    fi
+
+    logrun -s git tag -a $ersion -s -m "Release $version"
+    logrun -s git tag -a $version -s -m "Release $version"
+    logrun -s git push $REMOTE $version $ersion
+
+    # Leave $version-changes.txt around so we can generate release notes later
+    echo -e "$ersion\n" > $version-release-summary.txt
+    echo "We are pleased to release Cilium $version." >>  $version-release-summary.txt
+    tail -n+4 $version-changes.txt >> $version-release-summary.txt
+    logecho "Creating Github draft release"
+    logrun hub release create -d -F $version-release-summary.txt $version
+    logecho "Browse to $RELEASES_URL to see the draft release"
+
+    logecho
+    logecho "Next steps:"
+    logecho "* Wait for cilium docker images to be prepared"
+    logecho "* Prepare the helm template changes"
+    logecho "* When docker images are available, test deployment of new version"
+    logecho "* Push templates and announce release on GitHub / Slack"
+}
+
+main "$@"

--- a/daemon/cmd/agenthealth.go
+++ b/daemon/cmd/agenthealth.go
@@ -68,7 +68,7 @@ func (d *Daemon) startAgentHealthHTTPService(addr string) {
 		statusCode := http.StatusOK
 		sr := d.getStatus(true)
 		if isUnhealthy(&sr) {
-			statusCode = http.StatusInternalServerError
+			statusCode = http.StatusServiceUnavailable
 		}
 		w.WriteHeader(statusCode)
 	}))

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -112,8 +112,7 @@ var (
 
 			// Open socket for using gops to get stacktraces of the agent.
 			if err := gops.Listen(gops.Options{}); err != nil {
-				errorString := fmt.Sprintf("unable to start gops: %s", err)
-				fmt.Println(errorString)
+				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 				os.Exit(-1)
 			}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -109,6 +109,14 @@ var (
 				genMarkdown(cmd, cmdRefDir)
 				os.Exit(0)
 			}
+
+			// Open socket for using gops to get stacktraces of the agent.
+			if err := gops.Listen(gops.Options{}); err != nil {
+				errorString := fmt.Sprintf("unable to start gops: %s", err)
+				fmt.Println(errorString)
+				os.Exit(-1)
+			}
+
 			bootstrapStats.earlyInit.Start()
 			initEnv(cmd)
 			bootstrapStats.earlyInit.End(true)
@@ -136,12 +144,6 @@ func init() {
 func Execute() {
 	bootstrapStats.overall.Start()
 
-	// Open socket for using gops to get stacktraces of the agent.
-	if err := gops.Listen(gops.Options{}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
-		os.Exit(-1)
-	}
 	interruptCh := cleaner.registerSigHandler()
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -115,6 +115,12 @@ data:
   # for cilium-health.
   agent-health-port: "{{ .Values.global.agent.healthPort }}"
 {{- end }}
+{{- if .Values.policyEnforcementMode }}
+  # The agent can be put into the following three policy enforcement modes
+  # default, always and never.
+  # https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
+  enable-policy: "{{ lower .Values.policyEnforcementMode }}"
+{{- end }}
 
 {{- if .Values.global.prometheus.enabled }}
   # If you want metrics enabled in all of your Cilium agents, set the port for

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hubble-ui 
+  name: hubble-ui
 rules:
   - apiGroups:
       - networking.k8s.io

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrolebinding.yaml
@@ -5,8 +5,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: hubble-ui 
+  name: hubble-ui
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: hubble-ui 
+    name: hubble-ui

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -9,6 +9,10 @@ agent:
   keepDeprecatedLabels: false
   # Keep the deprecated probes when deploying Cilium DaemonSet
   keepDeprecatedProbes: false
+  # The agent can be put into the following three policy enforcement modes
+  # default, always and never.
+  # https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
+  policyEnforcementMode: "default"
 
 # Include the cilium-config ConfigMap
 config:

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -239,7 +239,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hubble-ui 
+  name: hubble-ui
 rules:
   - apiGroups:
       - networking.k8s.io
@@ -379,7 +379,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: hubble-ui 
+  name: hubble-ui
 subjects:
   - kind: ServiceAccount
     namespace: kube-system

--- a/operator/main.go
+++ b/operator/main.go
@@ -134,10 +134,9 @@ func main() {
 		doCleanup()
 	}()
 
-	// Open socket for using gops to get stacktraces of the agent.
+	// Open socket for using gops to get stacktraces of the operator.
 	if err := gops.Listen(gops.Options{}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
+		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 		os.Exit(-1)
 	}
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -69,6 +69,13 @@ var (
 				genMarkdown(cmd, cmdRefDir)
 				os.Exit(0)
 			}
+
+			// Open socket for using gops to get stacktraces of the operator.
+			if err := gops.Listen(gops.Options{}); err != nil {
+				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
+				os.Exit(-1)
+			}
+
 			initEnv()
 			runOperator()
 		},
@@ -133,12 +140,6 @@ func main() {
 		<-signals
 		doCleanup()
 	}()
-
-	// Open socket for using gops to get stacktraces of the operator.
-	if err := gops.Listen(gops.Options{}); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
-		os.Exit(-1)
-	}
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -798,17 +798,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
-		// Configure the new network policy with the proxies.
-		// Do this before updating the bpf policy maps, so that the proxy listeners have a chance to be
-		// ready when new traffic is redirected to them.
-		stats.proxyPolicyCalculation.Start()
-		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
-		stats.proxyPolicyCalculation.End(err == nil)
-		if err != nil {
-			return false, err
-		}
-		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
-
 		// Walk the L4Policy to add new redirects and update the desired policy for existing redirects.
 		// Do this before updating the bpf policy maps, so that the proxies are ready when new traffic
 		// is redirected to them.
@@ -827,6 +816,21 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 			datapathRegenCtxt.finalizeList.Append(finalizeFunc)
 			datapathRegenCtxt.revertStack.Push(revertFunc)
 		}
+
+		// Configure the new network policy with the proxies.
+		//
+		// This must be done after adding new redirects above, as waiting for policy update ACKs is
+		// disabled when there are no listeners, which is the case before the first redirect is added.
+		//
+		// Do this before updating the bpf policy maps below, so that the proxy listeners have a chance to be
+		// ready when new traffic is redirected to them.
+		stats.proxyPolicyCalculation.Start()
+		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
+		stats.proxyPolicyCalculation.End(err == nil)
+		if err != nil {
+			return false, err
+		}
+		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
 
 		// Synchronously try to update PolicyMap for this endpoint. If any
 		// part of updating the PolicyMap fails, bail out and do not generate

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -200,8 +200,8 @@ func (w *identityWatcher) stop() {
 }
 
 // LookupIdentity looks up the identity by its labels but does not create it.
-// This function will first search through the local cache and fall back to
-// querying the kvstore.
+// This function will first search through the local cache, then the caches for
+// remote kvstores and finally fall back to the main kvstore
 func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labels.Labels) *identity.Identity {
 	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
 		return reservedIdentity
@@ -216,7 +216,7 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 	}
 
 	lblArray := lbls.LabelArray()
-	id, err := m.IdentityAllocator.Get(ctx, GlobalIdentity{lblArray})
+	id, err := m.IdentityAllocator.GetIncludeRemoteCaches(ctx, GlobalIdentity{lblArray})
 	if err != nil {
 		return nil
 	}
@@ -231,7 +231,8 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 var unknownIdentity = identity.NewIdentity(identity.IdentityUnknown, labels.Labels{labels.IDNameUnknown: labels.NewLabel(labels.IDNameUnknown, "", labels.LabelSourceReserved)})
 
 // LookupIdentityByID returns the identity by ID. This function will first
-// search through the local cache and fall back to querying the kvstore.
+// search through the local cache, then the caches for remote kvstores and
+// finally fall back to the main kvstore
 func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id identity.NumericIdentity) *identity.Identity {
 	if id == identity.IdentityUnknown {
 		return unknownIdentity
@@ -249,7 +250,7 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return identity
 	}
 
-	allocatorKey, err := m.IdentityAllocator.GetByID(ctx, idpool.ID(id))
+	allocatorKey, err := m.IdentityAllocator.GetByIDIncludeRemoteCaches(ctx, idpool.ID(id))
 	if err != nil {
 		return nil
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -276,17 +276,17 @@ func (s *Service) UpsertService(params *lb.SVC) (bool, lb.ID, error) {
 
 	// Only add a HealthCheckNodePort server if this is a service which may
 	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
-	if onlyLocalBackends && filterBackends {
-		localBackendCount := len(backendsCopy)
-		if option.Config.EnableHealthCheckNodePort {
+	if option.Config.EnableHealthCheckNodePort {
+		if onlyLocalBackends && filterBackends {
+			localBackendCount := len(backendsCopy)
 			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
 				localBackendCount, svc.svcHealthCheckNodePort)
+		} else if svc.svcHealthCheckNodePort == 0 {
+			// Remove the health check server in case this service used to have
+			// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
+			// version, but not anymore.
+			s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 		}
-	} else if svc.svcHealthCheckNodePort == 0 {
-		// Remove the health check server in case this service used to have
-		// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
-		// version, but not anymore.
-		s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
 	}
 
 	if new {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -49,8 +49,7 @@ var (
 func init() {
 	// Open socket for using gops to get stacktraces in case the tests deadlock.
 	if err := gops.Listen(gops.Options{ShutdownCleanup: true}); err != nil {
-		errorString := fmt.Sprintf("unable to start gops: %s", err)
-		fmt.Println(errorString)
+		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
 		os.Exit(-1)
 	}
 

--- a/tests/envoy-smoke-test.sh
+++ b/tests/envoy-smoke-test.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${dir}/helpers.bash"
+# dir might have been overwritten by helpers.bash
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+TEST_NAME=$(get_filename_without_extension $0)
+LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
+redirect_debug_logs ${LOGS_DIR}
+
+set -ex
+
+function cleanup {
+  monitor_stop
+  echo "Tip: Add '--debug-verbose=flow' into cilium options in /etc/sysconfig/cilium to get Envoy debug logging."
+  # These are commented to allow for easier debugging, but are left as comments to remind how to clean up:
+  #  cilium service delete --all 2> /dev/null || true
+  #  cilium policy delete --all 2> /dev/null || true
+  #  docker rm -f server1 server2 client 2> /dev/null || true
+}
+
+function finish_test {
+  # Gathering files takes a long time and is not needed for live debugging.
+  #  gather_files ${TEST_NAME} ${TEST_SUITE}
+  cleanup
+}
+
+trap finish_test EXIT
+
+SERVER_LABEL="id.server"
+CLIENT_LABEL="id.client"
+
+SVC_IP="f00d::1:1"
+SVC_IP4="2.2.2.2"
+
+cleanup
+logs_clear
+
+function no_service_init {
+  cilium service delete --all
+  SERVER_IP=$SERVER1_IP;
+  SERVER_IP4=$SERVER1_IP4;
+}
+
+function service_init {
+  log "beginning service init"
+  cilium service update --frontend "$SVC_IP4:80" --id 2233 \
+			--backends "$SERVER1_IP4:80" \
+			--backends "$SERVER2_IP4:80"
+
+  cilium service update --frontend "[$SVC_IP]:80" --id 2234 \
+			--backends "[$SERVER1_IP]:80" \
+			--backends "[$SERVER2_IP]:80"
+
+  SERVER_IP=$SVC_IP
+  SERVER_IP4=$SVC_IP4
+  log "finished service init"
+}
+
+function proxy_init {
+  log "beginning proxy_init"
+  create_cilium_docker_network
+
+  if [ -z `docker ps -q -f name=^/server1$` ] ; then
+      docker run -dt --net=$TEST_NET --name server1 -l $SERVER_LABEL cilium/demo-httpd
+  fi
+  if [ -z `docker ps -q -f name=^/server2$` ] ; then
+      docker run -dt --net=$TEST_NET --name server2 -l $SERVER_LABEL cilium/demo-httpd
+  fi
+  if [ -z `docker ps -q -f name=^/client$` ] ; then
+      docker run -dt --net=cilium --name client -l id.client tgraf/netperf
+  fi
+  
+  SERVER1_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server1)
+  SERVER2_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server2)
+  SERVER1_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server1)
+  SERVER2_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server2)
+
+  SERVER_IP=$SERVER1_IP;
+  SERVER_IP4=$SERVER1_IP4;
+
+  wait_for_docker_ipv6_addr server1
+  wait_for_docker_ipv6_addr server2
+  wait_for_docker_ipv6_addr client
+
+  log "waiting for endpoints to get identities"
+  while [ `cilium endpoint list -o jsonpath='{range [*]}{.status.identity.id}{" "}{.status.identity.labels}{"\n"}' | grep '^[1-9][0-9]* .*id.\(server\|client\)' | cut -d ' ' -f1 | sort | uniq | wc -l` -ne 2 ] ; do
+    log "waiting..."
+    sleep 1
+  done
+
+  monitor_start
+  log "finished proxy_init"
+}
+
+function policy_single_egress {
+  cilium policy delete --all
+  cat <<EOF | policy_import_and_wait -
+[{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"reserved:host":""}},
+	    {"matchLabels":{"id.client":""}}
+	]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.client":""}},
+    "egress": [{
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }]
+}]
+EOF
+}
+
+function policy_many_egress {
+  cilium policy delete --all
+  cat <<EOF | policy_import_and_wait -
+[{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"reserved:host":""}},
+	    {"matchLabels":{"id.client":""}}
+	]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.client":""}},
+    "egress": [{
+        "toEndpoints": [{"matchLabels":{"id.server":""}}],
+	"toPorts": [{
+	    "ports": [{"port": "80",   "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }, {
+        "toEndpoints": [{"matchLabels":{"id.client":""}}],
+	"toPorts": [{
+	    "ports": [{"port": "80",   "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "GET",
+		    "path": "/self"
+                }]
+	    }
+	}]
+    }, {
+        "toEndpoints": [{"matchLabels":{"id.server":""}}],
+	"toPorts": [{
+	    "ports": [{"port": "8000", "protocol": "tcp"},
+		      {"port": "8080", "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "PUT",
+		    "path": "/publix"
+                }]
+	    }
+	}]
+    }]
+}]
+EOF
+}
+
+function policy_single_ingress {
+  cilium policy delete --all
+  cat <<EOF | policy_import_and_wait -
+[{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"reserved:host":""}},
+	    {"matchLabels":{"id.client":""}}
+	],
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }]
+}]
+EOF
+}
+
+function policy_many_ingress {
+  cilium policy delete --all
+  cat <<EOF | policy_import_and_wait -
+[{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"reserved:host":""}},
+	    {"matchLabels":{"id.client":""}}
+	],
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"},
+		      {"port": "8080", "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }]
+}]
+EOF
+}
+
+function policy_egress_and_ingress {
+  cilium policy delete --all
+  cat <<EOF | policy_import_and_wait -
+[{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"id.client":""}}
+	]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.client":""}},
+    "egress": [{
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+	"toPorts": [{
+	    "ports": [{"port": "8000", "protocol": "tcp"},
+		      {"port": "80",   "protocol": "tcp"},
+		      {"port": "8080", "protocol": "tcp"}],
+	    "rules": {
+                "HTTP": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }]
+}]
+EOF
+}
+
+function proxy_test {
+  log "beginning proxy test"
+  monitor_clear
+
+  log "trying to reach server IPv4 at http://$SERVER_IP4:80/public from client (expected: 200)"
+  RETURN=$(docker exec -i client bash -c "curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET http://$SERVER_IP4:80/public")
+  if [[ "${RETURN//$'\n'}" != "200" ]]; then
+    abort "GET /public, unexpected return ${RETURN//$'\n'} != 200"
+  fi
+
+  log "trying to reach server IPv6 at http://[$SERVER_IP]:80/public from client (expected: 200)"
+  RETURN=$(docker exec -i client bash -c "curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET http://[$SERVER_IP]:80/public")
+  if [[ "${RETURN//$'\n'}" != "200" ]]; then
+    abort "GET /public, unexpected return ${RETURN//$'\n'} != 200"
+  fi
+
+  log "trying to reach server IPv4 at http://$SERVER_IP4:80/private from client (expected: 403)"
+  RETURN=$(docker exec -i client bash -c "curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET http://$SERVER_IP4:80/private")
+  if [[ "${RETURN//$'\n'}" != "403" ]]; then
+    abort "GET /private, unexpected return ${RETURN//$'\n'} != 403"
+  fi
+
+  log "trying to reach server IPv6 at http://[$SERVER_IP]:80/private from client (expected: 403)"
+  RETURN=$(docker exec -i client bash -c "curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET http://[$SERVER_IP]:80/private")
+  if [[ "${RETURN//$'\n'}" != "403" ]]; then
+    abort "GET /private, unexpected return ${RETURN//$'\n'} != 403"
+  fi
+
+  log "finished proxy test"
+}
+
+proxy_init
+for state in "false" "true"; do
+  cilium config ConntrackLocal=$state
+
+  for service in "none" "lb"; do
+    case $service in
+      "none")
+        no_service_init;;
+      "lb")
+        service_init;;
+    esac
+
+    for policy in "egress" "ingress" "egress_and_ingress" "many_egress" "many_ingress"; do
+
+      log "+----------------------------------------------------------------------+"
+      log "Testing with Policy=$policy, Service=$service, Conntrack=$state"
+      log "+----------------------------------------------------------------------+"
+
+      case $policy in
+        "many_egress")
+          policy_many_egress;;
+        "egress")
+          policy_single_egress;;
+        "many_ingress")
+          policy_many_ingress;;
+        "ingress")
+          policy_single_ingress;;
+        "egress_and_ingress")
+          policy_egress_and_ingress;;
+      esac
+
+      proxy_test
+    done
+  done
+done
+
+log "deleting all services from Cilium"
+cilium service delete --all
+log "deleting all policies from Cilium"
+cilium policy delete --all 2> /dev/null || true
+log "removing containers"
+docker rm -f server1 server2 client 2> /dev/null || true
+
+test_succeeded "${TEST_NAME}"


### PR DESCRIPTION
v1.8 backports 2020-09-18

 * #12675 -- fix(12664): initialize gops in RootCmd execution function (@fristonio)
 * #13101 -- docs: Document restart-ginkgo CI-trigger phrase (@pchaigno)
 * #13141 -- operator: fix invocation with `--help` option (@tklauser)
 * #13044 -- contrib: Add release helper scripts for preparing micro releases (@joestringer)
      - conflict resolved: change on slightly different text (see commit message)
 * #13177 -- docs: Update kernel requirements for advanced features (@pchaigno)
      - removed bandwidth-manager requirement
 * #13190 -- service: Fix panic when restoring services with enable-health-check-nodeport: false (@gandro)
 * #13188 -- daemon: report HTTP service unavailable (503) in unhealthy state (@tklauser)
 * #13175 -- agent: Add CILIUM_ENABLE_POLICY env into the helm chart. (@camilo-schoeningh-sociomantic)
 * #12925 -- endpoint: Update proxy policy after adding redirects (@jrajahalme)
      - conflict resolved: seemingly unrelated file change omitted (see commit message)
 * #13197 -- ipam: Warn when failing to update CN status (@christarazi)
 * #13205 -- identity: Fix user-space security identity lookup in cluster mesh (@gandro)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12675 13101 13141 13044 13177 13190 13188 13175 12925 13197 13205; do contrib/backporting/set-labels.py $pr done 1.8; done
```
