### PR TITLE
[v1.8] k8s: delete CEPs for no running Pods

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -117,6 +117,9 @@ type dummyEpSyncher struct{}
 func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 }
 
+func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
 func (ds *DaemonSuite) SetUpSuite(c *C) {
 	// Register metrics once before running the suite
 	_, ds.collectors = metrics.CreateConfiguration([]string{"cilium_endpoint_state"})

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -811,6 +811,9 @@ func (d *dummyManager) AllocateID(id uint16) (uint16, error) {
 func (d *dummyManager) RunK8sCiliumEndpointSync(*endpoint.Endpoint, endpoint.EndpointStatusConfiguration) {
 }
 
+func (d *dummyManager) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
 func (d *dummyManager) UpdateReferences(map[id.PrefixType]string, *endpoint.Endpoint) {
 }
 

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -159,6 +159,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 		if err != nil {
 			// Disconnected EPs are not failures, clean them silently below
 			if !ep.IsDisconnecting() {
+				d.endpointManager.DeleteK8sCiliumEndpointSync(ep)
 				scopedLog.WithError(err).Warningf("Unable to restore endpoint, ignoring")
 				failed++
 			}

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -86,8 +87,8 @@ func enableCiliumEndpointSyncGC() {
 							ctx,
 							cep.Name,
 							meta_v1.DeleteOptions{PropagationPolicy: &PropagationPolicy})
-						if err != nil {
-							scopedLog.WithError(err).Debug("Unable to delete orphaned CEP")
+						if !k8serrors.IsNotFound(err) {
+							scopedLog.WithError(err).Warning("Unable to delete orphaned CEP")
 						}
 						return err
 					}

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -89,8 +89,8 @@ func enableCiliumEndpointSyncGC() {
 							meta_v1.DeleteOptions{PropagationPolicy: &PropagationPolicy})
 						if !k8serrors.IsNotFound(err) {
 							scopedLog.WithError(err).Warning("Unable to delete orphaned CEP")
+							return err
 						}
-						return err
 					}
 				}
 				return nil

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -68,6 +68,7 @@ type EndpointManager struct {
 // resources with Kubernetes.
 type EndpointResourceSynchronizer interface {
 	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration)
+	DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint)
 }
 
 // NewEndpointManager creates a new EndpointManager.

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -102,6 +102,9 @@ type dummyEpSyncher struct{}
 func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 }
 
+func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
 func (s *EndpointManagerSuite) TestLookup(c *C) {
 	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 	mgr := NewEndpointManager(&dummyEpSyncher{})

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -21,10 +21,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	pkgLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -40,6 +43,12 @@ const (
 	subsysEndpointSync = "endpointsynchronizer"
 )
 
+// controllerNameOf returns the controller name to synchronize endpoint in to
+// kubernetes.
+func controllerNameOf(epID uint16) string {
+	return fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", epID)
+}
+
 // EndpointSynchronizer currently is an empty type, which wraps around syncing
 // of CiliumEndpoint resources.
 type EndpointSynchronizer struct{}
@@ -52,7 +61,7 @@ type EndpointSynchronizer struct{}
 func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 	var (
 		endpointID     = e.ID
-		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", endpointID)
+		controllerName = controllerNameOf(endpointID)
 		scopedLog      = e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 	)
 
@@ -283,4 +292,55 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				}
 			},
 		})
+}
+
+// DeleteK8sCiliumEndpointSync replaces the endpoint controller to remove the
+// CEP from Kubernetes once the endpoint is stopped / removed from the
+// Cilium agent.
+func (epSync *EndpointSynchronizer) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+	controllerName := controllerNameOf(e.ID)
+
+	scopedLog := e.Logger(subsysEndpointSync).WithField("controller", controllerName)
+
+	if !k8s.IsEnabled() {
+		scopedLog.Debug("Not starting controller because k8s is disabled")
+		return
+	}
+
+	ciliumClient := k8s.CiliumClient().CiliumV2()
+
+	// The health endpoint doesn't really exist in k8s and updates to it caused
+	// arbitrary errors. Disable the controller for these endpoints.
+	if isHealthEP := e.HasLabels(pkgLabels.LabelHealth); isHealthEP {
+		scopedLog.Debug("Not starting unnecessary CEP controller for cilium-health endpoint")
+		return
+	}
+
+	// NOTE: The controller functions do NOT hold the endpoint locks
+	e.UpdateController(controllerName,
+		controller.ControllerParams{
+			StopFunc: func(ctx context.Context) error {
+				return deleteCEP(ctx, scopedLog, ciliumClient, e)
+			},
+		},
+	)
+}
+
+func deleteCEP(ctx context.Context, scopedLog *logrus.Entry, ciliumClient v2.CiliumV2Interface, e *endpoint.Endpoint) error {
+	podName := e.GetK8sPodName()
+	if podName == "" {
+		scopedLog.Debug("Skipping CiliumEndpoint deletion because it has no k8s pod name")
+		return nil
+	}
+	namespace := e.GetK8sNamespace()
+	if namespace == "" {
+		scopedLog.Debug("Skipping CiliumEndpoint deletion because it has no k8s namespace")
+		return nil
+	}
+	if err := ciliumClient.CiliumEndpoints(namespace).Delete(ctx, podName, meta_v1.DeleteOptions{}); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			scopedLog.WithError(err).Warning("Unable to delete CEP")
+		}
+	}
+	return nil
 }

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -291,6 +291,9 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					return nil
 				}
 			},
+			StopFunc: func(ctx context.Context) error {
+				return deleteCEP(ctx, scopedLog, ciliumClient, e)
+			},
 		})
 }
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -467,8 +467,12 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	go k.ciliumNodeInit(ciliumNPClient, asyncControllers)
 
 	// cilium endpoints
-	asyncControllers.Add(1)
-	go k.ciliumEndpointsInit(ciliumNPClient, asyncControllers)
+	// Don't watch for CiliumEndpoints to avoid populating ipcache with dangling
+	// CiliumEndpoints.
+	if !option.Config.DisableCiliumEndpointCRD {
+		asyncControllers.Add(1)
+		go k.ciliumEndpointsInit(ciliumNPClient, asyncControllers)
+	}
 
 	// kubernetes pods
 	asyncControllers.Add(1)

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -241,6 +241,9 @@ type dummyEpSyncher struct{}
 func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 }
 
+func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
 func (s *proxyTestSuite) TestKafkaRedirect(c *C) {
 	server := NewServer()
 	server.Start()


### PR DESCRIPTION
Partial backport of https://github.com/cilium/cilium/pull/13220

```upstream-prs
$ for pr in 13220; do contrib/backporting/set-labels.py $pr done 1.8; done
```

```release-note
Delete Cilium Endpoints as soon the Pod stops running to avoid stale state.
```