### PR TITLE
v1.7 backport 2020-09-29 for #13228

### DIFF
--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -214,7 +214,7 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 		return identity
 	}
 
-	if m.IdentityAllocator == nil {
+	if !identity.RequiresGlobalIdentity(lbls) || m.IdentityAllocator == nil {
 		return nil
 	}
 
@@ -251,6 +251,10 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 
 	if identity := m.localIdentities.lookupByID(id); identity != nil {
 		return identity
+	}
+
+	if id.HasLocalScope() {
+		return nil
 	}
 
 	allocatorKey, err := m.IdentityAllocator.GetByIDIncludeRemoteCaches(ctx, idpool.ID(id))


### PR DESCRIPTION
v1.7 backports 2020-09-29

 * #13228 -- identity: Avoid kvstore lookup for local identities (@gandro)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13228; do contrib/backporting/set-labels.py $pr done 1.7; done
```


This backport slightly modifies the upstream commit to avoid issues with the unit tests in v1.7