### PR TITLE
ci: lock docker build

### DIFF
--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -2,7 +2,15 @@
 
 set -e
 
-cd ..
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=gke/locking.sh
+source "${script_dir}/gke/locking.sh"
+
+pushd "${script_dir}/.."
+lock
+trap unlock EXIT
+
 DOCKER_BUILDKIT=1 make docker-images-all DOCKER_IMAGE_TAG="$2" DOCKER_FLAGS="$3"
 
 docker tag "cilium/cilium:$2" "$1/cilium/cilium:$2"


### PR DESCRIPTION
Docker build for concurrently running gke builds for same git sha
running on the same node will race, resulting in builds either
lacking an image to push or using different image than needed
(this became an issue with introduction of race detector-enabled images).
This affects only gke, since all other builds don't share a node.