### PR TITLE
bpf_host: emit '-> network' traces for egress packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1023,6 +1023,10 @@ out:
 	 (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) || \
 	 defined(ENABLE_MASQUERADE))
 	if ((ctx->mark & MARK_MAGIC_SNAT_DONE) != MARK_MAGIC_SNAT_DONE) {
+		/*
+		 * nodeport_nat_fwd tail calls in the majority of cases,
+		 * so control might never return to this program.
+		 */
 		ret = nodeport_nat_fwd(ctx);
 		if (IS_ERR(ret))
 			return send_drop_notify_error(ctx, 0, ret,
@@ -1031,7 +1035,7 @@ out:
 	}
 #endif
 	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0,
-			  0, ret, 0);
+			  0, ret, monitor);
 	return ret;
 }
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1024,6 +1024,12 @@ out:
 	 defined(ENABLE_MASQUERADE))
 	if ((ctx->mark & MARK_MAGIC_SNAT_DONE) != MARK_MAGIC_SNAT_DONE) {
 		/*
+		 * Store monitor aggregation value for use in NAT tail calls,
+		 * since they don't have any CT information in scope.
+		 */
+		ctx_store_meta(ctx, CB_CT_MONITOR, monitor);
+
+		/*
 		 * nodeport_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.
 		 */
@@ -1034,8 +1040,11 @@ out:
 						      METRIC_EGRESS);
 	}
 #endif
+
+	/* Trace packets destined for the wire when SNAT didn't take place. */
 	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0,
 			  0, ret, monitor);
+
 	return ret;
 }
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -505,28 +505,34 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
 #define TC_INDEX_F_SKIP_RECIRCULATION	8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
-/* ctx_{load,store}_meta() usage: */
+/*
+ * For use in ctx_{load,store}_meta(), which operates on sk_buff->cb.
+ * The verifier only exposes the first 5 slots in cb[], so this enum
+ * only contains 5 entries. Aliases are added to the slots to re-use
+ * them under different names in different parts of the datapath.
+ * Take care to not clobber slots used by other functions in the same
+ * code path.
+ */
 enum {
 	CB_SRC_LABEL,
-#define	CB_SVC_PORT		CB_SRC_LABEL	/* Alias, non-overlapping */
-#define	CB_PROXY_MAGIC		CB_SRC_LABEL	/* Alias, non-overlapping */
-#define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL	/* Alias, non-overlapping */
+#define	CB_SVC_PORT		CB_SRC_LABEL
+#define	CB_PROXY_MAGIC		CB_SRC_LABEL
+#define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL
 	CB_IFINDEX,
-#define	CB_SVC_ADDR_V4		CB_IFINDEX	/* Alias, non-overlapping */
-#define	CB_SVC_ADDR_V6_1	CB_IFINDEX	/* Alias, non-overlapping */
-#define	CB_ENCRYPT_IDENTITY	CB_IFINDEX	/* Alias, non-overlapping */
-#define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
+#define	CB_SVC_ADDR_V4		CB_IFINDEX
+#define	CB_SVC_ADDR_V6_1	CB_IFINDEX
+#define	CB_ENCRYPT_IDENTITY	CB_IFINDEX
+#define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX
 	CB_POLICY,
-#define	CB_SVC_ADDR_V6_2	CB_POLICY	/* Alias, non-overlapping */
+#define	CB_SVC_ADDR_V6_2	CB_POLICY
 	CB_NAT46_STATE,
-#define CB_NAT			CB_NAT46_STATE	/* Alias, non-overlapping */
-#define	CB_SVC_ADDR_V6_3	CB_NAT46_STATE	/* Alias, non-overlapping */
-#define	CB_FROM_HOST		CB_NAT46_STATE	/* Alias, non-overlapping */
+#define CB_NAT			CB_NAT46_STATE
+#define	CB_SVC_ADDR_V6_3	CB_NAT46_STATE
+#define	CB_FROM_HOST		CB_NAT46_STATE
 	CB_CT_STATE,
-#define	CB_SVC_ADDR_V6_4	CB_CT_STATE	/* Alias, non-overlapping */
-#define	CB_ENCRYPT_DST		CB_CT_STATE	/* Alias, non-overlapping,
-						 * Not used by xfrm.
-						 */
+#define	CB_SVC_ADDR_V6_4	CB_CT_STATE
+#define	CB_ENCRYPT_DST		CB_CT_STATE	/* not used by xfrm */
+#define	CB_CT_MONITOR		CB_CT_STATE
 };
 
 /* State values for NAT46 */

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -14,7 +14,7 @@
 
 # ifdef ENABLE_IPV6
 static __always_inline int
-ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id)
+ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 *monitor)
 {
 	int ret, verdict, l3_off = ETH_HLEN, l4_off, hdrlen;
 	struct ct_state ct_state_new = {}, ct_state = {};
@@ -22,7 +22,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id)
 	__u8 audited = 0;
 	struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple tuple = {};
-	__u32 dst_id = 0, monitor = 0;
+	__u32 dst_id = 0;
 	union v6addr orig_dip;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -44,7 +44,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id)
 		return hdrlen;
 	l4_off = l3_off + hdrlen;
 	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-			 &ct_state, &monitor);
+			 &ct_state, monitor);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -241,7 +241,7 @@ whitelist_snated_egress_connections(struct __ctx_buff *ctx, __u32 ipcache_srcid)
 
 static __always_inline int
 ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
-			__u32 ipcache_srcid __maybe_unused)
+			__u32 ipcache_srcid __maybe_unused, __u32 *monitor)
 {
 	struct ct_state ct_state_new = {}, ct_state = {};
 	int ret, verdict, l4_off, l3_off = ETH_HLEN;
@@ -249,7 +249,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	__u8 audited = 0;
 	struct remote_endpoint_info *info;
 	struct ipv4_ct_tuple tuple = {};
-	__u32 dst_id = 0, monitor = 0;
+	__u32 dst_id = 0;
 	void *data, *data_end;
 	struct iphdr *ip4;
 
@@ -271,7 +271,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	tuple.saddr = ip4->saddr;
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-			 &ct_state, &monitor);
+			 &ct_state, monitor);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -192,13 +192,18 @@ static __always_inline int nodeport_nat_ipv6_fwd(struct __ctx_buff *ctx,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
 	int ret;
+	__u32 monitor = ctx_load_meta(ctx, CB_CT_MONITOR);
 
 	ipv6_addr_copy(&target.addr, addr);
 
 	ret = snat_v6_needed(ctx, addr) ?
 	      snat_v6_process(ctx, NAT_DIR_EGRESS, &target) : CTX_ACT_OK;
+
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
+
+	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0, 0, ret, monitor);
+
 	return ret;
 }
 
@@ -921,12 +926,16 @@ static __always_inline int nodeport_nat_ipv4_fwd(struct __ctx_buff *ctx)
 		.addr = 0,
 	};
 	int ret = CTX_ACT_OK;
+	__u32 monitor = ctx_load_meta(ctx, CB_CT_MONITOR);
 
 	if (snat_v4_needed(ctx, &target.addr, &from_endpoint))
 		ret = snat_v4_process(ctx, NAT_DIR_EGRESS, &target,
 				      from_endpoint);
+
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
+
+	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0, 0, ret, monitor);
 
 	return ret;
 }
@@ -1529,6 +1538,7 @@ static __always_inline int nodeport_nat_fwd(struct __ctx_buff *ctx)
 
 	if (!validate_ethertype(ctx, &proto))
 		return CTX_ACT_OK;
+
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
@@ -1550,6 +1560,7 @@ static __always_inline int nodeport_nat_fwd(struct __ctx_buff *ctx)
 		build_bug_on(!(NODEPORT_PORT_MAX     < NODEPORT_PORT_MIN_NAT));
 		break;
 	}
+
 	return ret;
 }
 

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -141,6 +141,13 @@ static __always_inline bool emit_trace_notify(__u8 obs_point, __u32 monitor)
 		}
 	}
 
+	/*
+	 * Ignore sample when aggregation is enabled and 'monitor' is set to 0.
+	 * Rate limiting (trace message aggregation) relies on connection tracking,
+	 * so if there is no CT information available at the observation point,
+	 * then 'monitor' will be set to 0 to avoid emitting trace notifications
+	 * when aggregation is enabled (the default).
+	 */
 	if (MONITOR_AGGREGATION >= TRACE_AGGREGATE_ACTIVE_CT && !monitor)
 		return false;
 


### PR DESCRIPTION
<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/12561

See the issue above for the full context. The caveat is, this program is only attached to the native device egress if either the host firewall or BPF NodePort is enabled, so there still won't be any `TRACE_TO_NETWORK` visibility if that's not the case.

I've had to move the trace to fire before `nodeport_nat_fwd()` is called, since that function tail calls on the happy path, and there's no CT context available downstream from there. This could likely be improved when/if we adopt BTF and get rid of tail calls on kernels that support it.

I've also added `handle_to_netdev_ipv4()` to clean up `to_netdev()` a bit, to bring it on par with the ipv6 handling.

```release-note
bpf_host: emit '-> network' traces for packets leaving the node when Host Firewall or BPF NodePort are enabled
```