### PR TITLE
k8s/watchers: fix data race in (*K8sWatcher).addK8sServiceV1

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -365,6 +365,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	)
 
 	d.redirectPolicyManager.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)
+	d.redirectPolicyManager.RegisterGetStores(d.k8sWatcher)
 
 	bootstrapStats.daemonInit.End(true)
 

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -88,7 +88,7 @@ func (k *K8sWatcher) addCiliumLocalRedirectPolicy(clrp *cilium_v2.CiliumLocalRed
 
 	rp, policyAddErr := redirectpolicy.Parse(clrp, true)
 	if policyAddErr == nil {
-		_, policyAddErr = k.redirectPolicyManager.AddRedirectPolicy(*rp, k.podStore)
+		_, policyAddErr = k.redirectPolicyManager.AddRedirectPolicy(*rp)
 	}
 
 	if policyAddErr != nil {

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -84,9 +84,7 @@ func (k *K8sWatcher) addK8sServiceV1(svc *slim_corev1.Service, swg *lock.Stoppab
 	if svc.Spec.Type == slim_corev1.ServiceTypeClusterIP {
 		// The local redirect policies currently support services of type
 		// clusterIP only.
-		k.podStoreMU.RLock()
-		k.redirectPolicyManager.OnAddService(svcID, k.podStore)
-		k.podStoreMU.RUnlock()
+		k.redirectPolicyManager.OnAddService(svcID)
 	}
 	return nil
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -84,7 +84,9 @@ func (k *K8sWatcher) addK8sServiceV1(svc *slim_corev1.Service, swg *lock.Stoppab
 	if svc.Spec.Type == slim_corev1.ServiceTypeClusterIP {
 		// The local redirect policies currently support services of type
 		// clusterIP only.
+		k.podStoreMU.RLock()
 		k.redirectPolicyManager.OnAddService(svcID, k.podStore)
+		k.podStoreMU.RUnlock()
 	}
 	return nil
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -81,8 +81,6 @@ const (
 	metricCreate         = "create"
 	metricDelete         = "delete"
 	metricUpdate         = "update"
-
-	k8sPodResource = "pod"
 )
 
 func init() {
@@ -141,9 +139,9 @@ type svcManager interface {
 }
 
 type redirectPolicyManager interface {
-	AddRedirectPolicy(config redirectpolicy.LRPConfig, podStore cache.Store) (bool, error)
+	AddRedirectPolicy(config redirectpolicy.LRPConfig) (bool, error)
 	DeleteRedirectPolicy(config redirectpolicy.LRPConfig) error
-	OnAddService(svcID k8s.ServiceID, podStore cache.Store)
+	OnAddService(svcID k8s.ServiceID)
 	OnDeleteService(svcID k8s.ServiceID)
 	OnUpdatePod(pod *slim_corev1.Pod, needsReassign bool, ready bool)
 	OnDeletePod(pod *slim_corev1.Pod)
@@ -899,7 +897,7 @@ func (k *K8sWatcher) GetStore(name string) cache.Store {
 		return k.networkpolicyStore
 	case "namespace":
 		return k.namespaceStore
-	case k8sPodResource:
+	case "pod":
 		// Wait for podStore to get initialized.
 		<-k.podStoreSet
 		// Access to podStore is protected by podStoreMU.


### PR DESCRIPTION
Access to k.podStore must be protected by k.podStoreMU.

Closes #13603

Fixes: e7bb8a7eadb5 ("k8s/cilium Event handlers and processing logic for LRPs")