### PR TITLE
Azure IPAM: option to ignore primary addresses

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -18,6 +18,7 @@ cilium-operator-azure [flags]
       --azure-cloud-name string                   Name of the Azure cloud being used (default "AzurePublicCloud")
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
+      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)
       --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
       --cluster-id int                            Unique identifier of the cluster

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -20,6 +20,7 @@ cilium-operator [flags]
       --azure-cloud-name string                   Name of the Azure cloud being used (default "AzurePublicCloud")
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
+      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)
       --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
       --cluster-id int                            Unique identifier of the cluster

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -151,6 +151,10 @@ const (
 	// for retrieving Azure API credentials
 	AzureUserAssignedIdentityID = "azure-user-assigned-identity-id"
 
+	// AzureUsePrimaryAddress specify wether we should use or ignore the interface's
+	// primary IPConfiguration
+	AzureUsePrimaryAddress = "azure-use-primary-address"
+
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout = "crd-wait-timeout"
 
@@ -290,6 +294,10 @@ type OperatorConfig struct {
 	// for retrieving Azure API credentials
 	AzureUserAssignedIdentityID string
 
+	// AzureUsePrimaryAddress specify wether we should use or ignore the interface's
+	// primary IPConfiguration
+	AzureUsePrimaryAddress bool
+
 	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
 	CRDWaitTimeout time.Duration
 
@@ -343,6 +351,7 @@ func (c *OperatorConfig) Populate() {
 	c.AzureCloudName = viper.GetString(AzureCloudName)
 	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
 	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
+	c.AzureUsePrimaryAddress = viper.GetBool(AzureUsePrimaryAddress)
 	c.AzureUserAssignedIdentityID = viper.GetString(AzureUserAssignedIdentityID)
 
 	// Option maps and slices

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -38,5 +38,8 @@ func init() {
 	flags.String(operatorOption.AzureUserAssignedIdentityID, "", "ID of the user assigned identity used to auth with the Azure API")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureUserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
 
+	flags.Bool(operatorOption.AzureUsePrimaryAddress, true, "Use Azure IP address from interface's primary IPConfigurations")
+	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureUsePrimaryAddress, "AZURE_USE_PRIMARY_ADDRESS")
+
 	viper.BindPFlags(flags)
 }

--- a/pkg/azure/api/api_test.go
+++ b/pkg/azure/api/api_test.go
@@ -36,7 +36,7 @@ var _ = check.Suite(&ApiSuite{})
 
 func (a *ApiSuite) TestRateLimit(c *check.C) {
 	metricsAPI := mock.NewMockMetrics()
-	client, err := NewClient("", "dummy-subscription", "dummy-resource-group", "", metricsAPI, 10.0, 4)
+	client, err := NewClient("", "dummy-subscription", "dummy-resource-group", "", metricsAPI, 10.0, 4, true)
 	c.Assert(err, check.IsNil)
 	c.Assert(client, check.Not(check.IsNil))
 

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -78,7 +78,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	azureClient, err := azureAPI.NewClient(operatorOption.Config.AzureCloudName, subscriptionID, resourceGroupName, operatorOption.Config.AzureUserAssignedIdentityID, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst)
+	azureClient, err := azureAPI.NewClient(operatorOption.Config.AzureCloudName, subscriptionID, resourceGroupName, operatorOption.Config.AzureUserAssignedIdentityID, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, operatorOption.Config.AzureUsePrimaryAddress)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}


### PR DESCRIPTION
Cilium Azure IPAM allocates secondaries (Azure meaning) IPConfigs only, and must be provided with an interface having a [primary IPConfiguration](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface-addresses#primary) ready.

Nodes starting with a primary IPConfig will be served that IPConfig's address and its subnet's route by Azure DHCP
(as op. to non-primary IPConfigurations, which are managed by third parties tools like Cilium).

Unless explicitly configured to disable DHCP on that interface, the hosts will therefore be configured to use that IP and route.

Assuming an host with several interfaces, by placing that primary IP address into its IPAM pool, Cilium can allocate it
to a pod (or eg. cilium_host interface), and install rules and routes which will set the pod to preempt inbound traffic for that address.

Which also implies traffic from that interface's subnet won't reach the host (or hostnetworked pods), but the pod (and the
host can't exchange with other pods or hosts in that subnet).

The requirement to provide a pre-existing interface makes misconfiguration on Azure more likely (than ie. on AWS), and
requires some non intuitive hosts setup.

Disabling primary address usage by default would be a regression, so inappropriate for a 1.8 backport, hence the added flag.

```release-note
Azure IPAM: option to ignore primary addresses
```
