### PR TITLE
vagrant: New kubectl aliases

### DIFF
--- a/contrib/vagrant/scripts/04-install-kubectl.sh
+++ b/contrib/vagrant/scripts/04-install-kubectl.sh
@@ -24,6 +24,9 @@ alias k='kubectl'
 complete -F __start_kubectl k
 alias ks='kubectl -n kube-system'
 complete -F __start_kubectl ks
+alias wk='watch -n2 kubectl get pods -o wide'
+alias wks='watch -n2 kubectl -n kube-system get pods -o wide'
+alias wka='watch -n2 kubectl get all --all-namespaces -o wide'
 cilium_pod() {
     kubectl -n kube-system get pods -l k8s-app=cilium \
             -o jsonpath="{.items[?(@.spec.nodeName == \"\$1\")].metadata.name}"

--- a/contrib/vagrant/scripts/04-install-kubectl.sh
+++ b/contrib/vagrant/scripts/04-install-kubectl.sh
@@ -16,6 +16,20 @@ log "Installing kubernetes kubectl..."
 
 set -e
 
+# Add aliases and bash completion for kubectl
+cat <<EOF >> /home/vagrant/.bashrc
+# kubectl
+source <(kubectl completion bash)
+alias k='kubectl'
+complete -F __start_kubectl k
+alias ks='kubectl -n kube-system'
+complete -F __start_kubectl ks
+cilium_pod() {
+    kubectl -n kube-system get pods -l k8s-app=cilium \
+            -o jsonpath="{.items[?(@.spec.nodeName == \"\$1\")].metadata.name}"
+}
+EOF
+
 if [ -n "${INSTALL}" ]; then
     download_to "${cache_dir}" "kubectl" \
         "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -442,6 +442,10 @@ alias k='kubectl'
 complete -F __start_kubectl k
 alias ks='kubectl -n kube-system'
 complete -F __start_kubectl ks
+alias kslogs='kubectl -n kube-system logs -l k8s-app=cilium --tail=-1'
+alias wk='watch -n2 kubectl get pods -o wide'
+alias wks='watch -n2 kubectl -n kube-system get pods -o wide'
+alias wka='watch -n2 kubectl get all --all-namespaces -o wide'
 cilium_pod() {
     kubectl -n kube-system get pods -l k8s-app=cilium \
             -o jsonpath="{.items[?(@.spec.nodeName == \"\$1\")].metadata.name}"


### PR DESCRIPTION
This PR makes the list of aliases consistent across the dev. and test VMs. It also adds a couple new aliases I regularly use:
- `kslogs` dumps all Cilium logs from all agents.
- `wk` displays the output of `kubectl get pods -o wide` with updates every 2s. I often use it to watch the state of the connectivity checks or other test deployments while applying policies, etc.
- `wks` does the same as `wk` but for the kube-system namespace.