### PR TITLE
bump Alpine base image to 3.12

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.7.7-alpine3.11
+FROM docker.io/library/python:3.7.9-alpine3.11
 
 LABEL maintainer="maintainer@cilium.io"
 

--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -15,7 +15,7 @@ ARG LOCKDEBUG
 ARG RACE
 RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cilium-operator-aws
 
-FROM docker.io/library/alpine:3.9.3 as certs
+FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -15,7 +15,7 @@ ARG LOCKDEBUG
 ARG RACE
 RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cilium-operator-azure
 
-FROM docker.io/library/alpine:3.9.3 as certs
+FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -15,7 +15,7 @@ ARG LOCKDEBUG
 ARG RACE
 RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cilium-operator-generic
 
-FROM docker.io/library/alpine:3.9.3 as certs
+FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -15,7 +15,7 @@ ARG LOCKDEBUG
 ARG RACE
 RUN make RACE=$RACE NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG cilium-operator
 
-FROM docker.io/library/alpine:3.9.3 as certs
+FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -12,7 +12,7 @@ ARG LOCKDEBUG
 ARG RACE
 RUN make RACE=${RACE} NOSTRIP=${NOSTRIP} LOCKDEBUG=${LOCKDEBUG}
 
-FROM docker.io/library/alpine:3.11 as certs
+FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates


### PR DESCRIPTION
Note: bumping `Documentation/Dockerfile` to 3.12 breaks the image build (some python related errors) so it was simply bumped to latest 3.7 python instead.
