### PR TITLE
test: Debug RuntimeConntrackInVethModeTest flake

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -386,6 +386,7 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 
 		AfterFailed(func() {
 			vm.ReportFailed("cilium policy get")
+			vm.ReportFailed("cilium bpf policy get --all")
 		})
 
 		It("Conntrack-related configuration options for endpoints", func() {


### PR DESCRIPTION
This PR dumps the BPF map content on RuntimeonntrackInVethModeTest fails to help debug a flake.