### PR TITLE
ci: Run policy stress tests on a nightly basis

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,16 @@
+name: Nightly
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+jobs:
+  test-gke:
+    name: Start Nightly Policy Stress tests
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Request GKE test cluster
+        uses: docker://quay.io/isovalent/gke-test-cluster-requester:fe34abda190c31680968ba62634c788428d91706
+        env:
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --namespace=test-clusters --image=cilium/cilium-test-dev:latest "/usr/local/bin/cilium-test-gke.sh" "docker.io/cilium/cilium:latest" "docker.io/cilium/operator-generic:latest" "docker.io/cilium/hubble-relay:latest" "NightlyPolicyStress"

--- a/images/cilium-test/cilium-test-gke.sh
+++ b/images/cilium-test/cilium-test-gke.sh
@@ -24,10 +24,12 @@ kubectl create ns cilium || true
 
 CILIUM_IMAGE="${1}"
 CILIUM_OPERATOR_IMAGE="${2}"
+HUBBLE_RELAY_IMAGE="${3}"
+FOCUS="${4:-K8s*}"
 
-export CILIUM_IMAGE CILIUM_OPERATOR_IMAGE
+export CILIUM_IMAGE CILIUM_OPERATOR_IMAGE HUBBLE_RELAY_IMAGE FOCUS
 
-shift 2
+shift 4
 
 CNI_INTEGRATION=gke
 
@@ -41,9 +43,11 @@ cilium-test \
   -test.v \
   -ginkgo.v \
   -ginkgo.noColor \
-  -ginkgo.focus="K8s*" \
+  -ginkgo.focus="${FOCUS}" \
   -cilium.provision=false \
   -cilium.kubeconfig="${KUBECONFIG}" \
   -cilium.image="${CILIUM_IMAGE}" \
   -cilium.operator-image="${CILIUM_OPERATOR_IMAGE}" \
+  -cilium.hubble-relay-image="${HUBBLE_RELAY_IMAGE}" \
+  -cilium.registry="docker.io" \
   -cilium.passCLIEnvironment=true

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -556,6 +556,7 @@ func (kub *Kubectl) PrepareCluster() {
 		"kube-public",
 		"container-registry",
 		"cilium-ci-lock",
+		"prom",
 	})
 	if err != nil {
 		ginkgoext.Failf("Unable to delete non-essential namespaces: %s", err)


### PR DESCRIPTION
Left to do after this is merged - automate pushing `latest` tag to `cilium/cilium-test-dev` image in dockerhub, or retrieve git sha.

After review, let's drop the `pull_request` trigger.