### PR TITLE
install/kubernetes: consistent case spelling of iptables related values

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -404,8 +404,8 @@ data:
   enable-xt-socket-fallback: {{ .Values.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.installIptablesRules | quote }}
 
-{{- if hasKey .Values "ipTablesRandomFully" }}
-  iptables-random-fully: {{ .Values.ipTablesRandomFully | quote }}
+{{- if hasKey .Values "iptablesRandomFully" }}
+  iptables-random-fully: {{ .Values.iptablesRandomFully | quote }}
 {{- end }}
 
 {{- if hasKey .Values "iptablesLockTimeout" }}

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -271,7 +271,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		It("Check iptables masquerading with random-fully", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"bpf.masquerade":      "false",
-				"ipTablesRandomFully": "true",
+				"iptablesRandomFully": "true",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 


### PR DESCRIPTION
Make the case spelling of the newly introduced "ipTablesRandomFully"
value consistent with other iptables option values which use the
"iptables" spelling.

Fixes: 4e39def13bca ("daemon: Enable configuration of iptables --random-fully")