### PR TITLE
v1.9 backports 2020-10-19

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -60,7 +60,9 @@ jobs:
             --set nodeinit.enabled=true \
             --set kubeProxyReplacement=strict \
             --set ipam.mode=kubernetes \
+            --set image.tag=latest \
             --set image.pullPolicy=Never \
+            --set operator.image.tag=latest \
             --set operator.image.pullPolicy=Never \
             --set ipv6.enabled=true \
             --set ipv4.enabled=false \

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -106,7 +106,9 @@ jobs:
              --set hostPort.enabled=true \
              --set bpf.masquerade=false \
              --set ipam.mode=kubernetes \
+             --set image.tag=latest \
              --set image.pullPolicy=Never \
+             --set operator.image.tag=latest \
              --set operator.image.pullPolicy=Never \
              --set prometheus.enabled=true \
              --set operator.prometheus.enabled=true \

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -264,33 +264,31 @@ sock4_wildcard_lookup_full(struct lb4_key *key __maybe_unused,
 	return svc;
 }
 
-/* Service translation logic for a local-redirect service can cause
- * packets to be looped back to a service node-local backend after translation.
- * This can happen when the node-local backend itself tries to connect to the
- * service frontend for which it acts as a backend.
- * There are cases where this can break traffic flow if the backend needs to
- * forward the redirected traffic to the actual service frontend.
- * Hence, allow service translation for pod traffic getting redirected to
- * backend (across network namespaces), but skip service translation for backend
- * to itself or another service backend within the same namespace.
+/* Service translation logic for a local-redirect service can cause packets to
+ * be looped back to a service node-local backend after translation. This can
+ * happen when the node-local backend itself tries to connect to the service
+ * frontend for which it acts as a backend. There are cases where this can break
+ * traffic flow if the backend needs to forward the redirected traffic to the
+ * actual service frontend. Hence, allow service translation for pod traffic
+ * getting redirected to backend (across network namespaces), but skip service
+ * translation for backend to itself or another service backend within the same
+ * namespace. Currently only v4, but neither v4-in-v6 nor plain v6 supported.
  *
  * For example, in EKS cluster, a local-redirect service exists with the AWS
  * metadata IP, port as the frontend <169.254.169.254, 80> and kiam proxy as a
- * backend pod. When traffic destined to the frontend originates from the kiam pod
- * in namespace ns1 (host ns when the kiam proxy pod is deployed in hostNetwork
- * mode or regular pod ns) and the pod is selected as a backend, the traffic
- * would get looped back to the proxy pod.
- * Identify such cases by doing a socket lookup for the backend <ip, port> in its
- * namespace, ns1, and skip service translation.
+ * backend Pod. When traffic destined to the frontend originates from the kiam
+ * Pod in namespace ns1 (host ns when the kiam proxy Pod is deployed in
+ * hostNetwork mode or regular Pod ns) and the Pod is selected as a backend, the
+ * traffic would get looped back to the proxy Pod. Identify such cases by doing
+ * a socket lookup for the backend <ip, port> in its namespace, ns1, and skip
+ * service translation.
  */
 #ifdef BPF_HAVE_SOCKET_LOOKUP
 static __always_inline __maybe_unused bool
-sock4_skip_xlate_for_same_netns_backend(struct bpf_sock_addr *ctx,
-					const struct lb4_backend *backend)
+sock4_skip_xlate_if_same_netns(struct bpf_sock_addr *ctx,
+			       const struct lb4_backend *backend)
 {
 	struct bpf_sock_tuple tuple = {
-		.ipv4.saddr = 0,
-		.ipv4.sport = 0,
 		.ipv4.daddr = backend->address,
 		.ipv4.dport = backend->port,
 	};
@@ -298,18 +296,17 @@ sock4_skip_xlate_for_same_netns_backend(struct bpf_sock_addr *ctx,
 
 	switch (ctx->protocol) {
 	case IPPROTO_TCP:
-		sk = sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+		sk = sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
+				   BPF_F_CURRENT_NETNS, 0);
 		break;
 	case IPPROTO_UDP:
-		sk = sk_lookup_udp(ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+		sk = sk_lookup_udp(ctx, &tuple, sizeof(tuple.ipv4),
+				   BPF_F_CURRENT_NETNS, 0);
 		break;
 	default:
 		break;
 	}
 
-	/* There exists a socket listening on the <ip, port> of the backend
-	 * in the same namespace where socket connect call originates from.
-	 */
 	if (sk) {
 		sk_release(sk);
 		return true;
@@ -317,12 +314,11 @@ sock4_skip_xlate_for_same_netns_backend(struct bpf_sock_addr *ctx,
 
 	return false;
 }
-#endif
+#endif /* BPF_HAVE_SOCKET_LOOKUP */
 
 static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 					     struct bpf_sock_addr *ctx_full,
-					     const bool udp_only,
-					     const bool ipv6_context  __maybe_unused)
+					     const bool udp_only)
 {
 	union lb4_affinity_client_id id;
 	const bool in_hostns = ctx_in_hostns(ctx_full, &id.client_cookie);
@@ -402,12 +398,10 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	}
 
 #ifdef BPF_HAVE_SOCKET_LOOKUP
-	if (lb4_svc_is_localredirect(svc) && !ipv6_context &&
-	    sock4_skip_xlate_for_same_netns_backend(ctx_full, backend)) {
+	if (lb4_svc_is_localredirect(svc) && ctx_full == ctx &&
+	    sock4_skip_xlate_if_same_netns(ctx_full, backend))
 		return 0;
-	}
 #endif
-
 	if (lb4_svc_is_affinity(svc) && !backend_from_affinity)
 		lb4_update_affinity_by_netns(svc, &id, backend_id);
 
@@ -426,7 +420,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 __section("connect4")
 int sock4_connect(struct bpf_sock_addr *ctx)
 {
-	__sock4_xlate_fwd(ctx, ctx, false, false);
+	__sock4_xlate_fwd(ctx, ctx, false);
 	return SYS_PROCEED;
 }
 
@@ -514,7 +508,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 __section("sendmsg4")
 int sock4_sendmsg(struct bpf_sock_addr *ctx)
 {
-	__sock4_xlate_fwd(ctx, ctx, true, false);
+	__sock4_xlate_fwd(ctx, ctx, true);
 	return SYS_PROCEED;
 }
 
@@ -697,7 +691,7 @@ int sock6_xlate_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused,
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
-	ret = __sock4_xlate_fwd(&fake_ctx, ctx, udp_only, true);
+	ret = __sock4_xlate_fwd(&fake_ctx, ctx, udp_only);
 	if (ret < 0)
 		return ret;
 

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -52,7 +52,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 	parseBackendEntry := func(key bpf.MapKey, value bpf.MapValue) {
 		id := key.(lbmap.BackendKey).GetID()
-		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue)
+		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue).ToHost()
 	}
 	if err := lbmap.Backend4Map.DumpWithCallbackIfExists(parseBackendEntry); err != nil {
 		Fatalf("Unable to dump IPv4 backends table: %s", err)
@@ -65,8 +65,9 @@ func dumpSVC(serviceList map[string][]string) {
 		var entry string
 
 		svcKey := key.(lbmap.ServiceKey)
-		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.ToNetwork().String()
+		svcVal := value.(lbmap.ServiceValue).ToHost()
+		svc := svcKey.String()
+		svcKey = svcKey.ToHost()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -66,7 +66,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 		svcKey := key.(lbmap.ServiceKey)
 		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.String()
+		svc := svcKey.ToNetwork().String()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -103,7 +103,10 @@ func (k *AffinityMatchKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k)
 func (v *AffinityMatchValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 // String converts the key into a human readable string format
-func (k *AffinityMatchKey) String() string { return fmt.Sprintf("%d %d", k.BackendID, k.RevNATID) }
+func (k *AffinityMatchKey) String() string {
+	kHost := k.ToHost()
+	return fmt.Sprintf("%d %d", kHost.BackendID, kHost.RevNATID)
+}
 
 // String converts the value into a human readable string format
 func (v *AffinityMatchValue) String() string { return "" }
@@ -119,6 +122,13 @@ func (k *AffinityMatchKey) ToNetwork() *AffinityMatchKey {
 	// the SVC BPF maps
 	n.RevNATID = byteorder.HostToNetwork(n.RevNATID).(uint16)
 	return &n
+}
+
+// ToHost returns the key in the host byte order
+func (k *AffinityMatchKey) ToHost() *AffinityMatchKey {
+	h := *k
+	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
+	return &h
 }
 
 // Affinity4Key is the Go representation of lb4_affinity_key

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -39,15 +39,8 @@ var (
 		int(unsafe.Sizeof(AffinityMatchValue{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			aKey, aVal := mapKey.(*AffinityMatchKey), mapValue.(*AffinityMatchValue)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, aKey, aVal); err != nil {
-				return nil, nil, err
-			}
-
-			return aKey.ToNetwork(), aVal, nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 	Affinity4Map = bpf.NewMap(
 		Affinity4MapName,
 		bpf.MapTypeLRUHash,

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -107,7 +107,7 @@ func NewRevNat4Key(value uint16) *RevNat4Key {
 func (k *RevNat4Key) Map() *bpf.Map             { return RevNat4Map }
 func (k *RevNat4Key) NewValue() bpf.MapValue    { return &RevNat4Value{} }
 func (k *RevNat4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
-func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.Key) }
+func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.ToHost().(*RevNat4Key).Key) }
 func (k *RevNat4Key) GetKey() uint16            { return k.Key }
 
 // ToNetwork converts RevNat4Key to network byte order.
@@ -115,6 +115,13 @@ func (k *RevNat4Key) ToNetwork() RevNatKey {
 	n := *k
 	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
 	return &n
+}
+
+// ToHost converts RevNat4Key to host byte order.
+func (k *RevNat4Key) ToHost() RevNatKey {
+	h := *k
+	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -133,8 +140,16 @@ func (v *RevNat4Value) ToNetwork() RevNatValue {
 	return &n
 }
 
+// ToHost converts RevNat4Value to host byte order.
+func (k *RevNat4Value) ToHost() RevNatValue {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 func (v *RevNat4Value) String() string {
-	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+	vHost := v.ToHost().(*RevNat4Value)
+	return net.JoinHostPort(vHost.Address.String(), fmt.Sprintf("%d", vHost.Port))
 }
 
 type pad2uint8 [2]uint8
@@ -204,6 +219,13 @@ func (k *Service4Key) ToNetwork() ServiceKey {
 	return &n
 }
 
+// ToHost converts Service4Key to host byte order.
+func (k *Service4Key) ToHost() ServiceKey {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 type pad3uint8 [3]uint8
 
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
@@ -225,7 +247,8 @@ type Service4Value struct {
 }
 
 func (s *Service4Value) String() string {
-	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", s.BackendID, s.RevNat, s.Flags)
+	sHost := s.ToHost().(*Service4Value)
+	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", sHost.BackendID, sHost.RevNat, sHost.Flags)
 }
 
 func (s *Service4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
@@ -261,6 +284,13 @@ func (s *Service4Value) ToNetwork() ServiceValue {
 	n := *s
 	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
 	return &n
+}
+
+// ToHost converts Service4Value to host byte order.
+func (s *Service4Value) ToHost() ServiceValue {
+	h := *s
+	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -306,7 +336,8 @@ func NewBackend4Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend4V
 }
 
 func (v *Backend4Value) String() string {
-	return fmt.Sprintf("%s://%s:%d", v.Proto, v.Address, v.Port)
+	vHost := v.ToHost().(*Backend4Value)
+	return fmt.Sprintf("%s://%s:%d", vHost.Proto, vHost.Address, vHost.Port)
 }
 
 func (v *Backend4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
@@ -318,6 +349,13 @@ func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToHost converts Backend4Value to host byte order.
+func (v *Backend4Value) ToHost() BackendValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 type Backend4 struct {

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -108,7 +108,7 @@ func NewRevNat6Key(value uint16) *RevNat6Key {
 func (v *RevNat6Key) Map() *bpf.Map             { return RevNat6Map }
 func (v *RevNat6Key) NewValue() bpf.MapValue    { return &RevNat6Value{} }
 func (v *RevNat6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(v) }
-func (v *RevNat6Key) String() string            { return fmt.Sprintf("%d", v.Key) }
+func (v *RevNat6Key) String() string            { return fmt.Sprintf("%d", v.ToHost().(*RevNat6Key).Key) }
 func (v *RevNat6Key) GetKey() uint16            { return v.Key }
 
 // ToNetwork converts RevNat6Key to network byte order.
@@ -116,6 +116,13 @@ func (v *RevNat6Key) ToNetwork() RevNatKey {
 	n := *v
 	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
 	return &n
+}
+
+// ToNetwork converts RevNat6Key to host byte order.
+func (v *RevNat6Key) ToHost() RevNatKey {
+	h := *v
+	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -128,7 +135,8 @@ type RevNat6Value struct {
 func (v *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 func (v *RevNat6Value) String() string {
-	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+	vHost := v.ToHost().(*RevNat6Value)
+	return net.JoinHostPort(vHost.Address.String(), fmt.Sprintf("%d", vHost.Port))
 }
 
 // ToNetwork converts RevNat6Value to network byte order.
@@ -136,6 +144,13 @@ func (v *RevNat6Value) ToNetwork() RevNatValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToNetwork converts RevNat6Value to Host byte order.
+func (v *RevNat6Value) ToHost() RevNatValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 // Service6Key must match 'struct lb6_key_v2' in "bpf/lib/common.h".
@@ -197,6 +212,13 @@ func (k *Service6Key) ToNetwork() ServiceKey {
 	return &n
 }
 
+// ToHost converts Service6Key to host byte order.
+func (k *Service6Key) ToHost() ServiceKey {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 // Service6Value must match 'struct lb6_service_v2' in "bpf/lib/common.h".
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
@@ -210,7 +232,8 @@ type Service6Value struct {
 }
 
 func (s *Service6Value) String() string {
-	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", s.BackendID, s.RevNat, s.Flags)
+	sHost := s.ToHost().(*Service6Value)
+	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", sHost.BackendID, sHost.RevNat, sHost.Flags)
 }
 
 func (s *Service6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
@@ -245,6 +268,13 @@ func (s *Service6Value) ToNetwork() ServiceValue {
 	n := *s
 	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
 	return &n
+}
+
+// ToHost converts Service6Value to host byte order.
+func (s *Service6Value) ToHost() ServiceValue {
+	h := *s
+	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -290,7 +320,8 @@ func NewBackend6Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend6V
 }
 
 func (v *Backend6Value) String() string {
-	return fmt.Sprintf("%s://[%s]:%d", v.Proto, v.Address, v.Port)
+	vHost := v.ToHost().(*Backend6Value)
+	return fmt.Sprintf("%s://[%s]:%d", vHost.Proto, vHost.Address, vHost.Port)
 }
 
 func (v *Backend6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
@@ -302,6 +333,13 @@ func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToHost converts Backend6Value to host byte order.
+func (v *Backend6Value) ToHost() BackendValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 type Backend6 struct {

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -274,7 +274,7 @@ func (*LBBPFMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
 	matches := BackendIDByServiceIDSet{}
 
 	parse := func(key bpf.MapKey, value bpf.MapValue) {
-		matchKey := key.DeepCopyMapKey().(*AffinityMatchKey)
+		matchKey := key.DeepCopyMapKey().(*AffinityMatchKey).ToHost()
 		svcID := matchKey.RevNATID
 		backendID := uint16(matchKey.BackendID) // currently backend_id is u16
 
@@ -295,7 +295,7 @@ func (*LBBPFMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
 func (*LBBPFMap) DumpSourceRanges(ipv6 bool) (SourceRangeSetByServiceID, error) {
 	ret := SourceRangeSetByServiceID{}
 	parser := func(key bpf.MapKey, value bpf.MapValue) {
-		k := key.(SourceRangeKey)
+		k := key.(SourceRangeKey).ToHost()
 		revNATID := k.GetRevNATID()
 		if _, found := ret[revNATID]; !found {
 			ret[revNATID] = []*cidr.CIDR{}
@@ -370,13 +370,13 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 
 	parseBackendEntries := func(key bpf.MapKey, value bpf.MapValue) {
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 
 	parseSVCEntries := func(key bpf.MapKey, value bpf.MapValue) {
-		svcKey := key.DeepCopyMapKey().(ServiceKey)
-		svcValue := value.DeepCopyMapValue().(ServiceValue)
+		svcKey := key.DeepCopyMapKey().(ServiceKey).ToHost()
+		svcValue := value.DeepCopyMapValue().(ServiceValue).ToHost()
 
 		fe := svcFrontend(svcKey, svcValue)
 
@@ -452,7 +452,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		// No need to deep copy the key because we are using the ID which
 		// is a value.
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -61,6 +61,9 @@ type ServiceKey interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() ServiceKey
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceKey
 }
 
 // ServiceValue is the interface describing protocol independent value for services map v2.
@@ -99,6 +102,9 @@ type ServiceValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() ServiceValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceValue
 }
 
 // BackendKey is the interface describing protocol independent backend key.
@@ -127,6 +133,9 @@ type BackendValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() BackendValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() BackendValue
 }
 
 // Backend is the interface describing protocol independent backend used by services v2.
@@ -152,6 +161,9 @@ type RevNatKey interface {
 
 	// Returns the key value
 	GetKey() uint16
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatKey
 }
 
 type RevNatValue interface {
@@ -159,6 +171,9 @@ type RevNatValue interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() RevNatValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatValue
 }
 
 // BackendIDByServiceIDSet is the type of a set for checking whether a backend


### PR DESCRIPTION
 * #13613 -- bpf: simplify local redirect a bit for sock lb (@borkmann)
 * #13244 -- lbmap: Correct issue that port info display error (@Jianlin-lv)
 * #13664 -- smoketest: Add image tag as latest for cilium agent and operator (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13613 13244 13664; do contrib/backporting/set-labels.py $pr done 1.9; done
```
