### PR TITLE
helm: keep encryption interface value undefined

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -52,7 +52,6 @@ Helm chart for Cilium
 | enableCriticalPriorityClass | bool | `true` |  |
 | enableXTSocketFallback | bool | `true` |  |
 | encryption.enabled | bool | `false` |  |
-| encryption.interface | string | `"eth0"` |  |
 | encryption.keyFile | string | `"keys"` |  |
 | encryption.mountPath | string | `"/etc/ipsec"` |  |
 | encryption.nodeEncryption | bool | `false` |  |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -352,7 +352,7 @@ encryption:
   nodeEncryption: false
 
   # interface is the interface to use for encryption
-  interface: eth0
+  # interface: eth0
 
 # TODO: Add documentation
 endpointHealthChecking:


### PR DESCRIPTION
Keep the encryption interface parameter undefined so that cilium device
detection will kick in.

Fixes: #13662

