### PR TITLE
helm: renamed podsAnnotations variable into podAnnotations

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -27,6 +27,7 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+{{- with .Values.podsAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
       labels:
         k8s-app: cilium
 {{- if .Values.keepDeprecatedLabels }}

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-{{- with .Values.podsAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
+{{- with .Values.podAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
       labels:
         k8s-app: cilium
 {{- if .Values.keepDeprecatedLabels }}

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -5,7 +5,7 @@ image: cilium
 maxUnavailable: 2
 
 # Additional annotations for the agent pods
-podsAnnotations: {}
+podAnnotations: {}
 
 # Specifies annotation for service accounts
 serviceAccount:

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -4,6 +4,9 @@ image: cilium
 # update process.
 maxUnavailable: 2
 
+# Additional annotations for the agent pods
+podsAnnotations: {}
+
 # Specifies annotation for service accounts
 serviceAccount:
   annotations: {}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         prometheus.io/port: {{ .Values.global.operatorPrometheus.port | quote }}
         prometheus.io/scrape: "true"
 {{- end }}
-{{- with .Values.podsAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
+{{- with .Values.podAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
       labels:
         io.cilium/app: operator
         name: cilium-operator

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
         prometheus.io/port: {{ .Values.global.operatorPrometheus.port | quote }}
         prometheus.io/scrape: "true"
 {{- end }}
+{{- with .Values.podsAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
       labels:
         io.cilium/app: operator
         name: cilium-operator

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -8,7 +8,7 @@ serviceAccount:
 resources: {}
 
 # Additional annotations for the operator pods
-podsAnnotations: {}
+podAnnotations: {}
 
 # Number of replicas to run for cilium operator deployment.
 numReplicas: 2

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -7,6 +7,8 @@ serviceAccount:
 # Specifies the resources for the operator container
 resources: {}
 
+# Additional annotations for the operator pods
+podsAnnotations: {}
 
 # Number of replicas to run for cilium operator deployment.
 numReplicas: 2


### PR DESCRIPTION
This change follows-up onto https://github.com/cilium/cilium/pull/12189#issuecomment-705226944
It concerns the agent and operator charts