### PR TITLE
doc: add concepts/observability section, document Hubble in cluster mesh

### DIFF
--- a/Documentation/concepts/index.rst
+++ b/Documentation/concepts/index.rst
@@ -11,8 +11,8 @@ Concepts
 ########
 
 The concepts chapter provides a deeper overview and deep dives over all aspects
-of Cilium. If you are looking for a high-level introduction of Cilium, see the
-section :ref:`intro`.
+of Cilium and Hubble. If you are looking for a high-level introduction of
+Cilium and Hubble, see the section :ref:`intro`.
 
 Choose one of the following topics to start reading:
 
@@ -25,6 +25,7 @@ Choose one of the following topics to start reading:
    networking/index
    security/index
    ebpf/index
+   observability/index
    kubernetes/index
    clustermesh/index
    scalability/index

--- a/Documentation/concepts/observability/hubble-configuration.rst
+++ b/Documentation/concepts/observability/hubble-configuration.rst
@@ -1,0 +1,70 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _hubble_configure:
+
+********************
+Hubble Configuration
+********************
+
+This page provides guidance to configure Hubble in a way that suits your
+environment. Instructions to enable Hubble are provided as part of each
+Cilium :ref:`gs_install` guide.
+
+.. _hubble_configure_tls_certs:
+
+Use custom TLS certificates in distributed mode
+-----------------------------------------------
+
+In **distributed mode**, Hubble listens on a TCP port on the host network. This
+allows :ref:`hubble_relay` to communicate with all Hubble instances in the
+cluster. Connections between Hubble server and Hubble Relay instances are
+secured using mutual TLS (mTLS) by default.
+
+When using Helm, TLS certificates are automatically generated and distributed
+as Kubernetes secrets by Helm for use by Hubble and Hubble Relay provided that
+``global.hubble.tls.auto.enabled`` is set to ``true`` (default).
+
+.. note::
+
+   TLS certificates are (re-)generated every time Helm is used for install or
+   upgrade. As Hubble server and Hubble Relay support TLS certificates hot
+   reloading, including CA certificates, this does not disrupt any existing
+   connection. New connections are automatically established using the new
+   certificates without having to restart Hubble server or Hubble Relay.
+
+Hubble allows using custom TLS certificates rather than relying on
+automatically generated ones. This can be useful when using Hubble in
+distributed mode in a cluster mesh scenario for instance or when using
+certificates signed by a specific certificate authority (CA) is required.
+
+In order to use custom TLS certificates ``global.hubble.tls.auto.enabled`` must
+be set to ``false`` and TLS certificates manually provided.
+
+This can be done by specifying the options below to Helm at install or upgrade time:
+
+.. parsed-literal::
+    --set global.hubble.tls.auto.enabled=false                  # disable automatic TLS certificate generation
+    --set-file hubble-tls.ca.crt=ca.crt.b64                     # certificate of the CA that signs all certificates
+    --set-file hubble-tls.server.crt=server.crt.b64             # certificate for Hubble server
+    --set-file hubble-tls.server.key=server.key.b64             # private key for the Hubble server certificate
+    --set-file hubble-tls.relay.client.crt=relay-client.crt.b64 # client certificate for Hubble Relay to connect to Hubble instances
+    --set-file hubble-tls.relay.client.key=relay-client.key.b64 # private key for Hubble Relay client certificate
+    --set-file hubble-tls.relay.server.crt=relay-server.crt.b64 # server certificate for Hubble Relay
+    --set-file hubble-tls.relay.server.key=relay-server.key.b64 # private key for Hubble Relay server certificate
+
+Options ``hubble-tls.relay.server.crt`` and ``hubble-tls.relay.server.key``
+only need to be provided when ``global.hubble.relay.tls.enabled`` is set to
+``true`` to enable TLS for the Hubble Relay server (defaults to ``false``).
+
+.. note::
+
+   Provided files must be **base64 encoded** PEM certificates.
+
+   In addition, the **Common Name (CN)** and **Subject Alternative Name (SAN)**
+   of the certificate for Hubble server MUST be set to
+   ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
+   cluster name defined by ``global.cluster.name`` (defaults to ``default``).

--- a/Documentation/concepts/observability/index.rst
+++ b/Documentation/concepts/observability/index.rst
@@ -1,0 +1,16 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+*************
+Observability
+*************
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   intro
+   hubble-configuration

--- a/Documentation/concepts/observability/intro.rst
+++ b/Documentation/concepts/observability/intro.rst
@@ -1,0 +1,34 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _observability_intro:
+
+************
+Introduction
+************
+
+Observability is provided by Hubble which enables deep visibility into the
+communication and behavior of services as well as the networking infrastructure
+in a completely transparent manner. Hubble is able to provide visibility at the
+node level, cluster level or even across clusters in a :ref:`Cluster Mesh`
+scenario. For an introduction to Hubble and how it relates to Cilium, read the
+section :ref:`intro`.
+
+When configured for **local mode**, the Hubble API is scoped to each individual
+node on which the Cilium agent runs. In other words, networking visibility is
+only provided for traffic observed by the local Cilium agent. In this scenario,
+the only way to interact with the Hubble API is by using the Hubble CLI
+(``hubble``) to query the Hubble API provided via a local Unix Domain Socket.
+The Hubble CLI binary is installed by default on Cilium agent pods.
+
+When configured for **distributed mode** (implies local mode), full network
+visibility is provided by a component named Hubble Relay. In this scenario,
+the Hubble Relay service provides an Hubble API which scopes the entire cluster
+or even multiple clusters in a ClusterMesh scenario. Hubble data can be
+accessed by pointing a Hubble CLI (``hubble``) to the Hubble Relay service or
+via Hubble UI. Hubble UI is a web interface which enables automatic discovery of the
+services dependency graph at the L3/L4 and even L7 layer, allowing
+user-friendly visualization and filtering of data flows as a service map.

--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -420,6 +420,19 @@ the ``--cluster-name`` agent option or ``cluster-name`` ConfigMap option.
             name: rebel-base
             io.cilium.k8s.policy.cluster: cluster2
 
+Setting up Hubble
+#################
+
+In a ClusterMesh context with Hubble configured in **distributed mode**,
+:ref:`hubble_relay` provides cross-cluster visibility without any particular
+configuration.
+
+When mutual TLS (mTLS) is enabled (default in **distributed mode**), TLS
+certificates for Hubble and Hubble Relay need to be signed by the same
+Certificate Authority (CA) for both clusters. This can be achieved by disabling
+automatic TLS certificate generation and manually providing certificates as
+instructed in :ref:`hubble_configure_tls_certs`.
+
 Troubleshooting
 ###############
 

--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -23,8 +23,7 @@ networking infrastructure in a completely transparent manner.
            In Distributed mode, Hubble runs a gRPC service over HTTP on the
            host network. It is secured using mutual TLS (mTLS) by default to
            only allow access to Hubble Relay. Refer to
-           `Use custom TLS certificates in distributed mode (optional)`_ to
-           manually provide TLS certificates.
+           :ref:`hubble_configure_tls_certs` to manually provide TLS certificates.
 
         .. parsed-literal::
 
@@ -95,56 +94,3 @@ networking infrastructure in a completely transparent manner.
       kubectl port-forward -n $CILIUM_NAMESPACE svc/hubble-ui --address 0.0.0.0 --address :: 12000:80
 
   and then open http://localhost:12000/.
-
-Use custom TLS certificates in distributed mode (optional)
-----------------------------------------------------------
-
-In **distributed mode**, Hubble listens on a TCP port on the host network. This
-allows :ref:`hubble_relay` to communicate with all Hubble instances in the
-cluster. Connections between Hubble server and Hubble Relay instances are
-secured using mutual TLS (mTLS) by default.
-
-When using Helm, TLS certificates are automatically generated and distributed
-as Kubernetes secrets by Helm for use by Hubble and Hubble Relay provided that
-``global.hubble.tls.auto.enabled`` is set to ``true`` (default).
-
-.. note::
-
-   TLS certificates are (re-)generated every time Helm is used for install or
-   upgrade. As Hubble server and Hubble Relay support TLS certificates hot
-   reloading, including CA certificates, this does not disrupt any existing
-   connection. New connections are automatically established using the new
-   certificates without having to restart Hubble server or Hubble Relay.
-
-Hubble allows using custom TLS certificates rather than relying on
-automatically generated ones. This can be useful when using Hubble in
-distributed mode in a cluster mesh scenario for instance or when using
-certificates signed by a specific certificate authority (CA) is required.
-
-In order to use custom TLS certificates ``global.hubble.tls.auto.enabled`` must
-be set to ``false`` and TLS certificates manually provided.
-
-This can be done by specifying the options below to Helm at install or upgrade time:
-
-.. parsed-literal::
-    --set global.hubble.tls.auto.enabled=false                  # disable automatic TLS certificate generation
-    --set-file hubble-tls.ca.crt=ca.crt.b64                     # certificate of the CA that signs all certificates
-    --set-file hubble-tls.server.crt=server.crt.b64             # certificate for Hubble server
-    --set-file hubble-tls.server.key=server.key.b64             # private key for the Hubble server certificate
-    --set-file hubble-tls.relay.client.crt=relay-client.crt.b64 # client certificate for Hubble Relay to connect to Hubble instances
-    --set-file hubble-tls.relay.client.key=relay-client.key.b64 # private key for Hubble Relay client certificate
-    --set-file hubble-tls.relay.server.crt=relay-server.crt.b64 # server certificate for Hubble Relay
-    --set-file hubble-tls.relay.server.key=relay-server.key.b64 # private key for Hubble Relay server certificate
-
-Options ``hubble-tls.relay.server.crt`` and ``hubble-tls.relay.server.key``
-only need to be provided when ``global.hubble.relay.tls.enabled`` is set to
-``true`` to enable TLS for the Hubble Relay server (defaults to ``false``).
-
-.. note::
-
-   Provided files must be **base64 encoded** PEM certificates.
-
-   In addition, the **Common Name (CN)** and **Subject Alternative Name (SAN)**
-   of the certificate for Hubble server MUST be set to
-   ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
-   cluster name defined by ``global.cluster.name`` (defaults to ``default``).


### PR DESCRIPTION
This PR adds a new observability subsection in the concepts section. This new subsection currently consists of an intro to Hubble components and the different modes for Hubble (local and distributed) as well as a page for Hubble configuration.

Additionally, this PR updates the cluster mesh documentation with instructions for to configure Hubble for cluster mesh scenario (it's basically plug'n'play :) ). 

Note: ~#13291 needs to be merged first.~