### PR TITLE
Fix kubectl command in cassandra NetworkPolicy documentation.

### DIFF
--- a/Documentation/gettingstarted/cassandra.rst
+++ b/Documentation/gettingstarted/cassandra.rst
@@ -112,7 +112,7 @@ the Cassandra cluster identified by the 'cassandra-svc' DNS name:
 
 ::
 
-    $ kubectl exec -it $OUTPOST_POD cqlsh -- cassandra-svc
+    $ kubectl exec -it $OUTPOST_POD -- cqlsh cassandra-svc
     Connected to Test Cluster at cassandra-svc:9042.
     [cqlsh 5.0.1 | Cassandra 3.11.3 | CQL spec 3.4.4 | Native protocol v4]
     Use HELP for help.
@@ -246,7 +246,7 @@ Use another window to confirm that the *empire-hq* pod still has full access to 
 
 ::
 
-    $ kubectl exec -it $HQ_POD cqlsh -- cassandra-svc
+    $ kubectl exec -it $HQ_POD -- cqlsh cassandra-svc
     Connected to Test Cluster at cassandra-svc:9042.
     [cqlsh 5.0.1 | Cassandra 3.11.3 | CQL spec 3.4.4 | Native protocol v4]
     Use HELP for help.


### PR DESCRIPTION
This PR fixes incorrect kubectl command in Cassandra documentation in step [Securing Access to Cassandra with Cilium](https://docs.cilium.io/en/v1.8/gettingstarted/cassandra/#securing-access-to-cassandra-with-cilium)

Fixes: #13544

```release-note
Fix kubectl command in cassandra NetworkPolicy documentation.
```
