### PR TITLE
docs: Correct minikube start command in getting started guide

### DIFF
--- a/Documentation/gettingstarted/minikube-install.rst
+++ b/Documentation/gettingstarted/minikube-install.rst
@@ -26,7 +26,7 @@
 ::
 
      # Only available for minikube >= v1.12.1
-     minikube start --network-plugin=cilium --memory=4096
+     minikube start --cni=cilium --memory=4096
 
 .. note::
 


### PR DESCRIPTION
Starting minikube with `--network-plugin=cilium`, as [described in the getting started guide](https://docs.cilium.io/en/stable/gettingstarted/minikube/), fails for me and @gandro, the full log is [here](https://github.com/cilium/cilium/files/5364844/cilium-cni-fail.log).

I did some superficial digging, and it seems like changing the flag from `--network-plugin=cilium` to `--cni=cilium` causes minikube to correctly start a node with Cilium. I verified this by running the connectivity check and Star Wars example on the created cluster.

This PR updates the docs to correct the flag to minikube.
