### PR TITLE
CODEOWNERS: fix owner assignment for hubble related helm charts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,9 +83,7 @@ Dockerfile* @cilium/build
 /hubble-relay.Dockerfile @cilium/hubble
 /images @cilium/build
 /install/kubernetes/ @cilium/kubernetes @cilium/docs @cilium/helm
-/install/kubernetes/cilium/charts/hubble-relay @cilium/kubernetes @cilium/docs @cilium/helm @cilium/hubble
-/install/kubernetes/cilium/charts/hubble-tls @cilium/kubernetes @cilium/docs @cilium/helm @cilium/hubble
-/install/kubernetes/cilium/charts/hubble-ui @cilium/kubernetes @cilium/docs @cilium/helm @cilium/hubble
+/install/kubernetes/cilium/templates/hubble* @cilium/kubernetes @cilium/docs @cilium/helm @cilium/hubble
 jenkinsfiles @cilium/ci
 Jenkinsfile.nightly @cilium/ci
 /operator/ @cilium/operator


### PR DESCRIPTION
PR #13259 move helm chart files around and the CODEOWNERS file was not updated accordingly.
