### PR TITLE
kvstore: Do not write to read-only keys in join-cluster mode

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -709,7 +709,7 @@ func (e *Endpoint) FormatGlobalEndpointID() string {
 // This synchronizes the key-value store with a mapping of the endpoint's IP
 // with the numerical ID representing its security identity.
 func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
-	if option.Config.KVStore == "" || !endpointIP.IsSet() {
+	if option.Config.KVStore == "" || !endpointIP.IsSet() || option.Config.JoinCluster {
 		return
 	}
 

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -49,7 +51,9 @@ func initClient(ctx context.Context, module backendModule, opts *ExtraOptions) e
 		if isErr && err != nil {
 			scopedLog.WithError(err).Fatal("Unable to connect to kvstore")
 		}
-		deleteLegacyPrefixes(ctx)
+		if !option.Config.JoinCluster {
+			deleteLegacyPrefixes(ctx)
+		}
 	}()
 
 	return nil

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -202,7 +202,7 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 
 	n.Manager.NodeUpdated(n.LocalNode)
 
-	if option.Config.KVStore != "" {
+	if option.Config.KVStore != "" && !option.Config.JoinCluster {
 		go func() {
 			<-n.Registered
 			controller.NewManager().UpdateController("propagating local node change to kv-store",


### PR DESCRIPTION
When in --join-cluster mode, node registration is done using the
"noderegister" key. For such nodes the kvstore only allows writes to
the "noderegister" and ".initlock" keys, so avoid writing or deleting
other keys.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
