### PR TITLE
v1.8 backports 2020-10-02-2

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -35,7 +35,6 @@ import (
 	parserErrors "github.com/cilium/cilium/pkg/hubble/parser/errors"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/sirupsen/logrus"
 )
 
@@ -318,14 +317,6 @@ nextFlow:
 	}
 }
 
-func getUntil(req *observerpb.GetFlowsRequest, defaultTime *timestamp.Timestamp) (time.Time, error) {
-	until := req.GetUntil()
-	if until == nil {
-		until = defaultTime
-	}
-	return ptypes.Timestamp(until)
-}
-
 func logFilters(filters []*flowpb.FlowFilter) string {
 	var s []string
 	for _, f := range filters {
@@ -353,7 +344,7 @@ type flowsReader struct {
 	maxFlows             uint64
 	follow, timeRange    bool
 	flowsCount           uint64
-	start, end           time.Time
+	since, until         *time.Time
 }
 
 // newFlowsReader creates a new flowsReader that uses the given RingReader to
@@ -372,19 +363,25 @@ func newFlowsReader(r *container.RingReader, req *observerpb.GetFlowsRequest, lo
 		blacklist:  blacklist,
 		maxFlows:   req.Number,
 		follow:     req.Follow,
-		timeRange:  !req.Follow && req.Number == 0,
+		timeRange:  req.Since != nil || req.Until != nil,
 	}
-	if reader.timeRange { // apply time range filtering
-		var err error
-		reader.start, err = ptypes.Timestamp(req.GetSince())
+
+	if req.Since != nil {
+		since, err := ptypes.Timestamp(req.Since)
 		if err != nil {
 			return nil, err
 		}
-		reader.end, err = getUntil(req, ptypes.TimestampNow())
+		reader.since = &since
+	}
+
+	if req.Until != nil {
+		until, err := ptypes.Timestamp(req.Until)
 		if err != nil {
 			return nil, err
 		}
+		reader.until = &until
 	}
+
 	return reader, nil
 }
 
@@ -416,15 +413,18 @@ func (r *flowsReader) Next(ctx context.Context) (*flowpb.Flow, error) {
 		if e == nil {
 			return nil, io.EOF
 		}
+
 		if r.timeRange {
 			ts, err := ptypes.Timestamp(e.GetFlow().GetTime())
 			if err != nil {
 				return nil, err
 			}
-			if ts.After(r.end) {
+
+			if r.until != nil && ts.After(*r.until) {
 				return nil, io.EOF
 			}
-			if ts.Before(r.start) {
+
+			if r.since != nil && ts.Before(*r.since) {
 				continue
 			}
 		}
@@ -439,15 +439,15 @@ func (r *flowsReader) Next(ctx context.Context) (*flowpb.Flow, error) {
 // newRingReader creates a new RingReader that starts at the correct ring
 // offset to match the flow request.
 func newRingReader(ring *container.Ring, req *observerpb.GetFlowsRequest, whitelist, blacklist filters.FilterFuncs) (*container.RingReader, error) {
-	if req.Follow && req.Number == 0 { // no need to rewind
+	if req.Follow && req.Number == 0 && req.Since == nil {
+		// no need to rewind
 		return container.NewRingReader(ring, ring.LastWriteParallel()), nil
 	}
 
 	var err error
-	var start time.Time
-	since := req.GetSince()
-	if since != nil {
-		start, err = ptypes.Timestamp(since)
+	var since time.Time
+	if req.Since != nil {
+		since, err = ptypes.Timestamp(req.Since)
 		if err != nil {
 			return nil, err
 		}
@@ -475,12 +475,12 @@ func newRingReader(ring *container.Ring, req *observerpb.GetFlowsRequest, whitel
 			continue
 		}
 		flowsCount++
-		if since != nil {
+		if req.Since != nil {
 			ts, err := ptypes.Timestamp(e.GetFlow().GetTime())
 			if err != nil {
 				return nil, err
 			}
-			if ts.Before(start) {
+			if ts.Before(since) {
 				idx++ // we went backward 1 too far
 				break
 			}

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -20,8 +20,10 @@ package observer
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
@@ -30,8 +32,9 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,6 +129,85 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 	err = s.GetFlows(req, fakeServer)
 	assert.NoError(t, err)
 	assert.Equal(t, req.Number, uint64(i))
+}
+
+func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
+	numFlows := 100
+	queueSize := 0
+
+	since := time.Unix(5, 0)
+	sinceProto, err := ptypes.TimestampProto(since)
+	assert.NoError(t, err)
+	req := &observerpb.GetFlowsRequest{
+		Since:  sinceProto,
+		Follow: true,
+	}
+
+	pp := noopParser(t)
+	s, err := NewLocalServer(pp, log,
+		observeroption.WithMaxFlows(numFlows),
+		observeroption.WithMonitorBuffer(queueSize),
+	)
+	require.NoError(t, err)
+	go s.Start()
+
+	generateFlows := func(from, to int, m chan<- *flowpb.Payload) {
+		for i := from; i < to; i++ {
+			tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+			data := testutils.MustCreateL3L4Payload(tn)
+			m <- &flowpb.Payload{
+				Time:     &timestamp.Timestamp{Seconds: int64(i)},
+				HostName: fmt.Sprintf("node #%03d", i),
+				Data:     data,
+			}
+		}
+	}
+
+	// produce first half of flows before request and second half during request
+	m := s.GetEventsChannel()
+	generateFlows(0, numFlows/2, m)
+
+	receivedFlows := 0
+	fakeServer := &testutils.FakeGetFlowsServer{
+		OnSend: func(response *observerpb.GetFlowsResponse) error {
+			receivedFlows++
+			assert.Equal(t, response.GetTime(), response.GetFlow().GetTime())
+			assert.Equal(t, response.GetNodeName(), response.GetFlow().GetNodeName())
+
+			ts, err := ptypes.Timestamp(response.GetTime())
+			assert.NoError(t, err)
+			assert.True(t, !ts.Before(since), "flow had invalid timestamp. ts=%s, since=%s", ts, since)
+
+			// start producing flows once we have seen the most recent one.
+			// Most recently produced flow has timestamp (numFlows/2)-1, but is
+			// inaccessible to readers due to the way the ring buffer works
+			if int(ts.Unix()) == (numFlows/2)-2 {
+				go func() {
+					generateFlows(numFlows/2, numFlows, m)
+					close(m)
+				}()
+			}
+
+			// terminate the request once we have seen enough flows.
+			// we expected to see all generated flows, minus the ones filtered
+			// out by 'since', minus the one inaccessible in the ring buffer
+			if receivedFlows == numFlows-int(since.Unix())-1 {
+				// this will terminate the follow request
+				return io.EOF
+			}
+
+			return nil
+		},
+		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
+			OnContext: func() context.Context {
+				return context.Background()
+			},
+		},
+	}
+
+	err = s.GetFlows(req, fakeServer)
+	<-s.GetStopped()
+	assert.Equal(t, err, io.EOF)
 }
 
 type fakeCiliumDaemon struct{}


### PR DESCRIPTION
 * #13324 -- hubble: Support `--since` requests in combination with follow-mode (@gandro)

@gandro There was a conflict in the tests due to the changes brought by #12712. I updated the test to use `flowspb.Payload` instead of `observerTypes.MonitorEvent` for the `generateFlows` chan. PTAL.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13324; do contrib/backporting/set-labels.py $pr done 1.8; done
```