### PR TITLE
v1.7 backports 2020-09-25

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1178,6 +1178,9 @@ func (m *IptablesManager) addCiliumENIRules() error {
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
 
+	// Note: these rules need the xt_connmark module (iptables usually
+	// loads it when required, unless loading modules after boot has been
+	// disabled).
 	if err := runProg("iptables", append(
 		m.waitArgs,
 		"-t", "mangle",

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1165,6 +1165,10 @@ func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 }
 
 func (m *IptablesManager) addCiliumENIRules() error {
+	if !option.Config.EnableIPv4 {
+		return nil
+	}
+
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
 	if err := runProg("iptables", append(

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -705,7 +705,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 		oldKey = oldNode.EncryptionKey
 	}
 
-	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
+	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() && !n.nodeConfig.EncryptNode {
 		n.enableIPsec(newNode)
 		newKey = newNode.EncryptionKey
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -127,7 +127,16 @@ func addENIRules(sysSettings []setting) ([]setting, error) {
 		return sysSettings, nil
 	}
 
-	retSettings := append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
+	iface, err := route.NodeDeviceWithDefaultRoute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find interface with default route: %w", err)
+	}
+
+	retSettings := append(sysSettings, setting{
+		fmt.Sprintf("net.ipv4.conf.%s.rp_filter", iface.Attrs().Name),
+		"2",
+		false,
+	})
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,
 		Mark:     linux_defaults.MarkMultinodeNodeport,

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -123,6 +123,10 @@ func addENIRules(sysSettings []setting) ([]setting, error) {
 	// which the CIDR used by the endpoint has been configured.
 	//
 	// We want to reproduce equivalent rules to ensure correct routing.
+	if !option.Config.EnableIPv4 {
+		return sysSettings, nil
+	}
+
 	retSettings := append(sysSettings, setting{"net.ipv4.conf.eth0.rp_filter", "2", false})
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityNodeport,

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -578,11 +578,7 @@ func createUpdateCRD(clientset apiextensionsclient.Interface, CRDName string, cr
 		return false, err
 	})
 	if err != nil {
-		deleteErr := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.ObjectMeta.Name, nil)
-		if deleteErr != nil {
-			return fmt.Errorf("unable to delete k8s %s CRD %s. Deleting CRD due: %s", CRDName, deleteErr, err)
-		}
-		return err
+		return fmt.Errorf("error occurred waiting for CRD: %s", err)
 	}
 
 	scopedLog.Info("CRD (CustomResourceDefinition) is installed and up-to-date")


### PR DESCRIPTION
 * #13241 -- cilium: encrypt-node creates two IPsec tunnels but only uses one (@jrfastab)
 * ~#13228 -- identity: Avoid kvstore lookup for local identities (@gandro)~ too many unit tests fail, I will try in an another PR
 * #13234 -- EKS: improve rules for asymmetric routing (multi-node NodePort) (@qmonnet)
 * #13272 -- k8s: Remove CRD deleting functionality (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13241 13234 13272; do contrib/backporting/set-labels.py $pr done 1.7; done
```