### PR TITLE
route: support custom route rules and cluster gateway

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -65,6 +65,7 @@ cilium-agent [flags]
       --enable-bpf-clock-probe                        Enable BPF clock source probing for more efficient tick retrieval
       --enable-bpf-masquerade                         Masquerade packets from endpoints leaving the host with BPF instead of iptables
       --enable-bpf-tproxy                             Enable BPF-based proxy redirection, if support available
+      --enable-custom-route                           Install custom route rules for pod to reach public internet and outer cluster nodes
       --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host
       --enable-external-ips                           Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
@@ -107,6 +108,8 @@ cilium-agent [flags]
       --flannel-master-device string                  Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
       --flannel-uninstall-on-exit                     When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
       --force-local-policy-eval-at-source             Force policy evaluation of all local communication at the source endpoint (default true)
+      --gateway-ipv4-node-label string                Custom ipv4 route gateway (default "io.cilium.customroute.gateway.ipv4")
+      --gateway-ipv6-node-label string                Custom ipv6 route gateway (default "io.cilium.customroute.gateway.ipv6")
   -h, --help                                          help for cilium-agent
       --host-reachable-services-protos strings        Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
       --http-idle-timeout uint                        Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
@@ -208,6 +211,10 @@ cilium-agent [flags]
       --tofqdns-proxy-response-max-delay duration     The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
       --trace-payloadlen int                          Length of payload to capture when tracing (default 128)
   -t, --tunnel string                                 Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --underlay-cidr-ipv4-node-label string          Custom ipv4 underlay network cidr (default "io.cilium.customroute.underlay.cidr.ipv4")
+      --underlay-cidr-ipv6-node-label string          Custom ipv6 underlay network cidr (default "io.cilium.customroute.underlay.cidr.ipv6")
+      --underlay-cidr-len-ipv4-node-label string      Custom ipv4 underlay network cidr len (default "io.cilium.customroute.underlay.cidr.len.ipv4")
+      --underlay-cidr-len-ipv6-node-label string      Custom ipv6 underlay network cidr len (default "io.cilium.customroute.underlay.cidr.len.ipv6")
       --version                                       Print version information
       --write-cni-conf-when-ready string              Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -630,6 +630,27 @@ func init() {
 	flags.Int(option.MonitorQueueSizeName, 0, "Size of the event queue when reading monitor events")
 	option.BindEnv(option.MonitorQueueSizeName)
 
+	flags.Bool(option.EnableCustomRouteName, defaults.EnableCustomRoute, "Install custom route rules for pod to reach public internet and outer cluster nodes")
+	option.BindEnv(option.EnableCustomRouteName)
+
+	flags.String(option.GatewayIPv4NodeLabelName, defaults.GatewayIPv4NodeLabel, "Custom ipv4 route gateway")
+	option.BindEnv(option.GatewayIPv4NodeLabelName)
+
+	flags.String(option.GatewayIPv6NodeLabelName, defaults.GatewayIPv6NodeLabel, "Custom ipv6 route gateway")
+	option.BindEnv(option.GatewayIPv6NodeLabelName)
+
+	flags.String(option.UnderlayCidrIPv4NodeLabelName, defaults.UnderlayCidrIPv4NodeLabel, "Custom ipv4 underlay network cidr")
+	option.BindEnv(option.UnderlayCidrIPv4NodeLabelName)
+
+	flags.String(option.UnderlayCidrLenIPv4NodeLabelName, defaults.UnderlayCidrLenIPv4NodeLabel, "Custom ipv4 underlay network cidr len")
+	option.BindEnv(option.UnderlayCidrLenIPv4NodeLabelName)
+
+	flags.String(option.UnderlayCidrIPv6NodeLabelName, defaults.UnderlayCidrIPv6NodeLabel, "Custom ipv6 underlay network cidr")
+	option.BindEnv(option.UnderlayCidrIPv6NodeLabelName)
+
+	flags.String(option.UnderlayCidrLenIPv6NodeLabelName, defaults.UnderlayCidrLenIPv6NodeLabel, "Custom ipv6 underlay network cidr len")
+	option.BindEnv(option.UnderlayCidrLenIPv6NodeLabelName)
+
 	flags.Int(option.MTUName, 0, "Overwrite auto-detected MTU of underlying network")
 	option.BindEnv(option.MTUName)
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -793,7 +793,11 @@ nodePort:
 
 # The agent can be put into the following three policy enforcement modes
 # default, always and never.
+<<<<<<< HEAD
 # https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
+=======
+# https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
+>>>>>>> Helm: full refactor of helm charts, default values implemented, tests updated, kind cni integration
 # policyEnforcementMode: "default"
 
 # pprof is the GO pprof configuration

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -793,11 +793,7 @@ nodePort:
 
 # The agent can be put into the following three policy enforcement modes
 # default, always and never.
-<<<<<<< HEAD
 # https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
-=======
-# https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
->>>>>>> Helm: full refactor of helm charts, default values implemented, tests updated, kind cni integration
 # policyEnforcementMode: "default"
 
 # pprof is the GO pprof configuration

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -168,6 +168,27 @@ const (
 	// size per CPU
 	MonitorQueueSizePerCPU = 1024
 
+	// EnableCustomRoute enables custom route for pod network and cilium will fetch custom route from node label
+	EnableCustomRoute = false
+
+	// GatewayIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes public gateway
+	GatewayIPv4NodeLabel = "io.cilium.customroute.gateway.ipv4"
+
+	// GatewayIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes public gateway
+	GatewayIPv6NodeLabel = "io.cilium.customroute.gateway.ipv6"
+
+	// UnderlayCidrIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes underlay network cidr
+	UnderlayCidrIPv4NodeLabel = "io.cilium.customroute.underlay.cidr.ipv4"
+
+	// UnderlayCidrLenIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes underlay network cidr network prefix length
+	UnderlayCidrLenIPv4NodeLabel = "io.cilium.customroute.underlay.cidr.len.ipv4"
+
+	// UnderlayCidrIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes underlay network cidr
+	UnderlayCidrIPv6NodeLabel = "io.cilium.customroute.underlay.cidr.ipv6"
+
+	// UnderlayCidrLenIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes underlay network cidr network prefix length
+	UnderlayCidrLenIPv6NodeLabel = "io.cilium.customroute.underlay.cidr.len.ipv6"
+
 	// MonitorQueueSizePerCPUMaximum is the maximum value for the monitor
 	// queue size when derived from the number of CPUs
 	MonitorQueueSizePerCPUMaximum = 16384

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -580,6 +580,27 @@ const (
 	// MonitorQueueSizeName is the name of the option MonitorQueueSize
 	MonitorQueueSizeName = "monitor-queue-size"
 
+	// EnableCustomRoute enables custom route for pod network and cilium will fetch custom route from node label
+	EnableCustomRouteName = "enable-custom-route"
+
+	// GatewayIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes
+	GatewayIPv4NodeLabelName = "gateway-ipv4-node-label"
+
+	// GatewayIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes
+	GatewayIPv6NodeLabelName = "gateway-ipv6-node-label"
+
+	// UnderlayCidrIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes underlay network cidr
+	UnderlayCidrIPv4NodeLabelName = "underlay-cidr-ipv4-node-label"
+
+	// UnderlayCidrLenIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes underlay network cidr network prefix length
+	UnderlayCidrLenIPv4NodeLabelName = "underlay-cidr-len-ipv4-node-label"
+
+	// UnderlayCidrIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes underlay network cidr
+	UnderlayCidrIPv6NodeLabelName = "underlay-cidr-ipv6-node-label"
+
+	// UnderlayCidrLenIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes underlay network cidr network prefix length
+	UnderlayCidrLenIPv6NodeLabelName = "underlay-cidr-len-ipv6-node-label"
+
 	//FQDNRejectResponseCode is the name for the option for dns-proxy reject response code
 	FQDNRejectResponseCode = "tofqdns-dns-reject-response-code"
 
@@ -1546,6 +1567,27 @@ type DaemonConfig struct {
 	// MonitorQueueSize is the size of the monitor event queue
 	MonitorQueueSize int
 
+	// EnableCustomRoute enables custom route for pod network and cilium will fetch custom route from node label
+	EnableCustomRoute bool
+
+	// GatewayIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes gateway
+	GatewayIPv4NodeLabel string
+
+	// GatewayIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes gateway
+	GatewayIPv6NodeLabel string
+
+	// GatewayIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes underlay network cidr
+	UnderlayCidrIPv4NodeLabel string
+
+	// UnderlayCidrLenIPv4NodeLabel is the node label key where cilium get the ipv4 custom routes underlay network cidr network prefix length
+	UnderlayCidrLenIPv4NodeLabel string
+
+	// GatewayIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes underlay network cidr
+	UnderlayCidrIPv6NodeLabel string
+
+	// UnderlayCidrLenIPv6NodeLabel is the node label key where cilium get the ipv6 custom routes underlay network cidr network prefix length
+	UnderlayCidrLenIPv6NodeLabel string
+
 	// CLI options
 
 	BPFRoot                       string
@@ -2496,6 +2538,13 @@ func (c *DaemonConfig) Populate() {
 	c.MonitorAggregation = viper.GetString(MonitorAggregationName)
 	c.MonitorAggregationInterval = viper.GetDuration(MonitorAggregationInterval)
 	c.MonitorQueueSize = viper.GetInt(MonitorQueueSizeName)
+	c.EnableCustomRoute = viper.GetBool(EnableCustomRouteName)
+	c.GatewayIPv4NodeLabel = viper.GetString(GatewayIPv4NodeLabelName)
+	c.GatewayIPv6NodeLabel = viper.GetString(GatewayIPv6NodeLabelName)
+	c.UnderlayCidrIPv4NodeLabel = viper.GetString(UnderlayCidrIPv4NodeLabelName)
+	c.UnderlayCidrLenIPv4NodeLabel = viper.GetString(UnderlayCidrLenIPv4NodeLabelName)
+	c.UnderlayCidrIPv6NodeLabel = viper.GetString(UnderlayCidrIPv6NodeLabelName)
+	c.UnderlayCidrLenIPv6NodeLabel = viper.GetString(UnderlayCidrLenIPv6NodeLabelName)
 	c.MTU = viper.GetInt(MTUName)
 	c.NAT46Range = viper.GetString(NAT46Range)
 	c.FlannelMasterDevice = viper.GetString(FlannelMasterDevice)


### PR DESCRIPTION
In some cloud cases, packets destined outside of cluster should be sent to a cluster gateway. The cluster gateway connects the cluster and the rest of the world.
This patch choose to use custom route rules to support this. Custom route is a feature used widely in vpc cases like aws.And it could be disabled in cilium.
By now, only packets destined to internet are sent to cluster gateway. Packets sent to host cidr are nat at the host side as usual. But this could be changed in the future for ipv6 or inter-cluster communications.
This patch also fix conflicts between  custom routes and network policy.
Thanks.