### PR TITLE
v1.7 backports 2020-09-29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:ccad480c59aa8b946d98aaf79f8e9e38d6731fdc@sha256:215442a52fcd1022a97d7eae658c503ec693194a6f09f3488b8a360e509d5945 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:1177896bebde79915fe5f9092409bf0254084b4e@sha256:50fb77af2b3fa8a902bb11b26c97c2c230fba74bdb417a645bd938278a6f81df as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:0a9743dda269a0b0039c9db3cf7e0a637caad7a9 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:ccad480c59aa8b946d98aaf79f8e9e38d6731fdc@sha256:215442a52fcd1022a97d7eae658c503ec693194a6f09f3488b8a360e509d5945 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -205,7 +205,7 @@ func (s *XDSServer) getHttpFilterChainProto(clusterName string, tls bool) *envoy
 				}),
 			},
 		}, {
-			Name: "envoy.router",
+			Name: "envoy.filters.http.router",
 		}},
 		StreamIdleTimeout: &duration.Duration{}, // 0 == disabled
 		RouteSpecifier: &envoy_config_http.HttpConnectionManager_RouteConfig{
@@ -265,7 +265,7 @@ func (s *XDSServer) getHttpFilterChainProto(clusterName string, tls bool) *envoy
 		Filters: []*envoy_api_v2_listener.Filter{{
 			Name: "cilium.network",
 		}, {
-			Name: "envoy.http_connection_manager",
+			Name: "envoy.filters.network.http_connection_manager",
 			ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
 				TypedConfig: toAny(hcmConfig),
 			},
@@ -298,7 +298,7 @@ func (s *XDSServer) getTcpFilterChainProto(clusterName string) *envoy_api_v2_lis
 				}),
 			},
 		}, {
-			Name: "envoy.tcp_proxy",
+			Name: "envoy.filters.network.tcp_proxy",
 			ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
 				TypedConfig: toAny(&envoy_config_tcp.TcpProxy{
 					StatPrefix: "tcp_proxy",
@@ -379,7 +379,7 @@ func (s *XDSServer) AddListener(name string, kind policy.L7ParserType, port uint
 				}),
 			},
 		}, {
-			Name: "envoy.listener.tls_inspector",
+			Name: "envoy.filters.listener.tls_inspector",
 		}},
 	}
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -685,7 +685,8 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 			LdsConfig: &envoy_api_v2_core.ConfigSource{
 				ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
 					ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
-						ApiType: envoy_api_v2_core.ApiConfigSource_GRPC,
+						ApiType:                   envoy_api_v2_core.ApiConfigSource_GRPC,
+						SetNodeOnFirstMessageOnly: true,
 						GrpcServices: []*envoy_api_v2_core.GrpcService{
 							{
 								TargetSpecifier: &envoy_api_v2_core.GrpcService_EnvoyGrpc_{

--- a/pkg/envoy/xds/node.go
+++ b/pkg/envoy/xds/node.go
@@ -40,23 +40,20 @@ type NodeToIDFunc func(node *envoy_api_v2_core.Node) (string, error)
 // For instance:
 //
 //    "sidecar~10.1.1.0~v0.default~default.svc.cluster.local"
-func IstioNodeToIP(node *envoy_api_v2_core.Node) (string, error) {
-	if node == nil {
-		return "", errors.New("node is nil")
-	}
-	if node.GetId() == "" {
-		return "", errors.New("node.id is empty")
+func IstioNodeToIP(nodeId string) (string, error) {
+	if nodeId == "" {
+		return "", errors.New("nodeId is empty")
 	}
 
-	parts := strings.Split(node.Id, "~")
+	parts := strings.Split(nodeId, "~")
 	if len(parts) != 4 {
-		return "", fmt.Errorf("node.id is invalid: %s", node.Id)
+		return "", fmt.Errorf("nodeId is invalid: %s", nodeId)
 	}
 
 	ip := parts[1]
 
 	if net.ParseIP(ip) == nil {
-		return "", fmt.Errorf("node.id contains an invalid node IP address: %s", node.Id)
+		return "", fmt.Errorf("node.id contains an invalid node IP address: %s", nodeId)
 	}
 
 	return ip, nil

--- a/pkg/envoy/xds/node_test.go
+++ b/pkg/envoy/xds/node_test.go
@@ -17,8 +17,6 @@
 package xds
 
 import (
-	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
-
 	. "gopkg.in/check.v1"
 )
 
@@ -27,20 +25,16 @@ type NodeSuite struct{}
 var _ = Suite(&NodeSuite{})
 
 func (s *NodeSuite) TestIstioNodeToIP(c *C) {
-	var node envoy_api_v2_core.Node
 	var ip string
 	var err error
 
-	node.Id = "sidecar~10.1.1.0~v0.default~default.svc.cluster.local"
-	ip, err = IstioNodeToIP(&node)
+	ip, err = IstioNodeToIP("sidecar~10.1.1.0~v0.default~default.svc.cluster.local")
 	c.Assert(err, IsNil)
 	c.Check(ip, Equals, "10.1.1.0")
 
-	node.Id = "sidecar~10.1.1.0~v0.default"
-	_, err = IstioNodeToIP(&node)
+	_, err = IstioNodeToIP("sidecar~10.1.1.0~v0.default")
 	c.Assert(err, Not(IsNil))
 
-	node.Id = "sidecar~not-an-ip~v0.default~default.svc.cluster.local"
-	_, err = IstioNodeToIP(&node)
+	_, err = IstioNodeToIP("sidecar~not-an-ip~v0.default~default.svc.cluster.local")
 	c.Assert(err, Not(IsNil))
 }

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -126,7 +126,6 @@ func NewServer(resourceTypes map[string]*ResourceTypeConfiguration,
 func getXDSRequestFields(req *envoy_api_v2.DiscoveryRequest) logrus.Fields {
 	return logrus.Fields{
 		logfields.XDSAckedVersion: req.GetVersionInfo(),
-		logfields.XDSClientNode:   req.GetNode().GetId(),
 		logfields.XDSTypeURL:      req.GetTypeUrl(),
 		logfields.XDSNonce:        req.GetResponseNonce(),
 	}
@@ -143,6 +142,8 @@ func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, default
 
 	stopRecv := make(chan struct{})
 	defer close(stopRecv)
+
+	nodeId := ""
 
 	go func() {
 		defer close(reqCh)
@@ -165,7 +166,12 @@ func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, default
 			if req.GetTypeUrl() == "" {
 				req.TypeUrl = defaultTypeURL
 			}
+			if nodeId == "" {
+				nodeId = req.GetNode().GetId()
+				streamLog = streamLog.WithField(logfields.XDSClientNode, nodeId)
+			}
 			streamLog.WithFields(getXDSRequestFields(req)).Debug("received request from xDS stream")
+
 			select {
 			case <-stopRecv:
 				streamLog.Debug("stopping xDS stream handling")
@@ -259,6 +265,8 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 
 	streamLog.Info("starting xDS stream processing")
 
+	nodeIP := ""
+
 	for {
 		// Process either a new request from the xDS stream or a response
 		// from the resource watcher.
@@ -276,6 +284,18 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			}
 
 			req := recv.Interface().(*envoy_api_v2.DiscoveryRequest)
+
+			// only require Node to exist in the first request
+			if nodeIP == "" {
+				id := req.GetNode().GetId()
+				streamLog = streamLog.WithField(logfields.XDSClientNode, id)
+				var err error
+				nodeIP, err = IstioNodeToIP(id)
+				if err != nil {
+					streamLog.WithError(err).Error("invalid Node in xDS request")
+					return ErrInvalidNodeFormat
+				}
+			}
 
 			requestLog := streamLog.WithFields(getXDSRequestFields(req))
 
@@ -320,12 +340,6 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
-
-			nodeIP, err := IstioNodeToIP(req.GetNode())
-			if err != nil {
-				requestLog.WithError(err).Error("invalid Node in xDS request")
-				return ErrInvalidNodeFormat
-			}
 
 			// Response nonce is always the same as the response version.
 			// Request version indicates the last acked version. If the


### PR DESCRIPTION
Backported:
 * #12522 -- envoy: Require Node only on the first request of a stream
 * #13332 -- Envoy: Update to release 1.14.5 (@jrajahalme)

Skipped this time due to conflicts:
 * #11338 -- test: Support singleton manifests (@tgraf)
 * #13267 -- helm: configurable nodeSelector and tolerations for all charts (@mvisonneau)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12522 13332; do contrib/backporting/set-labels.py $pr done 1.7; done
```