### PR TITLE
cleanup/metrics: Remove deprecated metrics in 1.9

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -127,15 +127,13 @@ jobs:
 
       - name: Check prometheus metrics
         if: ${{ success() }}
-        env:
-          DEPRECATED_METRICS: cilium_bpf_map_ops_total|cilium_endpoint_count|cilium_identity_count|cilium_endpoint_regenerations|cilium_k8s_client_api_calls_counter|cilium_nodes_all_events_received_total|cilium_policy_count|cilium_policy_import_errors
         run: |
           cd $HOME
           cilium_pod=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].metadata.name}' )
           kubectl -n kube-system exec $cilium_pod -- sh -c "apt update && apt install curl -y"
           kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9090/metrics > metrics.prom
           go get -u github.com/prometheus/prometheus/cmd/promtool
-          egrep -v "${{ env.DEPRECATED_METRICS }}" metrics.prom | $HOME/go/bin/promtool check metrics
+          cat metrics.prom | $HOME/go/bin/promtool check metrics
 
       - name: Capture cilium-sysdump
         if: ${{ failure() }}

--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -193,8 +193,6 @@ Endpoint
 Name                                         Labels                                             Description
 ============================================ ================================================== ========================================================
 ``endpoint``                                                                                    Number of endpoints managed by this agent
-``endpoint_count``                                                                              Number of endpoints managed by this agent (deprecated,  use ``endpoint``)
-``endpoint_regenerations``                   ``outcome``                                        Count of all endpoint regenerations that have completed (deprecated,  use ``endpoint_regenerations_total``)
 ``endpoint_regenerations_total``             ``outcome``                                        Count of all endpoint regenerations that have completed
 ``endpoint_regeneration_time_stats_seconds`` ``scope``                                          Endpoint regeneration time stats
 ``endpoint_state``                           ``state``                                          Count of all endpoints
@@ -262,7 +260,6 @@ Name                                       Labels                               
 ``policy_regeneration_total``                                                                 Total number of policies regenerated successfully
 ``policy_regeneration_time_stats_seconds`` ``scope``                                          Policy regeneration time stats labeled by the scope
 ``policy_max_revision``                                                                       Highest policy revision number in the agent
-``policy_import_errors``                                                                      Number of times a policy import has failed (deprecated, use ``policy_import_errors_total``)
 ``policy_import_errors_total``                                                                Number of times a policy import has failed
 ``policy_endpoint_enforcement_status``                                                        Number of endpoints labeled by policy enforcement status
 ========================================== ================================================== ========================================================
@@ -285,7 +282,6 @@ Identity
 Name                                     Labels                                             Description
 ======================================== ================================================== ========================================================
 ``identity``                                                                                Number of identities currently allocated
-``identity_count``                                                                          Number of identities currently allocated (deprecated, use ``identity``)
 ======================================== ================================================== ========================================================
 
 Events external to Cilium
@@ -408,12 +404,12 @@ IPAM
 Name                                     Labels                                                            Description
 ======================================== ================================================================= ========================================================
 ``ipam_ips``                             ``type``                                                          Number of IPs allocated
-``ipam_allocation_ops``                  ``subnetId`` (deprecated), ``subnet_id``                          Number of IP allocation operations. ``subnetId`` is deprecated and will be removed in 1.10. Use ``subnet_id`` instead.
-``ipam_interface_creation_ops``          ``subnetId`` (deprecated), ``subnet_id``, ``status``              Number of interfaces creation operations. ``subnetId`` is deprecated and will be removed in 1.10. Use ``subnet_id`` instead.
+``ipam_allocation_ops``                  ``subnet_id``                                                     Number of IP allocation operations.
+``ipam_interface_creation_ops``          ``subnet_id``, ``status``                                         Number of interfaces creation operations.
 ``ipam_available``                                                                                         Number of interfaces with addresses available
 ``ipam_nodes_at_capacity``                                                                                 Number of nodes unable to allocate more addresses
 ``ipam_resync_total``                                                                                      Number of synchronization operations with external IPAM API
-``ipam_api_duration_seconds``            ``operation``, ``responseCode`` (deprecated), ``response_code``   Duration of interactions with external IPAM API. ``responseCode`` is deprecated and will be removed in 1.10. Use ``response_code`` instead.
+``ipam_api_duration_seconds``            ``operation``, ``response_code``                                  Duration of interactions with external IPAM API.
 ``ipam_api_rate_limit_duration_seconds`` ``operation``                                                     Duration of rate limiting while accessing external IPAM API
 ======================================== ================================================================= ========================================================
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -327,6 +327,29 @@ Annotations:
 
 .. _current_release_required_changes:
 
+.. _1.10_upgrade_notes:
+
+1.10 Upgrade Notes
+------------------
+
+Removed Metrics/Labels
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following metrics have been removed:
+
+* ``cilium_endpoint_regenerations`` is removed. Please use ``cilium_endpoint_regenerations_total`` instead.
+* ``cilium_k8s_client_api_calls_counter`` is removed. Please use ``cilium_k8s_client_api_calls_total`` instead.
+* ``cilium_identity_count`` is removed. Please use ``cilium_identity`` instead.
+* ``cilium_policy_count`` is removed. Please use ``cilium_policy`` instead.
+* ``cilium_policy_import_errors`` removed. Please use ``cilium_policy_import_errors_total`` instead.
+* Label ``mapName`` in ``cilium_bpf_map_ops_total`` is removed. Please use label ``map_name`` instead.
+* Label ``eventType`` in ``cilium_nodes_all_events_received_total`` removed. Please use label ``event_type`` instead.
+* Label ``responseCode`` in ``*api_duration_seconds`` removed. Please use label ``response_code`` instead.
+* Label ``subnetId`` in ``cilium_operator_ipam_allocation_ops`` is removed. Please use label ``subnet_id`` instead.
+* Label ``subnetId`` in ``cilium_operator_ipam_release_ops`` is removed. Please use label ``subnet_id`` instead.
+* Label ``subnetId`` and ``availabilityZone`` in ``cilium_operator_ipam_available_ips_per_subnet`` are removed. Please
+  use label ``subnet_id`` and ``availability_zone`` instead.
+
 .. _1.9_upgrade_notes:
 
 1.9 Upgrade Notes

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -310,13 +310,11 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 
 	identity.IterateReservedIdentities(func(_ string, _ identity.NumericIdentity) {
 		metrics.Identity.Inc()
-		metrics.IdentityCount.Inc()
 	})
 	if option.Config.EnableWellKnownIdentities {
 		// Must be done before calling policy.NewPolicyRepository() below.
 		num := identity.InitWellKnownIdentities(option.Config)
 		metrics.Identity.Add(float64(num))
-		metrics.IdentityCount.Add(float64(num))
 	}
 
 	nd := nodediscovery.NewNodeDiscovery(nodeMngr, mtuConfig, netConf)

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -270,7 +270,6 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 
 	newPrefixLengths, err := d.prefixLengths.Add(prefixes)
 	if err != nil {
-		metrics.PolicyImportErrors.Inc()
 		metrics.PolicyImportErrorsTotal.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to reference-count prefix lengths in CIDR policy")
@@ -285,7 +284,6 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		logger.Debug("CIDR policy has changed; recompiling base programs")
 		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			_ = d.prefixLengths.Delete(prefixes)
-			metrics.PolicyImportErrors.Inc()
 			metrics.PolicyImportErrorsTotal.Inc()
 			err2 := fmt.Errorf("Unable to recompile base programs: %s", err)
 			logger.WithError(err2).WithField("prefixes", prefixes).Warn(
@@ -300,7 +298,6 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 
 	if _, err := ipcache.AllocateCIDRs(prefixes); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
-		metrics.PolicyImportErrors.Inc()
 		metrics.PolicyImportErrorsTotal.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to allocate identities for CIDRs during policy add")

--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -38,7 +38,7 @@ func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Regi
 		Subsystem: subsystem,
 		Name:      "api_duration_seconds",
 		Help:      "Duration of interactions with API",
-	}, []string{"operation", "responseCode", "response_code"}) //TODO(sayboras): Remove deprecated tag responseCode in 1.10
+	}, []string{"operation", "response_code"})
 
 	m.RateLimit = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
@@ -56,8 +56,7 @@ func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Regi
 // ObserveAPICall must be called on every API call made with the operation
 // performed, the status code received and the duration of the call
 func (p *PrometheusMetrics) ObserveAPICall(operation, status string, duration float64) {
-	//TODO(sayboras): Remove deprecated tag responseCode in 1.10
-	p.ApiDuration.WithLabelValues(operation, status, status).Observe(duration)
+	p.ApiDuration.WithLabelValues(operation, status).Observe(duration)
 }
 
 // ObserveRateLimit must be called in case an API call was subject to rate limiting

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -861,8 +861,7 @@ func (m *Map) Update(key MapKey, value MapValue) error {
 
 	err = UpdateElement(m.fd, key.GetKeyPtr(), value.GetValuePtr(), 0)
 	if option.Config.MetricsConfig.BPFMapOps {
-		//TODO(sayboras): Remove deprecated label in 1.10
-		metrics.BPFMapOps.WithLabelValues(m.commonName(), m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
 	}
 	return err
 }
@@ -910,8 +909,7 @@ func (m *Map) Delete(key MapKey) error {
 
 	_, errno := deleteElement(m.fd, key.GetKeyPtr())
 	if option.Config.MetricsConfig.BPFMapOps {
-		//TODO(sayboras): Remove deprecated label in 1.10
-		metrics.BPFMapOps.WithLabelValues(m.commonName(), m.commonName(), metricOpDelete, metrics.Errno2Outcome(errno)).Inc()
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Errno2Outcome(errno)).Inc()
 	}
 	if errno != 0 {
 		err = fmt.Errorf("unable to delete element %s from map %s: %w", key, m.name, errno)

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -73,12 +73,10 @@ func (s *regenerationStatistics) SendMetrics() {
 
 	if !s.success {
 		// Endpoint regeneration failed, increase on failed metrics
-		metrics.EndpointRegenerationCount.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
 		metrics.EndpointRegenerationTotal.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
 		return
 	}
 
-	metrics.EndpointRegenerationCount.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
 	metrics.EndpointRegenerationTotal.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
 
 	sendMetrics(s, metrics.EndpointRegenerationTimeStats)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -156,16 +156,6 @@ func (mgr *EndpointManager) InitMetrics() {
 		// would result in negative counts.
 		// It must be thread-safe.
 
-		//TODO(sayboras): Remove deprecated metric in 1.10
-		metrics.EndpointCount = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: metrics.Namespace,
-			Name:      "endpoint_count",
-			Help:      "Number of endpoints managed by this agent (deprecated, use endpoint instead)",
-		},
-			func() float64 { return float64(len(mgr.GetEndpoints())) },
-		)
-		metrics.MustRegister(metrics.EndpointCount)
-
 		metrics.Endpoint = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Name:      "endpoint",

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -309,7 +309,6 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 		if err == nil {
 			if allocated || isNewLocally {
 				metrics.Identity.Inc()
-				metrics.IdentityCount.Inc()
 			}
 
 			if allocated && notifyOwner {
@@ -379,7 +378,6 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 	defer func() {
 		if released {
 			metrics.Identity.Dec()
-			metrics.IdentityCount.Dec()
 		}
 	}()
 

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -58,21 +58,21 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 		Subsystem: ipamSubsystem,
 		Name:      "allocation_ops",
 		Help:      "Number of IP allocation operations",
-	}, []string{"subnetId", "subnet_id"}) //TODO(sayboras): Remove deprecated tag subnetId in 1.10
+	}, []string{"subnet_id"})
 
 	m.ReleaseIpOps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
 		Name:      "release_ops",
 		Help:      "Number of IP release operations",
-	}, []string{"subnetId", "subnet_id"}) //TODO(sayboras): Remove deprecated tag subnetId in 1.10
+	}, []string{"subnet_id"})
 
 	m.AllocateInterfaceOps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
 		Name:      "interface_creation_ops",
 		Help:      "Number of interfaces allocated",
-	}, []string{"subnetId", "subnet_id", "status"}) //TODO(sayboras): Remove deprecated tag subnetId in 1.10
+	}, []string{"subnet_id", "status"})
 
 	m.AvailableInterfaces = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -86,9 +86,7 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 		Subsystem: ipamSubsystem,
 		Name:      "available_ips_per_subnet",
 		Help:      "Number of available IPs per subnet ID",
-	},
-		//TODO(sayboras): Remove deprecated tag subnetId, availabilityZone in 1.10
-		[]string{"subnetId", "subnet_id", "availabilityZone", "availability_zone"})
+	}, []string{"subnet_id", "availability_zone"})
 
 	m.Nodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -138,18 +136,15 @@ func (p *prometheusMetrics) ResyncTrigger() trigger.MetricsObserver {
 }
 
 func (p *prometheusMetrics) IncAllocationAttempt(status, subnetID string) {
-	// TODO(sayboras): Remove deprecated tag subnetID in 1.10
-	p.AllocateInterfaceOps.WithLabelValues(subnetID, subnetID, status).Inc()
+	p.AllocateInterfaceOps.WithLabelValues(subnetID, status).Inc()
 }
 
 func (p *prometheusMetrics) AddIPAllocation(subnetID string, allocated int64) {
-	// TODO(sayboras): Remove deprecated tag subnetID in 1.10
-	p.AllocateIpOps.WithLabelValues(subnetID, subnetID).Add(float64(allocated))
+	p.AllocateIpOps.WithLabelValues(subnetID).Add(float64(allocated))
 }
 
 func (p *prometheusMetrics) AddIPRelease(subnetID string, released int64) {
-	// TODO(sayboras): Remove deprecated tag subnetID in 1.10
-	p.ReleaseIpOps.WithLabelValues(subnetID, subnetID).Add(float64(released))
+	p.ReleaseIpOps.WithLabelValues(subnetID).Add(float64(released))
 }
 
 func (p *prometheusMetrics) SetAllocatedIPs(typ string, allocated int) {
@@ -161,8 +156,7 @@ func (p *prometheusMetrics) SetAvailableInterfaces(available int) {
 }
 
 func (p *prometheusMetrics) SetAvailableIPsPerSubnet(subnetID string, availabilityZone string, available int) {
-	// TODO(sayboras): Remove deprecated tag subnetID and availabilityZone in 1.10
-	p.AvailableIPsPerSubnet.WithLabelValues(subnetID, subnetID, availabilityZone, availabilityZone).Set(float64(available))
+	p.AvailableIPsPerSubnet.WithLabelValues(subnetID, availabilityZone).Set(float64(available))
 }
 
 func (p *prometheusMetrics) SetNodes(label string, nodes int) {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -220,7 +220,6 @@ func (*k8sMetrics) Observe(verb string, u url.URL, latency time.Duration) {
 }
 
 func (*k8sMetrics) Increment(code string, method string, host string) {
-	metrics.KubernetesAPICalls.WithLabelValues(host, method, code).Inc() //TODO(sayboras): Remove deprecated metric in 1.10
 	metrics.KubernetesAPICallsTotal.WithLabelValues(host, method, code).Inc()
 	// The 'code' is set to '<error>' in case an error is returned from k8s
 	// more info:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -168,11 +168,6 @@ const (
 	// LabelOperation is the label for BPF maps operations
 	LabelOperation = "operation"
 
-	// TODO(sayboras): Remove deprecated metric in 1.10
-	// LabelMapNameDeprecated is the label for the BPF map name
-	// Deprecated: in favor of LabelMapName
-	LabelMapNameDeprecated = "mapName"
-
 	// LabelMapName is the label for the BPF map name
 	LabelMapName = "map_name"
 
@@ -193,18 +188,6 @@ var (
 	// It must be thread-safe.
 	Endpoint prometheus.GaugeFunc
 
-	// TODO(sayboras): Remove deprecated metric in 1.10
-	// EndpointCount is a function used to collect this metric.
-	// It must be thread-safe.
-	// Deprecated: in favor of Endpoint
-	EndpointCount prometheus.GaugeFunc
-
-	// TODO(sayboras): Remove deprecated metric in 1.10
-	// EndpointRegenerationCount is a count of the number of times any endpoint
-	// has been regenerated and success/fail outcome
-	// Deprecated: in favor of EndpointRegenerationTotal
-	EndpointRegenerationCount = NoOpCounterVec
-
 	// EndpointRegenerationTotal is a count of the number of times any endpoint
 	// has been regenerated and success/fail outcome
 	EndpointRegenerationTotal = NoOpCounterVec
@@ -217,14 +200,8 @@ var (
 	EndpointRegenerationTimeStats = NoOpObserverVec
 
 	// Policy
-
 	// Policy is the number of policies loaded into the agent
 	Policy = NoOpGauge
-
-	// TODO(sayboras): Remove deprecated metric in 1.10
-	// PolicyCount is the number of policies loaded into the agent
-	// Deprecated: in favor of Policy
-	PolicyCount = NoOpGauge
 
 	// PolicyRegenerationCount is the total number of successful policy
 	// regenerations.
@@ -235,11 +212,6 @@ var (
 
 	// PolicyRevision is the current policy revision number for this agent
 	PolicyRevision = NoOpGauge
-
-	// TODO(sayboras): Remove deprecated metric in 1.10
-	// PolicyImportErrors is a count of failed policy imports
-	// Deprecated: in favor of PolicyImportErrorsTotal
-	PolicyImportErrors = NoOpCounter
 
 	// PolicyImportErrorsTotal is a count of failed policy imports
 	PolicyImportErrorsTotal = NoOpCounter
@@ -258,11 +230,6 @@ var (
 
 	// Identity is the number of identities currently in use on the node
 	Identity = NoOpGauge
-
-	// TODO(sayboras): Remove deprecated metric in 1.10
-	// IdentityCount is the number of identities currently in use on the node
-	// Deprecated: in favor of Identity
-	IdentityCount = NoOpGauge
 
 	// Events
 
@@ -386,12 +353,6 @@ var (
 	// KubernetesAPIInteractions is the total time taken to process an API call made
 	// to the kube-apiserver
 	KubernetesAPIInteractions = NoOpObserverVec
-
-	// TODO(sayboras): Remove deprecated metric in 1.10
-	// KubernetesAPICalls is the counter for all API calls made to
-	// kube-apiserver.
-	// Deprecated: Use KubernetesAPICallsTotal instead
-	KubernetesAPICalls = NoOpCounterVec
 
 	// KubernetesAPICallsTotal is the counter for all API calls made to
 	// kube-apiserver.
@@ -541,21 +502,17 @@ type Configuration struct {
 func DefaultMetrics() map[string]struct{} {
 	return map[string]struct{}{
 		Namespace + "_" + SubsystemAgent + "_api_process_time_seconds":               {},
-		Namespace + "_endpoint_regenerations":                                        {}, //TODO(sayboras): Remove deprecated metric in 1.10
 		Namespace + "_endpoint_regenerations_total":                                  {},
 		Namespace + "_endpoint_state":                                                {},
 		Namespace + "_endpoint_regeneration_time_stats_seconds":                      {},
 		Namespace + "_policy":                                                        {},
-		Namespace + "_policy_count":                                                  {}, //TODO(sayboras): Remove deprecated metric in 1.10
 		Namespace + "_policy_regeneration_total":                                     {},
 		Namespace + "_policy_regeneration_time_stats_seconds":                        {},
 		Namespace + "_policy_max_revision":                                           {},
-		Namespace + "_policy_import_errors":                                          {}, //TODO(sayboras): Remove deprecated metric in 1.10
 		Namespace + "_policy_import_errors_total":                                    {},
 		Namespace + "_policy_endpoint_enforcement_status":                            {},
 		Namespace + "_policy_implementation_delay":                                   {},
 		Namespace + "_identity":                                                      {},
-		Namespace + "_identity_count":                                                {}, //TODO(sayboras): Remove deprecated metric in 1.10
 		Namespace + "_event_ts":                                                      {},
 		Namespace + "_proxy_redirects":                                               {},
 		Namespace + "_policy_l7_total":                                               {},
@@ -582,7 +539,6 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_kubernetes_events_total":                                       {},
 		Namespace + "_kubernetes_events_received_total":                              {},
 		Namespace + "_" + SubsystemK8sClient + "_api_latency_time_seconds":           {},
-		Namespace + "_" + SubsystemK8sClient + "_api_calls_counter":                  {}, //TODO(sayboras): Remove deprecated metric in 1.10
 		Namespace + "_" + SubsystemK8sClient + "_api_calls_total":                    {},
 		Namespace + "_" + SubsystemK8s + "_cnp_status_completion_seconds":            {},
 		Namespace + "_ipam_events_total":                                             {},
@@ -624,17 +580,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, APIInteractions)
 			c.APIInteractionsEnabled = true
-
-		case Namespace + "_endpoint_regenerations":
-			EndpointRegenerationCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: Namespace,
-				Name:      "endpoint_regenerations",
-				Help: "Count of all endpoint regenerations that have completed, tagged by outcome" +
-					"(deprecated, use endpoint_regenerations_total instead)",
-			}, []string{"outcome"})
-
-			collectors = append(collectors, EndpointRegenerationCount)
-			c.EndpointRegenerationCountEnabled = true
 
 		case Namespace + "_endpoint_regenerations_total":
 			EndpointRegenerationTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -679,16 +624,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			collectors = append(collectors, Policy)
 			c.PolicyCountEnabled = true
 
-		case Namespace + "_policy_count":
-			PolicyCount = prometheus.NewGauge(prometheus.GaugeOpts{
-				Namespace: Namespace,
-				Name:      "policy_count",
-				Help:      "Number of policies currently loaded (deprecated, use policy instead)",
-			})
-
-			collectors = append(collectors, PolicyCount)
-			c.PolicyCountEnabled = true
-
 		case Namespace + "_policy_regeneration_total":
 			PolicyRegenerationCount = prometheus.NewCounter(prometheus.CounterOpts{
 				Namespace: Namespace,
@@ -718,17 +653,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, PolicyRevision)
 			c.PolicyRegenerationTimeStatsEnabled = true
-
-		case Namespace + "_policy_import_errors":
-			PolicyImportErrors = prometheus.NewCounter(prometheus.CounterOpts{
-				Namespace: Namespace,
-				Name:      "policy_import_errors",
-				Help: "Number of times a policy import has failed" +
-					"(deprecated, use policy_import_errors_total instead)",
-			})
-
-			collectors = append(collectors, PolicyImportErrors)
-			c.PolicyImportErrorsEnabled = true
 
 		case Namespace + "_policy_import_errors_total":
 			PolicyImportErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -768,16 +692,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			})
 
 			collectors = append(collectors, Identity)
-			c.IdentityCountEnabled = true
-
-		case Namespace + "_identity_count":
-			IdentityCount = prometheus.NewGauge(prometheus.GaugeOpts{
-				Namespace: Namespace,
-				Name:      "identity_count",
-				Help:      "Number of identities currently allocated (deprecated, use identity instead)",
-			})
-
-			collectors = append(collectors, IdentityCount)
 			c.IdentityCountEnabled = true
 
 		case Namespace + "_event_ts":
@@ -1086,18 +1000,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			collectors = append(collectors, KubernetesAPIInteractions)
 			c.KubernetesAPIInteractionsEnabled = true
 
-		case Namespace + "_" + SubsystemK8sClient + "_api_calls_counter":
-			KubernetesAPICalls = prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemK8sClient,
-				Name:      "api_calls_counter",
-				Help: "Number of API calls made to kube-apiserver labeled by host, method and return code." +
-					"(deprecated, use api_calls_total instead)",
-			}, []string{"host", LabelMethod, LabelAPIReturnCode})
-
-			collectors = append(collectors, KubernetesAPICalls)
-			c.KubernetesAPICallsEnabled = true
-
 		case Namespace + "_" + SubsystemK8sClient + "_api_calls_total":
 			KubernetesAPICallsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 				Namespace: Namespace,
@@ -1191,7 +1093,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem: SubsystemBPF,
 				Name:      "map_ops_total",
 				Help:      "Total operations on map, tagged by map name",
-			}, []string{LabelMapName, LabelMapNameDeprecated, LabelOperation, LabelOutcome})
+			}, []string{LabelMapName, LabelOperation, LabelOutcome})
 
 			collectors = append(collectors, BPFMapOps)
 			c.BPFMapOps = true

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -183,7 +183,7 @@ func NewManager(name string, dp datapath.NodeHandler, ipcache IPCache, c Configu
 		Subsystem: "nodes",
 		Name:      name + "_events_received_total",
 		Help:      "Number of node events received",
-	}, []string{"eventType", "event_type", "source"}) //TODO(sayboras): Remove deprecated tag eventType in 1.10
+	}, []string{"event_type", "source"})
 
 	m.metricNumNodes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.Namespace,
@@ -387,8 +387,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	m.mutex.Lock()
 	entry, oldNodeExists := m.nodes[nodeIdentity]
 	if oldNodeExists {
-		//TODO(sayboras): Remove deprecated metric in 1.10
-		m.metricEventsReceived.WithLabelValues("update", "update", string(n.Source)).Inc()
+		m.metricEventsReceived.WithLabelValues("update", string(n.Source)).Inc()
 
 		if !source.AllowOverwrite(entry.node.Source, n.Source) {
 			m.mutex.Unlock()
@@ -406,8 +405,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		}
 		entry.mutex.Unlock()
 	} else {
-		//TODO(sayboras): Remove deprecated metric in 1.10
-		m.metricEventsReceived.WithLabelValues("add", "add", string(n.Source)).Inc()
+		m.metricEventsReceived.WithLabelValues("add", string(n.Source)).Inc()
 		m.metricNumNodes.Inc()
 
 		entry = &nodeEntry{node: n}
@@ -428,8 +426,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // origins from. If the node was removed, NodeDelete() is invoked of the
 // datapath interface.
 func (m *Manager) NodeDeleted(n nodeTypes.Node) {
-	//TODO(sayboras): Remove deprecated metric in 1.10
-	m.metricEventsReceived.WithLabelValues("delete", "delete", string(n.Source)).Inc()
+	m.metricEventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
 
 	log.Debugf("Received node delete event from %s", n.Source)
 

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -184,7 +184,6 @@ func (n EndpointSelector) GetMatch(key string) ([]string, bool) {
 func labelSelectorToRequirements(labelSelector *slim_metav1.LabelSelector) *k8sLbls.Requirements {
 	selector, err := slim_metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
-		metrics.PolicyImportErrors.Inc()
 		metrics.PolicyImportErrorsTotal.Inc()
 		log.WithError(err).WithField(logfields.EndpointLabelSelector,
 			logfields.Repr(labelSelector)).Error("unable to construct selector in label selector")

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -245,7 +245,6 @@ func addDerivativePolicy(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 		if derivativeErr == nil {
 			break
 		}
-		metrics.PolicyImportErrors.Inc()
 		metrics.PolicyImportErrorsTotal.Inc()
 		scopedLog.WithError(derivativeErr).Error("Cannot create derivative rule. Installing deny-all rule.")
 		statusErr := updateDerivativeStatus(cnp, derivativePolicy.GetName(), derivativeErr, clusterScoped)
@@ -265,7 +264,6 @@ func addDerivativePolicy(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 	if err != nil {
 		statusErr := updateDerivativeStatus(cnp, derivativePolicy.GetName(), err, clusterScoped)
 		if statusErr != nil {
-			metrics.PolicyImportErrors.Inc()
 			metrics.PolicyImportErrorsTotal.Inc()
 			scopedLog.WithError(err).Error("Cannot update status for derivative policy")
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -383,7 +383,6 @@ func (p *Repository) AddListLocked(rules api.Rules) (ruleSlice, uint64) {
 	p.rules = append(p.rules, newList...)
 	p.BumpRevision()
 	metrics.Policy.Add(float64(len(newList)))
-	metrics.PolicyCount.Add(float64(len(newList)))
 	return newList, p.GetRevision()
 }
 
@@ -486,7 +485,6 @@ func (p *Repository) DeleteByLabelsLocked(lbls labels.LabelArray) (ruleSlice, ui
 		p.BumpRevision()
 		p.rules = new
 		metrics.Policy.Sub(float64(deleted))
-		metrics.PolicyCount.Sub(float64(deleted))
 	}
 
 	return deletedRules, p.GetRevision(), deleted


### PR DESCRIPTION
This commit is to clean up all deprecated metrics and labels in 1.9.
    
Signed-off-by: Tam Mach <sayboras@yahoo.com>

TODO:
- [x] Update docs (release note)

```release-note
cleanup/metrics: Cleanup deprecated metrics
```
