### PR TITLE
loader: Check if device has BPF prog before trying to detach it

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -243,9 +243,16 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			directions = append(directions, dirEgress)
 			objPaths = append(objPaths, netdevObjPath)
 		} else {
-			// Remove any previously attached device from egress path if BPF
-			// NodePort is disabled.
-			l.DeleteDatapath(ctx, device, dirEgress)
+			hasDatapath, err := l.HasDatapath(ctx, device, dirEgress)
+			if err != nil {
+				log.WithField("device", device).Error(err)
+			}
+			if hasDatapath || err != nil {
+				// Remove any previously attached device from egress path if BPF
+				// NodePort and host firewall are disabled.
+				err := l.DeleteDatapath(ctx, device, dirEgress)
+				log.WithField("device", device).Error(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
When running Cilium with the devices set, but neither kube-proxy-free or the host firewall enabled, cilium-agent will attempt to remove the previous BPF program from the native devices' egress tc hook. If no program is attached there (i.e., Cilium was running without host firewall and kube-proxy replacement before restarting), the removal will fail with the following error.

    level=error msg="Command execution failed" cmd="[tc filter delete dev enp0s8 egress]" error="exit status 2" subsys=datapath-loader
    level=warning msg="Error: Parent Qdisc doesn't exists." subsys=datapath-loader
    level=warning msg="We have an error talking to the kernel, -1" subsys=datapath-loader

This commit fixes this error by first checking that the device has a BPF program attached on egress.

I tested this in the dev. VM, by first starting Cilium with our kube-proxy-replacement, then without but keeping the devices configuration.

Fixes: #10994
Fixes: #13512
Updates: #11799