### PR TITLE
cilium: allow encryption/decryption to coexist with bpf_host logic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -47,6 +47,7 @@
 #include "lib/eps.h"
 #include "lib/host_firewall.h"
 #include "lib/overloadable.h"
+#include "lib/encrypt.h"
 
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
 static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx,
@@ -767,11 +768,16 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	int ret;
 
 #ifdef ENABLE_IPSEC
-	if (1) {
+	if (from_host) {
 		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 
 		if (magic == MARK_MAGIC_ENCRYPT)
 			return do_netdev_encrypt(ctx, proto);
+	} else {
+		int done = do_decrypt(ctx, proto);
+
+		if (!done)
+			return CTX_ACT_OK;
 	}
 #endif
 	bpf_clear_meta(ctx);

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -8,93 +8,18 @@
 #include <netdev_config.h>
 
 #include "lib/common.h"
-#include "lib/maps.h"
-#include "lib/ipv6.h"
 #include "lib/eth.h"
 #include "lib/dbg.h"
 #include "lib/trace.h"
-#include "lib/l3.h"
-#include "lib/drop.h"
-
-#ifdef ENABLE_IPV6
-static __always_inline int handle_ipv6(struct __ctx_buff *ctx)
-{
-#ifdef ENABLE_IPSEC
-	void *data_end, *data;
-	struct ipv6hdr *ip6;
-	bool decrypted;
-
-	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
-
-	if (!decrypted) {
-		/* IPSec is not currently enforce (feature coming soon)
-		 * so for now just handle normally
-		 */
-		if (ip6->nexthdr != IPPROTO_ESP)
-			return 0;
-
-		/* Decrypt "key" is determined by SPI */
-		ctx->mark = MARK_MAGIC_DECRYPT;
-
-		/* We are going to pass this up the stack for IPsec decryption
-		 * but eth_type_trans may already have labeled this as an
-		 * OTHERHOST type packet. To avoid being dropped by IP stack
-		 * before IPSec can be processed mark as a HOST packet.
-		 */
-		ctx_change_type(ctx, PACKET_HOST);
-		return CTX_ACT_OK;
-	}
-
-	ctx->mark = 0;
-	return redirect(CILIUM_IFINDEX, 0);
-#endif
-	return 0;
-}
-#endif /* ENABLE_IPV6 */
-
-#ifdef ENABLE_IPV4
-static __always_inline int handle_ipv4(struct __ctx_buff *ctx)
-{
-#ifdef ENABLE_IPSEC
-	void *data_end, *data;
-	struct iphdr *ip4;
-	bool decrypted;
-
-	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
-
-	if (!decrypted) {
-		/* IPSec is not currently enforce (feature coming soon)
-		 * so for now just handle normally
-		 */
-		if (ip4->protocol != IPPROTO_ESP)
-			goto out;
-		/* Decrypt "key" is determined by SPI */
-		ctx->mark = MARK_MAGIC_DECRYPT;
-		ctx_change_type(ctx, PACKET_HOST);
-		return CTX_ACT_OK;
-	}
-
-	ctx->mark = 0;
-	return redirect(CILIUM_IFINDEX, 0);
-out:
-#endif
-	return 0;
-}
-#endif
+#include "lib/encrypt.h"
 
 __section("from-network")
 int from_network(struct __ctx_buff *ctx)
 {
-	__u16 proto;
-	int ret = 0;
-
-	bpf_clear_meta(ctx);
-
 #ifdef ENABLE_IPSEC
+	__u16 proto;
+	int ret;
+
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT) {
 		send_trace_notify(ctx, TRACE_FROM_NETWORK, get_identity(ctx), 0, 0,
 				  ctx->ingress_ifindex,
@@ -106,30 +31,21 @@ int from_network(struct __ctx_buff *ctx)
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
 	}
 
-	if (!validate_ethertype(ctx, &proto)) {
-		/* Pass unknown traffic to the stack */
-		ret = CTX_ACT_OK;
-		return ret;
-	}
+	bpf_clear_meta(ctx);
 
-	switch (proto) {
-	case bpf_htons(ETH_P_IPV6):
-#ifdef ENABLE_IPV6
-		ret = handle_ipv6(ctx);
+#ifdef ENABLE_IPSEC
+	/* Pass unknown protocols to the stack */
+	if (!validate_ethertype(ctx, &proto))
+		return CTX_ACT_OK;
+
+	ret = do_decrypt(ctx, proto);
+	if (!ret)
+		return CTX_ACT_OK;
+	ctx->mark = 0;
+	return redirect(CILIUM_IFINDEX, 0);
 #endif
-		break;
-
-	case bpf_htons(ETH_P_IP):
-#ifdef ENABLE_IPV4
-		ret = handle_ipv4(ctx);
-#endif
-		break;
-
-	default:
-		/* Pass unknown traffic to the stack */
-		ret = CTX_ACT_OK;
-	}
-	return ret;
+	/* Pass unknown traffic to the stack */
+	return CTX_ACT_OK;
 }
 
 BPF_LICENSE("GPL");

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2020 Authors of Cilium */
+
+#ifndef __LIB_ENCRYPT_H_
+#define __LIB_ENCRYPT_H_
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+
+#include "lib/common.h"
+#include "lib/ipv6.h"
+#include "lib/l3.h"
+#include "lib/eth.h"
+
+#ifdef ENABLE_IPSEC
+static __always_inline int
+do_decrypt(struct __ctx_buff *ctx, __u16 proto)
+{
+	bool decrypted;
+
+	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+	if (!decrypted) {
+		void *data, *data_end;
+		__u8 protocol = 0;
+#ifdef ENABLE_IPV6
+		struct ipv6hdr *ip6;
+#endif
+#ifdef ENABLE_IPV4
+		struct iphdr *ip4;
+#endif
+
+		switch (proto) {
+#ifdef ENABLE_IPV6
+		case bpf_htons(ETH_P_IPV6):
+			if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+				break;
+			protocol = ip6->nexthdr;
+			break;
+#endif
+#ifdef ENABLE_IPV4
+		case bpf_htons(ETH_P_IP):
+			if (!revalidate_data(ctx, &data, &data_end, &ip4))
+				break;
+
+			protocol = ip4->protocol;
+			break;
+#endif
+		}
+
+		if (protocol == IPPROTO_ESP) {
+			/* Decrypt "key" is determined by SPI */
+			ctx->mark = MARK_MAGIC_DECRYPT;
+			/* We are going to pass this up the stack for IPsec decryption
+			 * but eth_type_trans may already have labeled this as an
+			 * OTHERHOST type packet. To avoid being dropped by IP stack
+			 * before IPSec can be processed mark as a HOST packet.
+			 */
+			ctx_change_type(ctx, PACKET_HOST);
+			return 0;
+		}
+	}
+	return -ENOENT;
+}
+#else
+static __always_inline int
+do_decrypt(struct __ctx_buff __maybe_unused *ctx, __u16 __maybe_unused proto)
+{
+	return -ENOENT;
+}
+#endif /* ENABLE_IPSEC */
+#endif /* __LIB_ENCRYPT_H_ */
+

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1185,10 +1185,6 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EnableBandwidthManager = false
 	}
 
-	if len(option.Config.Devices) != 0 && option.Config.EnableIPSec {
-		log.Fatalf("--%s cannot be used with IPSec.", option.Devices)
-	}
-
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
 	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -558,6 +558,24 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
+		It("Check connectivity with transparent encryption and direct routing with bpf_host", func() {
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
+			SkipIfIntegration(helpers.CIIntegrationGKE)
+			SkipItIfNoKubeProxy()
+
+			privateIface, err := kubectl.GetPrivateIface()
+			Expect(err).Should(BeNil(), "Unable to determine private iface")
+
+			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
+			deploymentManager.DeployCilium(map[string]string{
+				"global.tunnel":               "disabled",
+				"global.autoDirectNodeRoutes": "true",
+				"global.encryption.enabled":   "true",
+				"global.encryption.interface": privateIface,
+				"global.hostFirewall":         "false",
+			}, DeployCiliumOptionsAndDNS)
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+		})
 	})
 
 	Context("IPv4Only", func() {


### PR DESCRIPTION
We have added logic in the bpf_host that is attached to egress/ingress network facing device. This is the same device that is used by bpf_network for encryption. The result is bpf_network is loaded by bpf_init.sh and then bpf_host based programs are loaded by golang bpf loader replacing the bpf_network program. This results in traffic drops because encryption rules exist in xfrm datapath, but BPF side is not correctly implementing them. To fix make bpf_host do correct decrypt logic.

Additionally, workaround a kernel regression by simplifing the encryption/decryption rules in the encrypt-node case. Kernels 4.19 and earlier appear to work correctly with the current setup, but newer kernels (at least 5.4) is broken with the current setup. The new cleaner approach appears to work on all kernels testsed