### PR TITLE
Makes k8sNodeIP the preferred IP when initializing NodePort addresses.

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -129,10 +129,11 @@ func InitNodePortAddrs(devices []string) error {
 	if option.Config.EnableIPv4 {
 		ipv4NodePortAddrs = make(map[string]net.IP, len(devices))
 		for _, device := range devices {
-			ip, err := firstGlobalV4Addr(device, nil)
+			ip, err := firstGlobalV4Addr(device, GetK8sNodeIP())
 			if err != nil {
 				return fmt.Errorf("Failed to determine IPv4 of %s for NodePort", device)
 			}
+
 			ipv4NodePortAddrs[device] = ip
 		}
 	}
@@ -140,7 +141,7 @@ func InitNodePortAddrs(devices []string) error {
 	if option.Config.EnableIPv6 {
 		ipv6NodePortAddrs = make(map[string]net.IP, len(devices))
 		for _, device := range devices {
-			ip, err := firstGlobalV6Addr(device, nil)
+			ip, err := firstGlobalV6Addr(device, GetK8sNodeIP())
 			if err != nil {
 				return fmt.Errorf("Failed to determine IPv6 of %s for NodePort", device)
 			}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -33,6 +33,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const preferPublicIP bool = true
+
 var (
 	ipv4Loopback        net.IP
 	ipv4ExternalAddress net.IP
@@ -66,7 +68,7 @@ func makeIPv6HostIP() net.IP {
 // scope will be regarded as the system's node address.
 func InitDefaultPrefix(device string) {
 	if option.Config.EnableIPv4 {
-		ip, err := firstGlobalV4Addr(device, GetInternalIPv4())
+		ip, err := firstGlobalV4Addr(device, GetInternalIPv4(), preferPublicIP)
 		if err != nil {
 			return
 		}
@@ -101,7 +103,7 @@ func InitDefaultPrefix(device string) {
 	if option.Config.EnableIPv6 {
 		if ipv6Address == nil {
 			// Find a IPv6 node address first
-			ipv6Address, _ = firstGlobalV6Addr(device, GetIPv6Router())
+			ipv6Address, _ = firstGlobalV6Addr(device, GetIPv6Router(), preferPublicIP)
 			if ipv6Address == nil {
 				ipv6Address = makeIPv6HostIP()
 			}
@@ -129,7 +131,7 @@ func InitNodePortAddrs(devices []string) error {
 	if option.Config.EnableIPv4 {
 		ipv4NodePortAddrs = make(map[string]net.IP, len(devices))
 		for _, device := range devices {
-			ip, err := firstGlobalV4Addr(device, GetK8sNodeIP())
+			ip, err := firstGlobalV4Addr(device, GetK8sNodeIP(), !preferPublicIP)
 			if err != nil {
 				return fmt.Errorf("Failed to determine IPv4 of %s for NodePort", device)
 			}
@@ -141,7 +143,7 @@ func InitNodePortAddrs(devices []string) error {
 	if option.Config.EnableIPv6 {
 		ipv6NodePortAddrs = make(map[string]net.IP, len(devices))
 		for _, device := range devices {
-			ip, err := firstGlobalV6Addr(device, GetK8sNodeIP())
+			ip, err := firstGlobalV6Addr(device, GetK8sNodeIP(), !preferPublicIP)
 			if err != nil {
 				return fmt.Errorf("Failed to determine IPv6 of %s for NodePort", device)
 			}

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -86,7 +86,7 @@ retryScope:
 	}
 
 	if len(ipsPublic) != 0 {
-		if hasPreferred && ip.IsPublicAddr(preferredIP) {
+		if hasPreferred {
 			return preferredIP, nil
 		}
 

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -31,7 +31,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func firstGlobalAddr(intf string, preferredIP net.IP, family int) (net.IP, error) {
+func firstGlobalAddr(intf string, preferredIP net.IP, family int, preferPublic bool) (net.IP, error) {
 	var link netlink.Link
 	var ipLen int
 	var err error
@@ -85,8 +85,12 @@ retryScope:
 		}
 	}
 
+	if hasPreferred && !preferPublic {
+		return preferredIP, nil
+	}
+
 	if len(ipsPublic) != 0 {
-		if hasPreferred {
+		if hasPreferred && ip.IsPublicAddr(preferredIP) {
 			return preferredIP, nil
 		}
 
@@ -138,8 +142,8 @@ retryScope:
 // IPs belonging to that interface are considered.
 //
 // If preferredIP is present in the IP list it is returned irrespective of
-// the sort order. However, if preferredIP is a private IP and there are
-// public IPs, then public one is selected.
+// the sort order. However, if preferPublic is true and preferredIP is a
+// private IP, a public IP will be returned if it is assigned to the intf
 //
 // Passing intf and preferredIP will only return preferredIP if it is in
 // the IPs that belong to intf.
@@ -153,14 +157,14 @@ retryScope:
 // universe scope again (and then falling back to reduced scope).
 //
 // In case none of the above helped, we bail out with error.
-func firstGlobalV4Addr(intf string, preferredIP net.IP) (net.IP, error) {
-	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V4)
+func firstGlobalV4Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
+	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V4, preferPublic)
 }
 
 // firstGlobalV6Addr returns first IPv6 global IP of an interface, see
 // firstGlobalV4Addr for more details.
-func firstGlobalV6Addr(intf string, preferredIP net.IP) (net.IP, error) {
-	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V6)
+func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
+	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V6, preferPublic)
 }
 
 // getCiliumHostIPsFromNetDev returns the first IPv4 link local and returns


### PR DESCRIPTION
Currently, when running in kube-proxy replacement mode, `InitNodePortAddrs` selects NodePort address based on the logic of [firstGlobalAddr](https://github.com/cilium/cilium/blob/master/pkg/node/address_linux.go#L134) -- PublicIP > PrivateIP, without taking the k8s node IP into consideration. This may lead to public IP being selected when it's assigned to the same interface as the k8s node IP (e.g. this is how IPs are assigned in packet.net).

This change ensures that k8s Node IP is always selected and preferred over any public IP that may be assigned to the same interface.

The additional flag `preferPublicIP` is introduced to avoid breaking the behaviour introduced in #7749

Signed-off-by: Michael Kashin mmkashin@gmail.com

Fixes: #12988

