### PR TITLE
v1.8 backports 2020-09-22

### DIFF
--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -400,7 +400,7 @@ Use the following list of steps to troubleshoot issues with ClusterMesh:
 Generic
 =======
 
- #. Validate that the ``cilium-xxx`` as well as the ``cilium-operator-xxx` pods
+ #. Validate that the ``cilium-xxx`` as well as the ``cilium-operator-xxx`` pods
     are healthy and ready. It is important that the ``cilium-operator`` is
     healthy as well as it is responsible for synchronizing state from the local
     cluster into the kvstore. If this fails, check the logs of these pods to

--- a/daemon/cmd/agenthealth.go
+++ b/daemon/cmd/agenthealth.go
@@ -16,12 +16,16 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"syscall"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/option"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -45,14 +49,17 @@ func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) erro
 	return soerr
 }
 
-// startAgentHealthHTTPService registers a handler function for the /healthz
-// status HTTP endpoint exposed on addr. This endpoint reports the agent health
-// status and is equivalent to what the `cilium status --brief` CLI tool reports.
-func (d *Daemon) startAgentHealthHTTPService(addr string) {
-	lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
-	ln, err := lc.Listen(context.Background(), "tcp", addr)
-	if err != nil {
-		log.WithError(err).Fatalf("Unable to listen on %s for healthz status API server", addr)
+// startAgentHealthHTTPService registers a handler function for the /healthz status HTTP endpoint
+// exposed on localhost (127.0.0.1 and/or ::1, depending on IPv4/IPv6 options). This
+// endpoint reports the agent health status and is equivalent to what the `cilium status --brief`
+// CLI tool reports.
+func (d *Daemon) startAgentHealthHTTPService() {
+	var hosts []string
+	if option.Config.EnableIPv4 {
+		hosts = append(hosts, "127.0.0.1")
+	}
+	if option.Config.EnableIPv6 {
+		hosts = append(hosts, "::1")
 	}
 
 	mux := http.NewServeMux()
@@ -72,18 +79,37 @@ func (d *Daemon) startAgentHealthHTTPService(addr string) {
 		}
 		w.WriteHeader(statusCode)
 	}))
-	srv := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+
+	available := len(hosts)
+	for _, host := range hosts {
+		lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
+		addr := net.JoinHostPort(host, fmt.Sprintf("%d", option.Config.AgentHealthPort))
+		addrField := logrus.Fields{"address": addr}
+		ln, err := lc.Listen(context.Background(), "tcp", addr)
+		if errors.Is(err, unix.EADDRNOTAVAIL) {
+			log.WithFields(addrField).Info("healthz status API server not available")
+			available--
+			continue
+		} else if err != nil {
+			log.WithFields(addrField).WithError(err).Fatal("Unable to start healthz status API server")
+		}
+
+		go func(addr string, ln net.Listener) {
+			srv := &http.Server{
+				Addr:    addr,
+				Handler: mux,
+			}
+			err := srv.Serve(ln)
+			if errors.Is(err, http.ErrServerClosed) {
+				log.WithFields(addrField).Info("healthz status API server shutdown")
+			} else if err != nil {
+				log.WithFields(addrField).WithError(err).Fatal("Error serving healthz status API server")
+			}
+		}(addr, ln)
+		log.WithFields(addrField).Info("Started healthz status API server")
 	}
 
-	go func() {
-		err := srv.Serve(ln)
-		if err == http.ErrServerClosed {
-			log.Info("healthz status API server shutdown")
-		} else if err != nil {
-			log.WithError(err).Fatal("Unable to start healthz status API server")
-		}
-	}()
-	log.Infof("Started healthz status API server on address %s", addr)
+	if available <= 0 {
+		log.WithField("hosts", hosts).Fatal("No healthz status API server started")
+	}
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1385,7 +1385,7 @@ func runDaemon() {
 
 	metricsErrs := initMetrics()
 
-	d.startAgentHealthHTTPService(fmt.Sprintf("localhost:%d", option.Config.AgentHealthPort))
+	d.startAgentHealthHTTPService()
 
 	bootstrapStats.initAPI.Start()
 	srv := server.NewServer(d.instantiateAPI())

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -63,7 +63,11 @@ spec:
             - --brief
 {{- else }}
           httpGet:
+{{- if .Values.global.ipv4.enabled }}
             host: '127.0.0.1'
+{{- else }}
+            host: '::1'
+{{- end }}
             path: /healthz
             port: {{ .Values.global.agent.healthPort }}
             scheme: HTTP
@@ -88,7 +92,11 @@ spec:
             - --brief
 {{- else }}
           httpGet:
+{{- if .Values.global.ipv4.enabled }}
             host: '127.0.0.1'
+{{- else }}
+            host: '::1'
+{{- end }}
             path: /healthz
             port: {{ .Values.global.agent.healthPort }}
             scheme: HTTP

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -75,8 +75,10 @@ spec:
             readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
+{{- if .Values.tolerations }}
       tolerations:
-      - operator: Exists
+{{- toYaml .Values.tolerations | trim | nindent 8 }}
+{{- end }}
       volumes:
       - hostPath:
           path: {{ dir .Values.global.hubble.socketPath }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -13,6 +13,9 @@ resources: {}
 # Number of replicas run for the hubble-relay deployment.
 numReplicas: 1
 
+# Specifies the tolerations of the hubble-relay deployment
+tolerations: {}
+
 # Host to listen to. Specify an empty string to bind to all the interfaces.
 listenHost: ""
 

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -752,8 +752,6 @@ spec:
             readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - operator: Exists
       volumes:
       - hostPath:
           path: /var/run/cilium

--- a/operator/main.go
+++ b/operator/main.go
@@ -124,12 +124,12 @@ func initEnv() {
 	option.Config.EnableK8sLeasesFallbackDiscovery()
 }
 
-func doCleanup() {
+func doCleanup(exitCode int) {
 	isLeader.Store(false)
 	gops.Close()
 	close(shutdownSignal)
 	leaderElectionCtxCancel()
-	os.Exit(0)
+	os.Exit(exitCode)
 }
 
 func main() {
@@ -138,7 +138,7 @@ func main() {
 
 	go func() {
 		<-signals
-		doCleanup()
+		doCleanup(0)
 	}()
 
 	if err := rootCmd.Execute(); err != nil {
@@ -188,7 +188,16 @@ func runOperator() {
 	}
 	close(k8sInitDone)
 
-	k8sversion.Update(k8s.Client(), option.Config)
+	// We try to update the Kubernetes version and capabilities. If this fails,
+	// we cannot move forward as we can misinterpret the available Capabilities.
+	// For example, in a case where we got an error when checking for Leases support
+	// we should not assume that support is not available and run the operator
+	// in non HA mode. As this can conflict with other operator instances running
+	// in the cluster, that figured the capabilities correctly and is running in HA
+	// mode.
+	if err := k8sversion.Update(k8s.Client(), option.Config); err != nil {
+		log.WithError(err).Fatal("Unable to update Kubernetes capabilities")
+	}
 	capabilities := k8sversion.Capabilities()
 
 	if !capabilities.MinimalVersionMet {
@@ -248,7 +257,7 @@ func runOperator() {
 			OnStoppedLeading: func() {
 				log.WithField("operator-id", operatorID).Info("Leader election lost")
 				// Cleanup everything here, and exit.
-				doCleanup()
+				doCleanup(1)
 			},
 			OnNewLeader: func(identity string) {
 				if identity == operatorID {


### PR DESCRIPTION
 * #13221 -- doc: typo fix in gettingstarted clustermesh (@kAworu)
 * #13219 -- operator: fix operator behaviour when kube-apiserver is down (@fristonio)
 * #13203 -- daemon: listen on IPv4 and IPv6 for health endpoint (@tklauser)
 * #13237 -- helm: Remove default toleration on hubble-relay deployment (@gandro)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13221 13219 13203 13237; do contrib/backporting/set-labels.py $pr done 1.8; done
```