### PR TITLE
Avoid loops with local-redirect service translation

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -264,9 +264,65 @@ sock4_wildcard_lookup_full(struct lb4_key *key __maybe_unused,
 	return svc;
 }
 
+/* Service translation logic for a local-redirect service can cause
+ * packets to be looped back to a service node-local backend after translation.
+ * This can happen when the node-local backend itself tries to connect to the
+ * service frontend for which it acts as a backend.
+ * There are cases where this can break traffic flow if the backend needs to
+ * forward the redirected traffic to the actual service frontend.
+ * Hence, allow service translation for pod traffic getting redirected to
+ * backend (across network namespaces), but skip service translation for backend
+ * to itself or another service backend within the same namespace.
+ *
+ * For example, in EKS cluster, a local-redirect service exists with the AWS
+ * metadata IP, port as the frontend <169.254.169.254, 80> and kiam proxy as a
+ * backend pod. When traffic destined to the frontend originates from the kiam pod
+ * in namespace ns1 (host ns when the kiam proxy pod is deployed in hostNetwork
+ * mode or regular pod ns) and the pod is selected as a backend, the traffic
+ * would get looped back to the proxy pod.
+ * Identify such cases by doing a socket lookup for the backend <ip, port> in its
+ * namespace, ns1, and skip service translation.
+ */
+#ifdef BPF_HAVE_SOCKET_LOOKUP
+static __always_inline __maybe_unused bool
+sock4_skip_xlate_for_same_netns_backend(struct bpf_sock_addr *ctx,
+					const struct lb4_backend *backend)
+{
+	struct bpf_sock_tuple tuple = {
+		.ipv4.saddr = 0,
+		.ipv4.sport = 0,
+		.ipv4.daddr = backend->address,
+		.ipv4.dport = backend->port,
+	};
+	struct bpf_sock *sk = NULL;
+
+	switch (ctx->protocol) {
+	case IPPROTO_TCP:
+		sk = sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+		break;
+	case IPPROTO_UDP:
+		sk = sk_lookup_udp(ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+		break;
+	default:
+		break;
+	}
+
+	/* There exists a socket listening on the <ip, port> of the backend
+	 * in the same namespace where socket connect call originates from.
+	 */
+	if (sk) {
+		sk_release(sk);
+		return true;
+	}
+
+	return false;
+}
+#endif
+
 static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 					     struct bpf_sock_addr *ctx_full,
-					     const bool udp_only)
+					     const bool udp_only,
+					     const bool ipv6_context  __maybe_unused)
 {
 	union lb4_affinity_client_id id;
 	const bool in_hostns = ctx_in_hostns(ctx_full, &id.client_cookie);
@@ -347,6 +403,13 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 		return -ENOENT;
 	}
 
+#ifdef BPF_HAVE_SOCKET_LOOKUP
+	if (lb4_svc_is_localredirect(svc) && !ipv6_context &&
+	    sock4_skip_xlate_for_same_netns_backend(ctx_full, backend)) {
+		return 0;
+	}
+#endif
+
 	if (lb4_svc_is_affinity(svc) && !backend_from_affinity)
 		lb4_update_affinity_by_netns(svc, &id, backend_id);
 
@@ -365,7 +428,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 __section("connect4")
 int sock4_connect(struct bpf_sock_addr *ctx)
 {
-	__sock4_xlate_fwd(ctx, ctx, false);
+	__sock4_xlate_fwd(ctx, ctx, false, false);
 	return SYS_PROCEED;
 }
 
@@ -456,7 +519,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 __section("sendmsg4")
 int sock4_sendmsg(struct bpf_sock_addr *ctx)
 {
-	__sock4_xlate_fwd(ctx, ctx, true);
+	__sock4_xlate_fwd(ctx, ctx, true, false);
 	return SYS_PROCEED;
 }
 
@@ -639,7 +702,7 @@ int sock6_xlate_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused,
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
-	ret = __sock4_xlate_fwd(&fake_ctx, ctx, udp_only);
+	ret = __sock4_xlate_fwd(&fake_ctx, ctx, udp_only, true);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/include/bpf/features.h
+++ b/bpf/include/bpf/features.h
@@ -31,4 +31,9 @@
 # define BPF_HAVE_CSUM_LEVEL 1
 #endif
 
+#if HAVE_PROG_TYPE_HELPER(cgroup_sock_addr, bpf_sk_lookup_tcp) && \
+    HAVE_PROG_TYPE_HELPER(cgroup_sock_addr, bpf_sk_lookup_udp)
+# define BPF_HAVE_SOCKET_LOOKUP 1
+#endif
+
 #endif /* ____BPF_FEATURES____ */

--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -84,4 +84,12 @@ static int BPF_FUNC(sock_hash_update, struct bpf_sock_ops *skops, void *map,
 static int BPF_FUNC(msg_redirect_hash, struct sk_msg_md *md, void *map,
 		    void *key, __u64 flags);
 
+/* Socket lookup helpers */
+static struct bpf_sock *BPF_FUNC(sk_lookup_tcp, void *ctx,
+				 struct bpf_sock_tuple *tuple, __u32 tuple_size,
+				 __u64 netns, __u64 flags);
+static struct bpf_sock *BPF_FUNC(sk_lookup_udp, void *ctx,
+				 struct bpf_sock_tuple *tuple, __u32 tuple_size,
+				 __u64 netns, __u64 flags);
+
 #endif /* __BPF_HELPERS__ */

--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -54,9 +54,6 @@ static int BPF_FUNC_REMAP(skb_event_output, struct __sk_buff *skb, void *map,
 static struct bpf_sock *BPF_FUNC(skc_lookup_tcp, struct __sk_buff *skb,
 				 struct bpf_sock_tuple *tuple, __u32 tuple_size,
 				 __u64 netns, __u64 flags);
-static struct bpf_sock *BPF_FUNC(sk_lookup_udp, struct __sk_buff *skb,
-				 struct bpf_sock_tuple *tuple, __u32 tuple_size,
-				 __u64 netns, __u64 flags);
 static int BPF_FUNC(sk_release, struct bpf_sock *sk);
 static int BPF_FUNC(sk_assign, struct __sk_buff *skb, struct bpf_sock *sk,
 		    __u64 flags);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -559,7 +559,11 @@ enum {
 	SVC_FLAG_LOADBALANCER = (1 << 5),  /* LoadBalancer service */
 	SVC_FLAG_ROUTABLE     = (1 << 6),  /* Not a surrogate/ClusterIP entry */
 	SVC_FLAG_SOURCE_RANGE = (1 << 7),  /* Check LoadBalancer source range */
-	SVC_FLAG_LOCALREDIRECT = (1 << 8),  /* local redirect */
+};
+
+/* Service flags (lb{4,6}_service->flags2) */
+enum {
+	SVC_FLAG_LOCALREDIRECT = (1 << 0),  /* local redirect */
 };
 
 struct ipv6_ct_tuple {

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -333,6 +333,12 @@ bool lb6_svc_is_routable(const struct lb6_service *svc)
 	return __lb_svc_is_routable(svc->flags);
 }
 
+static __always_inline
+bool lb4_svc_is_localredirect(const struct lb4_service *svc __maybe_unused)
+{
+	return svc->flags2 & SVC_FLAG_LOCALREDIRECT;
+}
+
 static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 					   int l4_off, __be16 *port,
 					   __maybe_unused struct iphdr *ip4)


### PR DESCRIPTION
Service translation logic for a `local-redirect` service can cause packets to be looped back to a service node-local backend after translation. This can happen when the node-local pod itself tries to connect to the service frontend for which it acts as a backend. There are cases (e.g., kiam agent connecting the AWS metadata server on EKS) where this can break traffic flow if the backend needs to forward the redirected traffic to the actual service frontend.

Check commit description for more details about the issue and testing.

AWS metadata server doesn't seem to support IPv6 [1], hence the fix is applicable only to IPv4. IPv6 changes can be added in future.

Follow-ups:  end-to-end tests, update gsg with kernel requirement for the socket lookup

Fixes: #11646

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html