### PR TITLE
docs: NodePort XDP on GCP is not supported

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -769,6 +769,15 @@ When running Azure IPAM on a self-managed Kubernetes cluster, each ``v1.Node``
 must have the resource ID of its VM in the ``spec.providerID`` field.
 Refer to the :ref:`ipam_azure` reference for more information.
 
+NodePort XDP on GCP
+===================
+
+NodePort XDP on the Google Cloud Platform is currently not supported. Both
+virtual network interfaces available on Google Compute Engine (the older
+virtIO-based interface and the newer `gVNIC
+<https://cloud.google.com/compute/docs/instances/create-vm-with-gvnic>`_) are
+currently lacking support for native XDP.
+
 .. _NodePort Devices:
 
 NodePort Devices, Port and Bind settings

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -385,6 +385,7 @@ fs
 functionalities
 fwmark
 gRPC
+gVNIC
 gcc
 gcloud
 gcp
@@ -821,6 +822,7 @@ vers
 versa
 versioning
 veth
+virtIO
 virtio
 virtualbox
 virtualization


### PR DESCRIPTION
This adds a section about the current state of NodePort XDP on GCP. The
issue with the virtio device (#12105) still persists and the newer gVNIC
driver [1] (in beta) lacks support native XDP (as confirmed by @borkmann).

[1] https://cloud.google.com/compute/docs/instances/create-vm-with-gvnic
