### PR TITLE
v1.7 backports 2020-09-22

### DIFF
--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -397,7 +397,7 @@ Use the following list of steps to troubleshoot issues with ClusterMesh:
 Generic
 =======
 
- #. Validate that the ``cilium-xxx`` as well as the ``cilium-operator-xxx` pods
+ #. Validate that the ``cilium-xxx`` as well as the ``cilium-operator-xxx`` pods
     are healthy and ready. It is important that the ``cilium-operator`` is
     healthy as well as it is responsible for synchronizing state from the local
     cluster into the kvstore. If this fails, check the logs of these pods to


### PR DESCRIPTION
 * #13221 -- doc: typo fix in gettingstarted clustermesh (@kAworu)
 * #13219 -- operator: fix operator behaviour when kube-apiserver is down (@fristonio)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13221 13219; do contrib/backporting/set-labels.py $pr done 1.7; done
```