### PR TITLE
examples/doc Add example LRP yaml files for real-world use cases

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -493,6 +493,7 @@ keepDeprecatedProbes
 keyFile
 keyspace
 keyspaces
+kiam
 kops
 kprobe
 kprobes

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -30,6 +30,7 @@ Clusterwide
 Committer
 Committers
 ConnectX
+Corefile
 DDoS
 DMA'ed
 DNS
@@ -416,6 +417,7 @@ hexData
 hoc
 hostConfDirMountPath
 hostFirewall
+hostNetwork
 hostPort
 hostServices
 hostonlyif
@@ -671,6 +673,7 @@ queryable
 queueing
 rbac
 rc
+readinessProbe
 readthedocs
 rebase
 rebased
@@ -718,12 +721,15 @@ serviceMonitor
 servicePort
 sessionAffinity
 setrlimit
+setupinterface
+setupiptables
 sfc
 sg
 sha
 sidecarImageRegex
 sig
 skb
+skipteardown
 sleepAfterInit
 socketPath
 sockmap

--- a/examples/kubernetes-local-redirect/kiam-lrp.yaml
+++ b/examples/kubernetes-local-redirect/kiam-lrp.yaml
@@ -1,0 +1,20 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "kiam-redirect"
+  namespace: default
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "80"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: kiam
+        component: "agent"
+    toPorts:
+      - port: "8181"
+        protocol: TCP

--- a/examples/kubernetes-local-redirect/node-local-dns-lrp.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns-lrp.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumLocalRedirectPolicy
 metadata:
-  name: "nodelocaldns-lrp"
+  name: "nodelocaldns"
   namespace: kube-system
 spec:
   redirectFrontend:

--- a/examples/kubernetes-local-redirect/node-local-dns-lrp.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns-lrp.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "nodelocaldns-lrp"
+  namespace: kube-system
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: kube-dns
+      namespace: kube-system
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        k8s-app: node-local-dns
+    toPorts:
+      - port: "53"
+        name: dns
+        protocol: UDP
+      - port: "53"
+        name: dns-tcp
+        protocol: TCP

--- a/examples/kubernetes-local-redirect/node-local-dns.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns.yaml
@@ -1,0 +1,171 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-upstream
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNSUpstream"
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        health
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 0.0.0.0
+        forward . __PILLAR__UPSTREAM__SERVERS__
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: node-local-dns
+      annotations:
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.15.16
+        resources:
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args: [ "-localip", "169.254.20.10,__PILLAR__DNS__SERVER__", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream", "-skipteardown=true", "-setupinterface=false", "-setupiptables=false" ]
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+        - name: kube-dns-config
+          mountPath: /etc/kube-dns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true
+      - name: config-volume
+        configMap:
+          name: node-local-dns
+          items:
+            - key: Corefile
+              path: Corefile.base


### PR DESCRIPTION
Question: I need to add some notes about the yaml files (e.g., the port names need to match with the ones defined in Daemonset, etc). What's the best place to add such notes? One of the options is the local-redirect policy getting started guide [1].

Also, there are some changes required for the upstream yaml files (nodelocaldns and kiam daemonsets). Should we just mention the required changes in the gsg?


Fixes:#11646
Fixes:#13040

[1] https://github.com/cilium/cilium/blob/master/Documentation/gettingstarted/local-redirect-policy.rst