### PR TITLE
v1.8 backports 2020-09-30

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -79,11 +79,7 @@ data:
   #   backend. Upgrades from these older cilium versions should continue using
   #   the kvstore by commenting out the identity-allocation-mode below, or
   #   setting it to "kvstore".
-{{- if .Values.global.etcd.enabled }}
-  identity-allocation-mode: kvstore
-{{- else }}
   identity-allocation-mode: {{ .Values.global.identityAllocationMode }}
-{{- end }}
 {{- if .Values.global.identityHeartbeatTimeout }}
   identity-heartbeat-timeout: "{{ .Values.global.identityHeartbeatTimeout }}"
 {{- end }}


### PR DESCRIPTION
 * #13337 -- helm: Always respect global.identityAllocationMode (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13337; do contrib/backporting/set-labels.py $pr done 1.8; done
```