### PR TITLE
k8s: Make agent wait for CRDs

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -50,6 +50,7 @@ cilium-agent [flags]
       --config string                                 Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                             Configuration directory that contains a file for each option
       --conntrack-gc-interval duration                Overwrite the connection-tracking garbage collection interval
+      --crd-wait-timeout duration                     Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
       --datapath-mode string                          Datapath mode name (default "veth")
   -D, --debug                                         Enable debugging mode
       --debug-verbose strings                         List of enabled verbose debug groups

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1373,9 +1373,11 @@ func runDaemon() {
 	bootstrapStats.enableConntrack.End(true)
 
 	bootstrapStats.k8sInit.Start()
-	// Wait only for certain caches, but not all!
-	// (Check Daemon.InitK8sSubsystem() for more info)
-	<-d.k8sCachesSynced
+	if k8s.IsEnabled() {
+		// Wait only for certain caches, but not all!
+		// (Check Daemon.InitK8sSubsystem() for more info)
+		<-d.k8sCachesSynced
+	}
 	bootstrapStats.k8sInit.End(true)
 	restoreComplete := d.initRestore(restoredEndpoints)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1342,7 +1342,12 @@ func runDaemon() {
 		WithDefaultEndpointManager(),
 		linuxdatapath.NewDatapath(datapathConfig, iptablesManager))
 	if err != nil {
-		log.WithError(err).Fatal("Error while creating daemon")
+		select {
+		case <-server.ServerCtx.Done():
+			log.WithError(err).Debug("Error while creating daemon")
+		default:
+			log.WithError(err).Fatal("Error while creating daemon")
+		}
 		return
 	}
 
@@ -1369,7 +1374,7 @@ func runDaemon() {
 
 	bootstrapStats.k8sInit.Start()
 	// Wait only for certain caches, but not all!
-	// (Check Daemon.initK8sSubsystem() for more info)
+	// (Check Daemon.InitK8sSubsystem() for more info)
 	<-d.k8sCachesSynced
 	bootstrapStats.k8sInit.End(true)
 	restoreComplete := d.initRestore(restoredEndpoints)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -860,6 +860,9 @@ func init() {
 	flags.Var(option.NewNamedMapOptions(option.APIRateLimitName, &option.Config.APIRateLimit, nil), option.APIRateLimitName, "API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)")
 	option.BindEnv(option.APIRateLimitName)
 
+	flags.Duration(option.CRDWaitTimeout, 5*time.Minute, "Cilium will exit if CRDs are not available within this duration upon startup")
+	option.BindEnv(option.CRDWaitTimeout)
+
 	viper.BindPFlags(flags)
 
 	CustomCommandHelpFormat(RootCmd, option.HelpFlagSections)

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -65,7 +65,7 @@ func enableCiliumEndpointSyncGC(once bool) {
 		// If we are running this function "once" it means that we
 		// will delete all CEPs in the cluster regardless of the pod
 		// state.
-		watchers.PodsInit(k8s.WatcherCli(), stopCh)
+		watchers.PodsInit(k8s.WatcherClient(), stopCh)
 	}
 	<-k8sCiliumNodesCacheSynced
 

--- a/operator/k8s_pod_controller.go
+++ b/operator/k8s_pod_controller.go
@@ -41,7 +41,7 @@ var (
 func enableUnmanagedKubeDNSController() {
 	// These functions will block until the resources are synced with k8s.
 	watchers.CiliumEndpointsInit(k8s.CiliumClient().CiliumV2(), wait.NeverStop)
-	watchers.UnmanagedPodsInit(k8s.WatcherCli())
+	watchers.UnmanagedPodsInit(k8s.WatcherClient())
 
 	controller.NewManager().UpdateController("restart-unmanaged-kube-dns",
 		controller.ControllerParams{

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -123,7 +123,7 @@ func startSynchronizingServices() {
 
 	// Watch for v1.Service changes and push changes into ServiceCache
 	_, svcController := informer.NewInformer(
-		cache.NewFilteredListWatchFromClient(k8s.WatcherCli().CoreV1().RESTClient(),
+		cache.NewFilteredListWatchFromClient(k8s.WatcherClient().CoreV1().RESTClient(),
 			"services", v1.NamespaceAll, serviceOptsModifier),
 		&slim_corev1.Service{},
 		0,
@@ -171,14 +171,14 @@ func startSynchronizingServices() {
 	switch {
 	case k8s.SupportsEndpointSlice():
 		var endpointSliceEnabled bool
-		endpointController, endpointSliceEnabled = endpointSlicesInit(k8s.WatcherCli(), swgEps)
+		endpointController, endpointSliceEnabled = endpointSlicesInit(k8s.WatcherClient(), swgEps)
 		// the cluster has endpoint slices so we should not check for v1.Endpoints
 		if endpointSliceEnabled {
 			break
 		}
 		fallthrough
 	default:
-		endpointController = endpointsInit(k8s.WatcherCli(), swgEps, serviceOptsModifier)
+		endpointController = endpointsInit(k8s.WatcherClient(), swgEps, serviceOptsModifier)
 		go endpointController.Run(wait.NeverStop)
 	}
 

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
+	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -43,6 +44,11 @@ type K8sClient struct {
 // K8sCiliumClient is a wrapper around clientset.Interface.
 type K8sCiliumClient struct {
 	clientset.Interface
+}
+
+// K8sAPIExtensionsClient is a wrapper around clientset.Interface.
+type K8sAPIExtensionsClient struct {
+	apiextclientset.Interface
 }
 
 func updateNodeAnnotation(c kubernetes.Interface, nodeName string, encryptKey uint8, v4CIDR, v6CIDR *cidr.CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP, v6CiliumHostIP net.IP) error {

--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -24,7 +24,6 @@ import (
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/sirupsen/logrus"
@@ -92,11 +91,9 @@ func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 		return createNodeCRD(clientset)
 	})
 
-	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD {
-		g.Go(func() error {
-			return createIdentityCRD(clientset)
-		})
-	}
+	g.Go(func() error {
+		return createIdentityCRD(clientset)
+	})
 
 	g.Go(func() error {
 		return createCLRPCRD(clientset)

--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -57,8 +57,8 @@ const (
 	// CNCRDName is the full name of the CN CRD.
 	CNCRDName = k8sconstv2.CNKindDefinition + "/" + k8sconstv2.CustomResourceDefinitionVersion
 
-	// CLRPCRDNAME is the full name of the CLRP CRD.
-	CLRPCRDNAME = k8sconstv2.CLRPKindDefinition + "/" + k8sconstv2.CustomResourceDefinitionVersion
+	// CLRPCRDName is the full name of the CLRP CRD.
+	CLRPCRDName = k8sconstv2.CLRPKindDefinition + "/" + k8sconstv2.CustomResourceDefinitionVersion
 
 	// CCLRPCRDNAME is the full name of the CCLRP CRD.
 	CCLRPCRDNAME = k8sconstv2.CCLRPKindDefinition + "/" + k8sconstv2.CustomResourceDefinitionVersion
@@ -132,7 +132,7 @@ func GetPregeneratedCRD(crdName string) apiextensionsv1.CustomResourceDefinition
 		crdBytes, err = examplesCrdsCiliumidentitiesYamlBytes()
 	case CNCRDName:
 		crdBytes, err = examplesCrdsCiliumnodesYamlBytes()
-	case CLRPCRDNAME:
+	case CLRPCRDName:
 		crdBytes, err = examplesCrdsCiliumlocalredirectpoliciesYamlBytes()
 	case CCLRPCRDNAME:
 		crdBytes, err = examplesCrdsCiliumclusterwidelocalredirectpoliciesYamlBytes()
@@ -219,11 +219,11 @@ func createIdentityCRD(clientset apiextensionsclient.Interface) error {
 }
 
 func createCLRPCRD(clientset apiextensionsclient.Interface) error {
-	cLrpCRD := GetPregeneratedCRD(CLRPCRDNAME)
+	cLrpCRD := GetPregeneratedCRD(CLRPCRDName)
 
 	return createUpdateCRD(
 		clientset,
-		CLRPCRDNAME,
+		CLRPCRDName,
 		constructV1CRD(k8sconstv2.CLRPName, cLrpCRD),
 		newDefaultPoller(),
 	)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -32,8 +32,11 @@ import (
 	"github.com/cilium/cilium/pkg/version"
 
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextclientsetscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	"k8s.io/apimachinery/pkg/api/errors"
+	tablescheme "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -288,4 +291,10 @@ func runHeartbeat(heartBeat func(context.Context) error, timeout time.Duration, 
 func isConnReady(c kubernetes.Interface) error {
 	_, err := c.CoreV1().Namespaces().Get(context.TODO(), "kube-system", metav1.GetOptions{})
 	return err
+}
+
+func init() {
+	// Register the metav1.Table and metav1.PartialObjectMetadata for the
+	// apiextclientset.
+	utilruntime.Must(tablescheme.AddToScheme(apiextclientsetscheme.Scheme))
 }

--- a/pkg/k8s/init_test.go
+++ b/pkg/k8s/init_test.go
@@ -55,7 +55,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	// and we need to wait for the response of the channel.
 	patchChan := make(chan bool, 2)
 	fakeK8sClient := &fake.Clientset{}
-	k8sCli.Interface = fakeK8sClient
+	k8sCLI.Interface = fakeK8sClient
 	fakeK8sClient.AddReactor("patch", "nodes",
 		func(action testing.Action) (bool, runtime.Object, error) {
 			// If subresource is empty it means we are patching status and not
@@ -85,7 +85,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	c.Assert(node.GetIPv4AllocRange().String(), Equals, "10.2.0.0/16")
 	// IPv6 Node range is not checked because it shouldn't be changed.
 
-	err := k8sCli.AnnotateNode("node1",
+	err := k8sCLI.AnnotateNode("node1",
 		0,
 		node.GetIPv4AllocRange(),
 		node.GetIPv6AllocRange(),
@@ -120,7 +120,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	failAttempts := 0
 
 	fakeK8sClient = &fake.Clientset{}
-	k8sCli.Interface = fakeK8sClient
+	k8sCLI.Interface = fakeK8sClient
 	fakeK8sClient.AddReactor("patch", "nodes",
 		func(action testing.Action) (bool, runtime.Object, error) {
 			// If subresource is empty it means we are patching status and not
@@ -157,7 +157,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	c.Assert(node.GetIPv4AllocRange().String(), Equals, "10.254.0.0/16")
 	c.Assert(node.GetIPv6AllocRange().String(), Equals, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96")
 
-	err = k8sCli.AnnotateNode("node2",
+	err = k8sCLI.AnnotateNode("node2",
 		0,
 		node.GetIPv4AllocRange(),
 		node.GetIPv6AllocRange(),

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -63,6 +63,19 @@ type ServerCapabilities struct {
 	// This capability was introduced in K8s version 1.16, prior to which
 	// apiextensions/v1beta1 CRDs were used exclusively.
 	APIExtensionsV1CRD bool
+
+	// WatchPartialObjectMetadata is set to true when the K8s server supports a
+	// watch operation on the metav1.PartialObjectMetadata (and metav1.Table)
+	// resource.
+	//
+	// This capability was introduced in K8s version 1.15, prior to which
+	// watches cannot be performed on the aforementioned resources.
+	//
+	// Source:
+	//   - KEP:
+	//   https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190322-server-side-get-to-ga.md#goals
+	//   - PR: https://github.com/kubernetes/kubernetes/pull/71548
+	WatchPartialObjectMetadata bool
 }
 
 type cachedVersion struct {
@@ -94,6 +107,10 @@ var (
 	// v1 CRDs was introduced in K8s version 1.16.
 	isGEThanAPIExtensionsV1CRD = versioncheck.MustCompile(">=1.16.0")
 
+	// Constraint to check support for watching metav1.PartialObjectMetadata
+	// and metav1.Table types. Support was introduced in K8s 1.15.
+	isGEThanWatchPartialObjectMeta = versioncheck.MustCompile(">=1.15.0")
+
 	// isGEThanMinimalVersionConstraint is the minimal version required to run
 	// Cilium
 	isGEThanMinimalVersionConstraint = versioncheck.MustCompile(">=" + MinimalVersionConstraint)
@@ -124,6 +141,7 @@ func updateVersion(version go_version.Version) {
 	cached.capabilities.Patch = option.Config.K8sForceJSONPatch || isGEThanPatchConstraint(version)
 	cached.capabilities.MinimalVersionMet = isGEThanMinimalVersionConstraint(version)
 	cached.capabilities.APIExtensionsV1CRD = isGEThanAPIExtensionsV1CRD(version)
+	cached.capabilities.WatchPartialObjectMetadata = isGEThanWatchPartialObjectMeta(version)
 }
 
 func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) {

--- a/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
@@ -110,7 +110,7 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 	k.blockWaitGroupToSyncResources(
 		wait.NeverStop,
 		nil,
-		ciliumV2ClusterwidePolicyController,
+		ciliumV2ClusterwidePolicyController.HasSynced,
 		k8sAPIGroupCiliumClusterwideNetworkPolicyV2,
 	)
 

--- a/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
@@ -107,6 +107,7 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 		ccnpConverterFunc,
 		ccnpStore,
 	)
+
 	k.blockWaitGroupToSyncResources(
 		wait.NeverStop,
 		nil,

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -86,7 +86,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, as
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.
-		k.blockWaitGroupToSyncResources(isConnected, nil, ciliumEndpointInformer, k8sAPIGroupCiliumEndpointV2)
+		k.blockWaitGroupToSyncResources(isConnected, nil, ciliumEndpointInformer.HasSynced, k8sAPIGroupCiliumEndpointV2)
 
 		once.Do(func() {
 			// Signalize that we have put node controller in the wait group

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -64,6 +64,7 @@ func (k *K8sWatcher) ciliumLocalRedirectPolicyInit(ciliumLRPClient *k8s.K8sCiliu
 		},
 		k8s.ConvertToCiliumLocalRedirectPolicy,
 	)
+
 	k.blockWaitGroupToSyncResources(
 		wait.NeverStop,
 		nil,

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -67,7 +67,7 @@ func (k *K8sWatcher) ciliumLocalRedirectPolicyInit(ciliumLRPClient *k8s.K8sCiliu
 	k.blockWaitGroupToSyncResources(
 		wait.NeverStop,
 		nil,
-		lrpController,
+		lrpController.HasSynced,
 		k8sAPIGroupCiliumLocalRedirectPolicyV2,
 	)
 

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -174,7 +174,8 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClie
 		cnpConverterFunc,
 		cnpStore,
 	)
-	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, ciliumV2Controller, k8sAPIGroupCiliumNetworkPolicyV2)
+
+	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, ciliumV2Controller.HasSynced, k8sAPIGroupCiliumNetworkPolicyV2)
 	go ciliumV2Controller.Run(wait.NeverStop)
 	k.k8sAPIGroups.addAPI(k8sAPIGroupCiliumNetworkPolicyV2)
 }

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -30,7 +30,6 @@ import (
 )
 
 func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncControllers *sync.WaitGroup) {
-
 	// CiliumNode objects are used for node discovery until the key-value
 	// store is connected
 	var once sync.Once

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -91,7 +91,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.
-		k.blockWaitGroupToSyncResources(isConnected, swgNodes, ciliumNodeInformer, k8sAPIGroupCiliumNodeV2)
+		k.blockWaitGroupToSyncResources(isConnected, swgNodes, ciliumNodeInformer.HasSynced, k8sAPIGroupCiliumNodeV2)
 
 		once.Do(func() {
 			// Signalize that we have put node controller in the wait group

--- a/pkg/k8s/watchers/crd.go
+++ b/pkg/k8s/watchers/crd.go
@@ -1,0 +1,336 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/informer"
+	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
+
+	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+func (k *K8sWatcher) crdsInit(ctx context.Context, client apiextclientset.Interface) error {
+	crds := newCRDState(
+		map[string]bool{
+			cnpCRD:  false,
+			ccnpCRD: false,
+			cepCRD:  false,
+			cnCRD:   false,
+			cidCRD:  false,
+			clrpCRD: false,
+		},
+	)
+
+	_, crdController := informer.NewInformer(
+		newListWatchFromClient(
+			newCRDGetter(client),
+			fields.Everything(),
+		),
+		&metav1.PartialObjectMetadata{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { addCRD(&crds, obj) },
+			DeleteFunc: func(obj interface{}) { deleteCRD(&crds, obj) },
+		},
+		nil,
+	)
+
+	// Create a context so that we can timeout after the configured CRD wait
+	// peroid.
+	ctx, cancel := context.WithTimeout(ctx, option.Config.CRDWaitTimeout)
+	defer cancel()
+
+	crds.Lock()
+	for crd := range crds.m {
+		k.blockWaitGroupToSyncResources(
+			ctx.Done(),
+			nil,
+			func() bool {
+				crds.Lock()
+				defer crds.Unlock()
+				return crds.m[crd]
+			},
+			crd,
+		)
+	}
+	crds.Unlock()
+
+	// The above loop will call blockWaitGroupToSyncResources to populate the
+	// K8sWatcher state with the current state of the CRDs. It will check the
+	// state of each CRD, with the inline function provided. If the function
+	// reports that the given CRD is true (has been synced), it will close a
+	// channel associated with the given CRD. A subsequent call to
+	// (*K8sWatcher).WaitForCacheSync will notice that a given CRD's channel
+	// has been closed. Once all the CRDs passed to WaitForCacheSync have had
+	// their channels closed, the function unblocks.
+	//
+	// Meanwhile, the below code kicks off the controller that was instantiated
+	// above, and enters a loop looking for (1) if the context has deadlined or
+	// (2) if the entire CRD state has been synced (all CRDs found in the
+	// cluster). While we're in for-select loop, the controller is listening
+	// for either add or delete events to the customresourcedefinition resource
+	// (disguised inside a metav1.PartialObjectMetadata object). If (1) is
+	// encountered, then Cilium will fatal because it cannot proceed if the
+	// CRDs are not present. If (2) is encountered, then make sure the
+	// controller has exited by cancelling the context and we return out.
+
+	go crdController.Run(ctx.Done())
+	k.k8sAPIGroups.addAPI(k8sAPIGroupCRD)
+	// We no longer need this API to show up in `cilum status` as the
+	// controller will exit after this function.
+	defer k.k8sAPIGroups.removeAPI(k8sAPIGroupCRD)
+
+	log.Info("Waiting until all Cilium CRDs are available")
+
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.WithError(err).
+					Fatalf("Unable to find all Cilium CRDs necessary within "+
+						"%v timeout. Please ensure that Cilium Operator is "+
+						"running, as it's responsible for registering all "+
+						"the Cilium CRDs. The following CRDs were not found: %v",
+						option.Config.CRDWaitTimeout, crds.unSynced())
+			}
+			// If the context was canceled it means the daemon is being stopped
+			// so we can return the context's error.
+			return err
+		case <-ticker.C:
+			if crds.isSynced() {
+				ticker.Stop()
+				log.Info("All Cilium CRDs have been found and are available")
+				return nil
+			}
+		}
+	}
+}
+
+func addCRD(crds *crdState, obj interface{}) {
+	if pom := k8s.ObjToV1PartialObjectMetadata(obj); pom != nil {
+		crds.Lock()
+		crds.m[crdResourceName(pom.GetName())] = true
+		crds.Unlock()
+	}
+}
+
+func deleteCRD(crds *crdState, obj interface{}) {
+	if pom := k8s.ObjToV1PartialObjectMetadata(obj); pom != nil {
+		crds.Lock()
+		crds.m[crdResourceName(pom.GetName())] = false
+		crds.Unlock()
+	}
+}
+
+// isSynced returns whether all the CRDs inside `m` have all been synced,
+// meaning all CRDs we care about in Cilium exist in the cluster.
+func (s *crdState) isSynced() bool {
+	s.Lock()
+	defer s.Unlock()
+	for _, synced := range s.m {
+		if !synced {
+			return false
+		}
+	}
+	return true
+}
+
+// unSynced returns a slice containing all CRDs that currently have not been
+// synced.
+func (s *crdState) unSynced() []string {
+	s.Lock()
+	defer s.Unlock()
+	u := make([]string, 0, len(s.m))
+	for crd, synced := range s.m {
+		if !synced {
+			u = append(u, crd)
+		}
+	}
+	return u
+}
+
+// crdState contains the state of the CRDs inside the cluster.
+type crdState struct {
+	lock.Mutex
+
+	// m is a map which maps the CRD name to its synced state in the cluster.
+	// True means it exists, false means it doesn't exist.
+	m map[string]bool
+}
+
+func newCRDState(m map[string]bool) crdState {
+	return crdState{
+		m: m,
+	}
+}
+
+var (
+	cnpCRD  = crdResourceName(v2.CNPName)
+	ccnpCRD = crdResourceName(v2.CCNPName)
+	cepCRD  = crdResourceName(v2.CEPName)
+	cnCRD   = crdResourceName(v2.CNName)
+	cidCRD  = crdResourceName(v2.CIDName)
+	clrpCRD = crdResourceName(v2.CLRPName)
+)
+
+func crdResourceName(crd string) string {
+	return "crd:" + crd
+}
+
+// newListWatchFromClient is a copy of the NewListWatchFromClient from the
+// "k8s.io/client-go/tools/cache" package, with many alterations made to
+// efficiently retrieve Cilium CRDs. This is important because we don't want
+// each agent to fetch the full CRDs across the cluster, because they
+// potentially contain large validation schemas.
+//
+// This function also removes removes unnecessary calls from the upstream
+// version that set the namespace and the resource when performing `Get`.
+//
+//   - If the resource was set, the following error was observed:
+//     "customresourcedefinitions.apiextensions.k8s.io
+//     "customresourcedefinitions" not found".
+//   - If the namespace was set, the following error was observed:
+//     "an empty namespace may not be set when a resource name is provided".
+//
+// The namespace problem can be worked around by using NamespaceIfScoped, but
+// it's been omitted entirely here because it's equivalent in functionality.
+func newListWatchFromClient(c cache.Getter, fieldSelector fields.Selector) *cache.ListWatch {
+	optionsModifier := func(options *metav1.ListOptions) {
+		options.FieldSelector = fieldSelector.String()
+	}
+
+	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
+		// This lister  will retrieve the CRDs as a metav1.Table object. This
+		// is the same way that `kubectl get crds` returns them. In the
+		// metav1.Table object, it contains cells, which are
+		// metav1.PartialObjectMetadata objects containing the minimal
+		// representation of an objects in K8s (in this case a CRD). Once the
+		// metav1.Table is fetched, it is converted into a
+		// metav1.PartialObjectMetadataList which is what the controller
+		// (informer) expects the object type to be. If we returned the
+		// metav1.Table itself, the controller doesn't know how to handle that
+		// object type because it is not a list type.
+
+		optionsModifier(&options)
+
+		t := &metav1.Table{}
+		err := c.Get().
+			SetHeader("Accept", tableHeader).
+			VersionedParams(&options, metav1.ParameterCodec).
+			Do(context.TODO()).
+			Into(t)
+		if err != nil {
+			return nil, err
+		}
+		return tableToPomList(t), nil
+	}
+	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
+		// This watcher will retrieve each CRD that the lister has listed as
+		// individual metav1.PartialObjectMetadata because it is requesting the
+		// apiserver to return objects as such via the "Accept" header.
+
+		optionsModifier(&options)
+
+		options.Watch = true
+		return c.Get().
+			SetHeader("Accept", partialObjHeader).
+			VersionedParams(&options, metav1.ParameterCodec).
+			Watch(context.TODO())
+	}
+	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+}
+
+// tableToPomList converts a metav1.Table's cells into individual
+// metav1.PartialObjectMetadata objects, and returns them all placed in a
+// metav1.PartialObjectMetadataList.
+//
+// Note that K8s apiserver versions below 1.15 only have metav1beta1 version of
+// Table and PartialObjectMetadata. However, because both types marshall the
+// same to the same object because their fields have not changed (only a type
+// version promotion), the code still works. Hence, we do not need different
+// versions of this function to handle the different types. See
+// https://github.com/kubernetes/kubernetes/pull/77136.
+func tableToPomList(t *metav1.Table) *metav1.PartialObjectMetadataList {
+	list := &metav1.PartialObjectMetadataList{
+		TypeMeta: t.TypeMeta,
+		ListMeta: t.ListMeta,
+		Items:    make([]metav1.PartialObjectMetadata, 0, len(t.Rows)),
+	}
+
+	for _, row := range t.Rows {
+		var pom metav1.PartialObjectMetadata
+		if err := json.Unmarshal(row.Object.Raw, &pom); err != nil {
+			log.WithError(err).Errorf("Converting metav1.Table to metav1.PartialObjectMetadata, unexpected type %T found, skipping",
+				row.Object.Object)
+			continue
+		}
+
+		list.Items = append(list.Items, pom)
+	}
+
+	return list
+}
+
+const (
+	tableHeader      = "application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json"
+	partialObjHeader = "application/json;as=PartialObjectMetadata;v=v1;g=meta.k8s.io,application/json;as=PartialObjectMetadata;v=v1beta1;g=meta.k8s.io,application/json"
+)
+
+// Get instantiates a GET request from the K8s REST client to retrieve CRDs. We
+// define this getter because it's necessary to use the correct apiextensions
+// client (v1 or v1beta1) in order to retrieve the CRDs in a
+// backwards-compatible way. This implements the cache.Getter interface.
+func (c *crdGetter) Get() *rest.Request {
+	var req *rest.Request
+
+	if k8sversion.Capabilities().APIExtensionsV1CRD {
+		req = c.api.ApiextensionsV1().
+			RESTClient().
+			Get().
+			Name("customresourcedefinitions")
+	} else {
+		req = c.api.ApiextensionsV1beta1().
+			RESTClient().
+			Get().
+			Name("customresourcedefinitions")
+	}
+
+	return req
+}
+
+type crdGetter struct {
+	api apiextclientset.Interface
+}
+
+func newCRDGetter(c apiextclientset.Interface) *crdGetter {
+	return &crdGetter{api: c}
+}

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -82,7 +82,7 @@ func (k *K8sWatcher) endpointsInit(k8sClient kubernetes.Interface, swgEps *lock.
 		},
 		nil,
 	)
-	k.blockWaitGroupToSyncResources(wait.NeverStop, swgEps, endpointController, K8sAPIGroupEndpointV1Core)
+	k.blockWaitGroupToSyncResources(wait.NeverStop, swgEps, endpointController.HasSynced, K8sAPIGroupEndpointV1Core)
 	go endpointController.Run(wait.NeverStop)
 	k.k8sAPIGroups.addAPI(K8sAPIGroupEndpointV1Core)
 }

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -86,7 +86,7 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 		nil,
 	)
 	ecr := make(chan struct{})
-	k.blockWaitGroupToSyncResources(ecr, swgEps, endpointController, K8sAPIGroupEndpointSliceV1Beta1Discovery)
+	k.blockWaitGroupToSyncResources(ecr, swgEps, endpointController.HasSynced, K8sAPIGroupEndpointSliceV1Beta1Discovery)
 	go endpointController.Run(ecr)
 	k.k8sAPIGroups.addAPI(K8sAPIGroupEndpointSliceV1Beta1Discovery)
 

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -69,7 +69,7 @@ func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, asyncControl
 	)
 
 	k.namespaceStore = namespaceStore
-	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, namespaceController, k8sAPIGroupNamespaceV1Core)
+	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, namespaceController.HasSynced, k8sAPIGroupNamespaceV1Core)
 	k.k8sAPIGroups.addAPI(k8sAPIGroupNamespaceV1Core)
 	asyncControllers.Done()
 	namespaceController.Run(wait.NeverStop)

--- a/pkg/k8s/watchers/network_policy.go
+++ b/pkg/k8s/watchers/network_policy.go
@@ -80,7 +80,7 @@ func (k *K8sWatcher) networkPoliciesInit(k8sClient kubernetes.Interface, swgKNPs
 		nil,
 	)
 	k.networkpolicyStore = store
-	k.blockWaitGroupToSyncResources(wait.NeverStop, swgKNPs, policyController, k8sAPIGroupNetworkingV1Core)
+	k.blockWaitGroupToSyncResources(wait.NeverStop, swgKNPs, policyController.HasSynced, k8sAPIGroupNetworkingV1Core)
 	go policyController.Run(wait.NeverStop)
 
 	k.k8sAPIGroups.addAPI(k8sAPIGroupNetworkingV1Core)

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -56,7 +56,7 @@ func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
 		nil,
 	)
 
-	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, nodeController, k8sAPIGroupNodeV1Core)
+	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, nodeController.HasSynced, k8sAPIGroupNodeV1Core)
 	go nodeController.Run(wait.NeverStop)
 	k.k8sAPIGroups.addAPI(k8sAPIGroupNodeV1Core)
 }

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -121,7 +121,7 @@ func (k *K8sWatcher) podsInit(k8sClient kubernetes.Interface, asyncControllers *
 			close(k.podStoreSet)
 		})
 
-		k.blockWaitGroupToSyncResources(isConnected, nil, podController, K8sAPIGroupPodV1Core)
+		k.blockWaitGroupToSyncResources(isConnected, nil, podController.HasSynced, K8sAPIGroupPodV1Core)
 		once.Do(func() {
 			asyncControllers.Done()
 			k.k8sAPIGroups.addAPI(K8sAPIGroupPodV1Core)
@@ -150,7 +150,7 @@ func (k *K8sWatcher) podsInit(k8sClient kubernetes.Interface, asyncControllers *
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.
-		k.blockWaitGroupToSyncResources(isConnected, nil, podController, K8sAPIGroupPodV1Core)
+		k.blockWaitGroupToSyncResources(isConnected, nil, podController.HasSynced, K8sAPIGroupPodV1Core)
 		once.Do(func() {
 			asyncControllers.Done()
 			k.k8sAPIGroups.addAPI(K8sAPIGroupPodV1Core)

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -74,7 +74,7 @@ func (k *K8sWatcher) servicesInit(k8sClient kubernetes.Interface, swgSvcs *lock.
 		},
 		nil,
 	)
-	k.blockWaitGroupToSyncResources(wait.NeverStop, swgSvcs, svcController, K8sAPIGroupServiceV1Core)
+	k.blockWaitGroupToSyncResources(wait.NeverStop, swgSvcs, svcController.HasSynced, K8sAPIGroupServiceV1Core)
 	go svcController.Run(wait.NeverStop)
 	k.k8sAPIGroups.addAPI(K8sAPIGroupServiceV1Core)
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -450,7 +450,7 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 
 	// kubernetes network policies
 	swgKNP := lock.NewStoppableWaitGroup()
-	k.networkPoliciesInit(k8s.WatcherCli(), swgKNP)
+	k.networkPoliciesInit(k8s.WatcherClient(), swgKNP)
 
 	serviceOptModifier, err := utils.GetServiceListOptionsModifier()
 	if err != nil {
@@ -459,7 +459,7 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 
 	// kubernetes services
 	swgSvcs := lock.NewStoppableWaitGroup()
-	k.servicesInit(k8s.WatcherCli(), swgSvcs, serviceOptModifier)
+	k.servicesInit(k8s.WatcherClient(), swgSvcs, serviceOptModifier)
 
 	// kubernetes endpoints
 	swgEps := lock.NewStoppableWaitGroup()
@@ -469,14 +469,14 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	case k8s.SupportsEndpointSlice():
 		// We don't add the service option modifier here, as endpointslices do not
 		// mirror service proxy name label present in the corresponding service.
-		connected := k.endpointSlicesInit(k8s.WatcherCli(), swgEps)
+		connected := k.endpointSlicesInit(k8s.WatcherClient(), swgEps)
 		// The cluster has endpoint slices so we should not check for v1.Endpoints
 		if connected {
 			break
 		}
 		fallthrough
 	default:
-		k.endpointsInit(k8s.WatcherCli(), swgEps, serviceOptModifier)
+		k.endpointsInit(k8s.WatcherClient(), swgEps, serviceOptModifier)
 	}
 
 	// cilium network policies
@@ -502,14 +502,14 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 
 	// kubernetes pods
 	asyncControllers.Add(1)
-	go k.podsInit(k8s.WatcherCli(), asyncControllers)
+	go k.podsInit(k8s.WatcherClient(), asyncControllers)
 
 	// kubernetes nodes
-	k.nodesInit(k8s.WatcherCli())
+	k.nodesInit(k8s.WatcherClient())
 
 	// kubernetes namespaces
 	asyncControllers.Add(1)
-	go k.namespacesInit(k8s.WatcherCli(), asyncControllers)
+	go k.namespacesInit(k8s.WatcherClient(), asyncControllers)
 
 	asyncControllers.Wait()
 	close(k.controllersStarted)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -295,7 +295,7 @@ func (k *K8sWatcher) cancelWaitGroupToSyncResources(resourceName string) {
 func (k *K8sWatcher) blockWaitGroupToSyncResources(
 	stop <-chan struct{},
 	swg *lock.StoppableWaitGroup,
-	informer cache.Controller,
+	hasSyncedFunc cache.InformerSynced,
 	resourceName string,
 ) {
 
@@ -306,7 +306,7 @@ func (k *K8sWatcher) blockWaitGroupToSyncResources(
 	go func() {
 		scopedLog := log.WithField("kubernetesResource", resourceName)
 		scopedLog.Debug("waiting for cache to synchronize")
-		if ok := cache.WaitForCacheSync(stop, informer.HasSynced); !ok {
+		if ok := cache.WaitForCacheSync(stop, hasSyncedFunc); !ok {
 			select {
 			case <-stop:
 				// do not fatal if the channel was stopped

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -854,6 +854,10 @@ const (
 
 	// APIRateLimitName enables configuration of the API rate limits
 	APIRateLimitName = "api-rate-limit"
+
+	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
+	// available.
+	CRDWaitTimeout = "crd-wait-timeout"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -2004,6 +2008,10 @@ type DaemonConfig struct {
 
 	// APIRateLimitName enables configuration of the API rate limits
 	APIRateLimit map[string]string
+
+	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
+	// available.
+	CRDWaitTimeout time.Duration
 }
 
 var (
@@ -2537,6 +2545,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableIPv4FragmentsTracking = viper.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = viper.GetInt(FragmentsMapEntriesName)
 	c.K8sServiceProxyName = viper.GetString(K8sServiceProxyName)
+	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
 
 	c.populateDevices()
 


### PR DESCRIPTION
See commit msgs.

```release-note
Cilium Agent will now wait for CRDs to become available instead of the Operator; the Operator will register the CRDs
```