### PR TITLE
v1.8 backport 2020-10-20

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1037,6 +1037,9 @@ Limitations
       resources to corresponding ``EndpointSlices`` and thus allowing backing ``Endpoints``
       to work. For a more detailed discussion see
       `#12438 <https://github.com/cilium/cilium/issues/12438>`__.
+    * As per `k8s Service <https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types>`__,
+      Cilium's eBPF kube-proxy replacement disallow access of a ClusterIP service
+      from outside a cluster.
 
 Further Readings
 ################

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -327,6 +327,10 @@ advised to first check whether the NodePort request actually arrived on the node
 containing the backend. If this was not the case, then switching back to the default
 SNAT mode would be advised as a workaround.
 
+Also, in some public cloud provider environments, which implement a source /
+destination IP address checking (e.g. AWS), the checking has to be disabled in
+order for the DSR mode to work.
+
 Above helm example configuration in a kube-proxy-free environment with DSR-only mode
 enabled would look as follows:
 

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -78,6 +78,10 @@ type mockCIDRAllocator struct {
 	OnInRange      func(cidr *net.IPNet) bool
 }
 
+func (d *mockCIDRAllocator) String() string {
+	return "clusterCIDR: 10.0.0.0/24, nodeMask: 24"
+}
+
 func (d *mockCIDRAllocator) Occupy(cidr *net.IPNet) error {
 	if d.OnOccupy != nil {
 		return d.OnOccupy(cidr)

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -386,6 +386,7 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 
 		AfterFailed(func() {
 			vm.ReportFailed("cilium policy get")
+			vm.ReportFailed("cilium bpf policy get --all")
 		})
 
 		It("Conntrack-related configuration options for endpoints", func() {


### PR DESCRIPTION
v1.8 backports 2020-10-20

 * #13299 -- Add log when allocate nodecidr failure (@konghui)
 * #13295 -- test: Debug RuntimeConntrackInVethModeTest flake (@pchaigno)
 * #13640 -- docs: Document some caveats of kube-proxy replacement (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13299 13295 13640; do contrib/backporting/set-labels.py $pr done 1.8; done
```
