### PR TITLE
test: enable hubble tls in ci

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -110,7 +110,6 @@ var (
 		// Enable embedded Hubble, both on unix socket and TCP port 4244.
 		"global.hubble.enabled":       "true",
 		"global.hubble.listenAddress": ":4244",
-		"global.hubble.tls.enabled":   "false",
 
 		// We need CNP node status to know when a policy is being enforced
 		"config.enableCnpStatusUpdates": "true",

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -142,7 +142,7 @@ func SuperNetperf(sessions int, endpoint string, perfTest PerfTest, options stri
 
 // Netcat returns the string representing the netcat command to the specified
 // endpoint. It takes a variadic optionalValues arguments, This is passed to
-// fmt.Sprintf uses in the netcat message
+// fmt.Sprintf uses in the netcat message.
 func Netcat(endpoint string, optionalValues ...interface{}) string {
 	if len(optionalValues) > 0 {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
@@ -171,4 +171,21 @@ func PythonBind(addr string, port uint16, proto string) string {
 	return fmt.Sprintf(
 		`/usr/bin/python3 -c 'import socket; socket.socket(%s).bind((%q, %d))`,
 		strings.Join(opts, ", "), addr, port)
+}
+
+// ReadFile returns the string representing a cat command to read the file at
+// the give path.
+func ReadFile(path string) string {
+	return fmt.Sprintf("cat %q", path)
+}
+
+// OpenSSLShowCerts retrieve the TLS certificate presented at the given
+// host:port when serverName is requested. The openssl cli is available in the
+// Cilium pod.
+func OpenSSLShowCerts(host string, port uint16, serverName string) string {
+	serverNameFlag := ""
+	if serverName != "" {
+		serverNameFlag = fmt.Sprintf("-servername %q", serverName)
+	}
+	return fmt.Sprintf("openssl s_client -connect %s:%d %s -showcerts | openssl x509 -outform PEM", host, port, serverNameFlag)
 }


### PR DESCRIPTION
Enable TLS for Hubble and verify that the expected certificate is served.