### PR TITLE
test: Disable host firewall by default when running tests locally

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -575,7 +575,7 @@ func DoesNotHaveHosts(count int) func() bool {
 
 // RunsWithHostFirewall returns true is Cilium runs with the host firewall enabled.
 func RunsWithHostFirewall() bool {
-	return os.Getenv("HOST_FIREWALL") != "0"
+	return os.Getenv("HOST_FIREWALL") != "0" && os.Getenv("HOST_FIREWALL") != ""
 }
 
 // RunsWithKubeProxy returns true if cilium runs together with k8s' kube-proxy.


### PR DESCRIPTION
The host firewall is disabled by default in the CI (unless you have label `ci/host-firewall` on your PR). The same should be true when running tests locally with the test VMs.

`os.Getenv("HOST_FIREWALL")` returns an empty string for undefined env. variables, so we also need to match on that.