### PR TITLE
docker: update Hubble CLI to v0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 #
 # Hubble CLI
 #
-FROM quay.io/cilium/hubble:master-186fa10@sha256:ea39cadaeffdeff1eaaef31a80f2f2e4120e006a0411ba3142f903bc6654fe41 as hubble
+FROM quay.io/cilium/hubble:v0.7.0@sha256:6a0df10f9131c6f450b389419e78525701ed77d2ae8220fee901062ef5500ed6 as hubble
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-cni/cni-unin
 COPY --from=builder /go/src/github.com/cilium/cilium/contrib/packaging/docker/init-container.sh /init-container.sh
 WORKDIR /home/cilium
 RUN groupadd -f cilium \
+    && /usr/bin/hubble completion bash > /etc/bash_completion.d/hubble \
     && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 
 ENV INITSYSTEM="SYSTEMD"


### PR DESCRIPTION
Update the Hubble CLI binary found in the Cilium agent to v0.7.0 that was [released yesterday](https://github.com/cilium/hubble/releases/tag/v0.7.0) and has full support for Cilium/Hubble 1.9. In addition, install bash completion for Hubble for a better user experience.