### PR TITLE
helm: Always respect global.identityAllocationMode

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -93,11 +93,7 @@ data:
   #   backend. Upgrades from these older cilium versions should continue using
   #   the kvstore by commenting out the identity-allocation-mode below, or
   #   setting it to "kvstore".
-{{- if .Values.global.etcd.enabled }}
-  identity-allocation-mode: kvstore
-{{- else }}
   identity-allocation-mode: {{ .Values.global.identityAllocationMode }}
-{{- end }}
 {{- if .Values.global.identityHeartbeatTimeout }}
   identity-heartbeat-timeout: "{{ .Values.global.identityHeartbeatTimeout }}"
 {{- end }}


### PR DESCRIPTION
This option was not being respected in the case where the user enables
etcd configuration. In this case, when also configuring Cluster Mesh, it
is important to manage identities via the kvstore to ensure that remote
clusters have access to the identities of the local cluster. However,
for users who are not using Cluster Mesh, it is reasonable to run Cilium
with identities managed via CRDs, and deployments may already be
deployed in this way. Failing to respect the option means that users who
upgrade may observe temporary dataplane upgrade during upgrade due to
the transition from CRD to kvstore for identity management.

To prevent unintentional dataplane outage during upgrade from earlier
releases, revert the helm changes from commit 8c9539205ed ("doc: Fix
clustermesh documentation to set the correct identityMode").

The above commit already clarified the instructions for clustermesh
users, which was the main goal of that commit so no other changes are
necessary in this commit.

Fixes: 8c9539205ed ("doc: Fix clustermesh documentation to set the correct identityMode")
Reported-by: Dan Sexton <dan.b.sexton@gmail.com>