### PR TITLE
.github, .travis: bump golangci-lint to 1.31

### DIFF
--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1.2.1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.27
+          version: v1.31
 
   precheck:
     runs-on: ubuntu-latest

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -50,4 +50,4 @@ GO111MODULE=off go get golang.org/x/tools/cmd/cover
 GO111MODULE=off go get github.com/mattn/goveralls
 
 # Install golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0


### PR DESCRIPTION
Make the version consistent in the GitHub action and Travis CI.
