### PR TITLE
bpf: Do not try to open map when creating unpinned map

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -467,13 +467,13 @@ func (m *Map) OpenOrCreate() (bool, error) {
 	return m.openOrCreate(true)
 }
 
-// OpenOrCreateUnpinned is similar to OpenOrCreate (see above) but without
-// pinning the map to the file system if it had to be created.
-func (m *Map) OpenOrCreateUnpinned() (bool, error) {
+// CreateUnpinned creates the map without pinning it to the file system.
+func (m *Map) CreateUnpinned() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	return m.openOrCreate(false)
+	_, err := m.openOrCreate(false)
+	return err
 }
 
 // Create is similar to OpenOrCreate, but closes the map after creating or

--- a/pkg/maps/lbmap/maglev.go
+++ b/pkg/maps/lbmap/maglev.go
@@ -39,7 +39,7 @@ var MaglevOuter6Map *bpf.Map
 
 func InitMaglevMaps(ipv4 bool, ipv6 bool) error {
 	dummyInnerMap := newInnerMaglevMap("cilium_lb_maglev_dummy")
-	if _, err := dummyInnerMap.OpenOrCreateUnpinned(); err != nil {
+	if err := dummyInnerMap.CreateUnpinned(); err != nil {
 		return err
 	}
 	defer dummyInnerMap.Close()
@@ -93,7 +93,7 @@ func updateMaglevTable(ipv6 bool, revNATID uint16, backendIDs []uint16) error {
 	}
 
 	innerMap := newInnerMaglevMap(innerMapName)
-	if _, err := innerMap.OpenOrCreateUnpinned(); err != nil {
+	if err := innerMap.CreateUnpinned(); err != nil {
 		return err
 	}
 	defer innerMap.Close()

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -72,7 +72,7 @@ func HaveFullLPM() bool {
 			&probeKey{}, int(unsafe.Sizeof(probeKey{})),
 			&probeValue{}, int(unsafe.Sizeof(probeValue{})),
 			1, bpf.BPF_F_NO_PREALLOC, 0, bpf.ConvertKeyValue).WithCache()
-		_, err := m.OpenOrCreateUnpinned()
+		err := m.CreateUnpinned()
 		defer m.Close()
 		if err != nil {
 			return


### PR DESCRIPTION
Previously, the `OpenOrCreateUnpinned()` method tried to open a map before creating it. Obviously, such map could not been openned as it was not pinned to the bpf fs (unless there existed a map with the same name). Fix this by avoiding the opening.

Also, rename the method to `CreateUnpinned()` to reflect better the nature of the method.

Finally, add a unit test for the method.

Fixes: e5cddc76 ("cilium: add OpenOrCreateUnpinned helper for Cilium maps")

---

In the end I think that this PR is a minor optimization, as name of any map which was created via `OpenOrCreateUnpinned()` didn't clash with any existing map, so no maps were unexpectedly mixed. Therefore, I don't think that it's worth backporting to `v1.{6,7,8}`.