### PR TITLE
fix: fix missing arguments declaration funcs in pkg/node/address_darwin

### DIFF
--- a/pkg/node/address_darwin.go
+++ b/pkg/node/address_darwin.go
@@ -20,11 +20,11 @@ import (
 	"net"
 )
 
-func firstGlobalV4Addr(intf string, preferredIP net.IP) (net.IP, error) {
+func firstGlobalV4Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
 	return net.IP{}, nil
 }
 
-func firstGlobalV6Addr(intf string, preferredIP net.IP) (net.IP, error) {
+func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
 	return net.IP{}, nil
 }
 


### PR DESCRIPTION
This fix is needed to be able to run single unit tests on macOS.

Two functions in address_darwin.go are missing argument `preferPublic bool`:

* firstGlobalV4Addr
* firstGlobalV6Addr

Without this fix, running go test fails:

```
 go test ./pkg/policy -check.list

go test ./pkg/policy -check.list
# github.com/cilium/cilium/pkg/node
pkg/node/address.go:71:31: too many arguments in call to firstGlobalV4Addr
	have (string, net.IP, bool)
	want (string, net.IP)
pkg/node/address.go:106:38: too many arguments in call to firstGlobalV6Addr
	have (string, net.IP, bool)
	want (string, net.IP)
pkg/node/address.go:134:32: too many arguments in call to firstGlobalV4Addr
	have (string, net.IP, bool)
	want (string, net.IP)
pkg/node/address.go:146:32: too many arguments in call to firstGlobalV6Addr
	have (string, net.IP, bool)
	want (string, net.IP)
FAIL	github.com/cilium/cilium/pkg/policy [build failed]
```



Signed-off-by: Sergey Generalov <sergey@genbit.ru>