### PR TITLE
fsnotify: correctly check for event operation

### DIFF
--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -99,10 +99,13 @@ func (cdw *configDirectoryWatcher) watch() error {
 			case event := <-cdw.watcher.Events:
 				name := filepath.Base(event.Name)
 				log.WithField(fieldClusterName, name).Debugf("Received fsnotify event: %+v", event)
-				switch event.Op {
-				case fsnotify.Create, fsnotify.Write, fsnotify.Chmod:
+				switch {
+				case event.Op&fsnotify.Create == fsnotify.Create,
+					event.Op&fsnotify.Write == fsnotify.Write,
+					event.Op&fsnotify.Chmod == fsnotify.Chmod:
 					cdw.lifecycle.add(name, event.Name)
-				case fsnotify.Remove, fsnotify.Rename:
+				case event.Op&fsnotify.Remove == fsnotify.Remove,
+					event.Op&fsnotify.Rename == fsnotify.Rename:
 					cdw.lifecycle.remove(name)
 				}
 

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -337,7 +337,7 @@ func (o *objectCache) watchTemplatesDirectory(ctx context.Context) error {
 			if !open {
 				break
 			}
-			if event.Op&fsnotify.Remove != 0 {
+			if event.Op&fsnotify.Remove == fsnotify.Remove {
 				log.WithField(logfields.Path, event.Name).Debug("Detected template removal")
 				templateHash := filepath.Base(filepath.Dir(event.Name))
 				o.delete(templateHash)

--- a/pkg/ipmasq/ipmasq.go
+++ b/pkg/ipmasq/ipmasq.go
@@ -156,8 +156,12 @@ func (a *IPMasqAgent) Start() {
 			case event := <-a.watcher.Events:
 				log.Debugf("Received fsnotify event: %+v", event)
 
-				switch event.Op {
-				case fsnotify.Create, fsnotify.Write, fsnotify.Chmod, fsnotify.Remove, fsnotify.Rename:
+				switch {
+				case event.Op&fsnotify.Create == fsnotify.Create,
+					event.Op&fsnotify.Write == fsnotify.Write,
+					event.Op&fsnotify.Chmod == fsnotify.Chmod,
+					event.Op&fsnotify.Remove == fsnotify.Remove,
+					event.Op&fsnotify.Rename == fsnotify.Rename:
 					if err := a.Update(); err != nil {
 						log.WithError(err).Warn("Failed to update")
 					}


### PR DESCRIPTION
_**Note**: Backporting for v1.7 will fail to apply the ipmasq part of the patch as ipmasq isn't in v1.7 and can safely be ignored._

fsnotify Event.Op is a bit mask and testing for strict equality might
not detect the event operation correctly.

This patch make it so we check for fsnotify event operation
consistently as documented at https://github.com/fsnotify/fsnotify.