### PR TITLE
docs: Document some caveats of kube-proxy replacement

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -442,6 +442,10 @@ advised to first check whether the NodePort request actually arrived on the node
 containing the backend. If this was not the case, then switching back to the default
 SNAT mode would be advised as a workaround.
 
+Also, in some public cloud provider environments, which implement a source /
+destination IP address checking (e.g. AWS), the checking has to be disabled in
+order for the DSR mode to work.
+
 Above helm example configuration in a kube-proxy-free environment with DSR-only mode
 enabled would look as follows:
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1183,6 +1183,9 @@ Limitations
       resources to corresponding ``EndpointSlices`` and thus allowing backing ``Endpoints``
       to work. For a more detailed discussion see
       `#12438 <https://github.com/cilium/cilium/issues/12438>`__.
+    * As per `k8s Service <https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types>`__,
+      Cilium's eBPF kube-proxy replacement disallow access of a ClusterIP service
+      from outside a cluster.
 
 Further Readings
 ################


### PR DESCRIPTION
The documented caveats could have saved a few hours of debugging (https://github.com/cilium/cilium/issues/13600 and some other users on slack).

Reviewable per commit. 