### PR TITLE
docs: mention install/upgrade.rst in contrib guide

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -97,6 +97,8 @@ requirements have been met:
 
 #. All commits are signed off. See the section :ref:`dev_coo`.
 
+#. Document any user-facing or breaking changes in ``Documentation/install/upgrade.rst``.
+
 #. (optional) Pick the appropriate milestone for which this PR is being
    targeted, e.g. ``1.6``, ``1.7``. This is in particular important in the time
    frame between the feature freeze and final release date.


### PR DESCRIPTION
I couldn't find any reference to `upgrade.rst` in 'How To Contribute' or anywhere else in the repo. Adding it might help improve the experience for first-time contributors and reduce the need for pointing out `upgrade.rst` to newbies. :slightly_smiling_face: 