### PR TITLE
v1.8 backports 2020-10-15

### DIFF
--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -199,19 +199,46 @@ func (w *identityWatcher) stop() {
 	close(w.stopChan)
 }
 
+// isLocalIdentityAllocatorInitialized returns true if m.localIdentities is not nil.
+func (m *CachingIdentityAllocator) isLocalIdentityAllocatorInitialized() bool {
+	select {
+	case <-m.localIdentityAllocatorInitialized:
+		return m.localIdentities != nil
+	default:
+		return false
+	}
+}
+
+// isGlobalIdentityAllocatorInitialized returns true if m.IdentityAllocator is not nil.
+// Note: This does not mean that the identities have been synchronized,
+// see WaitForInitialGlobalIdentities to wait for a fully populated cache.
+func (m *CachingIdentityAllocator) isGlobalIdentityAllocatorInitialized() bool {
+	select {
+	case <-m.globalIdentityAllocatorInitialized:
+		return m.IdentityAllocator != nil
+	default:
+		return false
+	}
+}
+
 // LookupIdentity looks up the identity by its labels but does not create it.
 // This function will first search through the local cache, then the caches for
-// remote kvstores and finally fall back to the main kvstore
+// remote kvstores and finally fall back to the main kvstore.
+// May return nil for lookups if the allocator has not yet been synchronized.
 func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labels.Labels) *identity.Identity {
 	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
 		return reservedIdentity
+	}
+
+	if !m.isLocalIdentityAllocatorInitialized() {
+		return nil
 	}
 
 	if identity := m.localIdentities.lookup(lbls); identity != nil {
 		return identity
 	}
 
-	if !identity.RequiresGlobalIdentity(lbls) || m.IdentityAllocator == nil {
+	if !identity.RequiresGlobalIdentity(lbls) || !m.isGlobalIdentityAllocatorInitialized() {
 		return nil
 	}
 
@@ -233,6 +260,7 @@ var unknownIdentity = identity.NewIdentity(identity.IdentityUnknown, labels.Labe
 // LookupIdentityByID returns the identity by ID. This function will first
 // search through the local cache, then the caches for remote kvstores and
 // finally fall back to the main kvstore
+// May return nil for lookups if the allocator has not yet been synchronized.
 func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id identity.NumericIdentity) *identity.Identity {
 	if id == identity.IdentityUnknown {
 		return unknownIdentity
@@ -242,7 +270,7 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return identity
 	}
 
-	if m.IdentityAllocator == nil {
+	if !m.isLocalIdentityAllocatorInitialized() {
 		return nil
 	}
 
@@ -250,7 +278,7 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return identity
 	}
 
-	if id.HasLocalScope() {
+	if !m.isGlobalIdentityAllocatorInitialized() || id.HasLocalScope() {
 		return nil
 	}
 

--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -95,7 +95,7 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 		if alloc.nextID == startingID && rollover {
 			break
 		} else if alloc.nextID == alloc.maxID {
-			alloc.nextID = FirstFreeServiceID
+			alloc.nextID = alloc.initNextID
 			rollover = true
 		}
 


### PR DESCRIPTION
* #13576 -- service: Use initNextID in acquireLocalID() (@hzhou8)
 * #13514 -- identity: Fix nil pointer panic in LookupIdentityByID (@gandro)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13576 13514; do contrib/backporting/set-labels.py $pr done 1.8; done
```