### PR TITLE
helm: Update documentation links to point to stable

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -324,7 +324,7 @@ enableCnpStatusUpdates: false
 # when the xt_socket kernel module is missing and it is needed for
 # the datapath L7 redirection to work properly.  See documentation
 # for details on when this can be disabled:
-# http://docs.cilium.io/en/latest/install/system_requirements/#admin-kernel-version.
+# http://docs.cilium.io/en/stable/install/system_requirements/#admin-kernel-version.
 enableXTSocketFallback: true
 
 # encryption is the encryption specific configuration
@@ -793,7 +793,7 @@ nodePort:
 
 # The agent can be put into the following three policy enforcement modes
 # default, always and never.
-# https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
+# https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
 # policyEnforcementMode: "default"
 
 # pprof is the GO pprof configuration


### PR DESCRIPTION
These settings should point to the currently supported stable version of
the docs rather than the development version, point to stable instead of
latest.