### PR TITLE
helm: Add extraConfig in configmap template

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -593,3 +593,7 @@ data:
   # Configure service proxy name for Cilium.
   k8s-service-proxy-name: {{ .Values.global.k8s.serviceProxyName | quote }}
 {{- end }}
+
+{{- if .Values.extraConfig }}
+{{ toYaml .Values.extraConfig | indent 2 }}
+{{- end }}


### PR DESCRIPTION
This allows users to provide additional fields in the configmap without
having them explicitly listed in the template. For example, you can do:

    % cat my-config.yaml
    config:
      extraConfig:
        my-config-a: "1234"
        my-config-b: |-
          test 1
          test 2
          test 3
    % helm install ./cilium -n kube-system -f ./my-config.yaml

to add my-config-a and my-config-b to cilium-config. This could be
useful in case the template is missing some fields.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>
