### PR TITLE
smoketest: Add image tag as latest for cilium agent and operator

### DIFF
--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -60,7 +60,9 @@ jobs:
             --set nodeinit.enabled=true \
             --set kubeProxyReplacement=strict \
             --set ipam.mode=kubernetes \
+            --set image.tag=latest \
             --set image.pullPolicy=Never \
+            --set operator.image.tag=latest \
             --set operator.image.pullPolicy=Never \
             --set ipv6.enabled=true \
             --set ipv4.enabled=false \

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -106,7 +106,9 @@ jobs:
              --set hostPort.enabled=true \
              --set bpf.masquerade=false \
              --set ipam.mode=kubernetes \
+             --set image.tag=latest \
              --set image.pullPolicy=Never \
+             --set operator.image.tag=latest \
              --set operator.image.pullPolicy=Never \
              --set prometheus.enabled=true \
              --set operator.prometheus.enabled=true \


### PR DESCRIPTION
This commit is to add two additional flag `image.tag=latest` and
`operator.image.tag=latest` in smoketest. These two docker images are
built and loaded into cluster as part of smoke test with tag as latest.
Additionally, there is _pullPolicy_  flag set as _Never_ to make sure that 
these images will be used for testing.

Setting `image.tag=latest` and `operator.image.tag=latest` will make
sure that smoke test will work for master and any release branch v1.9.x

Signed-off-by: Tam Mach <sayboras@yahoo.com>
