### PR TITLE
lbmap: Correct issue that port info display error

### DIFF
--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -52,7 +52,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 	parseBackendEntry := func(key bpf.MapKey, value bpf.MapValue) {
 		id := key.(lbmap.BackendKey).GetID()
-		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue)
+		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue).ToHost()
 	}
 	if err := lbmap.Backend4Map.DumpWithCallbackIfExists(parseBackendEntry); err != nil {
 		Fatalf("Unable to dump IPv4 backends table: %s", err)
@@ -65,8 +65,9 @@ func dumpSVC(serviceList map[string][]string) {
 		var entry string
 
 		svcKey := key.(lbmap.ServiceKey)
-		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.ToNetwork().String()
+		svcVal := value.(lbmap.ServiceValue).ToHost()
+		svc := svcKey.String()
+		svcKey = svcKey.ToHost()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -66,7 +66,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 		svcKey := key.(lbmap.ServiceKey)
 		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.String()
+		svc := svcKey.ToNetwork().String()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -103,7 +103,10 @@ func (k *AffinityMatchKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k)
 func (v *AffinityMatchValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 // String converts the key into a human readable string format
-func (k *AffinityMatchKey) String() string { return fmt.Sprintf("%d %d", k.BackendID, k.RevNATID) }
+func (k *AffinityMatchKey) String() string {
+	kHost := k.ToHost()
+	return fmt.Sprintf("%d %d", kHost.BackendID, kHost.RevNATID)
+}
 
 // String converts the value into a human readable string format
 func (v *AffinityMatchValue) String() string { return "" }
@@ -119,6 +122,13 @@ func (k *AffinityMatchKey) ToNetwork() *AffinityMatchKey {
 	// the SVC BPF maps
 	n.RevNATID = byteorder.HostToNetwork(n.RevNATID).(uint16)
 	return &n
+}
+
+// ToHost returns the key in the host byte order
+func (k *AffinityMatchKey) ToHost() *AffinityMatchKey {
+	h := *k
+	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
+	return &h
 }
 
 // Affinity4Key is the Go representation of lb4_affinity_key

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -39,15 +39,8 @@ var (
 		int(unsafe.Sizeof(AffinityMatchValue{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			aKey, aVal := mapKey.(*AffinityMatchKey), mapValue.(*AffinityMatchValue)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, aKey, aVal); err != nil {
-				return nil, nil, err
-			}
-
-			return aKey.ToNetwork(), aVal, nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 	Affinity4Map = bpf.NewMap(
 		Affinity4MapName,
 		bpf.MapTypeLRUHash,

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -107,7 +107,7 @@ func NewRevNat4Key(value uint16) *RevNat4Key {
 func (k *RevNat4Key) Map() *bpf.Map             { return RevNat4Map }
 func (k *RevNat4Key) NewValue() bpf.MapValue    { return &RevNat4Value{} }
 func (k *RevNat4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
-func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.Key) }
+func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.ToHost().(*RevNat4Key).Key) }
 func (k *RevNat4Key) GetKey() uint16            { return k.Key }
 
 // ToNetwork converts RevNat4Key to network byte order.
@@ -115,6 +115,13 @@ func (k *RevNat4Key) ToNetwork() RevNatKey {
 	n := *k
 	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
 	return &n
+}
+
+// ToHost converts RevNat4Key to host byte order.
+func (k *RevNat4Key) ToHost() RevNatKey {
+	h := *k
+	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -133,8 +140,16 @@ func (v *RevNat4Value) ToNetwork() RevNatValue {
 	return &n
 }
 
+// ToHost converts RevNat4Value to host byte order.
+func (k *RevNat4Value) ToHost() RevNatValue {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 func (v *RevNat4Value) String() string {
-	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+	vHost := v.ToHost().(*RevNat4Value)
+	return net.JoinHostPort(vHost.Address.String(), fmt.Sprintf("%d", vHost.Port))
 }
 
 type pad2uint8 [2]uint8
@@ -204,6 +219,13 @@ func (k *Service4Key) ToNetwork() ServiceKey {
 	return &n
 }
 
+// ToHost converts Service4Key to host byte order.
+func (k *Service4Key) ToHost() ServiceKey {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 type pad3uint8 [3]uint8
 
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
@@ -225,7 +247,8 @@ type Service4Value struct {
 }
 
 func (s *Service4Value) String() string {
-	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", s.BackendID, s.RevNat, s.Flags)
+	sHost := s.ToHost().(*Service4Value)
+	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", sHost.BackendID, sHost.RevNat, sHost.Flags)
 }
 
 func (s *Service4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
@@ -261,6 +284,13 @@ func (s *Service4Value) ToNetwork() ServiceValue {
 	n := *s
 	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
 	return &n
+}
+
+// ToHost converts Service4Value to host byte order.
+func (s *Service4Value) ToHost() ServiceValue {
+	h := *s
+	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -306,7 +336,8 @@ func NewBackend4Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend4V
 }
 
 func (v *Backend4Value) String() string {
-	return fmt.Sprintf("%s://%s:%d", v.Proto, v.Address, v.Port)
+	vHost := v.ToHost().(*Backend4Value)
+	return fmt.Sprintf("%s://%s:%d", vHost.Proto, vHost.Address, vHost.Port)
 }
 
 func (v *Backend4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
@@ -318,6 +349,13 @@ func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToHost converts Backend4Value to host byte order.
+func (v *Backend4Value) ToHost() BackendValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 type Backend4 struct {

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -108,7 +108,7 @@ func NewRevNat6Key(value uint16) *RevNat6Key {
 func (v *RevNat6Key) Map() *bpf.Map             { return RevNat6Map }
 func (v *RevNat6Key) NewValue() bpf.MapValue    { return &RevNat6Value{} }
 func (v *RevNat6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(v) }
-func (v *RevNat6Key) String() string            { return fmt.Sprintf("%d", v.Key) }
+func (v *RevNat6Key) String() string            { return fmt.Sprintf("%d", v.ToHost().(*RevNat6Key).Key) }
 func (v *RevNat6Key) GetKey() uint16            { return v.Key }
 
 // ToNetwork converts RevNat6Key to network byte order.
@@ -116,6 +116,13 @@ func (v *RevNat6Key) ToNetwork() RevNatKey {
 	n := *v
 	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
 	return &n
+}
+
+// ToNetwork converts RevNat6Key to host byte order.
+func (v *RevNat6Key) ToHost() RevNatKey {
+	h := *v
+	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -128,7 +135,8 @@ type RevNat6Value struct {
 func (v *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 func (v *RevNat6Value) String() string {
-	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+	vHost := v.ToHost().(*RevNat6Value)
+	return net.JoinHostPort(vHost.Address.String(), fmt.Sprintf("%d", vHost.Port))
 }
 
 // ToNetwork converts RevNat6Value to network byte order.
@@ -136,6 +144,13 @@ func (v *RevNat6Value) ToNetwork() RevNatValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToNetwork converts RevNat6Value to Host byte order.
+func (v *RevNat6Value) ToHost() RevNatValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 // Service6Key must match 'struct lb6_key_v2' in "bpf/lib/common.h".
@@ -197,6 +212,13 @@ func (k *Service6Key) ToNetwork() ServiceKey {
 	return &n
 }
 
+// ToHost converts Service6Key to host byte order.
+func (k *Service6Key) ToHost() ServiceKey {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 // Service6Value must match 'struct lb6_service_v2' in "bpf/lib/common.h".
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
@@ -210,7 +232,8 @@ type Service6Value struct {
 }
 
 func (s *Service6Value) String() string {
-	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", s.BackendID, s.RevNat, s.Flags)
+	sHost := s.ToHost().(*Service6Value)
+	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", sHost.BackendID, sHost.RevNat, sHost.Flags)
 }
 
 func (s *Service6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
@@ -245,6 +268,13 @@ func (s *Service6Value) ToNetwork() ServiceValue {
 	n := *s
 	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
 	return &n
+}
+
+// ToHost converts Service6Value to host byte order.
+func (s *Service6Value) ToHost() ServiceValue {
+	h := *s
+	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -290,7 +320,8 @@ func NewBackend6Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend6V
 }
 
 func (v *Backend6Value) String() string {
-	return fmt.Sprintf("%s://[%s]:%d", v.Proto, v.Address, v.Port)
+	vHost := v.ToHost().(*Backend6Value)
+	return fmt.Sprintf("%s://[%s]:%d", vHost.Proto, vHost.Address, vHost.Port)
 }
 
 func (v *Backend6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
@@ -302,6 +333,13 @@ func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToHost converts Backend6Value to host byte order.
+func (v *Backend6Value) ToHost() BackendValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 type Backend6 struct {

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -274,7 +274,7 @@ func (*LBBPFMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
 	matches := BackendIDByServiceIDSet{}
 
 	parse := func(key bpf.MapKey, value bpf.MapValue) {
-		matchKey := key.DeepCopyMapKey().(*AffinityMatchKey)
+		matchKey := key.DeepCopyMapKey().(*AffinityMatchKey).ToHost()
 		svcID := matchKey.RevNATID
 		backendID := uint16(matchKey.BackendID) // currently backend_id is u16
 
@@ -295,7 +295,7 @@ func (*LBBPFMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
 func (*LBBPFMap) DumpSourceRanges(ipv6 bool) (SourceRangeSetByServiceID, error) {
 	ret := SourceRangeSetByServiceID{}
 	parser := func(key bpf.MapKey, value bpf.MapValue) {
-		k := key.(SourceRangeKey)
+		k := key.(SourceRangeKey).ToHost()
 		revNATID := k.GetRevNATID()
 		if _, found := ret[revNATID]; !found {
 			ret[revNATID] = []*cidr.CIDR{}
@@ -370,13 +370,13 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 
 	parseBackendEntries := func(key bpf.MapKey, value bpf.MapValue) {
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 
 	parseSVCEntries := func(key bpf.MapKey, value bpf.MapValue) {
-		svcKey := key.DeepCopyMapKey().(ServiceKey)
-		svcValue := value.DeepCopyMapValue().(ServiceValue)
+		svcKey := key.DeepCopyMapKey().(ServiceKey).ToHost()
+		svcValue := value.DeepCopyMapValue().(ServiceValue).ToHost()
 
 		fe := svcFrontend(svcKey, svcValue)
 
@@ -452,7 +452,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		// No need to deep copy the key because we are using the ID which
 		// is a value.
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -61,6 +61,9 @@ type ServiceKey interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() ServiceKey
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceKey
 }
 
 // ServiceValue is the interface describing protocol independent value for services map v2.
@@ -99,6 +102,9 @@ type ServiceValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() ServiceValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceValue
 }
 
 // BackendKey is the interface describing protocol independent backend key.
@@ -127,6 +133,9 @@ type BackendValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() BackendValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() BackendValue
 }
 
 // Backend is the interface describing protocol independent backend used by services v2.
@@ -152,6 +161,9 @@ type RevNatKey interface {
 
 	// Returns the key value
 	GetKey() uint16
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatKey
 }
 
 type RevNatValue interface {
@@ -159,6 +171,9 @@ type RevNatValue interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() RevNatValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatValue
 }
 
 // BackendIDByServiceIDSet is the type of a set for checking whether a backend


### PR DESCRIPTION
The port info is stored in the bpf map in network byte order;

bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb4_backends
key: 02 00  value: 0a 00 00 55 00 35 00 00
key: 01 00  value: 0a a9 d0 d6 19 2b 00 00
key: 04 00  value: 0a 00 00 64 00 35 00 00
key: 08 00  value: 0a 00 01 db 00 50 00 00
key: 03 00  value: 0a 00 00 55 23 c1 00 00
key: 05 00  value: 0a 00 00 64 23 c1 00 00
key: 07 00  value: 0a 00 01 e6 00 50 00 00
key: 06 00  value: 0a 00 00 59 00 50 00 00

cilium map get cilium_lb4_backends
Key   Value                    State   Error
6     ANY://10.0.0.89:20480    sync
7     ANY://10.0.1.230:20480   sync
8     ANY://10.0.1.219:20480   sync

When displaying the given lbmap content, the port needs to be
converted to host byte order.

cilium map get cilium_lb4_backends
Key   Value                 State   Error
8     ANY://10.0.0.64:80    sync
6     ANY://10.0.1.158:80   sync
7     ANY://10.0.1.66:80    sync

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Fixes: #13243 