### PR TITLE
contrib: Improve start-release.sh script

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -59,7 +59,7 @@ main() {
     local new_proj="$2"
 
     git fetch $remote
-    git checkout -b pr/prepare-$version $remote/v$branch
+    git checkout -b pr/prepare-$version $remote/$branch
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
@@ -72,7 +72,7 @@ main() {
 
     logecho "Next steps:"
     logecho "* Check all changes and add to a new commit"
-    logecho "* Push the PR to Github for review"
+    logecho "* Push the PR to Github for review ('submit-release.sh')"
     logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
 


### PR DESCRIPTION
Due to an extra `v` in the branch name, this script would fail with:

```
  $ ~/git/cilium/contrib/release/start-release.sh v1.6.12 128
  fatal: 'origin/vv1.6' is not a commit and a branch 'pr/prepare-v1.6.12' cannot be created from it

  Signal ERR caught!

  Traceback (line function script):
  62 main /home/joe/git/cilium/contrib/release/start-release.sh
```

Fix it.

While we're at it, update the instructions at the end for next
steps, since there's also now a `submit-backport.sh` script to send the
PR from the CLI.