### PR TITLE
doc: Kubeadm guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -4,8 +4,59 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+**************************
 Installation using kubeadm
-==========================
+**************************
 
-Instructions about installing Cilium on Kubernetes cluster deployed by kubeadm
-are available in the `official Kubernetes documentation <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network>`_.
+This guide describes deploying Cilium on a Kubernetes cluster created with
+``kubeadm``.
+
+For installing ``kubeadm`` on your system, please refer to `the official
+kubeadm documentation
+<https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>`_
+The official documentation also describes additional options of kubeadm which
+are not mentioned here.
+
+If you are interested in using Cilium's kube-proxy replacement, please
+follow the :ref:`kubeproxy-free` guide and skip this one.
+
+Create the cluster
+==================
+
+Initialize the control plane via executing on it:
+
+.. code:: bash
+
+   kubeadm init
+
+.. note::
+   If you want to use Cilium's kube-proxy replacement, kubeadm needs to skip
+   the kube-proxy deployment phase, so it has to be executed with the
+   ``--skip-phases=addon/kube-proxy`` option:
+
+   .. code:: bash
+
+      kubeadm init --skip-phases=addon/kube-proxy
+
+   For more information please refer to the :ref:`kubeproxy-free` guide.
+
+Afterwards, join worker nodes by specifying the control-plane node IP address
+and the token returned by ``kubeadm init``:
+
+.. code:: bash
+
+   kubeadm join <..>
+
+Deploy Cilium
+=============
+
+.. include:: k8s-install-download-release.rst
+
+Deploy Cilium release via Helm:
+
+.. code:: bash
+
+   helm install cilium |CHART_RELEASE| --namespace kube-system
+
+.. include:: k8s-install-validate.rst
+.. include:: hubble-enable.rst


### PR DESCRIPTION
The official kubeadm documentation [0] used to have instructions for
deploying various network providers, including Cilium, but it doesn't
anymore. This change adds instructions about deploying Cilium on kubeadm
managed clusters to our documentation.

[0] https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/

Fixes #13278

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>