### PR TITLE
build: Fix CC for CGO compilation for Arm

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -18,8 +18,9 @@ ENV GOOS=${TARGETOS} \
   GOARCH=${TARGETARCH}
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  make build-container install-container \
-  NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/out/${TARGETOS}/${TARGETARCH} IMAGE_CROSS_TARGET_PLATFORM=${TARGETOS}/${TARGETARCH}
+  if [ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ] ; then export CC=aarch64-linux-gnu-gcc ; fi ; \
+    make build-container install-container \
+      NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/out/${TARGETOS}/${TARGETARCH} IMAGE_CROSS_TARGET_PLATFORM=${TARGETOS}/${TARGETARCH}
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
   cd /go/src/github.com/cilium/cilium/plugins/cilium-cni \


### PR DESCRIPTION
Setting of CC environment variable was accidentally dropped and
broke the build. This change re-introduces CC for Arm target.

Fixes: #13551 (implement multiple platform architecture docker images for cilium and hubble-relay)