### PR TITLE
Helm: Adapt Hubble ingress template to the new Ingress API

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -9,12 +9,33 @@ Create chart name and version as used by the chart label.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "ingress.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0, <1.19.0" .Capabilities.KubeVersion.Version -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else if semverCompare "^1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate backend for Hubble UI ingress.
+*/}}
+{{- define "ingress.paths" -}}
+{{ if semverCompare ">=1.4-0, <1.19-0" .Capabilities.KubeVersion.Version -}}
+backend:
+  serviceName: hubble-ui
+  servicePort: http
+{{- else if semverCompare "^1.19-0" .Capabilities.KubeVersion.Version -}}
+pathType: Prefix
+backend:
+  service:
+    name: hubble-ui
+    port:
+      name: http
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Generate TLS certificates for Hubble Server and Hubble Relay.

--- a/install/kubernetes/cilium/templates/hubble-ui-ingress.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-ingress.yaml
@@ -21,8 +21,6 @@ spec:
       http:
         paths:
           - path: /
-            backend:
-              serviceName: hubble-ui
-              servicePort: http
+{{ include "ingress.paths" $ | indent 12 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Description of change -->
Ingress and IngressClass resources have graduated to networking.k8s.io/v1 in Kubernetes v1.19. This also introduced [changes to the objects.](https://github.com/kubernetes/kubernetes/pull/89778)

Also in Helm, `GitVersion` is being deprecated and has thus been replaced with `Version`.

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

Fixes: #13611

```release-note
Helm: Adapt Hubble ingress template to the new Ingress API
```
