### PR TITLE
v1.8 backports 2020-10-14

### DIFF
--- a/Documentation/gettingstarted/cassandra.rst
+++ b/Documentation/gettingstarted/cassandra.rst
@@ -112,7 +112,7 @@ the Cassandra cluster identified by the 'cassandra-svc' DNS name:
 
 ::
 
-    $ kubectl exec -it $OUTPOST_POD cqlsh -- cassandra-svc
+    $ kubectl exec -it $OUTPOST_POD -- cqlsh cassandra-svc
     Connected to Test Cluster at cassandra-svc:9042.
     [cqlsh 5.0.1 | Cassandra 3.11.3 | CQL spec 3.4.4 | Native protocol v4]
     Use HELP for help.
@@ -246,7 +246,7 @@ Use another window to confirm that the *empire-hq* pod still has full access to 
 
 ::
 
-    $ kubectl exec -it $HQ_POD cqlsh -- cassandra-svc
+    $ kubectl exec -it $HQ_POD -- cqlsh cassandra-svc
     Connected to Test Cluster at cassandra-svc:9042.
     [cqlsh 5.0.1 | Cassandra 3.11.3 | CQL spec 3.4.4 | Native protocol v4]
     Use HELP for help.

--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -4,8 +4,59 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+**************************
 Installation using kubeadm
-==========================
+**************************
 
-Instructions about installing Cilium on Kubernetes cluster deployed by kubeadm
-are available in the `official Kubernetes documentation <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network>`_.
+This guide describes deploying Cilium on a Kubernetes cluster created with
+``kubeadm``.
+
+For installing ``kubeadm`` on your system, please refer to `the official
+kubeadm documentation
+<https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>`_
+The official documentation also describes additional options of kubeadm which
+are not mentioned here.
+
+If you are interested in using Cilium's kube-proxy replacement, please
+follow the :ref:`kubeproxy-free` guide and skip this one.
+
+Create the cluster
+==================
+
+Initialize the control plane via executing on it:
+
+.. code:: bash
+
+   kubeadm init
+
+.. note::
+   If you want to use Cilium's kube-proxy replacement, kubeadm needs to skip
+   the kube-proxy deployment phase, so it has to be executed with the
+   ``--skip-phases=addon/kube-proxy`` option:
+
+   .. code:: bash
+
+      kubeadm init --skip-phases=addon/kube-proxy
+
+   For more information please refer to the :ref:`kubeproxy-free` guide.
+
+Afterwards, join worker nodes by specifying the control-plane node IP address
+and the token returned by ``kubeadm init``:
+
+.. code:: bash
+
+   kubeadm join <..>
+
+Deploy Cilium
+=============
+
+.. include:: k8s-install-download-release.rst
+
+Deploy Cilium release via Helm:
+
+.. code:: bash
+
+   helm install cilium |CHART_RELEASE| --namespace kube-system
+
+.. include:: k8s-install-validate.rst
+.. include:: hubble-enable.rst

--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -229,8 +229,8 @@ using AWS or GCP. Azure does not need additional configuration.
          aws_region="$(jq -r < "${CLUSTER_NAME}/metadata.json" '.aws.region')"
          cluster_tag="$(jq -r < "${CLUSTER_NAME}/metadata.json" '.aws.identifier[0] | to_entries | "Name=tag:\(.[0].key),Values=\(.[0].value)"')"
 
-         worker_sg="$(aws ec2 describe-security-groups --region "${aws_region}" --filters "${cluster_tag}" "Name=tag:Name,Values=${infraID}-worker-sg" | jq -r .SecurityGroups[0].GroupId)"
-         master_sg="$(aws ec2 describe-security-groups --region "${aws_region}" --filters "${cluster_tag}" "Name=tag:Name,Values=${infraID}-master-sg" | jq -r .SecurityGroups[0].GroupId)"
+         worker_sg="$(aws ec2 describe-security-groups --region "${aws_region}" --filters "${cluster_tag}" "Name=tag:Name,Values=${infraID}-worker-sg" | jq -r '.SecurityGroups[0].GroupId')"
+         master_sg="$(aws ec2 describe-security-groups --region "${aws_region}" --filters "${cluster_tag}" "Name=tag:Name,Values=${infraID}-master-sg" | jq -r '.SecurityGroups[0].GroupId')"
 
          aws ec2 authorize-security-group-ingress --region "${aws_region}" \
             --ip-permissions \

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -456,9 +456,11 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
+	bool has_l4_header = false;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+	has_l4_header = ipv4_has_l4_header(ip4);
 
 	tuple.nexthdr = ip4->protocol;
 
@@ -488,7 +490,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 		if (svc) {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off,
 					&csum_off, &key, &tuple, svc, &ct_state_new,
-					ip4->saddr);
+					ip4->saddr, has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
 			hairpin_flow |= ct_state_new.loopback;
@@ -605,7 +607,7 @@ ct_recreate4:
 		}
 # ifdef ENABLE_DSR
 		if (ct_state.dsr) {
-			ret = xlate_dsr_v4(ctx, &tuple, l4_off);
+			ret = xlate_dsr_v4(ctx, &tuple, l4_off, has_l4_header);
 			if (ret != 0)
 				return ret;
 		}
@@ -614,7 +616,7 @@ ct_recreate4:
 
 		if (ct_state.rev_nat_index) {
 			ret = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
-					  &ct_state, &tuple, 0);
+					  &ct_state, &tuple, 0, has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
 		}
@@ -1090,6 +1092,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	struct ct_state ct_state_new = {};
 	bool skip_ingress_proxy = false;
 	bool is_untracked_fragment = false;
+	bool has_l4_header = false;
 	__u32 monitor = 0;
 	__be32 orig_sip;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
@@ -1097,6 +1100,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+	has_l4_header = ipv4_has_l4_header(ip4);
 
 	policy_clear_mark(ctx);
 	tuple.nexthdr = ip4->protocol;
@@ -1111,7 +1115,8 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	orig_sip = ip4->saddr;
 
 	l4_off = l3_off + ipv4_hdrlen(ip4);
-	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
+	if (has_l4_header)
+		csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 #ifndef ENABLE_IPV4_FRAGMENTS
 	/* Indicate that this is a datagram fragment for which we cannot
 	 * retrieve L4 ports. Do not set flag if we support fragmentation.
@@ -1151,7 +1156,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 
 		ret2 = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
 				   &ct_state, &tuple,
-				   REV_NAT_F_TUPLE_SADDR);
+				   REV_NAT_F_TUPLE_SADDR, has_l4_header);
 		if (IS_ERR(ret2))
 			return ret2;
 	}

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -656,7 +656,7 @@ if [ "$HOST_DEV1" != "$HOST_DEV2" ]; then
 fi
 
 # Remove bpf_xdp.o from previously used devices
-for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep -v cilium); do
+for iface in $(ip -o -a l | grep prog/xdp | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep -v cilium); do
 	[ "$iface" == "$XDP_DEV" ] && continue
 	for mode in xdpdrv xdpgeneric; do
 		xdp_unload "$iface" "$mode"

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -72,19 +72,25 @@ static __always_inline bool ipv4_is_fragment(const struct iphdr *ip4)
 	return ip4->frag_off & bpf_htons(0x3FFF);
 }
 
-static __always_inline bool ipv4_is_in_subnet(__be32 addr,
-					      __be32 subnet, int prefixlen)
-{
-	return (addr & bpf_htonl(~((1<<(32-prefixlen))-1))) == subnet;
-}
-
-#ifdef ENABLE_IPV4_FRAGMENTS
 static __always_inline bool ipv4_is_not_first_fragment(const struct iphdr *ip4)
 {
 	/* Ignore "More fragments" bit to catch all fragments but the first */
 	return ip4->frag_off & bpf_htons(0x1FFF);
 }
 
+/* Simply a reverse of ipv4_is_not_first_fragment to avoid double negative. */
+static __always_inline bool ipv4_has_l4_header(const struct iphdr *ip4)
+{
+	return !ipv4_is_not_first_fragment(ip4);
+}
+
+static __always_inline bool ipv4_is_in_subnet(__be32 addr,
+					      __be32 subnet, int prefixlen)
+{
+	return (addr & bpf_htonl(~((1 << (32 - prefixlen)) - 1))) == subnet;
+}
+
+#ifdef ENABLE_IPV4_FRAGMENTS
 static __always_inline int
 ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 		      struct ipv4_frag_l4ports *ports)

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -853,14 +853,14 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 					 struct csum_offset *csum_off,
 					 struct ipv4_ct_tuple *tuple, int flags,
 					 const struct lb4_reverse_nat *nat,
-					 const struct ct_state *ct_state)
+					 const struct ct_state *ct_state, bool has_l4_header)
 {
 	__be32 old_sip, new_sip, sum = 0;
 	int ret;
 
 	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT, nat->address, nat->port);
 
-	if (nat->port) {
+	if (nat->port && has_l4_header) {
 		ret = reverse_map_l4_port(ctx, tuple->nexthdr, nat->port, l4_off, csum_off);
 		if (IS_ERR(ret))
 			return ret;
@@ -931,7 +931,7 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
 				       struct csum_offset *csum_off,
 				       struct ct_state *ct_state,
-				       struct ipv4_ct_tuple *tuple, int flags)
+				       struct ipv4_ct_tuple *tuple, int flags, bool has_l4_header)
 {
 	struct lb4_reverse_nat *nat;
 
@@ -941,7 +941,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 		return 0;
 
 	return __lb4_rev_nat(ctx, l3_off, l4_off, csum_off, tuple, flags, nat,
-			     ct_state);
+			     ct_state, has_l4_header);
 }
 
 /** Extract IPv4 LB key from packet
@@ -967,7 +967,8 @@ static __always_inline int lb4_extract_key(struct __ctx_buff *ctx __maybe_unused
 	/* FIXME: set after adding support for different L4 protocols in LB */
 	key->proto = 0;
 	key->address = (dir == CT_INGRESS) ? ip4->saddr : ip4->daddr;
-	csum_l4_offset_and_flags(ip4->protocol, csum_off);
+	if (ipv4_has_l4_header(ip4))
+		csum_l4_offset_and_flags(ip4->protocol, csum_off);
 
 	return extract_l4_port(ctx, ip4->protocol, l4_off, &key->dport, ip4);
 }
@@ -1062,7 +1063,7 @@ static __always_inline int
 lb4_xlate(struct __ctx_buff *ctx, __be32 *new_daddr, __be32 *new_saddr __maybe_unused,
 	  __be32 *old_saddr __maybe_unused, __u8 nexthdr __maybe_unused, int l3_off,
 	  int l4_off, struct csum_offset *csum_off, struct lb4_key *key,
-	  const struct lb4_backend *backend __maybe_unused)
+	  const struct lb4_backend *backend __maybe_unused, bool has_l4_header)
 {
 	__be32 sum;
 	int ret;
@@ -1093,8 +1094,10 @@ lb4_xlate(struct __ctx_buff *ctx, __be32 *new_daddr, __be32 *new_saddr __maybe_u
 				    BPF_F_PSEUDO_HDR) < 0)
 			return DROP_CSUM_L4;
 	}
+
 	if (backend->port && key->dport != backend->port &&
-	    (nexthdr == IPPROTO_TCP || nexthdr == IPPROTO_UDP)) {
+	    (nexthdr == IPPROTO_TCP || nexthdr == IPPROTO_UDP) &&
+	    has_l4_header) {
 		__be16 tmp = backend->port;
 
 		/* Port offsets for UDP and TCP are the same */
@@ -1205,7 +1208,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 				     struct lb4_key *key,
 				     struct ipv4_ct_tuple *tuple,
 				     const struct lb4_service *svc,
-				     struct ct_state *state, __be32 saddr)
+				     struct ct_state *state, __be32 saddr, bool has_l4_header)
 {
 	__u32 monitor; /* Deliberately ignored; regular CT will determine monitoring. */
 	__be32 new_saddr = 0, new_daddr;
@@ -1359,7 +1362,7 @@ update_state:
 
 	return lb4_xlate(ctx, &new_daddr, &new_saddr, &saddr,
 			 tuple->nexthdr, l3_off, l4_off, csum_off, key,
-			 backend);
+			 backend, has_l4_header);
 drop_no_service:
 		tuple->flags = flags;
 		return DROP_NO_SERVICE;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1001,7 +1001,7 @@ static __always_inline int handle_dsr_v4(struct __ctx_buff *ctx, bool *dsr)
 
 static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 					const struct ipv4_ct_tuple *tuple,
-					int l4_off)
+					int l4_off, bool has_l4_header)
 {
 	struct ipv4_ct_tuple nat_tup = *tuple;
 	struct ipv4_nat_entry *entry;
@@ -1013,7 +1013,7 @@ static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 
 	entry = snat_v4_lookup(&nat_tup);
 	if (entry)
-		ret = snat_v4_rewrite_egress(ctx, &nat_tup, entry, l4_off);
+		ret = snat_v4_rewrite_egress(ctx, &nat_tup, entry, l4_off, has_l4_header);
 	return ret;
 }
 
@@ -1241,8 +1241,9 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		if (!lb4_src_range_ok(svc, ip4->saddr))
 			return DROP_NOT_IN_SRC_RANGE;
 
-		ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off, &csum_off,
-				&key, &tuple, svc, &ct_state_new, ip4->saddr);
+		ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off,
+				&csum_off, &key, &tuple, svc, &ct_state_new,
+				ip4->saddr, ipv4_has_l4_header(ip4));
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -1392,7 +1393,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret2 = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
 				   &ct_state, &tuple,
-				   REV_NAT_F_TUPLE_SADDR);
+				   REV_NAT_F_TUPLE_SADDR, ipv4_has_l4_header(ip4));
 		if (IS_ERR(ret2))
 			return ret2;
 

--- a/examples/kubernetes-cassandra/cass-populate-tables.sh
+++ b/examples/kubernetes-cassandra/cass-populate-tables.sh
@@ -4,8 +4,8 @@ CASS_SERVER_POD=$(kubectl get pods -l app=cass-server -o jsonpath='{.items[0].me
 
 # create tables
 
-kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"CREATE KEYSPACE deathstar WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 2 };\""
-kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"CREATE TABLE deathstar.scrum_notes (creation timeuuid, empire_member_id uuid, content varchar, PRIMARY KEY (empire_member_id));\"" 
+kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"CREATE KEYSPACE deathstar WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 2 };\""
+kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"CREATE TABLE deathstar.scrum_notes (creation timeuuid, empire_member_id uuid, content varchar, PRIMARY KEY (empire_member_id));\"" 
 
 UUID1=`uuidgen`
 UPDATE1="Trying to figure out if we should paint it medium grey, light grey, or medium-light grey.  Not blocked."
@@ -17,17 +17,16 @@ UUID3=`uuidgen`
 UPDATE3="Designed protective shield for deathstar.  Could be based on nearby moon.  Feature punted to v2.  Not blocked."
 QUERY3="INSERT INTO deathstar.scrum_notes (empire_member_id, creation, content) values ($UUID3, now(), '${UPDATE3}');"
 
-kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"$QUERY1\"" 
-kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"$QUERY2\"" 
-kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"$QUERY3\"" 
+kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"$QUERY1\""
+kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"$QUERY2\""
+kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"$QUERY3\""
 
 
-kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"CREATE KEYSPACE attendance WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 2 };\""
-kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"CREATE TABLE attendance.daily_records (creation timeuuid, loc_id uuid, present boolean, empire_member_id uuid, PRIMARY KEY (loc_id));\"" 
+kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"CREATE KEYSPACE attendance WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 2 };\""
+kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"CREATE TABLE attendance.daily_records (creation timeuuid, loc_id uuid, present boolean, empire_member_id uuid, PRIMARY KEY (loc_id));\"" 
 
-for i in `seq 0 10`; do 
+for i in `seq 0 10`; do
 	mUUID=`uuidgen`
 	lUUID=`uuidgen`
-	kubectl exec $CASS_SERVER_POD sh -- -c "cqlsh -e \"INSERT INTO attendance.daily_records (creation, loc_id, present, empire_member_id) values (now(), $lUUID, true, $mUUID);\""
-done 
-
+	kubectl exec $CASS_SERVER_POD -- sh -c "cqlsh -e \"INSERT INTO attendance.daily_records (creation, loc_id, present, empire_member_id) values (now(), $lUUID, true, $mUUID);\""
+done

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -70,13 +70,6 @@ func (m *InstancesManager) GetPoolQuota() (quota ipamTypes.PoolQuotaMap) {
 	return pool
 }
 
-// GetPoolQuota returns the number of available IPs in all IP pools
-func (m *InstancesManager) FindSubnetForAllocation(preferredPoolIDs []ipamTypes.PoolID) (ipamTypes.PoolID, int) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	return m.subnets.FirstSubnetWithAvailableAddresses(preferredPoolIDs)
-}
-
 // Resync fetches the list of EC2 instances and subnets and updates the local
 // cache in the instanceManager. It returns the time when the resync has
 // started or time.Time{} if it did not complete.


### PR DESCRIPTION
 * #13517 -- pkg/azure: fix potential deadlocks (@aanm)
 * #13488 -- doc: Kubeadm guide (@mrostecki)
 * #13534 -- Fix script cass-populate-tables from cassandra examples. (@velp)
 * #13545 -- Fix kubectl command in cassandra NetworkPolicy documentation. (@velp)
 * #13532 -- bpf: only clean up XDP from devices with XDP attached (@jaffcheng)
 * #13476 -- Fix wrong csum for non-first ipv4 fragments (@liuyuan10)
 * #13560 -- docs: Fix shell syntax issue in OpenShift guide (@errordeveloper)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13517 13488 13534 13545 13532 13476 13560; do contrib/backporting/set-labels.py $pr done 1.8; done
```