### PR TITLE
v1.8 backports 2020-10-19

### DIFF
--- a/Documentation/operations/performance/index.rst
+++ b/Documentation/operations/performance/index.rst
@@ -49,8 +49,8 @@ Download the Cilium performance evaluation scripts:
 
 .. code-block:: shell-session
 
-  $ git clone https://github.com/cilium/perfeval.git
-  $ cd perfeval
+  $ git clone https://github.com/cilium/cilium-perf-networking.git
+  $ cd cilium-perf-networking
 
 Packet Servers
 --------------
@@ -60,8 +60,7 @@ the Packet machines to use a `"Mixed/Hybrid"
 <https://www.packet.com/developers/docs/network/advanced/layer-2/>`_ network
 mode, where the secondary interfaces of the machines share a flat L2 network.
 While this can be done on the Packet web UI, we include appropriate Terraform
-files to automate this process.
-
+(version 0.13) files to automate this process.
 
 .. code-block:: shell-session
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -243,9 +243,16 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			directions = append(directions, dirEgress)
 			objPaths = append(objPaths, netdevObjPath)
 		} else {
-			// Remove any previously attached device from egress path if BPF
-			// NodePort is disabled.
-			l.DeleteDatapath(ctx, device, dirEgress)
+			hasDatapath, err := l.HasDatapath(ctx, device, dirEgress)
+			if err != nil {
+				log.WithField("device", device).Error(err)
+			}
+			if hasDatapath || err != nil {
+				// Remove any previously attached device from egress path if BPF
+				// NodePort and host firewall are disabled.
+				err := l.DeleteDatapath(ctx, device, dirEgress)
+				log.WithField("device", device).Error(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
 * #13596 -- docs/performance: update scripts repo and tf version (@kkourt)
 * #13591 -- loader: Check if device has BPF prog before trying to detach it (@pchaigno)

Skipped due to conflicts:
 * #13383 -- daemon: Enable configuration of iptables --random-fully (@kh34)
 * #13244 -- lbmap: Correct issue that port info display error (@Jianlin-lv)

EDIT: I removed the following PR as it was found (thanks @aanm) that it introduces a regression that leads to a deadlock situation when some endpoints are being deleted on restore. cc @christarazi 

 * #13608 -- daemon: Init endpoint queue during validation (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13596 13591; do contrib/backporting/set-labels.py $pr done 1.8; done
```