### PR TITLE
k8s: Consider session affinity parameters when comparing Services

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -32,7 +32,7 @@ import (
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func getAnnotationIncludeExternal(svc *slim_corev1.Service) bool {
@@ -293,7 +293,8 @@ func (s *Service) DeepEquals(o *Service) bool {
 		s.HealthCheckNodePort == o.HealthCheckNodePort &&
 		s.FrontendIP.Equal(o.FrontendIP) &&
 		comparator.MapStringEquals(s.Labels, o.Labels) &&
-		comparator.MapStringEquals(s.Selector, o.Selector) {
+		comparator.MapStringEquals(s.Selector, o.Selector) &&
+		s.SessionAffinity == o.SessionAffinity {
 
 		if ((s.Ports == nil) != (o.Ports == nil)) ||
 			len(s.Ports) != len(o.Ports) {
@@ -364,6 +365,11 @@ func (s *Service) DeepEquals(o *Service) bool {
 				return false
 			}
 		}
+
+		if s.SessionAffinity && s.SessionAffinityTimeoutSec != o.SessionAffinityTimeoutSec {
+			return false
+		}
+
 		return true
 	}
 	return false

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -587,6 +587,88 @@ func TestService_Equals(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "session affinity was added",
+			fields: &Service{
+				FrontendIP: net.ParseIP("1.1.1.1"),
+				IsHeadless: false,
+				Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+					loadbalancer.FEPortName("foo"): {
+						Protocol: loadbalancer.NONE,
+						Port:     1,
+					},
+				},
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+				Selector: map[string]string{
+					"baz": "foz",
+				},
+				SessionAffinity: false,
+			},
+			args: args{
+				o: &Service{
+					FrontendIP: net.ParseIP("1.1.1.1"),
+					IsHeadless: false,
+					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+						loadbalancer.FEPortName("foo"): {
+							Protocol: loadbalancer.NONE,
+							Port:     1,
+						},
+					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Selector: map[string]string{
+						"baz": "foz",
+					},
+					SessionAffinity: true,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "session affinity timeout changed",
+			fields: &Service{
+				FrontendIP: net.ParseIP("1.1.1.1"),
+				IsHeadless: false,
+				Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+					loadbalancer.FEPortName("foo"): {
+						Protocol: loadbalancer.NONE,
+						Port:     1,
+					},
+				},
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+				Selector: map[string]string{
+					"baz": "foz",
+				},
+				SessionAffinity:           true,
+				SessionAffinityTimeoutSec: 1,
+			},
+			args: args{
+				o: &Service{
+					FrontendIP: net.ParseIP("1.1.1.1"),
+					IsHeadless: false,
+					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+						loadbalancer.FEPortName("foo"): {
+							Protocol: loadbalancer.NONE,
+							Port:     1,
+						},
+					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Selector: map[string]string{
+						"baz": "foz",
+					},
+					SessionAffinity:           true,
+					SessionAffinityTimeoutSec: 2,
+				},
+			},
+			want: false,
+		},
+		{
 			name: "both nil",
 			args: args{},
 			want: true,


### PR DESCRIPTION
Previously, if the `sessionAffinity` or `sessionAffinityTimeoutSec` of a Service changed, cilium would ignore the change. This meant that even though cilium correctly handles `sessionAffinity`, changing the `sessionAffinity` of a service without any other changes did not cause cilium to change its handling.

Add `sessionAffinity` and `sessionAffinityTimeoutSec` handling to the comparator for services, so that cilium will notice affinity changes.

Fixes: #12489

```release-note
Fix handling of changes to session affinity configuration for Kubernetes services.
```
