### PR TITLE
endpoint: Avoid benign error messages on restoration

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1066,7 +1066,12 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 	}
 
 	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
-		identitymanager.Remove(e.SecurityIdentity)
+		// Restored endpoint may be created with a reserved identity of 5
+		// (init), which is not registered in the identity manager and
+		// therefore doesn't need to be removed.
+		if e.SecurityIdentity.ID != identity.ReservedIdentityInit {
+			identitymanager.Remove(e.SecurityIdentity)
+		}
 
 		releaseCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 		defer cancel()


### PR DESCRIPTION
During the endpoint restoration process, when we parse the endpoints, [we assign them a reserved init identity if they don't already have an identity](https://github.com/cilium/cilium/blob/80a71791320df34df5b6252b9680553e38d88d20/pkg/endpoint/endpoint.go#L819). If we later remove the endpoint (because the corresponding K8s pod or interface are missing), we attempt to remove the identity from the identity manager. That last operation results in the following error message because the init identity was never added to the manager.

    level=error msg="removing identity not added to the identity manager!" identity=5 subsys=identitymanager

This pull request fixes it by skipping the removal attempt from the manager in the case of identity init.