### PR TITLE
ci: Do not label control plane nodes with cilium.io/node

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -571,7 +571,7 @@ func (kub *Kubectl) PrepareCluster() {
 
 // labelNodes labels all Kubernetes nodes for use by the CI tests
 func (kub *Kubectl) labelNodes() error {
-	cmd := KubectlCmd + " get nodes -o json | jq -r '[ .items[].metadata.name ]'"
+	cmd := KubectlCmd + " get nodes -o json | jq -r '[ .items[] | select(.metadata.labels[\"node-role.kubernetes.io/controlplane\"] == null).metadata.name ]'"
 	res := kub.ExecShort(cmd)
 	if !res.WasSuccessful() {
 		return fmt.Errorf("unable to retrieve all nodes with '%s': %s", cmd, res.OutputPrettyPrint())


### PR DESCRIPTION
Labeling control plane nodes with cilium.io/node when running against a
target cluster was causing some applications to fail to schedule
properly.

Fixes: #13395
