### PR TITLE
Testing in DualStack K8s environment

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4047,7 +4047,10 @@ func validateCiliumSvcLB(cSvc models.Service, lbMap map[string][]string) error {
 	if cSvc.Status.Realized.FrontendAddress.Scope == models.FrontendAddressScopeInternal {
 		scope = "/i"
 	}
-	frontendAddress := cSvc.Status.Realized.FrontendAddress.IP + ":" + strconv.Itoa(int(cSvc.Status.Realized.FrontendAddress.Port)) + scope
+
+	frontendAddress := net.JoinHostPort(
+		cSvc.Status.Realized.FrontendAddress.IP,
+		strconv.Itoa(int(cSvc.Status.Realized.FrontendAddress.Port))) + scope
 	bpfBackends, ok := lbMap[frontendAddress]
 	if !ok {
 		return fmt.Errorf("%s bpf lb map entry not found", frontendAddress)
@@ -4055,7 +4058,7 @@ func validateCiliumSvcLB(cSvc models.Service, lbMap map[string][]string) error {
 
 BACKENDS:
 	for _, addr := range cSvc.Status.Realized.BackendAddresses {
-		backend := *addr.IP + ":" + strconv.Itoa(int(addr.Port))
+		backend := net.JoinHostPort(*addr.IP, strconv.Itoa(int(addr.Port)))
 		for _, bpfAddr := range bpfBackends {
 			if strings.Contains(bpfAddr, backend) {
 				continue BACKENDS


### PR DESCRIPTION
Followups:
- [ ] Add IPv6 services tests using K8s services rather than manually plumbing the services.
- [ ] Remove old manual plumbing for IPv6 services from tests.

Related - #9917