### PR TITLE
docs: GKE - fix some indentation, specify bash code segments

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -17,18 +17,18 @@ GKE Requirements
 
 2. Create a project or use an existing one
 
-::
+.. code:: bash
 
-   export GKE_PROJECT=gke-clusters
-   gcloud projects create $GKE_PROJECT
-   gcloud config set project $GKE_PROJECT
+    export GKE_PROJECT=gke-clusters
+    gcloud projects create $GKE_PROJECT
+    gcloud config set project $GKE_PROJECT
 
 
 3. Enable the GKE API for the project if not already done
 
-::
+.. code:: bash
 
-   gcloud services enable container.googleapis.com
+    gcloud services enable container.googleapis.com
 
 Create a GKE Cluster
 ====================


### PR DESCRIPTION
For https://github.com/cilium/cilium/issues/13627.

Does what it says on the tin. The content of the GKE getting-started guide itself is still 100% correct as far as I can tell.

There's still some weird indentation going on in the connectivity test block, but looks like that's caused by the use of `only`, which requires the subsequent `parsed-literal` block to be indented. Haven't found a way to unindent the rendered text, but that's super minor.