### PR TITLE
daemon: Add LB-only mode (--datapath-mode=lb-only)

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -654,14 +654,16 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		}
 	}
 
-	// This needs to be done after the node addressing has been configured
-	// as the node address is required as suffix.
-	// well known identities have already been initialized above.
-	// Ignore the channel returned by this function, as we want the global
-	// identity allocator to run asynchronously.
-	d.identityAllocator.InitIdentityAllocator(k8s.CiliumClient(), nil)
+	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		// This needs to be done after the node addressing has been configured
+		// as the node address is required as suffix.
+		// well known identities have already been initialized above.
+		// Ignore the channel returned by this function, as we want the global
+		// identity allocator to run asynchronously.
+		d.identityAllocator.InitIdentityAllocator(k8s.CiliumClient(), nil)
 
-	d.bootstrapClusterMesh(nodeMngr)
+		d.bootstrapClusterMesh(nodeMngr)
+	}
 
 	bootstrapStats.bpfBase.Start()
 	err = d.init()

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -977,7 +977,8 @@ func initEnv(cmd *cobra.Command) {
 
 	// This check is here instead of in DaemonConfig.Populate (invoked at the
 	// start of this function as option.Config.Populate) to avoid an import loop.
-	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !k8s.IsEnabled() {
+	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !k8s.IsEnabled() &&
+		option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
 		log.Fatal("CRD Identity allocation mode requires k8s to be configured.")
 	}
 
@@ -1171,6 +1172,18 @@ func initEnv(cmd *cobra.Command) {
 		if option.Config.InstallIptRules {
 			option.Config.Ipvlan.OperationMode = connector.OperationModeL3S
 		}
+	case datapathOption.DatapathModeLBOnly:
+		log.Info("Running in LB-only mode")
+		option.Config.KubeProxyReplacement = option.KubeProxyReplacementPartial
+		option.Config.EnableHostReachableServices = true
+		option.Config.EnableHostPort = false
+		option.Config.EnableNodePort = true
+		option.Config.EnableExternalIPs = true
+		option.Config.Tunnel = option.TunnelDisabled
+		option.Config.EnableHealthChecking = false
+		option.Config.Masquerade = false
+		option.Config.InstallIptRules = false
+		option.Config.EnableL7Proxy = false
 	default:
 		log.WithField(logfields.DatapathMode, option.Config.DatapathMode).Fatal("Invalid datapath mode")
 	}

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -170,10 +171,6 @@ func (d *Daemon) getHostRoutingStatus() *models.HostRouting {
 }
 
 func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
-	if !k8s.IsEnabled() {
-		return &models.KubeProxyReplacement{Mode: models.KubeProxyReplacementModeDisabled}
-	}
-
 	var mode string
 	switch option.Config.KubeProxyReplacement {
 	case option.KubeProxyReplacementStrict:
@@ -865,7 +862,7 @@ func (d *Daemon) startStatusCollector() {
 		},
 	}
 
-	if k8s.IsEnabled() {
+	if k8s.IsEnabled() || option.Config.DatapathMode == datapathOption.DatapathModeLBOnly {
 		// kube-proxy replacement configuration does not change after
 		// initKubeProxyReplacementOptions() has been executed, so it's fine to
 		// statically set the field here.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -293,25 +293,26 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 			sort.Strings(sr.Kubernetes.K8sAPIVersions)
 			fmt.Fprintf(w, "Kubernetes APIs:\t[\"%s\"]\n", strings.Join(sr.Kubernetes.K8sAPIVersions, "\", \""))
 		}
-		if sr.KubeProxyReplacement != nil {
-			devices := ""
-			if sr.KubeProxyReplacement.Mode != models.KubeProxyReplacementModeDisabled {
-				for i, dev := range sr.KubeProxyReplacement.Devices {
-					kubeProxyDevices += dev
-					if dev == sr.KubeProxyReplacement.DirectRoutingDevice {
-						kubeProxyDevices += " (Direct Routing)"
-					}
-					if i+1 != len(sr.KubeProxyReplacement.Devices) {
-						kubeProxyDevices += ", "
-					}
+
+	}
+	if sr.KubeProxyReplacement != nil {
+		devices := ""
+		if sr.KubeProxyReplacement.Mode != models.KubeProxyReplacementModeDisabled {
+			for i, dev := range sr.KubeProxyReplacement.Devices {
+				kubeProxyDevices += dev
+				if dev == sr.KubeProxyReplacement.DirectRoutingDevice {
+					kubeProxyDevices += " (Direct Routing)"
 				}
-				if len(sr.KubeProxyReplacement.Devices) > 0 {
-					devices = "[" + kubeProxyDevices + "]"
+				if i+1 != len(sr.KubeProxyReplacement.Devices) {
+					kubeProxyDevices += ", "
 				}
 			}
-			fmt.Fprintf(w, "KubeProxyReplacement:\t%s\t%s\n",
-				sr.KubeProxyReplacement.Mode, devices)
+			if len(sr.KubeProxyReplacement.Devices) > 0 {
+				devices = "[" + kubeProxyDevices + "]"
+			}
 		}
+		fmt.Fprintf(w, "KubeProxyReplacement:\t%s\t%s\n",
+			sr.KubeProxyReplacement.Mode, devices)
 	}
 	if sr.Cilium != nil {
 		fmt.Fprintf(w, "Cilium:\t%s\t%s\n", sr.Cilium.State, sr.Cilium.Msg)

--- a/pkg/datapath/option/option.go
+++ b/pkg/datapath/option/option.go
@@ -22,4 +22,7 @@ const (
 
 	// DatapathModeIpvlan specifies ipvlan datapath mode.
 	DatapathModeIpvlan = "ipvlan"
+
+	// DatapathModeLBOnly specifies lb-only datapath mode.
+	DatapathModeLBOnly = "lb-only"
 )

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -18,6 +18,9 @@ package k8s
 import (
 	"os"
 	"strings"
+
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -77,6 +80,10 @@ func Configure(apiServerURL, kubeconfigPath string, qps float32, burst int) {
 
 // IsEnabled checks if Cilium is being used in tandem with Kubernetes.
 func IsEnabled() bool {
+	if option.Config.DatapathMode == datapathOption.DatapathModeLBOnly {
+		return false
+	}
+
 	return config.APIServerURL != "" ||
 		config.KubeconfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&


### PR DESCRIPTION
The LB-only mode is intended to be run on load-balancing nodes which have connectivity neither to kube-apiserver nor kvstore. In this mode services are supposed to be configured via Cilium REST API.

Chris has successfully figured out that disabling the identity allocator is enough for cilium-agent to run such on nodes (no connectivity to kube-apiserver/kvstore). Therefore, the LB-only mode disabled it.

In addition, when running in the LB-only mode, cilium-agent will configure some flags to achieve the following:

* Enable kube-proxy replacement's NodePort and ExternalIPs implementation for access from outside, and HostReachableServices - from inside LB node.
* Do not install iptables-rules and disable L7 proxy.
* Disable the tunnel mode.
* Disable health-checking (it's going to be implemented separately).

An example how to run cilium-agent in the LB-only mode:

    # ./daemon/cilium-agent                               \
        --enable-ipv4=true --enable-ipv6=false          \
        --datapath-mode=lb-only --node-port-algorithm=maglev \
        --devices=eth0

Afterwards, a service can be added with:

    # ./cilium/cilium service update                    \
        --frontend '7.7.7.7:80'                         \
        --backends '192.168.34.11:80,192.168.34.12:80'  \
        --id 101 --k8s-external

Keep it mind that the LB-only mode hasn't been optimized yet - e.g. some controllers are unnecessary, and thus can be disabled. This will be addressed in the future. Next step is to introduce e2e tests.

```release-note
Add --datapath-mode=lb which allows cilium-agent to run as a standalone loadbalancer
```

Signed-off-by: Chris Tarazi <chris@isovalent.com>
Signed-off-by: Martynas Pumputis <m@lambda.lt>