### PR TITLE
install/kubernetes: remove nodePort.device from values

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -814,9 +814,6 @@ nodePort:
   # range is the port range to use for NodePort
   # range: "30000,32767"
 
-  # device is the name of the device handling NodePort requests
-  # device: eth0
-
   # mode is the mode of NodePort feature
   # mode: snat
 


### PR DESCRIPTION
This was replaced by the devices value in commit 298cb137d93e
("helm/daemon: Add --devices for attaching bpf_host.o") amd is no longer
effective since commit 0dfe71094b4f ("test: bump stable version to
1.8").