### PR TITLE
fqdn: remove unused fields and funcs after DNS poller removal

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -137,7 +137,6 @@ func (d *Daemon) updateSelectorCacheFQDNs(ctx context.Context, selectors map[pol
 func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, preCachePath string) (err error) {
 	cfg := fqdn.Config{
 		MinTTL:          option.Config.ToFQDNsMinTTL,
-		OverLimit:       option.Config.ToFQDNsMaxIPsPerHost,
 		Cache:           fqdn.NewDNSCache(option.Config.ToFQDNsMinTTL),
 		UpdateSelectors: d.updateSelectors,
 	}

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/miekg/dns"
 )
 
 // Config is a simple configuration structure to set how pkg/fqdn subcomponents
@@ -29,16 +28,9 @@ type Config struct {
 	// MinTTL is the time used by the poller to cache information.
 	MinTTL int
 
-	// OverLimit is the number of max entries that a host can have in the DNS cache.
-	OverLimit int
-
 	// Cache is where the poller stores DNS data used to generate rules.
 	// When set to nil, it uses fqdn.DefaultDNSCache, a global cache instance.
 	Cache *DNSCache
-
-	// DNSConfig includes the Resolver IPs, port, timeout and retry count. It is
-	// expected to be  generated from /etc/resolv.conf.
-	DNSConfig *dns.ClientConfig
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.

--- a/pkg/fqdn/doc.go
+++ b/pkg/fqdn/doc.go
@@ -101,7 +101,7 @@
 // === L3 DNS ===
 // L3 DNS rules control L3 connections and not the DNS requests themselves.
 // They rely on DNS lookup cache information and it must come from the DNS
-// proxy, via a L7 DNS rule, or from the DNS poller (deprecated in cilium 1.8).
+// proxy, or via a L7 DNS rule.
 //
 //  - toFQDNs:
 //      - matchName: "my-remote-service.com"


### PR DESCRIPTION
These are unused after commit ec972c7e6bc5 ("daemon, fqdn: remove DNS
poller implementation").

Follow-up for #13229