### PR TITLE
 bpf: properly handle IPv4 fragmented packets in host firewall

### DIFF
--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -343,7 +343,7 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id)
 	tuple.daddr = ip4->daddr;
 	tuple.saddr = ip4->saddr;
 	l4_off = l3_off + ipv4_hdrlen(ip4);
-#  ifndef IPV4_FRAGMENTS
+#  ifndef ENABLE_IPV4_FRAGMENTS
 	/* Indicate that this is a datagram fragment for which we cannot
 	 * retrieve L4 ports. Do not set flag if we support fragmentation.
 	 */


### PR DESCRIPTION
This commit fixes a typo in the IPV4_FRAGMENTS constant in the BPF host
filewall, which should have been named ENABLE_IPV4_FRAGMENTS.

As IPV4_FRAGMENTS was never defined, this bug caused the
`is_untracked_fragment` variable in `ipv4_host_policy_ingress` to be set
to `true` even when IPv4 fragment tracking was effectively enabled.

This in turn caused the host firewall to always fail the L4 policy
lookup for all IPv4 fragment and to always fall back to the L3 policy
lookup, potentially returning the incorrect DROP_FRAG_NOSUPPORT error
in case no policy allowing the traffic was in place.

Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>