### PR TITLE
helm: bring back hubble dependencies validation

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -1,0 +1,15 @@
+{{/* validate hubble config */}}
+{{- if .Values.hubble.ui.enabled }}
+  {{- if not .Values.hubble.relay.enabled }}
+    {{ fail "Hubble UI requires .Values.hubble.relay.enabled=true" }}
+  {{- end }}
+{{- end }}
+{{- if .Values.hubble.relay.enabled }}
+  {{- if not .Values.hubble.enabled }}
+    {{ fail "Hubble Relay requires .Values.hubble.enabled=true" }}
+  {{- end }}
+  {{/* the port is currently hard-coded and need to be set to this specific value */}}
+  {{- if ne .Values.hubble.listenAddress ":4244" }}
+    {{ fail "Hubble Relay requires .Values.hubble.listenAddress=:4244" }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
PR #11577 added checks to ensure that the following conditions are met:

  - Hubble UI requires Hubble Relay
  - Hubble Relay requires Hubble

These checks were pruned as part of the Helm refactoring PR (#13259) so
this commit adds them back. This ensures that invalid Hubble settings
such as enabling UI without enable Relay are caught early to avoid
confusion.

Fixes: #13537
