### PR TITLE
test: check logs of operator and hubble relay

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -670,7 +670,7 @@ func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 	}()
 
 	blacklist := GetBadLogMessages()
-	failIfContainsBadLogMsg(logs, blacklist)
+	failIfContainsBadLogMsg(logs, "Cilium", blacklist)
 
 	fmt.Fprint(CheckLogs, logutils.LogErrorsSummary(logs))
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -202,6 +202,14 @@ const (
 	// the test are saved.
 	CiliumTestLog = "cilium-test.log"
 
+	// HubbleRelayTestLog is the filename where the hubble relay logs that happens during
+	// the test are saved.
+	HubbleRelayTestLog = "hubble-relay-test.log"
+
+	// CiliumOperatorTestLog is the filename where the cilium operator logs that happens during
+	// the test are saved.
+	CiliumOperatorTestLog = "cilium-operator-test.log"
+
 	// FakeIPv4WorldAddress is an IP which is used in some datapath tests
 	// for simulating external IPv4 connectivity.
 	FakeIPv4WorldAddress = "192.168.254.254"

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -462,7 +462,7 @@ func CanRunK8sVersion(ciliumVersion, k8sVersionStr string) (bool, error) {
 // failIfContainsBadLogMsg makes a test case to fail if any message from
 // given log messages contains an entry from the blacklist (map key) AND
 // does not contain ignore messages (map value).
-func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
+func failIfContainsBadLogMsg(logs, label string, blacklist map[string][]string) {
 	uniqueFailures := make(map[string]int)
 	for _, msg := range strings.Split(logs, "\n") {
 		for fail, ignoreMessages := range blacklist {
@@ -488,7 +488,7 @@ func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 			fmt.Fprintf(CheckLogs, "⚠️  Found %q in logs %d times\n", f, c)
 		}
 		failureMsgs := strings.Join(failures, "\n")
-		Fail(fmt.Sprintf("Found %d Cilium logs matching list of errors that must be investigated:\n%s", len(uniqueFailures), failureMsgs))
+		Fail(fmt.Sprintf("Found %d %s logs matching list of errors that must be investigated:\n%s", len(uniqueFailures), label, failureMsgs))
 	}
 }
 

--- a/test/k8sT/Conformance.go
+++ b/test/k8sT/Conformance.go
@@ -70,8 +70,7 @@ var _ = Describe("K8sConformance", func() {
 	})
 
 	JustAfterEach(func() {
-		blacklist := helpers.GetBadLogMessages()
-		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
 	Context("Portmap Chaining", func() {

--- a/test/k8sT/Identity.go
+++ b/test/k8sT/Identity.go
@@ -56,8 +56,7 @@ var _ = Describe("K8sIdentity", func() {
 	})
 
 	JustAfterEach(func() {
-		blacklist := helpers.GetBadLogMessages()
-		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
 	Context("Identity expiration", func() {

--- a/test/k8sT/StressPolicy.go
+++ b/test/k8sT/StressPolicy.go
@@ -43,8 +43,7 @@ var _ = Describe("NightlyPolicyStress", func() {
 	})
 
 	JustAfterEach(func() {
-		blacklist := helpers.GetBadLogMessages()
-		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		backgroundCancel()
 	})
 


### PR DESCRIPTION
This change expands Cilium logs checking at the end of the tests to also
check operator and hubble relay logs for bad log messages.