### PR TITLE
v1.7 backports 2020-10-05

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/mountinfo"
 )
 
 // BugtoolConfiguration creates and loads the configuration file used to run
@@ -37,6 +38,33 @@ type BugtoolConfiguration struct {
 func setupDefaultConfig(path string, k8sPods []string, confDir, cmdDir string) (*BugtoolConfiguration, error) {
 	c := BugtoolConfiguration{defaultCommands(confDir, cmdDir, k8sPods)}
 	return &c, save(&c, path)
+}
+
+func bpffsMountpoint() string {
+	mountInfos, err := mountinfo.GetMountInfo()
+	if err != nil {
+		return ""
+	}
+
+	// To determine the mountpoint of the BPF fs we iterate through the list
+	// of mount info (i.e. /proc/self/mounts entries) and return the first
+	// one which has the "bpf" fs type and the "/" root.
+	//
+	// The root == "/" condition allows us to ignore all BPF fs which are
+	// sub mounts (such as for example /sys/fs/bpf/{xdp, ip, sk, sa}) of the
+	// one with the "/" root.
+	//
+	// Moreover, as Cilium will refuse to start if there are multiple BPF fs
+	// which have "/" as their root, we can assume there will be at most one
+	// mountpoint which matches the conditions and so we return it as soon
+	// as we find it.
+	for _, mountInfo := range mountInfos {
+		if mountInfo.FilesystemType == "bpf" && mountInfo.Root == "/" {
+			return mountInfo.MountPoint
+		}
+	}
+
+	return ""
 }
 
 func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
@@ -65,21 +93,6 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"dmesg --time-format=iso",
 		"bpftool map show",
 		"bpftool prog show",
-		// LB and CT map for debugging services; using bpftool for a reliable dump
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb4_services_v2",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb4_services",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb4_backends",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb4_reverse_nat",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_ct4_global",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_ct_any4_global",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb6_services_v2",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb6_services",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb6_backends",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb6_reverse_nat",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_ct6_global",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_ct_any6_global",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_snat_v4_external",
-		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_snat_v6_external",
 		// Versions
 		"docker version",
 		"docker info",
@@ -105,6 +118,26 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		fmt.Sprintf("gops stats $(pidof %s)", components.CiliumAgentName),
 		// Get list of open file descriptors managed by the agent
 		fmt.Sprintf("ls -la /proc/$(pidof %s)/fd", components.CiliumAgentName),
+	}
+
+	if bpffsMountpoint := bpffsMountpoint(); bpffsMountpoint != "" {
+		commands = append(commands, []string{
+			// LB and CT map for debugging services; using bpftool for a reliable dump
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_services_v2", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_services", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_backends", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_reverse_nat", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct4_global", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct_any4_global", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_services_v2", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_services", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_backends", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb6_reverse_nat", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct6_global", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct_any6_global", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_snat_v4_external", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_snat_v6_external", bpffsMountpoint),
+		}...)
 	}
 
 	// Commands that require variables and / or more configuration are added

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -59,7 +59,7 @@ main() {
     local new_proj="$2"
 
     git fetch $remote
-    git checkout -b pr/prepare-$version $remote/v$branch
+    git checkout -b pr/prepare-$version $remote/$branch
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
@@ -72,7 +72,7 @@ main() {
 
     logecho "Next steps:"
     logecho "* Check all changes and add to a new commit"
-    logecho "* Push the PR to Github for review"
+    logecho "* Push the PR to Github for review ('submit-release.sh')"
     logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
 

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -343,7 +343,9 @@ EOF
 
 cat <<EOF >> "$filename"
 sleep 2s
-echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
+if [ -n "\${K8S}" ]; then
+    echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
+fi
 echo 'CILIUM_OPTS="${cilium_options}"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPERATOR_OPTS="${cilium_operator_options}"' >> /etc/sysconfig/cilium
 echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium

--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -99,10 +99,13 @@ func (cdw *configDirectoryWatcher) watch() error {
 			case event := <-cdw.watcher.Events:
 				name := filepath.Base(event.Name)
 				log.WithField(fieldClusterName, name).Debugf("Received fsnotify event: %+v", event)
-				switch event.Op {
-				case fsnotify.Create, fsnotify.Write, fsnotify.Chmod:
+				switch {
+				case event.Op&fsnotify.Create == fsnotify.Create,
+					event.Op&fsnotify.Write == fsnotify.Write,
+					event.Op&fsnotify.Chmod == fsnotify.Chmod:
 					cdw.lifecycle.add(name, event.Name)
-				case fsnotify.Remove, fsnotify.Rename:
+				case event.Op&fsnotify.Remove == fsnotify.Remove,
+					event.Op&fsnotify.Rename == fsnotify.Rename:
 					cdw.lifecycle.remove(name)
 				}
 

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -322,7 +322,7 @@ func (o *objectCache) watchTemplatesDirectory(ctx context.Context) error {
 			if !open {
 				break
 			}
-			if event.Op&fsnotify.Remove != 0 {
+			if event.Op&fsnotify.Remove == fsnotify.Remove {
 				log.WithField(logfields.Path, event.Name).Debug("Detected template removal")
 				templateHash := filepath.Base(filepath.Dir(event.Name))
 				o.delete(templateHash)


### PR DESCRIPTION
 * #13342 -- bugtool: get bpffs mountpoint from /proc/mounts (@jibi)
    - Small conflict, removed the affinity maps as they are not present in v1.7.
 * #13357 -- contrib: Improve start-release.sh script (@joestringer)
 * #13325 -- fsnotify: correctly check for event operation (@kAworu)
    - Small conflict for ipmasq, ignored as per PR comment.
  * #11086 -- vagrant: Only set K8S_NODE_NAME if K8S=1 (@jrajahalme)

Not backported:
  * #11338 -- test: Support singleton manifests (@tgraf)
    - Non-trivial conflict. Not sure if it's worth backporting, see https://github.com/cilium/cilium/issues/11311#issuecomment-703521024.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13342 13357 13325 11086; do contrib/backporting/set-labels.py $pr done 1.7; done
```