### PR TITLE
v1.7 backport 2020-10-20

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -724,6 +724,7 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 
 		AfterFailed(func() {
 			vm.ReportFailed("cilium policy get")
+			vm.ReportFailed("cilium bpf policy get --all")
 		})
 
 		It("Conntrack-related configuration options for endpoints", func() {


### PR DESCRIPTION
v1.7 backports 2020-10-20

 * #13295 -- test: Debug RuntimeConntrackInVethModeTest flake (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13295 ; do contrib/backporting/set-labels.py $pr done 1.7; done
```
