### PR TITLE
images: Fix handling of git tags

### DIFF
--- a/images/scripts/make-image-tag.sh
+++ b/images/scripts/make-image-tag.sh
@@ -50,8 +50,11 @@ else
   image_dir="${root_dir}"
   git_tag="$(git name-rev --name-only --tags HEAD)"
   if printf "%s" "${git_tag}" | grep -q -E '^[v]?[0-9]+\.[0-9]+\.[0-9]+.*$' ; then
-    # ensure version tag always has the v prefix
-    image_tag="$(printf "%s" "${git_tag}" | sed 's/^[v]*/v/')"
+    # get tag in conventional format, since name-rev use the format with ^0 suffix,
+    # however name-rev is required to determine presence of a tag
+    git_tag="$(git tag --sort tag --points-at "${git_tag}")"
+    # ensure version tag always has the v prefix and drop duplicates
+    image_tag="$(printf "%s" "${git_tag}" | sed 's/^[v]*/v/' | uniq)"
   else
     # if no version tag is given, use commit hash
     image_tag="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
This imports changes from cilium/image-tools#72. ~This will need to be cherry-picked to v1.9 branch.~