### PR TITLE
v1.6 backports 2020-10-07

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -59,7 +59,7 @@ main() {
     local new_proj="$2"
 
     git fetch $remote
-    git checkout -b pr/prepare-$version $remote/v$branch
+    git checkout -b pr/prepare-$version $remote/$branch
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
@@ -72,7 +72,7 @@ main() {
 
     logecho "Next steps:"
     logecho "* Check all changes and add to a new commit"
-    logecho "* Push the PR to Github for review"
+    logecho "* Push the PR to Github for review ('submit-release.sh')"
     logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
 

--- a/pkg/contexthelpers/context.go
+++ b/pkg/contexthelpers/context.go
@@ -24,7 +24,7 @@ type SuccessChan chan bool
 // NewConditionalTimeoutContext returns a context which is cancelled when
 // success is not reported within the specified timeout
 func NewConditionalTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc, SuccessChan) {
-	ch := make(SuccessChan)
+	ch := make(SuccessChan, 1)
 	c, cancel := context.WithCancel(ctx)
 
 	go func() {

--- a/pkg/contexthelpers/context_test.go
+++ b/pkg/contexthelpers/context_test.go
@@ -58,6 +58,10 @@ func (b *ContextSuite) TestConditionalTimeoutContext(c *check.C) {
 		c.Errorf("context cancelled despite reporting success")
 	case <-time.After(100 * time.Millisecond):
 	}
-
 	cancel()
+
+	_, _, ch = NewConditionalTimeoutContext(context.Background(), 10*time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
+	// validate that sending to success channel does not deadlock after the timeout
+	ch <- false
 }


### PR DESCRIPTION
* #13357 -- contrib: Improve start-release.sh script (@joestringer)
 * #13408 -- contexthelpers: Fix deadlock when nobody recvs on success channel (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13357 13408; do contrib/backporting/set-labels.py $pr done 1.6; done
```