### PR TITLE
test/vagrant: Fix NFS setup for test VMs

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -96,8 +96,13 @@ Vagrant.configure("2") do |config|
             inline: "ip -6 a a fd05::1/96 dev enp0s9 || true"
 
         # This network is only used by NFS
-        server.vm.network "private_network", type: "dhcp"
-        server.vm.synced_folder cilium_dir, cilium_path, nfs: $NFS
+        if $NFS
+            # This network is only used by NFS
+            server.vm.network "private_network", ip: "192.168.38.10"
+            server.vm.synced_folder cilium_dir, cilium_path, type: "nfs", nfs_udp: false
+        else
+            server.vm.synced_folder cilium_dir, cilium_path
+        end
 
         # Provision section
         server.vm.provision :shell,
@@ -170,9 +175,13 @@ Vagrant.configure("2") do |config|
                 run: "always",
                 inline: "ip -6 a a fd05::1#{i}/96 dev enp0s9 || true"
 
-            # This network is only used by NFS
-            server.vm.network "private_network", type: "dhcp"
-            server.vm.synced_folder cilium_dir, cilium_path, nfs: $NFS
+            if $NFS
+                # This network is only used by NFS
+                server.vm.network "private_network", ip: "192.168.38.1#{i}"
+                server.vm.synced_folder cilium_dir, cilium_path, type: "nfs", nfs_udp: false
+            else
+                server.vm.synced_folder cilium_dir, cilium_path
+            end
             # Provision section
             server.vm.provision :shell,
                 :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=1"


### PR DESCRIPTION
The well-known `interrupted system call` errors started popping up in the test VMs as well. These are caused by newer Go versions being more stringent with slow system calls through the rsync shared directory. Using NFS proved to be a good way to avoid these errors in the dev. VMs.

This pull request fixes the NFS setup in test VMs to allow for the same workaround (using `NFS=1`).

@jibi Could you try this on your side and see if it helps?