### PR TITLE
Set device MTU in init.sh to route MTU

### DIFF
--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -87,7 +87,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	if changes > 0 {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetRouteMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
 			return api.Error(PatchConfigFailureCode, msg)
 		}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -224,7 +224,7 @@ func (d *Daemon) init() error {
 			}
 		}
 
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetRouteMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			return err
 		}
 	}
@@ -758,7 +758,7 @@ func (d *Daemon) Close() {
 // endpoints may or may not have successfully regenerated.
 func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
-	if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+	if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetRouteMTU(), d.Datapath(), d.l7Proxy); err != nil {
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)
 	}
 

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -283,7 +283,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	if newPrefixLengths && !bpfIPCache.BackedByLPM() {
 		// Only recompile if configuration has changed.
 		logger.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetRouteMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			_ = d.prefixLengths.Delete(prefixes)
 			metrics.PolicyImportErrors.Inc()
 			metrics.PolicyImportErrorsTotal.Inc()
@@ -601,7 +601,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 	if !bpfIPCache.BackedByLPM() && prefixesChanged {
 		// Only recompile if configuration has changed.
 		log.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetRouteMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			log.WithError(err).Error("Unable to recompile base programs")
 		}
 


### PR DESCRIPTION
Somehow the per route MTU for cilium_host is not taking effect and node
port traffic is being fragmented at outer encap layer (in mix mode with
kubeproxy).

This commit changes MTU of cilium_net, cilium_host and
cilium_vxlan/geneve to route MTU (with encap and encryption overhead
accounted for). A side effect is cilium_host mtu is also changed in
ipvlan mode (MTU - encryption overhead). Please let me know if it
doesn't make sense.

Fixes: #13349

Signed-off-by: Yuan Liu <liuyuan@google.com>

Please ensure your pull request adheres to the following guidelines:

- [* ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [*] All code is covered by unit and/or runtime tests where feasible.
- [* ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ *] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [* ] Provide a title or release-note blurb suitable for the release notes.
- [* ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Fix fragmentation happening on outer layer in tunneling mode.
```
