### PR TITLE
docs: Add link to CI failure triage to contributing guide

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -212,6 +212,9 @@ Getting a pull request merged
       #. Single node runtime tests
       #. Multi node Kubernetes tests
 
+      If a CI test fails which seems unrelated to your PR, it may be a flaky
+      test. Follow the process described in :ref:`ci_failure_triage`.
+
 #. As part of the submission, GitHub will have requested a review from the
    respective code owners according to the ``CODEOWNERS`` file in the
    repository.

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -180,6 +180,7 @@ from the main Vagrantfile, for example:
 To start a local k8s 1.18 cluster with one CI VM locally, run:
 
 ::
+
     $ cd test
     $ K8S_VERSION=1.18 K8S_NODES=1 ./vagrant-local-start.sh
 
@@ -193,6 +194,7 @@ can run ``make clean`` in ``tests`` to delete the cached vagrant box.
 To start the CI runtime VM locally, run:
 
 ::
+
     $ cd test
     $ ./vagrant-local-start-runtime.sh
 

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -319,6 +319,8 @@ example patch that shows how this can be achieved.
 
                             //This test should run in each PR for now.
 
+.. _ci_failure_triage:
+
 CI Failure Triage
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As requested by @joestringer. It turns out there's already a detailed section on identifying flaky tests in the docs, this just adds a link to it from the Development Guide.