### PR TITLE
Don't auto disable session affinity with kube-proxy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -98,7 +98,7 @@ cilium-agent [flags]
       --enable-node-port                                     Enable NodePort type services by Cilium
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-remote-node-identity                          Enable use of remote node identity
-      --enable-session-affinity                              Enable support for service session affinity
+      --enable-session-affinity                              Enable support for service session affinity (default true)
       --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tracing                                       Enable tracing while determining policy (debugging)
       --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -591,7 +591,7 @@ func init() {
 	flags.Bool(option.NodePortBindProtection, true, "Reject application bind(2) requests to service ports in the NodePort range")
 	option.BindEnv(option.NodePortBindProtection)
 
-	flags.Bool(option.EnableSessionAffinity, false, "Enable support for service session affinity")
+	flags.Bool(option.EnableSessionAffinity, true, "Enable support for service session affinity")
 	option.BindEnv(option.EnableSessionAffinity)
 
 	flags.Bool(option.EnableIdentityMark, true, "Enable setting identity mark for local traffic")

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -103,10 +103,11 @@ func TestMain(m *testing.M) {
 	// state left on disk.
 	option.Config.EnableHostIPRestore = false
 
-	// Disable the replacement, as its initialization function execs bpftool
+	// Disable the replacement and session affinity, as its initialization function execs bpftool
 	// which requires root privileges. This would require marking the test suite
 	// as privileged.
 	option.Config.KubeProxyReplacement = option.KubeProxyReplacementDisabled
+	option.Config.EnableSessionAffinity = false
 
 	time.Local = time.UTC
 	os.Exit(m.Run())


### PR DESCRIPTION
Right now, session affinity is being automatically disabled when
running with kube-proxy. This leaves pod with no session affinity
support.

Actually the session affinity is already supported in the lxc tc hook so
we can enable it without host reachable services.

Signed-off-by: Yuan Liu <liuyuan@google.com>

```release-note
Enable session affinity by default and avoid disabling it when used with kube-proxy
```
