### PR TITLE
test: Fix kube-proxy-free on GKE due to wrong k8sServiceHost value

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2220,15 +2220,17 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 	}
 
 	if !RunsWithKubeProxy() {
-		nodeIP, err := kub.GetNodeIPByLabel(K8s1, false)
-		if err != nil {
-			return fmt.Errorf("Cannot retrieve Node IP for k8s1: %s", err)
-		}
-
 		opts := map[string]string{
 			"kubeProxyReplacement": "strict",
-			"k8sServiceHost":       nodeIP,
-			"k8sServicePort":       "6443",
+		}
+
+		if GetCurrentIntegration() != CIIntegrationGKE {
+			nodeIP, err := kub.GetNodeIPByLabel(K8s1, false)
+			if err != nil {
+				return fmt.Errorf("Cannot retrieve Node IP for k8s1: %s", err)
+			}
+			opts["k8sServiceHost"] = nodeIP
+			opts["k8sServicePort"] = "6443"
 		}
 
 		if RunsOnNetNextOr419Kernel() {


### PR DESCRIPTION
On GKE, kube-apiserver doesn't run on the first node as in our Jenkins builds, leading to a failure to start Cilium in kube-proxy-free mode. Since kube-proxy is always provisioned on GKE, we don't need to specify k8sServiceHost and k8sServicePort on GKE.

I tested this by running:
```
CNI_INTEGRATION=gke KERNEL=419 K8S_VERSION=1.16 KUBEPROXY=0 ginkgo -v --focus "K8sServicesTest.*fragments*" \
  -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium" \
  -cilium.operator-image="docker.io/cilium/operator" -cilium.hubble-relay-image="docker.io/cilium/hubble-relay" \
  -cilium.passCLIEnvironment=true
```
The test itself failed but Cilium did successfully come up.

Reported-by: @jibi 