### PR TITLE
hubble: Support `--since` requests in combination with follow-mode

### DIFF
--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -20,6 +20,7 @@ package observer
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,6 +131,88 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 	err = s.GetFlows(req, fakeServer)
 	assert.NoError(t, err)
 	assert.Equal(t, req.Number, uint64(i))
+}
+
+func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
+	numFlows := 100
+	queueSize := 0
+
+	since := time.Unix(5, 0)
+	sinceProto, err := ptypes.TimestampProto(since)
+	assert.NoError(t, err)
+	req := &observerpb.GetFlowsRequest{
+		Since:  sinceProto,
+		Follow: true,
+	}
+
+	pp := noopParser(t)
+	s, err := NewLocalServer(pp, log,
+		observeroption.WithMaxFlows(numFlows),
+		observeroption.WithMonitorBuffer(queueSize),
+	)
+	require.NoError(t, err)
+	go s.Start()
+
+	generateFlows := func(from, to int, m chan<- *observerTypes.MonitorEvent) {
+		for i := from; i < to; i++ {
+			tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+			data := testutils.MustCreateL3L4Payload(tn)
+			m <- &observerTypes.MonitorEvent{
+				Timestamp: time.Unix(int64(i), 0),
+				NodeName:  fmt.Sprintf("node #%03d", i),
+				Payload: &observerTypes.PerfEvent{
+					Data: data,
+					CPU:  0,
+				},
+			}
+		}
+	}
+
+	// produce first half of flows before request and second half during request
+	m := s.GetEventsChannel()
+	generateFlows(0, numFlows/2, m)
+
+	receivedFlows := 0
+	fakeServer := &testutils.FakeGetFlowsServer{
+		OnSend: func(response *observerpb.GetFlowsResponse) error {
+			receivedFlows++
+			assert.Equal(t, response.GetTime(), response.GetFlow().GetTime())
+			assert.Equal(t, response.GetNodeName(), response.GetFlow().GetNodeName())
+
+			ts, err := ptypes.Timestamp(response.GetTime())
+			assert.NoError(t, err)
+			assert.True(t, !ts.Before(since), "flow had invalid timestamp. ts=%s, since=%s", ts, since)
+
+			// start producing flows once we have seen the most recent one.
+			// Most recently produced flow has timestamp (numFlows/2)-1, but is
+			// inaccessible to readers due to the way the ring buffer works
+			if int(ts.Unix()) == (numFlows/2)-2 {
+				go func() {
+					generateFlows(numFlows/2, numFlows, m)
+					close(m)
+				}()
+			}
+
+			// terminate the request once we have seen enough flows.
+			// we expected to see all generated flows, minus the ones filtered
+			// out by 'since', minus the one inaccessible in the ring buffer
+			if receivedFlows == numFlows-int(since.Unix())-1 {
+				// this will terminate the follow request
+				return io.EOF
+			}
+
+			return nil
+		},
+		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
+			OnContext: func() context.Context {
+				return context.Background()
+			},
+		},
+	}
+
+	err = s.GetFlows(req, fakeServer)
+	<-s.GetStopped()
+	assert.Equal(t, err, io.EOF)
 }
 
 type fakeCiliumDaemon struct{}


### PR DESCRIPTION
Previously, the observer implementation assumed time range filters on
the request are not compatible with follow-mode. This however is no
longer the case, we can now apply the since filter when rewinding the
ring buffer. This means that if the user specifies a `since` timestamp,
we first dump all flows newer than `since` before we enter follow-mode.

Fixes: cilium/hubble#363


```release-note
Fix issue where Hubble did not properly support `--follow` queries with a `--since` filter
```
