### PR TITLE
cilium: print names for reserved identities in `cilium ip list`

### DIFF
--- a/Documentation/cmdref/cilium_ip_list.md
+++ b/Documentation/cmdref/cilium_ip_list.md
@@ -16,6 +16,7 @@ cilium ip list [flags]
 
 ```
   -h, --help            help for list
+  -n, --numeric         Print numeric identities
   -o, --output string   json| jsonpath='{}'
   -v, --verbose         Print all fields of ipcache
 ```


### PR DESCRIPTION
Currently, the identities in the output of `cilium ip list` are always
in numeric format:

```
$ cilium ip list
IP                       IDENTITY   SOURCE
0.0.0.0/0                2
10.0.0.39/32             1
10.0.0.78/32             4
10.0.0.109/32            61205      k8s
10.0.0.179/32            39864      k8s
10.0.2.15/32             1
10.192.1.86/32           4
10.192.1.110/32          4
10.192.1.144/32          7749       k8s
10.192.1.169/32          4
172.28.128.6/32          1
192.168.9.1/32           1
192.168.36.1/32          7749       k8s
192.168.36.11/32         1
192.168.37.11/32         1
f00d::a0f:0:0:76d5/128   7749       k8s
f00d::a0f:0:0:79ba/128   4
f00d::a0f:0:0:9fb8/128   4
f00d::a0f:0:0:f4ec/128   4
fc00::10ca:1/128         7749       k8s
```

Make it easier to immediately recognize reserved identities by their
name (without having to remember them) by changing the output to print
the name by default:

```
$ cilium ip list
IP                       IDENTITY   SOURCE
0.0.0.0/0                world
10.0.0.39/32             host
10.0.0.78/32             health
10.0.0.109/32            61205      k8s
10.0.0.179/32            39864      k8s
10.0.2.15/32             host
10.192.1.86/32           health
10.192.1.110/32          health
10.192.1.144/32          7749       k8s
10.192.1.169/32          health
172.28.128.6/32          host
192.168.9.1/32           host
192.168.36.1/32          7749       k8s
192.168.36.11/32         host
192.168.37.11/32         host
f00d::a0f:0:0:76d5/128   7749       k8s
f00d::a0f:0:0:79ba/128   health
f00d::a0f:0:0:9fb8/128   health
f00d::a0f:0:0:f4ec/128   health
fc00::10ca:1/128         7749       k8s
```

This behavior can be disabled (i.e. the identities are all printed in
numeric format) by specifying the `-n` flag.

```release-note
Show names for reserved identities in `cilium ip list`.
```
