### PR TITLE
helm: configurable nodeSelector and tolerations for all charts

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -370,8 +370,10 @@ spec:
       serviceAccount: cilium
       serviceAccountName: cilium
       terminationGracePeriodSeconds: 1
+{{- with .Values.tolerations }}
       tolerations:
-      - operator: Exists
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}
       volumes:
         # To keep state between restarts / upgrades
       - hostPath:

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -26,3 +26,9 @@ initResources:
   requests:
     cpu: "100m"
     memory: "100Mi"
+
+## Node tolerations for pod assignment on nodes with taints
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations:
+- operator: Exists

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -69,9 +69,13 @@ spec:
 {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
-{{- if .Values.tolerations }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | trim | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
-{{- toYaml .Values.tolerations | trim | nindent 8 }}
+      {{- toYaml . | trim | nindent 6 }}
 {{- end }}
       volumes:
       - configMap:

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -44,3 +44,12 @@ servicePort:
 # Specifies annotation for service accounts
 serviceAccount:
   annotations: {}
+
+# Node labels for pod assignment
+# ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Node tolerations for pod assignment on nodes with taints
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations: []

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -13,6 +13,14 @@ spec:
       labels:
         k8s-app: hubble-ui
     spec:
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | trim | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}
       serviceAccount: hubble-ui
       serviceAccountName: hubble-ui
       containers:

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -45,3 +45,12 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+# Node labels for pod assignment
+# ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Node tolerations for pod assignment on nodes with taints
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations: []

--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -69,5 +69,11 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | trim | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
-      - operator: Exists
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/managed-etcd/values.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/values.yaml
@@ -3,3 +3,13 @@ tag: v2.0.7
 
 serviceAccount:
   annotations: {}
+
+# Node labels for pod assignment
+# ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Node tolerations for pod assignment on nodes with taints
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations:
+- operator: Exists

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -14,8 +14,10 @@ spec:
       labels:
         app: cilium-node-init
     spec:
+{{- with .Values.tolerations }}
       tolerations:
-      - operator: Exists
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}
       hostPID: true
       hostNetwork: true
 {{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")}}

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -17,3 +17,9 @@ expectAzureVnet: false
 
 # Revert nodeinit changes via preStop container lifecycle hook
 revertReconfigureKubelet: false
+
+## Node tolerations for pod assignment on nodes with taints
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations:
+- operator: Exists

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -203,8 +203,14 @@ spec:
 {{- end }}
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | trim | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
-        - operator: Exists
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -12,3 +12,13 @@ podsAnnotations:
 
 # Number of replicas to run for cilium operator deployment.
 numReplicas: 2
+
+# Node labels for pod assignment
+# ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Node tolerations for pod assignment on nodes with taints
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations:
+- operator: Exists

--- a/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
@@ -135,16 +135,10 @@ spec:
       serviceAccount: cilium-pre-flight
       serviceAccountName: cilium-pre-flight
       terminationGracePeriodSeconds: 1
+{{- with .Values.tolerations }}
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}
       volumes:
         # To keep state between restarts / upgrades
       - hostPath:

--- a/install/kubernetes/cilium/charts/preflight/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/deployment.yaml
@@ -69,14 +69,12 @@ spec:
       serviceAccount: cilium-pre-flight
       serviceAccountName: cilium-pre-flight
       terminationGracePeriodSeconds: 1
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | trim | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/preflight/values.yaml
+++ b/install/kubernetes/cilium/charts/preflight/values.yaml
@@ -11,3 +11,21 @@ tofqdnsPreCache: ""
 # Cilium. This will make sure the user will have the policies deployed in the
 # cluster with the right schema.
 validateCNPs: true
+
+# Node labels for pod assignment
+# ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Node tolerations for pod assignment on nodes with taints
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations:
+- effect: NoSchedule
+  key: node.kubernetes.io/not-ready
+- effect: NoSchedule
+  key: node-role.kubernetes.io/master
+- effect: NoSchedule
+  key: node.cloudprovider.kubernetes.io/uninitialized
+  value: "true"
+- key: CriticalAddonsOnly
+  operator: "Exists"

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -1009,7 +1009,7 @@ spec:
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
       tolerations:
-        - operator: Exists
+      - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -644,7 +644,7 @@ spec:
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
       tolerations:
-        - operator: Exists
+      - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:


### PR DESCRIPTION
Added configuration options nodeSelector (deployments) and tolerations (daemonsets and deployments)
for all the existing charts:
  - agent
  - hubble-relay
  - hubble-ui
  - managed-etcd
  - nodeinit
  - operator
  - preflight

On the preflight one, I also simplified the tolerations with a single 'operator: Exists'. Other than
that, the behaviour with default values should remain identical.

Initially, my use case was to be able to avoid having the hubble-relay pods running on tainted nodes.
I went forward with updating all the charts as I felt this could probably be useful for others.

Signed-off-by: Maxime VISONNEAU <maxime.visonneau@gmail.com>

```release-note
Configurable nodeSelector and tolerations for all charts
```
