### PR TITLE
daemon: Enable configuration of iptables --random-fully

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,6 +107,7 @@ Juan Jimenez-Anca                       cortopy@users.noreply.github.com
 Julien Balestra                         julien.balestra@datadoghq.com
 Julien Kassar                           github@kassisol.com
 Junli Ou                                oujunli306@gmail.com
+Karl Heins                              karlheins@northwesternmutual.com
 Katarzyna Borkmann                      kasia@iogearbox.net
 Kevin Burke                             kevin@burke.dev
 Kiran Bondalapati                       kiran@bondalapati.com

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -132,6 +132,7 @@ cilium-agent [flags]
       --ipam string                                   Backend to use for IPAM (default "cluster-pool")
       --ipsec-key-file string                         Path to IPSec key file
       --iptables-lock-timeout duration                Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                         Set iptables flag random-fully on masquerading rules
       --ipv4-node string                              IPv4 address of node (default "auto")
       --ipv4-pod-subnets strings                      List of IPv4 pod subnets to preconfigure for encryption
       --ipv4-range string                             Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -613,6 +613,9 @@ func init() {
 	flags.Duration(option.IPTablesLockTimeout, 5*time.Second, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
 	option.BindEnv(option.IPTablesLockTimeout)
 
+	flags.Bool(option.IPTablesRandomFully, false, "Set iptables flag random-fully on masquerading rules")
+	option.BindEnv(option.IPTablesRandomFully)
+
 	flags.Int(option.MaxCtrlIntervalName, 0, "Maximum interval (in seconds) between controller runs. Zero is no limit.")
 	flags.MarkHidden(option.MaxCtrlIntervalName)
 	option.BindEnv(option.MaxCtrlIntervalName)

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -404,6 +404,10 @@ data:
   enable-xt-socket-fallback: {{ .Values.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.installIptablesRules | quote }}
 
+{{- if hasKey .Values "ipTablesRandomFully" }}
+  iptables-random-fully: {{ .Values.ipTablesRandomFully | quote }}
+{{- end }}
+
 {{- if hasKey .Values "iptablesLockTimeout" }}
   iptables-lock-timeout: {{ .Values.iptablesLockTimeout | quote }}
 {{- end }}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -946,18 +946,22 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			// * Non-tunnel mode:
 			//   * May not be targeted to an IP in the cluster range
 			if option.Config.EgressMasqueradeInterfaces != "" {
-				if err := runProg("iptables", append(
+				progArgs := append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
 					"!", "-d", datapath.RemoteSNATDstAddrExclusionCIDR().String(),
 					"-o", option.Config.EgressMasqueradeInterfaces,
 					"-m", "comment", "--comment", "cilium masquerade non-cluster",
-					"-j", "MASQUERADE"), false); err != nil {
+					"-j", "MASQUERADE")
+				if option.Config.IPTablesRandomFully {
+					progArgs = append(progArgs, "--random-fully")
+				}
+				if err := runProg("iptables", progArgs, false); err != nil {
 					return err
 				}
 			} else {
-				if err := runProg("iptables", append(
+				progArgs := append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
@@ -965,7 +969,11 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 					"!", "-d", datapath.RemoteSNATDstAddrExclusionCIDR().String(),
 					"!", "-o", "cilium_+",
 					"-m", "comment", "--comment", "cilium masquerade non-cluster",
-					"-j", "MASQUERADE"), false); err != nil {
+					"-j", "MASQUERADE")
+				if option.Config.IPTablesRandomFully {
+					progArgs = append(progArgs, "--random-fully")
+				}
+				if err := runProg("iptables", progArgs, false); err != nil {
 					return err
 				}
 			}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -320,6 +320,9 @@ const (
 
 	IPTablesLockTimeout = "iptables-lock-timeout"
 
+	// IPTablesRandomFully sets iptables flag random-fully on masquerading rules
+	IPTablesRandomFully = "iptables-random-fully"
+
 	// IPv6NodeAddr is the IPv6 address of node
 	IPv6NodeAddr = "ipv6-node"
 
@@ -1080,6 +1083,7 @@ var HelpFlagSections = []FlagsSection{
 			DisableIptablesFeederRules,
 			InstallIptRules,
 			IPTablesLockTimeout,
+			IPTablesRandomFully,
 		},
 	},
 	{
@@ -1513,6 +1517,10 @@ type DaemonConfig struct {
 	// IPTablesLockTimeout defines the "-w" iptables option when the
 	// iptables CLI is directly invoked from the Cilium agent.
 	IPTablesLockTimeout time.Duration
+
+	// IPTablesRandomFully defines the "--random-fully" iptables option when the
+	// iptables CLI is directly invoked from the Cilium agent.
+	IPTablesRandomFully bool
 
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
@@ -2490,6 +2498,7 @@ func (c *DaemonConfig) Populate() {
 	c.IPMasqAgentConfigPath = viper.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
 	c.IPTablesLockTimeout = viper.GetDuration(IPTablesLockTimeout)
+	c.IPTablesRandomFully = viper.GetBool(IPTablesRandomFully)
 	c.IPSecKeyFile = viper.GetString(IPSecKeyFileName)
 	c.ModePreFilter = viper.GetString(PrefilterMode)
 	c.EnableMonitor = viper.GetBool(EnableMonitorName)

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -267,6 +267,18 @@ var _ = Describe("K8sDatapathConfig", func() {
 					Should(BeTrue(), "Connectivity test to http://google.com failed")
 			}
 		})
+
+		It("Check iptables masquerading with random-fully", func() {
+			deploymentManager.DeployCilium(map[string]string{
+				"bpf.masquerade":      "false",
+				"ipTablesRandomFully": "true",
+			}, DeployCiliumOptionsAndDNS)
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+
+			By("Test iptables masquerading")
+			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
+				Should(BeTrue(), "Connectivity test to http://google.com failed")
+		})
 	})
 
 	Context("DirectRouting", func() {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #13037 

```release-note
Add a new daemon CLI argument, "--iptables-random-fully" to specify the
iptables "--random-fully" argument when invoking the iptables CLI binary
directly from cilium-agent.
```

