### PR TITLE
helm: Add check for prometheus service monitoring CRDs

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -9,3 +9,10 @@
     {{ fail "Hubble Relay requires .Values.hubble.enabled=true" }}
   {{- end }}
 {{- end }}
+
+{{/* validate service monitoring CRDs */}}
+{{- if and (.Values.prometheus.enabled) (or (.Values.prometheus.serviceMonitor.enabled) (.Values.operator.prometheus.serviceMonitor.enabled)) }}
+  {{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+      {{ fail "Service Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml" }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -468,6 +468,9 @@ hubble:
     port: 9091
     # Creates ServiceMonitor resources for Prometheus Operator
     serviceMonitor:
+      # Enable service monitors.
+      # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+      ##
       enabled: false
 
   metricsServer: ""
@@ -857,6 +860,9 @@ prometheus:
   # serviceMonitor enables the required service monitors to be used with
   # Prometheus
   serviceMonitor:
+    # Enable service monitors.
+    # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+    ##
     enabled: false
     # namespace is the Kubernetes namespace where Prometheus expects to find
     # service monitors configured:
@@ -1137,6 +1143,9 @@ operator:
     enabled: false
     port: 6942
     serviceMonitor:
+      # Enable service monitors.
+      # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+      ##
       enabled: false
 
 


### PR DESCRIPTION
## Description 

helm: Add check for prometheus service monitoring CRDs

Service Monitnor CRD (e.g. monitoring.coreos.com/v1) is no longer
managed and installed as part of cilium chart. This commit is to
add validation to check if monitoring.coreos.com/v1 CRD is required
and available before installation.

Relates: #13513

**TODO**: Update docs with step by step installation, maybe on this page https://docs.cilium.io/en/v1.9.0-rc2/operations/metrics/#installation, I will do it in separate PR. 

```release-note
helm: Add check for prometheus service monitoring CRDs
```
