### PR TITLE
endpoint: rename policy/endpoint regeneration 'buildDuration' to 'total'

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -372,6 +372,8 @@ Deprecated Metrics/Labels
     label ``subnet_id`` instead.
   * Label ``subnetId`` and ``availabilityZone`` in ``cilium_operator_ipam_available_ips_per_subnet`` are deprecated and will be removed in 1.10. Please use
     label ``subnet_id`` and ``availability_zone`` instead.
+  * Label ``scope`` in ``cilium_endpoint_regeneration_time_stats_seconds`` had its ``buildDuration`` value renamed to ``total``.
+  * Label ``scope`` in ``cilium_policy_regeneration_time_stats_seconds`` had its ``buildDuration`` value renamed to ``total``.
 
 Removed options
 ~~~~~~~~~~~~~~~

--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
@@ -5933,7 +5933,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"buildDuration\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -6033,7 +6033,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"buildDuration\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -6285,7 +6285,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"buildDuration\"}[5m]))) by (scope)",
+              "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",
@@ -6385,7 +6385,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"buildDuration\"}[5m]))) by (scope)",
+              "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	loaderMetrics "github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/spanstat"
 
@@ -96,7 +95,7 @@ func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 		"proxyWaitForAck":        &s.proxyWaitForAck,
 		"mapSync":                &s.mapSync,
 		"prepareBuild":           &s.prepareBuild,
-		logfields.BuildDuration:  &s.totalTime,
+		"total":                  &s.totalTime,
 	}
 	for k, v := range s.datapathRealization.GetMap() {
 		result[k] = v
@@ -123,7 +122,7 @@ func (ps *policyRegenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 		"waitingForIdentityCache":    &ps.waitingForIdentityCache,
 		"waitingForPolicyRepository": &ps.waitingForPolicyRepository,
 		"policyCalculation":          &ps.policyCalculation,
-		logfields.BuildDuration:      &ps.totalTime,
+		"total":                      &ps.totalTime,
 	}
 }
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -110,14 +110,8 @@ const (
 	// IPv6 is an IPv6 address
 	IPv6 = "ipv6"
 
-	// BuildDuration is the time elapsed to build a BPF program
-	BuildDuration = "buildDuration"
-
 	// BPFCompilationTime is the time elapsed to build a BPF endpoint program
 	BPFCompilationTime = "BPFCompilationTime"
-
-	// EndpointRegenerationTime is the time elapsed to generate an endpoint
-	EndpointRegenerationTime = "endpointRegenerationTime"
 
 	// StartTime is the start time of an event
 	StartTime = "startTime"


### PR DESCRIPTION
This patch aims to address #13222.

I've considered using an existing `logfields` constant `EndpointRegenerationTime = "endpointRegenerationTime"` instead, but that made the metrics look like this:

`cilium_policy_regeneration_time_stats_seconds      scope="policyRegenerationTime" status="success"                                                   0.000104`

.. and that felt a little redundant. Please let me know what you think!

@pchaigno 

```release-note
The metrics `endpoint_regeneration_time_stats` and `policy_regeneration_time_stats` had their 'buildTime' scopes renamed to 'total'.
```