### PR TITLE
identity: Fix nil pointer panic in LookupIdentityByID

### DIFF
--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -199,19 +199,46 @@ func (w *identityWatcher) stop() {
 	close(w.stopChan)
 }
 
+// isLocalIdentityAllocatorInitialized returns true if m.localIdentities is not nil.
+func (m *CachingIdentityAllocator) isLocalIdentityAllocatorInitialized() bool {
+	select {
+	case <-m.localIdentityAllocatorInitialized:
+		return m.localIdentities != nil
+	default:
+		return false
+	}
+}
+
+// isGlobalIdentityAllocatorInitialized returns true if m.IdentityAllocator is not nil.
+// Note: This does not mean that the identities have been synchronized,
+// see WaitForInitialGlobalIdentities to wait for a fully populated cache.
+func (m *CachingIdentityAllocator) isGlobalIdentityAllocatorInitialized() bool {
+	select {
+	case <-m.globalIdentityAllocatorInitialized:
+		return m.IdentityAllocator != nil
+	default:
+		return false
+	}
+}
+
 // LookupIdentity looks up the identity by its labels but does not create it.
 // This function will first search through the local cache, then the caches for
-// remote kvstores and finally fall back to the main kvstore
+// remote kvstores and finally fall back to the main kvstore.
+// May return nil for lookups if the allocator has not yet been synchronized.
 func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labels.Labels) *identity.Identity {
 	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
 		return reservedIdentity
+	}
+
+	if !m.isLocalIdentityAllocatorInitialized() {
+		return nil
 	}
 
 	if identity := m.localIdentities.lookup(lbls); identity != nil {
 		return identity
 	}
 
-	if !identity.RequiresGlobalIdentity(lbls) || m.IdentityAllocator == nil {
+	if !identity.RequiresGlobalIdentity(lbls) || !m.isGlobalIdentityAllocatorInitialized() {
 		return nil
 	}
 
@@ -233,6 +260,7 @@ var unknownIdentity = identity.NewIdentity(identity.IdentityUnknown, labels.Labe
 // LookupIdentityByID returns the identity by ID. This function will first
 // search through the local cache, then the caches for remote kvstores and
 // finally fall back to the main kvstore
+// May return nil for lookups if the allocator has not yet been synchronized.
 func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id identity.NumericIdentity) *identity.Identity {
 	if id == identity.IdentityUnknown {
 		return unknownIdentity
@@ -242,11 +270,15 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return identity
 	}
 
+	if !m.isLocalIdentityAllocatorInitialized() {
+		return nil
+	}
+
 	if identity := m.localIdentities.lookupByID(id); identity != nil {
 		return identity
 	}
 
-	if id.HasLocalScope() || m.IdentityAllocator == nil {
+	if !m.isGlobalIdentityAllocatorInitialized() || id.HasLocalScope() {
 		return nil
 	}
 


### PR DESCRIPTION
Because the identity allocator is initialized asynchronously via
`InitIdentityAllocator`, its internal local identitiy allocator might
not have been initialized yet when the lookup functions are called.
This can cause nil pointer panics, as observed in #13479.

Before b194612c004c3e69289286e9a35d337b2645fc50, this nil pointer panic could not occur in
`LookupIdentityByID` as the function checked for `m.IdentityAllocator != nil`
which also implies `m.localIdentities != nil`.
This commit adds an explict check for `m.localIdentities`.

Fixes: #13479
Fixes: b194612c004c ("identity: Avoid kvstore lookup for local identities")

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>

---

Note: While the backported version of b194612c004c in v1.7 and v1.8 does not suffer from the nil pointer panic due to an early check fo `m.IdentityAllocator != nil` , I think we should still back-port this to fix the potential nil-pointer panic in `LookupIdentity` which is also fixed by this commit. 