### PR TITLE
k8s Don't treat empty pod IPs as error condition

### DIFF
--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -15,7 +15,6 @@
 package utils
 
 import (
-	"fmt"
 	"sort"
 
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
@@ -121,9 +120,9 @@ func GetLatestPodReadiness(podStatus slim_corev1.PodStatus) slim_corev1.Conditio
 
 // ValidIPs return a sorted slice of unique IP addresses retrieved from the given PodStatus.
 // Returns an error when no IPs are found.
-func ValidIPs(podStatus slim_corev1.PodStatus) ([]string, error) {
+func ValidIPs(podStatus slim_corev1.PodStatus) []string {
 	if len(podStatus.PodIPs) == 0 && len(podStatus.PodIP) == 0 {
-		return nil, fmt.Errorf("empty PodIPs")
+		return nil
 	}
 
 	// make it a set first to avoid repeated IP addresses
@@ -142,7 +141,7 @@ func ValidIPs(podStatus slim_corev1.PodStatus) ([]string, error) {
 		ips = append(ips, ipStr)
 	}
 	sort.Strings(ips)
-	return ips, nil
+	return ips
 }
 
 // IsPodRunning returns true if the pod is considered to be in running state.

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -204,9 +204,10 @@ func (k *K8sWatcher) addK8sPodV1(pod *slim_corev1.Pod) error {
 	}
 
 	skipped := false
-	podIPs, err := k8sUtils.ValidIPs(pod.Status)
+	var err error
+	podIPs := k8sUtils.ValidIPs(pod.Status)
 
-	if err == nil {
+	if len(podIPs) > 0 {
 		skipped, err = k.updatePodHostData(pod, podIPs)
 
 		// There might be duplicate callbacks here since this function is also
@@ -716,9 +717,9 @@ func (k *K8sWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 		return true, fmt.Errorf("pod is using host networking")
 	}
 
-	podIPs, err := k8sUtils.ValidIPs(pod.Status)
-	if err != nil {
-		return true, err
+	podIPs := k8sUtils.ValidIPs(pod.Status)
+	if len(podIPs) == 0 {
+		return true, nil
 	}
 
 	k.DeleteHostPortMapping(pod, podIPs)

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -255,11 +255,12 @@ func (rpm *Manager) OnUpdatePodLocked(pod *slimcorev1.Pod, removeOld bool, upser
 		return
 	}
 
-	podIPs, err := k8sUtils.ValidIPs(pod.Status)
-	if err != nil {
+	podIPs := k8sUtils.ValidIPs(pod.Status)
+	if len(podIPs) == 0 {
 		return
 	}
 	var podData *podMetadata
+	var err error
 	if podData, err = rpm.getPodMetadata(pod, podIPs); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			logfields.K8sPodName:   pod.Name,
@@ -516,6 +517,7 @@ func (rpm *Manager) getLocalPodsForPolicy(config *LRPConfig) []*podMetadata {
 	var (
 		retPods []*podMetadata
 		podData *podMetadata
+		err     error
 	)
 
 	podStore := rpm.storeGetter.GetStore("pod")
@@ -524,8 +526,8 @@ func (rpm *Manager) getLocalPodsForPolicy(config *LRPConfig) []*podMetadata {
 		if !ok || !config.checkNamespace(pod.GetNamespace()) {
 			continue
 		}
-		podIPs, err := k8sUtils.ValidIPs(pod.Status)
-		if err != nil {
+		podIPs := k8sUtils.ValidIPs(pod.Status)
+		if len(podIPs) == 0 {
 			continue
 		}
 		if podData, err = rpm.getPodMetadata(pod, podIPs); err != nil {

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -323,7 +323,7 @@ func (m *ManagerSuite) TestManager_AddRedirectPolicy_SvcMatcherDuplicateConfig(c
 func (m *ManagerSuite) TestManager_AddrMatcherConfigSinglePort(c *C) {
 	// Add an addressMatcher type LRP with single port. The policy config
 	// frontend should have 2 pod backends with each of the podIPs.
-	podIPs, _ := utils.ValidIPs(pod1.Status)
+	podIPs := utils.ValidIPs(pod1.Status)
 	expectedbes := make([]backend, len(podIPs))
 	for i := range podIPs {
 		expectedbes[i] = backend{
@@ -356,7 +356,7 @@ func (m *ManagerSuite) TestManager_AddrMatcherConfigSinglePort(c *C) {
 	pod3 := pod2.DeepCopy()
 	pod3.Labels["test"] = "foo"
 	pod3ID := pod2ID
-	podIPs, _ = utils.ValidIPs(pod3.Status)
+	podIPs = utils.ValidIPs(pod3.Status)
 	expectedbes2 := make([]backend, 0, len(expectedbes)+len(podIPs))
 	expectedbes2 = append(expectedbes2, expectedbes...)
 	for i := range podIPs {
@@ -435,7 +435,7 @@ func (m *ManagerSuite) TestManager_AddrMatcherConfigMultiplePorts(c *C) {
 	configAddrType.backendPortsByPortName = map[string]*bePortInfo{
 		beP1.name: &configAddrType.backendPorts[0],
 		beP2.name: &configAddrType.backendPorts[1]}
-	podIPs, _ := utils.ValidIPs(pod1.Status)
+	podIPs := utils.ValidIPs(pod1.Status)
 	expectedbes := make([]backend, 0, len(podIPs))
 	for i := range podIPs {
 		expectedbes = append(expectedbes, backend{
@@ -505,7 +505,7 @@ func (m *ManagerSuite) TestManager_AddrMatcherConfigDualStack(c *C) {
 	// Only ipv4 backend(s) for ipv4 frontend
 	pod3 := pod1.DeepCopy()
 	pod3ID := pod1ID
-	podIPs, _ := utils.ValidIPs(pod3.Status)
+	podIPs := utils.ValidIPs(pod3.Status)
 	expectedbes4 := make([]backend, 0, len(podIPs))
 	for i := range podIPs {
 		expectedbes4 = append(expectedbes4, backend{


### PR DESCRIPTION
Fix the original behavior where empty pod IPs during pod watcher callbacks were treated as error conditions.

Fixes: #13631