### PR TITLE
docs: Clarify when GITHUB_TOKEN is needed

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -180,7 +180,7 @@ the labels for the PRs that are backported, based on the
 
    .. code-block:: bash
 
-      # contrib/backporting/submit-backport
+      $ GITHUB_TOKEN=xxx contrib/backporting/submit-backport
 
 Via GitHub web interface
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +237,7 @@ listed in the pull request description.
 
 .. code-block:: bash
 
-   $ for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done
+   $ GITHUB_TOKEN=xxx for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done
 
 Backporting guide for others
 ----------------------------
@@ -264,4 +264,4 @@ When merging a backport PR, set the labels of the backported PRs to
 
 .. code-block:: bash
 
-    $ for pr in 12894 12621 12973 12977 12952; do contrib/backporting/set-labels.py $pr done 1.8; done
+    $ GITHUB_TOKEN=xxx for pr in 12894 12621 12973 12977 12952; do contrib/backporting/set-labels.py $pr done 1.8; done


### PR DESCRIPTION
This PR adds `GITHUB_TOKEN=xxx` to all backport commands that require the GitHub token. This is to help contributors who blindly copy-paste commands, such as myself...