### PR TITLE
Rename azure-user-assigned-identity-name to azure-user-assigned-identity-id

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -15,60 +15,60 @@ cilium-operator-azure [flags]
 ### Options
 
 ```
-      --azure-cloud-name string                    Name of the Azure cloud being used (default "AzurePublicCloud")
-      --azure-resource-group string                Resource group to use for Azure IPAM
-      --azure-subscription-id string               Subscription ID to access Azure API
-      --azure-user-assigned-identity-name string   Name of the user assigned identity used to auth with the Azure API
-      --cilium-endpoint-gc-interval duration       GC interval for cilium endpoints (default 5m0s)
-      --cluster-id int                             Unique identifier of the cluster
-      --cluster-name string                        Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr string              IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int            Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr string              IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int            Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-node-status-gc-interval duration       GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
-      --cnp-status-update-interval duration        Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
-      --config string                              Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                          Configuration directory that contains a file for each option
-  -D, --debug                                      Enable debugging mode
-      --enable-ipv4                                Enable IPv4 support (default true)
-      --enable-ipv6                                Enable IPv6 support (default true)
-      --enable-k8s-api-discovery                   Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                  Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                  Enable k8s event handover to kvstore for improved scalability
-      --enable-metrics                             Enable Prometheus metrics
-  -h, --help                                       help for cilium-operator-azure
-      --identity-allocation-mode string            Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration              GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration         Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
-      --identity-heartbeat-timeout duration        Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ipam string                                Backend to use for IPAM (default "azure")
-      --k8s-api-server string                      Kubernetes API server URL
-      --k8s-client-burst int                       Burst value allowed for the K8s client
-      --k8s-client-qps float32                     Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                 Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                       Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                             Key-value store type
-      --kvstore-opt map                            Key-value store options (default map[])
-      --leader-election-lease-duration duration    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                   Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                   Queries per second limit when accessing external IPAM APIs (default 20)
-      --log-driver strings                         Logging endpoints to use for example syslog
-      --log-opt map                                Log driver options for cilium-operator (default map[])
-      --nodes-gc-interval duration                 GC interval for nodes store in the kvstore (default 2m0s)
-      --operator-api-serve-addr string             Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string      Address to serve Prometheus metrics (default ":6942")
-      --parallel-alloc-workers int                 Maximum number of parallel IPAM workers (default 50)
-      --subnet-ids-filter strings                  Subnets IDs (separated by commas)
-      --subnet-tags-filter stringToString          Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
-      --synchronize-k8s-nodes                      Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                   Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int         Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --version                                    Print version information
+      --azure-cloud-name string                   Name of the Azure cloud being used (default "AzurePublicCloud")
+      --azure-resource-group string               Resource group to use for Azure IPAM
+      --azure-subscription-id string              Subscription ID to access Azure API
+      --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
+      --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
+      --cluster-id int                            Unique identifier of the cluster
+      --cluster-name string                       Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr string             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr string             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
+      --config string                             Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                         Configuration directory that contains a file for each option
+  -D, --debug                                     Enable debugging mode
+      --enable-ipv4                               Enable IPv4 support (default true)
+      --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
+      --enable-metrics                            Enable Prometheus metrics
+  -h, --help                                      help for cilium-operator-azure
+      --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration             GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ipam string                               Backend to use for IPAM (default "azure")
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                            Key-value store type
+      --kvstore-opt map                           Key-value store options (default map[])
+      --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                        Logging endpoints to use for example syslog
+      --log-opt map                               Log driver options for cilium-operator (default map[])
+      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
+      --subnet-ids-filter strings                 Subnets IDs (separated by commas)
+      --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
+      --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --version                                   Print version information
 ```
 

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -15,65 +15,65 @@ cilium-operator [flags]
 ### Options
 
 ```
-      --aws-instance-limit-mapping map             Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
-      --aws-release-excess-ips                     Enable releasing excess free IP addresses from AWS ENI.
-      --azure-cloud-name string                    Name of the Azure cloud being used (default "AzurePublicCloud")
-      --azure-resource-group string                Resource group to use for Azure IPAM
-      --azure-subscription-id string               Subscription ID to access Azure API
-      --azure-user-assigned-identity-name string   Name of the user assigned identity used to auth with the Azure API
-      --cilium-endpoint-gc-interval duration       GC interval for cilium endpoints (default 5m0s)
-      --cluster-id int                             Unique identifier of the cluster
-      --cluster-name string                        Name of the cluster (default "default")
-      --cluster-pool-ipv4-cidr string              IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int            Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr string              IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int            Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --cnp-node-status-gc-interval duration       GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
-      --cnp-status-update-interval duration        Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
-      --config string                              Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                          Configuration directory that contains a file for each option
-  -D, --debug                                      Enable debugging mode
-      --ec2-api-endpoint string                    AWS API endpoint for the EC2 service
-      --enable-ipv4                                Enable IPv4 support (default true)
-      --enable-ipv6                                Enable IPv6 support (default true)
-      --enable-k8s-api-discovery                   Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                  Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                  Enable k8s event handover to kvstore for improved scalability
-      --enable-metrics                             Enable Prometheus metrics
-      --eni-tags map                               ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
-  -h, --help                                       help for cilium-operator
-      --identity-allocation-mode string            Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration              GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration         Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
-      --identity-heartbeat-timeout duration        Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ipam string                                Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server string                      Kubernetes API server URL
-      --k8s-client-burst int                       Burst value allowed for the K8s client
-      --k8s-client-qps float32                     Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                 Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                       Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                             Key-value store type
-      --kvstore-opt map                            Key-value store options (default map[])
-      --leader-election-lease-duration duration    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                   Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                   Queries per second limit when accessing external IPAM APIs (default 20)
-      --log-driver strings                         Logging endpoints to use for example syslog
-      --log-opt map                                Log driver options for cilium-operator (default map[])
-      --nodes-gc-interval duration                 GC interval for nodes store in the kvstore (default 2m0s)
-      --operator-api-serve-addr string             Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string      Address to serve Prometheus metrics (default ":6942")
-      --parallel-alloc-workers int                 Maximum number of parallel IPAM workers (default 50)
-      --subnet-ids-filter strings                  Subnets IDs (separated by commas)
-      --subnet-tags-filter stringToString          Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
-      --synchronize-k8s-nodes                      Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
-      --synchronize-k8s-services                   Synchronize Kubernetes services to kvstore (default true)
-      --unmanaged-pod-watcher-interval int         Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-apdater-limit-via-api           Use the EC2 API to update the instance type to adapter limits
-      --version                                    Print version information
+      --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
+      --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
+      --azure-cloud-name string                   Name of the Azure cloud being used (default "AzurePublicCloud")
+      --azure-resource-group string               Resource group to use for Azure IPAM
+      --azure-subscription-id string              Subscription ID to access Azure API
+      --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
+      --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
+      --cluster-id int                            Unique identifier of the cluster
+      --cluster-name string                       Name of the cluster (default "default")
+      --cluster-pool-ipv4-cidr string             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr string             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
+      --config string                             Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                         Configuration directory that contains a file for each option
+  -D, --debug                                     Enable debugging mode
+      --ec2-api-endpoint string                   AWS API endpoint for the EC2 service
+      --enable-ipv4                               Enable IPv4 support (default true)
+      --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
+      --enable-metrics                            Enable Prometheus metrics
+      --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
+  -h, --help                                      help for cilium-operator
+      --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration             GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ipam string                               Backend to use for IPAM (default "cluster-pool")
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                            Key-value store type
+      --kvstore-opt map                           Key-value store options (default map[])
+      --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --log-driver strings                        Logging endpoints to use for example syslog
+      --log-opt map                               Log driver options for cilium-operator (default map[])
+      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
+      --subnet-ids-filter strings                 Subnets IDs (separated by commas)
+      --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
+      --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-services                  Synchronize Kubernetes services to kvstore (default true)
+      --unmanaged-pod-watcher-interval int        Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --update-ec2-apdater-limit-via-api          Use the EC2 API to update the instance type to adapter limits
+      --version                                   Print version information
 ```
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -147,9 +147,9 @@ const (
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup = "azure-resource-group"
 
-	// UserAssignedIdentityID is the id of the user assigned identity used
+	// AzureUserAssignedIdentityID is the id of the user assigned identity used
 	// for retrieving Azure API credentials
-	UserAssignedIdentityID = "azure-user-assigned-identity-id"
+	AzureUserAssignedIdentityID = "azure-user-assigned-identity-id"
 
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout = "crd-wait-timeout"
@@ -286,9 +286,9 @@ type OperatorConfig struct {
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup string
 
-	// UserAssignedIdentityID is the id of the user assigned identity used
+	// AzureUserAssignedIdentityID is the id of the user assigned identity used
 	// for retrieving Azure API credentials
-	UserAssignedIdentityID string
+	AzureUserAssignedIdentityID string
 
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout time.Duration
@@ -343,7 +343,7 @@ func (c *OperatorConfig) Populate() {
 	c.AzureCloudName = viper.GetString(AzureCloudName)
 	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
 	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
-	c.UserAssignedIdentityID = viper.GetString(UserAssignedIdentityID)
+	c.AzureUserAssignedIdentityID = viper.GetString(AzureUserAssignedIdentityID)
 
 	// Option maps and slices
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -147,9 +147,9 @@ const (
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup = "azure-resource-group"
 
-	// UserAssignedIdentityName is the name of the user assigned identity used
+	// UserAssignedIdentityID is the id of the user assigned identity used
 	// for retrieving Azure API credentials
-	UserAssignedIdentityName = "azure-user-assigned-identity-name"
+	UserAssignedIdentityID = "azure-user-assigned-identity-id"
 
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout = "crd-wait-timeout"
@@ -286,9 +286,9 @@ type OperatorConfig struct {
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup string
 
-	// UserAssignedIdentityName is the name of the user assigned identity used
+	// UserAssignedIdentityID is the id of the user assigned identity used
 	// for retrieving Azure API credentials
-	UserAssignedIdentityName string
+	UserAssignedIdentityID string
 
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout time.Duration
@@ -343,7 +343,7 @@ func (c *OperatorConfig) Populate() {
 	c.AzureCloudName = viper.GetString(AzureCloudName)
 	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
 	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
-	c.UserAssignedIdentityName = viper.GetString(UserAssignedIdentityName)
+	c.UserAssignedIdentityID = viper.GetString(UserAssignedIdentityID)
 
 	// Option maps and slices
 

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -35,8 +35,8 @@ func init() {
 	flags.String(operatorOption.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
 
-	flags.String(operatorOption.UserAssignedIdentityName, "", "Name of the user assigned identity used to auth with the Azure API")
-	option.BindEnvWithLegacyEnvFallback(operatorOption.UserAssignedIdentityName, "AZURE_USER_ASSIGNED_IDENTITY_NAME")
+	flags.String(operatorOption.UserAssignedIdentityID, "", "ID of the user assigned identity used to auth with the Azure API")
+	option.BindEnvWithLegacyEnvFallback(operatorOption.UserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
 
 	viper.BindPFlags(flags)
 }

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -35,8 +35,8 @@ func init() {
 	flags.String(operatorOption.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
 
-	flags.String(operatorOption.UserAssignedIdentityID, "", "ID of the user assigned identity used to auth with the Azure API")
-	option.BindEnvWithLegacyEnvFallback(operatorOption.UserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
+	flags.String(operatorOption.AzureUserAssignedIdentityID, "", "ID of the user assigned identity used to auth with the Azure API")
+	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureUserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
 
 	viper.BindPFlags(flags)
 }

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -62,8 +62,8 @@ type MetricsAPI interface {
 	ObserveRateLimit(operation string, duration time.Duration)
 }
 
-func constructAuthorizer(cloudName, userAssignedIdentityName string) (autorest.Authorizer, error) {
-	if userAssignedIdentityName != "" {
+func constructAuthorizer(cloudName, userAssignedIdentityID string) (autorest.Authorizer, error) {
+	if userAssignedIdentityID != "" {
 		env, err := azure.EnvironmentFromName(cloudName)
 		if err != nil {
 			return nil, err
@@ -75,7 +75,7 @@ func constructAuthorizer(cloudName, userAssignedIdentityName string) (autorest.A
 
 		spToken, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint,
 			env.ServiceManagementEndpoint,
-			userAssignedIdentityName)
+			userAssignedIdentityID)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func constructAuthorizer(cloudName, userAssignedIdentityName string) (autorest.A
 }
 
 // NewClient returns a new Azure client
-func NewClient(cloudName, subscriptionID, resourceGroup, userAssignedIdentityName string, metrics MetricsAPI, rateLimit float64, burst int) (*Client, error) {
+func NewClient(cloudName, subscriptionID, resourceGroup, userAssignedIdentityID string, metrics MetricsAPI, rateLimit float64, burst int) (*Client, error) {
 	c := &Client{
 		resourceGroup:   resourceGroup,
 		interfaces:      network.NewInterfacesClient(subscriptionID),
@@ -102,7 +102,7 @@ func NewClient(cloudName, subscriptionID, resourceGroup, userAssignedIdentityNam
 		limiter:         helpers.NewApiLimiter(metrics, rateLimit, burst),
 	}
 
-	authorizer, err := constructAuthorizer(cloudName, userAssignedIdentityName)
+	authorizer, err := constructAuthorizer(cloudName, userAssignedIdentityID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -78,7 +78,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	azureClient, err := azureAPI.NewClient(operatorOption.Config.AzureCloudName, subscriptionID, resourceGroupName, operatorOption.Config.UserAssignedIdentityName, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst)
+	azureClient, err := azureAPI.NewClient(operatorOption.Config.AzureCloudName, subscriptionID, resourceGroupName, operatorOption.Config.UserAssignedIdentityID, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -78,7 +78,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	azureClient, err := azureAPI.NewClient(operatorOption.Config.AzureCloudName, subscriptionID, resourceGroupName, operatorOption.Config.UserAssignedIdentityID, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst)
+	azureClient, err := azureAPI.NewClient(operatorOption.Config.AzureCloudName, subscriptionID, resourceGroupName, operatorOption.Config.AzureUserAssignedIdentityID, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}


### PR DESCRIPTION
Via https://github.com/cilium/cilium/pull/12592 the `cilium-operator` got a new method of retrieving Azure API credentials via `user-assigned-identities`. The CLI flag to specifying the identity was named incorrectly.

The correct way to do this is via specifying the ID of the identity rather than the name of it (Azure go SDK expects the ID). 

```release-note
Rename azure-user-assigned-identity-name to azure-user-assigned-identity-id
```
