### PR TITLE
pkg/endpoint: reduce cardinality of prometheus labels

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1640,7 +1640,8 @@ type MetadataResolverCB func(ns, podName string) (pod *slim_corev1.Pod, _ []slim
 // will handle updates (such as pkg/k8s/watchers informers).
 func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 	done := make(chan struct{})
-	controllerName := fmt.Sprintf("resolve-labels-%s", e.GetK8sNamespaceAndPodName())
+	const controllerPrefix = "resolve-labels"
+	controllerName := fmt.Sprintf("%s-%s", controllerPrefix, e.GetK8sNamespaceAndPodName())
 	go func() {
 		select {
 		case <-done:
@@ -1656,7 +1657,7 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 				ns, podName := e.GetK8sNamespace(), e.GetK8sPodName()
 				pod, cp, identityLabels, info, _, err := resolveMetadata(ns, podName)
 				if err != nil {
-					e.Logger(controllerName).WithError(err).Warning("Unable to fetch kubernetes labels")
+					e.Logger(controllerPrefix).WithError(err).Warning("Unable to fetch kubernetes labels")
 					return err
 				}
 				e.SetPod(pod)


### PR DESCRIPTION
If the controller that is used for label resolution fails, the
prometheus metrics will increase its cardinality since the uniquely
controller name was being used as a prometheus label. To avoid this, we
will reference these warnings with a common subsystem name,
'resolve-labels'.

Fixes: a31ab29f57b2 ("endpoint: Run labels controller under ep manager")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/13678

```release-note
 reduce cardinality of prometheus labels
```
