### PR TITLE
v1.6 backports 2020-09-22

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -1,0 +1,72 @@
+---
+name: Release a new version of Cilium
+about: Create a checklist for an upcoming release
+title: 'vX.Y.Z release'
+labels: kind/release
+assignees: ''
+
+---
+
+## Pre-release
+
+- [ ] Create a [new project] for the next release version
+- [ ] Add build targets for the new release on [Docker Hub]
+  - All versions:
+    - [cilium](https://hub.docker.com/repository/docker/cilium/cilium/builds/edit)
+    - [operator](https://hub.docker.com/repository/docker/cilium/operator/builds/edit)
+    - [docker-plugin](https://hub.docker.com/repository/docker/cilium/docker-plugin/builds/edit)
+  - Cilium v1.8 or later:
+    - [operator-generic](https://hub.docker.com/repository/docker/cilium/operator-generic/builds/edit)
+    - [operator-aws](https://hub.docker.com/repository/docker/cilium/operator-aws/builds/edit)
+    - [operator-azure](https://hub.docker.com/repository/docker/cilium/operator-azure/builds/edit)
+    - [hubble-relay](https://hub.docker.com/repository/docker/cilium/hubble-relay/builds/edit)
+- [ ] Check that there are no [release blockers] for the targeted release version
+- [ ] Ensure that outstanding [backport PRs] are merged
+- [ ] Consider building new [cilium-runtime images] and bumping the base image
+      versions on this branch
+- [ ] Move any unresolved issues/PRs from old release project into the newly
+      created release project
+- [ ] Push a PR including the changes necessary for the new release:
+  - [ ] Pull latest branch
+  - [ ] Run `contrib/release/start-release.sh'
+  - [ ] (If applicable) Update the `cilium_version` and `cilium_tag` in
+        `examples/getting-started/Vagrantfile`
+  - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
+  - [ ] Submit PR (`contrib/release/submit-release.sh`)
+- [ ] Merge PR
+- [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
+  - Pull latest branch locally and run `contrib/release/tag-release.sh`
+- [ ] Wait for docker builds to complete
+  - [cilium](https://hub.docker.com/repository/docker/cilium/cilium/builds)
+  - [operator](https://hub.docker.com/repository/docker/cilium/operator/builds)
+  - [docker-plugin](https://hub.docker.com/repository/docker/cilium/docker-plugin/builds)
+- [ ] Create helm charts artifacts in [Cilium charts] repository using
+      [cilium helm release tool] for both the `vX.Y.Z` release and `vX.Y` branch
+      & push to repository
+- [ ] Run sanity check of Helm install using connectivity-check script.
+      Suggested approach: Follow the full [GKE getting started guide].
+- [ ] Check draft release from [releases] page and publish the release
+- [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
+
+## Post-release
+
+- [ ] Prepare post-release changes to master branch using `contrib/release/bump-readme.sh`
+- [ ] Update the `stable` tags for each Cilium image on Docker Hub (if applicable)
+- [ ] Update external tools and guides to point to the new Cilium version:
+  - [ ] [kops]
+  - [ ] [kubespray]
+
+
+[release blockers]: https://github.com/cilium/cilium/labels/priority%2Frelease-blocker
+[backport PRs]: https://github.com/cilium/cilium/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+backports
+[new project]: https://github.com/cilium/cilium/projects/new
+[Cilium release-notes tool]: https://github.com/cilium/release
+[Docker Hub]: https://hub.docker.com/orgs/cilium/repositories
+[Cilium charts]: https://github.com/cilium/charts
+[releases]: https://github.com/cilium/cilium/releases
+[Stable releases]: https://github.com/cilium/cilium#stable-releases
+[kops]: https://github.com/kubernetes/kops/
+[kubespray]: https://github.com/kubernetes-sigs/kubespray/
+[cilium helm release tool]: https://github.com/cilium/charts/blob/master/prepare_artifacts.sh
+[GKE getting started guide]: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-gke/
+[cilium-runtime images]: https://quay.io/repository/cilium/cilium-runtime

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+RELEASE_TOOL_PATH="${RELEASE_TOOL_PATH:-$GOPATH/src/github.com/cilium/release}"
+RELNOTES="$RELEASE_TOOL_PATH/release"
+RELNOTESCACHE="release-state.json"
+
+usage() {
+    logecho "usage: $0 <OLD-VERSION> <NEW-VERSION>"
+    logecho "OLD-VERSION    Previous release version for comparison"
+    logecho "NEW-VERSION    Target release version"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+[-rc0-9]*"; then
+        usage 2>&1
+        common::exit 1 "Invalid NEW-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(echo $1 | sed 's/^v//')"
+    local ersion="$(echo $2 | sed 's/^v//')"
+    local version="v$ersion"
+
+    logecho "Generating CHANGELOG.md"
+    rm -f $RELNOTESCACHE
+    echo -e "# Changelog\n\n## $version" > $version-changes.txt
+    $RELNOTES --base $old_version --head $(git rev-parse HEAD) >> $version-changes.txt
+    cp $version-changes.txt CHANGELOG-new.md
+    if [[ -e CHANGELOG.md ]]; then
+        tail -n+2 CHANGELOG.md >> CHANGELOG-new.md
+    fi
+    mv CHANGELOG-new.md CHANGELOG.md
+    logecho "Generated CHANGELOG.md"
+}
+
+main "$@"

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+ACTS_YAML=".github/cilium-actions.yml"
+
+usage() {
+    logecho "usage: $0 <VERSION> <GH-PROJECT>"
+    logecho "VERSION    Target release version"
+    logecho "GH-PROJECT Project ID for next release"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+
+    if ! echo "$2" | grep -q "^[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid GH-PROJECT ID argument. Expected [0-9]+"
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ "$(git status -s | grep -v "^??" | wc -l)" -gt 0 ]]; then
+        git status -s | grep -v "^??"
+        common::exit 1 "Unmerged changes in tree prevent preparing release PR."
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local old_version="$(cat VERSION)"
+    local ersion="$(echo $1 | sed 's/^v//')"
+    local version="v$ersion"
+    local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
+    local remote="origin"
+    local new_proj="$2"
+
+    git fetch $remote
+    git checkout -b pr/prepare-$version $remote/v$branch
+
+    logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
+    echo $ersion > VERSION
+    logrun make -C install/kubernetes all
+    logrun make update-authors
+    old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
+    sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+
+    $DIR/prep-changelog.sh "$old_version" "$version"
+
+    logecho "Next steps:"
+    logecho "* Check all changes and add to a new commit"
+    logecho "* Push the PR to Github for review"
+    logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
+    logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
+
+    # Leave $version-changes.txt around for prep-release.sh usage later
+}
+
+main "$@"

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+BRANCH="${1:-""}"
+if [ "$BRANCH" = "" ]; then
+    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
+fi
+BRANCH=$(echo "$BRANCH" | sed 's/^v//')
+
+RELEASE="v$(cat VERSION)"
+SUMMARY=${2:-}
+GENERATE_SUMMARY=false
+if [ "$SUMMARY" = "" ]; then
+    SUMMARY="$RELEASE-changes.txt"
+    GENERATE_SUMMARY=true
+fi
+
+if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+    echo "usage: $0 [branch version] [release-summary]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
+    exit 1
+fi
+
+if ! hub help | grep -q "pull-request"; then
+    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+    echo "Please install this tool first." 1>&2
+    exit 1
+fi
+
+if ! git diff --quiet; then
+    echo "Local changes found in git tree. Exiting release process..." 1>&2
+    exit 1
+fi
+
+if ! git log --oneline | grep -q $RELEASE; then
+    echo "Latest commit does not match commit title for release:" 1>&2
+    git log -1
+    exit 1
+fi
+
+if $GENERATE_SUMMARY; then
+    CHANGELOG=$SUMMARY
+    SUMMARY="$RELEASE-pr-$(date --rfc-3339=date).txt"
+    echo "Prepare for release $RELEASE" > $SUMMARY
+    tail -n+4 $CHANGELOG >> $SUMMARY
+fi
+
+echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+cat $SUMMARY 1>&2
+echo -e "\nSending pull request..." 2>&1
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git push origin "$PR_BRANCH"
+hub pull-request -b "v$BRANCH" -l kind/release,backport/$BRANCH -F $SUMMARY

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+REMOTE="$(get_remote)"
+CHARTS_PATH="${CHARTS_PATH:-$GOPATH/src/github.com/cilium/charts}"
+CHARTS_TOOL="prepare_artifacts.sh"
+RELEASES_URL="https://github.com/cilium/cilium/releases"
+VERSION=""
+
+usage() {
+    echo "usage: $0 [VERSION]"
+    echo "CHARTS_REPO Path to local copy of github.com/cilium/charts"
+    echo
+    echo "--help     Print this help message"
+}
+
+handle_args() {
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 1
+    fi
+
+    if [[ ! -e VERSION ]]; then
+        common::exit 1 "VERSION file not found. Is this directory a Cilium repository?"
+    fi
+
+    if [[ ! -e "$CHARTS_PATH/$CHARTS_TOOL" ]]; then
+        usage
+        common::exit 1 "CHARTS_PATH='$CHARTS_PATH' invalid. Clone from github.com/cilium/charts"
+    fi
+
+    if ! which hub >/dev/null; then
+        echo "This tool relies on 'hub' from https://github.com/github/hub ." 1>&2
+        common::exit 1 "Please install this tool first."
+    fi
+
+    if [[ $# -ge 1 ]]; then
+        VERSION="$1"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local ersion="$(cat VERSION)"
+    if [[ "$VERSION" != "" ]]; then
+        ersion="$(echo $VERSION | sed 's/^v//')"
+    fi
+    local version="v$ersion"
+
+    if [[ ! -e $version-changes.txt ]]; then
+        common::exit 1 "Generate release notes via contrib/release/start-release.sh"
+    fi
+
+    echo "Current HEAD is:"
+    git log --oneline -1 $(git rev-parse HEAD)
+    echo "Create git tags for $version with this commit"
+    if ! common::askyorn ; then
+        common::exit 0 "Aborting release preparation."
+    fi
+
+    logrun -s git tag -a $ersion -s -m "Release $version"
+    logrun -s git tag -a $version -s -m "Release $version"
+    logrun -s git push $REMOTE $version $ersion
+
+    # Leave $version-changes.txt around so we can generate release notes later
+    echo -e "$ersion\n" > $version-release-summary.txt
+    echo "We are pleased to release Cilium $version." >>  $version-release-summary.txt
+    tail -n+4 $version-changes.txt >> $version-release-summary.txt
+    logecho "Creating Github draft release"
+    logrun hub release create -d -F $version-release-summary.txt $version
+    logecho "Browse to $RELEASES_URL to see the draft release"
+
+    logecho
+    logecho "Next steps:"
+    logecho "* Wait for cilium docker images to be prepared"
+    logecho "* Prepare the helm template changes"
+    logecho "* When docker images are available, test deployment of new version"
+    logecho "* Push templates and announce release on GitHub / Slack"
+}
+
+main "$@"


### PR DESCRIPTION
 * #13044 -- contrib: Add release helper scripts for preparing micro releases (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13044; do contrib/backporting/set-labels.py $pr done 1.6; done
```