### PR TITLE
test: Restart unmanaged pods in log gatherer ns

### DIFF
--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -162,6 +162,8 @@ func RedeployCiliumWithMerge(vm *helpers.Kubectl,
 func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, options map[string]string) {
 	redeployCilium(vm, ciliumFilename, options)
 
+	vm.RestartUnmanagedPodsInNamespace(helpers.LogGathererNamespace)
+
 	vm.RedeployKubernetesDnsIfNecessary()
 
 	switch helpers.GetCurrentIntegration() {


### PR DESCRIPTION
Log gatherer pods were not restarted, if during Cilium restarts
they become unmanaged, they may lose connectivity,
causing tests to fail.