### PR TITLE
pkg/option: re-introduce conntrack-gc-interval flag

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2610,6 +2610,8 @@ func (c *DaemonConfig) Populate() {
 		c.FixedIdentityMapping = m
 	}
 
+	c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
+
 	if m := viper.GetStringMapString(KVStoreOpt); len(m) != 0 {
 		c.KVStoreOpt = m
 	}


### PR DESCRIPTION
This flag was accidentally removed, re-adding it.

Fixes: 1cb5e185f301 ("daemon: remove deprecated conntrack-garbage-collector-interval option")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
re-introduce conntrack-gc-interval flag that was accidentally removed 
```
