### PR TITLE
helm: remove hubble-ca-certs secret

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-tls/templates/secret.yaml
+++ b/install/kubernetes/cilium/charts/hubble-tls/templates/secret.yaml
@@ -1,20 +1,6 @@
 {{- if and (.Values.global.hubble.enabled) (.Values.global.hubble.listenAddress) (.Values.global.hubble.tls.enabled) }}
 ---
 apiVersion: v1
-kind: Secret
-metadata:
-  name: hubble-ca-certs
-  namespace: {{ .Release.Namespace }}
-type: kubernetes.io/tls
-data:
-{{- if and (.Values.global.hubble.tls.auto.enabled) (eq .Values.global.hubble.tls.auto.method "helm") }}
-{{ include "ca.gen-certs" . | indent 2 }}
-{{- else }}
-  tls.crt: {{ .Values.ca.crt }}
-  tls.key: {{ .Values.ca.key }}
-{{- end }}
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hubble-ca-cert

--- a/install/kubernetes/cilium/charts/hubble-tls/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-tls/values.yaml
@@ -1,7 +1,6 @@
-# base64 encoded PEM values for the hubble CA certificate and private key
+# base64 encoded PEM values for the hubble CA certificate
 ca:
   crt:
-  key:
 # base64 encoded PEM values for the hubble server certificate and private key
 server:
   crt:


### PR DESCRIPTION
This Kubernetes TLS secret is actually unused, let's remove it.