### PR TITLE
EKS: improve rules for asymmetric routing (multi-node NodePort)

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -1189,13 +1190,19 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		return nil
 	}
 
+	iface, err := route.NodeDeviceWithDefaultRoute(option.Config.EnableIPv4, option.Config.EnableIPv6)
+	if err != nil {
+		return fmt.Errorf("failed to find interface with default route: %w", err)
+	}
+
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+
 	if err := runProg("iptables", append(
 		m.waitArgs,
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
-		"-i", "eth0",
+		"-i", iface.Attrs().Name,
 		"-m", "comment", "--comment", "cilium: primary ENI",
 		"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
 		"-j", "CONNMARK", "--set-xmark", nfmask+"/"+ctmask),

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1185,6 +1185,10 @@ func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 }
 
 func (m *IptablesManager) addCiliumENIRules() error {
+	if !option.Config.EnableIPv4 {
+		return nil
+	}
+
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
 	if err := runProg("iptables", append(

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1198,6 +1198,9 @@ func (m *IptablesManager) addCiliumENIRules() error {
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
 
+	// Note: these rules need the xt_connmark module (iptables usually
+	// loads it when required, unless loading modules after boot has been
+	// disabled).
 	if err := runProg("iptables", append(
 		m.waitArgs,
 		"-t", "mangle",

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -138,7 +138,16 @@ func addENIRules(sysSettings []setting) ([]setting, error) {
 		return sysSettings, nil
 	}
 
-	retSettings := append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
+	iface, err := route.NodeDeviceWithDefaultRoute(option.Config.EnableIPv4, option.Config.EnableIPv6)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find interface with default route: %w", err)
+	}
+
+	retSettings := append(sysSettings, setting{
+		fmt.Sprintf("net.ipv4.conf.%s.rp_filter", iface.Attrs().Name),
+		"2",
+		false,
+	})
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -110,6 +110,43 @@ func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 	return fw.Flush()
 }
 
+type setting struct {
+	name      string
+	val       string
+	ignoreErr bool
+}
+
+func addENIRules(sysSettings []setting) ([]setting, error) {
+	// AWS ENI mode requires symmetric routing, see
+	// iptables.addCiliumENIRules().
+	// The default AWS daemonset installs the following rules that are used
+	// for NodePort traffic between nodes:
+	//
+	// # sysctl -w net.ipv4.conf.eth0.rp_filter=2
+	// # iptables -t mangle -A PREROUTING -i eth0 -m comment --comment "AWS, primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
+	// # iptables -t mangle -A PREROUTING -i eni+ -m comment --comment "AWS, primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
+	// # ip rule add fwmark 0x80/0x80 lookup main
+	//
+	// It marks packets coming from another node through eth0, and restores
+	// the mark on the return path to force a lookup into the main routing
+	// table. Without these rules, the "ip rules" set by the cilium-cni
+	// plugin tell the host to lookup into the table related to the VPC for
+	// which the CIDR used by the endpoint has been configured.
+	//
+	// We want to reproduce equivalent rules to ensure correct routing.
+	retSettings := append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
+	if err := route.ReplaceRule(route.Rule{
+		Priority: linux_defaults.RulePriorityNodeport,
+		Mark:     linux_defaults.MarkMultinodeNodeport,
+		Mask:     linux_defaults.MaskMultinodeNodeport,
+		Table:    route.MainTable,
+	}); err != nil {
+		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+	}
+
+	return retSettings, nil
+}
+
 // Reinitialize (re-)configures the base datapath configuration including global
 // BPF programs, netfilter rule configuration and reserving routes in IPAM for
 // locally detected prefixes. It may be run upon initial Cilium startup, after
@@ -119,12 +156,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args []string
 		ret  error
 	)
-
-	type setting struct {
-		name      string
-		val       string
-		ignoreErr bool
-	}
 
 	args = make([]string, initArgMax)
 
@@ -299,31 +330,9 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		logfields.BPFClockSource: clockSource[option.Config.ClockSource],
 	}).Info("Setting up BPF datapath")
 
-	// AWS ENI mode requires symmetric routing, see
-	// iptables.addCiliumENIRules().
-	// The default AWS daemonset installs the following rules that are used
-	// for NodePort traffic between nodes:
-	//
-	// # sysctl -w net.ipv4.conf.eth0.rp_filter=2
-	// # iptables -t mangle -A PREROUTING -i eth0 -m comment --comment "AWS, primary ENI" -m addrtype --dst-type LOCAL --limit-iface-in -j CONNMARK --set-xmark 0x80/0x80
-	// # iptables -t mangle -A PREROUTING -i eni+ -m comment --comment "AWS, primary ENI" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
-	// # ip rule add fwmark 0x80/0x80 lookup main
-	//
-	// It marks packets coming from another node through eth0, and restores
-	// the mark on the return path to force a lookup into the main routing
-	// table. Without these rules, the "ip rules" set by the cilium-cni
-	// plugin tell the host to lookup into the table related to the VPC for
-	// which the CIDR used by the endpoint has been configured.
-	//
-	// We want to reproduce equivalent rules to ensure correct routing.
 	if option.Config.IPAM == ipamOption.IPAMENI {
-		sysSettings = append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
-		if err := route.ReplaceRule(route.Rule{
-			Priority: linux_defaults.RulePriorityNodeport,
-			Mark:     linux_defaults.MarkMultinodeNodeport,
-			Mask:     linux_defaults.MaskMultinodeNodeport,
-			Table:    route.MainTable,
-		}); err != nil {
+		var err error
+		if sysSettings, err = addENIRules(sysSettings); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
 		}
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -134,6 +134,10 @@ func addENIRules(sysSettings []setting) ([]setting, error) {
 	// which the CIDR used by the endpoint has been configured.
 	//
 	// We want to reproduce equivalent rules to ensure correct routing.
+	if !option.Config.EnableIPv4 {
+		return sysSettings, nil
+	}
+
 	retSettings := append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,


### PR DESCRIPTION
Multi-node NodePort traffic on EKS needs specific rules regarding asymmetric routing. This PR improves the way those rules are implemented.

The most important change is related to the interface for which the rules are used. So far we have been creating them for the `eth0` interface (namely), because this is what EKS uses... With the default Amazon Linux 2 distribution. But EKS can also run with Ubuntu for example, and the name of the interface is not the same in that case. Instead of `eth0`, use the interface with the default route. I checked that this selects the same interfaces as the default AWS deamonset for the two AMIs Amazon Linux 2 (`eth0`) and Ubuntu 18.04 (`ens5`), and that `pod-to-b-multi-node-nodeport` from connectivity tests gets ready in both cases.

Other changes are minor, please refer to individual commits for details.

Fixes: #12770
Fixes: #13143
