### PR TITLE
docs: Clarify session affinity support on <5.7

### DIFF
--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -168,17 +168,17 @@ additional kernel features continues to progress in the Linux community. Some
 of Cilium's features are dependent on newer kernel versions and are thus
 enabled by upgrading to more recent kernel versions as detailed below.
 
-============================= ===============================
-Cilium Feature                Minimum Kernel Version
-============================= ===============================
-:ref:`concepts_fragmentation` >= 4.10
-:ref:`cidr_limitations`       >= 4.11
-:ref:`host-services`          >= 4.19.57, >= 5.1.16,  >= 5.2
-:ref:`kubeproxy-free`         >= 4.19.57, >= 5.1.16,  >= 5.2
-:ref:`bandwidth-manager`      >= 5.1
-:ref:`session-affinity`       >= 5.7
-BPF-based proxy redirection   >= 5.7
-============================= ===============================
+======================================== ===============================
+Cilium Feature                           Minimum Kernel Version
+======================================== ===============================
+:ref:`concepts_fragmentation`            >= 4.10
+:ref:`cidr_limitations`                  >= 4.11
+:ref:`host-services`                     >= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`kubeproxy-free`                    >= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`bandwidth-manager`                 >= 5.1
+Full support for :ref:`session-affinity` >= 5.7
+BPF-based proxy redirection              >= 5.7
+======================================== ===============================
 
 .. _req_kvstore:
 


### PR DESCRIPTION
Because network namespace cookies are only available in v5.7+, on older kernels, all pods on a given node will be serviced by the same backend for a given service, for east-west traffic.

Fixes: #13177