### PR TITLE
pkg/azure/ipam: fix data race in (*Node).PopulateStatusFields

### DIFF
--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -48,6 +48,9 @@ func (n *Node) UpdatedNode(obj *v2.CiliumNode) {
 // resource with Azure specific information
 func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 	k8sObj.Status.Azure.Interfaces = []types.AzureInterface{}
+
+	n.manager.mutex.RLock()
+	defer n.manager.mutex.RUnlock()
 	n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.InterfaceRevision) error {
 		iface, ok := interfaceObj.Resource.(*types.AzureInterface)
 		if ok {


### PR DESCRIPTION
Fixes the following data race:

```
WARNING: DATA RACE
Write at 0x00c000358270 by goroutine 57:
  github.com/cilium/cilium/pkg/azure/ipam.(*InstancesManager).Resync()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/azure/ipam/instances.go:98 +0x933
  github.com/cilium/cilium/pkg/ipam.(*NodeManager).instancesAPIResync()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:186 +0x8b
  github.com/cilium/cilium/pkg/ipam.NewNodeManager.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:168 +0x8f
  github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/trigger/trigger.go:206 +0x5cf

Previous read at 0x00c000358270 by goroutine 250:
  github.com/cilium/cilium/pkg/azure/ipam.(*Node).PopulateStatusFields()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/azure/ipam/node.go:51 +0x11a
  github.com/cilium/cilium/pkg/ipam.(*Node).syncToAPIServer()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/ipam/node.go:716 +0x232
  github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update.func4()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:305 +0x75
  github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/trigger/trigger.go:206 +0x5cf

Goroutine 57 (running) created at:
  github.com/cilium/cilium/pkg/trigger.NewTrigger()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/trigger/trigger.go:129 +0x2c4
  github.com/cilium/cilium/pkg/ipam.NewNodeManager()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:163 +0x356
  github.com/cilium/cilium/pkg/azure/ipam.(*IPAMSuite).TestIpamManyNodes()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/azure/ipam/ipam_test.go:319 +0x52e
  runtime.call32()
      /home/travis/.gimme/versions/go1.15.2.linux.amd64/src/runtime/asm_amd64.s:540 +0x3d
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.15.2.linux.amd64/src/reflect/value.go:336 +0xd8
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:781 +0xabb
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xe1

Goroutine 250 (running) created at:
  github.com/cilium/cilium/pkg/trigger.NewTrigger()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/trigger/trigger.go:129 +0x2c4
  github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:300 +0xfe5
  github.com/cilium/cilium/pkg/azure/ipam.(*IPAMSuite).TestIpamManyNodes()
      /home/travis/gopath/src/github.com/cilium/cilium/pkg/azure/ipam/ipam_test.go:345 +0xbcd
  runtime.call32()
      /home/travis/.gimme/versions/go1.15.2.linux.amd64/src/runtime/asm_amd64.s:540 +0x3d
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.15.2.linux.amd64/src/reflect/value.go:336 +0xd8
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:781 +0xabb
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xe1
```

Closes #13580

Fixes: b89979a697be ("ipam: Move instance ID retrieval into generic code")