### PR TITLE
eni: Fix data race during multiple updates at once

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -228,12 +228,11 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 	return n.manager.api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int64(a.AvailableForAllocation))
 }
 
-func (n *Node) getSecurityGroupIDs(ctx context.Context) ([]string, error) {
+func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec) ([]string, error) {
 	// 1. check explicit security groups associations via checking Spec.ENI.SecurityGroups
 	// 2. check if Spec.ENI.SecurityGroupTags is passed and if so filter by those
 	// 3. if 1 and 2 give no results derive the security groups from eth0
 
-	eniSpec := n.k8sObj.Spec.ENI
 	if len(eniSpec.SecurityGroups) > 0 {
 		return eniSpec.SecurityGroups, nil
 	}
@@ -336,18 +335,31 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 		return 0, errUnableToDetermineLimits, fmt.Errorf(errUnableToDetermineLimits)
 	}
 
-	bestSubnet := n.manager.FindSubnetByTags(n.k8sObj.Spec.ENI.VpcID, n.k8sObj.Spec.ENI.AvailabilityZone, n.k8sObj.Spec.ENI.SubnetTags)
+	n.mutex.RLock()
+	resource := *n.k8sObj
+	n.mutex.RUnlock()
+
+	bestSubnet := n.manager.FindSubnetByTags(resource.Spec.ENI.VpcID, resource.Spec.ENI.AvailabilityZone, resource.Spec.ENI.SubnetTags)
 	if bestSubnet == nil {
-		return 0, errUnableToFindSubnet, fmt.Errorf("No matching subnet available for interface creation (VPC=%s AZ=%s SubnetTags=%s",
-			n.k8sObj.Spec.ENI.VpcID, n.k8sObj.Spec.ENI.AvailabilityZone, n.k8sObj.Spec.ENI.SubnetTags)
+		return 0,
+			errUnableToFindSubnet,
+			fmt.Errorf(
+				"No matching subnet available for interface creation (VPC=%s AZ=%s SubnetTags=%s",
+				resource.Spec.ENI.VpcID,
+				resource.Spec.ENI.AvailabilityZone,
+				resource.Spec.ENI.SubnetTags,
+			)
 	}
 
-	securityGroupIDs, err := n.getSecurityGroupIDs(ctx)
+	securityGroupIDs, err := n.getSecurityGroupIDs(ctx, resource.Spec.ENI)
 	if err != nil {
-		return 0, errUnableToGetSecurityGroups, fmt.Errorf("%s %s", errUnableToGetSecurityGroups, err)
+		return 0,
+			errUnableToGetSecurityGroups,
+			fmt.Errorf("%s %s", errUnableToGetSecurityGroups, err)
 	}
 
 	desc := "Cilium-CNI (" + n.node.InstanceID() + ")"
+
 	// Must allocate secondary ENI IPs as needed, up to ENI instance limit - 1 (reserve 1 for primary IP)
 	toAllocate := math.IntMin(allocation.MaxIPsToAllocate, limits.IPv4-1)
 	// Validate whether request has already been fulfilled in the meantime
@@ -355,7 +367,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 		return 0, "", nil
 	}
 
-	index := n.findNextIndex(int64(*n.k8sObj.Spec.ENI.FirstInterfaceIndex))
+	index := n.findNextIndex(int64(*resource.Spec.ENI.FirstInterfaceIndex))
 
 	scopedLog = scopedLog.WithFields(logrus.Fields{
 		"securityGroupIDs": securityGroupIDs,
@@ -396,7 +408,9 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 			return toAllocate, "", nil
 		}
 
-		return 0, errUnableToAttachENI, fmt.Errorf("%s at index %d: %s", errUnableToAttachENI, index, err)
+		return 0,
+			errUnableToAttachENI,
+			fmt.Errorf("%s at index %d: %s", errUnableToAttachENI, index, err)
 	}
 
 	scopedLog = scopedLog.WithFields(logrus.Fields{
@@ -408,7 +422,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 	scopedLog.Info("Attached ENI to instance")
 
-	if n.k8sObj.Spec.ENI.DeleteOnTermination == nil || *n.k8sObj.Spec.ENI.DeleteOnTermination {
+	if resource.Spec.ENI.DeleteOnTermination == nil || *resource.Spec.ENI.DeleteOnTermination {
 		// We have an attachment ID from the last API, which lets us mark the
 		// interface as delete on termination
 		err = n.manager.api.ModifyNetworkInterface(ctx, eniID, attachmentID, true)

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -42,11 +42,11 @@ const (
 // Node represents a Kubernetes node running Cilium with an associated
 // CiliumNode custom resource
 type Node struct {
-	// mutex protects all members of this structure
-	mutex lock.RWMutex
-
 	// node contains the general purpose fields of a node
 	node *ipam.Node
+
+	// mutex protects members below this field
+	mutex lock.RWMutex
 
 	// enis is the list of ENIs attached to the node indexed by ENI ID.
 	// Protected by Node.mutex.


### PR DESCRIPTION
This data race was found by modifying the
(*ENISuite).TestNodeManagerDefaultAllocation test to inject spurious
update calls to the IPAM NodeManager for the CiliumNode that's already
being updated.

Fixes:

```
WARNING: DATA RACE
Read at 0x00c0005a09e8 by goroutine 36:
  github.com/cilium/cilium/pkg/aws/eni.(*Node).CreateInterface()
      /home/chris/code/cilium/cilium/pkg/aws/eni/node.go:358 +0x4aa
  github.com/cilium/cilium/pkg/ipam.(*Node).createInterface()
      /home/chris/code/cilium/cilium/pkg/ipam/node.go:441 +0x2a1
  github.com/cilium/cilium/pkg/ipam.(*Node).maintainIPPool()
      /home/chris/code/cilium/cilium/pkg/ipam/node.go:634 +0x868
  github.com/cilium/cilium/pkg/ipam.(*Node).MaintainIPPool()
      /home/chris/code/cilium/cilium/pkg/ipam/node.go:678 +0xd0
  github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update.func2()
      /home/chris/code/cilium/cilium/pkg/ipam/node_manager.go:279 +0xab
  github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter()
      /home/chris/code/cilium/cilium/pkg/trigger/trigger.go:206 +0x4db

Previous write at 0x00c0005a09e8 by goroutine 40:
  github.com/cilium/cilium/pkg/aws/eni.(*Node).UpdatedNode()
      /home/chris/code/cilium/cilium/pkg/aws/eni/node.go:66 +0x85
  github.com/cilium/cilium/pkg/ipam.(*Node).UpdatedResource()
      /home/chris/code/cilium/cilium/pkg/ipam/node.go:325 +0x81
  github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update.func1()
      /home/chris/code/cilium/cilium/pkg/ipam/node_manager.go:263 +0x8e
  github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update()
      /home/chris/code/cilium/cilium/pkg/ipam/node_manager.go:321 +0x1e6
  github.com/cilium/cilium/pkg/aws/eni.(*ENISuite).TestNodeManagerDefaultAllocation.func2()
      /home/chris/code/cilium/cilium/pkg/aws/eni/node_manager_test.go:276 +0x6f

Goroutine 36 (running) created at:
  github.com/cilium/cilium/pkg/trigger.NewTrigger()
      /home/chris/code/cilium/cilium/pkg/trigger/trigger.go:129 +0x24e
  github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update()
      /home/chris/code/cilium/cilium/pkg/ipam/node_manager.go:274 +0x659
  github.com/cilium/cilium/pkg/aws/eni.(*ENISuite).TestNodeManagerDefaultAllocation()
      /home/chris/code/cilium/cilium/pkg/aws/eni/node_manager_test.go:262 +0xc15
  runtime.call32()
      /usr/lib/go/src/runtime/asm_amd64.s:540 +0x3d
  reflect.Value.Call()
      /usr/lib/go/src/reflect/value.go:336 +0xd8
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/chris/code/cilium/cilium/vendor/gopkg.in/check.v1/check.go:781 +0xabb
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/chris/code/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xe1

Goroutine 40 (running) created at:
  github.com/cilium/cilium/pkg/aws/eni.(*ENISuite).TestNodeManagerDefaultAllocation()
      /home/chris/code/cilium/cilium/pkg/aws/eni/node_manager_test.go:274 +0x10b2
  runtime.call32()
      /usr/lib/go/src/runtime/asm_amd64.s:540 +0x3d
  reflect.Value.Call()
      /usr/lib/go/src/reflect/value.go:336 +0xd8
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/chris/code/cilium/cilium/vendor/gopkg.in/check.v1/check.go:781 +0xabb
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/chris/code/cilium/cilium/vendor/gopkg.in/check.v1/check.go:675 +0xe1
```

Fixes: https://github.com/cilium/cilium/issues/13251

Validated fix by deploying connectivity check on EKS.

```release-note
Fix potential bug in ENI IPAM when multiple updates at the same time are performed to the a CiliumNode resource
```