### PR TITLE
k8s: Remove CRD deleting functionality

### DIFF
--- a/operator/crd_test.go
+++ b/operator/crd_test.go
@@ -112,13 +112,6 @@ func (s *crdTestSuite) TestGetCRD(c *C) {
 	err = waitForCRD(context.TODO(), client, "bar")
 	c.Assert(err, ErrorMatches, ".*timeout waiting for CRD bar.*")
 
-	err = client.ApiextensionsV1().CustomResourceDefinitions().Delete(
-		context.TODO(),
-		v1CRD.GetName(),
-		metav1.DeleteOptions{},
-	)
-	c.Assert(err, IsNil)
-
 	// v1beta1 CRDs
 
 	_, err = client.ApiextensionsV1beta1().CustomResourceDefinitions().Create(
@@ -139,11 +132,4 @@ func (s *crdTestSuite) TestGetCRD(c *C) {
 
 	err = waitForCRD(context.TODO(), client, "bar")
 	c.Assert(err, ErrorMatches, ".*timeout waiting for CRD bar.*")
-
-	err = client.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(
-		context.TODO(),
-		v1beta1CRD.GetName(),
-		metav1.DeleteOptions{},
-	)
-	c.Assert(err, IsNil)
 }

--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -441,17 +441,6 @@ func waitForV1CRD(
 		return false, err
 	})
 	if err != nil {
-		if deleteErr := client.CustomResourceDefinitions().Delete(
-			context.TODO(),
-			crd.ObjectMeta.Name,
-			metav1.DeleteOptions{},
-		); deleteErr != nil {
-			scopedLog.WithError(err).WithFields(logrus.Fields{
-				"deleteErr": deleteErr,
-			}).Error("Failed to delete CRD")
-			return fmt.Errorf("unable to delete CRD: %w", deleteErr)
-		}
-
 		return fmt.Errorf("error occurred waiting for CRD: %w", err)
 	}
 

--- a/pkg/k8s/apis/cilium.io/v2/client/v1beta1.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/v1beta1.go
@@ -234,17 +234,6 @@ func waitForV1beta1CRD(
 		return false, err
 	})
 	if err != nil {
-		if deleteErr := client.CustomResourceDefinitions().Delete(
-			context.TODO(),
-			crd.ObjectMeta.Name,
-			metav1.DeleteOptions{},
-		); deleteErr != nil {
-			scopedLog.WithError(err).WithFields(logrus.Fields{
-				"deleteErr": deleteErr,
-			}).Error("Failed to delete CRD")
-			return fmt.Errorf("unable to delete CRD: %w", deleteErr)
-		}
-
 		return fmt.Errorf("error occurred waiting for CRD: %w", err)
 	}
 


### PR DESCRIPTION
This commit removes the ability to delete CRDs from Cilium because that
would delete all the CRs in the cluster.

Follow-up from:
https://github.com/cilium/cilium/pull/11477#discussion_r487816729

Updates: https://github.com/cilium/cilium/issues/12737

```release-note
Prevent Cilium from deleting all custom resources especially CNP & CCNP installed inside the cluster
```