### PR TITLE
v1.7 backports 2020-10-02

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -53,6 +53,7 @@ cilium-agent [flags]
       --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
       --disable-k8s-services                          Disable east-west K8s load balancing by cilium
       --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
+      --enable-api-rate-limit                         Enables the use of the API rate limiting configuration
       --enable-auto-protect-node-port-range           Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -20,6 +20,7 @@ cilium-agent [flags]
       --allow-icmp-frag-needed                        Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                        Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --annotate-k8s-node                             Annotate Kubernetes node (default true)
+      --api-rate-limit map                            API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
       --auto-create-cilium-node-resource              Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                       Enable automatic L2 routing between nodes
       --blacklist-conflicting-routes                  Don't blacklist IP allocations conflicting with local non-cilium routes (default true)

--- a/Documentation/configuration/api-rate-limiting.rst
+++ b/Documentation/configuration/api-rate-limiting.rst
@@ -1,0 +1,149 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _api_rate_limiting:
+
+*****************
+API Rate Limiting
+*****************
+
+The per node Cilium agent is essentially event-driven. For example, the CNI
+plugin is invoked when a new workload is scheduled onto the node which in turn
+makes an API call to the Cilium agent to allocate an IP address and create the
+Cilium endpoint. Another example is loading of network policy or service
+definitions where changes of these definitions will create an event which will
+notify the Cilium agent that a modification is required.
+
+Due to being event-driven, the amount of work performed by the Cilium agent
+highly depends on the rate of external events it receives. In order to
+constrain the resources that the Cilium agent consumes, it can be helpful to
+restrict the rate and allowed parallel executions of API calls.
+
+Default Rate Limits
+===================
+
+The following API calls are currently subject to rate limiting:
+
+========================== ====== ===== ============= ============ ================= =========== ===============================
+API Call                   Limit  Burst Max Parallel  Min Parallel Max Wait Duration Auto Adjust Estimated Processing Duration
+========================== ====== ===== ============= ============ ================= =========== ===============================
+``PUT /endpoint/{id}``     0.5/s  4     4                          15s               True        2s
+``DELETE /endpoint/{id}``               4             4                              True        200ms
+``GET /endpoint/{id}/*``   4/s    4     4             2            10s               True        200ms
+``PATCH /endpoint/{id}*``  0.5/s  4     4                          15s               True        1s
+``GET /endpoint``          1/s    4     2             2                              True        300ms
+========================== ====== ===== ============= ============ ================= =========== ===============================
+
+Configuration
+=============
+
+The ``api-rate-limit`` option can be used to overwrite individual settings of the
+default configuration:
+
+.. code::
+
+   --api-rate-limit endpoint-create=rate-limit:2/s,rate-burst:4
+
+API call to Configuration mapping
+---------------------------------
+
+========================== ====================
+API Call                   Config Name
+========================== ====================
+``PUT /endpoint/{id}``     ``endpoint-create``
+``DELETE /endpoint/{id}``  ``endpoint-delete``
+``GET /endpoint/{id}/*``   ``endpoint-get``
+``PATCH /endpoint/{id}*``  ``endponit-patch``
+``GET /endpoint``          ``endpoint-list``
+========================== ==================== 
+
+Configuration Parameters
+------------------------
+
+================================= ========= ========= =====================================================================================
+Configuration Key                 Example   Default   Description
+================================= ========= ========= =====================================================================================
+``rate-limit``                    ``5/m``   None      Allowed requests per time unit in the format ``<number>/<duration>``.
+``rate-burst``                    ``4``     None      Burst of API requests allowed by rate limiter.
+``min-wait-duration``             ``10ms``  0         Minimum wait duration each API call has to wait before being processed.
+``max-wait-duration``             ``15s``   0         Maximum duration an API call is allowed to wait before it fails.
+``estimated-processing-duration`` ``100ms`` 0         Estimated processing duration of an average API call. Used for automatic adjustment.
+``auto-adjust``                   ``true``  ``false`` Enable automatic adjustment of ``rate-limit``, ``rate-burst`` and ``parallel-requests``.
+``parallel-requests``             ``4``     0         Number of parallel API calls allowed.
+``min-parallel-requests``         ``2``     0         Lower limit of parallel requests when auto-adjusting.
+``max-parallel-requests``         ``6``     0         Upper limit of parallel requests when auto-adjusting.
+``mean-over``                     ``10``    10        Number of API calls to calculate mean processing duration for auto adjustment.
+``log``                           ``true``  ``false`` Log an Info message for each API call processed.
+``delayed-adjustment-factor``     ``0.25``  0.5       Factor for slower adjustment of ``rate-burst`` and ``parallel-requests``.
+``max-adjustment-factor``         ``10.0``  100.0     Maximum factor the auto-adjusted values can deviate from the initial base values configured.
+================================= ========= ========= =====================================================================================
+
+Valid duration values
+---------------------
+
+The ``rate-limit`` option expects a value in the form ``<number>/<duration>``
+where ``<duration>`` is a value that can be parsed with `ParseDuration()
+<https://golang.org/pkg/time/#ParseDuration>`_. The supported units are:
+``ns``, ``us``, ``ms``, ``s``, ``m``, ``h``.
+
+**Examples:**
+
+* ``rate-limit:10/2m``
+* ``rate-limit:3.5/h``
+* ``rate-limit:1/100ms``
+
+Automatic Adjustment
+====================
+
+Static values are relatively useless as the Cilium agent will run on different
+machine types. Deriving rate limits based on number of available CPU cores or
+available memory can be misleading as well as the Cilium agent may be subject
+to CPU and memory constraints.
+
+For this reason, all API call rate limiting is done with automatic adjustment
+of the limits with the goal to stay as close as possible to the configured
+estimated processing duration. This processing duration is specified for each
+group of API call and is constantly monitored.
+
+On completion of every API call, new limits are calculated. For this purpose, an
+adjustment factor is calculated:
+
+.. code-block:: go
+
+    AdjustmentFactor := EstimatedProcessingDuration / MeanProcessingDuration
+    AdjustmentFactor = Min(Max(AdjustmentFactor, 1.0/MaxAdjustmentFactor), MaxAdjustmentFactor)
+
+This adjustment factor is then applied to ``rate-limit``, ``rate-burst`` and
+``parallel-requests`` and will steer the mean processing duration to get closer
+to the estimated processing duration.
+
+If ``delayed-adjustment-factor`` is specified, then this additional factor is
+used to slow the growth of the ``rate-burst`` and ``parallel-requests`` as both
+values should typically adjust slower than ``rate-limit``:
+
+.. code-block:: go
+
+    NewValue = OldValue * AdjustmentFactor
+    NewValue = OldValue + ((NewValue - OldValue) * DelayedAdjustmentFactor)
+
+Metrics
+=======
+
+All API calls subject to rate limiting will expose :ref:`metrics_api_rate_limiting`. Example:
+
+.. code::
+
+    cilium_api_limiter_adjustment_factor                  api_call="endpoint-create"                               0.695787
+    cilium_api_limiter_processed_requests_total           api_call="endpoint-create" outcome="success"             7.000000
+    cilium_api_limiter_processing_duration_seconds        api_call="endpoint-create" value="estimated"             2.000000
+    cilium_api_limiter_processing_duration_seconds        api_call="endpoint-create" value="mean"                  2.874443
+    cilium_api_limiter_rate_limit                         api_call="endpoint-create" value="burst"                 4.000000
+    cilium_api_limiter_rate_limit                         api_call="endpoint-create" value="limit"                 0.347894
+    cilium_api_limiter_requests_in_flight                 api_call="endpoint-create" value="in-flight"             0.000000
+    cilium_api_limiter_requests_in_flight                 api_call="endpoint-create" value="limit"                 0.000000
+    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="max"                  15.000000
+    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="mean"                  0.000000
+    cilium_api_limiter_wait_duration_seconds              api_call="endpoint-create" value="min"                   0.000000

--- a/Documentation/configuration/index.rst
+++ b/Documentation/configuration/index.rst
@@ -1,0 +1,18 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _configuration:
+
+Configuration
+=============
+
+Core Agent
+----------
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   api-rate-limiting

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -227,6 +227,23 @@ Name                             Labels                           Description
 ``api_process_time_seconds``                                      Processing time of all the API calls made to the cilium-agent, labeled by API method, API path and returned HTTP code.
 ================================ ================================ ========================================================
 
+.. _metrics_api_rate_limiting:
+
+API Rate Limiting
+~~~~~~~~~~~~~~~~~
+
+===================================================== ================================ ========================================================
+Name                                                  Labels                           Description
+===================================================== ================================ ========================================================
+``cilium_api_limiter_adjustment_factor``              ``api_call``                     Most recent adjustment factor for automatic adjustment
+``cilium_api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Total number of API requests processed
+``cilium_api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Mean and estimated processing duration in seconds
+``cilium_api_limiter_rate_limit``                     ``api_call``, ``value``          Current rate limiting configuration (limit and burst)
+``cilium_api_limiter_requests_in_flight``             ``api_call``  ``value``          Current and maximum allowed number of requests in flight
+``cilium_api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Mean, min, and max wait duration
+``cilium_api_limiter_wait_history_duration_seconds``  ``api_call``                     Histogram of wait duration per API call processed
+===================================================== ================================ ========================================================
+
 FQDN
 ~~~~
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -469,7 +469,7 @@ New ConfigMap Options
     1. For the initial upgrade, the options ``transmit-host-src: true``,
        ``allow-host-src: true``, and ``enable-remote-node-identity: false``
        must be set. This guarantees that:
-       
+
        * Existing NetworkPolicy will continue to work.
        * New 1.7 nodes will continue to transmit using the old host identity to
          guarantee compatibility with 1.6 nodes during the rolling upgrade

--- a/daemon/api_limits.go
+++ b/daemon/api_limits.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rate"
 )
 
@@ -109,6 +110,10 @@ var apiRateLimitDefaults = map[string]rate.APILimiterParameters{
 type apiRateLimitingMetrics struct{}
 
 func (a *apiRateLimitingMetrics) ProcessedRequest(name string, v rate.MetricsValues) {
+	if !option.Config.EnableAPIRateLimit {
+		return
+	}
+
 	metrics.APILimiterProcessingDuration.WithLabelValues(name, "mean").Set(v.MeanProcessingDuration)
 	metrics.APILimiterProcessingDuration.WithLabelValues(name, "estimated").Set(v.EstimatedProcessingDuration)
 	metrics.APILimiterWaitDuration.WithLabelValues(name, "mean").Set(v.MeanWaitDuration)

--- a/daemon/api_limits.go
+++ b/daemon/api_limits.go
@@ -1,0 +1,124 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/rate"
+)
+
+const (
+	apiRequestEndpointCreate = "endpoint-create"
+	apiRequestEndpointDelete = "endpoint-delete"
+	apiRequestEndpointGet    = "endpoint-get"
+	apiRequestEndpointPatch  = "endpoint-patch"
+	apiRequestEndpointList   = "endpoint-list"
+)
+
+var apiRateLimitDefaults = map[string]rate.APILimiterParameters{
+	// PUT /endpoint/{id}
+	apiRequestEndpointCreate: {
+		AutoAdjust:                  true,
+		EstimatedProcessingDuration: time.Second * 2,
+		RateLimit:                   0.5,
+		RateBurst:                   4,
+		ParallelRequests:            4,
+		SkipInitial:                 4,
+		MaxWaitDuration:             15 * time.Second,
+		Log:                         true,
+	},
+	// DELETE /endpoint/{id}
+	//
+	// No maximum wait time is enforced as delete calls should always
+	// succeed. Permit a large number of parallel requests to minimize
+	// latency of delete calls, if the system performance allows for it,
+	// the maximum number of parallel requests will grow to a larger number
+	// but it will never shrink below 4. Logging is enabled for visibility
+	// as frequency should be low.
+	apiRequestEndpointDelete: {
+		EstimatedProcessingDuration: 200 * time.Millisecond,
+		AutoAdjust:                  true,
+		ParallelRequests:            4,
+		MinParallelRequests:         4,
+		Log:                         true,
+	},
+	// GET /endpoint/{id}/healthz
+	// GET /endpoint/{id}/log
+	// GET /endpoint/{id}/labels
+	// GET /endpoint/{id}/config
+	//
+	// All GET calls to endpoint attributes are grouped together and rate
+	// limited.
+	apiRequestEndpointGet: {
+		AutoAdjust:                  true,
+		EstimatedProcessingDuration: time.Millisecond * 200,
+		RateLimit:                   4.0,
+		RateBurst:                   4,
+		ParallelRequests:            4,
+		MinParallelRequests:         2,
+		SkipInitial:                 4,
+		MaxWaitDuration:             10 * time.Second,
+	},
+	// PATCH /endpoint/{id}
+	// PATCH /endpoint/{id}/config
+	// PATCH /endpoint/{id}/labels
+	//
+	// These calls are similar PUT /endpoint/{id} but put into a separate
+	// group as they are less likely to be expensive. They can be expensive
+	// though if datapath regenerations are required. Logging is enabled
+	// for visibility.
+	apiRequestEndpointPatch: {
+		AutoAdjust:                  true,
+		EstimatedProcessingDuration: time.Second,
+		RateLimit:                   0.5,
+		RateBurst:                   4,
+		ParallelRequests:            4,
+		SkipInitial:                 4,
+		MaxWaitDuration:             15 * time.Second,
+		Log:                         true,
+	},
+	// GET /endpoint
+	//
+	// Listing endpoints should be relatively quick, even with a large
+	// number of endpoints on a node. Always permit two parallel requests
+	// and rely on rate limiting to throttle if load becomes high.
+	apiRequestEndpointList: {
+		AutoAdjust:                  true,
+		EstimatedProcessingDuration: time.Millisecond * 300,
+		RateLimit:                   1.0,
+		RateBurst:                   4,
+		ParallelRequests:            2,
+		MinParallelRequests:         2,
+	},
+}
+
+type apiRateLimitingMetrics struct{}
+
+func (a *apiRateLimitingMetrics) ProcessedRequest(name string, v rate.MetricsValues) {
+	metrics.APILimiterProcessingDuration.WithLabelValues(name, "mean").Set(v.MeanProcessingDuration)
+	metrics.APILimiterProcessingDuration.WithLabelValues(name, "estimated").Set(v.EstimatedProcessingDuration)
+	metrics.APILimiterWaitDuration.WithLabelValues(name, "mean").Set(v.MeanWaitDuration)
+	metrics.APILimiterWaitDuration.WithLabelValues(name, "max").Set(v.MaxWaitDuration.Seconds())
+	metrics.APILimiterWaitDuration.WithLabelValues(name, "min").Set(v.MinWaitDuration.Seconds())
+	metrics.APILimiterRequestsInFlight.WithLabelValues(name, "in-flight").Set(float64(v.CurrentRequestsInFlight))
+	metrics.APILimiterRequestsInFlight.WithLabelValues(name, "limit").Set(float64(v.ParallelRequests))
+	metrics.APILimiterRateLimit.WithLabelValues(name, "limit").Set(float64(v.Limit))
+	metrics.APILimiterRateLimit.WithLabelValues(name, "burst").Set(float64(v.Burst))
+	metrics.APILimiterAdjustmentFactor.WithLabelValues(name).Set(v.AdjustmentFactor)
+	metrics.APILimiterWaitHistoryDuration.WithLabelValues(name).Observe(v.WaitDuration.Seconds())
+	metrics.APILimiterProcessedRequests.WithLabelValues(name, metrics.Error2Outcome(v.Error)).Inc()
+}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -763,6 +763,9 @@ func init() {
 	flags.Var(option.NewNamedMapOptions(option.APIRateLimitName, &option.Config.APIRateLimit, nil), option.APIRateLimitName, "API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)")
 	option.BindEnv(option.APIRateLimitName)
 
+	flags.Bool(option.EnableAPIRateLimit, false, "Enables the use of the API rate limiting configuration")
+	option.BindEnv(option.EnableAPIRateLimit)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -760,6 +760,9 @@ func init() {
 	flags.Duration(option.K8sHeartbeatTimeout, 30*time.Second, "Configures the timeout for api-server heartbeat, set to 0 to disable")
 	option.BindEnv(option.K8sHeartbeatTimeout)
 
+	flags.Var(option.NewNamedMapOptions(option.APIRateLimitName, &option.Config.APIRateLimit, nil), option.APIRateLimitName, "API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)")
+	option.BindEnv(option.APIRateLimitName)
+
 	viper.BindPFlags(flags)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
-	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873
 	google.golang.org/grpc v1.23.1
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
@@ -491,7 +491,7 @@ replace (
 	golang.org/x/sync => golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys => golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // pinned to release-branch.go1.13
 	golang.org/x/text => golang.org/x/text v0.3.2
-	golang.org/x/time => golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
+	golang.org/x/time => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools => golang.org/x/tools v0.0.0-20190821162956-65e3620a7ae7 // pinned to release-branch.go1.13
 	golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	gonum.org/v1/gonum => gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
-golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20190821162956-65e3620a7ae7 h1:PVCvyir09Xgta5zksNZDkrL+eSm/Y+gQxRG3IfqNQ3A=
 golang.org/x/tools v0.0.0-20190821162956-65e3620a7ae7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -348,3 +348,4 @@ data:
   enable-well-known-identities: "false"
 {{- end }}
   enable-remote-node-identity: {{ .Values.global.remoteNodeIdentity | quote }}
+  enable-api-rate-limit: {{ .Values.global.enableAPIRateLimit | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -370,6 +370,9 @@ global:
   # remoteNodeIdentity enables use of the remote node identity
   remoteNodeIdentity: true
 
+  # enableAPIRateLimit enables the use of API rate limiting
+  enableAPIRateLimit: false
+
   proxy:
     # Regular expression matching compatible Istio sidecar istio-proxy
     # container image names

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -753,6 +753,9 @@ const (
 	// LeaderElectionRetryPeriod is the duration the LeaderElector clients should wait between
 	// tries of the actions in operator HA deployment.
 	LeaderElectionRetryPeriod = "leader-election-retry-period"
+
+	// APIRateLimitName enables configuration of the API rate limits
+	APIRateLimitName = "api-rate-limit"
 )
 
 // Default string arguments
@@ -1515,6 +1518,9 @@ type DaemonConfig struct {
 	// LeaderElectionRetryPeriod is the duration that LeaderElector clients should wait between
 	// retries of the actions in operator HA deployment.
 	LeaderElectionRetryPeriod time.Duration
+
+	// APIRateLimitName enables configuration of the API rate limits
+	APIRateLimit map[string]string
 }
 
 var (
@@ -1556,6 +1562,7 @@ var (
 		k8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 
 		k8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
+		APIRateLimit:                     make(map[string]string),
 	}
 )
 
@@ -2110,6 +2117,10 @@ func (c *DaemonConfig) Populate() {
 		c.ConntrackGCInterval = time.Duration(val) * time.Second
 	} else {
 		c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
+	}
+
+	if m := viper.GetStringMapString(APIRateLimitName); len(m) != 0 {
+		c.APIRateLimit = m
 	}
 
 	for _, option := range viper.GetStringSlice(EndpointStatus) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -756,6 +756,9 @@ const (
 
 	// APIRateLimitName enables configuration of the API rate limits
 	APIRateLimitName = "api-rate-limit"
+
+	// EnableAPIRateLimit enables the use of API rate limiting.
+	EnableAPIRateLimit = "enable-api-rate-limit"
 )
 
 // Default string arguments
@@ -1521,6 +1524,9 @@ type DaemonConfig struct {
 
 	// APIRateLimitName enables configuration of the API rate limits
 	APIRateLimit map[string]string
+
+	// EnableAPIRateLimit enables the use of API rate limiting.
+	EnableAPIRateLimit bool
 }
 
 var (
@@ -2018,6 +2024,7 @@ func (c *DaemonConfig) Populate() {
 	c.CTMapEntriesTimeoutSVCAny = viper.GetDuration(CTMapEntriesTimeoutSVCAnyName)
 	c.CTMapEntriesTimeoutSYN = viper.GetDuration(CTMapEntriesTimeoutSYNName)
 	c.CTMapEntriesTimeoutFIN = viper.GetDuration(CTMapEntriesTimeoutFINName)
+	c.EnableAPIRateLimit = viper.GetBool(EnableAPIRateLimit)
 
 	if nativeCIDR := viper.GetString(IPv4NativeRoutingCIDR); nativeCIDR != "" {
 		c.ipv4NativeRoutingCIDR = cidr.MustParseCIDR(nativeCIDR)

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/uuid"
 
 	"github.com/sirupsen/logrus"
@@ -802,7 +803,7 @@ func (d dummyRequest) Error(err error)             {}
 // restrictions.
 func (s *APILimiterSet) Wait(ctx context.Context, name string) (LimitedRequest, error) {
 	l, ok := s.limiters[name]
-	if !ok {
+	if !option.Config.EnableAPIRateLimit || !ok {
 		return dummyRequest{}, nil
 	}
 

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -1,0 +1,810 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rate
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/uuid"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/time/rate"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "rate")
+
+const (
+	defaultMeanOver                = 10
+	defaultDelayedAdjustmentFactor = 0.50
+	defaultMaxAdjustmentFactor     = 100.0
+
+	// waitSemaphoreWeight is the maximum resolution of the wait semaphore,
+	// the higher this value, the more accurate the ParallelRequests
+	// requirement is implemented
+	waitSemaphoreResolution = 10000000
+
+	logUUID                    = "uuid"
+	logAPICallName             = "name"
+	logProcessingDuration      = "processingDuration"
+	logParallelRequests        = "parallelRequests"
+	logMinWaitDuration         = "minWaitDuration"
+	logMaxWaitDuration         = "maxWaitDuration"
+	logMaxWaitDurationParallel = "maxWaitDurationParallel"
+	logWaitDurationLimit       = "waitDurationLimiter"
+	logWaitDurationTotal       = "waitDurationTotal"
+	logLimit                   = "limit"
+	logBurst                   = "burst"
+	logTotalDuration           = "totalDuration"
+	logError                   = "err"
+	logSkipped                 = "rateLimiterSkipped"
+)
+
+// APILimiter is an extension to x/time/rate.Limiter specifically for Cilium
+// API calls. It allows to automatically adjust the rate, burst and maximum
+// parallel API calls to stay as close as possible to an estimated processing
+// time.
+type APILimiter struct {
+	// name is the name of the API call. This field is immutable after
+	// NewAPILimiter()
+	name string
+
+	// params is the parameters of the limiter. This field is immutable
+	// after NewAPILimiter()
+	params APILimiterParameters
+
+	// metrics points to the metrics implementation provided by the caller
+	// of the APILimiter. This field is immutable after NewAPILimiter()
+	metrics MetricsObserver
+
+	// mutex protects all fields below this line
+	mutex lock.RWMutex
+
+	// meanProcessingDuration is the latest mean processing duration,
+	// calculated based on processingDurations
+	meanProcessingDuration float64
+
+	// processingDurations is the last params.MeanOver processing durations
+	processingDurations []time.Duration
+
+	// meanWaitDuration is the latest mean wait duration, calculated based
+	// on waitDurations
+	meanWaitDuration float64
+
+	// waitDurations is the last params.MeanOver wait durations
+	waitDurations []time.Duration
+
+	// parallelRequests is the currently allowed maximum parallel
+	// requests. This defaults to params.MaxParallel requests and is then
+	// adjusted automatically if params.AutoAdjust is enabled.
+	parallelRequests int
+
+	// adjustmentFactor is the latest adjustment factor. It is the ratio
+	// between params.EstimatedProcessingDuration and
+	// meanProcessingDuration.
+	adjustmentFactor float64
+
+	// limiter is the rate limiter based on params.RateLimit and
+	// params.RateBurst.
+	limiter *rate.Limiter
+
+	// currentRequestsInFlight is the number of parallel API requests
+	// currently in flight
+	currentRequestsInFlight int
+
+	// requestsProcessed is the total number of processed requests
+	requestsProcessed int64
+
+	// requestsScheduled is the total number of scheduled requests
+	requestsScheduled int64
+
+	// parallelWaitSemaphore is the semaphore used to implement
+	// params.MaxParallel. It is initialized with a capacity of
+	// waitSemaphoreResolution and each API request will acquire
+	// waitSemaphoreResolution/params.MaxParallel tokens.
+	parallelWaitSemaphore *semaphore.Weighted
+}
+
+// APILimiterParameters is the configuration of an APILimiter. The structure
+// may not be mutated after it has been passed into NewAPILimiter().
+type APILimiterParameters struct {
+	// EstimatedProcessingDuration is the estimated duration an API call
+	// will take. This value is used if AutoAdjust is enabled to
+	// automatically adjust rate limits to stay as close as possible to the
+	// estimated processing duration.
+	EstimatedProcessingDuration time.Duration
+
+	// AutoAdjust enables automatic adjustment of the values
+	// ParallelRequests, RateLimit, and RateBurst in order to keep the
+	// mean processing duration close to EstimatedProcessingDuration
+	AutoAdjust bool
+
+	// MeanOver is the number of entries to keep in order to calculate the
+	// mean processing and wait duration
+	MeanOver int
+
+	// ParallelRequests is the parallel requests allowed. If AutoAdjust is
+	// enabled, the value will adjust automatically.
+	ParallelRequests int
+
+	// MaxParallelRequests is the maximum parallel requests allowed. If
+	// AutoAdjust is enabled, then the ParalelRequests will never grow
+	// above MaxParallelRequests.
+	MaxParallelRequests int
+
+	// MinParallelRequests is the minimum parallel requests allowed. If
+	// AutoAdjust is enabled, then the ParallelRequests will never fall
+	// below MinParallelRequests.
+	MinParallelRequests int
+
+	// RateLimit is the initial number of API requests allowed per second.
+	// If AutoAdjust is enabled, the value will adjust automatically.
+	RateLimit rate.Limit
+
+	// RateBurst is the initial allowed burst of API requests allowed. If
+	// AutoAdjust is enabled, the value will adjust automatically.
+	RateBurst int
+
+	// MinWaitDuration is the minimum time an API request always has to
+	// wait before the Wait() function returns an error.
+	MinWaitDuration time.Duration
+
+	// MaxWaitDuration is the maximum time an API request is allowed to
+	// wait before the Wait() function returns an error.
+	MaxWaitDuration time.Duration
+
+	// Log enables info logging of processed API requests. This should only
+	// be used for low frequency API calls.
+	Log bool
+
+	// DelayedAdjustmentFactor is percentage of the AdjustmentFactor to be
+	// applied to RateBurst and MaxWaitDuration defined as a value between
+	// 0.0..1.0. This is used to steer a slower reaction of the RateBurst
+	// and ParallelRequests compared to RateLimit.
+	DelayedAdjustmentFactor float64
+
+	// SkipInitial is the number of initial API calls for which to not
+	// apply any rate limiting. This is useful to define a learning phase
+	// in the beginning to allow for auto adjustment before imposing wait
+	// durations and rate limiting on API calls.
+	SkipInitial int
+
+	// MaxAdjustmentFactor is the maximum adjustment factor when AutoAdjust
+	// is enabled. Base values will not adjust more than by this factor.
+	MaxAdjustmentFactor float64
+}
+
+// MergeUserConfig merges the provided user configuration into the existing
+// parameters and returns a new copy.
+func (p APILimiterParameters) MergeUserConfig(config string) (APILimiterParameters, error) {
+	if err := (&p).mergeUserConfig(config); err != nil {
+		return APILimiterParameters{}, err
+	}
+
+	return p, nil
+}
+
+// NewAPILimiter returns a new APILimiter based on the parameters and metrics implementation
+func NewAPILimiter(name string, p APILimiterParameters, metrics MetricsObserver) *APILimiter {
+	if p.MeanOver == 0 {
+		p.MeanOver = defaultMeanOver
+	}
+
+	if p.MinParallelRequests == 0 {
+		p.MinParallelRequests = 1
+	}
+
+	if p.RateBurst == 0 {
+		p.RateBurst = 1
+	}
+
+	if p.DelayedAdjustmentFactor == 0.0 {
+		p.DelayedAdjustmentFactor = defaultDelayedAdjustmentFactor
+	}
+
+	if p.MaxAdjustmentFactor == 0.0 {
+		p.MaxAdjustmentFactor = defaultMaxAdjustmentFactor
+	}
+
+	l := &APILimiter{
+		name:                  name,
+		params:                p,
+		parallelRequests:      p.ParallelRequests,
+		parallelWaitSemaphore: semaphore.NewWeighted(waitSemaphoreResolution),
+		metrics:               metrics,
+	}
+
+	if p.RateLimit != 0 {
+		l.limiter = rate.NewLimiter(p.RateLimit, p.RateBurst)
+	}
+
+	return l
+}
+
+// NewAPILimiterFromConfig returns a new APILimiter based on user configuration
+func NewAPILimiterFromConfig(name, config string, metrics MetricsObserver) (*APILimiter, error) {
+	p := &APILimiterParameters{}
+
+	if err := p.mergeUserConfig(config); err != nil {
+		return nil, err
+	}
+
+	return NewAPILimiter(name, *p, metrics), nil
+}
+
+func (p *APILimiterParameters) mergeUserConfigKeyValue(key, value string) error {
+	switch strings.ToLower(key) {
+	case "rate-limit":
+		limit, err := parseRate(value)
+		if err != nil {
+			return fmt.Errorf("unable to parse rate %q: %w", value, err)
+		}
+		p.RateLimit = limit
+	case "rate-burst":
+		burst, err := strconv.ParseUint(value, 0, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse integer %q: %w", value, err)
+		}
+		p.RateBurst = int(burst)
+	case "min-wait-duration":
+		minWaitDuration, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("unable to parse duration %q: %w", value, err)
+		}
+		p.MinWaitDuration = minWaitDuration
+	case "max-wait-duration":
+		maxWaitDuration, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("unable to parse duration %q: %w", value, err)
+		}
+		p.MaxWaitDuration = maxWaitDuration
+	case "estimated-processing-duration":
+		estProcessingDuration, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("unable to parse duration %q: %w", value, err)
+		}
+		p.EstimatedProcessingDuration = estProcessingDuration
+	case "auto-adjust":
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("unable to parse bool %q: %w", value, err)
+		}
+		p.AutoAdjust = v
+	case "parallel-requests":
+		parallel, err := strconv.ParseUint(value, 0, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse integer %q: %w", value, err)
+		}
+		p.ParallelRequests = int(parallel)
+	case "min-parallel-requests":
+		minParallel, err := strconv.ParseUint(value, 0, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse integer %q: %w", value, err)
+		}
+		p.MinParallelRequests = int(minParallel)
+	case "max-parallel-requests":
+		maxParallel, err := strconv.ParseUint(value, 0, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse integer %q: %w", value, err)
+		}
+		p.MaxParallelRequests = int(maxParallel)
+	case "mean-over":
+		meanOver, err := strconv.ParseUint(value, 0, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse integer %q: %w", value, err)
+		}
+		p.MeanOver = int(meanOver)
+	case "log":
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("unable to parse bool %q: %w", value, err)
+		}
+		p.Log = v
+	case "delayed-adjustment-factor":
+		delayedAdjustmentFactor, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse float %q: %w", value, err)
+		}
+		p.DelayedAdjustmentFactor = delayedAdjustmentFactor
+	case "max-adjustment-factor":
+		maxAdjustmentFactor, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse float %q: %w", value, err)
+		}
+		p.MaxAdjustmentFactor = maxAdjustmentFactor
+	case "skip-initial":
+		skipInitial, err := strconv.ParseUint(value, 0, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse integer %q: %w", value, err)
+		}
+		p.SkipInitial = int(skipInitial)
+	default:
+		return fmt.Errorf("unknown rate limiting option %q", key)
+	}
+
+	return nil
+}
+
+func (p *APILimiterParameters) mergeUserConfig(config string) error {
+	tokens := strings.Split(config, ",")
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+
+		t := strings.SplitN(token, ":", 2)
+		if len(t) != 2 {
+			return fmt.Errorf("unable to parse rate limit option %q, must in the form name=option:value[,option:value]", token)
+		}
+
+		if err := p.mergeUserConfigKeyValue(t[0], t[1]); err != nil {
+			return fmt.Errorf("unable to parse rate limit option %q with value %q: %w", t[0], t[1], err)
+		}
+	}
+
+	return nil
+}
+
+func (l *APILimiter) delayedAdjustment(current, min, max float64) (n float64) {
+	n = current * l.adjustmentFactor
+	n = current + ((n - current) * l.params.DelayedAdjustmentFactor)
+	if min > 0.0 && n < min {
+		n = min
+	}
+	if max > 0.0 && n > max {
+		n = max
+	}
+	return
+}
+
+func (l *APILimiter) calculateAdjustmentFactor() float64 {
+	f := l.params.EstimatedProcessingDuration.Seconds() / l.meanProcessingDuration
+	if f > l.params.MaxAdjustmentFactor {
+		f = l.params.MaxAdjustmentFactor
+	}
+	if f < 1.0/l.params.MaxAdjustmentFactor {
+		f = 1.0 / l.params.MaxAdjustmentFactor
+	}
+	return f
+}
+
+func (l *APILimiter) adjustmentLimit(newValue, initialValue float64) float64 {
+	return math.Max(initialValue/l.params.MaxAdjustmentFactor, math.Min(initialValue*l.params.MaxAdjustmentFactor, newValue))
+}
+
+func (l *APILimiter) adjustedBurst() int {
+	newBurst := l.delayedAdjustment(float64(l.params.RateBurst), float64(l.params.MinParallelRequests), 0.0)
+	return int(math.Round(l.adjustmentLimit(newBurst, float64(l.params.RateBurst))))
+}
+
+func (l *APILimiter) adjustedLimit() rate.Limit {
+	newLimit := rate.Limit(float64(l.params.RateLimit) * l.adjustmentFactor)
+	return rate.Limit(l.adjustmentLimit(float64(newLimit), float64(l.params.RateLimit)))
+}
+
+func (l *APILimiter) adjustedParallelRequests() int {
+	newParallelRequests := l.delayedAdjustment(float64(l.params.ParallelRequests),
+		float64(l.params.MinParallelRequests), float64(l.params.MaxParallelRequests))
+	return int(l.adjustmentLimit(newParallelRequests, float64(l.params.ParallelRequests)))
+}
+
+func (l *APILimiter) requestFinished(r *limitedRequest, err error) {
+	if r.finished {
+		return
+	}
+
+	r.finished = true
+
+	processingDuration := time.Since(r.startTime)
+	totalDuration := time.Since(r.scheduleTime)
+
+	scopedLog := log.WithFields(logrus.Fields{
+		logAPICallName:        l.name,
+		logUUID:               r.uuid,
+		logProcessingDuration: processingDuration,
+		logTotalDuration:      totalDuration,
+		logWaitDurationTotal:  r.waitDuration,
+	})
+
+	if err != nil {
+		scopedLog = scopedLog.WithField(logError, err)
+	}
+
+	if l.params.Log {
+		scopedLog.Info("API call has been processed")
+	} else {
+		scopedLog.Debug("API call has been processed")
+	}
+
+	if r.waitSemaphoreWeight != 0 {
+		l.parallelWaitSemaphore.Release(r.waitSemaphoreWeight)
+	}
+
+	l.mutex.Lock()
+
+	l.requestsProcessed++
+	l.currentRequestsInFlight--
+
+	l.processingDurations = append(l.processingDurations, processingDuration)
+	if exceed := len(l.processingDurations) - l.params.MeanOver; exceed > 0 {
+		l.processingDurations = l.processingDurations[exceed:]
+	}
+	l.meanProcessingDuration = calcMeanDuration(l.processingDurations)
+
+	l.waitDurations = append(l.waitDurations, r.waitDuration)
+	if exceed := len(l.waitDurations) - l.params.MeanOver; exceed > 0 {
+		l.waitDurations = l.waitDurations[exceed:]
+	}
+	l.meanWaitDuration = calcMeanDuration(l.waitDurations)
+
+	if l.params.AutoAdjust && l.params.EstimatedProcessingDuration != 0 {
+		l.adjustmentFactor = l.calculateAdjustmentFactor()
+		l.parallelRequests = l.adjustedParallelRequests()
+
+		if l.limiter != nil {
+			l.limiter.SetLimit(l.adjustedLimit())
+
+			newBurst := l.adjustedBurst()
+			l.limiter.SetBurst(newBurst)
+		}
+	}
+
+	values := MetricsValues{
+		EstimatedProcessingDuration: l.params.EstimatedProcessingDuration.Seconds(),
+		WaitDuration:                r.waitDuration,
+		MaxWaitDuration:             l.params.MaxWaitDuration,
+		MinWaitDuration:             l.params.MinWaitDuration,
+		MeanProcessingDuration:      l.meanProcessingDuration,
+		MeanWaitDuration:            l.meanWaitDuration,
+		ParallelRequests:            l.parallelRequests,
+		CurrentRequestsInFlight:     l.currentRequestsInFlight,
+		AdjustmentFactor:            l.adjustmentFactor,
+		Error:                       err,
+	}
+
+	if l.limiter != nil {
+		values.Limit = l.limiter.Limit()
+		values.Burst = l.limiter.Burst()
+	}
+	l.mutex.Unlock()
+
+	if l.metrics != nil {
+		l.metrics.ProcessedRequest(l.name, values)
+	}
+}
+
+// calcMeanDuration returns the mean duration in seconds
+func calcMeanDuration(durations []time.Duration) float64 {
+	total := 0.0
+	for _, t := range durations {
+		total += t.Seconds()
+	}
+	return total / float64(len(durations))
+}
+
+// LimitedRequest represents a request that is being limited. It is returned
+// by Wait() and the caller of Wait() is responsible to call Done() or Error()
+// when the API call has been processed or resulted in an error. It is safe to
+// call Error() and then Done(). It is not safe to call Done(), Error(), or
+// WaitDuration() concurrently.
+type LimitedRequest interface {
+	Done()
+	Error(err error)
+	WaitDuration() time.Duration
+}
+
+type limitedRequest struct {
+	limiter             *APILimiter
+	startTime           time.Time
+	scheduleTime        time.Time
+	waitDuration        time.Duration
+	waitSemaphoreWeight int64
+	uuid                string
+	finished            bool
+}
+
+// WaitDuration returns the duration the request had to wait
+func (l *limitedRequest) WaitDuration() time.Duration {
+	return l.waitDuration
+}
+
+// Done must be called when the API request has been successfully processed
+func (l *limitedRequest) Done() {
+	l.limiter.requestFinished(l, nil)
+}
+
+// Error must be called when the API request resulted in an error
+func (l *limitedRequest) Error(err error) {
+	l.limiter.requestFinished(l, err)
+}
+
+// Wait blocks until the next API call is allowed to be processed. If the
+// configured MaxWaitDuration is exceeded, an error is returned. On success, a
+// LimitedRequest is returned on which Done() must be called when the API call
+// has completed or Error() if an error occurred.
+func (l *APILimiter) Wait(ctx context.Context) (req LimitedRequest, err error) {
+	var (
+		limitWaitDuration   time.Duration
+		waitDuration        time.Duration
+		waitSemaphoreWeight int64
+		uuid                = uuid.NewUUID().String()
+		scheduledAt         = time.Now()
+		r                   *rate.Reservation
+	)
+
+	l.mutex.Lock()
+
+	l.requestsScheduled++
+
+	scopedLog := log.WithFields(logrus.Fields{
+		logAPICallName:      l.name,
+		logUUID:             uuid,
+		logParallelRequests: l.parallelRequests,
+	})
+
+	if l.params.MaxWaitDuration > 0 {
+		scopedLog = scopedLog.WithField(logMaxWaitDuration, l.params.MaxWaitDuration)
+	}
+
+	if l.params.MinWaitDuration > 0 {
+		scopedLog = scopedLog.WithField(logMinWaitDuration, l.params.MinWaitDuration)
+	}
+
+	select {
+	case <-ctx.Done():
+		if l.params.Log {
+			scopedLog.Warning("Not processing API request due to cancelled context")
+		}
+		l.mutex.Unlock()
+		return nil, fmt.Errorf("request cancelled while waiting for rate limiting slot: %w", ctx.Err())
+	default:
+	}
+
+	skip := l.params.SkipInitial > 0 && l.requestsScheduled <= int64(l.params.SkipInitial)
+	if skip {
+		scopedLog = scopedLog.WithField(logSkipped, skip)
+	}
+
+	if !skip && l.limiter != nil {
+		r = l.limiter.Reserve()
+		limitWaitDuration = r.Delay()
+
+		defer func() {
+			// In case the request is cancelled, also cancel the
+			// reservation so it does not impact the wait duration.
+			// The wait duration should only increase if requests
+			// are actually processed.
+			if err != nil && r != nil {
+				r.Cancel()
+			}
+		}()
+
+		scopedLog = scopedLog.WithFields(logrus.Fields{
+			logLimit:             fmt.Sprintf("%.2f/s", l.limiter.Limit()),
+			logBurst:             l.limiter.Burst(),
+			logWaitDurationLimit: limitWaitDuration,
+		})
+	}
+	parallelRequests := l.parallelRequests
+	l.mutex.Unlock()
+
+	if l.params.Log {
+		scopedLog.Info("Processing API request with rate limiter")
+	} else {
+		scopedLog.Debug("Processing API request with rate limiter")
+	}
+
+	if skip {
+		goto skipRateLimiter
+	}
+
+	if l.params.MinWaitDuration > 0 && limitWaitDuration < l.params.MinWaitDuration {
+		limitWaitDuration = l.params.MinWaitDuration
+	}
+
+	if (l.params.MaxWaitDuration > 0 && limitWaitDuration > l.params.MaxWaitDuration) || limitWaitDuration == rate.InfDuration {
+		if l.params.Log {
+			scopedLog.Warning("Not processing API request. Wait duration exceeds maximum")
+		}
+		return nil, fmt.Errorf("request would have to wait %v to be served (maximum wait duration: %v)",
+			limitWaitDuration, l.params.MaxWaitDuration)
+	}
+
+	if limitWaitDuration != 0 {
+		select {
+		case <-time.After(limitWaitDuration):
+		case <-ctx.Done():
+			if l.params.Log {
+				scopedLog.Warning("Not processing API request due to cancelled context while waiting")
+			}
+			return nil, fmt.Errorf("request cancelled while waiting for rate limiting slot: %w", ctx.Err())
+		}
+	}
+
+	if parallelRequests > 0 {
+		waitCtx := ctx
+		if l.params.MaxWaitDuration > 0 {
+			maxWaitDurationParallel := l.params.MaxWaitDuration - limitWaitDuration
+			scopedLog = scopedLog.WithField(logMaxWaitDurationParallel, maxWaitDurationParallel)
+			ctx2, cancel := context.WithTimeout(ctx, maxWaitDurationParallel)
+			defer cancel()
+			waitCtx = ctx2
+		}
+		waitSemaphoreWeight = int64(waitSemaphoreResolution / parallelRequests)
+		err := l.parallelWaitSemaphore.Acquire(waitCtx, waitSemaphoreWeight)
+		if err != nil {
+			if l.params.Log {
+				scopedLog.Warning("Not processing API request. Wait duration for maximum parallel requests exceeds maximum")
+			}
+			return nil, fmt.Errorf("timed out while waiting to be served with %d parallel requests: %w", parallelRequests, err)
+		}
+	}
+
+	waitDuration = time.Since(scheduledAt)
+
+skipRateLimiter:
+
+	l.mutex.Lock()
+	l.currentRequestsInFlight++
+	l.mutex.Unlock()
+
+	log.WithFields(logrus.Fields{
+		logAPICallName:       l.name,
+		logUUID:              uuid,
+		logWaitDurationTotal: waitDuration,
+	}).Debug("API call is ready to be served")
+
+	if l.params.Log {
+		scopedLog.Info("Processing API request with rate limiter")
+	} else {
+		scopedLog.Debug("Processing API request with rate limiter")
+	}
+
+	return &limitedRequest{
+		limiter:             l,
+		startTime:           time.Now(),
+		scheduleTime:        scheduledAt,
+		waitDuration:        waitDuration,
+		waitSemaphoreWeight: waitSemaphoreWeight,
+		uuid:                uuid,
+	}, nil
+}
+
+func parseRate(r string) (rate.Limit, error) {
+	tokens := strings.SplitN(r, "/", 2)
+	if len(tokens) != 2 {
+		return 0, fmt.Errorf("not in the form number/interval")
+	}
+
+	f, err := strconv.ParseFloat(tokens[0], 64)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse float %q: %w", tokens[0], err)
+	}
+
+	// Reject rates such as 1/1 or 10/10 as it will default to nanoseconds
+	// which is likely unexpected to the user. Require an explicit suffix.
+	if _, err := strconv.ParseInt(string(tokens[1]), 10, 64); err == nil {
+		return 0, fmt.Errorf("interval %q must contain duration suffix", tokens[1])
+	}
+
+	// If duration is provided as "m" or "s", convert it into "1m" or "1s"
+	if _, err := strconv.ParseInt(string(tokens[1][0]), 10, 64); err != nil {
+		tokens[1] = "1" + tokens[1]
+	}
+
+	d, err := time.ParseDuration(tokens[1])
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse duration %q: %w", tokens[1], err)
+	}
+
+	return rate.Limit(f / d.Seconds()), nil
+}
+
+// APILimiterSet is a set of APILimiter indexed by name
+type APILimiterSet struct {
+	limiters map[string]*APILimiter
+	metrics  MetricsObserver
+}
+
+// MetricsValues is the snapshot of relevant values to feed into the
+// MetricsObserver
+type MetricsValues struct {
+	WaitDuration                time.Duration
+	MinWaitDuration             time.Duration
+	MaxWaitDuration             time.Duration
+	MeanProcessingDuration      float64
+	MeanWaitDuration            float64
+	EstimatedProcessingDuration float64
+	ParallelRequests            int
+	Limit                       rate.Limit
+	Burst                       int
+	CurrentRequestsInFlight     int
+	AdjustmentFactor            float64
+	Error                       error
+}
+
+// MetricsObserver is the interface that must be implemented to extract metrics
+type MetricsObserver interface {
+	// ProcessedRequest is invoked after invocation of an API call
+	ProcessedRequest(name string, values MetricsValues)
+}
+
+// NewAPILimiterSet creates a new APILimiterSet based on a set of rate limiting
+// configurations and the default configuration. Any rate limiter that is
+// configured in the config OR the defaults will be configured and made
+// available via the Limiter(name) and Wait() function.
+func NewAPILimiterSet(config map[string]string, defaults map[string]APILimiterParameters, metrics MetricsObserver) (*APILimiterSet, error) {
+	limiters := map[string]*APILimiter{}
+
+	for name, p := range defaults {
+		// Merge user config into defaults when provided
+		if userConfig, ok := config[name]; ok {
+			combinedParams, err := p.MergeUserConfig(userConfig)
+			if err != nil {
+				return nil, err
+			}
+			p = combinedParams
+		}
+
+		limiters[name] = NewAPILimiter(name, p, metrics)
+	}
+
+	for name, c := range config {
+		if _, ok := defaults[name]; !ok {
+			l, err := NewAPILimiterFromConfig(name, c, metrics)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse rate limiting configuration %s=%s: %w", name, c, err)
+			}
+
+			limiters[name] = l
+		}
+	}
+
+	return &APILimiterSet{
+		limiters: limiters,
+		metrics:  metrics,
+	}, nil
+}
+
+// Limiter returns the APILimiter with a given name
+func (s *APILimiterSet) Limiter(name string) *APILimiter {
+	return s.limiters[name]
+}
+
+type dummyRequest struct{}
+
+func (d dummyRequest) WaitDuration() time.Duration { return 0 }
+func (d dummyRequest) Done()                       {}
+func (d dummyRequest) Error(err error)             {}
+
+// Wait invokes Wait() on the APILimiter with the given name. If the limiter
+// does not exist, a dummy limiter is used which will not impose any
+// restrictions.
+func (s *APILimiterSet) Wait(ctx context.Context, name string) (LimitedRequest, error) {
+	l, ok := s.limiters[name]
+	if !ok {
+		return dummyRequest{}, nil
+	}
+
+	return l.Wait(ctx)
+}

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -1,0 +1,718 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package rate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	"golang.org/x/time/rate"
+	"gopkg.in/check.v1"
+)
+
+type metrics struct {
+	MetricsValues
+	numSuccess int
+	numError   int
+}
+
+type mockMetrics struct {
+	metrics map[string]*metrics
+}
+
+func newMockMetrics() *mockMetrics {
+	return &mockMetrics{
+		metrics: map[string]*metrics{},
+	}
+}
+
+func (m *mockMetrics) ProcessedRequest(name string, v MetricsValues) {
+	me, ok := m.metrics[name]
+	if !ok {
+		me = &metrics{}
+		m.metrics[name] = me
+	}
+
+	if v.Error != nil {
+		me.numError++
+	} else {
+		me.numSuccess++
+	}
+
+	me.WaitDuration += v.WaitDuration
+	me.MaxWaitDuration = v.MaxWaitDuration
+	me.MeanProcessingDuration = v.MeanProcessingDuration
+	me.MeanWaitDuration = v.MeanWaitDuration
+	me.EstimatedProcessingDuration = v.EstimatedProcessingDuration
+	me.ParallelRequests = v.ParallelRequests
+	me.Limit = v.Limit
+	me.Burst = v.Burst
+	me.CurrentRequestsInFlight = v.CurrentRequestsInFlight
+	me.AdjustmentFactor = v.AdjustmentFactor
+}
+
+func (b *ControllerSuite) TestNewAPILimiter(c *check.C) {
+	a := NewAPILimiter("foo", APILimiterParameters{}, nil)
+
+	req, err := a.Wait(context.Background())
+	c.Assert(err, check.IsNil)
+	c.Assert(req, check.Not(check.IsNil))
+	req.Done()
+}
+
+func (b *ControllerSuite) TestCancelContext(c *check.C) {
+	// Validate that error is returned when context is cancelled while
+	// request is in flight
+	a := NewAPILimiter("foo", APILimiterParameters{Log: true}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req, err := a.Wait(ctx)
+	c.Assert(err, check.ErrorMatches, "request cancelled while waiting for rate limiting slot.*")
+	c.Assert(req, check.IsNil)
+}
+
+func (b *ControllerSuite) TestAutoAdjust(c *check.C) {
+	// Test automatic adjustment of rate limiting parameters
+	initialParallelRequests := 10
+	initialRateLimit := rate.Limit(4.0)
+	initialRateBurst := 2
+
+	a := NewAPILimiter("foo", APILimiterParameters{
+		AutoAdjust:                  true,
+		ParallelRequests:            initialParallelRequests,
+		EstimatedProcessingDuration: 10 * time.Millisecond,
+		RateLimit:                   initialRateLimit,
+		RateBurst:                   initialRateBurst,
+	}, nil)
+
+	req, err := a.Wait(context.Background())
+	c.Assert(err, check.IsNil)
+	c.Assert(req, check.Not(check.IsNil))
+
+	time.Sleep(20 * time.Millisecond)
+	req.Done()
+
+	req, _ = a.Wait(context.Background())
+	time.Sleep(15 * time.Millisecond)
+	req.Done()
+
+	req, _ = a.Wait(context.Background())
+	time.Sleep(18 * time.Millisecond)
+	req.Done()
+
+	c.Assert(a.parallelRequests, check.Not(check.Equals), initialParallelRequests)
+	c.Assert(a.limiter.Limit(), check.Not(check.Equals), initialRateLimit)
+	// burst should not adjust this quickly
+	c.Assert(a.limiter.Burst(), check.Equals, initialRateBurst)
+	c.Assert(a.requestsProcessed, check.Equals, int64(3))
+}
+
+func (b *ControllerSuite) TestMeanProcessingDuration(c *check.C) {
+	// Simulate several requests and calculate the mean processing duration
+	// over fewer requests. Verify calculation of mean processing duration
+	iterations := int64(10)
+	a := NewAPILimiter("foo", APILimiterParameters{
+		MeanOver:                    int(iterations) - 1,
+		EstimatedProcessingDuration: 10 * time.Millisecond,
+		ParallelRequests:            2,
+	}, nil)
+
+	for i := int64(0); i < iterations; i++ {
+		req, err := a.Wait(context.Background())
+		c.Assert(err, check.IsNil)
+		c.Assert(req, check.Not(check.IsNil))
+		go func(r LimitedRequest) {
+			time.Sleep(20 * time.Millisecond)
+			r.Done()
+		}(req)
+	}
+
+	c.Assert(testutils.WaitUntil(func() bool {
+		a.mutex.RLock()
+		defer a.mutex.RUnlock()
+		return a.requestsProcessed == iterations
+	}, 5*time.Second), check.IsNil)
+
+	c.Assert(a.requestsProcessed, check.Equals, iterations)
+	// Check if mean value is within range, it should be close to 20ms
+	meanInRange := a.meanProcessingDuration < (25*time.Millisecond).Seconds() && a.meanProcessingDuration > (15*time.Millisecond).Seconds()
+	c.Assert(meanInRange, check.Equals, true)
+}
+
+func (b *ControllerSuite) TestMinParallelRequests(c *check.C) {
+	// Run a limiter with an initial 10 max parallel requests with a lower
+	// limit of 2 parallel requests. Auto adjust and feed it with requests
+	// that take 10ms with an estimated processing time of 1ms.
+	//
+	// The max parallel window should shrink to the minimum
+	a := NewAPILimiter("foo", APILimiterParameters{
+		EstimatedProcessingDuration: time.Nanosecond,
+		AutoAdjust:                  true,
+		ParallelRequests:            10,
+		MinParallelRequests:         2,
+		DelayedAdjustmentFactor:     1.0,
+		Log:                         true,
+	}, nil)
+
+	for i := 0; i < 10; i++ {
+		req, err := a.Wait(context.Background())
+		c.Assert(err, check.IsNil)
+		c.Assert(req, check.Not(check.IsNil))
+		go func(r LimitedRequest) {
+			time.Sleep(10 * time.Millisecond)
+			r.Done()
+		}(req)
+	}
+
+	c.Assert(testutils.WaitUntil(func() bool {
+		a.mutex.RLock()
+		defer a.mutex.RUnlock()
+		return a.requestsProcessed == 10
+	}, 5*time.Second), check.IsNil)
+
+	c.Assert(a.requestsProcessed, check.Equals, int64(10))
+	c.Assert(a.parallelRequests, check.Equals, 2)
+}
+
+func (b *ControllerSuite) TestMaxWaitDurationExceeded(c *check.C) {
+	// Test parallel request limiting when the maximum waiting duration is
+	// exceeded. A set of requests must fail.
+	a := NewAPILimiter("foo", APILimiterParameters{
+		EstimatedProcessingDuration: 5 * time.Millisecond,
+		AutoAdjust:                  true,
+		ParallelRequests:            2,
+		MinParallelRequests:         2,
+		MaxWaitDuration:             10 * time.Millisecond,
+		Log:                         true,
+	}, nil)
+
+	var mutex lock.Mutex
+	failedRequests := 0
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			req, err := a.Wait(context.Background())
+			if err != nil {
+				mutex.Lock()
+				failedRequests++
+				mutex.Unlock()
+			} else {
+				c.Assert(req, check.Not(check.IsNil))
+				time.Sleep(10 * time.Millisecond)
+				req.Done()
+			}
+		}()
+	}
+
+	c.Assert(testutils.WaitUntil(func() bool {
+		mutex.Lock()
+		defer mutex.Unlock()
+		a.mutex.RLock()
+		defer a.mutex.RUnlock()
+		return (int(a.requestsProcessed) + failedRequests) == 10
+	}, 5*time.Second), check.IsNil)
+
+	c.Assert(int(a.requestsProcessed)+failedRequests, check.Equals, 10)
+	c.Assert(failedRequests, check.Not(check.Equals), 0)
+}
+
+func (b *ControllerSuite) TestLimitCancelContext(c *check.C) {
+	a := NewAPILimiter("foo", APILimiterParameters{
+		MinWaitDuration: time.Minute,
+		RateLimit:       1.0 / 60.0, // 1 request/minute
+		RateBurst:       1,
+		Log:             true,
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	req, err := a.Wait(ctx)
+	c.Assert(err, check.ErrorMatches, "request cancelled while waiting for rate limiting slot.*")
+	c.Assert(req, check.IsNil)
+}
+
+func (b *ControllerSuite) TestLimitWaitDurationExceeded(c *check.C) {
+	// Test when rate limiting waiting duration exceeded the maximum wait
+	// duration. A set of requests must fail.
+	a := NewAPILimiter("foo", APILimiterParameters{
+		RateLimit:       1.0 / 60.0, // 1 request/minute
+		RateBurst:       2,
+		MaxWaitDuration: time.Millisecond,
+		Log:             true,
+	}, nil)
+
+	var mutex lock.Mutex
+	failedRequests := 0
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			req, err := a.Wait(context.Background())
+			if err != nil {
+				c.Assert(err, check.ErrorMatches, "request would have to wait.*")
+				mutex.Lock()
+				failedRequests++
+				mutex.Unlock()
+			} else {
+				c.Assert(req, check.Not(check.IsNil))
+				time.Sleep(10 * time.Millisecond)
+				req.Done()
+			}
+		}()
+	}
+
+	c.Assert(testutils.WaitUntil(func() bool {
+		mutex.Lock()
+		defer mutex.Unlock()
+		a.mutex.RLock()
+		defer a.mutex.RUnlock()
+		return (int(a.requestsProcessed) + failedRequests) == 10
+	}, 5*time.Second), check.IsNil)
+
+	c.Assert(int(a.requestsProcessed)+failedRequests, check.Equals, 10)
+	c.Assert(failedRequests, check.Not(check.Equals), 0)
+}
+
+func (b *ControllerSuite) TestMaxParallelRequests(c *check.C) {
+	// Test blocking of max-parallel-requests by allowing two parallel
+	// requests and having a third request fail due to a very short
+	// MaxWaitDuration
+	a := NewAPILimiter("foo", APILimiterParameters{
+		ParallelRequests: 2,
+		MaxWaitDuration:  time.Millisecond,
+		AutoAdjust:       true,
+	}, nil)
+
+	// Process request 1 without completing it
+	req1, err := a.Wait(context.Background())
+	c.Assert(err, check.IsNil)
+	c.Assert(req1, check.Not(check.IsNil))
+
+	// Process request 2 without completing it
+	req2, err := a.Wait(context.Background())
+	c.Assert(err, check.IsNil)
+	c.Assert(req2, check.Not(check.IsNil))
+
+	// request 3 will fail due to MaxWaitDuration=1ms
+	req3, err := a.Wait(context.Background())
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(req3, check.IsNil)
+
+	// Finish request 1 to unblock another attempt to process request 3
+	req1.Done()
+
+	// request 3 will succeed now
+	req3, err = a.Wait(context.Background())
+	c.Assert(err, check.IsNil)
+	c.Assert(req3, check.Not(check.IsNil))
+
+	req2.Done()
+	req3.Done()
+}
+
+func (b *ControllerSuite) TestParseRate(c *check.C) {
+	l, err := parseRate("foo")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.Equals, rate.Limit(0))
+
+	l, err = parseRate("1/foo")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.Equals, rate.Limit(0))
+
+	l, err = parseRate("/1s")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.Equals, rate.Limit(0))
+
+	l, err = parseRate("foo/1s")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.Equals, rate.Limit(0))
+
+	l, err = parseRate("1/1s")
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Equals, rate.Limit(1.0))
+
+	l, err = parseRate("1/5m")
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Equals, rate.Limit(1.0/(5*60)))
+
+	l, err = parseRate("10/m")
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Equals, rate.Limit(10.0/60))
+
+	l, err = parseRate("1/10")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.Equals, rate.Limit(0))
+}
+
+func (b *ControllerSuite) TestNewAPILimiterFromConfig(c *check.C) {
+	l, err := NewAPILimiterFromConfig("foo", "foo", nil)
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.IsNil)
+
+	l, err = NewAPILimiterFromConfig("foo", "rate-limit:5/m", nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.params.RateLimit, check.Equals, rate.Limit(5.0/60.0))
+
+	l, err = NewAPILimiterFromConfig("foo", "estimated-processing-duration:100ms", nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.params.EstimatedProcessingDuration, check.Equals, time.Millisecond*100)
+
+	l, err = NewAPILimiterFromConfig("foo", "rate-limit:5/m,rate-burst:2", nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.params.RateLimit, check.Equals, rate.Limit(5.0/60.0))
+	c.Assert(l.params.RateBurst, check.Equals, 2)
+
+	l, err = NewAPILimiterFromConfig("foo", "auto-adjust:true,parallel-requests:2,max-parallel-requests:3,min-parallel-requests:2,skip-initial:5", nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.params.AutoAdjust, check.Equals, true)
+	c.Assert(l.params.ParallelRequests, check.Equals, 2)
+	c.Assert(l.params.MaxParallelRequests, check.Equals, 3)
+	c.Assert(l.params.MinParallelRequests, check.Equals, 2)
+	c.Assert(l.params.SkipInitial, check.Equals, 5)
+
+	l, err = NewAPILimiterFromConfig("foo", "delayed-adjustment-factor:0.5,log:true,max-wait-duration:2s,min-wait-duration:100ms,max-adjustment-factor:50.0", nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.params.DelayedAdjustmentFactor, check.Equals, 0.5)
+	c.Assert(l.params.Log, check.Equals, true)
+	c.Assert(l.params.MaxWaitDuration, check.Equals, 2*time.Second)
+	c.Assert(l.params.MinWaitDuration, check.Equals, 100*time.Millisecond)
+	c.Assert(l.params.MaxAdjustmentFactor, check.Equals, 50.0)
+}
+
+func (b *ControllerSuite) TestNewAPILimiterSet(c *check.C) {
+	// Empty configuration
+	l, err := NewAPILimiterSet(nil, nil, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+
+	// Invalid user config
+	l, err = NewAPILimiterSet(map[string]string{
+		"foo": "foo",
+	}, nil, nil)
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.IsNil)
+
+	// Default value only
+	l, err = NewAPILimiterSet(nil, map[string]APILimiterParameters{
+		"foo": {
+			RateLimit: rate.Limit(1.0 / 60.0),
+		},
+	}, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.Limiter("foo"), check.Not(check.IsNil))
+	c.Assert(l.Limiter("foo2"), check.IsNil)
+
+	// User config only
+	l, err = NewAPILimiterSet(map[string]string{
+		"foo": "rate-limit:2/m,rate-burst:2",
+	}, nil, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.Limiter("foo").params.RateLimit, check.Equals, rate.Limit(1.0/30.0))
+	c.Assert(l.Limiter("foo").params.RateBurst, check.Equals, 2)
+
+	// Overwrite default and combine with new user config while also
+	// preserving some default values
+	l, err = NewAPILimiterSet(map[string]string{
+		"foo": "rate-limit:2/m,rate-burst:2",
+	}, map[string]APILimiterParameters{
+		"foo": {
+			RateLimit:  rate.Limit(1.0 / 60.0),
+			AutoAdjust: true,
+		},
+	}, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+	c.Assert(l.Limiter("foo").params.RateLimit, check.Equals, rate.Limit(1.0/30.0))
+	c.Assert(l.Limiter("foo").params.RateBurst, check.Equals, 2)
+	c.Assert(l.Limiter("foo").params.AutoAdjust, check.Equals, true)
+
+	// Overwrite default with an invalid value
+	l, err = NewAPILimiterSet(map[string]string{
+		"foo": "rate-limit:foo,rate-burst:2",
+	}, map[string]APILimiterParameters{
+		"foo": {
+			RateLimit: rate.Limit(1.0 / 60.0),
+		},
+	}, nil)
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(l, check.IsNil)
+}
+
+func (b *ControllerSuite) TestAPILimiterMetrics(c *check.C) {
+	// Validate setting of metrics via interface
+	metrics := newMockMetrics()
+
+	l, err := NewAPILimiterSet(nil, map[string]APILimiterParameters{
+		"foo": {
+			EstimatedProcessingDuration: 10 * time.Millisecond,
+			MaxWaitDuration:             200 * time.Millisecond,
+			ParallelRequests:            2,
+			RateLimit:                   rate.Limit(1.0 * 10.0),
+			RateBurst:                   2,
+			Log:                         true,
+		},
+	}, metrics)
+	c.Assert(err, check.IsNil)
+	c.Assert(l, check.Not(check.IsNil))
+
+	req0, err := l.Wait(context.Background(), "unknown-call")
+	c.Assert(err, check.IsNil)
+	c.Assert(req0, check.Not(check.IsNil))
+	req0.Done()
+	c.Assert(req0.WaitDuration(), check.Equals, time.Duration(0))
+
+	req1, err := l.Wait(context.Background(), "foo")
+	c.Assert(err, check.IsNil)
+	c.Assert(req1, check.Not(check.IsNil))
+	time.Sleep(5 * time.Millisecond)
+	req1.Done()
+
+	req2, err := l.Wait(context.Background(), "foo")
+	c.Assert(err, check.IsNil)
+	c.Assert(req2, check.Not(check.IsNil))
+	time.Sleep(5 * time.Millisecond)
+	req2.Done()
+
+	req3, err := l.Wait(context.Background(), "foo")
+	c.Assert(err, check.IsNil)
+	c.Assert(req2, check.Not(check.IsNil))
+	time.Sleep(5 * time.Millisecond)
+	req3.Error(fmt.Errorf("error"))
+	req3.Done()
+
+	a := l.Limiter("foo")
+
+	c.Assert(metrics.metrics["foo"].WaitDuration, check.Equals, req1.WaitDuration()+req2.WaitDuration()+req3.WaitDuration())
+	c.Assert(metrics.metrics["foo"].numSuccess, check.Equals, 2)
+	c.Assert(metrics.metrics["foo"].numError, check.Equals, 1)
+	c.Assert(metrics.metrics["foo"].Limit, check.Equals, a.params.RateLimit)
+	c.Assert(metrics.metrics["foo"].Burst, check.Equals, a.params.RateBurst)
+	c.Assert(metrics.metrics["foo"].ParallelRequests, check.Equals, a.params.ParallelRequests)
+	c.Assert(metrics.metrics["foo"].EstimatedProcessingDuration, check.Equals, a.params.EstimatedProcessingDuration.Seconds())
+	c.Assert(metrics.metrics["foo"].MeanProcessingDuration, check.Equals, a.meanProcessingDuration)
+	c.Assert(metrics.metrics["foo"].MeanWaitDuration, check.Equals, a.meanWaitDuration)
+	c.Assert(metrics.metrics["foo"].AdjustmentFactor, check.Equals, a.adjustmentFactor)
+}
+
+func (b *ControllerSuite) TestAPILimiterMergeUserConfig(c *check.C) {
+	// Merge empty configuration into empty configuration. Nothing should change
+	o := APILimiterParameters{}
+	n, err := o.MergeUserConfig("")
+	c.Assert(err, check.IsNil)
+	c.Assert(o.EstimatedProcessingDuration, check.Equals, n.EstimatedProcessingDuration)
+	c.Assert(o.AutoAdjust, check.Equals, n.AutoAdjust)
+	c.Assert(o.MeanOver, check.Equals, n.MeanOver)
+	c.Assert(o.MaxParallelRequests, check.Equals, n.MaxParallelRequests)
+	c.Assert(o.MinParallelRequests, check.Equals, n.MinParallelRequests)
+	c.Assert(o.RateLimit, check.Equals, n.RateLimit)
+	c.Assert(o.RateBurst, check.Equals, n.RateBurst)
+	c.Assert(o.MaxWaitDuration, check.Equals, n.MaxWaitDuration)
+	c.Assert(o.Log, check.Equals, n.Log)
+
+	// Overwrite defaults with user configuration, check updated values
+	o = APILimiterParameters{
+		AutoAdjust:          false,
+		MaxParallelRequests: 4,
+	}
+	n, err = o.MergeUserConfig("auto-adjust:true,max-parallel-requests:3,min-parallel-requests:2")
+	c.Assert(err, check.IsNil)
+	c.Assert(o.EstimatedProcessingDuration, check.Equals, n.EstimatedProcessingDuration)
+	c.Assert(n.AutoAdjust, check.Equals, true)
+	c.Assert(o.MeanOver, check.Equals, n.MeanOver)
+	c.Assert(n.MaxParallelRequests, check.Equals, 3)
+	c.Assert(n.MinParallelRequests, check.Equals, 2)
+	c.Assert(o.RateLimit, check.Equals, n.RateLimit)
+	c.Assert(o.RateBurst, check.Equals, n.RateBurst)
+	c.Assert(o.MaxWaitDuration, check.Equals, n.MaxWaitDuration)
+	c.Assert(o.Log, check.Equals, n.Log)
+
+	// Merge invalid configuration, must fail
+	_, err = o.MergeUserConfig("foo")
+	c.Assert(err, check.Not(check.IsNil))
+}
+
+func (b *ControllerSuite) TestParseUserConfigKeyValue(c *check.C) {
+	p := &APILimiterParameters{}
+
+	c.Assert(p.mergeUserConfigKeyValue("", ""), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("foo", ""), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("rate-limit", "10"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("rate-limit", "10/m"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("rate-burst", "foo"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("rate-burst", "10"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("max-wait-duration", "100sm"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("max-wait-duration", "100ms"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("min-wait-duration", "100sm"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("min-wait-duration", "100ms"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("estimated-processing-duration", "100sm"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("estimated-processing-duration", "100ms"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("auto-adjust", "not-true"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("auto-adjust", "true"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("auto-adjust", "false"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("max-parallel-requests", "ss"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("max-parallel-requests", "10"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("parallel-requests", "ss"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("parallel-requests", "10"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("min-parallel-requests", "ss"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("min-parallel-requests", "10"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("mean-over", "foo"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("mean-over", "10"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("log", "not-true"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("log", "true"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("log", "false"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("delayed-adjustment-factor", "0.25"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("delayed-adjustment-factor", "foo"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("max-adjustment-factor", "0.25"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("max-adjustment-factor", "foo"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfigKeyValue("skip-initial", "2"), check.IsNil)
+	c.Assert(p.mergeUserConfigKeyValue("skip-initial", "foo"), check.Not(check.IsNil))
+}
+
+func (b *ControllerSuite) TestParseUserConfig(c *check.C) {
+	p := &APILimiterParameters{}
+	c.Assert(p.mergeUserConfig("auto-adjust:true,"), check.IsNil)
+	c.Assert(p.AutoAdjust, check.Equals, true)
+	c.Assert(p.mergeUserConfig("auto-adjust:false,rate-limit:10/s,"), check.IsNil)
+	c.Assert(p.AutoAdjust, check.Equals, false)
+	c.Assert(p.RateLimit, check.Equals, rate.Limit(10.0))
+	c.Assert(p.mergeUserConfig("auto-adjust"), check.Not(check.IsNil))
+	c.Assert(p.mergeUserConfig("1:2:3"), check.Not(check.IsNil))
+}
+
+func (b *ControllerSuite) TestCalcMeanDuration(c *check.C) {
+	c.Assert(calcMeanDuration([]time.Duration{10, 10.0, 10.0, 10.0}), check.Equals, time.Duration(10.0).Seconds())
+}
+
+func (b *ControllerSuite) TestDelayedAdjustment(c *check.C) {
+	l := APILimiter{
+		adjustmentFactor: 1.5,
+		params:           APILimiterParameters{DelayedAdjustmentFactor: 0.5},
+	}
+	c.Assert(l.delayedAdjustment(1.0, 0.0, 0.0), check.Equals, 1.25)
+	c.Assert(l.delayedAdjustment(1.0, 2.0, 0.0), check.Equals, 2.0)
+	c.Assert(l.delayedAdjustment(1.0, 0.0, 1.1), check.Equals, 1.1)
+}
+
+func (b *ControllerSuite) TestSkipInitial(c *check.C) {
+	// Validate that SkipInitial skips all waiting duration
+	iterations := 10
+	a := NewAPILimiter("foo", APILimiterParameters{
+		SkipInitial:      iterations,
+		RateLimit:        1.0,
+		ParallelRequests: 2,
+	}, nil)
+
+	for i := 0; i < iterations; i++ {
+		req, err := a.Wait(context.Background())
+		c.Assert(err, check.IsNil)
+		c.Assert(req, check.Not(check.IsNil))
+		go func(r LimitedRequest) {
+			time.Sleep(20 * time.Millisecond)
+			r.Done()
+		}(req)
+	}
+
+	c.Assert(testutils.WaitUntil(func() bool {
+		a.mutex.RLock()
+		defer a.mutex.RUnlock()
+		return a.requestsProcessed == int64(iterations)
+	}, 5*time.Second), check.IsNil)
+
+	c.Assert(a.requestsProcessed, check.Equals, int64(iterations))
+	c.Assert(a.meanWaitDuration, check.Equals, 0.0)
+}
+
+func (b *ControllerSuite) TestCalculateAdjustmentFactor(c *check.C) {
+	estimatedProcessingDuration := time.Second
+	maxAdjustmentFactor := 20.0
+	a := NewAPILimiter("foo", APILimiterParameters{
+		EstimatedProcessingDuration: estimatedProcessingDuration,
+		MaxAdjustmentFactor:         maxAdjustmentFactor,
+	}, nil)
+
+	a.meanProcessingDuration = estimatedProcessingDuration.Seconds()
+	c.Assert(a.calculateAdjustmentFactor(), check.Equals, 1.0)
+
+	a.meanProcessingDuration = estimatedProcessingDuration.Seconds() / 2
+	c.Assert(a.calculateAdjustmentFactor(), check.Equals, 2.0)
+
+	a.meanProcessingDuration = (time.Second * 1000).Seconds()
+	c.Assert(a.calculateAdjustmentFactor(), check.Equals, 1.0/maxAdjustmentFactor)
+
+	a.meanProcessingDuration = (time.Second / 1000).Seconds()
+	c.Assert(a.calculateAdjustmentFactor(), check.Equals, 1.0*maxAdjustmentFactor)
+}
+
+func (b *ControllerSuite) TestAdjustmentLimit(c *check.C) {
+	a := NewAPILimiter("foo", APILimiterParameters{MaxAdjustmentFactor: 2.0}, nil)
+	c.Assert(a.adjustmentLimit(10.0, 2.0), check.Equals, 4.0)
+	c.Assert(a.adjustmentLimit(1.5, 2.0), check.Equals, 1.5)
+	c.Assert(a.adjustmentLimit(0.9, 2.0), check.Equals, 1.0)
+}
+
+func (b *ControllerSuite) TestAdjustedBurst(c *check.C) {
+	a := NewAPILimiter("foo", APILimiterParameters{
+		RateLimit:               1.0,
+		RateBurst:               1,
+		DelayedAdjustmentFactor: 0.5,
+		MaxAdjustmentFactor:     2.0,
+	}, nil)
+	a.adjustmentFactor = 4.0
+	c.Assert(a.adjustedBurst(), check.Equals, 2)
+}
+
+func (b *ControllerSuite) TestAdjustedLimit(c *check.C) {
+	a := NewAPILimiter("foo", APILimiterParameters{
+		RateLimit:           1.0,
+		MaxAdjustmentFactor: 2.0,
+	}, nil)
+	a.adjustmentFactor = 4.0
+	c.Assert(a.adjustedLimit(), check.Equals, rate.Limit(2.0))
+	a.adjustmentFactor = 0.25
+	c.Assert(a.adjustedLimit(), check.Equals, rate.Limit(0.5))
+	a.adjustmentFactor = 1.0
+	c.Assert(a.adjustedLimit(), check.Equals, rate.Limit(1.0))
+}
+
+func (b *ControllerSuite) TestAdjustedParallelRequests(c *check.C) {
+	a := NewAPILimiter("foo", APILimiterParameters{
+		ParallelRequests:        2,
+		DelayedAdjustmentFactor: 0.5,
+		MaxAdjustmentFactor:     2.0,
+	}, nil)
+	a.adjustmentFactor = 4.0
+	c.Assert(a.adjustedParallelRequests(), check.Equals, 4)
+	a.adjustmentFactor = 0.25
+	c.Assert(a.adjustedParallelRequests(), check.Equals, 1)
+	a.adjustmentFactor = 1.0
+	c.Assert(a.adjustedParallelRequests(), check.Equals, 2)
+}

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	"golang.org/x/time/rate"
@@ -468,6 +469,9 @@ func (b *ControllerSuite) TestNewAPILimiterSet(c *check.C) {
 }
 
 func (b *ControllerSuite) TestAPILimiterMetrics(c *check.C) {
+	option.Config.EnableAPIRateLimit = true
+	defer func() { option.Config.EnableAPIRateLimit = false }()
+
 	// Validate setting of metrics via interface
 	metrics := newMockMetrics()
 

--- a/vendor/golang.org/x/time/rate/rate.go
+++ b/vendor/golang.org/x/time/rate/rate.go
@@ -223,7 +223,12 @@ func (lim *Limiter) Wait(ctx context.Context) (err error) {
 // canceled, or the expected wait time exceeds the Context's Deadline.
 // The burst limit is ignored if the rate limit is Inf.
 func (lim *Limiter) WaitN(ctx context.Context, n int) (err error) {
-	if n > lim.burst && lim.limit != Inf {
+	lim.mu.Lock()
+	burst := lim.burst
+	limit := lim.limit
+	lim.mu.Unlock()
+
+	if n > burst && limit != Inf {
 		return fmt.Errorf("rate: Wait(n=%d) exceeds limiter's burst %d", n, lim.burst)
 	}
 	// Check if ctx is already cancelled
@@ -279,6 +284,23 @@ func (lim *Limiter) SetLimitAt(now time.Time, newLimit Limit) {
 	lim.last = now
 	lim.tokens = tokens
 	lim.limit = newLimit
+}
+
+// SetBurst is shorthand for SetBurstAt(time.Now(), newBurst).
+func (lim *Limiter) SetBurst(newBurst int) {
+	lim.SetBurstAt(time.Now(), newBurst)
+}
+
+// SetBurstAt sets a new burst size for the limiter.
+func (lim *Limiter) SetBurstAt(now time.Time, newBurst int) {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	now, _, tokens := lim.advance(now)
+
+	lim.last = now
+	lim.tokens = tokens
+	lim.burst = newBurst
 }
 
 // reserveN is a helper method for AllowN, ReserveN, and WaitN.
@@ -370,5 +392,9 @@ func (limit Limit) durationFromTokens(tokens float64) time.Duration {
 // tokensFromDuration is a unit conversion function from a time duration to the number of tokens
 // which could be accumulated during that duration at a rate of limit tokens per second.
 func (limit Limit) tokensFromDuration(d time.Duration) float64 {
-	return d.Seconds() * float64(limit)
+	// Split the integer and fractional parts ourself to minimize rounding errors.
+	// See golang.org/issues/34861.
+	sec := float64(d/time.Second) * float64(limit)
+	nsec := float64(d%time.Second) * float64(limit)
+	return sec + nsec/1e9
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -503,7 +503,7 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
-# golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 => golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
+# golang.org/x/time v0.0.0-20191024005414-555d28b269f0 => golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 => golang.org/x/tools v0.0.0-20190821162956-65e3620a7ae7
 golang.org/x/tools/go/ast/astutil


### PR DESCRIPTION
* #13319 -- Automatic rate limiting of endpoint API calls (@tgraf)
  * Note:
     * Added 3 new commits from the upstream PR; one for vendoring in an update to `golang.org/x/time`, another for the `--enable-api-rate-limit` flag, and subsequent Helm chart change for the flag
     * For other conflict resolutions, see commit msgs with `Backporter's notes`

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13319; do contrib/backporting/set-labels.py $pr done 1.7; done
```