### PR TITLE
hubble/relay: print better error message on peer conn dial failure

### DIFF
--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -39,6 +39,11 @@ var defaultOptions = options{
 		Options: []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithBlock(),
+			grpc.FailOnNonTempDialError(true),
+			// TODO: uncomment the line below once grpc-go is >= v1.30.0
+			// currently blocked on v1.29.1, see the following PR for details
+			// https://github.com/cilium/cilium/pull/13405
+			// grpc.WithReturnConnectionError(),
 		},
 	},
 	backoff: &backoff.Exponential{

--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -75,8 +75,15 @@ func New(options ...Option) (*Server, error) {
 		),
 		pool.WithClientConnBuilder(pool.GRPCClientConnBuilder{
 			DialTimeout: opts.dialTimeout,
-			Options:     []grpc.DialOption{grpc.WithBlock()},
-			TLSConfig:   opts.clientTLSConfig,
+			Options: []grpc.DialOption{
+				grpc.WithBlock(),
+				grpc.FailOnNonTempDialError(true),
+				// TODO: uncomment the line below once grpc-go is >= v1.30.0
+				// currently blocked on v1.29.1, see the following PR for details
+				// https://github.com/cilium/cilium/pull/13405
+				// grpc.WithReturnConnectionError(),
+			},
+			TLSConfig: opts.clientTLSConfig,
 		}),
 		pool.WithRetryTimeout(opts.retryTimeout),
 		pool.WithLogger(opts.log),


### PR DESCRIPTION
To connect to peers via gRPC, Hubble Relay uses `grpc.DialContext()`
with a dial timeout. When a connection attempt to a peer fails, the
following error message is returned: `context deadline exceeded`.
This provides no value when trying to debug the issue. Is the peer
unreachable? Is this a TLS configuration issue? etc.

By using the dial option `grpc.FailOnNonTempDialError(true)`, we get
better error messages on non-temporary dial errors, such as:

    connection error: desc = "transport: error while dialing: dial tcp 172.18.0.4:4244: connect: connection refused"

Using the option `grpc.WithReturnConnectionError()`, we would get a
message that contains both the last connection error that occurred and
the `context.DeadlineExceeded` error. This greatly improves the
situation for errors that are deemed transient. Example:

    context deadline exceeded: connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for *.hubble-relay.cilium.io, not localhost"

However, this is only available starting with grpc-go v1.30.0 and due to
the issue described [here](https://github.com/cilium/cilium/pull/13405#issuecomment-704766707), we are currently stuck with v1.29.1. Thus,
this commit adds the option but comments it with a TODO note so that it
can be caught up and uncommented when upgrading grpc-go becomes
possible.

```release-note
Hubble Relay: improve error log message on peer connection failure.
```
