### PR TITLE
cilium: encrypt-node creates two IPsec tunnels but only uses one

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -704,7 +704,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		oldKey = oldNode.EncryptionKey
 	}
 
-	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
+	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() && !n.nodeConfig.EncryptNode {
 		n.enableIPsec(newNode)
 		newKey = newNode.EncryptionKey
 	}


### PR DESCRIPTION
When we enable encrypt-node to encrypt all host traffic instead of just
the pod traffic we setup two tunnels. The first tunnel is the typical
one used in the case where encrypt-node is not set. This tunnel uses
the cilium_host ip address range. The second tunnel uses the nodes IP
per the encrypt-interface parameter or in the auto-discovered case the
IP found after inspecting the route tables.

On new kernels having duplicate entires in the 'ip xfrm policy' table
that matches to multiple sates appears to be causing packets to be
dropped. This was working on 4.19 kernels, but broke on upgrade to 5.4
kernels. We have not found the exact patch or fixed the regression. But,
it is actually better/simpler to only have a single tunnel running in
the encrypt-node case. This means fewer xfrm rules and is much easier
to understand when only one rule can match a packet.

Before this patch the xfrm policy/state looked like this with states
and policies for both the 44.* xfrm tunnel and the 10.* xfrm tunnel.

# ip x s
src 0.0.0.0 dst 44.0.0.20
	proto esp spi 0x00000003 reqid 1 mode tunnel
	replay-window 0
	mark 0xd00/0xf00 output-mark 0xd00
	aead rfc4106(gcm(aes)) 0xd0561beea6ab84e073edf1e76c49e9c0c6531d52 128
	anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0
src 0.0.0.0 dst 10.0.0.200
	proto esp spi 0x00000003 reqid 1 mode tunnel
	replay-window 0
	mark 0xd00/0xf00 output-mark 0xd00
	aead rfc4106(gcm(aes)) 0xd0561beea6ab84e073edf1e76c49e9c0c6531d52 128
	anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0
src 44.0.0.20 dst 44.0.0.10
	proto esp spi 0x00000003 reqid 1 mode tunnel
	replay-window 0
	mark 0x3e00/0xff00 output-mark 0xe00
	aead rfc4106(gcm(aes)) 0xd0561beea6ab84e073edf1e76c49e9c0c6531d52 128
	anti-replay context: seq 0x0, oseq 0x25d, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0
src 10.0.0.200 dst 10.0.1.135
	proto esp spi 0x00000003 reqid 1 mode tunnel
	replay-window 0
	mark 0x3e00/0xff00 output-mark 0xe00
	aead rfc4106(gcm(aes)) 0xd0561beea6ab84e073edf1e76c49e9c0c6531d52 128
	anti-replay context: seq 0x0, oseq 0x589, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0

# ip x p

src 0.0.0.0/0 dst 44.0.0.20/32
	dir fwd priority 0
	mark 0xd00/0xf00
	tmpl src 0.0.0.0 dst 44.0.0.20
		proto esp reqid 1 mode tunnel
src 0.0.0.0/0 dst 44.0.0.20/32
	dir in priority 0
	mark 0xd00/0xf00
	tmpl src 0.0.0.0 dst 44.0.0.20
		proto esp reqid 1 mode tunnel
src 0.0.0.0/0 dst 10.0.0.0/24
	dir fwd priority 0
	mark 0xd00/0xf00
	tmpl src 0.0.0.0 dst 10.0.0.200
		proto esp reqid 1 mode tunnel
src 0.0.0.0/0 dst 10.0.0.0/24
	dir in priority 0
	mark 0xd00/0xf00
	tmpl src 0.0.0.0 dst 10.0.0.200
		proto esp reqid 1 mode tunnel
src 0.0.0.0/0 dst 10.0.1.0/24
	dir out priority 0
	mark 0x3e00/0xff00
	tmpl src 44.0.0.20 dst 44.0.0.10
		proto esp spi 0x00000003 reqid 1 mode tunnel
src 0.0.0.0/0 dst 44.0.0.10/32
	dir out priority 0
	mark 0x3e00/0xff00
	tmpl src 44.0.0.20 dst 44.0.0.10
		proto esp spi 0x00000003 reqid 1 mode tunnel
src 10.0.0.0/24 dst 10.0.1.0/24
	dir out priority 0
	mark 0x3e00/0xff00
	tmpl src 10.0.0.200 dst 10.0.1.135
		proto esp spi 0x00000003 reqid 1 mode tunnel

Now we get only the single 44* xfrm tunnel,

# ip x s
src 0.0.0.0 dst 44.0.0.20
	proto esp spi 0x00000003 reqid 1 mode tunnel
	replay-window 0
	mark 0xd00/0xf00 output-mark 0xd00
	aead rfc4106(gcm(aes)) 0xd0561beea6ab84e073edf1e76c49e9c0c6531d52 128
	anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0
src 44.0.0.20 dst 44.0.0.10
	proto esp spi 0x00000003 reqid 1 mode tunnel
	replay-window 0
	mark 0x3e00/0xff00 output-mark 0xe00
	aead rfc4106(gcm(aes)) 0xd0561beea6ab84e073edf1e76c49e9c0c6531d52 128
	anti-replay context: seq 0x0, oseq 0x4423, bitmap 0x00000000
	sel src 0.0.0.0/0 dst 0.0.0.0/0
# ip x p
src 0.0.0.0/0 dst 44.0.0.20/32
	dir fwd priority 0
	mark 0xd00/0xf00
	tmpl src 0.0.0.0 dst 44.0.0.20
		proto esp reqid 1 mode tunnel
src 0.0.0.0/0 dst 44.0.0.20/32
	dir in priority 0
	mark 0xd00/0xf00
	tmpl src 0.0.0.0 dst 44.0.0.20
		proto esp reqid 1 mode tunnel
src 0.0.0.0/0 dst 10.0.1.0/24
	dir out priority 0
	mark 0x3e00/0xff00
	tmpl src 44.0.0.20 dst 44.0.0.10
		proto esp spi 0x00000003 reqid 1 mode tunnel
src 0.0.0.0/0 dst 44.0.0.10/32
	dir out priority 0
	mark 0x3e00/0xff00
	tmpl src 44.0.0.20 dst 44.0.0.10
		proto esp spi 0x00000003 reqid 1 mode tunnel

There are two key pieces here. First, pod traffic is encrypted by the
policy with dst 10.0.1.0/24 which is the peer nodes pod IP ranges. If
we had multiple nodes we would have multiple entries here. And then
second, because we now encrypt always with the 44.* IP tunnel we can
eliminate a set of state rules.

Considering this is both cleaner and will work on all kernels regardless
of fix for kernel regression lets use this for encrypt-node use cases
instead.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>
