### PR TITLE
pkg/labelsfilter: add more unit test and rewrite docs

### DIFF
--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -89,10 +89,23 @@ will be used to evaluate Cilium identities:
 The above configuration would only include the following labels when evaluating
 Cilium identities:
 
-- io.kubernetes.pod.namespace=*
-- k8s-app=*
-- app=*
-- name=*
+- io.kubernetes.pod.namespace*=.*
+- k8s-app*=*
+- app*=*
+- name*=*
+
+Labels with the same prefix as defined in the configuration will also be
+considered. This lists some examples of labels that would also be evaluated for
+Cilium identities:
+
+- k8s-app-team*=*
+- app-production*=*
+- name-defined*=*
+
+When a single "inclusive label" is added to the filter, all labels not defined
+in the default list will be excluded. For example, pods running with the
+security labels ``team=team-1, env=prod`` will have the label ``env=prod``
+ignored as soon Cilium is started with the filter ``k8s:team``.
 
 Excluding Labels
 ----------------

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -41,17 +41,12 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 		"id.lizards.k8s":              labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
 		"io.kubernetes.pod.namespace": labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
 		"app.kubernetes.io":           labels.NewLabel("app.kubernetes.io", "my-nginx", labels.LabelSourceContainer),
+		"foo2.lizards.k8s":            labels.NewLabel("foo2.lizards.k8s", "web", labels.LabelSourceK8s),
 	}
 
-	dlpcfg := defaultLabelPrefixCfg()
-	d, err := parseLabelPrefix(":!ignor[eE]")
+	err := ParseLabelPrefixCfg([]string{":!ignor[eE]", "id.*", "foo"}, "")
 	c.Assert(err, IsNil)
-	c.Assert(d, Not(IsNil))
-	dlpcfg.LabelPrefixes = append(dlpcfg.LabelPrefixes, d)
-	d, err = parseLabelPrefix("id.*")
-	c.Assert(err, IsNil)
-	c.Assert(d, Not(IsNil))
-	dlpcfg.LabelPrefixes = append(dlpcfg.LabelPrefixes, d)
+	dlpcfg := validLabelPrefixes
 	allNormalLabels := map[string]string{
 		"io.kubernetes.container.hash":                              "cf58006d",
 		"io.kubernetes.container.name":                              "POD",
@@ -79,6 +74,14 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	allLabels["id.lizards.k8s"] = labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
 	c.Assert(len(filtered), Equals, 4)
+	// Checking that it does not need to an exact match of "foo", but "foo2" also works since it's not a regex
+	allLabels["foo2.lizards.k8s"] = labels.NewLabel("foo2.lizards.k8s", "web", labels.LabelSourceK8s)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
+	// Checking that "foo" only works if it's the prefix of a label
+	allLabels["lizards.foo.lizards.k8s"] = labels.NewLabel("lizards.foo.lizards.k8s", "web", labels.LabelSourceK8s)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
 	c.Assert(filtered, checker.DeepEquals, wanted)
 	// Making sure we are deep copying the labels
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", "I can change this and doesn't affect any one")


### PR DESCRIPTION
This change is only adding more unit tests to better understand the
behavior of the labelsfilter as well as improving the documentation for
the expectation of filtering labels.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Improve documentation of filtering unnecessary labels
```
