### PR TITLE
helm: Correct indentation for imagePullSecret

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -47,7 +47,7 @@ spec:
 {{- end }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 6 }}
+{{ toYaml .Values.imagePullSecrets | indent 6 }}
 {{- end }}
       containers:
 {{- if .Values.sleepAfterInit }}

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -54,7 +54,7 @@ spec:
 {{- end }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{ toYaml .Values.imagePullSecrets | indent 6 }}
 {{- end }}
       containers:
       - args:


### PR DESCRIPTION
This commit is to correct indentation for imagePullSecret

Signed-off-by: Tam Mach <sayboras@yahoo.com>

## Testing

<details>
<summary>Before</summary>

```diff
diff --git a/install/kubernetes/cilium/values.yaml b/install/kubernetes/cilium/values.yaml
index ce7c9b629..29f1c0b46 100644
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -11,7 +11,7 @@ rbac:
   create: true
 
 imagePullSecrets:
-# - name: "image-pull-secret"
+ - name: "image-pull-secret"
 
 # kubeConfigPath: ~/.kube/config
 # k8sServiceHost:
diff --git a/install/kubernetes/experimental-install.yaml b/install/kubernetes/experimental-install.yaml
index eb9ee6ab7..ae2e29178 100644
--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -656,6 +656,8 @@ spec:
                 values:
                 - cilium
             topologyKey: kubernetes.io/hostname
+      imagePullSecrets:
+            - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -905,6 +907,8 @@ spec:
                 values:
                 - operator
             topologyKey: "kubernetes.io/hostname"
+      imagePullSecrets:
+                - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -990,6 +994,8 @@ spec:
                   values:
                     - cilium
             topologyKey: "kubernetes.io/hostname"
+      imagePullSecrets:
+        - name: image-pull-secret
       containers:
         - name: hubble-relay
           image: docker.io/cilium/hubble-relay:latest
diff --git a/install/kubernetes/quick-install.yaml b/install/kubernetes/quick-install.yaml
index 2b4f305b9..19bd03d4c 100644
--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -393,6 +393,8 @@ spec:
                 values:
                 - cilium
             topologyKey: kubernetes.io/hostname
+      imagePullSecrets:
+            - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -637,6 +639,8 @@ spec:
                 values:
                 - operator
             topologyKey: "kubernetes.io/hostname"
+      imagePullSecrets:
+                - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map

```

</details>

<details>
<summary>After</summary>

```diff
diff --git a/install/kubernetes/cilium/values.yaml b/install/kubernetes/cilium/values.yaml
index ce7c9b629..29f1c0b46 100644
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -11,7 +11,7 @@ rbac:
   create: true
 
 imagePullSecrets:
-# - name: "image-pull-secret"
+ - name: "image-pull-secret"
 
 # kubeConfigPath: ~/.kube/config
 # k8sServiceHost:
diff --git a/install/kubernetes/experimental-install.yaml b/install/kubernetes/experimental-install.yaml
index eb9ee6ab7..a11947c85 100644
--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -656,6 +656,8 @@ spec:
                 values:
                 - cilium
             topologyKey: kubernetes.io/hostname
+      imagePullSecrets:
+      - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -905,6 +907,8 @@ spec:
                 values:
                 - operator
             topologyKey: "kubernetes.io/hostname"
+      imagePullSecrets:
+      - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -990,6 +994,8 @@ spec:
                   values:
                     - cilium
             topologyKey: "kubernetes.io/hostname"
+      imagePullSecrets:
+        - name: image-pull-secret
       containers:
         - name: hubble-relay
           image: docker.io/cilium/hubble-relay:latest
diff --git a/install/kubernetes/quick-install.yaml b/install/kubernetes/quick-install.yaml
index 2b4f305b9..ba7d02ced 100644
--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -393,6 +393,8 @@ spec:
                 values:
                 - cilium
             topologyKey: kubernetes.io/hostname
+      imagePullSecrets:
+      - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -637,6 +639,8 @@ spec:
                 values:
                 - operator
             topologyKey: "kubernetes.io/hostname"
+      imagePullSecrets:
+      - name: image-pull-secret
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
```

</details>

```release-note
helm: Correct indentation for imagePullSecret
```
