### PR TITLE
helm: Remove hardcoded port check for hubble, etc

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -22,6 +22,8 @@ LATEST_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
 DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_PULLPOLICY_REGEX := '\([pP]ullPolicy:\) .*'
+QUICK_OPTIONS := \
+    --set hubble.tls.enabled=false
 EXPERIMENTAL_OPTIONS := \
     --set hubble.enabled=true \
     --set hubble.listenAddress=":4244" \
@@ -45,7 +47,7 @@ HELM_DOCS := $(DOCKER_RUN) $(HELM_DOCS_IMAGE)
 all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL)
 
 $(QUICK_INSTALL) quick-install: $(shell find cilium/ -type f) update-versions
-	$(QUIET)helm template cilium cilium --namespace=kube-system > $(QUICK_INSTALL)
+	$(QUIET)helm template cilium cilium --namespace=kube-system $(QUICK_OPTIONS) > $(QUICK_INSTALL)
 
 $(EXPERIMENTAL_INSTALL) experimental-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)

--- a/install/kubernetes/cilium/templates/hubble-ca-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ca-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.preflight.enabled) .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
+{{- if and (not .Values.preflight.enabled) .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled }}
 {{- if or (and (.Values.hubble.tls.auto.enabled) (eq .Values.hubble.tls.auto.method "helm")) .Values.hubble.tls.ca.cert }}
 apiVersion: v1
 kind: ConfigMap

--- a/install/kubernetes/cilium/templates/hubble-relay-client-tls-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-client-tls-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.hubble.relay.enabled) (.Values.hubble.tls.enabled) (hasKey .Values.hubble "listenAddress") }}
+{{- if and (.Values.hubble.relay.enabled) (.Values.hubble.tls.enabled) }}
 {{- if or (and (.Values.hubble.tls.auto.enabled) (eq .Values.hubble.tls.auto.method "helm")) .Values.hubble.relay.tls.client.cert .Values.hubble.relay.tls.client.key }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/hubble-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble-server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent (not .Values.preflight.enabled) .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.hubble.enabled .Values.hubble.tls.enabled }}
 {{- if or (and (.Values.hubble.tls.auto.enabled) (eq .Values.hubble.tls.auto.method "helm")) .Values.hubble.tls.server.cert .Values.hubble.tls.server.key }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -8,8 +8,4 @@
   {{- if not .Values.hubble.enabled }}
     {{ fail "Hubble Relay requires .Values.hubble.enabled=true" }}
   {{- end }}
-  {{/* the port is currently hard-coded and need to be set to this specific value */}}
-  {{- if ne .Values.hubble.listenAddress ":4244" }}
-    {{ fail "Hubble Relay requires .Values.hubble.listenAddress=:4244" }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
The overly restrictive deployment options for hubble server
cause validation errors unnecessarily when valid configuration
changes are made.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>
