### PR TITLE
v1.7 backports 2020-10-19

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -152,7 +152,7 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
+    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "^$entry_sub" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then


### PR DESCRIPTION
v1.7 backports 2020-10-19

 * #13630 -- contrib: match commit subject exactly when searching for upstream commit (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ contrib/backporting/set-labels.py 13630 done 1.7
```
