### PR TITLE
Fix install/kubernetes update-versions make target

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -6,7 +6,10 @@ include ../../Makefile.defs
 # Workaround until we branch for v1.9
 VERSION := 1.8.90
 
+HUBBLE_PROXY_VERSION := "v1.14.5"
+HUBBLE_UI_VERSION := "v0.7.2"
 MANAGED_ETCD_VERSION := "v2.0.7"
+NODEINIT_VERSION := "af2a99046eca96c0138551393b21a5c044c7fe79"
 
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
 EXPERIMENTAL_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/experimental-install.yaml"
@@ -17,7 +20,6 @@ VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+.*'
 LATEST_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
 DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
-CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
 CILIUM_PULLPOLICY_REGEX := '\([pP]ullPolicy:\) .*'
 EXPERIMENTAL_OPTIONS := \
     --set hubble.enabled=true \
@@ -30,10 +32,10 @@ EXPERIMENTAL_OPTIONS := \
 
 all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL)
 
-$(QUICK_INSTALL) quick-install: $(shell find cilium/ -type f)
+$(QUICK_INSTALL) quick-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system > $(QUICK_INSTALL)
 
-$(EXPERIMENTAL_INSTALL) experimental-install: $(shell find cilium/ -type f)
+$(EXPERIMENTAL_INSTALL) experimental-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
 
 update-versions:
@@ -41,18 +43,31 @@ update-versions:
 	@# Update chart versions to point to the current version.
 	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS)/ | \
 		xargs -0 -l sed -i -e 's/'$(CILIUM_CHART_REGEX)'/\1 $(VERSION)/g'
-	@# Fix up the cilium tag
-	$(QUIET)$(shell											\
-		if echo $(VERSION) | grep -q $(LATEST_VERSION_REGEX); then				\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $$chart;				\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $$chart;			\
-		elif echo $(VERSION) | grep -q $(DEV_VERSION_REGEX); then				\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(subst -dev,,$(VERSION))/' $$chart;	\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $$chart;			\
-		else											\
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $$chart;			\
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $$chart;		\
-		fi;											\
+	@# Fix up the container image tags
+	$(QUIET)$(shell														\
+		cilium_version="v$(VERSION)";											\
+		hubble_version=$(HUBBLE_UI_VERSION);										\
+		pull_policy="IfNotPresent";											\
+		if echo "$(VERSION)" | grep -q $(LATEST_VERSION_REGEX); then							\
+			cilium_version="latest";										\
+			hubble_version="latest";										\
+			pull_policy="Always";											\
+		elif echo "$(VERSION)" | grep -q $(DEV_VERSION_REGEX); then							\
+			cilium_version="v$(subst -dev,,$(VERSION))";								\
+			hubble_version="$(HUBBLE_UI_VERSION)";									\
+			pull_policy="Always";											\
+		fi;														\
+		# image.tag operator.image.tag preflight.image.tag hubble.relay.image.tag;					\
+		sed -i 's/tag: .*/tag: '$$cilium_version'/g' $(CILIUM_VALUES);							\
+		# hubble.ui.frontend.image.tag hubble.ui.backend.image.tag;							\
+		sed -i '/repository.*hubble-ui.*/{!b;n;s/tag.*/tag: '$$hubble_version'/}' $(CILIUM_VALUES);			\
+		# etcd.image.tag												\
+		sed -i '/repository.*etcd-operator.*/{!b;n;s/tag.*/tag: '$(MANAGED_ETCD_VERSION)'/}' $(CILIUM_VALUES)		\
+		# hubble.ui.proxy.image.tag											\
+		sed -i '/repository.*envoy.*/{!b;n;s/tag.*/tag: '$(HUBBLE_PROXY_VERSION)'/}' $(CILIUM_VALUES)			\
+		# nodeinit.image.tag												\
+		sed -i '/repository.*cilium\/startup-script.*/{!b;n;s/tag.*/tag: '$(NODEINIT_VERSION)'/}' $(CILIUM_VALUES)	\
+		sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 '$$pull_policy'/' $$chart;						\
 	)
 
 lint:

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -3,6 +3,9 @@
 
 include ../../Makefile.defs
 
+# Workaround until we branch for v1.9
+VERSION := 1.8.90
+
 MANAGED_ETCD_VERSION := "v2.0.7"
 
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -42,7 +42,7 @@ update-versions:
 	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS)/ | \
 		xargs -0 -l sed -i -e 's/'$(CILIUM_CHART_REGEX)'/\1 $(VERSION)/g'
 	@# Fix up the cilium tag
-	$(QUIET)for chart in $(CILIUM_VALUES); do							\
+	$(QUIET)$(shell											\
 		if echo $(VERSION) | grep -q $(LATEST_VERSION_REGEX); then				\
 			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $$chart;				\
 			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $$chart;			\
@@ -52,7 +52,8 @@ update-versions:
 		else											\
 			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $$chart;			\
 			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $$chart;		\
-		fi; done
+		fi;											\
+	)
 
 lint:
 	$(QUIET)helm lint --with-subcharts --values ./cilium/values.yaml ./cilium

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -592,7 +592,7 @@ hubble:
     proxy:
       image:
         repository: docker.io/envoyproxy/envoy
-        tag: v1.14.1
+        tag: v1.14.5
         pullPolicy: Always
       # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
       #     resources:
@@ -861,7 +861,7 @@ etcd:
 
   image:
     repository: docker.io/cilium/cilium-etcd-operator
-    tag: latest
+    tag: v2.0.7
     pullPolicy: Always
 
   ## cilium-etcd-operator priorityClassName

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -483,11 +483,8 @@ hubble:
 
     # Configuration for Hubble Relay
     image:
-      # repository of the docker image
       repository: docker.io/cilium/hubble-relay
-      # tag is the container image tag to use
       tag: latest
-      # pullPolicy is the container image pull policy
       pullPolicy: Always
 
     # Specifies the resources for the hubble-relay pods

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -1075,7 +1075,7 @@ spec:
           resources:
             {}
         - name: proxy
-          image: "docker.io/envoyproxy/envoy:v1.14.1"
+          image: "docker.io/envoyproxy/envoy:v1.14.5"
           imagePullPolicy: Always
           ports:
             - containerPort: 8081


### PR DESCRIPTION
Rework the `make -C install//kubernetes update-versions` make target to properly inject image tags into all the new Helm locations introduced by #13259 .

Tested by manually changing the `VERSION` file to test out `1.9-dev`, `1.8.5` and `1.9.90` and eyeballing the YAML changes.

Review commit-by-commit.