### PR TITLE
api-limiter: Make auto adjust test less flaky

### DIFF
--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -64,7 +64,7 @@ type outcome string
 const (
 	outcomeParallelMaxWait outcome = "fail-parallel-wait"
 	outcomeLimitMaxWait    outcome = "fail-limit-wait"
-	outcomeReqCancelled            = "request-cancelled"
+	outcomeReqCancelled    outcome = "request-cancelled"
 )
 
 // APILimiter is an extension to x/time/rate.Limiter specifically for Cilium

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -111,15 +111,17 @@ func (b *ControllerSuite) TestAutoAdjust(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(req, check.Not(check.IsNil))
 
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	req.Done()
 
-	req, _ = a.Wait(context.Background())
-	time.Sleep(15 * time.Millisecond)
+	req, err = a.Wait(context.Background())
+	c.Assert(err, check.IsNil)
+	time.Sleep(10 * time.Millisecond)
 	req.Done()
 
-	req, _ = a.Wait(context.Background())
-	time.Sleep(18 * time.Millisecond)
+	req, err = a.Wait(context.Background())
+	c.Assert(err, check.IsNil)
+	time.Sleep(10 * time.Millisecond)
 	req.Done()
 
 	c.Assert(a.parallelRequests, check.Not(check.Equals), initialParallelRequests)


### PR DESCRIPTION
Fixes: #13508
    
The auto adjust unit test relies on time.Sleep to schedule multiple requests. The existing sleep times were close to the limit for the test to pass. This commit shortens the times so the test is less sensitive to delays and more likely to pass.
    
The use of a fake clock in the tests, e.g. [`github.com/jonboulle/clockwork`](github.com/jonboulle/clockwork), to make the tests both reliable and more accurate was investigated. However, the existing code builds on `golang.org/x/time/rate` which itself does not have support for a fake clock in tests, so `golang.org/x/time/rate` would need to updated first.