### PR TITLE
contrib: match commit subject exactly when searching for upstream commit

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -152,7 +152,7 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
+    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "^$entry_sub" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then


### PR DESCRIPTION
In `generate_commit_list_for_pr`, the commit subject is used to determine
the upstream commit ID from `$REMOTE/master`. However, if in the meantime
another commit with e.g. a `Fixes` tag that mentions this commit subject,
it appears first and leads to the original commit not being found. This
can be demonstrated using #13383:

```
 * PR: 13383 -- daemon: Enable configuration of iptables --random-fully (@kh34) -- https://github.com/cilium/cilium/pull/13383
   Merge with 2 commit(s) merged at: Wed, 14 Oct 2020 11:41:51 +0200!
     Branch:     master (!)                          refs/pull/13383/head
                 ----------                          -------------------
     v (start)
     |  Warning: No commit correlation found!    via dbac86cffc6d57e8c093d2821e0d794f4c13d284 ("daemon: Enable configuration of iptables --random-fully")
     |  350f0b36fd9b4cf23ebc11f4365c5c89591d0ff4 via 22d4554e963e2d8029ff95087ac03e55e90a7377 ("test: Test iptables masquerading with --random-fully")
     v (end)

$ # this is the git log command (with the subject added) from
$ # contrib/backporting/check-stable that should extract a single
$ # upstream commit
$ git log -F --since="1year" --pretty="%H %s" --no-merges --grep "daemon: Enable configuration of iptables --random-fully" origin/master
078ec543d36a8f5d6caed5c4649c74c72090ae20 install/kubernetes: consistent case spelling of iptables related values
4e39def13bca568a21087238877fbc60f8751567 daemon: Enable configuration of iptables --random-fully
$ git show 078ec543d36a8f5d6caed5c4649c74c72090ae20
commit 078ec543d36a8f5d6caed5c4649c74c72090ae20
Author: Tobias Klauser <tklauser@distanz.ch>
Date:   Wed Oct 14 11:58:29 2020 +0200

    install/kubernetes: consistent case spelling of iptables related values

    Make the case spelling of the newly introduced "ipTablesRandomFully"
    value consistent with other iptables option values which use the
    "iptables" spelling.

    Fixes: 4e39def13bca ("daemon: Enable configuration of iptables --random-fully")
    Signed-off-by: Tobias Klauser <tklauser@distanz.ch>
```

Note the `Fixes: ...` line in commit 078ec543d36a8f5d6caed5c4649c74c72090ae20 above.

Fix this behavior by grepping for the subject line from start of line:

```
$ git log -F --since="1year" --pretty="%H %s" --no-merges --extended-regexp --grep "^daemon: Enable configuration of iptables --random-fully" origin/master
4e39def13bca568a21087238877fbc60f8751567 daemon: Enable configuration of iptables --random-fully

 * PR: 13383 -- daemon: Enable configuration of iptables --random-fully (@kh34) -- https://github.com/cilium/cilium/pull/13383
   Merge with 2 commit(s) merged at: Wed, 14 Oct 2020 11:41:51 +0200!
     Branch:     master (!)                          refs/pull/13383/head
                 ----------                          -------------------
     v (start)
     |  4e39def13bca568a21087238877fbc60f8751567 via dbac86cffc6d57e8c093d2821e0d794f4c13d284 ("daemon: Enable configuration of iptables --random-fully")
     |  350f0b36fd9b4cf23ebc11f4365c5c89591d0ff4 via 22d4554e963e2d8029ff95087ac03e55e90a7377 ("test: Test iptables masquerading with --random-fully")
     v (end)
```

Reported-by: Robin Hahling <robin.hahling@gw-computing.net>