### PR TITLE
service: Use initNextID in acquireLocalID()

### DIFF
--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -95,7 +95,7 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 		if alloc.nextID == startingID && rollover {
 			break
 		} else if alloc.nextID == alloc.maxID {
-			alloc.nextID = FirstFreeServiceID
+			alloc.nextID = alloc.initNextID
 			rollover = true
 		}
 


### PR DESCRIPTION
When rolling over, it should use initNextID instead of FirstFreeServiceID,
which doesn't belong to the IDAllocator. This would create problems if
FirstFreeServiceID and FirstFreeBackendID have different values although now
they happen to be the same.

Fixes: ab9cf4ba4206 ("service: Make local ID allocator more service agnostic")
Signed-off-by: Han Zhou <hzhou8@ebay.com>