### PR TITLE
identity: Avoid kvstore lookup for local identities

### DIFF
--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -211,7 +211,7 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 		return identity
 	}
 
-	if m.IdentityAllocator == nil {
+	if !identity.RequiresGlobalIdentity(lbls) || m.IdentityAllocator == nil {
 		return nil
 	}
 
@@ -242,12 +242,12 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return identity
 	}
 
-	if m.IdentityAllocator == nil {
-		return nil
-	}
-
 	if identity := m.localIdentities.lookupByID(id); identity != nil {
 		return identity
+	}
+
+	if id.HasLocalScope() || m.IdentityAllocator == nil {
+		return nil
 	}
 
 	allocatorKey, err := m.IdentityAllocator.GetByIDIncludeRemoteCaches(ctx, idpool.ID(id))


### PR DESCRIPTION
Reserved and CIDR identities are local to the agent and not stored in
the kvstore. This commit changes the identity cache to avoid performing
a kvstore lookup for CIDR entries (which is currently done when a CIDR
identity is released). 

This PR is an optimization and should not change any observable
behavior (besides less unnecessary calls the kvstore).
This is a follow-up to https://github.com/cilium/cilium/pull/13205#discussion_r490306171

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
