### PR TITLE
pkg/hubble: ignore klog/v2 in goleak detector

### DIFF
--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -183,6 +183,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 		t,
 		// ignore go routines started by the redirect we do from klog to logrus
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	ring := NewRing(15)
 	for i := 0; i < 15; i++ {

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -562,6 +562,7 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 		t,
 		// ignore go routines started by the redirect we do from klog to logrus
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
@@ -619,6 +620,7 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 		t,
 		// ignore go routines started by the redirect we do from klog to logrus
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
@@ -701,6 +703,7 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 		t,
 		// ignore go routines started by the redirect we do from klog to logrus
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>