### PR TITLE
helm: bump hubble-ui patch version in chart values

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -3,14 +3,14 @@ frontendImage:
   repository: quay.io/cilium/hubble-ui
   # Ref: https://github.com/cilium/hubble-ui/releases
   # Ref: https://quay.io/repository/cilium/hubble-ui?tab=tags
-  tag: v0.7.1
+  tag: v0.7.2
   pullPolicy: IfNotPresent
 backendImage:
   repository: quay.io/cilium/hubble-ui-backend
   # tag is the container image tag to use.
   # Ref: https://github.com/cilium/hubble-ui/releases
   # Ref: https://quay.io/repository/cilium/hubble-ui-backend?tab=tags
-  tag: v0.7.1
+  tag: v0.7.2
   pullPolicy: IfNotPresent
 proxyImage:
   repository: docker.io/envoyproxy/envoy

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -877,7 +877,7 @@ spec:
       serviceAccountName: hubble-ui
       containers:
         - name: frontend
-          image: "quay.io/cilium/hubble-ui:v0.7.1"
+          image: "quay.io/cilium/hubble-ui:v0.7.2"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -885,7 +885,7 @@ spec:
           resources:
             {}
         - name: backend
-          image: "quay.io/cilium/hubble-ui-backend:v0.7.1"
+          image: "quay.io/cilium/hubble-ui-backend:v0.7.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: EVENTS_SERVER_PORT


### PR DESCRIPTION
Use v0.7.2 by default for hubble-ui
