### PR TITLE
examples: getting-started: bump Cilium docker image to 1.9

### DIFF
--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -55,6 +55,15 @@ it will print:
     ==> default: Creating cilium-docker-plugin
     $
 
+By default the script will deploy Cilium ``1.9`` but it's possible to specify a
+different version with the ``CILIUM_VERSION`` environment variable.
+
+For example, the following command will start Vagrant with Cilium ``1.x``:
+
+::
+
+    $ CILIUM_VERSION=v1.x vagrant up
+
 If the script exits with an error message, do not attempt to proceed with the
 tutorial, as later steps will not work properly.   Instead, contact us on the
 `Cilium Slack channel`_.

--- a/examples/getting-started/README.rst
+++ b/examples/getting-started/README.rst
@@ -4,6 +4,15 @@ Getting Started with Vagrant
 This is a simple Vagrant environment to experiment with Cilium. To get started,
 simply run ``vagrant up`` and then log into the VM with ``vagrant ssh``.
 
+The version of the Cilium docker image (which defaults to ``1.9``) can be
+controlled with the ``CILIUM_VERSION`` environment variable.
+
+For example, the following command will start Vagrant with Cilium ``1.x``:
+
+::
+
+    $ CILIUM_VERSION=v1.x vagrant up
+
 For further instructions, please see the `Getting started guide`_.
 
 .. _Getting started guide: https://cilium.readthedocs.io/en/latest/gettingstarted/docker

--- a/examples/getting-started/README.rst
+++ b/examples/getting-started/README.rst
@@ -27,8 +27,10 @@ For further instructions, please see the `Getting started guide`_.
     Cilium:                 Ok         OK
     NodeMonitor:            Disabled
     Cilium health daemon:   Ok
-    IPAM:                   IPv4: 2/65535 allocated from 10.15.0.0/16,
-    Controller Status:      14/14 healthy
-    Proxy Status:           OK, ip 10.15.225.211, 0 redirects active on ports 10000-20000
+    IPAM:                   IPv4: 3/65535 allocated from 10.15.0.0/16,
+    BandwidthManager:       Disabled
+    Masquerading:           IPTables
+    Controller Status:      21/21 healthy
+    Proxy Status:           OK, ip 10.15.55.93, 1 redirects active on ports 10000-20000
     Hubble:                 Disabled
-    Cluster health:         1/1 reachable   (2020-04-17T10:55:03Z)
+    Cluster health:         1/1 reachable   (2020-10-22T12:09:24Z)

--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -3,9 +3,9 @@
 
 Vagrant.require_version ">= 2.0.0"
 
-cilium_version = (ENV['CILIUM_VERSION'] || "v1.7.2")
+cilium_version = (ENV['CILIUM_VERSION'] || "v1.9")
 cilium_opts = (ENV['CILIUM_OPTS'] || "--enable-ipv6=false --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 -t vxlan")
-cilium_tag = (ENV['CILIUM_TAG'] || "v1.7.2")
+cilium_tag = (ENV['CILIUM_TAG'] || "v1.9")
 
 # This runs only once when vagrant box is provisioned for the first time
 $bootstrap = <<SCRIPT

--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -5,7 +5,6 @@ Vagrant.require_version ">= 2.0.0"
 
 cilium_version = (ENV['CILIUM_VERSION'] || "v1.9")
 cilium_opts = (ENV['CILIUM_OPTS'] || "--enable-ipv6=false --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 -t vxlan")
-cilium_tag = (ENV['CILIUM_TAG'] || "v1.9")
 
 # This runs only once when vagrant box is provisioned for the first time
 $bootstrap = <<SCRIPT
@@ -18,9 +17,9 @@ cid=$(docker create docker.io/cilium/cilium:#{cilium_version})
 docker cp "${cid}:/usr/bin/cilium" /usr/local/bin/cilium
 docker rm -f ${cid}
 
-# Store specified tag and options for docker-compose so we can rerun easily
+# Store specified cilium version and options for docker-compose so we can rerun easily
 cat > /home/vagrant/cilium/examples/getting-started/.env <<EOF
-CILIUM_TAG=#{cilium_tag}
+CILIUM_VERSION=#{cilium_version}
 CILIUM_OPTS=#{cilium_opts}
 EOF
 
@@ -56,12 +55,12 @@ Vagrant.configure(2) do |config|
     # install docker runtime
     config.vm.provision :docker, images: [
 	"consul:1.1.0",
-	"cilium/cilium:#{cilium_tag}"
+	"cilium/cilium:#{cilium_version}"
     ]
 
     config.vm.provision "bootstrap", type: "shell", inline: $bootstrap
     config.vm.provision "run", type: "shell", run: "always",
-       env: {"CILIUM_TAG" => cilium_tag, "CILIUM_OPTS" => cilium_opts},
+       env: {"CILIUM_VERSION" => cilium_version, "CILIUM_OPTS" => cilium_opts},
        privileged: false, inline: $run
 
 end

--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   cilium:
     container_name: cilium
-    image: docker.io/cilium/cilium:${CILIUM_TAG}
+    image: docker.io/cilium/cilium:${CILIUM_VERSION}
     command: cilium-agent ${CILIUM_OPTS}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -21,7 +21,7 @@ services:
 
   cilium_docker:
     container_name: cilium-docker-plugin
-    image: docker.io/cilium/docker-plugin:${CILIUM_TAG}
+    image: docker.io/cilium/docker-plugin:${CILIUM_VERSION}
     command: cilium-docker
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Bump cilium docker image used in the getting started [guide](https://docs.cilium.io/en/v1.9.0-rc2/gettingstarted/docker/) from `1.7` to `1.9`.
I tried again the tutorial with the new version and steps stand correct