### PR TITLE
helm: remove unused var in make quick-install target

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -27,7 +27,7 @@ EXPERIMENTAL_OPTIONS := \
 all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL)
 
 $(QUICK_INSTALL) quick-install: $(shell find cilium/ -type f)
-	$(QUIET)helm template cilium cilium --namespace=kube-system $(OPTS) > $(QUICK_INSTALL)
+	$(QUIET)helm template cilium cilium --namespace=kube-system > $(QUICK_INSTALL)
 
 $(EXPERIMENTAL_INSTALL) experimental-install: $(shell find cilium/ -type f)
 	$(QUIET)helm template cilium cilium --namespace=kube-system $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)


### PR DESCRIPTION
I believe this variable was added at some point while #13259 was in progress and then remained. Remove it as it's unused.