### PR TITLE
docs: remove redundant "--set ipam.node=kubernetes" from GKE GSG

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -91,7 +91,6 @@ below. This will ensure all pods are managed by Cilium.
       --set nodeinit.removeCbrBridge=true \\
       --set cni.binPath=/home/kubernetes/bin \\
       --set gke.enabled=true \\
-      --set ipam.mode=kubernetes \\
       --set nativeRoutingCIDR=$NATIVE_CIDR
 
 The NodeInit DaemonSet is required to prepare the GKE nodes as nodes are added


### PR DESCRIPTION
File `install/kubernetes/cilium/templates/cilium-configmap.yaml` contains the following:

    {{- if .Values.gke.enabled }}
      ipam: "kubernetes"
      tunnel: "disabled"
      enable-endpoint-routes: "true"
      enable-local-node-route: "false"
    {{- end }}

In other words, when `gke.enabled` is set to `true` for Helm, the IPAM is automatically set to `kubernetes`. Therefore, it is redundant to pass it to the Helm command line. Let's remove it from the GSG.