### PR TITLE
Envoy: Update to release 1.14.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:595bb722a4ab35576e89952f11cea3fd5aad63bc@sha256:b6eead55288b9ee61f763a99a31e5ff81661ea4d847c693eb8b6891b9b5ca3c3 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:1177896bebde79915fe5f9092409bf0254084b4e@sha256:50fb77af2b3fa8a902bb11b26c97c2c230fba74bdb417a645bd938278a6f81df as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 


### PR DESCRIPTION
Update Envoy to release 1.14.5

```release-note
Envoy is updated to release 1.14.5
```
