### PR TITLE
v1.7 backports 2020-10-09 - fix TLS visibility GSG

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1,6 +1,7 @@
 Alemayhu
 Ansible
 Apiserver
+artii
 BPF
 Backport
 Backporting
@@ -296,6 +297,7 @@ hardcoded
 hardcoding
 hashtable
 hashtables
+herokuapp
 hexData
 hoc
 hostscope
@@ -528,7 +530,6 @@ supergalatic
 superset
 svc
 sw
-swapi
 sys
 syscall
 sysctl

--- a/examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
+++ b/examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
@@ -10,7 +10,7 @@ spec:
       class: mediabot
   egress:
   - toFQDNs:
-    - matchName: "swapi.co"
+    - matchName: "artii.herokuapp.com"
     toPorts:
     - ports:
       - port: "443"
@@ -18,7 +18,7 @@ spec:
       terminatingTLS:
         secret:
           namespace: "kube-system"
-          name: "swapi-tls-data"
+          name: "artii-tls-data"
       originatingTLS:
         secret:
           namespace: "kube-system"

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -48,8 +48,8 @@ var _ = Describe("K8sPolicyTest", func() {
 		l7PolicyKafka        string
 		l7PolicyTLS          string
 		TLSCaCerts           string
-		TLSSWapiCrt          string
-		TLSSWapiKey          string
+		TLSArtiiCrt          string
+		TLSArtiiKey          string
 		TLSLyftCrt           string
 		TLSLyftKey           string
 		TLSCa                string
@@ -79,8 +79,8 @@ var _ = Describe("K8sPolicyTest", func() {
 		l7PolicyKafka = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-kafka.yaml")
 		l7PolicyTLS = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-TLS.yaml")
 		TLSCaCerts = helpers.ManifestGet(kubectl.BasePath(), "testCA.crt")
-		TLSSWapiCrt = helpers.ManifestGet(kubectl.BasePath(), "internal-swapi.crt")
-		TLSSWapiKey = helpers.ManifestGet(kubectl.BasePath(), "internal-swapi.key")
+		TLSArtiiCrt = helpers.ManifestGet(kubectl.BasePath(), "internal-artii.crt")
+		TLSArtiiKey = helpers.ManifestGet(kubectl.BasePath(), "internal-artii.key")
 		TLSLyftCrt = helpers.ManifestGet(kubectl.BasePath(), "internal-lyft.crt")
 		TLSLyftKey = helpers.ManifestGet(kubectl.BasePath(), "internal-lyft.key")
 		TLSCa = helpers.ManifestGet(kubectl.BasePath(), "ca.crt")
@@ -316,8 +316,8 @@ var _ = Describe("K8sPolicyTest", func() {
 			res = kubectl.CreateSecret("generic", "test-client", "default", "--from-file="+TLSCa)
 			res.ExpectSuccess("Cannot create secret %s", "test-client")
 
-			res = kubectl.CreateSecret("tls", "swapi-server", "default", "--cert="+TLSSWapiCrt+" --key="+TLSSWapiKey)
-			res.ExpectSuccess("Cannot create secret %s", "swapi-server")
+			res = kubectl.CreateSecret("tls", "artii-server", "default", "--cert="+TLSArtiiCrt+" --key="+TLSArtiiKey)
+			res.ExpectSuccess("Cannot create secret %s", "artii-server")
 
 			res = kubectl.CreateSecret("tls", "lyft-server", "default", "--cert="+TLSLyftCrt+" --key="+TLSLyftKey)
 			res.ExpectSuccess("Cannot create secret %s", "lyft-server")
@@ -331,14 +331,14 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 --max-time 15 %s https://swapi.co:443/api/planets/1/", "-v --cacert /cacert.pem"))
-			res.ExpectSuccess("Cannot connect from %q to 'https://swapi.co:443/api/planets/1/'",
+				helpers.CurlFail("--retry 5 -4 --max-time 15 %s 'https://artii.herokuapp.com/make?text=cilium&font=univers'", "-v --cacert /cacert.pem"))
+			res.ExpectSuccess("Cannot connect from %q to 'https://artii.herokuapp.com/make?text=cilium&font=univers'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 %s https://swapi.co:443/api/planets/2/", "-v --cacert /cacert.pem"))
-			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://swapi.co:443/api/planets/2/'",
+				helpers.CurlFail("--retry 5 -4 %s 'https://artii.herokuapp.com:443/fonts_list'", "-v --cacert /cacert.pem"))
+			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://artii.herokuapp.com:443/fonts_list'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(

--- a/test/k8sT/manifests/l7-policy-TLS.yaml
+++ b/test/k8sT/manifests/l7-policy-TLS.yaml
@@ -32,7 +32,7 @@ spec:
       rules:
         http:
         - method: "GET"
-          path: "^/make(\?.*)?$"
+          path: "^/make(\\?.*)?$"
           headerMatches:
           - mismatch: REPLACE
             name: "User-Agent"

--- a/test/k8sT/manifests/l7-policy-TLS.yaml
+++ b/test/k8sT/manifests/l7-policy-TLS.yaml
@@ -16,7 +16,7 @@ spec:
         dns:
           - matchPattern: "*"
   - toFQDNs:
-    - matchPattern: "swapi.co"
+    - matchPattern: "artii.herokuapp.com"
     toPorts:
     - ports:
       - port: "443"
@@ -24,7 +24,7 @@ spec:
       terminatingTLS:
         secret:
           namespace: "default"
-          name: "swapi-server"
+          name: "artii-server"
       originatingTLS:
         secret:
           namespace: "default"
@@ -32,7 +32,7 @@ spec:
       rules:
         http:
         - method: "GET"
-          path: "/api/planets/1/"
+          path: "^/make(\?.*)?$"
           headerMatches:
           - mismatch: REPLACE
             name: "User-Agent"


### PR DESCRIPTION
* #13452 -- docs: Fix TLS visibility GSG (@jrajahalme)
   * Also backport 92aa025e9012 (`docs, test: replace swapi by artii.herokuapp.com for TLS visibility`, #11080) to avoid a conflict and to improve v1.7 documentation, along with its fix 8ed026ada6b0 (`test: fix escaping in l7 tls vis policy`, #12303).

Skipped:

 * #13472 -- Fix race condition in DeepEqual function (@aanm)
   * I believe it does not apply to v1.7, see https://github.com/cilium/cilium/pull/13472#issuecomment-706186879.
   * [EDIT] In fact it does, but I missed the relevant code (see below). Will be backported in a separate PR.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13452; do contrib/backporting/set-labels.py $pr done 1.7; done
```