### PR TITLE
Follow-up for `cilium ip list` identity lookup

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -245,7 +245,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium bpf policy get --all --numeric",
 		"cilium bpf sha list",
 		"cilium bpf fs show",
-		"cilium ip list -o json",
+		"cilium ip list -n -o json",
 		"cilium map list --verbose",
 		"cilium service list",
 		"cilium status --verbose",

--- a/cilium/cmd/identity_get.go
+++ b/cilium/cmd/identity_get.go
@@ -77,7 +77,7 @@ var identityGetCmd = &cobra.Command{
 
 			params := identityApi.NewGetIdentityIDParams().WithID(args[0]).WithTimeout(api.ClientTimeout)
 			if id, err := client.Policy.GetIdentityID(params); err != nil {
-				Fatalf("Cannot get identity for given ID %s: %s\n", id, err)
+				Fatalf("Cannot get identity for given ID %s: %s\n", args[0], err)
 			} else {
 				printIdentities([]*models.Identity{id.Payload})
 			}


### PR DESCRIPTION
Follow-up for #13304 to address review comments post-merge, namely https://github.com/cilium/cilium/pull/13304#issuecomment-700314189 and https://github.com/cilium/cilium/pull/13304#issuecomment-700314867.

The main change is the lookup of all known identities in `cilium ip list` by default, leading to output such as:

```
$ cilium ip list
IP                              IDENTITY                                          SOURCE
0.0.0.0/0                       world                                             
::/0                            world                                             
10.0.2.15/32                    host                                              
10.11.0.78/32                   k8s:io.cilium.k8s.policy.cluster=default          k8s
                                k8s:k8s-app=kube-dns                              
                                k8s:io.kubernetes.pod.namespace=kube-system       
                                k8s:io.cilium.k8s.policy.serviceaccount=coredns   
10.11.0.90/32                   host                                              
10.11.0.116/32                  health                                            
10.11.1.123/32                  host                                              
10.11.1.251/32                  health                                            
192.168.33.11/32                host                                              
192.168.34.11/32                host                                              
fd00::b/128                     host                                              
fd00::2d7c/128                  health                                            
fd00::9998/128                  k8s:k8s-app=kube-dns                              k8s
                                k8s:io.kubernetes.pod.namespace=kube-system       
                                k8s:io.cilium.k8s.policy.serviceaccount=coredns   
                                k8s:io.cilium.k8s.policy.cluster=default          
fd00::e57e/128                  host                                              
fd00::1:e9b/128                 host                                              
fd00::1:8742/128                health                                            
fd01::b/128                     host                                              
fe80::ccf4:b3ff:fe16:de79/128   host 
```

See commit messages for details.