### PR TITLE
update cilium and hubble-relay dockerfiles to use built-in buildx ARGs

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -26,6 +26,11 @@ LLC   ?= llc
 HOST_CC    ?= gcc
 HOST_STRIP ?= strip
 
+ifeq ($(IMAGE_CROSS_TARGET_PLATFORM),linux/arm64)
+  HOST_CC ?= aarch64-linux-gnu-gcc
+  HOST_STRIP ?= aarch64-linux-gnu-strip
+endif
+
 # Define all at the top here so that Makefiles which include this one will hit
 # the 'all' target first (which we expect to be overridden by the includer).
 all:

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,41 +6,41 @@
 ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:73e2f220d7ddf84e8eda58e9908fa24098223241
 ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:3aab71e5992e23e4e4ec169e9851f5fd3eb33632
 
-FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder
+FROM ${CILIUM_BUILDER_IMAGE} as builder
 
+ARG TARGETOS
+ARG TARGETARCH
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG RACE
 
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  make build-container install-container \
-    NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/out/linux/amd64
+ENV GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH}
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  env GOARCH=arm64 CC=aarch64-linux-gnu-gcc \
-    make build-container install-container \
-      NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/out/linux/arm64 \
-      HOST_CC=aarch64-linux-gnu-gcc HOST_STRIP=aarch64-linux-gnu-strip
+  make build-container install-container \
+  NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/out/${TARGETOS}/${TARGETARCH} IMAGE_CROSS_TARGET_PLATFORM=${TARGETOS}/${TARGETARCH}
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
   cd /go/src/github.com/cilium/cilium/plugins/cilium-cni \
-    && cp cni-install.sh cni-uninstall.sh /out/linux/amd64 \
-    && cp cni-install.sh cni-uninstall.sh /out/linux/arm64
+  && cp cni-install.sh cni-uninstall.sh /out/${TARGETOS}/${TARGETARCH}
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
   cd /go/src/github.com/cilium/cilium/contrib/packaging/docker \
-    && cp init-container.sh /out/linux/amd64 \
-    && cp init-container.sh /out/linux/arm64
+  && cp init-container.sh /out/${TARGETOS}/${TARGETARCH}
 
 FROM ${CILIUM_RUNTIME_IMAGE}
-ARG TARGETPLATFORM
+
+ARG TARGETOS
+ARG TARGETARCH
+
 LABEL maintainer="maintainer@cilium.io"
 
-COPY --from=builder /out/${TARGETPLATFORM} /
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH} /
 
 WORKDIR /home/cilium
 
 RUN groupadd -f cilium \
-    && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
+  && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 
 CMD ["/usr/bin/cilium"]

--- a/images/hubble-proto/Dockerfile
+++ b/images/hubble-proto/Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/library/golang:1.15.3-alpine3.12 as builder
 
 RUN apk add --no-cache \
-    curl \
-    bash \
-    make \
-    && true
+  curl \
+  bash \
+  make \
+  && true
 
 COPY install-protoplugins.sh /tmp/install-protoplugins.sh
 RUN /tmp/install-protoplugins.sh
@@ -13,11 +13,13 @@ RUN /tmp/install-protoplugins.sh
 
 FROM docker.io/library/alpine:3.12
 
+WORKDIR /proto
+
 RUN apk add --no-cache \
-    curl \
-    bash \
-    make \
-    && true
+  curl \
+  bash \
+  make \
+  && true
 
 COPY install-glibc.sh /tmp/install-glibc.sh
 RUN /tmp/install-glibc.sh
@@ -25,12 +27,11 @@ RUN /tmp/install-glibc.sh
 COPY install-protoc.sh /tmp/install-protoc.sh
 RUN /tmp/install-protoc.sh
 
-RUN mkdir /proto
-COPY --from=builder /proto/protoc-gen-go /proto
-COPY --from=builder /proto/protoc-gen-go-grpc /proto
-COPY --from=builder /proto/protoc-gen-go-json /proto
+COPY --from=builder /proto/protoc-gen-go .
+COPY --from=builder /proto/protoc-gen-go-grpc .
+COPY --from=builder /proto/protoc-gen-go-json .
 
-COPY Makefile.docker /proto/Makefile
+COPY Makefile.docker ./Makefile
 
 WORKDIR /source
 

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -6,29 +6,31 @@
 ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:73e2f220d7ddf84e8eda58e9908fa24098223241
 ARG CA_CERTIFICATES_IMAGE=docker.io/cilium/ca-certificates:69a9f5d66ff96bf97e8b9dc107e92aa9ddbdc9a8
 
-FROM --platform=linux/amd64 ${CILIUM_BUILDER_IMAGE} as builder
+FROM ${CILIUM_BUILDER_IMAGE} as builder
 
+ARG TARGETOS
+ARG TARGETARCH
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG RACE
 
+ENV GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH}
+
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
   make -C hubble-relay \
-    NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 \
-  && mkdir -p /out/linux/amd64/usr/bin && mv hubble-relay/hubble-relay /out/linux/amd64/usr/bin
-
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  env GOARCH=arm64 \
-    make -C hubble-relay \
-      NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 \
-  && mkdir -p /out/linux/arm64/usr/bin && mv hubble-relay/hubble-relay /out/linux/arm64/usr/bin
-
+  NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 \
+  && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv hubble-relay/hubble-relay /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
 FROM ${CA_CERTIFICATES_IMAGE}
-ARG TARGETPLATFORM
+
+ARG TARGETOS
+ARG TARGETARCH
+
 LABEL maintainer="maintainer@cilium.io"
 
-COPY --from=builder /out/${TARGETPLATFORM} /
-
 WORKDIR /
+
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH} .
+
 CMD ["/usr/bin/hubble-relay"]


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Implementing docker buildx cross-architecture compilation for cilium and hubble-relay images.
Fixes: #issue-number


