### PR TITLE
Expose operator azure-user-assigned-identity-id flag to its chart

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -325,6 +325,9 @@ data:
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
   enable-local-node-route: "false"
+{{- if .Values.azure.userAssignedIdentityID }}
+  azure-user-assigned-identity-id: {{ .Values.azure.userAssignedIdentityID | quote }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.flannel.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -162,6 +162,7 @@ azure:
   # tenantID: 00000000-0000-0000-0000-000000000000
   # clientID: 00000000-0000-0000-0000-000000000000
   # clientSecret: 00000000-0000-0000-0000-000000000000
+  # userAssignedIdentityID: 00000000-0000-0000-0000-000000000000
 
 # TODO: Add documentation
 bandwidthManager: false


### PR DESCRIPTION
Exposing Cilium Operator's flag --azure-user-assigned-identity-id to its chart.

Signed-off-by: Andor Nemeth <ombre9@gmail.com>