### PR TITLE
pkg/k8s: mark unused 'k8s-watcher-queue-size' flag for removal

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -155,7 +155,6 @@ cilium-agent [flags]
       --k8s-require-ipv6-pod-cidr                            Require IPv6 PodCIDR to be specified in node resource
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --k8s-watcher-endpoint-selector string                 K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --k8s-watcher-queue-size uint                          Queue size used to serialize each k8s event type (default 1024)
       --keep-config                                          When restoring state, keeps containers' configuration in place
       --kube-proxy-replacement string                        auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
       --kube-proxy-replacement-healthz-bind-address string   The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -718,6 +718,12 @@ Deprecated Metrics/Labels
   * Label ``scope`` in ``cilium_endpoint_regeneration_time_stats_seconds`` had its ``buildDuration`` value renamed to ``total``.
   * Label ``scope`` in ``cilium_policy_regeneration_time_stats_seconds`` had its ``buildDuration`` value renamed to ``total``.
 
+Deprecated options
+~~~~~~~~~~~~~~~~~~
+
+* ``k8s-watcher-queue-size``: This option does not have any effect since 1.8
+  and is planned to be removed in 1.10.
+
 Removed options
 ~~~~~~~~~~~~~~~
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -508,6 +508,7 @@ func init() {
 
 	flags.Uint(option.K8sWatcherQueueSize, 1024, "Queue size used to serialize each k8s event type")
 	option.BindEnv(option.K8sWatcherQueueSize)
+	flags.MarkDeprecated(option.K8sWatcherQueueSize, "Unused flag, will be removed in 1.10")
 
 	flags.String(option.LabelPrefixFile, "", "Valid label prefixes file path")
 	option.BindEnv(option.LabelPrefixFile)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -383,7 +383,7 @@ func (k *K8sWatcher) WaitForCRDsToRegister(ctx context.Context) error {
 // caches essential for daemon are synchronized.
 func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
 	cachesSynced := make(chan struct{})
-	if err := k.EnableK8sWatcher(ctx, option.Config.K8sWatcherQueueSize); err != nil {
+	if err := k.EnableK8sWatcher(ctx); err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.WithError(err).Fatal("Unable to start K8s watchers for Cilium")
 		}
@@ -459,8 +459,7 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
 
 // EnableK8sWatcher watches for policy, services and endpoint changes on the Kubernetes
 // api server defined in the receiver's daemon k8sClient.
-// queueSize specifies the queue length used to serialize k8s events.
-func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context, queueSize uint) error {
+func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context) error {
 	if !k8s.IsEnabled() {
 		log.Debug("Not enabling k8s event listener because k8s is not enabled")
 		return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1399,10 +1399,6 @@ type DaemonConfig struct {
 	// status in kube-apiserver.
 	K8sForceJSONPatch bool
 
-	// K8sWatcherQueueSize is the queue size used to serialize each k8s event
-	// type.
-	K8sWatcherQueueSize uint
-
 	// MTU is the maximum transmission unit of the underlying network
 	MTU int
 
@@ -2489,7 +2485,6 @@ func (c *DaemonConfig) Populate() {
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
 	c.K8sSyncTimeout = viper.GetDuration(K8sSyncTimeoutName)
-	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
 	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepConfig = viper.GetBool(KeepConfig)
 	c.KVStore = viper.GetString(KVStore)


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Needs https://github.com/cilium/cilium/pull/13418 to be merged first.