### PR TITLE
test: use correct test image in nightlies, restart pods in gke tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,10 +7,13 @@ jobs:
     name: Start Nightly Policy Stress tests
     runs-on: ubuntu-18.04
     steps:
+      - name: Trim git sha
+        id: vars
+        run: echo "::set-output name=sha_short::$(echo ${GITHUB_SHA:0:9})"
       - name: Request GKE test cluster
         uses: docker://quay.io/isovalent/gke-test-cluster-requester:fe34abda190c31680968ba62634c788428d91706
         env:
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --namespace=test-clusters --image=cilium/cilium-test-dev:latest "/usr/local/bin/cilium-test-gke.sh" "docker.io/cilium/cilium:latest" "docker.io/cilium/operator-generic:latest" "docker.io/cilium/hubble-relay:latest" "NightlyPolicyStress"
+          args: --namespace=test-clusters --image=cilium/cilium-test-dev:${{ steps.vars.outputs.sha_short }} "/usr/local/bin/cilium-test-gke.sh" "docker.io/cilium/cilium:latest" "docker.io/cilium/operator-generic:latest" "docker.io/cilium/hubble-relay:latest" "NightlyPolicyStress"

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -136,6 +136,7 @@ var (
 		"global.nodeinit.enabled":     "true",
 		"nodeinit.reconfigureKubelet": "true",
 		"nodeinit.removeCbrBridge":    "true",
+		"nodeinit.restartPods":        "true",
 		"global.cni.binPath":          "/home/kubernetes/bin",
 		"global.nodePort.mode":        "snat",
 		"global.gke.enabled":          "true",


### PR DESCRIPTION
This change retrieves the tag of `cilium-test-dev` image to use in nightly run based on `GITHUB_SHA` env var, since there is no automation in place to push `latest` tag for this image.