### PR TITLE
bpf: add metrics for fragmented ipv4 packets

### DIFF
--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -226,8 +226,9 @@ enum Verdict {
     ERROR = 3;
 }
 
-// Taken from pkg/monitor/api/drop.go. Note that non-drop reasons (i.e. values
-// less than api.DropMin) are not used here.
+// These values are shared with pkg/monitor/api/drop.go and bpf/lib/common.h.
+// Note that non-drop reasons (i.e. values less than api.DropMin) are not used
+// here.
 enum DropReason {
     // non-drop reasons
     DROP_REASON_UNKNOWN = 0;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -7,6 +7,8 @@
 #include <ep_config.h>
 #include <node_config.h>
 
+#include <bpf/verifier.h>
+
 #include <linux/icmpv6.h>
 
 #define EVENT_SOURCE LXC_ID
@@ -1152,6 +1154,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	/* Check it this is return traffic to an egress proxy.
 	 * Do not redirect again if the packet is coming from the egress proxy.
 	 */
+	relax_verifier();
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect &&
 	    !tc_index_skip_egress_proxy(ctx)) {
 		/* This is a reply, the proxy port does not need to be embedded

--- a/bpf/include/bpf/verifier.h
+++ b/bpf/include/bpf/verifier.h
@@ -4,7 +4,7 @@
 #ifndef __BPF_VERIFIER__
 #define __BPF_VERIFIER__
 
-#include "csum.h"
+#include "compiler.h"
 
 /* relax_verifier is a dummy helper call to introduce a pruning checkpoint
  * to help relax the verifier to avoid reaching complexity limits on older
@@ -13,9 +13,7 @@
 static __always_inline void relax_verifier(void)
 {
 #ifdef NEEDS_RELAX_VERIFIER
-       int foo = 0;
-
-       csum_diff(0, 0, &foo, 1, 0);
+       volatile int __maybe_unused id = get_smp_processor_id();
 #endif
 }
 

--- a/bpf/include/bpf/verifier.h
+++ b/bpf/include/bpf/verifier.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2016-2020 Authors of Cilium */
+
+#ifndef __BPF_VERIFIER__
+#define __BPF_VERIFIER__
+
+#include "csum.h"
+
+/* relax_verifier is a dummy helper call to introduce a pruning checkpoint
+ * to help relax the verifier to avoid reaching complexity limits on older
+ * kernels.
+ */
+static __always_inline void relax_verifier(void)
+{
+#ifdef NEEDS_RELAX_VERIFIER
+       int foo = 0;
+
+       csum_diff(0, 0, &foo, 1, 0);
+#endif
+}
+
+#endif /* __BPF_VERIFIER__ */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -401,8 +401,9 @@ enum {
 #define LB_LOOKUP_SCOPE_INT	1
 
 /* Cilium metrics direction for dropping/forwarding packet */
+#define METRIC_EGRESS   0
 #define METRIC_INGRESS  1
-#define METRIC_EGRESS   2
+#define METRIC_SERVICE  2
 
 /* Magic ctx->mark identifies packets origination and encryption status.
  *

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -328,6 +328,9 @@ enum {
 /* Cilium error codes, must NOT overlap with TC return codes.
  * These also serve as drop reasons for metrics,
  * where reason > 0 corresponds to -(DROP_*)
+ *
+ * These are shared with pkg/monitor/api/drop.go and api/v1/flow/flow.proto.
+ * When modifying any of the below, those files should also be updated.
  */
 #define DROP_UNUSED1		-130 /* unused */
 #define DROP_UNUSED2		-131 /* unused */
@@ -387,6 +390,9 @@ enum {
 /* Cilium metrics reasons for forwarding packets and other stats.
  * If reason is larger than below then this is a drop reason and
  * value corresponds to -(DROP_*), see above.
+ *
+ * These are shared with pkg/monitor/api/drop.go.
+ * When modifying any of the below, those files should also be updated.
  */
 #define REASON_FORWARDED		0
 #define REASON_PLAINTEXT		3
@@ -395,6 +401,8 @@ enum {
 #define REASON_LB_NO_BACKEND		6
 #define REASON_LB_REVNAT_UPDATE		7
 #define REASON_LB_REVNAT_STALE		8
+#define REASON_FRAG_PACKET		9
+#define REASON_FRAG_PACKET_UPDATE	10
 
 /* Lookup scope for externalTrafficPolicy=Local */
 #define LB_LOOKUP_SCOPE_EXT	0

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -7,6 +7,8 @@
 #include <linux/icmpv6.h>
 #include <linux/icmp.h>
 
+#include <bpf/verifier.h>
+
 #include "common.h"
 #include "utils.h"
 #include "ipv4.h"
@@ -206,6 +208,8 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 {
 	struct ct_entry *entry;
 	int reopen;
+
+	relax_verifier();
 
 	entry = map_lookup_elem(map, tuple);
 	if (entry) {
@@ -665,6 +669,8 @@ static __always_inline int ct_lookup4(const void *map,
 		}
 		goto out;
 	}
+
+	relax_verifier();
 
 	/* Lookup entry in forward direction */
 	if (dir != CT_SERVICE) {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -535,14 +535,14 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_CT_INVALID_HDR;
 
-	if (unlikely(ipv4_is_fragment(ip4)))
-		return ipv4_handle_fragment(ctx, ip4, off, dir,
-					    (struct ipv4_frag_l4ports *)&tuple->dport,
-					    has_l4_header);
-#endif
+	return ipv4_handle_fragmentation(ctx, ip4, off, dir,
+				    (struct ipv4_frag_l4ports *)&tuple->dport,
+				    has_l4_header);
+#else
 	/* load sport + dport into tuple */
 	if (ctx_load_bytes(ctx, off, &tuple->dport, 4) < 0)
 		return DROP_CT_INVALID_HDR;
+#endif
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -517,6 +517,7 @@ ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 
 static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 						    int off,
+						    int dir __maybe_unused,
 						    struct ipv4_ct_tuple *tuple,
 						    bool *has_l4_header __maybe_unused)
 {
@@ -531,7 +532,7 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 		return DROP_CT_INVALID_HDR;
 
 	if (unlikely(ipv4_is_fragment(ip4)))
-		return ipv4_handle_fragment(ctx, ip4, off,
+		return ipv4_handle_fragment(ctx, ip4, off, dir,
 					    (struct ipv4_frag_l4ports *)&tuple->dport,
 					    has_l4_header);
 #endif
@@ -616,7 +617,7 @@ static __always_inline int ct_lookup4(const void *map,
 		break;
 
 	case IPPROTO_TCP:
-		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, &has_l4_header);
+		err = ipv4_ct_extract_l4_ports(ctx, off, dir, tuple, &has_l4_header);
 		if (err < 0)
 			return err;
 
@@ -632,7 +633,7 @@ static __always_inline int ct_lookup4(const void *map,
 		break;
 
 	case IPPROTO_UDP:
-		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, NULL);
+		err = ipv4_ct_extract_l4_ports(ctx, off, dir, tuple, NULL);
 		if (err < 0)
 			return err;
 

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -7,6 +7,7 @@
 #include <linux/ip.h>
 
 #include "dbg.h"
+#include "metrics.h"
 
 struct ipv4_frag_id {
 	__be32	daddr;
@@ -107,7 +108,7 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 }
 
 static __always_inline int
-ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off,
+ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off, int dir,
 			    const struct ipv4_frag_id *frag_id,
 			    struct ipv4_frag_l4ports *ports)
 {
@@ -117,7 +118,9 @@ ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off,
 	if (ret < 0)
 		return ret;
 
-	map_update_elem(&IPV4_FRAG_DATAGRAMS_MAP, frag_id, ports, BPF_ANY);
+	if (map_update_elem(&IPV4_FRAG_DATAGRAMS_MAP, frag_id, ports, BPF_ANY))
+		update_metrics(ctx_full_len(ctx), dir, REASON_FRAG_PACKET_UPDATE);
+
 	/* Do not return an error if map update failed, as nothing prevents us
 	 * to process the current packet normally.
 	 */
@@ -126,7 +129,7 @@ ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off,
 
 static __always_inline int
 ipv4_handle_fragment(struct __ctx_buff *ctx,
-		     const struct iphdr *ip4, int l4_off,
+		     const struct iphdr *ip4, int l4_off, int dir,
 		     struct ipv4_frag_l4ports *ports,
 		     bool *has_l4_header)
 {
@@ -140,6 +143,8 @@ ipv4_handle_fragment(struct __ctx_buff *ctx,
 		.pad = 0,
 	};
 
+	update_metrics(ctx_full_len(ctx), dir, REASON_FRAG_PACKET);
+
 	not_first_fragment = ipv4_is_not_first_fragment(ip4);
 	if (has_l4_header)
 		*has_l4_header = !not_first_fragment;
@@ -151,7 +156,7 @@ ipv4_handle_fragment(struct __ctx_buff *ctx,
 	 * we receive). Fragment has L4 header, we can retrieve L4 ports and
 	 * create an entry in datagrams map.
 	 */
-	return ipv4_frag_register_datagram(ctx, l4_off, &frag_id, ports);
+	return ipv4_frag_register_datagram(ctx, l4_off, dir, &frag_id, ports);
 }
 #endif
 

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -340,7 +340,9 @@ bool lb4_svc_is_localredirect(const struct lb4_service *svc __maybe_unused)
 }
 
 static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
-					   int l4_off, __be16 *port,
+					   int l4_off,
+					   int dir __maybe_unused,
+					   __be16 *port,
 					   __maybe_unused struct iphdr *ip4)
 {
 	int ret;
@@ -354,7 +356,7 @@ static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 
 			if (unlikely(ipv4_is_fragment(ip4))) {
 				ret = ipv4_handle_fragment(ctx, ip4, l4_off,
-							   &ports,
+							   dir, &ports,
 							   NULL);
 				if (IS_ERR(ret))
 					return ret;
@@ -513,7 +515,8 @@ static __always_inline int lb6_extract_key(struct __ctx_buff *ctx __maybe_unused
 	ipv6_addr_copy(&key->address, addr);
 	csum_l4_offset_and_flags(tuple->nexthdr, csum_off);
 
-	return extract_l4_port(ctx, tuple->nexthdr, l4_off, &key->dport, NULL);
+	return extract_l4_port(ctx, tuple->nexthdr, l4_off, dir, &key->dport,
+			       NULL);
 }
 
 static __always_inline
@@ -1033,7 +1036,7 @@ static __always_inline int lb4_extract_key(struct __ctx_buff *ctx __maybe_unused
 	if (ipv4_has_l4_header(ip4))
 		csum_l4_offset_and_flags(ip4->protocol, csum_off);
 
-	return extract_l4_port(ctx, ip4->protocol, l4_off, &key->dport, ip4);
+	return extract_l4_port(ctx, ip4->protocol, l4_off, dir, &key->dport, ip4);
 }
 
 static __always_inline

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -354,15 +354,12 @@ static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 		if (ip4) {
 			struct ipv4_frag_l4ports ports = { };
 
-			if (unlikely(ipv4_is_fragment(ip4))) {
-				ret = ipv4_handle_fragment(ctx, ip4, l4_off,
-							   dir, &ports,
-							   NULL);
-				if (IS_ERR(ret))
-					return ret;
-				*port = ports.dport;
-				break;
-			}
+			ret = ipv4_handle_fragmentation(ctx, ip4, l4_off,
+							dir, &ports, NULL);
+			if (IS_ERR(ret))
+				return ret;
+			*port = ports.dport;
+			break;
 		}
 #endif
 		/* Port offsets for UDP and TCP are the same */

--- a/bpf/tests/ipv6_test.h
+++ b/bpf/tests/ipv6_test.h
@@ -2,8 +2,6 @@
 /* Copyright (C) 2018-2020 Authors of Cilium */
 
 #include "lib/ipv6.h"
-
-#define SKIP_UNDEF_LPM_LOOKUP_FN
 #include "lib/maps.h"
 
 static void test_ipv6_addr_clear_suffix(void)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1281,6 +1281,10 @@ func initEnv(cmd *cobra.Command) {
 			}
 		}
 	}
+
+	if !probes.NewProbeManager().GetMisc().HaveLargeInsnLimit {
+		option.Config.NeedsRelaxVerifier = true
+	}
 }
 
 func (d *Daemon) initKVStore() {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -190,6 +190,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if option.Config.NeedsRelaxVerifier {
+		cDefinesMap["NEEDS_RELAX_VERIFIER"] = "1"
+	}
+
 	cDefinesMap["TRACE_PAYLOAD_LEN"] = fmt.Sprintf("%dULL", option.Config.TracePayloadlen)
 	cDefinesMap["MTU"] = fmt.Sprintf("%d", cfg.MtuConfig.GetDeviceMTU())
 

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -131,11 +131,17 @@ type MapTypes struct {
 	HaveStackMapType               bool `json:"have_stack_map_type"`
 }
 
+// Misc contains bools exposing miscellaneous eBPF features.
+type Misc struct {
+	HaveLargeInsnLimit bool `json:"have_large_insn_limit"`
+}
+
 // Features contains BPF feature checks returned by bpftool.
 type Features struct {
 	SystemConfig `json:"system_config"`
 	MapTypes     `json:"map_types"`
 	Helpers      map[string][]string `json:"helpers"`
+	Misc         `json:"misc"`
 }
 
 // ProbeManager is a manager of BPF feature checks.
@@ -287,6 +293,11 @@ func (p *ProbeManager) GetOptionalConfig() map[KernelParam]bool {
 // GetMapTypes returns information about supported BPF map types.
 func (p *ProbeManager) GetMapTypes() *MapTypes {
 	return &p.features.MapTypes
+}
+
+// GetMisc returns information about miscellaneous eBPF features.
+func (p *ProbeManager) GetMisc() *Misc {
+	return &p.features.Misc
 }
 
 // GetHelpers returns information about available BPF helpers for the given

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -48,19 +48,21 @@ const (
 	// of 2**16 (2 uint8) to 2**10 (1 uint8 + 2 bits).
 	MaxEntries = 1024
 	// dirIngress and dirEgress values should match with
-	// METRIC_INGRESS and METRIC_EGRESS in bpf/lib/common.h
+	// METRIC_INGRESS, METRIC_EGRESS and METRIC_SERVICE
+	// in bpf/lib/common.h
+	dirEgress  = 0
 	dirIngress = 1
-	dirEgress  = 2
-	dirUnknown = 0
+	dirService = 2
 )
 
-// direction is the metrics direction i.e ingress (to an endpoint)
-// or egress (from an endpoint). If it's none of the above, we return
-// UNKNOWN direction.
+// direction is the metrics direction i.e ingress (to an endpoint),
+// egress (from an endpoint) or service (NodePort service being accessed from
+// outside or a ClusterIP service being accessed from inside the cluster).
+// If it's none of the above, we return UNKNOWN direction.
 var direction = map[uint8]string{
-	dirUnknown: "UNKNOWN",
-	dirIngress: "INGRESS",
 	dirEgress:  "EGRESS",
+	dirIngress: "INGRESS",
+	dirService: "SERVICE",
 }
 
 type pad3uint16 [3]uint16
@@ -123,13 +125,10 @@ func (k *Key) String() string {
 
 // MetricDirection gets the direction in human readable string format
 func MetricDirection(dir uint8) string {
-	switch dir {
-	case dirIngress:
-		return direction[dir]
-	case dirEgress:
-		return direction[dir]
+	if desc, ok := direction[dir]; ok {
+		return desc
 	}
-	return direction[dirUnknown]
+	return "UNKNOWN"
 }
 
 // Direction gets the direction in human readable string format

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -24,6 +24,7 @@ var DropMin uint8 = 130
 // DropInvalid is the Invalid packet reason.
 var DropInvalid uint8 = 2
 
+// These values are shared with bpf/lib/common.h and api/v1/flow/flow.proto.
 var errors = map[uint8]string{
 	0:   "Success",
 	2:   "Invalid packet",
@@ -33,6 +34,8 @@ var errors = map[uint8]string{
 	6:   "LB, sock cgroup: No backend entry found",
 	7:   "LB, sock cgroup: Reverse entry update failed",
 	8:   "LB, sock cgroup: Reverse entry stale",
+	9:   "Fragmented packet",
+	10:  "Fragmented packet entry update failed",
 	130: "Invalid source mac",      // Unused
 	131: "Invalid destination mac", // Unused
 	132: "Invalid source ip",

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2042,6 +2042,11 @@ type DaemonConfig struct {
 	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
 	// available.
 	CRDWaitTimeout time.Duration
+
+	// NeedsRelaxVerifier enables the relax_verifier() helper which is used
+	// to introduce state pruning points for the verifier in the datapath
+	// program.
+	NeedsRelaxVerifier bool
 }
 
 var (

--- a/test/bpf/unit-test.c
+++ b/test/bpf/unit-test.c
@@ -8,6 +8,14 @@
 #include <stdlib.h>
 
 #include "lib/utils.h"
+
+/* SKIP_UNDEF_LPM_LOOKUP_FN is used to control if the LPM_LOOKUP_FN macro in
+ * lib/maps.h should be defined or not.
+ *
+ * As lib/common.h includes in turn lib/maps.h, define SKIP_UNDEF_LPM_LOOKUP_FN
+ * here since unit tests require the LPM_LOOKUP_FN macro to be defined.
+ */
+#define SKIP_UNDEF_LPM_LOOKUP_FN
 #include "lib/common.h"
 
 #include "node_config.h"

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -15,7 +15,9 @@
 package helpers
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -188,4 +190,13 @@ func OpenSSLShowCerts(host string, port uint16, serverName string) string {
 		serverNameFlag = fmt.Sprintf("-servername %q", serverName)
 	}
 	return fmt.Sprintf("openssl s_client -connect %s:%d %s -showcerts | openssl x509 -outform PEM", host, port, serverNameFlag)
+}
+
+// GetBPFPacketsCount returns the number of packets for a given drop reason and
+// direction by parsing BPF metrics.
+func GetBPFPacketsCount(kubectl *Kubectl, pod, reason, direction string) (int, error) {
+	cmd := fmt.Sprintf("cilium bpf metrics list | awk '/%s *%s/ {print $4}'", reason, direction)
+	res := kubectl.CiliumExecMustSucceed(context.TODO(), pod, cmd)
+
+	return strconv.Atoi(strings.TrimSpace(res.Stdout()))
 }

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -753,7 +753,7 @@ var _ = Describe("K8sServicesTest", func() {
 		}
 
 		// srcPod:     Name of pod sending the datagram
-		// srcPort:    Source UDP port
+		// srcPort:    Source UDP port (should be different for each doFragmentRequest invocation to allow distinct CT table entries)
 		// dstPodIP:   Receiver pod IP (for checking in CT table)
 		// dstPodPort: Receiver pod port (for checking in CT table)
 		// dstIP:      Target endpoint IP for sending the datagram
@@ -818,6 +818,9 @@ var _ = Describe("K8sServicesTest", func() {
 				countOutK8s2, _ = strconv.Atoi(strings.TrimSpace(res.Stdout()))
 			}
 
+			fragmentedPacketsBeforeK8s1, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s1, "Fragmented packet", "INGRESS")
+			fragmentedPacketsBeforeK8s2, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s2, "Fragmented packet", "INGRESS")
+
 			// Send datagram
 			By("Sending a fragmented packet from %s to endpoint %s", srcPod, net.JoinHostPort(dstIP, fmt.Sprintf("%d", dstPort)))
 			cmd := fmt.Sprintf("bash -c 'dd if=/dev/zero bs=%d count=%d | nc -u -w 1 -p %d %s %d'", blockSize, blockCount, srcPort, dstIP, dstPort)
@@ -863,6 +866,14 @@ var _ = Describe("K8sServicesTest", func() {
 				Equal([]int{countOutK8s1, countOutK8s2 + delta}),
 				Equal([]int{countOutK8s1 + delta, countOutK8s2}),
 			), "Failed to account for IPv4 fragments to %s (out)", dstIP)
+
+			fragmentedPacketsAfterK8s1, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s1, "Fragmented packet", "INGRESS")
+			fragmentedPacketsAfterK8s2, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s2, "Fragmented packet", "INGRESS")
+
+			ExpectWithOffset(2, []int{fragmentedPacketsAfterK8s1, fragmentedPacketsAfterK8s2}).To(SatisfyAny(
+				Equal([]int{fragmentedPacketsBeforeK8s1, fragmentedPacketsBeforeK8s2 + delta}),
+				Equal([]int{fragmentedPacketsBeforeK8s1 + delta, fragmentedPacketsBeforeK8s2}),
+			), "Failed to account for INGRESS IPv4 fragments in BPF metrics", dstIP)
 		}
 
 		getIPv4AddrForIface := func(nodeName, iface string) string {


### PR DESCRIPTION
This commit introduces 2 new metrics in the datapath logic related to
fragmented IPv4 packets:

* `REASON_FRAG_PACKET`: number of received fragmented packets
* `REASON_FRAG_PACKET_UPDATE`: number of failures in updating the
`IPV4_FRAG_DATAGRAMS_MAP` map to register the first logical fragment of
a datagram

Regarding testing: I did a smoke test by running `make build_all` and I'm now waiting for e2e tests to finish