### PR TITLE
endpoint: Fix goroutine leak when EP is deleted

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1642,7 +1642,11 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 	done := make(chan struct{})
 	controllerName := fmt.Sprintf("resolve-labels-%s", e.GetK8sNamespaceAndPodName())
 	go func() {
-		<-done
+		select {
+		case <-done:
+		case <-e.aliveCtx.Done():
+			return
+		}
 		e.controllers.RemoveController(controllerName)
 	}()
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1679,8 +1679,7 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 				close(done)
 				return nil
 			},
-			RunInterval: 30 * time.Second,
-			Context:     e.aliveCtx,
+			Context: e.aliveCtx,
 		},
 	)
 }


### PR DESCRIPTION
The metadata resolver controller can be put in a scenario where it can
never succeed if the Cilium K8s pod cache is out-of-sync with the
current view of pods in the cluster. The cache can be out-of-sync if
there's heavy load on the cluster and especially on the apiserver. This
leaves the Cilium pod cache starved. When the pod cache is starved,
Cilium may never have an up-to-date view of the pods running in the
cluster, and therefore may never be able to resolve labels for pods
because the fetch will return "pod not found".

Eventually, kubelet (or maybe even the user) will give up on the pod and
remove it, thereby Cilium begins removing the endpoint. The controller
is stopped, but the goroutine waiting on the `done` channel will never
receive, hence the leak.

This commit fixes the goroutine leak when the controller never succeeds
and therefore, never closes the `done` channel. The fix is to add a
`select` statement to also watch the endpoint's `aliveCtx` which is
cancelled (and the context's `Done` channel is closed) when the endpoint
is deleted.

This commit was validated by forcing the metadata resolver to never find
a pod (manually hardcode the wrong pod name), and ensuring that the 
`gops stack` output does not contain an entry like:

```
goroutine 1244259 [chan receive, 1434 minutes]:
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunMetadataResolver.func1(0xc0055d2a20, 0xc0049ff600, 0xc0055d2ae0, 0x5d)
	/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1531 +0x34
created by github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunMetadataResolver
	/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1530 +0x11e
```

Fixes: https://github.com/cilium/cilium/issues/13680

```release-note
Fix bug where Cilium leaks a goroutine when an endpoint is deleted. This leak, if left running in a high pod churn environment, can cause Cilium to exceed its memory usage and get OOM killed.
```