### PR TITLE
test: fix ipv6 addr configuration for vm interfaces

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -84,11 +84,11 @@ Vagrant.configure("2") do |config|
             virtualbox__intnet: "cilium-k8s-2#{$BUILD_NUMBER}-#{$JOB_NAME}-#{$K8S_VERSION}"
 
         # @TODO: Clean this one when https://github.com/hashicorp/vagrant/issues/9822 is fixed.
-        server.vm.provision "ipv6-config",
+        server.vm.provision "ipv6-config-primary",
             type: "shell",
             run: "always",
             inline: "ip -6 a a fd04::1/96 dev enp0s8 || true"
-        server.vm.provision "ipv6-config",
+        server.vm.provision "ipv6-config-secondary",
             type: "shell",
             run: "always",
             inline: "ip -6 a a fd05::1/96 dev enp0s9 || true"
@@ -159,11 +159,11 @@ Vagrant.configure("2") do |config|
                 virtualbox__intnet: "cilium-k8s-2#{$BUILD_NUMBER}-#{$JOB_NAME}-#{$K8S_VERSION}"
 
             # @TODO: Clean this one when https://github.com/hashicorp/vagrant/issues/9822 is fixed.
-            server.vm.provision "ipv6-config",
+            server.vm.provision "ipv6-config-primary",
                 type: "shell",
                 run: "always",
                 inline: "ip -6 a a fd04::1#{i}/96 dev enp0s8 || true"
-            server.vm.provision "ipv6-config",
+            server.vm.provision "ipv6-config-secondary",
                 type: "shell",
                 run: "always",
                 inline: "ip -6 a a fd05::1#{i}/96 dev enp0s9 || true"


### PR DESCRIPTION
See commit message for more detail:

Before:

```
3: enp0s8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:34:d3:2d brd ff:ff:ff:ff:ff:ff
    inet 192.168.36.11/24 brd 192.168.36.255 scope global enp0s8
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:fe34:d32d/64 scope link
       valid_lft forever preferred_lft forever
4: enp0s9: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:43:f0:b4 brd ff:ff:ff:ff:ff:ff
    inet 192.168.37.11/24 brd 192.168.37.255 scope global enp0s9
       valid_lft forever preferred_lft forever
    inet6 fd05::11/96 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:fe43:f0b4/64 scope link
       valid_lft forever preferred_lft forever
```

After
```
3: enp0s8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:b1:40:fc brd ff:ff:ff:ff:ff:ff
    inet 192.168.36.11/24 brd 192.168.36.255 scope global enp0s8
       valid_lft forever preferred_lft forever
    inet6 fd04::11/96 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:feb1:40fc/64 scope link
       valid_lft forever preferred_lft forever
4: enp0s9: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:fb:14:e7 brd ff:ff:ff:ff:ff:ff
    inet 192.168.37.11/24 brd 192.168.37.255 scope global enp0s9
       valid_lft forever preferred_lft forever
    inet6 fd05::11/96 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:fefb:14e7/64 scope link
       valid_lft forever preferred_lft forever
```

The required address gets assigned to both the interfaces.