### PR TITLE
feat(helm): Add cleanup step for helm delete

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -46,10 +46,10 @@ HELM_DOCS := $(DOCKER_RUN) $(HELM_DOCS_IMAGE)
 all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL) docs
 
 $(QUICK_INSTALL) quick-install: $(shell find cilium/ -type f) update-versions
-	$(QUIET)helm template cilium cilium --namespace=kube-system $(QUICK_OPTIONS) > $(QUICK_INSTALL)
+	$(QUIET)helm template cilium cilium --no-hooks --namespace=kube-system $(QUICK_OPTIONS) > $(QUICK_INSTALL)
 
 $(EXPERIMENTAL_INSTALL) experimental-install: $(shell find cilium/ -type f) update-versions
-	$(QUIET)helm template cilium cilium --namespace=kube-system $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
+	$(QUIET)helm template cilium cilium --no-hooks --namespace=kube-system $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
 
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"

--- a/install/kubernetes/cilium/templates/cilium-agent-cleanup-job.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-cleanup-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+      {{- end }}
+      containers:
+        - name: post-delete-job
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - cilium
+            - cleanup


### PR DESCRIPTION
This commit is to add step for `cilium cleanup` as part of helm delete
hook.

Closes #13183

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
feat(helm): Add cleanup step for helm delete
```

TODO:
- [ ] Run clean up for all nodes
- [ ] Manual Test during upgrade/update with re-use values
- [ ] Test as part of GHA ?
- [ ] Docs