### PR TITLE
test: Increase timeout for waiting LB IP addr on GKE

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -916,7 +916,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 			if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
 				// Testing LoadBalancer types subject to bpf_sock.
-				lbIP, err := kubectl.GetLoadBalancerIP(helpers.DefaultNamespace, "test-lb", 30*time.Second)
+				lbIP, err := kubectl.GetLoadBalancerIP(helpers.DefaultNamespace, "test-lb", 60*time.Second)
 				Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")
 
 				testURLsFromHosts = append(testURLsFromHosts, []string{


### PR DESCRIPTION
Recently, the test case which waits for LB IP addr started to fail:

    github.com/cilium/cilium/test/ginkgo-ext/scopes.go:514
    Cannot retrieve loadbalancer IP for test-lb
    Expected
	<*errors.errorString | 0xc000324af0>: {
	    s: "could not get service LoadBalancer IP addr: 30s timeout expired",
	}
    to be nil
    github.com/cilium/cilium/test/k8sT/Services.go:920

This happens because on GKE we use GCP LB which provisioning might take longer
than 30s. For now, let's increase the timeout. If it doesn't help, we can
always rely on dummy-lb instead.

Fix #13554 