### PR TITLE
vagrant: Add host name argument in vagrant port command

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -607,7 +607,7 @@ elif [ -n "${PROVISION}" ]; then
 else
     vagrant up $PROVISION_ARGS $1
     if [ "$?" -eq "0" -a -n "${K8S}" ]; then
-        host_port=$(vagrant port --guest 6443)
+        host_port=$(vagrant port --guest 6443 k8s1)
         vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed "s;server:.*:6443;server: https://k8s1:$host_port;g" > vagrant.kubeconfig
         echo "Add '127.0.0.1 k8s1' to your /etc/hosts to use vagrant.kubeconfig file for kubectl"
     fi


### PR DESCRIPTION
This commit is to add required argument for `vagrant port` command to
avoid below error
    
```shell script
$ vagrant port --guest 6443
The
provider reported there are no forwarded ports for this virtual
machine.
This can be caused if there are no ports specified in the
Vagrantfile or
if the virtual machine is not currently running. Please
check that the
virtual machine is running and try again.
```

Relates to b68af484d