### PR TITLE
cilium, ipsec: Do revalidate_data_pull() early in do_decrypt() case

### DIFF
--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -18,7 +18,6 @@ int from_network(struct __ctx_buff *ctx)
 {
 #ifdef ENABLE_IPSEC
 	__u16 proto;
-	int ret;
 
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT) {
 		send_trace_notify(ctx, TRACE_FROM_NETWORK, get_identity(ctx), 0, 0,
@@ -38,14 +37,11 @@ int from_network(struct __ctx_buff *ctx)
 	if (!validate_ethertype(ctx, &proto))
 		return CTX_ACT_OK;
 
-	ret = do_decrypt(ctx, proto);
-	if (!ret)
-		return CTX_ACT_OK;
-	ctx->mark = 0;
-	return redirect(CILIUM_IFINDEX, 0);
-#endif
-	/* Pass unknown traffic to the stack */
+	return do_decrypt(ctx, proto);
+#else
+	/* nop if IPSec is disabled */
 	return CTX_ACT_OK;
+#endif
 }
 
 BPF_LICENSE("GPL");

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -16,56 +16,65 @@
 static __always_inline int
 do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 {
+	void *data, *data_end;
+	__u8 protocol = 0;
 	bool decrypted;
+#ifdef ENABLE_IPV6
+	struct ipv6hdr *ip6;
+#endif
+#ifdef ENABLE_IPV4
+	struct iphdr *ip4;
+#endif
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
-	if (!decrypted) {
-		void *data, *data_end;
-		__u8 protocol = 0;
+
+	switch (proto) {
 #ifdef ENABLE_IPV6
-		struct ipv6hdr *ip6;
+	case bpf_htons(ETH_P_IPV6):
+		if (!revalidate_data_pull(ctx, &data, &data_end, &ip6)) {
+			ctx->mark = 0;
+			return CTX_ACT_OK;
+		}
+		protocol = ip6->nexthdr;
+		break;
 #endif
 #ifdef ENABLE_IPV4
-		struct iphdr *ip4;
-#endif
-
-		switch (proto) {
-#ifdef ENABLE_IPV6
-		case bpf_htons(ETH_P_IPV6):
-			if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
-				break;
-			protocol = ip6->nexthdr;
-			break;
-#endif
-#ifdef ENABLE_IPV4
-		case bpf_htons(ETH_P_IP):
-			if (!revalidate_data(ctx, &data, &data_end, &ip4))
-				break;
-
-			protocol = ip4->protocol;
-			break;
-#endif
+	case bpf_htons(ETH_P_IP):
+		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+			ctx->mark = 0;
+			return CTX_ACT_OK;
 		}
-
-		if (protocol == IPPROTO_ESP) {
-			/* Decrypt "key" is determined by SPI */
-			ctx->mark = MARK_MAGIC_DECRYPT;
-			/* We are going to pass this up the stack for IPsec decryption
-			 * but eth_type_trans may already have labeled this as an
-			 * OTHERHOST type packet. To avoid being dropped by IP stack
-			 * before IPSec can be processed mark as a HOST packet.
-			 */
-			ctx_change_type(ctx, PACKET_HOST);
-			return 0;
-		}
+		protocol = ip4->protocol;
+		break;
+#endif
+	default:
+		return CTX_ACT_OK;
 	}
-	return -ENOENT;
+
+	if (!decrypted) {
+		/* Allow all non-ESP packets up the stack per normal case
+		 * without encryption enabled.
+		 */
+		if (protocol != IPPROTO_ESP)
+			return CTX_ACT_OK;
+		/* Decrypt "key" is determined by SPI */
+		ctx->mark = MARK_MAGIC_DECRYPT;
+		/* We are going to pass this up the stack for IPsec decryption
+		 * but eth_type_trans may already have labeled this as an
+		 * OTHERHOST type packet. To avoid being dropped by IP stack
+		 * before IPSec can be processed mark as a HOST packet.
+		 */
+		ctx_change_type(ctx, PACKET_HOST);
+		return CTX_ACT_OK;
+	}
+	ctx->mark = 0;
+	return redirect(CILIUM_IFINDEX, 0);
 }
 #else
 static __always_inline int
 do_decrypt(struct __ctx_buff __maybe_unused *ctx, __u16 __maybe_unused proto)
 {
-	return -ENOENT;
+	return CTX_ACT_OK;
 }
 #endif /* ENABLE_IPSEC */
 #endif /* __LIB_ENCRYPT_H_ */


### PR DESCRIPTION
When we created a lib for encryption the pull_data call was pulled
into the per protocol cases versus being called regardless of if
its been decrypted already or not.

Lets pull it back to the previous location.

Next we returned a drop code DROP_INVALID incorrectly as well
so lets make that an accept return code. We shouldn't be dropping
packets from here, lets let the stack or upper layer Cilium code do
that if it needs to.

Finally for same reason above lets allow all non esp packets to
go up the stack. The will still hit a Cilium policy program later
so let that code work as expected.

Fixes #13528

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

---

@nebril bisected an encryption failure back to this patch 7ba0e83acc458 and this corrects the difference between the old code and the new lib based code. However it seems that the pull should be unnecessary to me unless we have a miss in the cilium_host codebase as well? 