### PR TITLE
v1.7 backports 2020-10-09 - Race condition in DeepEqual function

### DIFF
--- a/pkg/comparator/comparator.go
+++ b/pkg/comparator/comparator.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,6 +75,46 @@ func MapBoolEquals(m1, m2 map[string]bool) bool {
 		if v2, ok := m2[k1]; !ok || v2 != v1 {
 			return false
 		}
+	}
+	return true
+}
+
+// MapStringEqualsIgnoreKeys returns true if both maps have the same values for
+// the keys that are not present in the 'ignoreKeys'.
+func MapStringEqualsIgnoreKeys(m1, m2 map[string]string, ignoreKeys []string) bool {
+	switch {
+	case m1 == nil && m2 == nil:
+		return true
+	case m1 == nil && m2 != nil,
+		m1 != nil && m2 == nil:
+		return false
+	}
+	ignoredM1 := 0
+	for k1, v1 := range m1 {
+		var ignore bool
+		for _, ig := range ignoreKeys {
+			if k1 == ig {
+				ignore = true
+				break
+			}
+		}
+		if ignore {
+			ignoredM1++
+			continue
+		}
+		if v2, ok := m2[k1]; !ok || v2 != v1 {
+			return false
+		}
+	}
+
+	ignoredM2 := 0
+	for _, ig := range ignoreKeys {
+		if _, ok := m2[ig]; ok {
+			ignoredM2++
+		}
+	}
+	if len(m1)-ignoredM1 != len(m2)-ignoredM2 {
+		return false
 	}
 	return true
 }

--- a/pkg/comparator/comparator_test.go
+++ b/pkg/comparator/comparator_test.go
@@ -152,3 +152,116 @@ func (s *ComparatorSuite) TestMapBoolEquals(c *C) {
 		c.Assert(MapBoolEquals(tt.m1, tt.m2), Equals, tt.want)
 	}
 }
+
+func (s *ComparatorSuite) TestMapStringEqualsIgnoreKeys(c *C) {
+	tests := []struct {
+		name         string
+		m1           map[string]string
+		m2           map[string]string
+		keysToIgnore []string
+		want         bool
+	}{
+		{
+			name: "test-1",
+			m1:   nil,
+			m2:   nil,
+			want: true,
+		},
+		{
+			m1: map[string]string{
+				"foo": "bar",
+			},
+			m2: map[string]string{
+				"foo": "bar",
+			},
+			want: true,
+		},
+		{
+			name: "test-2",
+			m1:   map[string]string{},
+			m2:   map[string]string{},
+			want: true,
+		},
+		{
+			name: "test-3",
+			m1: map[string]string{
+				"fo": "bar",
+			},
+			m2: map[string]string{
+				"foo": "bar",
+			},
+			want: false,
+		},
+		{
+			name: "test-4",
+			m1:   nil,
+			m2: map[string]string{
+				"foo": "bar",
+			},
+			want: false,
+		},
+		{
+			name: "test-5",
+			m1: map[string]string{
+				"foo": "bar",
+			},
+			m2:   nil,
+			want: false,
+		},
+		{
+			name: "test-6",
+			m1: map[string]string{
+				"foo": "bar",
+			},
+			m2:   nil,
+			want: false,
+		},
+		{
+			name: "test-7",
+			m1: map[string]string{
+				"foo": "bar",
+			},
+			m2:           nil,
+			keysToIgnore: []string{"foo"},
+			// Although we are ignoring "foo", m2 is nil.
+			want: false,
+		},
+		{
+			name: "test-8",
+			m1: map[string]string{
+				"foo": "bar",
+			},
+			m2:           map[string]string{},
+			keysToIgnore: []string{"foo"},
+			want:         true,
+		},
+		{
+			name: "test-9",
+			m1:   map[string]string{},
+			m2: map[string]string{
+				"foo": "bar",
+			},
+			keysToIgnore: []string{"foo"},
+			want:         true,
+		},
+		{
+			name:         "test-10",
+			m1:           map[string]string{},
+			m2:           map[string]string{},
+			keysToIgnore: []string{"foo"},
+			want:         true,
+		},
+		{
+			name: "test-10",
+			m1:   nil,
+			m2: map[string]string{
+				"foo": "bar",
+			},
+			keysToIgnore: []string{"foo"},
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		c.Assert(MapStringEqualsIgnoreKeys(tt.m1, tt.m2, tt.keysToIgnore), Equals, tt.want, Commentf("%s", tt.name))
+	}
+}

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -162,21 +162,11 @@ func EqualV2CNP(cnp1, cnp2 *types.SlimCNP) bool {
 		return false
 	}
 
-	// Ignore v1.LastAppliedConfigAnnotation annotation
-	lastAppliedCfgAnnotation1, ok1 := cnp1.GetAnnotations()[v1.LastAppliedConfigAnnotation]
-	lastAppliedCfgAnnotation2, ok2 := cnp2.GetAnnotations()[v1.LastAppliedConfigAnnotation]
-	defer func() {
-		if ok1 && cnp1.GetAnnotations() != nil {
-			cnp1.GetAnnotations()[v1.LastAppliedConfigAnnotation] = lastAppliedCfgAnnotation1
-		}
-		if ok2 && cnp2.GetAnnotations() != nil {
-			cnp2.GetAnnotations()[v1.LastAppliedConfigAnnotation] = lastAppliedCfgAnnotation2
-		}
-	}()
-	delete(cnp1.GetAnnotations(), v1.LastAppliedConfigAnnotation)
-	delete(cnp2.GetAnnotations(), v1.LastAppliedConfigAnnotation)
-
-	return comparator.MapStringEquals(cnp1.GetAnnotations(), cnp2.GetAnnotations()) &&
+	return comparator.MapStringEqualsIgnoreKeys(
+		cnp1.GetAnnotations(),
+		cnp2.GetAnnotations(),
+		// Ignore v1.LastAppliedConfigAnnotation annotation
+		[]string{v1.LastAppliedConfigAnnotation}) &&
 		reflect.DeepEqual(cnp1.Spec, cnp2.Spec) &&
 		reflect.DeepEqual(cnp1.Specs, cnp2.Specs)
 }


### PR DESCRIPTION
* #13472 -- Fix race condition in DeepEqual function (@aanm)
   * Conflict on second commit. In order to resolve it:
     * Report the change to `pkg/k8s/factory_functions.go` instead of `pkg/k8s/apis/cilium.io/v2/cnp_types.go`, where the code is located in v1.9.
     * Also keep the check on `reflect.deepEqual(...)` added to the value returned by the function, as is the case in branch v1.7 (changed in v1.9 with commit c813a15 (`k8s: Explicitly embed CRD types into CCNP`).

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13472; do contrib/backporting/set-labels.py $pr done 1.7; done
```