### PR TITLE
CODEOWNERS: change docs to docs-structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,27 +1,27 @@
 # Code owners groups and a brief description of their areas:
-# @cilium/janitors      Catch-all for code not otherwise owned
-# @cilium/agent         Cilium Agent
-# @cilium/aws           Integration with AWS
-# @cilium/azure         Integration with Azure
-# @cilium/bpf           BPF Data Path
-# @cilium/build         Building and packaging
-# @cilium/ci            Continuous integration, testing
-# @cilium/cli           Commandline interfaces
-# @cilium/contributing  Developer documentation & tools
-# @cilium/docker        Docker plugin
-# @cilium/docs          Documentation, examples
-# @cilium/endpoint      Endpoint package
-# @cilium/health        Cilium cluster health tool
-# @cilium/hubble        Hubble integration
-# @cilium/ipam          IPAM
-# @cilium/kubernetes    K8s integration, K8s CNI plugin
-# @cilium/kvstore       Key/Value store: Consul, etcd
-# @cilium/loadbalancer  Load balancer
-# @cilium/monitor       Cilium node monitor tool
-# @cilium/operator      Cilium operator
-# @cilium/policy        Policy behaviour
-# @cilium/proxy         L7 proxy, Envoy
-# @cilium/vendor        Vendoring, dependency management
+# @cilium/janitors           Catch-all for code not otherwise owned
+# @cilium/agent              Cilium Agent
+# @cilium/aws                Integration with AWS
+# @cilium/azure              Integration with Azure
+# @cilium/bpf                BPF Data Path
+# @cilium/build              Building and packaging
+# @cilium/ci                 Continuous integration, testing
+# @cilium/cli                Commandline interfaces
+# @cilium/contributing       Developer documentation & tools
+# @cilium/docker             Docker plugin
+# @cilium/docs-structure     Documentation, examples
+# @cilium/endpoint           Endpoint package
+# @cilium/health             Cilium cluster health tool
+# @cilium/hubble             Hubble integration
+# @cilium/ipam               IPAM
+# @cilium/kubernetes         K8s integration, K8s CNI plugin
+# @cilium/kvstore            Key/Value store: Consul, etcd
+# @cilium/loadbalancer       Load balancer
+# @cilium/monitor            Cilium node monitor tool
+# @cilium/operator           Cilium operator
+# @cilium/policy             Policy behaviour
+# @cilium/proxy              L7 proxy, Envoy
+# @cilium/vendor             Vendoring, dependency management
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
@@ -30,7 +30,7 @@
 /.github/ @cilium/contributing
 /.github/workflows/ @cilium/ci
 /.github/workflows/coccicheck.yaml @cilium/ci @cilium/bpf
-/.github/workflows/docs.yaml @cilium/ci @cilium/docs
+/.github/workflows/docs.yaml @cilium/ci @cilium/docs-structure
 /.github/workflows/images.yaml @cilium/ci @cilium/build
 /api/ @cilium/api
 /api/v1/flow/ @cilium/api @cilium/hubble
@@ -64,7 +64,7 @@ Dockerfile* @cilium/build
 /daemon/cmd/proxy.go @cilium/proxy
 /daemon/cmd/state.go @cilium/endpoint
 /daemon/cmd/sysctl_linux.go @cilium/bpf
-/Documentation/ @cilium/docs
+/Documentation/ @cilium/docs-structure
 /Documentation/cmdref @cilium/nonexistantteam
 /Documentation/bpf.rst @cilium/bpf
 /Documentation/contributing/ @cilium/contributing
@@ -74,7 +74,7 @@ Dockerfile* @cilium/build
 /Documentation/gettingstarted/hubble.rst @cilium/hubble
 /Documentation/hubble.rst @cilium/hubble
 /envoy/ @cilium/proxy
-/examples/ @cilium/docs
+/examples/ @cilium/docs-structure
 /examples/crds/ @cilium/kubernetes
 /examples/kubernetes/ @cilium/kubernetes
 /examples/minikube/ @cilium/kubernetes
@@ -82,8 +82,8 @@ Dockerfile* @cilium/build
 /hubble-relay/ @cilium/hubble
 /hubble-relay.Dockerfile @cilium/hubble
 /images @cilium/build
-/install/kubernetes/ @cilium/kubernetes @cilium/docs @cilium/helm
-/install/kubernetes/cilium/templates/hubble* @cilium/kubernetes @cilium/docs @cilium/helm @cilium/hubble
+/install/kubernetes/ @cilium/kubernetes @cilium/docs-structure @cilium/helm
+/install/kubernetes/cilium/templates/hubble* @cilium/kubernetes @cilium/docs-structure @cilium/helm @cilium/hubble
 jenkinsfiles @cilium/ci
 Jenkinsfile.nightly @cilium/ci
 /operator/ @cilium/operator
@@ -154,7 +154,7 @@ Jenkinsfile.nightly @cilium/ci
 /plugins/cilium-cni/ @cilium/kubernetes
 /plugins/cilium-docker/ @cilium/docker
 /proxylib/ @cilium/proxy
-/README.rst @cilium/docs
+/README.rst @cilium/docs-structure
 /test/ @cilium/ci
 /test/bpf/ @cilium/ci @cilium/bpf
 /test/Makefile* @cilium/ci @cilium/build


### PR DESCRIPTION
Rename team docs to docs-structure.

Signed-off-by: André Martins <andre@cilium.io>