### PR TITLE
[RFC] Enable policy-free DNS visibility

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -347,6 +347,9 @@ func init() {
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
 	option.BindEnv(option.EnableAutoDirectRoutingName)
 
+	flags.Bool(option.EnableDNSVisibility, false, "Enable DNS visibility for endpoints by default, without needing to annotate a pod, in the case of K8s")
+	option.BindEnv(option.EnableDNSVisibility)
+
 	flags.Bool(option.EnableBPFTProxy, defaults.EnableBPFTProxy, "Enable BPF-based proxy redirection, if support available")
 	option.BindEnv(option.EnableBPFTProxy)
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -643,3 +643,7 @@ data:
   # Configure service proxy name for Cilium.
   k8s-service-proxy-name: {{ .Values.global.k8s.serviceProxyName | quote }}
 {{- end }}
+
+{{- if hasKey .Values "enableDNSVisibility" }}
+  enable-dns-visibility: {{ .Values.enableDNSVisibility | quote }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/config/values.yaml
+++ b/install/kubernetes/cilium/charts/config/values.yaml
@@ -63,3 +63,7 @@
 # Set the connection-tracking garbage collection interval. If not set, the value will be
 # calculated automatically on startup of cilium-agent. A low value will consume more CPU cycles.
 #conntrackGCInterval: "0s"
+
+# Whether to enable DNS visibility by default for all pods, without needing a
+# pod annotation.
+#enableDNSVisibility: false

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2378,7 +2378,17 @@ func (e *Endpoint) SetDefaultConfiguration(restore bool) {
 
 func (e *Endpoint) setDefaultPolicyConfig() {
 	e.SetDefaultOpts(option.Config.Opts)
+
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
 	e.desiredPolicy.IngressPolicyEnabled = alwaysEnforce
 	e.desiredPolicy.EgressPolicyEnabled = alwaysEnforce
+
+	if option.Config.EnableDNSVisibility {
+		var err error
+		e.visibilityPolicy, err = policy.NewVisibilityPolicy(policy.DefaultDNSVisibility)
+		if err != nil {
+			e.getLogger().WithError(err).Warn("Failed to add DNS visibility policy, moving on")
+			return
+		}
+	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -608,6 +608,9 @@ const (
 	// EnableAutoDirectRoutingName is the name for the EnableAutoDirectRouting option
 	EnableAutoDirectRoutingName = "auto-direct-node-routes"
 
+	// EnableDNSVisibility is the name for the EnableDNSVisibility option
+	EnableDNSVisibility = "enable-dns-visibility"
+
 	// EnableIPSecName is the name of the option to enable IPSec
 	EnableIPSecName = "enable-ipsec"
 
@@ -1660,6 +1663,11 @@ type DaemonConfig struct {
 	// other nodes when available
 	EnableAutoDirectRouting bool
 
+	// EnableDNSVisibility specifies whether to enable DNS visibility for
+	// endpoints by default, without needing to annotate a pod, in the case of
+	// K8s.
+	EnableDNSVisibility bool
+
 	// EnableLocalNodeRoute controls installation of the route which points
 	// the allocation prefix of the local node.
 	EnableLocalNodeRoute bool
@@ -2401,6 +2409,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableBPFTProxy = viper.GetBool(EnableBPFTProxy)
 	c.EnableXTSocketFallback = viper.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = viper.GetBool(EnableAutoDirectRoutingName)
+	c.EnableDNSVisibility = viper.GetBool(EnableDNSVisibility)
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = viper.GetBool(EnableHealthChecking)
 	c.EnableEndpointHealthChecking = viper.GetBool(EnableEndpointHealthChecking)

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -29,6 +29,12 @@ var (
 	annotationRegex       = regexp.MustCompile(fmt.Sprintf(`^((%s)(,(%s))*)$`, singleAnnotationRegex, singleAnnotationRegex))
 )
 
+const (
+	// DefaultDNSVisibility is the default annotation value for a DNS
+	// visibility policy.
+	DefaultDNSVisibility = "<Egress/53/UDP/DNS>"
+)
+
 func validateL7ProtocolWithDirection(dir string, proto L7ParserType) error {
 	switch proto {
 	case ParserTypeHTTP:


### PR DESCRIPTION
This PR is currently serving as an RFC for implementing policy-free DNS
visibility. This is the minimum implementation required to do so. See
https://github.com/cilium/hubble/issues/92.

This PR implements policy-free DNS visibility by allowing the user to set a
flag on Cilium (`--enable-dns-visibility`). This flag informs Cilium that upon
endpoint creation, it should inject a DNS visibility policy. Once the flag is
set, all endpoints will default to having DNS visibility. Other visibility
policies can be [set via pod annotations](https://docs.cilium.io/en/latest/policy/visibility/#proxy-visibility). If another annotation is added, the 
visibility policy will still contain DNS visibility. In other words, DNS visibility will
continue in the cluster, and is **not** overwritten. This can be tweaked in future 
iterations, if we prefer the overwriting behavior.

What's missing in this PR taking a comprehensive look at policy enforcement.
CNPs / CCNPs should be considered the source of truth for what to do with
traffic, regardless of the flag set. The constraint is to never allow the
visibility policy to allow traffic that should be denied. It's worth mentioning
that during my testing, I applied an [FQDN policy](https://docs.cilium.io/en/latest/gettingstarted/dns/#dns-policies-using-patterns) and tweaked it to allow only
resolution of `*.twitter.com` domains, I observed that all other domains were 
denied, which is good. This is expected.

I am open to hearing feedback on this approach and whether this PR has some
blind spots, especially from the policy enforcement perspective.

---

Tested by following:
https://docs.cilium.io/en/latest/gettingstarted/dns/#deploy-the-demo-application

See commit msgs.