### PR TITLE
Fix wrong csum for non-first ipv4 fragments

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -72,19 +72,25 @@ static __always_inline bool ipv4_is_fragment(const struct iphdr *ip4)
 	return ip4->frag_off & bpf_htons(0x3FFF);
 }
 
-static __always_inline bool ipv4_is_in_subnet(__be32 addr,
-					      __be32 subnet, int prefixlen)
-{
-	return (addr & bpf_htonl(~((1<<(32-prefixlen))-1))) == subnet;
-}
-
-#ifdef ENABLE_IPV4_FRAGMENTS
 static __always_inline bool ipv4_is_not_first_fragment(const struct iphdr *ip4)
 {
 	/* Ignore "More fragments" bit to catch all fragments but the first */
 	return ip4->frag_off & bpf_htons(0x1FFF);
 }
 
+/* Simply a reverse of ipv4_is_not_first_fragment to avoid double negative. */
+static __always_inline bool ipv4_has_l4_header(const struct iphdr *ip4)
+{
+	return !ipv4_is_not_first_fragment(ip4);
+}
+
+static __always_inline bool ipv4_is_in_subnet(__be32 addr,
+					      __be32 subnet, int prefixlen)
+{
+	return (addr & bpf_htonl(~((1 << (32 - prefixlen)) - 1))) == subnet;
+}
+
+#ifdef ENABLE_IPV4_FRAGMENTS
 static __always_inline int
 ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 		      struct ipv4_frag_l4ports *ports)


### PR DESCRIPTION
Before this commit, natting are blindly changing l4 ports to non-first ipv4
fragments, causing wrong csum.

Also fixes the same issue during the rev natting for dsr.

Signed-off-by: Yuan Liu <liuyuan@google.com>

```release-note
Fix natting of non-first ipv4 fragments.
```
