### PR TITLE
Follow-up fixes for the API rate limiter

### DIFF
--- a/daemon/cmd/api_limits.go
+++ b/daemon/cmd/api_limits.go
@@ -119,6 +119,11 @@ func (a *apiRateLimitingMetrics) ProcessedRequest(name string, v rate.MetricsVal
 	metrics.APILimiterRateLimit.WithLabelValues(name, "limit").Set(float64(v.Limit))
 	metrics.APILimiterRateLimit.WithLabelValues(name, "burst").Set(float64(v.Burst))
 	metrics.APILimiterAdjustmentFactor.WithLabelValues(name).Set(v.AdjustmentFactor)
-	metrics.APILimiterWaitHistoryDuration.WithLabelValues(name).Observe(v.WaitDuration.Seconds())
-	metrics.APILimiterProcessedRequests.WithLabelValues(name, metrics.Error2Outcome(v.Error)).Inc()
+
+	if v.Outcome == "" {
+		metrics.APILimiterWaitHistoryDuration.WithLabelValues(name).Observe(v.WaitDuration.Seconds())
+		v.Outcome = metrics.Error2Outcome(v.Error)
+	}
+
+	metrics.APILimiterProcessedRequests.WithLabelValues(name, v.Outcome).Inc()
 }

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -668,16 +668,12 @@ skipRateLimiter:
 	l.currentRequestsInFlight++
 	l.mutex.Unlock()
 
-	log.WithFields(logrus.Fields{
-		logAPICallName:       l.name,
-		logUUID:              uuid,
-		logWaitDurationTotal: waitDuration,
-	}).Debug("API call is ready to be served")
+	scopedLog = scopedLog.WithField(logWaitDurationTotal, waitDuration)
 
 	if l.params.Log {
-		scopedLog.Info("Processing API request with rate limiter")
+		scopedLog.Info("API request released by rate limiter")
 	} else {
-		scopedLog.Debug("Processing API request with rate limiter")
+		scopedLog.Debug("API request released by rate limiter")
 	}
 
 	return &limitedRequest{

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -19,11 +19,13 @@ package rate
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/testutils"
 
+	"golang.org/x/sync/semaphore"
 	"golang.org/x/time/rate"
 	"gopkg.in/check.v1"
 )
@@ -715,4 +717,50 @@ func (b *ControllerSuite) TestAdjustedParallelRequests(c *check.C) {
 	c.Assert(a.adjustedParallelRequests(), check.Equals, 1)
 	a.adjustmentFactor = 1.0
 	c.Assert(a.adjustedParallelRequests(), check.Equals, 2)
+}
+
+func (b *ControllerSuite) TestStressRateLimiter(c *check.C) {
+	a := NewAPILimiter("foo", APILimiterParameters{
+		EstimatedProcessingDuration: 5 * time.Millisecond,
+		RateLimit:                   1000.0,
+		ParallelRequests:            50,
+		RateBurst:                   1,
+		MaxWaitDuration:             10 * time.Millisecond,
+		AutoAdjust:                  true,
+	}, nil)
+
+	var (
+		sem                = semaphore.NewWeighted(100)
+		completed, retries int32
+	)
+
+	go func() {
+		for i := 0; i < 1000; i++ {
+			sem.Acquire(context.Background(), 1)
+			go func() {
+				var (
+					err error
+					req LimitedRequest
+				)
+				for req == nil {
+					req, err = a.Wait(context.Background())
+					if err == nil {
+						time.Sleep(5 * time.Millisecond)
+						req.Done()
+						atomic.AddInt32(&completed, 1)
+						sem.Release(1)
+						return
+					}
+					atomic.AddInt32(&retries, 1)
+				}
+			}()
+		}
+	}()
+
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadInt32(&completed) == 1000
+	}, 5*time.Second), check.IsNil)
+
+	log.Infof("%+v", a)
+	log.Infof("Total retries: %v", atomic.LoadInt32(&retries))
 }


### PR DESCRIPTION
So far, the rate-limiting has been enforced before enforcing parallel
requests. In theory, this is better because we can return error code
429 earlier to tell callers to slow down.

In practice, many callers will retry immediately anyway which means that
all the limiting will happen by the rate limiter. The rate limiter
relies on reservations that need to be canceled. If too many requests
happen in parallel, reservations can't be canceled quickly enough.

By swapping the enforcement of parallel requests with the rate limiter,
all requests will block for at least MaxWaitDuration if more than the
allowed number of parallel requests are pending which will naturally
pace the callers.

As the semaphore enforcing parallel requests now has to be released in
error scenarios, change the structure of Wait() to have a single error
handling structure. By reusing finishRequest(), the metrics handler has
to be adjusted slightly to account for new outcomes as it now bumps the
metric for canceled requests as well.