### PR TITLE
Pr/v1.8 backport 2020 09 22 2

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -700,7 +700,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		oldKey = oldNode.EncryptionKey
 	}
 
-	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
+	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() && !n.nodeConfig.EncryptNode {
 		n.enableIPsec(newNode)
 		newKey = newNode.EncryptionKey
 	}


### PR DESCRIPTION
v1.8 backports 2020-09-22

 * #13241 -- cilium: encrypt-node creates two IPsec tunnels but only uses one (@jrfastab)
 ~~* #13228 -- identity: Avoid kvstore lookup for local identities (@gandro)~~

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13241; do contrib/backporting/set-labels.py $pr done 1.8; done
```