### PR TITLE
Move single-use symbols out of pkg/common

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
 	fakedatapath "github.com/cilium/cilium/pkg/datapath/fake"
@@ -147,7 +146,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	ds.d = d
 
-	kvstore.Client().DeletePrefix(context.TODO(), common.OperationalPath)
+	kvstore.Client().DeletePrefix(context.TODO(), kvstore.OperationalPath)
 	kvstore.Client().DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
 
 	ds.OnGetPolicyRepository = d.GetPolicyRepository
@@ -176,7 +175,7 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	}
 
 	if ds.kvstoreInit {
-		kvstore.Client().DeletePrefix(context.TODO(), common.OperationalPath)
+		kvstore.Client().DeletePrefix(context.TODO(), kvstore.OperationalPath)
 		kvstore.Client().DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
 	}
 

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -15,37 +15,11 @@
 package common
 
 const (
-	// Consul dedicated constants
-
-	// OperationalPath is the base path to store the operational details in the kvstore.
-	OperationalPath = "cilium-net/operational"
-
-	// ServicesKeyPath is the base path where services are stored in the kvstore.
-	ServicesKeyPath = OperationalPath + "/ServicesV2/SHA256SUMServices"
-	// ServicePathV1 is the base path for the services stored in the kvstore.
-	ServicePathV1 = OperationalPath + "/Services/"
-
 	// Miscellaneous dedicated constants
 
-	// NodeConfigFile is the name of the C header which contains the node's
-	// network parameters.
-	NodeConfigFile = "node_config.h"
 	// CHeaderFileName is the name of the C header file for BPF programs for a
 	// particular endpoint.
 	CHeaderFileName = "ep_config.h"
-	// OldCHeaderFileName is the previous name of the C header file for BPF
-	// programs for a particular endpoint. It can be removed once Cilium v1.8
-	// is the oldest supported version.
-	OldCHeaderFileName = "lxc_config.h"
-	// NetdevHeaderFileName is the name of the header file used for bpf_host.c and bpf_overlay.c.
-	NetdevHeaderFileName = "netdev_config.h"
-	// PreFilterHeaderFileName is the name of the header file used for bpf_xdp.c.
-	PreFilterHeaderFileName = "filter_config.h"
-	// HostObjFileName is the name of the host object file.
-	HostObjFileName = "bpf_host.o"
-	// CiliumCHeaderPrefix is the prefix using when printing/writing an endpoint in a
-	// base64 form.
-	CiliumCHeaderPrefix = "CILIUM_BASE64_"
 
 	// PossibleCPUSysfsPath is used to retrieve the number of CPUs for per-CPU maps.
 	PossibleCPUSysfsPath = "/sys/devices/system/cpu/possible"

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -89,32 +88,6 @@ func RequireRootPrivilege(cmd string) {
 		fmt.Fprintf(os.Stderr, "Please run %q command(s) with root privileges.\n", cmd)
 		os.Exit(1)
 	}
-}
-
-// MoveNewFilesTo copies all files, that do not exist in newDir, from oldDir.
-func MoveNewFilesTo(oldDir, newDir string) error {
-	oldFiles, err := ioutil.ReadDir(oldDir)
-	if err != nil {
-		return err
-	}
-	newFiles, err := ioutil.ReadDir(newDir)
-	if err != nil {
-		return err
-	}
-
-	for _, oldFile := range oldFiles {
-		exists := false
-		for _, newFile := range newFiles {
-			if oldFile.Name() == newFile.Name() {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			os.Rename(filepath.Join(oldDir, oldFile.Name()), filepath.Join(newDir, oldFile.Name()))
-		}
-	}
-	return nil
 }
 
 // MapStringStructToSlice returns a slice with all keys of the given

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -75,8 +75,15 @@ const (
 // time. It can only be accessed when GetCompilationLock() is being held.
 var firstInitialization = true
 
+const (
+	// netdevHeaderFileName is the name of the header file used for bpf_host.c and bpf_overlay.c.
+	netdevHeaderFileName = "netdev_config.h"
+	// preFilterHeaderFileName is the name of the header file used for bpf_xdp.c.
+	preFilterHeaderFileName = "filter_config.h"
+)
+
 func (l *Loader) writeNetdevHeader(dir string, o datapath.BaseProgramOwner) error {
-	headerPath := filepath.Join(dir, common.NetdevHeaderFileName)
+	headerPath := filepath.Join(dir, netdevHeaderFileName)
 	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
 
 	f, err := os.Create(headerPath)
@@ -94,7 +101,7 @@ func (l *Loader) writeNetdevHeader(dir string, o datapath.BaseProgramOwner) erro
 
 // Must be called with option.Config.EnablePolicyMU locked.
 func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
-	headerPath := filepath.Join(dir, common.PreFilterHeaderFileName)
+	headerPath := filepath.Join(dir, preFilterHeaderFileName)
 	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
 	f, err := os.Create(headerPath)
 	if err != nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -52,6 +52,15 @@ import (
 const (
 	// EndpointGenerationTimeout specifies timeout for proxy completion context
 	EndpointGenerationTimeout = 330 * time.Second
+
+	// OldCHeaderFileName is the previous name of the C header file for BPF
+	// programs for a particular endpoint. It can be removed once Cilium v1.8
+	// is the oldest supported version.
+	oldCHeaderFileName = "lxc_config.h"
+
+	// ciliumCHeaderPrefix is the prefix using when printing/writing an endpoint in a
+	// base64 form.
+	ciliumCHeaderPrefix = "CILIUM_BASE64_"
 )
 
 // policyMapPath returns the path to the policy map of endpoint.
@@ -86,7 +95,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		var verBase64 string
 		verBase64, err = version.Base64()
 		if err == nil {
-			fmt.Fprintf(fw, " * %s%s:%s\n * \n", common.CiliumCHeaderPrefix,
+			fmt.Fprintf(fw, " * %s%s:%s\n * \n", ciliumCHeaderPrefix,
 				verBase64, epStr64)
 		}
 	}
@@ -177,7 +186,7 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	// nonexistent file, only create the symlink if the header file
 	// creation/replacement file succeeded above.
 	if !e.IsHost() && err == nil {
-		oldHeaderPath := filepath.Join(prefix, common.OldCHeaderFileName)
+		oldHeaderPath := filepath.Join(prefix, oldCHeaderFileName)
 		if _, err := os.Stat(oldHeaderPath); err != nil {
 			// The symlink doesn't already exists.
 			if err := renameio.Symlink(common.CHeaderFileName, oldHeaderPath); err != nil {

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -1,0 +1,91 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package endpoint
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"gopkg.in/check.v1"
+)
+
+func (s *EndpointSuite) TestMoveNewFilesTo(c *check.C) {
+	oldDir := c.MkDir()
+	newDir := c.MkDir()
+	f1, err := ioutil.TempFile(oldDir, "")
+	c.Assert(err, check.IsNil)
+	f2, err := ioutil.TempFile(oldDir, "")
+	c.Assert(err, check.IsNil)
+	f3, err := ioutil.TempFile(newDir, "")
+	c.Assert(err, check.IsNil)
+
+	// Copy the same file in both directories to make sure the same files
+	// are not moved from the old directory into the new directory.
+	err = ioutil.WriteFile(filepath.Join(oldDir, "foo"), []byte(""), os.FileMode(0644))
+	c.Assert(err, check.IsNil)
+	err = ioutil.WriteFile(filepath.Join(newDir, "foo"), []byte(""), os.FileMode(0644))
+	c.Assert(err, check.IsNil)
+
+	compareDir := func(dir string, wantedFiles []string) {
+		files, err := ioutil.ReadDir(dir)
+		c.Assert(err, check.IsNil)
+		filesNames := make([]string, 0, len(wantedFiles))
+		for _, file := range files {
+			filesNames = append(filesNames, file.Name())
+		}
+		c.Assert(wantedFiles, checker.DeepEquals, filesNames)
+	}
+
+	type args struct {
+		oldDir string
+		newDir string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErr    bool
+		wantOldDir []string
+		wantNewDir []string
+	}{
+		{
+			name: "copying from one directory to the other",
+			args: args{
+				oldDir: oldDir,
+				newDir: newDir,
+			},
+			wantErr: false,
+			wantOldDir: []string{
+				"foo",
+			},
+			wantNewDir: []string{
+				f1.Name(),
+				f2.Name(),
+				f3.Name(),
+				"foo",
+			},
+		},
+	}
+	for _, tt := range tests {
+		if err := moveNewFilesTo(tt.args.oldDir, tt.args.newDir); (err != nil) != tt.wantErr {
+			c.Assert(err != nil, check.Equals, tt.wantErr)
+			compareDir(tt.args.oldDir, tt.wantOldDir)
+			compareDir(tt.args.newDir, tt.wantNewDir)
+		}
+	}
+}

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -44,7 +44,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// getCiliumVersionString returns the first line containing common.CiliumCHeaderPrefix.
+// getCiliumVersionString returns the first line containing ciliumCHeaderPrefix.
 func getCiliumVersionString(epCHeaderFilePath string) ([]byte, error) {
 	f, err := os.Open(epCHeaderFilePath)
 	if err != nil {
@@ -60,14 +60,17 @@ func getCiliumVersionString(epCHeaderFilePath string) ([]byte, error) {
 		if err != nil {
 			return []byte{}, err
 		}
-		if bytes.Contains(b, []byte(common.CiliumCHeaderPrefix)) {
+		if bytes.Contains(b, []byte(ciliumCHeaderPrefix)) {
 			return b, nil
 		}
 	}
 }
 
+// hostObjFileName is the name of the host object file.
+const hostObjFileName = "bpf_host.o"
+
 func hasHostObjectFile(epDir string) bool {
-	hostObjFilepath := filepath.Join(epDir, common.HostObjFileName)
+	hostObjFilepath := filepath.Join(epDir, hostObjFileName)
 	_, err := os.Stat(hostObjFilepath)
 	return err == nil
 }
@@ -101,7 +104,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, basePath
 		// the new.
 		// We can switch this to use the new header file once v1.8 is the
 		// oldest supported version.
-		cHeaderFile := filepath.Join(epDir, common.OldCHeaderFileName)
+		cHeaderFile := filepath.Join(epDir, oldCHeaderFileName)
 		if isHost {
 			// Host endpoint doesn't have an old header file so that it's not
 			// restored on downgrades.

--- a/pkg/kvstore/backwards_compat.go
+++ b/pkg/kvstore/backwards_compat.go
@@ -14,10 +14,14 @@
 
 package kvstore
 
-import (
-	"context"
+import "context"
 
-	"github.com/cilium/cilium/pkg/common"
+const (
+	// OperationalPath is the base path to store the operational details in the kvstore.
+	OperationalPath = "cilium-net/operational"
+
+	// servicePathV1 is the base path for the services stored in the kvstore.
+	servicePathV1 = OperationalPath + "/Services/"
 )
 
 // deleteLegacyPrefixes removes old kvstore prefixes of non-persistent keys
@@ -35,5 +39,5 @@ import (
 //
 func deleteLegacyPrefixes(ctx context.Context) {
 	// Delete all keys in old services prefix
-	Client().DeletePrefix(ctx, common.ServicePathV1)
+	Client().DeletePrefix(ctx, servicePathV1)
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2058,9 +2058,13 @@ func (c *DaemonConfig) IsPodSubnetsDefined() bool {
 	return len(c.IPv4PodSubnets) > 0 || len(c.IPv6PodSubnets) > 0
 }
 
+// NodeConfigFile is the name of the C header which contains the node's
+// network parameters.
+const nodeConfigFile = "node_config.h"
+
 // GetNodeConfigPath returns the full path of the NodeConfigFile.
 func (c *DaemonConfig) GetNodeConfigPath() string {
-	return filepath.Join(c.GetGlobalsDir(), common.NodeConfigFile)
+	return filepath.Join(c.GetGlobalsDir(), nodeConfigFile)
 }
 
 // GetGlobalsDir returns the path for the globals directory.


### PR DESCRIPTION
Packages like _common_ or _util_ usually become a dumping ground for all sorts of unrelated code, see e.g. https://dave.cheney.net/2019/01/08/avoid-package-names-like-base-util-or-common

Thus, slim down `pkg/common` a bit by moving funcs and consts used only by a single package to that respective package and also un-export them.