### PR TITLE
datapath/connector: remove unused funcs

### DIFF
--- a/pkg/datapath/connector/add.go
+++ b/pkg/datapath/connector/add.go
@@ -17,16 +17,12 @@ package connector
 import (
 	"crypto/sha256"
 	"fmt"
-	"net"
 
-	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/sysctl"
 
-	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
@@ -70,93 +66,4 @@ func truncateString(epID string, maxLen uint) string {
 // DisableRpFilter tries to disable rpfilter on specified interface
 func DisableRpFilter(ifName string) error {
 	return sysctl.Disable(fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName))
-}
-
-// GetNetInfoFromPID returns the index of the interface parent, the MAC address
-// and IP address of the first interface that contains an IP address with global
-// scope.
-func GetNetInfoFromPID(pid int) (int, string, net.IP, error) {
-	netNs, err := ns.GetNS(fmt.Sprintf("/proc/%d/ns/net", pid))
-	if err != nil {
-		return 0, "", nil, err
-	}
-	defer netNs.Close()
-
-	var (
-		lxcMAC      string
-		parentIndex int
-		ip          net.IP
-	)
-
-	err = netNs.Do(func(_ ns.NetNS) error {
-		links, err := netlink.LinkList()
-		if err != nil {
-			return err
-		}
-		for _, l := range links {
-			addrs, err := netlink.AddrList(l, netlink.FAMILY_V4)
-			if err != nil {
-				return err
-			}
-			for _, addr := range addrs {
-				if addr.IP.IsGlobalUnicast() {
-					ip = addr.IP
-					lxcMAC = l.Attrs().HardwareAddr.String()
-					parentIndex = l.Attrs().ParentIndex
-					log.Debugf("link found: %+v", l.Attrs())
-					return nil
-				}
-			}
-		}
-		return nil
-	})
-	return parentIndex, lxcMAC, ip, err
-}
-
-// GetVethInfo populates the given endpoint with the arguments provided where
-// * nodeIfName - Node Interface Name
-// * parentIdx - Interface Index of the container veth pair in the host side.
-// * netNSMac - MAC address of the veth pair in the container side.
-func GetVethInfo(nodeIfName string, parentIdx int, netNSMac string, ep *models.EndpointChangeRequest) error {
-	nodeVet, err := netlink.LinkByName(nodeIfName)
-	if err != nil {
-		return fmt.Errorf("unable to lookup veth just created: %s", err)
-	}
-	l, err := netlink.LinkByIndex(parentIdx)
-	if err != nil {
-		return err
-	}
-	ep.Mac = netNSMac
-	ep.HostMac = nodeVet.Attrs().HardwareAddr.String()
-	ep.InterfaceIndex = int64(parentIdx)
-	ep.InterfaceName = l.Attrs().Name
-	return nil
-}
-
-func DeriveEndpointFrom(hostDevice, containerID string, pid int) (*models.EndpointChangeRequest, error) {
-	parentIdx, lxcMAC, ip, err := GetNetInfoFromPID(pid)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get net info from PID %d: %s", pid, err)
-	}
-	if parentIdx == 0 {
-		return nil, fmt.Errorf("unable to find master index interface for %s: %s", ip, err)
-	}
-	// _, ip6, err := ipam.AllocateNext("ipv6")
-	// if err != nil {
-	// 	return nil, fmt.Errorf("unable to allocate IPv6 address: %s", err)
-	// }
-	epModel := &models.EndpointChangeRequest{
-		Addressing: &models.AddressPair{
-			IPV4: ip.String(),
-			// IPV6: ip6.String(),
-		},
-		ContainerID: containerID,
-		State:       models.EndpointStateWaitingForIdentity,
-	}
-	err = GetVethInfo(hostDevice, parentIdx, lxcMAC, epModel)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get veth info: %s", err)
-
-	}
-	return epModel, nil
 }

--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -141,9 +141,3 @@ func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.Endpoin
 
 	return veth, &peer, nil
 }
-
-// CheckLink returns an error if a link with linkName does not exist.
-func CheckLink(linkName string) error {
-	_, err := netlink.LinkByName(linkName)
-	return err
-}


### PR DESCRIPTION
The last remaining user of `DeriveEndpointFrom` was removed by commit
532ad9d44a6f ("rm pkg/workloads"). `GetNetInfoFromPID` and `GetVethInfo`
were only used by `DeriveEndpointFrom`, so remove them as well.

Also move the single-use function `CheckLink` to where it is used.