### PR TITLE
monitor: Display human-readable identities

### DIFF
--- a/Documentation/cmdref/cilium_monitor.md
+++ b/Documentation/cmdref/cilium_monitor.md
@@ -25,6 +25,7 @@ cilium monitor [flags]
       --hex                     Do not dissect, print payload in HEX
   -j, --json                    Enable json output. Shadows -v flag
       --monitor-socket string   Configure monitor socket path
+  -n, --numeric                 Display all security identities as numeric values
       --related-to []uint16     Filter by either source or destination endpoint id
       --to []uint16             Filter by destination endpoint id
   -t, --type []string           Filter by event types [agent capture debug drop l7 policy-verdict trace]

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -70,6 +70,7 @@ func init() {
 	monitorCmd.Flags().BoolSliceVarP(&verbosity, "verbose", "v", nil, "Enable verbose output (-v, -vv)")
 	monitorCmd.Flags().Lookup("verbose").NoOptDefVal = "false"
 	monitorCmd.Flags().BoolVarP(&printer.JSONOutput, "json", "j", false, "Enable json output. Shadows -v flag")
+	monitorCmd.Flags().BoolVarP(&printer.Numeric, "numeric", "n", false, "Display all security identities as numeric values")
 	monitorCmd.Flags().StringVar(&socketPath, "monitor-socket", "", "Configure monitor socket path")
 	viper.BindEnv("monitor-socket", "CILIUM_MONITOR_SOCK")
 	viper.BindPFlags(monitorCmd.Flags())

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -463,16 +463,16 @@ func decodeSecurityIdentities(dn *monitor.DropNotify, tn *monitor.TraceNotify, p
 ) {
 	switch {
 	case dn != nil:
-		sourceSecurityIdentiy = dn.SrcLabel
-		destinationSecurityIdentity = dn.DstLabel
+		sourceSecurityIdentiy = uint32(dn.SrcLabel)
+		destinationSecurityIdentity = uint32(dn.DstLabel)
 	case tn != nil:
-		sourceSecurityIdentiy = tn.SrcLabel
-		destinationSecurityIdentity = tn.DstLabel
+		sourceSecurityIdentiy = uint32(tn.SrcLabel)
+		destinationSecurityIdentity = uint32(tn.DstLabel)
 	case pvn != nil:
 		if pvn.IsTrafficIngress() {
-			sourceSecurityIdentiy = pvn.RemoteLabel
+			sourceSecurityIdentiy = uint32(pvn.RemoteLabel)
 		} else {
-			destinationSecurityIdentity = pvn.RemoteLabel
+			destinationSecurityIdentity = uint32(pvn.RemoteLabel)
 		}
 	}
 

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -264,9 +264,9 @@ func TestDecodeTraceNotify(t *testing.T) {
 	buf.Write(buffer.Bytes())
 	require.NoError(t, err)
 	identityGetter := &testutils.FakeIdentityGetter{OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
-		if securityIdentity == tn.SrcLabel {
+		if securityIdentity == uint32(tn.SrcLabel) {
 			return &models.Identity{Labels: []string{"src=label"}}, nil
-		} else if securityIdentity == tn.DstLabel {
+		} else if securityIdentity == uint32(tn.DstLabel) {
 			return &models.Identity{Labels: []string{"dst=label"}}, nil
 		}
 		return nil, fmt.Errorf("identity not found for %d", securityIdentity)
@@ -308,9 +308,9 @@ func TestDecodeDropNotify(t *testing.T) {
 	require.NoError(t, err)
 	identityGetter := &testutils.FakeIdentityGetter{
 		OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
-			if securityIdentity == dn.SrcLabel {
+			if securityIdentity == uint32(dn.SrcLabel) {
 				return &models.Identity{Labels: []string{"src=label"}}, nil
-			} else if securityIdentity == dn.DstLabel {
+			} else if securityIdentity == uint32(dn.DstLabel) {
 				return &models.Identity{Labels: []string{"dst=label"}}, nil
 			}
 			return nil, fmt.Errorf("identity not found for %d", securityIdentity)
@@ -328,10 +328,10 @@ func TestDecodeDropNotify(t *testing.T) {
 }
 
 func TestDecodePolicyVerdictNotify(t *testing.T) {
-	var remoteLabel uint32 = 123
+	var remoteLabel identity.NumericIdentity = 123
 	identityGetter := &testutils.FakeIdentityGetter{
 		OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
-			if securityIdentity == remoteLabel {
+			if securityIdentity == uint32(remoteLabel) {
 				return &models.Identity{Labels: []string{"dst=label"}}, nil
 			}
 			return nil, fmt.Errorf("identity not found for %d", securityIdentity)
@@ -412,8 +412,8 @@ func TestDecodeDropReason(t *testing.T) {
 func TestDecodeLocalIdentity(t *testing.T) {
 	tn := monitor.TraceNotifyV0{
 		Type:     byte(api.MessageTypeTrace),
-		SrcLabel: uint32(123 | identity.LocalIdentityFlag),
-		DstLabel: uint32(456 | identity.LocalIdentityFlag),
+		SrcLabel: 123 | identity.LocalIdentityFlag,
+		DstLabel: 456 | identity.LocalIdentityFlag,
 	}
 	data, err := testutils.CreateL3L4Payload(tn)
 	require.NoError(t, err)

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -48,7 +48,7 @@ func (s *IdentityTestSuite) TestReservedID(c *C) {
 	// This is an obsoleted identity, we verify that it returns 0
 	i = GetReservedID("cluster")
 	c.Assert(i, Equals, NumericIdentity(0))
-	c.Assert(i.String(), Equals, "0")
+	c.Assert(i.String(), Equals, "unknown")
 
 	i = GetReservedID("health")
 	c.Assert(i, Equals, NumericIdentity(4))

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -287,6 +287,7 @@ var (
 		labels.IDNameRemoteNode: ReservedIdentityRemoteNode,
 	}
 	reservedIdentityNames = map[NumericIdentity]string{
+		IdentityUnknown:            "unknown",
 		ReservedIdentityHost:       labels.IDNameHost,
 		ReservedIdentityWorld:      labels.IDNameWorld,
 		ReservedIdentityUnmanaged:  labels.IDNameUnmanaged,

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -34,8 +35,8 @@ type DropNotify struct {
 	Hash     uint32
 	OrigLen  uint32
 	CapLen   uint32
-	SrcLabel uint32
-	DstLabel uint32
+	SrcLabel identity.NumericIdentity
+	DstLabel identity.NumericIdentity
 	DstID    uint32
 	Unused   uint32
 	// data
@@ -43,7 +44,7 @@ type DropNotify struct {
 
 // DumpInfo prints a summary of the drop messages.
 func (n *DropNotify) DumpInfo(data []byte) {
-	fmt.Printf("xx drop (%s) flow %#x to endpoint %d, identity %d->%d: %s\n",
+	fmt.Printf("xx drop (%s) flow %#x to endpoint %d, identity %s->%s: %s\n",
 		api.DropReason(n.SubType), n.Hash, n.DstID, n.SrcLabel, n.DstLabel,
 		GetConnectionSummary(data[DropNotifyLen:]))
 }
@@ -54,7 +55,7 @@ func (n *DropNotify) DumpVerbose(dissect bool, data []byte, prefix string) {
 		prefix, n.Hash, n.Source, n.OrigLen, api.DropReason(n.SubType))
 
 	if n.SrcLabel != 0 || n.DstLabel != 0 {
-		fmt.Printf(", identity %d->%d", n.SrcLabel, n.DstLabel)
+		fmt.Printf(", identity %s->%s", n.SrcLabel, n.DstLabel)
 	}
 
 	if n.DstID != 0 {
@@ -95,11 +96,11 @@ type DropNotifyVerbose struct {
 	Mark      string `json:"mark,omitempty"`
 	Reason    string `json:"reason,omitempty"`
 
-	Source   uint16 `json:"source"`
-	Bytes    uint32 `json:"bytes"`
-	SrcLabel uint32 `json:"srcLabel"`
-	DstLabel uint32 `json:"dstLabel"`
-	DstID    uint32 `json:"dstID"`
+	Source   uint16                   `json:"source"`
+	Bytes    uint32                   `json:"bytes"`
+	SrcLabel identity.NumericIdentity `json:"srcLabel"`
+	DstLabel identity.NumericIdentity `json:"dstLabel"`
+	DstID    uint32                   `json:"dstID"`
 
 	Summary *DissectSummary `json:"summary,omitempty"`
 }

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -17,6 +17,7 @@ package monitor
 import (
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -57,7 +58,7 @@ type PolicyVerdictNotify struct {
 	OrigLen     uint32
 	CapLen      uint16
 	Version     uint16
-	RemoteLabel uint32
+	RemoteLabel identity.NumericIdentity
 	Verdict     int32
 	DstPort     uint16
 	Proto       uint8
@@ -108,7 +109,7 @@ func (n *PolicyVerdictNotify) DumpInfo(data []byte) {
 	if n.IsTrafficIngress() {
 		dir = "ingress"
 	}
-	fmt.Printf("Policy verdict log: flow %#x local EP ID %d, remote ID %d, proto %d, %s, action %s, match %s, %s\n",
+	fmt.Printf("Policy verdict log: flow %#x local EP ID %d, remote ID %s, proto %d, %s, action %s, match %s, %s\n",
 		n.Hash, n.Source, n.RemoteLabel, n.Proto, dir, GetPolicyActionString(n.Verdict, n.IsTrafficAudited()),
 		n.GetPolicyMatchType(), GetConnectionSummary(data[PolicyVerdictNotifyLen:]))
 }

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -23,6 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -58,8 +59,8 @@ type TraceNotifyV0 struct {
 	OrigLen  uint32
 	CapLen   uint16
 	Version  uint16
-	SrcLabel uint32
-	DstLabel uint32
+	SrcLabel identity.NumericIdentity
+	DstLabel identity.NumericIdentity
 	DstID    uint16
 	Reason   uint8
 	Flags    uint8
@@ -201,11 +202,11 @@ func (n *TraceNotify) DataOffset() uint {
 func (n *TraceNotify) DumpInfo(data []byte) {
 	hdrLen := n.DataOffset()
 	if n.encryptReason() != "" {
-		fmt.Printf("%s %s flow %#x identity %d->%d state %s ifindex %s orig-ip %s: %s\n",
+		fmt.Printf("%s %s flow %#x identity %s->%s state %s ifindex %s orig-ip %s: %s\n",
 			n.traceSummary(), n.encryptReason(), n.Hash, n.SrcLabel, n.DstLabel,
 			n.traceReason(), ifname(int(n.Ifindex)), n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:]))
 	} else {
-		fmt.Printf("%s flow %#x identity %d->%d state %s ifindex %s orig-ip %s: %s\n",
+		fmt.Printf("%s flow %#x identity %s->%s state %s ifindex %s orig-ip %s: %s\n",
 			n.traceSummary(), n.Hash, n.SrcLabel, n.DstLabel,
 			n.traceReason(), ifname(int(n.Ifindex)), n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:]))
 	}
@@ -221,7 +222,7 @@ func (n *TraceNotify) DumpVerbose(dissect bool, data []byte, prefix string) {
 	}
 
 	if n.SrcLabel != 0 || n.DstLabel != 0 {
-		fmt.Printf(", identity %d->%d", n.SrcLabel, n.DstLabel)
+		fmt.Printf(", identity %s->%s", n.SrcLabel, n.DstLabel)
 	}
 
 	fmt.Printf(", orig-ip " + n.OriginalIP().String())
@@ -268,11 +269,11 @@ type TraceNotifyVerbose struct {
 	ObservationPoint string `json:"observationPoint"`
 	TraceSummary     string `json:"traceSummary"`
 
-	Source   uint16 `json:"source"`
-	Bytes    uint32 `json:"bytes"`
-	SrcLabel uint32 `json:"srcLabel"`
-	DstLabel uint32 `json:"dstLabel"`
-	DstID    uint16 `json:"dstID"`
+	Source   uint16                   `json:"source"`
+	Bytes    uint32                   `json:"bytes"`
+	SrcLabel identity.NumericIdentity `json:"srcLabel"`
+	DstLabel identity.NumericIdentity `json:"dstLabel"`
+	DstID    uint16                   `json:"dstID"`
 
 	Summary *DissectSummary `json:"summary,omitempty"`
 }

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -28,6 +28,13 @@ import (
 	"github.com/google/gopacket/layers"
 )
 
+type DisplayFormat bool
+
+const (
+	DisplayLabel   DisplayFormat = false
+	DisplayNumeric DisplayFormat = true
+)
+
 type parserCache struct {
 	eth     layers.Ethernet
 	ip4     layers.IPv4

--- a/pkg/monitor/format/format.go
+++ b/pkg/monitor/format/format.go
@@ -54,6 +54,7 @@ type MonitorFormatter struct {
 	Hex        bool
 	JSONOutput bool
 	Verbosity  Verbosity
+	Numeric    bool
 }
 
 // NewMonitorFormatter returns a new formatter with default configuration.
@@ -66,6 +67,7 @@ func NewMonitorFormatter(verbosity Verbosity) *MonitorFormatter {
 		Related:    Uint16Flags{},
 		JSONOutput: false,
 		Verbosity:  verbosity,
+		Numeric:    bool(monitor.DisplayLabel),
 	}
 }
 
@@ -97,12 +99,12 @@ func (m *MonitorFormatter) dropEvents(prefix string, data []byte) {
 	if m.match(monitorAPI.MessageTypeDrop, dn.Source, uint16(dn.DstID)) {
 		switch m.Verbosity {
 		case INFO, DEBUG:
-			dn.DumpInfo(data)
+			dn.DumpInfo(data, monitor.DisplayFormat(m.Numeric))
 		case JSON:
 			dn.DumpJSON(data, prefix)
 		default:
 			fmt.Println(msgSeparator)
-			dn.DumpVerbose(!m.Hex, data, prefix)
+			dn.DumpVerbose(!m.Hex, data, prefix, monitor.DisplayFormat(m.Numeric))
 		}
 	}
 }
@@ -117,12 +119,12 @@ func (m *MonitorFormatter) traceEvents(prefix string, data []byte) {
 	if m.match(monitorAPI.MessageTypeTrace, tn.Source, tn.DstID) {
 		switch m.Verbosity {
 		case INFO, DEBUG:
-			tn.DumpInfo(data)
+			tn.DumpInfo(data, monitor.DisplayFormat(m.Numeric))
 		case JSON:
 			tn.DumpJSON(data, prefix)
 		default:
 			fmt.Println(msgSeparator)
-			tn.DumpVerbose(!m.Hex, data, prefix)
+			tn.DumpVerbose(!m.Hex, data, prefix, monitor.DisplayFormat(m.Numeric))
 		}
 	}
 }
@@ -135,7 +137,7 @@ func (m *MonitorFormatter) policyVerdictEvents(prefix string, data []byte) {
 	}
 
 	if m.match(monitorAPI.MessageTypePolicyVerdict, pn.Source, uint16(pn.RemoteLabel)) {
-		pn.DumpInfo(data)
+		pn.DumpInfo(data, monitor.DisplayFormat(m.Numeric))
 	}
 }
 

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1568,7 +1568,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 				By("Testing cilium monitor output")
 				monitorRes.ExpectContains(
-					fmt.Sprintf("local EP ID %s, remote ID 1, proto 1, ingress, action audit", endpointID),
+					fmt.Sprintf("local EP ID %s, remote ID host, proto 1, ingress, action audit", endpointID),
 					"No ingress policy log record",
 				)
 
@@ -1609,7 +1609,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 				By("Testing cilium monitor output")
 				monitorRes.ExpectContains(
-					fmt.Sprintf("ID %s, remote ID 1, proto 1, egress, action audit", endpointID),
+					fmt.Sprintf("ID %s, remote ID host, proto 1, egress, action audit", endpointID),
 					"No egress policy log record",
 				)
 


### PR DESCRIPTION
This pull request changes `cilium monitor`'s output to display human-readable identities instead of numbers for reserved (fixed) identities.

The output before this pull request resembles:

    <- host flow 0x0 identity 2->0 state new ifindex enp0s8 orig-ip 0.0.0.0: 192.168.33.12:31313 -> 10.11.0.113:40364 tcp SYN, ACK

After:

    <- host flow 0x0 identity world->unknown state new ifindex enp0s8 orig-ip 0.0.0.0: 192.168.33.12:31313 -> 10.11.0.113:40364 tcp SYN, ACK

Please see individual commit messages for details.