### PR TITLE
v1.8 backports 2020-10-08

### DIFF
--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -199,7 +199,7 @@ func initK8s(ctx context.Context) (crdBackend allocator.Backend, crdAllocator *a
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 
-	if err := k8s.GetNodeSpec(); err != nil {
+	if err := k8s.WaitForNodeInformation(); err != nil {
 		log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -458,7 +458,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			d.nodeDiscovery.UpdateCiliumNodeResource()
 		}
 
-		if err := k8s.GetNodeSpec(); err != nil {
+		if err := k8s.WaitForNodeInformation(); err != nil {
 			log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 		}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -452,7 +452,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			log.WithError(err).Fatal("Unable to register CRDs")
 		}
 
-		if option.Config.IPAM == ipamOption.IPAMOperator {
+		if option.Config.IPAM == ipamOption.IPAMClusterPool {
 			// Create the CiliumNode custom resource. This call will block until
 			// the custom resource has been created
 			d.nodeDiscovery.UpdateCiliumNodeResource()

--- a/examples/kubernetes/connectivity-check/Makefile
+++ b/examples/kubernetes/connectivity-check/Makefile
@@ -24,7 +24,9 @@ DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 	--volume $(CURDIR)/../../..:/src \
 	--user "$(shell id -u):$(shell id -g)"
 
-CUE_IMAGE := "docker.io/cuelang/cue:v0.2.2@sha256:2ea932c771212db140c9996c6fff1d236f3f84ae82add914374cee553b6fc60c"
+CUE_VERSION := "v0.2.2"
+CUE_SHA := "2ea932c771212db140c9996c6fff1d236f3f84ae82add914374cee553b6fc60c"
+CUE_IMAGE := "docker.io/cuelang/cue:$(CUE_VERSION)@sha256:$(CUE_SHA)"
 CUE := $(DOCKER_RUN) $(CUE_IMAGE)
 
 all: $(ALL_TARGETS)
@@ -88,6 +90,8 @@ inspect:
 
 help:
 	$(QUIET)$(CUE) cmd help
+	@echo "The cue CLI may be installed via the following command:"
+	@echo "$$ go get cuelang.org/go@$(CUE_VERSION)"
 
 list:
 	$(QUIET)$(CUE) cmd ls

--- a/examples/kubernetes/connectivity-check/README.md
+++ b/examples/kubernetes/connectivity-check/README.md
@@ -33,7 +33,7 @@ multiple files per the following logic:
   for various connectivity checks at different layers and using different
   features. L7 policy checks are defined in `proxy.cue` and not `policy.cue`.
 * `*_tool.cue`: Various CLI tools for listing and generating the YAML
-  definitons used above. For more information, run `make help` in this
+  definitions used above. For more information, run `make help` in this
   directory.
 
 For more information, see https://github.com/cilium/cilium/pull/12599 .

--- a/examples/kubernetes/connectivity-check/README.md
+++ b/examples/kubernetes/connectivity-check/README.md
@@ -37,3 +37,31 @@ multiple files per the following logic:
   directory.
 
 For more information, see https://github.com/cilium/cilium/pull/12599 .
+
+## Listing and generating connectivity checks
+
+```
+$ make help
+List connectivity-check resources specified in this directory
+
+Usage:
+  cue [-t component=<component>] [-t kind=<kind>] [-t name=<name>] [-t quarantine=true] [-t topology=<topology>] [-t traffic=any] [-t type=<tooltype>] <command>
+
+Available Commands:
+  dump   Generate connectivity-check YAMLs from the cuelang scripts
+  ls     List connectivity-check resources specified in this directory
+
+Available filters:
+  component   { all | default | network | policy | services | hostport | proxy } (default excludes hostport, proxy)
+  kind        { Deployment | Service | CiliumNetworkPolicy } (default: all)
+  quarantine  { true | false } (default: false)
+  topology    { any | single-node } (default: any)
+  traffic     { any | internal | external } (default: any)
+  type        { autocheck | tool } (default: autocheck)
+
+Example command:
+$ cue -t component=all ls
+
+The cue CLI may be installed via the following command:
+$ go get cuelang.org/go@v0.2.2
+```

--- a/examples/kubernetes/connectivity-check/main_tool.cue
+++ b/examples/kubernetes/connectivity-check/main_tool.cue
@@ -104,6 +104,17 @@ command: help: ccCommand & {
 			"Available Commands:",
 			"  dump\t\t\t\(command.dump.short)",
 			"  ls  \t\t\t\(command.ls.short)",
+			"",
+			"Available filters:",
+			"  component\t\t{ all | default | network | policy | services | hostport | proxy } (default excludes hostport, proxy)",
+			"  kind\t\t{ Deployment | Service | CiliumNetworkPolicy } (default: all)",
+			"  quarantine\t\t{ true | false } (default: false)",
+			"  topology\t\t{ any | single-node } (default: any)",
+			"  traffic\t\t{ any | internal | external } (default: any)",
+			"  type\t\t{ autocheck | tool } (default: autocheck)",
+			"",
+			"Example command:",
+			"$ cue -t component=all ls",
 		]
 		text: tabwriter.Write(helpText)
 	}

--- a/examples/kubernetes/connectivity-check/main_tool.cue
+++ b/examples/kubernetes/connectivity-check/main_tool.cue
@@ -15,17 +15,17 @@ objectSets: [
 	ingressCNP,
 ]
 
-globalFlags: "[-t component=<component>] [-t kind=<kind>] [-t name=<name>] [-t topology=<topology>] [-t quarantine=true] [-t type=<tooltype>] [-t traffic=any]"
+globalFlags: "[-t component=<component>] [-t kind=<kind>] [-t name=<name>] [-t quarantine=true] [-t topology=<topology>] [-t traffic=any] [-t type=<tooltype>]"
 
 ccCommand: {
 	#flags: {
 		component:  "all" | *"default" | "network" | "policy" | "services" | "hostport" | "proxy" @tag(component,short=all|default|network|policy|services|hostport|proxy)
-		name:       *"" | string                                                                  @tag(name)
-		topology:   *"any" | "single-node"                                                        @tag(topology,short=any|single-node)
 		kind:       *"" | "Deployment" | "Service" | "CiliumNetworkPolicy"                        @tag(kind,short=Deployment|Service|CiliumNetworkPolicy)
-		type:       *"autocheck" | "tool"                                                         @tag(type,short=autocheck|tool)
+		name:       *"" | string                                                                  @tag(name)
 		quarantine: *"false" | "true"                                                             @tag(quarantine,short=false|true)
+		topology:   *"any" | "single-node"                                                        @tag(topology,short=any|single-node)
 		traffic:    *"any" | "internal" | "external"                                              @tag(traffic,short=any|internal|external)
+		type:       *"autocheck" | "tool"                                                         @tag(type,short=autocheck|tool)
 	}
 
 	task: filterComponent: {

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -475,13 +475,6 @@ data:
 {{- end }}
 {{- if and .Values.global.k8s .Values.global.k8s.requireIPv4PodCIDR }}
   k8s-require-ipv4-pod-cidr: {{ .Values.global.k8s.requireIPv4PodCIDR | quote }}
-{{- else }}
-{{- if eq $ipam "cluster-pool" }}
-  k8s-require-ipv4-pod-cidr: {{ .Values.global.ipv4.enabled | quote}}
-{{- end }}
-{{- end }}
-{{- if eq $ipam "cluster-pool" }}
-  k8s-require-ipv6-pod-cidr: {{ .Values.global.ipv6.enabled | quote}}
 {{- end }}
 {{- if and .Values.global.endpointRoutes .Values.global.endpointRoutes.enabled }}
   enable-endpoint-routes: {{ .Values.global.endpointRoutes.enabled | quote }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -127,8 +127,6 @@ data:
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   enable-session-affinity: "true"
-  k8s-require-ipv4-pod-cidr: "true"
-  k8s-require-ipv6-pod-cidr: "false"
   enable-endpoint-health-checking: "true"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -113,8 +113,6 @@ data:
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   enable-session-affinity: "true"
-  k8s-require-ipv4-pod-cidr: "true"
-  k8s-require-ipv6-pod-cidr: "false"
   enable-endpoint-health-checking: "true"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -160,7 +160,7 @@ func init() {
 				return "cilium-operator-aws"
 			case ipamOption.IPAMAzure:
 				return "cilium-operator-azure"
-			case ipamOption.IPAMKubernetes, ipamOption.IPAMOperator, ipamOption.IPAMCRD:
+			case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool, ipamOption.IPAMCRD:
 				return "cilium-operator-generic"
 			default:
 				return ""
@@ -208,13 +208,13 @@ func init() {
 
 	flags.String(operatorOption.IPAMOperatorV4CIDR, "",
 		fmt.Sprintf("IPv4 CIDR Range for Pods in cluster. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, ipamOption.IPAMOperator,
+			option.IPAM, ipamOption.IPAMClusterPool,
 			option.EnableIPv4Name, "true"))
 	option.BindEnv(operatorOption.IPAMOperatorV4CIDR)
 
 	flags.Int(operatorOption.NodeCIDRMaskSizeIPv4, 24,
 		fmt.Sprintf("Mask size for each IPv4 podCIDR per node. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, ipamOption.IPAMOperator,
+			option.IPAM, ipamOption.IPAMClusterPool,
 			option.EnableIPv4Name, "true"))
 	option.BindEnv(operatorOption.NodeCIDRMaskSizeIPv4)
 
@@ -223,13 +223,13 @@ func init() {
 
 	flags.String(operatorOption.IPAMOperatorV6CIDR, "",
 		fmt.Sprintf("IPv6 CIDR Range for Pods in cluster. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, ipamOption.IPAMOperator,
+			option.IPAM, ipamOption.IPAMClusterPool,
 			option.EnableIPv6Name, "true"))
 	option.BindEnv(operatorOption.IPAMOperatorV6CIDR)
 
 	flags.Int(operatorOption.NodeCIDRMaskSizeIPv6, 112,
 		fmt.Sprintf("Mask size for each IPv6 podCIDR per node. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, ipamOption.IPAMOperator,
+			option.IPAM, ipamOption.IPAMClusterPool,
 			option.EnableIPv6Name, "true"))
 	option.BindEnv(operatorOption.NodeCIDRMaskSizeIPv6)
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -206,11 +206,11 @@ func init() {
 	flags.Bool(option.EnableIPv4Name, defaults.EnableIPv4, "Enable IPv4 support")
 	option.BindEnv(option.EnableIPv4Name)
 
-	flags.String(operatorOption.IPAMOperatorV4CIDR, "",
+	flags.String(operatorOption.ClusterPoolIPv4CIDR, "",
 		fmt.Sprintf("IPv4 CIDR Range for Pods in cluster. Requires '%s=%s' and '%s=%s'",
 			option.IPAM, ipamOption.IPAMClusterPool,
 			option.EnableIPv4Name, "true"))
-	option.BindEnv(operatorOption.IPAMOperatorV4CIDR)
+	option.BindEnv(operatorOption.ClusterPoolIPv4CIDR)
 
 	flags.Int(operatorOption.NodeCIDRMaskSizeIPv4, 24,
 		fmt.Sprintf("Mask size for each IPv4 podCIDR per node. Requires '%s=%s' and '%s=%s'",
@@ -221,11 +221,11 @@ func init() {
 	flags.Bool(option.EnableIPv6Name, defaults.EnableIPv6, "Enable IPv6 support")
 	option.BindEnv(option.EnableIPv6Name)
 
-	flags.String(operatorOption.IPAMOperatorV6CIDR, "",
+	flags.String(operatorOption.ClusterPoolIPv6CIDR, "",
 		fmt.Sprintf("IPv6 CIDR Range for Pods in cluster. Requires '%s=%s' and '%s=%s'",
 			option.IPAM, ipamOption.IPAMClusterPool,
 			option.EnableIPv6Name, "true"))
-	option.BindEnv(operatorOption.IPAMOperatorV6CIDR)
+	option.BindEnv(operatorOption.ClusterPoolIPv6CIDR)
 
 	flags.Int(operatorOption.NodeCIDRMaskSizeIPv6, 112,
 		fmt.Sprintf("Mask size for each IPv6 podCIDR per node. Requires '%s=%s' and '%s=%s'",

--- a/operator/main.go
+++ b/operator/main.go
@@ -300,6 +300,9 @@ func onOperatorStartLeading(ctx context.Context) {
 	var (
 		nodeManager *allocator.NodeEventHandler
 	)
+
+	log.WithField(logfields.Mode, option.Config.IPAM).Info("Initializing IPAM")
+
 	switch ipamMode := option.Config.IPAM; ipamMode {
 	case ipamOption.IPAMAzure, ipamOption.IPAMENI, ipamOption.IPAMClusterPool:
 		alloc, providerBuiltin := allocatorProviders[ipamMode]

--- a/operator/main.go
+++ b/operator/main.go
@@ -301,7 +301,7 @@ func onOperatorStartLeading(ctx context.Context) {
 		nodeManager *allocator.NodeEventHandler
 	)
 	switch ipamMode := option.Config.IPAM; ipamMode {
-	case ipamOption.IPAMAzure, ipamOption.IPAMENI, ipamOption.IPAMOperator:
+	case ipamOption.IPAMAzure, ipamOption.IPAMENI, ipamOption.IPAMClusterPool:
 		alloc, providerBuiltin := allocatorProviders[ipamMode]
 		if !providerBuiltin {
 			log.Fatalf("%s allocator is not supported by this version of %s", ipamMode, binaryName)
@@ -323,7 +323,7 @@ func onOperatorStartLeading(ctx context.Context) {
 		nodeManager = &nm
 
 		switch ipamMode {
-		case ipamOption.IPAMOperator:
+		case ipamOption.IPAMClusterPool:
 			// We will use CiliumNodes as the source of truth for the podCIDRs.
 			// Once the CiliumNodes are synchronized with the operator we will
 			// be able to watch for K8s Node events which they will be used

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -113,13 +113,13 @@ const (
 	// IPAMSubnetsTags are optional tags used to filter subnets, and interfaces within those subnets
 	IPAMSubnetsTags = "subnet-tags-filter"
 
-	// IPAMOperatorV4CIDR is the cluster IPv4 podCIDR that should be used to
-	// allocate pods in the node.
-	IPAMOperatorV4CIDR = "cluster-pool-ipv4-cidr"
+	// ClusterPoolIPv4CIDR is the cluster's IPv4 CIDR to allocate
+	// individual PodCIDR ranges from when using the ClusterPool ipam mode.
+	ClusterPoolIPv4CIDR = "cluster-pool-ipv4-cidr"
 
-	// IPAMOperatorV6CIDR is the cluster IPv6 podCIDR that should be used to
-	// allocate pods in the node.
-	IPAMOperatorV6CIDR = "cluster-pool-ipv6-cidr"
+	// ClusterPoolIPv6CIDR is the cluster's IPv6 CIDR to allocate
+	// individual PodCIDR ranges from when using the ClusterPool ipam mode.
+	ClusterPoolIPv6CIDR = "cluster-pool-ipv6-cidr"
 
 	// NodeCIDRMaskSizeIPv4 is the IPv4 podCIDR mask size that will be used
 	// per node.
@@ -264,13 +264,13 @@ type OperatorConfig struct {
 
 	// IPAM Operator options
 
-	// IPAMOperatorV4CIDR is the cluster IPv4 podCIDR that should be used to
+	// ClusterPoolIPv4CIDR is the cluster IPv4 podCIDR that should be used to
 	// allocate pods in the node.
-	IPAMOperatorV4CIDR []string
+	ClusterPoolIPv4CIDR []string
 
-	// IPAMOperatorV6CIDR is the cluster IPv6 podCIDR that should be used to
+	// ClusterPoolIPv6CIDR is the cluster IPv6 podCIDR that should be used to
 	// allocate pods in the node.
-	IPAMOperatorV6CIDR []string
+	ClusterPoolIPv6CIDR []string
 
 	// NodeCIDRMaskSizeIPv4 is the IPv4 podCIDR mask size that will be used
 	// per node.
@@ -350,8 +350,8 @@ func (c *OperatorConfig) Populate() {
 	c.UnmanagedPodWatcherInterval = viper.GetInt(UnmanagedPodWatcherInterval)
 	c.NodeCIDRMaskSizeIPv4 = viper.GetInt(NodeCIDRMaskSizeIPv4)
 	c.NodeCIDRMaskSizeIPv6 = viper.GetInt(NodeCIDRMaskSizeIPv6)
-	c.IPAMOperatorV4CIDR = viper.GetStringSlice(IPAMOperatorV4CIDR)
-	c.IPAMOperatorV6CIDR = viper.GetStringSlice(IPAMOperatorV6CIDR)
+	c.ClusterPoolIPv4CIDR = viper.GetStringSlice(ClusterPoolIPv4CIDR)
+	c.ClusterPoolIPv6CIDR = viper.GetStringSlice(ClusterPoolIPv6CIDR)
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
 	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
 	c.LeaderElectionLeaseDuration = viper.GetDuration(LeaderElectionLeaseDuration)

--- a/operator/provider_operator_register.go
+++ b/operator/provider_operator_register.go
@@ -23,5 +23,5 @@ import (
 )
 
 func init() {
-	allocatorProviders[ipamOption.IPAMOperator] = &allocatorOperator.AllocatorOperator{}
+	allocatorProviders[ipamOption.IPAMClusterPool] = &allocatorOperator.AllocatorOperator{}
 }

--- a/operator/provider_operator_register.go
+++ b/operator/provider_operator_register.go
@@ -18,10 +18,10 @@ package main
 
 import (
 	// These dependencies should be included only when this file is included in the build.
-	allocatorOperator "github.com/cilium/cilium/pkg/ipam/allocator/operator" // Operator allocator.
+	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
 func init() {
-	allocatorProviders[ipamOption.IPAMClusterPool] = &allocatorOperator.AllocatorOperator{}
+	allocatorProviders[ipamOption.IPAMClusterPool] = &clusterpool.AllocatorOperator{}
 }

--- a/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package operator
+package clusterpool
 
 import (
 	"errors"
@@ -34,7 +34,7 @@ import (
 	"github.com/cilium/ipam/cidrset"
 )
 
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-operator")
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-clusterpool")
 
 type ErrCIDRColision struct {
 	cidr      string

--- a/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/cilium/ipam/cidrset"
+	"github.com/sirupsen/logrus"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-clusterpool")
@@ -89,7 +90,10 @@ func (a *AllocatorOperator) Init() error {
 
 // Start kicks of Operator allocation.
 func (a *AllocatorOperator) Start(updater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
-	log.Info("Starting Operator IP allocator...")
+	log.WithFields(logrus.Fields{
+		logfields.IPv4CIDRs: operatorOption.Config.ClusterPoolIPv4CIDR,
+		logfields.IPv6CIDRs: operatorOption.Config.ClusterPoolIPv6CIDR,
+	}).Info("Starting ClusterPool IP allocator")
 
 	var (
 		iMetrics trigger.MetricsObserver

--- a/pkg/ipam/allocator/clusterpool/clusterpool_test.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool_test.go
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package operator
+package clusterpool
 
 import (
 	"errors"

--- a/pkg/ipam/allocator/operator/operator.go
+++ b/pkg/ipam/allocator/operator/operator.go
@@ -61,28 +61,28 @@ type AllocatorOperator struct {
 
 // Init sets up Cilium allocator based on given options
 func (a *AllocatorOperator) Init() error {
-	if len(operatorOption.Config.IPAMOperatorV4CIDR) != 0 {
+	if len(operatorOption.Config.ClusterPoolIPv4CIDR) != 0 {
 		if !option.Config.EnableIPv4 {
 			return errors.New("IPv4CIDR can not be set if IPv4 is not enabled")
 		}
-		v4Allocators, err := newCIDRSets(false, operatorOption.Config.IPAMOperatorV4CIDR, operatorOption.Config.NodeCIDRMaskSizeIPv4)
+		v4Allocators, err := newCIDRSets(false, operatorOption.Config.ClusterPoolIPv4CIDR, operatorOption.Config.NodeCIDRMaskSizeIPv4)
 		if err != nil {
 			return fmt.Errorf("unable to initialize IPv4 allocator %w", err)
 		}
 		a.v4CIDRSet = v4Allocators
 	}
-	if len(operatorOption.Config.IPAMOperatorV6CIDR) != 0 {
+	if len(operatorOption.Config.ClusterPoolIPv6CIDR) != 0 {
 		if !option.Config.EnableIPv6 {
 			return errors.New("IPv6CIDR can not be set if IPv6 is not enabled")
 		}
-		v6Allocators, err := newCIDRSets(true, operatorOption.Config.IPAMOperatorV6CIDR, operatorOption.Config.NodeCIDRMaskSizeIPv6)
+		v6Allocators, err := newCIDRSets(true, operatorOption.Config.ClusterPoolIPv6CIDR, operatorOption.Config.NodeCIDRMaskSizeIPv6)
 		if err != nil {
 			return fmt.Errorf("unable to initialize IPv6 allocator %w", err)
 		}
 		a.v6CIDRSet = v6Allocators
 	}
 	if len(a.v4CIDRSet)+len(a.v6CIDRSet) == 0 {
-		return fmt.Errorf("either '%s' or '%s' need to be set", operatorOption.IPAMOperatorV4CIDR, operatorOption.IPAMOperatorV6CIDR)
+		return fmt.Errorf("either '%s' or '%s' need to be set", operatorOption.ClusterPoolIPv4CIDR, operatorOption.ClusterPoolIPv6CIDR)
 	}
 	return nil
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -108,7 +108,7 @@ func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owne
 	}
 
 	switch c.IPAMMode() {
-	case ipamOption.IPAMHostScopeLegacy, ipamOption.IPAMKubernetes, ipamOption.IPAMOperator:
+	case ipamOption.IPAMHostScopeLegacy, ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool:
 		log.WithFields(logrus.Fields{
 			logfields.V4Prefix: nodeAddressing.IPv4().AllocationCIDR(),
 			logfields.V6Prefix: nodeAddressing.IPv6().AllocationCIDR(),

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -34,7 +34,7 @@ const (
 	// option.IPAM
 	IPAMAzure = "azure"
 
-	// IPAMOperator is the value to select the Operator IPAM mode for
+	// IPAMClusterPool is the value to select the cluster pool mode for
 	// option.IPAM
-	IPAMOperator = "cluster-pool"
+	IPAMClusterPool = "cluster-pool"
 )

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -46,6 +46,7 @@ const (
 func waitForNodeInformation(ctx context.Context, nodeName string) *nodeTypes.Node {
 	backoff := backoff.Exponential{
 		Min:    time.Duration(200) * time.Millisecond,
+		Max:    2 * time.Minute,
 		Factor: 2.0,
 		Name:   "k8s-node-retrieval",
 	}

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -191,9 +191,10 @@ func Init(conf k8sconfig.Configuration) error {
 	return nil
 }
 
-// GetNodeSpec retrieves this node spec from kubernetes. This node information
-// can either be derived from a CiliumNode or a Kubernetes node.
-func GetNodeSpec() error {
+// WaitForNodeInformation retrieves the node information via the CiliumNode or
+// Kubernetes Node resource. This function will block until the information is
+// received.
+func WaitForNodeInformation() error {
 	// Use of the environment variable overwrites the node-name
 	// automatically derived
 	nodeName := nodeTypes.GetName()

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -83,8 +83,7 @@ func retrieveNodeInformation(nodeName string) (*nodeTypes.Node, error) {
 				return nil, nil
 			}
 
-			return nil, fmt.Errorf("unable to retrieve k8s node information: %s", err)
-
+			return nil, fmt.Errorf("unable to retrieve CiliumNode: %s", err)
 		}
 
 		no := nodeTypes.ParseCiliumNode(ciliumNode)
@@ -118,11 +117,11 @@ func retrieveNodeInformation(nodeName string) (*nodeTypes.Node, error) {
 	}
 
 	if requireIPv4CIDR && n.IPv4AllocCIDR == nil {
-		return nil, fmt.Errorf("required IPv4 pod CIDR not present in node resource")
+		return nil, fmt.Errorf("required IPv4 PodCIDR not available")
 	}
 
 	if requireIPv6CIDR && n.IPv6AllocCIDR == nil {
-		return nil, fmt.Errorf("required IPv6 pod CIDR not present in node resource")
+		return nil, fmt.Errorf("required IPv6 PodCIDR not available")
 	}
 
 	return n, nil

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -74,7 +74,7 @@ func retrieveNodeInformation(nodeName string) (*nodeTypes.Node, error) {
 	mightAutoDetectDevices := option.MightAutoDetectDevices()
 	var n *nodeTypes.Node
 
-	if option.Config.IPAM == ipamOption.IPAMOperator {
+	if option.Config.IPAM == ipamOption.IPAMClusterPool {
 		ciliumNode, err := CiliumClient().CiliumV2().CiliumNodes().Get(context.TODO(), nodeName, v1.GetOptions{})
 		if err != nil {
 			// If no CIDR is required, retrieving the node information is

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -248,7 +248,7 @@ func WaitForNodeInformation() error {
 		// if node resource could not be received, fail if
 		// PodCIDR requirement has been requested
 		if option.Config.K8sRequireIPv4PodCIDR || option.Config.K8sRequireIPv6PodCIDR {
-			log.Fatal("Unable to derive PodCIDR from Kubernetes node resource, giving up")
+			log.Fatal("Unable to derive PodCIDR via Node or CiliumNode resource, giving up")
 		}
 	}
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -445,4 +445,7 @@ const (
 	// HelpMessage is the help message corresponding to a log message.
 	// This is to make sure we keep separate contexts for logs and help messages.
 	HelpMessage = "helpMessage"
+
+	// Mode describes an operations mode
+	Mode = "mode"
 )

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -165,6 +165,12 @@ const (
 	// V6Prefix is a IPv6 subnet/CIDR prefix
 	V6Prefix = "v6Prefix"
 
+	// IPv4CIDRs is a list of IPv4 CIDRs
+	IPv4CIDRs = "ipv4CIDRs"
+
+	// IPv6CIDRs is a list of IPv6 CIDRs
+	IPv6CIDRs = "ipv6CIDRs"
+
 	// CIDR is a IPv4/IPv4 subnet/CIDR
 	CIDR = "cidr"
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -322,7 +322,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
 	}
 
 	switch option.Config.IPAM {
-	case ipamOption.IPAMOperator:
+	case ipamOption.IPAMClusterPool:
 		// We want to keep the podCIDRs untouched in this IPAM mode because
 		// the operator will verify if it can assign such podCIDRs.
 		// If the user was running in non-IPAM Operator mode and then switched

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -223,6 +223,8 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 		return
 	}
 
+	log.WithField(logfields.Node, nodeTypes.GetName()).Info("Creating or updating CiliumNode resource")
+
 	ciliumClient := k8s.CiliumClient()
 
 	for retryCount := 0; retryCount < maxRetryCount; retryCount++ {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2580,7 +2580,7 @@ func (c *DaemonConfig) Populate() {
 	}
 
 	switch c.IPAM {
-	case ipamOption.IPAMKubernetes:
+	case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool:
 		if c.EnableIPv4 {
 			c.K8sRequireIPv4PodCIDR = true
 		}


### PR DESCRIPTION
* #13028 -- ClusterPool IPAM fixes & cleanups (@tgraf)
   * Conflict on the first commit (`ipam: Rename IPAMOperator to IPAMClusterPool`).
     This is due to `ipamOption.IPAMHostScopeLegacy` still being present in v1.8, it is replaced for v1.9 only with `ipamOption.IPAMOperator` (commit 175bd96bff1c from #12984).
     Fixed by **not** renaming `ipamOption.IPAMHostScopeLegacy`, which remains the default IPAM module on this branch.
 * #13432 -- Improve connectivity-check cue CLI help and documentation (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13028 13432; do contrib/backporting/set-labels.py $pr done 1.8; done
```