### PR TITLE
hubble: Fix filter by reply reporting flows with unknown reply state 

### DIFF
--- a/pkg/hubble/filters/reply.go
+++ b/pkg/hubble/filters/reply.go
@@ -16,6 +16,7 @@ package filters
 
 import (
 	"context"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
@@ -26,9 +27,32 @@ func filterByReplyField(replyParams []bool) FilterFunc {
 		if len(replyParams) == 0 {
 			return true
 		}
-		switch ev.Event.(type) {
+		switch f := ev.Event.(type) {
 		case v1.Flow:
-			reply := ev.GetFlow().GetReply()
+			// FIMXE: In events originating from TraceNotify, the `reply`
+			// field is determined from the connection tracking state in
+			// the datapath. Unfortunately, not all trace points have the
+			// connection tracking state available. For certain trace point
+			// events, we do not know if it actually was a reply or not.
+			//
+			// Ideally, we would fix this in the parser and make the `reply`
+			// an optional boolean, so we can distinguish between a `false`
+			// value and an absent value. This however is a breaking change
+			// in the API. Therefore, we only report flows here for which we
+			// know that the reply field is reliable:
+			if f.GetEventType().GetType() == monitorAPI.MessageTypeTrace {
+				obsPoint := uint8(f.GetEventType().GetSubType())
+				if !monitorAPI.TraceObservationPointHasConnState(obsPoint) {
+					return false
+				}
+			}
+			// For PolicyVerdict and Drop events, we statically assume they
+			// always have `reply=false`, as the flow is not yet established
+			// when the policy verdict is taken.
+			// For all other events (including Accesslog/L7), we assume the
+			// parser populates the Reply field reliably.
+
+			reply := f.GetReply()
 			for _, replyParam := range replyParams {
 				if reply == replyParam {
 					return true

--- a/pkg/hubble/filters/reply_test.go
+++ b/pkg/hubble/filters/reply_test.go
@@ -22,6 +22,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
 func Test_filterByReplyField(t *testing.T) {
@@ -64,6 +65,34 @@ func Test_filterByReplyField(t *testing.T) {
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{false}}},
 				ev: &v1.Event{Event: &flowpb.Flow{Reply: false}},
+			},
+			want: true,
+		},
+		{
+			name: "trace-event-from-endpoint",
+			args: args{
+				f: []*flowpb.FlowFilter{{Reply: []bool{false}}},
+				ev: &v1.Event{Event: &flowpb.Flow{
+					EventType: &flowpb.CiliumEventType{
+						Type:    monitorAPI.MessageTypeTrace,
+						SubType: monitorAPI.TraceFromLxc,
+					},
+					Reply: false,
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "trace-event-to-endpoint",
+			args: args{
+				f: []*flowpb.FlowFilter{{Reply: []bool{false}}},
+				ev: &v1.Event{Event: &flowpb.Flow{
+					EventType: &flowpb.CiliumEventType{
+						Type:    monitorAPI.MessageTypeTrace,
+						SubType: monitorAPI.TraceToLxc,
+					},
+					Reply: false,
+				}},
 			},
 			want: true,
 		},

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -170,6 +170,22 @@ func TraceObservationPoint(obsPoint uint8) string {
 	return fmt.Sprintf("%d", obsPoint)
 }
 
+// TraceObservationPointHasConnState returns true if the observation point
+// obsPoint populates the TraceNotify.Reason field with connection tracking
+// information.
+func TraceObservationPointHasConnState(obsPoint uint8) bool {
+	switch obsPoint {
+	case TraceToLxc,
+		TraceToProxy,
+		TraceToHost,
+		TraceToStack,
+		TraceToNetwork:
+		return true
+	default:
+		return false
+	}
+}
+
 // AgentNotify is a notification from the agent. The notification is stored
 // in its JSON-encoded representation
 type AgentNotify struct {


### PR DESCRIPTION
This fixes a bug where a Hubble filter on `reply=false` would report flows
for which we actually do not know if they were replies or not. Not all
trace points have connection tracking state available, thus looking at
the reply flag alone is not sufficient to tell if something a flow was a
reply or not.

Ideally, we would fix this in the parser and make the `reply` an
optional boolean, so we can distinguish between a `false` value and an
absent value. This however is a breaking change in the Hubble API, which
we want to avoid. Therefore, this commit modifies the reply filter to
only report flows here for which we know that the reply field is
reliable.

```release-note
Fixes a bug where a Hubble filter on `reply=false` would report flows for which the actual reply state is unknown.
```
