### PR TITLE
helm: Remove default toleration on hubble-relay deployment

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -69,8 +69,10 @@ spec:
 {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
+{{- if .Values.tolerations }}
       tolerations:
-      - operator: Exists
+{{- toYaml .Values.tolerations | trim | nindent 8 }}
+{{- end }}
       volumes:
       - configMap:
           name: hubble-relay-config

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -13,6 +13,9 @@ resources: {}
 # Number of replicas run for the hubble-relay deployment.
 numReplicas: 1
 
+# Specifies the tolerations of the hubble-relay deployment
+tolerations: {}
+
 # Host to listen to. Specify an empty string to bind to all the interfaces.
 listenHost: ""
 

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -837,8 +837,6 @@ spec:
             readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - operator: Exists
       volumes:
       - configMap:
           name: hubble-relay-config


### PR DESCRIPTION
This removes the default toleration of the hubble-relay deployment which
allowed it to be scheduled on any node. In contrast to cilium and
cilium-operator, which are capable of running in the host network
namespace, Hubble Relay does require pod connectivity to be functional.

The existing catch-all toleration was intended to provide cluster-wide
network visibility in cases where nodes are unavailable. However, the
current toleration can cause Hubble Relay to be scheduled on these
unhealthy nodes and prevent it from running correctly, even though
untainted nodes would have been available.

Single-node clusters (such as minikube) intended to run workloads will
not have any tainted nodes and are thus are unaffected by this change.
Users who who have taints on every node in their cluster will have to
use the newly introduced `hubble-relay.tolerations` Helm value to
introduce custom tolerations for Hubble Relay.

Fixes: #13166

```release-note
Remove the default toleration on hubble-relay deployment.
Set the Helm value `hubble-relay.tolerations[0].operator=Exists` to restore the previous behavior.
```
