### PR TITLE
datapath: Fix handling of enable-endpoint-routes

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -298,10 +298,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		}
 	}
 
-	if option.Config.EnableEndpointRoutes == true {
-		args[initArgMode] = "routed"
-	}
-
 	if option.Config.EnableNodePort {
 		args[initArgNodePort] = "true"
 		if option.Config.EnableIPv4 {


### PR DESCRIPTION
When #13346 was backported to v1.8 branch this case hasn't been
patched correctly due difference betwen v1.8 and master.

Fixes: b8a0f01ad9 ("datapath: Support enable-endpoint-routes with encapsulation")