### PR TITLE
[v1.7] document option for enabling API rate limiting

### DIFF
--- a/Documentation/configuration/api-rate-limiting.rst
+++ b/Documentation/configuration/api-rate-limiting.rst
@@ -40,6 +40,20 @@ API Call                   Limit  Burst Max Parallel  Min Parallel Max Wait Dura
 Configuration
 =============
 
+.. note:: Before version 1.9, API rate limiting is disabled by default.
+
+The feature can be enabled with the ``enable-api-rate-limit`` option:
+
+.. code::
+
+    --enable-api-rate-limit=true
+
+Or with Helm:
+
+.. code::
+
+    --set global.enableAPIRateLimit=true
+
 The ``api-rate-limit`` option can be used to overwrite individual settings of the
 default configuration:
 

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -149,6 +149,7 @@ data:
   enable-endpoint-health-checking: "true"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"
+  enable-api-rate-limit: "false"
 ---
 # Source: cilium/charts/agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Follow-up to #13392 (backport for API rate limiting):

* Document the `--enable-api-rate-limit` option (defaulting to `false`) necessary to enable the feature on v1.7.
* Re-generate the quick-install.yaml file.

The same changes are added to the v1.8 backports in #13421.