### PR TITLE
updating operator dockerfile with built-in buildx ARGs

### DIFF
--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -6,29 +6,31 @@
 ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:618b6b93c98b3075048861a512fa93525ef3f1f1
 ARG CA_CERTIFICATES_IMAGE=docker.io/cilium/ca-certificates:69a9f5d66ff96bf97e8b9dc107e92aa9ddbdc9a8
 
-FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder
+FROM ${CILIUM_BUILDER_IMAGE} as builder
 
+ARG TARGETOS
+ARG TARGETARCH
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG RACE
 
+ENV GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH}
+
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
   make -C operator \
-    NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 \
-  && mkdir -p /out/linux/amd64/usr/bin && mv operator/cilium-operator* /out/linux/amd64/usr/bin
-
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  env GOARCH=arm64 \
-    make -C operator \
-      NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 \
-  && mkdir -p /out/linux/arm64/usr/bin && mv operator/cilium-operator* /out/linux/arm64/usr/bin
-
+  NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 \
+  && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv operator/cilium-operator* /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
 FROM ${CA_CERTIFICATES_IMAGE}
-ARG TARGETPLATFORM
+
+ARG TARGETOS
+ARG TARGETARCH
+
 LABEL maintainer="maintainer@cilium.io"
 
-COPY --from=builder /out/${TARGETPLATFORM} /
-
 WORKDIR /
+
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH} .
+
 CMD ["/usr/bin/cilium-operator-generic"]


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Updating the Dockerfile for the operator image to remove additional layers in the builder stage and tidy the logic whilst trying to speed up build time using the built-in ARGs available in `buildx`.

This change also makes it trivial to add additional platform architectures without needing to change the Dockerfile logic.

An additional commit might be to test changing `FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} as builder` for performance 