### PR TITLE
Fix extraction of manifest for OpenShift

### DIFF
--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -161,11 +161,9 @@ Copy Cilium manifest to ``${CLUSTER_NAME}/manifests``:
 
 .. code:: bash
 
-   for component in config agent operator
-      do for resource in cilium/charts/${component}/templates/*
-          do cp "${resource}" "${CLUSTER_NAME}/manifests/cluster-network-04-cilium-${component}-$(basename ${resource})"
-      done
-   done
+    for resource in cilium/templates/*
+        do cp "${resource}" "${CLUSTER_NAME}/manifests/cluster-network-04-cilium-$(basename ${resource})"
+    done
 
 Create the cluster:
 


### PR DESCRIPTION
Since Cilium subcharts were refactored into a sinlge large chart,
the layout of `helm template` output changed also. This fixes
OpenShift instructions to work with the new layout.

Fixes: e9cb43c03179 (Helm: full refactor of helm charts, default values implemented, tests updated, kind cni integration)