### PR TITLE
Restores ClusterIP service entry upon LRP removal.

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -353,6 +353,8 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		d.redirectPolicyManager,
 	)
 
+	d.redirectPolicyManager.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)
+
 	bootstrapStats.daemonInit.End(true)
 
 	// Cleanup on exit if running in tandem with Flannel.

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -87,8 +87,7 @@ func (k *K8sWatcher) addCiliumLocalRedirectPolicy(clrp *cilium_v2.CiliumLocalRed
 
 	rp, policyAddErr := redirectpolicy.Parse(clrp, true)
 	if policyAddErr == nil {
-		_, policyAddErr = k.redirectPolicyManager.AddRedirectPolicy(*rp, &k.K8sSvcCache,
-			k.podStore)
+		_, policyAddErr = k.redirectPolicyManager.AddRedirectPolicy(*rp, k.podStore)
 	}
 
 	if policyAddErr != nil {

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -84,7 +84,7 @@ func (k *K8sWatcher) addK8sServiceV1(svc *slim_corev1.Service, swg *lock.Stoppab
 	if svc.Spec.Type == slim_corev1.ServiceTypeClusterIP {
 		// The local redirect policies currently support services of type
 		// clusterIP only.
-		k.redirectPolicyManager.OnAddService(svcID, &k.K8sSvcCache, k.podStore)
+		k.redirectPolicyManager.OnAddService(svcID, k.podStore)
 	}
 	return nil
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -140,9 +140,9 @@ type svcManager interface {
 }
 
 type redirectPolicyManager interface {
-	AddRedirectPolicy(config redirectpolicy.LRPConfig, svcCache *k8s.ServiceCache, podStore cache.Store) (bool, error)
+	AddRedirectPolicy(config redirectpolicy.LRPConfig, podStore cache.Store) (bool, error)
 	DeleteRedirectPolicy(config redirectpolicy.LRPConfig) error
-	OnAddService(svcID k8s.ServiceID, svcCache *k8s.ServiceCache, podStore cache.Store)
+	OnAddService(svcID k8s.ServiceID, podStore cache.Store)
 	OnDeleteService(svcID k8s.ServiceID)
 	OnUpdatePod(pod *slim_corev1.Pod)
 	OnDeletePod(pod *slim_corev1.Pod)


### PR DESCRIPTION
Deleting an LRP shadowing a ClusterIP service today will delete such
service entry entirely, this is problematic in cases where the original
service is still needed, e.g., NodeLocalDNS.

This allows for restoring ClusterIP service when correspoding LRP is
removed. We acquire original service info from Cilium's service cache
and enforce an update event to restore the service entry.

With LRP, `cilium service list`:
```
ID   Frontend            Service Type          Backend
1    10.91.240.10:53     LocalRedirect         1 => 10.88.1.242:53                                                           
2    10.91.241.27:53     ClusterIP             1 => 10.88.1.117:53                                                                                                    
                                               2 => 10.88.0.46:53                            			             
3    10.91.240.1:443     ClusterIP             1 => 35.193.66.178:443
4    10.91.254.119:443	 ClusterIP             1 => 10.88.1.127:443
```

After removing the LRP, `cilium service list`:
```
ID   Frontend            Service Type   Backend
2    10.91.241.27:53     ClusterIP      1 => 10.88.1.117:53
                                        2 => 10.88.0.46:53
3    10.91.240.1:443     ClusterIP      1 => 35.193.66.178:443
4    10.91.254.119:443   ClusterIP      1 => 10.88.1.127:443
5    10.91.240.10:53     ClusterIP      1 => 10.88.1.117:53
                                        2 => 10.88.0.46:53
```

Signed-off-by: Weilong Cui <cuiwl@google.com>

Fixes: #13268 
