### PR TITLE
test: further increase range of accepted values for bandwidth test

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -321,9 +321,7 @@ func (res *CmdRes) FloatOutput() (float64, error) {
 }
 
 // InRange returns nil if res matches the expected value range or error otherwise
-func (res *CmdRes) InRange(expectedValue, maxDeviation int) error {
-	min := expectedValue - maxDeviation
-	max := expectedValue + maxDeviation
+func (res *CmdRes) InRange(min, max int) error {
 	raw, err := res.FloatOutput()
 	if err != nil {
 		return err

--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -31,7 +31,8 @@ var _ = Describe("K8sBandwidthTest", func() {
 		testClientPod  = "run=netperf-client-pod"
 		testClientHost = "run=netperf-client-host"
 
-		maxRateDeviation = 7
+		maxRateDeviation = 5
+		minBandwidth     = 1
 	)
 
 	var (
@@ -122,7 +123,7 @@ var _ = Describe("K8sBandwidthTest", func() {
 						"Request from %s pod to pod with IP %s failed", pod, targetIP)
 					By("Session test completed, netperf result raw: %s", res.SingleOut())
 					if rate > 0 {
-						ExpectWithOffset(1, res.InRange(rate, maxRateDeviation)).To(BeNil(),
+						ExpectWithOffset(1, res.InRange(minBandwidth, rate+maxRateDeviation)).To(BeNil(),
 							"Rate mismatch")
 					}
 				}


### PR DESCRIPTION
Our current range for the 25Mbps target is [18; 32]. We seem to always
fall short of the 18 bound.

Expected cases of regressions are likely to be either a lack of
connectivity or a lack of rate limiting. So with a range [1; 30] we're
likely to catch most regression cases without missing on cases where
there's no rate limiting (which we could miss if we keep increase the
whole range).

Fixes: #13062
Co-authored-by: Daniel Borkmann <daniel@iogearbox.net>
Signed-off-by: Paul Chaignon <paul@cilium.io>