### PR TITLE
bpf: only clean up XDP from devices with XDP attached

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -656,7 +656,7 @@ if [ "$HOST_DEV1" != "$HOST_DEV2" ]; then
 fi
 
 # Remove bpf_xdp.o from previously used devices
-for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep -v cilium); do
+for iface in $(ip -o -a l | grep prog/xdp | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep -v cilium); do
 	[ "$iface" == "$XDP_DEV" ] && continue
 	for mode in xdpdrv xdpgeneric; do
 		xdp_unload "$iface" "$mode"


### PR DESCRIPTION
Currently, during agent startup, cilium removes XDP from all
interfaces except for `cilium_host`, `cilium_net` and `$XDP_DEV`
regardless of whether there is an XDP program attached to it.

For some drivers, e.g. Mellanox mlx5, the following command will
cause device reset regardless of whether there is an XDP program
attached to it, which introduces node and pod network interruption:
`ip link set dev $DEV xdpdrv off`.

This patch adds a check of XDP program existence to avoid such
network interruption.

Fixes: #13526
Reported-by: ArthurChiao <arthurchiao@hotmail.com>
Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>
