### PR TITLE
Add log when allocate nodecidr failure

### DIFF
--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -78,6 +78,10 @@ type mockCIDRAllocator struct {
 	OnInRange      func(cidr *net.IPNet) bool
 }
 
+func (d *mockCIDRAllocator) String() string {
+	return "clusterCIDR: 10.0.0.0/24, nodeMask: 24"
+}
+
 func (d *mockCIDRAllocator) Occupy(cidr *net.IPNet) error {
 	if d.OnOccupy != nil {
 		return d.OnOccupy(cidr)


### PR DESCRIPTION
If user enconter an error when ipam allocate nodecidr failure where. It hang at log 
`required IPv4 pod CIDR not present in node resource`
like this issue: https://github.com/cilium/cilium/issues/12956

I think it should return a error and show it to the user.

[Edit] See also related PR for IPAM: https://github.com/cilium/ipam/pull/1