### PR TITLE
maps: move mocks into separate testutils/mockmaps package

### DIFF
--- a/cilium/cmd/bpf_ct_list_test.go
+++ b/cilium/cmd/bpf_ct_list_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 	"github.com/cilium/cilium/pkg/tuple"
 	"github.com/cilium/cilium/pkg/types"
 
@@ -120,7 +121,7 @@ func dumpAndRead(maps []interface{}, dump dumpCallback, c *C, args ...interface{
 func (s *BPFCtListSuite) TestDumpCt4(c *C) {
 
 	ctMaps := [2]ctmap.CtMap{
-		ctmap.NewCtMockMap(
+		mockmaps.NewCtMockMap(
 			[]ctmap.CtMapRecord{
 				{
 					Key:   &ctKey4,
@@ -132,7 +133,7 @@ func (s *BPFCtListSuite) TestDumpCt4(c *C) {
 				},
 			},
 		),
-		ctmap.NewCtMockMap(
+		mockmaps.NewCtMockMap(
 			[]ctmap.CtMapRecord{
 				{
 					Key:   &ctKey4,
@@ -158,13 +159,13 @@ func (s *BPFCtListSuite) TestDumpCt4(c *C) {
 		Key:   &ctmap.CtKey4{TupleKey4: ctDump[0].Key},
 		Value: ctDump[0].Value,
 	}
-	c.Assert(ctRecordDump, checker.DeepEquals, ctMaps[0].(*ctmap.CtMockMap).Entries[0])
+	c.Assert(ctRecordDump, checker.DeepEquals, ctMaps[0].(*mockmaps.CtMockMap).Entries[0])
 }
 
 func (s *BPFCtListSuite) TestDumpCt6(c *C) {
 
 	ctMaps := [2]ctmap.CtMap{
-		ctmap.NewCtMockMap(
+		mockmaps.NewCtMockMap(
 			[]ctmap.CtMapRecord{
 				{
 					Key:   &ctKey6,
@@ -176,7 +177,7 @@ func (s *BPFCtListSuite) TestDumpCt6(c *C) {
 				},
 			},
 		),
-		ctmap.NewCtMockMap(
+		mockmaps.NewCtMockMap(
 			[]ctmap.CtMapRecord{
 				{
 					Key:   &ctKey6,
@@ -202,5 +203,5 @@ func (s *BPFCtListSuite) TestDumpCt6(c *C) {
 		Key:   &ctmap.CtKey6{TupleKey6: ctDump[0].Key},
 		Value: ctDump[0].Value,
 	}
-	c.Assert(ctRecordDump, checker.DeepEquals, ctMaps[0].(*ctmap.CtMockMap).Entries[0])
+	c.Assert(ctRecordDump, checker.DeepEquals, ctMaps[0].(*mockmaps.CtMockMap).Entries[0])
 }

--- a/cilium/cmd/bpf_nat_list_test.go
+++ b/cilium/cmd/bpf_nat_list_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 	"github.com/cilium/cilium/pkg/tuple"
 	"github.com/cilium/cilium/pkg/types"
 
@@ -84,7 +85,7 @@ type natRecord6 struct {
 func (s *BPFNatListSuite) TestDumpNat4(c *C) {
 
 	natMaps := [2]nat.NatMap{
-		nat.NewNatMockMap(
+		mockmaps.NewNatMockMap(
 			[]nat.NatMapRecord{
 				{
 					Key:   &natKey4,
@@ -96,7 +97,7 @@ func (s *BPFNatListSuite) TestDumpNat4(c *C) {
 				},
 			},
 		),
-		nat.NewNatMockMap(
+		mockmaps.NewNatMockMap(
 			[]nat.NatMapRecord{
 				{
 					Key:   &natKey4,
@@ -122,13 +123,13 @@ func (s *BPFNatListSuite) TestDumpNat4(c *C) {
 		Key:   &nat.NatKey4{TupleKey4Global: tuple.TupleKey4Global{TupleKey4: natDump[0].Key}},
 		Value: natDump[0].Value,
 	}
-	c.Assert(natRecordDump, checker.DeepEquals, natMaps[0].(*nat.NatMockMap).Entries[0])
+	c.Assert(natRecordDump, checker.DeepEquals, natMaps[0].(*mockmaps.NatMockMap).Entries[0])
 }
 
 func (s *BPFNatListSuite) TestDumpNat6(c *C) {
 
 	natMaps := [2]nat.NatMap{
-		nat.NewNatMockMap(
+		mockmaps.NewNatMockMap(
 			[]nat.NatMapRecord{
 				{
 					Key:   &natKey6,
@@ -140,7 +141,7 @@ func (s *BPFNatListSuite) TestDumpNat6(c *C) {
 				},
 			},
 		),
-		nat.NewNatMockMap(
+		mockmaps.NewNatMockMap(
 			[]nat.NatMapRecord{
 				{
 					Key:   &natKey6,
@@ -166,5 +167,5 @@ func (s *BPFNatListSuite) TestDumpNat6(c *C) {
 		Key:   &nat.NatKey6{TupleKey6Global: tuple.TupleKey6Global{TupleKey6: natDump[0].Key}},
 		Value: natDump[0].Value,
 	}
-	c.Assert(natRecordDump, checker.DeepEquals, natMaps[0].(*nat.NatMockMap).Entries[0])
+	c.Assert(natRecordDump, checker.DeepEquals, natMaps[0].(*mockmaps.NatMockMap).Entries[0])
 }

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -251,7 +251,9 @@ type GCFilter struct {
 // EmitCTEntryCBFunc is the type used for the EmitCTEntryCB callback in GCFilter
 type EmitCTEntryCBFunc func(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry)
 
-func doDumpEntries(m CtMap) (string, error) {
+// DoDumpEntries iterates through Map m and writes the values of the ct entries
+// in m to a string.
+func DoDumpEntries(m CtMap) (string, error) {
 	var buffer bytes.Buffer
 
 	cb := func(k bpf.MapKey, v bpf.MapValue) {
@@ -271,7 +273,7 @@ func doDumpEntries(m CtMap) (string, error) {
 // DumpEntries iterates through Map m and writes the values of the ct entries
 // in m to a string.
 func (m *Map) DumpEntries() (string, error) {
-	return doDumpEntries(m)
+	return DoDumpEntries(m)
 }
 
 // newMap creates a new CT map of the specified type with the specified name.

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -119,7 +119,9 @@ func NewMap(name string, v4 bool, entries int) *Map {
 	}
 }
 
-func doDumpEntries(m NatMap) (string, error) {
+// DoDumpEntries iterates through Map m and writes the values of the
+// nat entries in m to a string.
+func DoDumpEntries(m NatMap) (string, error) {
 	var buffer bytes.Buffer
 
 	nsecStart, _ := bpf.GetMtime()
@@ -138,7 +140,7 @@ func doDumpEntries(m NatMap) (string, error) {
 // DumpEntries iterates through Map m and writes the values of the
 // nat entries in m to a string.
 func (m *Map) DumpEntries() (string, error) {
-	return doDumpEntries(m)
+	return DoDumpEntries(m)
 }
 
 type gcStats struct {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -23,17 +23,17 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/maps/lbmap"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/service/healthserver"
+	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 
 	. "gopkg.in/check.v1"
 )
 
 type ManagerTestSuite struct {
 	svc                       *Service
-	lbmap                     *lbmap.LBMockMap // for accessing public fields
+	lbmap                     *mockmaps.LBMockMap // for accessing public fields
 	svcHealth                 *healthserver.MockHealthHTTPServerFactory
 	prevOptionSessionAffinity bool
 	prevOptionLBSourceRanges  bool
@@ -46,8 +46,8 @@ func (m *ManagerTestSuite) SetUpTest(c *C) {
 	backendIDAlloc.resetLocalID()
 
 	m.svc = NewService(nil)
-	m.svc.lbmap = lbmap.NewLBMockMap()
-	m.lbmap = m.svc.lbmap.(*lbmap.LBMockMap)
+	m.svc.lbmap = mockmaps.NewLBMockMap()
+	m.lbmap = m.svc.lbmap.(*mockmaps.LBMockMap)
 
 	m.svcHealth = healthserver.NewMockHealthHTTPServerFactory()
 	m.svc.healthServer = healthserver.WithHealthHTTPServerFactory(m.svcHealth)
@@ -274,7 +274,7 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 	c.Assert(err, IsNil)
 
 	// Restart service, but keep the lbmap to restore services from
-	lbmap := m.svc.lbmap.(*lbmap.LBMockMap)
+	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 	m.svc = NewService(nil)
 	m.svc.lbmap = lbmap
 
@@ -356,7 +356,7 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 	c.Assert(len(m.lbmap.AffinityMatch[uint16(id1)]), Equals, 2)
 
 	// Restart service, but keep the lbmap to restore services from
-	lbmap := m.svc.lbmap.(*lbmap.LBMockMap)
+	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 	m.svc = NewService(nil)
 	m.svc.lbmap = lbmap
 	err = m.svc.RestoreServices()

--- a/pkg/testutils/mockmaps/ctmap.go
+++ b/pkg/testutils/mockmaps/ctmap.go
@@ -12,52 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nat
+package mockmaps
 
 import (
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 )
 
-// NatMockMap implements the NatMap interface and can be used for unit tests.
-type NatMockMap struct {
-	Entries []NatMapRecord
+// CtMockMap implements the CtMap interface and can be used for unit tests.
+type CtMockMap struct {
+	Entries []ctmap.CtMapRecord
 }
 
-// NewNatMockMap is a constructor for a NatMockMap.
-func NewNatMockMap(records []NatMapRecord) *NatMockMap {
-	m := &NatMockMap{}
+// NewCtMockMap is a constructor for a CtMockMap.
+func NewCtMockMap(records []ctmap.CtMapRecord) *CtMockMap {
+	m := &CtMockMap{}
 	m.Entries = records
 	return m
 }
 
 // Open does nothing, mock maps need not be opened.
-func (m *NatMockMap) Open() error {
+func (m *CtMockMap) Open() error {
 	return nil
 }
 
 // Close does nothing, mock maps need not be closed either.
-func (m *NatMockMap) Close() error {
+func (m *CtMockMap) Close() error {
 	return nil
 }
 
 // Path returns a mock path for the mock map.
-func (m *NatMockMap) Path() (string, error) {
+func (m *CtMockMap) Path() (string, error) {
 	return "/this/is/a/mock/map", nil
 }
 
 // DumpEntries iterates through Map m and writes the values of the ct entries
 // in m to a string.
-func (m *NatMockMap) DumpEntries() (string, error) {
-	return doDumpEntries(m)
+func (m *CtMockMap) DumpEntries() (string, error) {
+	return ctmap.DoDumpEntries(m)
 }
 
 // DumpWithCallback runs the callback on each entry of the mock map.
-func (m *NatMockMap) DumpWithCallback(cb bpf.DumpCallback) error {
+func (m *CtMockMap) DumpWithCallback(cb bpf.DumpCallback) error {
 	if cb == nil {
 		return nil
 	}
 	for _, e := range m.Entries {
-		cb(e.Key, e.Value)
+		cb(e.Key, &e.Value)
 	}
 	return nil
 }

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package lbmap
+package mockmaps
 
 import (
 	"fmt"
@@ -21,25 +21,26 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
 )
 
 type LBMockMap struct {
 	BackendByID   map[uint16]*lb.Backend
 	ServiceByID   map[uint16]*lb.SVC
-	AffinityMatch BackendIDByServiceIDSet
-	SourceRanges  SourceRangeSetByServiceID
+	AffinityMatch lbmap.BackendIDByServiceIDSet
+	SourceRanges  lbmap.SourceRangeSetByServiceID
 }
 
 func NewLBMockMap() *LBMockMap {
 	return &LBMockMap{
 		BackendByID:   map[uint16]*lb.Backend{},
 		ServiceByID:   map[uint16]*lb.SVC{},
-		AffinityMatch: BackendIDByServiceIDSet{},
-		SourceRanges:  SourceRangeSetByServiceID{},
+		AffinityMatch: lbmap.BackendIDByServiceIDSet{},
+		SourceRanges:  lbmap.SourceRangeSetByServiceID{},
 	}
 }
 
-func (m *LBMockMap) UpsertService(p *UpsertServiceParams) error {
+func (m *LBMockMap) UpsertService(p *lbmap.UpsertServiceParams) error {
 	backendsList := make([]lb.Backend, 0, len(p.Backends))
 	for name, backendID := range p.Backends {
 		b, found := m.BackendByID[backendID]
@@ -145,7 +146,7 @@ func (m *LBMockMap) DeleteAffinityMatch(revNATID uint16, backendID uint16) error
 	return nil
 }
 
-func (m *LBMockMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
+func (m *LBMockMap) DumpAffinityMatches() (lbmap.BackendIDByServiceIDSet, error) {
 	return m.AffinityMatch, nil
 }
 
@@ -163,6 +164,6 @@ func (m *LBMockMap) UpdateSourceRanges(revNATID uint16, prevRanges []*cidr.CIDR,
 	return nil
 }
 
-func (m *LBMockMap) DumpSourceRanges(ipv6 bool) (SourceRangeSetByServiceID, error) {
+func (m *LBMockMap) DumpSourceRanges(ipv6 bool) (lbmap.SourceRangeSetByServiceID, error) {
 	return m.SourceRanges, nil
 }

--- a/pkg/testutils/mockmaps/nat.go
+++ b/pkg/testutils/mockmaps/nat.go
@@ -12,52 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ctmap
+package mockmaps
 
 import (
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/maps/nat"
 )
 
-// CtMockMap implements the CtMap interface and can be used for unit tests.
-type CtMockMap struct {
-	Entries []CtMapRecord
+// NatMockMap implements the NatMap interface and can be used for unit tests.
+type NatMockMap struct {
+	Entries []nat.NatMapRecord
 }
 
-// NewCtMockMap is a constructor for a CtMockMap.
-func NewCtMockMap(records []CtMapRecord) *CtMockMap {
-	m := &CtMockMap{}
+// NewNatMockMap is a constructor for a NatMockMap.
+func NewNatMockMap(records []nat.NatMapRecord) *NatMockMap {
+	m := &NatMockMap{}
 	m.Entries = records
 	return m
 }
 
 // Open does nothing, mock maps need not be opened.
-func (m *CtMockMap) Open() error {
+func (m *NatMockMap) Open() error {
 	return nil
 }
 
 // Close does nothing, mock maps need not be closed either.
-func (m *CtMockMap) Close() error {
+func (m *NatMockMap) Close() error {
 	return nil
 }
 
 // Path returns a mock path for the mock map.
-func (m *CtMockMap) Path() (string, error) {
+func (m *NatMockMap) Path() (string, error) {
 	return "/this/is/a/mock/map", nil
 }
 
 // DumpEntries iterates through Map m and writes the values of the ct entries
 // in m to a string.
-func (m *CtMockMap) DumpEntries() (string, error) {
-	return doDumpEntries(m)
+func (m *NatMockMap) DumpEntries() (string, error) {
+	return nat.DoDumpEntries(m)
 }
 
 // DumpWithCallback runs the callback on each entry of the mock map.
-func (m *CtMockMap) DumpWithCallback(cb bpf.DumpCallback) error {
+func (m *NatMockMap) DumpWithCallback(cb bpf.DumpCallback) error {
 	if cb == nil {
 		return nil
 	}
 	for _, e := range m.Entries {
-		cb(e.Key, &e.Value)
+		cb(e.Key, e.Value)
 	}
 	return nil
 }


### PR DESCRIPTION
This commit introduces some preliminary work to consolidate the mock
maps used for testing (#13305) by moving the implementations of the
different mocks (ctmap, lbmap and nat) into a single `mockmaps` package
in `testutils`.

No changes in the interface of the mocks are introduced yet.