### PR TITLE
docs: Remove "Experimental" from GKE E2E test section

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -481,8 +481,8 @@ An example invocation is
 
   CNI_INTEGRATION=eks K8S_VERSION=1.13 ginkgo --focus="K8s" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium:latest" -cilium.operator-image="docker.io/cilium/operator-generic:latest" -cilium.passCLIEnvironment=true
 
-GKE (experimental)
-^^^^^^^^^^^^^^^^^^^^^^
+Running in GKE
+^^^^^^^^^^^^^^
 
 1- Setup a cluster as in :ref:`k8s_install_gke` or utilize an existing
 cluster.


### PR DESCRIPTION
Since we're now running this in CI and several of us are using it, I'm guessing we can't really call it "Experimental" anymore.