### PR TITLE
v1.8 backports 2020-10-22

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ Juan Jimenez-Anca                       cortopy@users.noreply.github.com
 Julien Balestra                         julien.balestra@datadoghq.com
 Julien Kassar                           github@kassisol.com
 Junli Ou                                oujunli306@gmail.com
+Karl Heins                              karlheins@northwesternmutual.com
 Katarzyna Borkmann                      kasia@iogearbox.net
 Kevin Burke                             kevin@burke.dev
 Kiran Bondalapati                       kiran@bondalapati.com

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -122,6 +122,7 @@ cilium-agent [flags]
       --ipam string                                   Backend to use for IPAM (default "hostscope-legacy")
       --ipsec-key-file string                         Path to IPSec key file
       --iptables-lock-timeout duration                Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                         Set iptables flag random-fully on masquerading rules
       --ipv4-node string                              IPv4 address of node (default "auto")
       --ipv4-pod-subnets strings                      List of IPv4 pod subnets to preconfigure for encryption
       --ipv4-range string                             Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -39,7 +39,7 @@ when to use a kvstore:
 
 .. include:: requirements_intro.rst
 
-You will also need an external etcd version 3.1.0 or higher
+You will also need an external etcd version 3.1.0 or higher.
 
 Configure Cilium
 ===========================
@@ -58,7 +58,8 @@ Deploy Cilium release via Helm:
       --namespace kube-system \\
       --set global.etcd.enabled=true \\
       --set "global.etcd.endpoints[0]=http://etcd-endpoint1:2379" \\
-      --set "global.etcd.endpoints[1]=http://etcd-endpoint2:2379"
+      --set "global.etcd.endpoints[1]=http://etcd-endpoint2:2379" \\
+      --set "global.etcd.endpoints[2]=http://etcd-endpoint3:2379"
 
 
 Optional: Configure the SSL certificates
@@ -69,7 +70,7 @@ key and certificate of etcd:
 
 .. code:: bash
 
-   kubectl create secret generic -n kube-system cilium-etcd-secrets \
+    kubectl create secret generic -n kube-system cilium-etcd-secrets \
         --from-file=etcd-client-ca.crt=ca.crt \
         --from-file=etcd-client.key=client.key \
         --from-file=etcd-client.crt=client.crt
@@ -84,7 +85,8 @@ of http for the etcd endpoint URLs:
       --set global.etcd.enabled=true \\
       --set global.etcd.ssl=true \\
       --set "global.etcd.endpoints[0]=https://etcd-endpoint1:2379" \\
-      --set "global.etcd.endpoints[1]=https://etcd-endpoint2:2379"
+      --set "global.etcd.endpoints[1]=https://etcd-endpoint2:2379" \\
+      --set "global.etcd.endpoints[2]=https://etcd-endpoint3:2379"
 
 Validate the Installation
 =========================
@@ -95,8 +97,8 @@ Verify that Cilium pods were started on each of your worker nodes
 
     kubectl --namespace kube-system get ds cilium
     NAME            DESIRED   CURRENT   READY     NODE-SELECTOR   AGE
-    cilium          4         4         4         <none>          2m
+    cilium          4         4         4         <none>          3m2s
 
     kubectl -n kube-system get deployments cilium-operator
     NAME              READY   UP-TO-DATE   AVAILABLE   AGE
-    cilium-operator   1/1     1            1           5m25s
+    cilium-operator   2/2     2            2           2m6s

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -17,18 +17,18 @@ GKE Requirements
 
 2. Create a project or use an existing one
 
-::
+.. code:: bash
 
-   export GKE_PROJECT=gke-clusters
-   gcloud projects create $GKE_PROJECT
-   gcloud config set project $GKE_PROJECT
+    export GKE_PROJECT=gke-clusters
+    gcloud projects create $GKE_PROJECT
+    gcloud config set project $GKE_PROJECT
 
 
 3. Enable the GKE API for the project if not already done
 
-::
+.. code:: bash
 
-   gcloud services enable container.googleapis.com
+    gcloud services enable container.googleapis.com
 
 Create a GKE Cluster
 ====================

--- a/Documentation/gettingstarted/memcached.rst
+++ b/Documentation/gettingstarted/memcached.rst
@@ -89,10 +89,10 @@ We suggest having a main terminal window to execute *kubectl* commands and two a
 
 In **all three** terminal windows, set some handy environment variables for the demo with the following script:
 
-.. parsed-literal::x
+.. parsed-literal::
 
-   $  curl -s \ |SCM_WEB|\/examples/kubernetes-memcached/memcd-env.sh > memcd-env.sh
-   $  source memcd-env.sh
+    $ curl -s \ |SCM_WEB|\/examples/kubernetes-memcached/memcd-env.sh > memcd-env.sh
+    $ source memcd-env.sh
 
 
 In the terminal window dedicated for the A-wing pod, exec in, use python to import the binary memcached library and set the client connection to the memcached server:

--- a/Documentation/gettingstarted/requirements_intro.rst
+++ b/Documentation/gettingstarted/requirements_intro.rst
@@ -3,7 +3,7 @@ Requirements
 
 Make sure your Kubernetes environment is meeting the requirements:
 
-* Kubernetes >= 1.9
+* Kubernetes >= 1.12
 * Linux kernel >= 4.9
 * Kubernetes in CNI mode
 * Mounted BPF filesystem mounted on all worker nodes

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -322,7 +322,7 @@ Connectivity Problems
 Cilium connectivity tests
 ------------------------------------
 
-The Cilium connectivity test_ deploys a series of services, deployments, and
+The Cilium connectivity test deploys a series of services, deployments, and
 CiliumNetworkPolicy which will use various connectivity paths to connect to
 each other. Connectivity paths include with and without service load-balancing
 and various network policy combinations.
@@ -354,8 +354,6 @@ type. If tests pass, it suggests functionality of the referenced subsystem.
 The pod name indicates the connectivity
 variant and the readiness and liveness gate indicates success or failure of the
 test:
-
-.. _test: \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
 
 .. code:: shell-session
 

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -52,7 +52,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 	parseBackendEntry := func(key bpf.MapKey, value bpf.MapValue) {
 		id := key.(lbmap.BackendKey).GetID()
-		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue)
+		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue).ToHost()
 	}
 	if err := lbmap.Backend4Map.DumpWithCallbackIfExists(parseBackendEntry); err != nil {
 		Fatalf("Unable to dump IPv4 backends table: %s", err)
@@ -65,8 +65,9 @@ func dumpSVC(serviceList map[string][]string) {
 		var entry string
 
 		svcKey := key.(lbmap.ServiceKey)
-		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.ToNetwork().String()
+		svcVal := value.(lbmap.ServiceValue).ToHost()
+		svc := svcKey.String()
+		svcKey = svcKey.ToHost()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -66,7 +66,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 		svcKey := key.(lbmap.ServiceKey)
 		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.String()
+		svc := svcKey.ToNetwork().String()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -593,6 +593,9 @@ func init() {
 	flags.Duration(option.IPTablesLockTimeout, 5*time.Second, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
 	option.BindEnv(option.IPTablesLockTimeout)
 
+	flags.Bool(option.IPTablesRandomFully, false, "Set iptables flag random-fully on masquerading rules")
+	option.BindEnv(option.IPTablesRandomFully)
+
 	flags.Int(option.MaxCtrlIntervalName, 0, "Maximum interval (in seconds) between controller runs. Zero is no limit.")
 	flags.MarkHidden(option.MaxCtrlIntervalName)
 	option.BindEnv(option.MaxCtrlIntervalName)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -385,8 +385,8 @@ data:
 {{- if .Values.global.iptablesLockTimeout }}
   iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
 {{- end }}
-{{- if .Values.global.ipTablesRandomFully }}
-  iptables-random-fully: {{ .Values.global.ipTablesRandomFully | quote }}
+{{- if .Values.global.iptablesRandomFully }}
+  iptables-random-fully: {{ .Values.global.iptablesRandomFully | quote }}
 {{- end }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nativeRoutingCIDR }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -385,6 +385,9 @@ data:
 {{- if .Values.global.iptablesLockTimeout }}
   iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
 {{- end }}
+{{- if .Values.global.ipTablesRandomFully }}
+  iptables-random-fully: {{ .Values.global.ipTablesRandomFully | quote }}
+{{- end }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nativeRoutingCIDR }}
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}

--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -78,7 +78,7 @@ func (k EndpointKey) ToIP() net.IP {
 // String provides a string representation of the EndpointKey.
 func (k EndpointKey) String() string {
 	if ip := k.ToIP(); ip != nil {
-		return fmt.Sprintf("%s:%d", ip.String(), k.Key)
+		return net.JoinHostPort(ip.String(), fmt.Sprintf("%d", k.Key))
 	}
 	return "nil"
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -939,18 +939,22 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			// * Non-tunnel mode:
 			//   * May not be targeted to an IP in the cluster range
 			if option.Config.EgressMasqueradeInterfaces != "" {
-				if err := runProg("iptables", append(
+				progArgs := append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
 					"!", "-d", datapath.RemoteSNATDstAddrExclusionCIDR().String(),
 					"-o", option.Config.EgressMasqueradeInterfaces,
 					"-m", "comment", "--comment", "cilium masquerade non-cluster",
-					"-j", "MASQUERADE"), false); err != nil {
+					"-j", "MASQUERADE")
+				if option.Config.IPTablesRandomFully {
+					progArgs = append(progArgs, "--random-fully")
+				}
+				if err := runProg("iptables", progArgs, false); err != nil {
 					return err
 				}
 			} else {
-				if err := runProg("iptables", append(
+				progArgs := append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
@@ -958,7 +962,11 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 					"!", "-d", datapath.RemoteSNATDstAddrExclusionCIDR().String(),
 					"!", "-o", "cilium_+",
 					"-m", "comment", "--comment", "cilium masquerade non-cluster",
-					"-j", "MASQUERADE"), false); err != nil {
+					"-j", "MASQUERADE")
+				if option.Config.IPTablesRandomFully {
+					progArgs = append(progArgs, "--random-fully")
+				}
+				if err := runProg("iptables", progArgs, false); err != nil {
 					return err
 				}
 			}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1667,8 +1667,7 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 				close(done)
 				return nil
 			},
-			RunInterval: 30 * time.Second,
-			Context:     e.aliveCtx,
+			Context: e.aliveCtx,
 		},
 	)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1637,7 +1637,11 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 	done := make(chan struct{})
 	controllerName := fmt.Sprintf("resolve-labels-%s", e.GetK8sNamespaceAndPodName())
 	go func() {
-		<-done
+		select {
+		case <-done:
+		case <-e.aliveCtx.Done():
+			return
+		}
 		e.controllers.RemoveController(controllerName)
 	}()
 

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -103,7 +103,10 @@ func (k *AffinityMatchKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k)
 func (v *AffinityMatchValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 // String converts the key into a human readable string format
-func (k *AffinityMatchKey) String() string { return fmt.Sprintf("%d %d", k.BackendID, k.RevNATID) }
+func (k *AffinityMatchKey) String() string {
+	kHost := k.ToHost()
+	return fmt.Sprintf("%d %d", kHost.BackendID, kHost.RevNATID)
+}
 
 // String converts the value into a human readable string format
 func (v *AffinityMatchValue) String() string { return "" }
@@ -119,6 +122,13 @@ func (k *AffinityMatchKey) ToNetwork() *AffinityMatchKey {
 	// the SVC BPF maps
 	n.RevNATID = byteorder.HostToNetwork(n.RevNATID).(uint16)
 	return &n
+}
+
+// ToHost returns the key in the host byte order
+func (k *AffinityMatchKey) ToHost() *AffinityMatchKey {
+	h := *k
+	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
+	return &h
 }
 
 // Affinity4Key is the Go representation of lb4_affinity_key

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -39,15 +39,8 @@ var (
 		int(unsafe.Sizeof(AffinityMatchValue{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			aKey, aVal := mapKey.(*AffinityMatchKey), mapValue.(*AffinityMatchValue)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, aKey, aVal); err != nil {
-				return nil, nil, err
-			}
-
-			return aKey.ToNetwork(), aVal, nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 	Affinity4Map = bpf.NewMap(
 		Affinity4MapName,
 		bpf.MapTypeLRUHash,

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -134,7 +134,7 @@ func (v *RevNat4Value) ToNetwork() RevNatValue {
 }
 
 func (v *RevNat4Value) String() string {
-	return fmt.Sprintf("%s:%d", v.Address, v.Port)
+	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
 }
 
 type pad2uint8 [2]uint8
@@ -171,11 +171,11 @@ func NewService4Key(ip net.IP, port uint16, proto u8proto.U8proto, scope uint8, 
 }
 
 func (k *Service4Key) String() string {
+	addr := net.JoinHostPort(k.Address.String(), fmt.Sprintf("%d", k.Port))
 	if k.Scope == loadbalancer.ScopeInternal {
-		return fmt.Sprintf("%s:%d/i", k.Address, k.Port)
-	} else {
-		return fmt.Sprintf("%s:%d", k.Address, k.Port)
+		addr += "/i"
 	}
+	return addr
 }
 
 func (k *Service4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -107,7 +107,7 @@ func NewRevNat4Key(value uint16) *RevNat4Key {
 func (k *RevNat4Key) Map() *bpf.Map             { return RevNat4Map }
 func (k *RevNat4Key) NewValue() bpf.MapValue    { return &RevNat4Value{} }
 func (k *RevNat4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
-func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.Key) }
+func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.ToHost().(*RevNat4Key).Key) }
 func (k *RevNat4Key) GetKey() uint16            { return k.Key }
 
 // ToNetwork converts RevNat4Key to network byte order.
@@ -115,6 +115,13 @@ func (k *RevNat4Key) ToNetwork() RevNatKey {
 	n := *k
 	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
 	return &n
+}
+
+// ToHost converts RevNat4Key to host byte order.
+func (k *RevNat4Key) ToHost() RevNatKey {
+	h := *k
+	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -133,8 +140,16 @@ func (v *RevNat4Value) ToNetwork() RevNatValue {
 	return &n
 }
 
+// ToHost converts RevNat4Value to host byte order.
+func (k *RevNat4Value) ToHost() RevNatValue {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 func (v *RevNat4Value) String() string {
-	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+	vHost := v.ToHost().(*RevNat4Value)
+	return net.JoinHostPort(vHost.Address.String(), fmt.Sprintf("%d", vHost.Port))
 }
 
 type pad2uint8 [2]uint8
@@ -204,6 +219,13 @@ func (k *Service4Key) ToNetwork() ServiceKey {
 	return &n
 }
 
+// ToHost converts Service4Key to host byte order.
+func (k *Service4Key) ToHost() ServiceKey {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 type pad3uint8 [3]uint8
 
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
@@ -224,7 +246,8 @@ type Service4Value struct {
 }
 
 func (s *Service4Value) String() string {
-	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", s.BackendID, s.RevNat, s.Flags)
+	sHost := s.ToHost().(*Service4Value)
+	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", sHost.BackendID, sHost.RevNat, sHost.Flags)
 }
 
 func (s *Service4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
@@ -254,6 +277,13 @@ func (s *Service4Value) ToNetwork() ServiceValue {
 	n := *s
 	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
 	return &n
+}
+
+// ToHost converts Service4Value to host byte order.
+func (s *Service4Value) ToHost() ServiceValue {
+	h := *s
+	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -299,7 +329,8 @@ func NewBackend4Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend4V
 }
 
 func (v *Backend4Value) String() string {
-	return fmt.Sprintf("%s://%s:%d", v.Proto, v.Address, v.Port)
+	vHost := v.ToHost().(*Backend4Value)
+	return fmt.Sprintf("%s://%s:%d", vHost.Proto, vHost.Address, vHost.Port)
 }
 
 func (v *Backend4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
@@ -311,6 +342,13 @@ func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToHost converts Backend4Value to host byte order.
+func (v *Backend4Value) ToHost() BackendValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 type Backend4 struct {

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -108,7 +108,7 @@ func NewRevNat6Key(value uint16) *RevNat6Key {
 func (v *RevNat6Key) Map() *bpf.Map             { return RevNat6Map }
 func (v *RevNat6Key) NewValue() bpf.MapValue    { return &RevNat6Value{} }
 func (v *RevNat6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(v) }
-func (v *RevNat6Key) String() string            { return fmt.Sprintf("%d", v.Key) }
+func (v *RevNat6Key) String() string            { return fmt.Sprintf("%d", v.ToHost().(*RevNat6Key).Key) }
 func (v *RevNat6Key) GetKey() uint16            { return v.Key }
 
 // ToNetwork converts RevNat6Key to network byte order.
@@ -116,6 +116,13 @@ func (v *RevNat6Key) ToNetwork() RevNatKey {
 	n := *v
 	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
 	return &n
+}
+
+// ToNetwork converts RevNat6Key to host byte order.
+func (v *RevNat6Key) ToHost() RevNatKey {
+	h := *v
+	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -128,7 +135,8 @@ type RevNat6Value struct {
 func (v *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 func (v *RevNat6Value) String() string {
-	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+	vHost := v.ToHost().(*RevNat6Value)
+	return net.JoinHostPort(vHost.Address.String(), fmt.Sprintf("%d", vHost.Port))
 }
 
 // ToNetwork converts RevNat6Value to network byte order.
@@ -136,6 +144,13 @@ func (v *RevNat6Value) ToNetwork() RevNatValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToNetwork converts RevNat6Value to Host byte order.
+func (v *RevNat6Value) ToHost() RevNatValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 // Service6Key must match 'struct lb6_key_v2' in "bpf/lib/common.h".
@@ -197,6 +212,13 @@ func (k *Service6Key) ToNetwork() ServiceKey {
 	return &n
 }
 
+// ToHost converts Service6Key to host byte order.
+func (k *Service6Key) ToHost() ServiceKey {
+	h := *k
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
+}
+
 // Service6Value must match 'struct lb6_service_v2' in "bpf/lib/common.h".
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
@@ -209,7 +231,8 @@ type Service6Value struct {
 }
 
 func (s *Service6Value) String() string {
-	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", s.BackendID, s.RevNat, s.Flags)
+	sHost := s.ToHost().(*Service6Value)
+	return fmt.Sprintf("%d (%d) [FLAGS: 0x%x]", sHost.BackendID, sHost.RevNat, sHost.Flags)
 }
 
 func (s *Service6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
@@ -238,6 +261,13 @@ func (s *Service6Value) ToNetwork() ServiceValue {
 	n := *s
 	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
 	return &n
+}
+
+// ToHost converts Service6Value to host byte order.
+func (s *Service6Value) ToHost() ServiceValue {
+	h := *s
+	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	return &h
 }
 
 // +k8s:deepcopy-gen=true
@@ -283,7 +313,8 @@ func NewBackend6Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend6V
 }
 
 func (v *Backend6Value) String() string {
-	return fmt.Sprintf("%s://[%s]:%d", v.Proto, v.Address, v.Port)
+	vHost := v.ToHost().(*Backend6Value)
+	return fmt.Sprintf("%s://[%s]:%d", vHost.Proto, vHost.Address, vHost.Port)
 }
 
 func (v *Backend6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
@@ -295,6 +326,13 @@ func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
 	return &n
+}
+
+// ToHost converts Backend6Value to host byte order.
+func (v *Backend6Value) ToHost() BackendValue {
+	h := *v
+	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	return &h
 }
 
 type Backend6 struct {

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -126,7 +126,10 @@ type RevNat6Value struct {
 }
 
 func (v *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
-func (v *RevNat6Value) String() string              { return fmt.Sprintf("%s:%d", v.Address, v.Port) }
+
+func (v *RevNat6Value) String() string {
+	return net.JoinHostPort(v.Address.String(), fmt.Sprintf("%d", v.Port))
+}
 
 // ToNetwork converts RevNat6Value to network byte order.
 func (v *RevNat6Value) ToNetwork() RevNatValue {

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -211,7 +211,7 @@ func (*LBBPFMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
 	matches := BackendIDByServiceIDSet{}
 
 	parse := func(key bpf.MapKey, value bpf.MapValue) {
-		matchKey := key.DeepCopyMapKey().(*AffinityMatchKey)
+		matchKey := key.DeepCopyMapKey().(*AffinityMatchKey).ToHost()
 		svcID := matchKey.RevNATID
 		backendID := uint16(matchKey.BackendID) // currently backend_id is u16
 
@@ -232,7 +232,7 @@ func (*LBBPFMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
 func (*LBBPFMap) DumpSourceRanges(ipv6 bool) (SourceRangeSetByServiceID, error) {
 	ret := SourceRangeSetByServiceID{}
 	parser := func(key bpf.MapKey, value bpf.MapValue) {
-		k := key.(SourceRangeKey)
+		k := key.(SourceRangeKey).ToHost()
 		revNATID := k.GetRevNATID()
 		if _, found := ret[revNATID]; !found {
 			ret[revNATID] = []*cidr.CIDR{}
@@ -307,13 +307,13 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 
 	parseBackendEntries := func(key bpf.MapKey, value bpf.MapValue) {
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 
 	parseSVCEntries := func(key bpf.MapKey, value bpf.MapValue) {
-		svcKey := key.DeepCopyMapKey().(ServiceKey)
-		svcValue := value.DeepCopyMapValue().(ServiceValue)
+		svcKey := key.DeepCopyMapKey().(ServiceKey).ToHost()
+		svcValue := value.DeepCopyMapValue().(ServiceValue).ToHost()
 
 		fe := svcFrontend(svcKey, svcValue)
 
@@ -389,7 +389,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		// No need to deep copy the key because we are using the ID which
 		// is a value.
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -61,6 +61,9 @@ type ServiceKey interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() ServiceKey
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceKey
 }
 
 // ServiceValue is the interface describing protocol independent value for services map v2.
@@ -99,6 +102,9 @@ type ServiceValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() ServiceValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceValue
 }
 
 // BackendKey is the interface describing protocol independent backend key.
@@ -127,6 +133,9 @@ type BackendValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() BackendValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() BackendValue
 }
 
 // Backend is the interface describing protocol independent backend used by services v2.
@@ -152,6 +161,9 @@ type RevNatKey interface {
 
 	// Returns the key value
 	GetKey() uint16
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatKey
 }
 
 type RevNatValue interface {
@@ -159,6 +171,9 @@ type RevNatValue interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() RevNatValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatValue
 }
 
 // BackendIDByServiceIDSet is the type of a set for checking whether a backend

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -309,6 +309,9 @@ const (
 
 	IPTablesLockTimeout = "iptables-lock-timeout"
 
+	// IPTablesRandomFully sets iptables flag random-fully on masquerading rules
+	IPTablesRandomFully = "iptables-random-fully"
+
 	// IPv6NodeAddr is the IPv6 address of node
 	IPv6NodeAddr = "ipv6-node"
 
@@ -1046,6 +1049,7 @@ var HelpFlagSections = []FlagsSection{
 			DisableIptablesFeederRules,
 			InstallIptRules,
 			IPTablesLockTimeout,
+			IPTablesRandomFully,
 		},
 	},
 	{
@@ -1463,6 +1467,10 @@ type DaemonConfig struct {
 	// IPTablesLockTimeout defines the "-w" iptables option when the
 	// iptables CLI is directly invoked from the Cilium agent.
 	IPTablesLockTimeout time.Duration
+
+	// IPTablesRandomFully defines the "--random-fully" iptables option when the
+	// iptables CLI is directly invoked from the Cilium agent.
+	IPTablesRandomFully bool
 
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
@@ -2383,6 +2391,7 @@ func (c *DaemonConfig) Populate() {
 	c.IPMasqAgentConfigPath = viper.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
 	c.IPTablesLockTimeout = viper.GetDuration(IPTablesLockTimeout)
+	c.IPTablesRandomFully = viper.GetBool(IPTablesRandomFully)
 	c.IPSecKeyFile = viper.GetString(IPSecKeyFileName)
 	c.ModePreFilter = viper.GetString(PrefilterMode)
 	c.MonitorAggregation = viper.GetString(MonitorAggregationName)

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -16,6 +16,7 @@ package proxy
 
 import (
 	"fmt"
+	"net"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -46,7 +47,7 @@ func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServe
 	l := r.listener
 	if envoyProxy != nil {
 		redir := &envoyRedirect{
-			listenerName: fmt.Sprintf("%s:%d", l.name, l.proxyPort),
+			listenerName: net.JoinHostPort(l.name, fmt.Sprintf("%d", l.proxyPort)),
 			xdsServer:    xdsServer,
 		}
 		// Only use original source address for egress

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -303,7 +303,7 @@ func (client *SSHClient) newSession() (*ssh.Session, error) {
 	} else {
 		connection, err = ssh.Dial(
 			"tcp",
-			fmt.Sprintf("%s:%d", client.Host, client.Port),
+			net.JoinHostPort(client.Host, fmt.Sprintf("%d", client.Port)),
 			client.Config)
 
 		if err != nil {

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -105,18 +105,19 @@ func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
 }
 
 // CurlWithRetries returns the string representation of the curl command that
-// retry the request if transient problems occur. Parameter retries are indicated the maximum retry times.
-// If the endpoint already contain "curl", the function will add --retry flag at the end of the command and return.
-// If the endpoint didn't contain "curl", the function will generate the command with --retry flag and return.
-func CurlWithRetries(endpoint string, retries int, optionalValues ...interface{}) string {
+// retries the request if transient problems occur. The parameter "retries"
+// indicates the maximum number of attempts.  If flag "fail" is true, the
+// function will call CurlFail() and add --retry flag at the end of the command
+// and return.  If flag "fail" is false, the function will generate the command
+// with --retry flag and return.
+func CurlWithRetries(endpoint string, retries int, fail bool, optionalValues ...interface{}) string {
+	if fail {
+		return fmt.Sprintf(
+			`%s --retry %d`,
+			CurlFail(endpoint, optionalValues...), retries)
+	}
 	if len(optionalValues) > 0 {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
-	}
-	if strings.Contains(endpoint, "curl") {
-		if strings.Contains(endpoint, "--retry") {
-			return endpoint
-		}
-		return fmt.Sprintf(`%s --retry %d `, endpoint, retries)
 	}
 	return fmt.Sprintf(
 		`curl --path-as-is -s  -D /dev/stderr --output /dev/stderr --retry %d %s`,

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -104,6 +104,25 @@ func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
 		CurlConnectTimeout, endpoint)
 }
 
+// CurlWithRetries returns the string representation of the curl command that
+// retry the request if transient problems occur. Parameter retries are indicated the maximum retry times.
+// If the endpoint already contain "curl", the function will add --retry flag at the end of the command and return.
+// If the endpoint didn't contain "curl", the function will generate the command with --retry flag and return.
+func CurlWithRetries(endpoint string, retries int, optionalValues ...interface{}) string {
+	if len(optionalValues) > 0 {
+		endpoint = fmt.Sprintf(endpoint, optionalValues...)
+	}
+	if strings.Contains(endpoint, "curl") {
+		if strings.Contains(endpoint, "--retry") {
+			return endpoint
+		}
+		return fmt.Sprintf(`%s --retry %d `, endpoint, retries)
+	}
+	return fmt.Sprintf(
+		`curl --path-as-is -s  -D /dev/stderr --output /dev/stderr --retry %d %s`,
+		retries, endpoint)
+}
+
 // Netperf returns the string representing the netperf command to use when testing
 // connectivity between endpoints.
 func Netperf(endpoint string, perfTest PerfTest, options string) string {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -273,7 +273,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		It("Check iptables masquerading with random-fully", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"bpf.masquerade":      "false",
-				"ipTablesRandomFully": "true",
+				"iptablesRandomFully": "true",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -269,6 +269,18 @@ var _ = Describe("K8sDatapathConfig", func() {
 					Should(BeTrue(), "Connectivity test to http://google.com failed")
 			}
 		})
+
+		It("Check iptables masquerading with random-fully", func() {
+			deploymentManager.DeployCilium(map[string]string{
+				"bpf.masquerade":      "false",
+				"ipTablesRandomFully": "true",
+			}, DeployCiliumOptionsAndDNS)
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+
+			By("Test iptables masquerading")
+			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
+				Should(BeTrue(), "Connectivity test to http://google.com failed")
+		})
 	})
 
 	Context("DirectRouting", func() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -749,7 +749,7 @@ func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNod
 	pods, err := kubectl.GetPodNames(namespace, label)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve pod names by label %s", label)
 
-	cmd := helpers.CurlFail(outsideURL)
+	cmd := helpers.CurlWithRetries(outsideURL, 10, true)
 	if expectNodeIP || expectPodIP {
 		cmd += " | grep client_address="
 		hostIPs, err = kubectl.GetPodsHostIPs(namespace, label)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -151,7 +151,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				By("HTTP connectivity to 1.1.1.1")
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("--retry 5 http://1.1.1.1/"))
+					helpers.CurlWithRetries(helpers.CurlFail("http://1.1.1.1/"), 5))
 
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
 					"HTTP egress connectivity to 1.1.1.1 from pod %q", pod)
@@ -394,25 +394,25 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 --max-time 15 %s 'https://artii.herokuapp.com/make?text=cilium&font=univers'", "-v --cacert /cacert.pem"))
+				helpers.CurlWithRetries(helpers.CurlFail("-4 --max-time 15 %s 'https://artii.herokuapp.com/make?text=cilium&font=univers'", "-v --cacert /cacert.pem"), 5))
 			res.ExpectSuccess("Cannot connect from %q to 'https://artii.herokuapp.com/make?text=cilium&font=univers'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 %s 'https://artii.herokuapp.com:443/fonts_list'", "-v --cacert /cacert.pem"))
+				helpers.CurlWithRetries(helpers.CurlFail("-4 %s 'https://artii.herokuapp.com:443/fonts_list'", "-v --cacert /cacert.pem"), 5))
 			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://artii.herokuapp.com:443/fonts_list'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 %s https://www.lyft.com:443/privacy", "-v --cacert /cacert.pem"))
+				helpers.CurlWithRetries(helpers.CurlFail("-4 %s https://www.lyft.com:443/privacy", "-v --cacert /cacert.pem"), 5))
 			res.ExpectSuccess("Cannot connect from %q to 'https://www.lyft.com:443/privacy'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 %s https://www.lyft.com:443/private", "-v --cacert /cacert.pem"))
+				helpers.CurlWithRetries(helpers.CurlFail("-4 %s https://www.lyft.com:443/private", "-v --cacert /cacert.pem"), 5))
 			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://www.lyft.com:443/private'",
 				appPods[helpers.App2])
 		}, 500)
@@ -672,7 +672,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("--retry 5 http://1.1.1.1/"))
+					helpers.CurlWithRetries(helpers.CurlFail("http://1.1.1.1/"), 5))
 				res.ExpectSuccess("Egress connectivity should be allowed for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -943,7 +943,7 @@ var _ = Describe("K8sPolicyTest", func() {
 						"vagrant-cache.ci.cilium.io.",
 					)
 					if retryCurl {
-						curlCmd = helpers.CurlFail("--retry 5 " + resource)
+						curlCmd = helpers.CurlWithRetries(helpers.CurlFail(resource), 5)
 					} else {
 						curlCmd = helpers.CurlFail(resource)
 					}
@@ -956,7 +956,7 @@ var _ = Describe("K8sPolicyTest", func() {
 					)
 
 					if retryCurl {
-						curlCmd = helpers.CurlFail(fmt.Sprintf("--retry 5 http://%s/public", resource))
+						curlCmd = helpers.CurlWithRetries(helpers.CurlFail(fmt.Sprintf("http://%s/public", resource)), 5)
 					} else {
 						curlCmd = helpers.CurlFail(fmt.Sprintf("http://%s/public", resource))
 					}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -151,7 +151,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				By("HTTP connectivity to 1.1.1.1")
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlWithRetries(helpers.CurlFail("http://1.1.1.1/"), 5))
+					helpers.CurlWithRetries("http://1.1.1.1/", 5, true))
 
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
 					"HTTP egress connectivity to 1.1.1.1 from pod %q", pod)
@@ -394,25 +394,25 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlWithRetries(helpers.CurlFail("-4 --max-time 15 %s 'https://artii.herokuapp.com/make?text=cilium&font=univers'", "-v --cacert /cacert.pem"), 5))
+				helpers.CurlWithRetries("-4 --max-time 15 %s 'https://artii.herokuapp.com/make?text=cilium&font=univers'", 5, true, "-v --cacert /cacert.pem"))
 			res.ExpectSuccess("Cannot connect from %q to 'https://artii.herokuapp.com/make?text=cilium&font=univers'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlWithRetries(helpers.CurlFail("-4 %s 'https://artii.herokuapp.com:443/fonts_list'", "-v --cacert /cacert.pem"), 5))
+				helpers.CurlWithRetries("-4 %s 'https://artii.herokuapp.com:443/fonts_list'", 5, true, "-v --cacert /cacert.pem"))
 			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://artii.herokuapp.com:443/fonts_list'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlWithRetries(helpers.CurlFail("-4 %s https://www.lyft.com:443/privacy", "-v --cacert /cacert.pem"), 5))
+				helpers.CurlWithRetries("-4 %s https://www.lyft.com:443/privacy", 5, true, "-v --cacert /cacert.pem"))
 			res.ExpectSuccess("Cannot connect from %q to 'https://www.lyft.com:443/privacy'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlWithRetries(helpers.CurlFail("-4 %s https://www.lyft.com:443/private", "-v --cacert /cacert.pem"), 5))
+				helpers.CurlWithRetries("-4 %s https://www.lyft.com:443/private", 5, true, "-v --cacert /cacert.pem"))
 			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://www.lyft.com:443/private'",
 				appPods[helpers.App2])
 		}, 500)
@@ -672,7 +672,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlWithRetries(helpers.CurlFail("http://1.1.1.1/"), 5))
+					helpers.CurlWithRetries("http://1.1.1.1/", 5, true))
 				res.ExpectSuccess("Egress connectivity should be allowed for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -943,7 +943,7 @@ var _ = Describe("K8sPolicyTest", func() {
 						"vagrant-cache.ci.cilium.io.",
 					)
 					if retryCurl {
-						curlCmd = helpers.CurlWithRetries(helpers.CurlFail(resource), 5)
+						curlCmd = helpers.CurlWithRetries(resource, 5, true)
 					} else {
 						curlCmd = helpers.CurlFail(resource)
 					}
@@ -956,7 +956,7 @@ var _ = Describe("K8sPolicyTest", func() {
 					)
 
 					if retryCurl {
-						curlCmd = helpers.CurlWithRetries(helpers.CurlFail(fmt.Sprintf("http://%s/public", resource)), 5)
+						curlCmd = helpers.CurlWithRetries(fmt.Sprintf("http://%s/public", resource), 5, true)
 					} else {
 						curlCmd = helpers.CurlFail(fmt.Sprintf("http://%s/public", resource))
 					}

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -260,7 +260,7 @@ var _ = Describe("K8sFQDNTest", func() {
 
 		res = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App3],
-			helpers.CurlFail("--retry 5 "+world2Target))
+			helpers.CurlWithRetries(helpers.CurlFail(world2Target), 5))
 		res.ExpectSuccess("Can't connect to to a valid target when it should work")
 
 		res = kubectl.ExecPodCmd(

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -260,7 +260,7 @@ var _ = Describe("K8sFQDNTest", func() {
 
 		res = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App3],
-			helpers.CurlWithRetries(helpers.CurlFail(world2Target), 5))
+			helpers.CurlWithRetries(world2Target, 5, true))
 		res.ExpectSuccess("Can't connect to to a valid target when it should work")
 
 		res = kubectl.ExecPodCmd(

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -92,7 +92,7 @@ var _ = Describe("K8sIstioTest", func() {
 			os = ciliumIstioctlOSes[runtime.GOOS]
 		}
 		ciliumIstioctlURL := "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-" + os + ".tar.gz"
-		res := kubectl.Exec(fmt.Sprintf("curl --retry 5 -L %s | tar xz", ciliumIstioctlURL))
+		res := kubectl.Exec(helpers.CurlWithRetries(fmt.Sprintf("curl -L %s | tar xz", ciliumIstioctlURL), 5))
 		res.ExpectSuccess("unable to download %s", ciliumIstioctlURL)
 		res = kubectl.ExecShort("./cilium-istioctl version")
 		res.ExpectSuccess("unable to execute cilium-istioctl")

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -92,7 +92,7 @@ var _ = Describe("K8sIstioTest", func() {
 			os = ciliumIstioctlOSes[runtime.GOOS]
 		}
 		ciliumIstioctlURL := "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-" + os + ".tar.gz"
-		res := kubectl.Exec(helpers.CurlWithRetries(fmt.Sprintf("curl -L %s | tar xz", ciliumIstioctlURL), 5))
+		res := kubectl.Exec(helpers.CurlWithRetries(fmt.Sprintf("curl -L %s | tar xz", ciliumIstioctlURL), 5, false))
 		res.ExpectSuccess("unable to download %s", ciliumIstioctlURL)
 		res = kubectl.ExecShort("./cilium-istioctl version")
 		res.ExpectSuccess("unable to execute cilium-istioctl")

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -16,6 +16,7 @@ package RuntimeTest
 
 import (
 	"fmt"
+	"net"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -161,8 +162,8 @@ var _ = Describe("RuntimeLB", func() {
 			Expect(err).Should(BeNil())
 
 			status := vm.ServiceAdd(svcID, service, []string{
-				fmt.Sprintf("%s:80", httpd1["IPv4"]),
-				fmt.Sprintf("%s:80", httpd2["IPv4"])})
+				net.JoinHostPort(httpd1["IPv4"], "80"),
+				net.JoinHostPort(httpd2["IPv4"], "80")})
 			status.ExpectSuccess("failed to create service %s=>{httpd1,httpd2}", service)
 
 			By("Making HTTP request via the service before restart")
@@ -238,13 +239,13 @@ var _ = Describe("RuntimeLB", func() {
 
 			By("Configuring services")
 
-			service1 := fmt.Sprintf("2.2.2.100:%d", svcPort)
-			service2 := fmt.Sprintf("[f00d::1:1]:%d", svcPort)
-			service3 := fmt.Sprintf("2.2.2.101:%d", svcPort)
+			service1 := net.JoinHostPort("2.2.2.100", fmt.Sprintf("%d", svcPort))
+			service2 := net.JoinHostPort("f00d::1:1", fmt.Sprintf("%d", svcPort))
+			service3 := net.JoinHostPort("2.2.2.101", fmt.Sprintf("%d", svcPort))
 			services := map[string]string{
-				service1: fmt.Sprintf("%s:80", httpd1[helpers.IPv4]),
-				service2: fmt.Sprintf("[%s]:80", httpd2[helpers.IPv6]),
-				service3: fmt.Sprintf("%s:80", httpd2[helpers.IPv4]),
+				service1: net.JoinHostPort(httpd1[helpers.IPv4], "80"),
+				service2: net.JoinHostPort(httpd2[helpers.IPv6], "80"),
+				service3: net.JoinHostPort(httpd2[helpers.IPv4], "80"),
 			}
 			svc := 100
 			for fe, be := range services {


### PR DESCRIPTION
* #13383 -- daemon: Enable configuration of iptables --random-fully (@kh34)
   - Minor conflicts due to Helm refactoring.
 * #12975 -- Use net.JoinHostPort to construct network address strings (@tklauser)
   - Pulled in to simplify the backport of the next PR.
 * #13244 -- lbmap: Correct issue that port info display error (@Jianlin-lv)
 * #13651 -- docs: fix minor issue in cilium support with external etcd gsg (@fristonio)
   - Minor conflicts due to Helm refactoring.
 * #13645 -- docs: GKE - fix some indentation, specify bash code segments (@ti-mo)
 * #13661 -- docs: Fix broken formating and link (@pchaigno)
 * #13683 -- endpoint: Fix goroutine leak when EP is deleted (@christarazi)
 * #13673 -- docs: improve Host Firewall GSG (@qmonnet)
   - Minor conflicts due to Helm refactoring.
 * #13556 -- install/kubernetes: consistent case spelling of iptables related values (@tklauser)
   - Minor conflicts due to Helm refactoring.
 * #12408 -- ci: refactor curl / wget test helpers with retries (@JieJhih)
   - Pulled in to simplify backport of the next PR.
 * #13694 -- test: improve debugging of dns issues, add retries to external conn check (@nebril)
   - Pulled in to fix flake introduced by #13383.

Skipped due to potential regression:
 * #13608 -- daemon: Init endpoint queue during validation (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13383 12975 13244 13651 13645 13661 13683 13673 13556 12408 13694; do contrib/backporting/set-labels.py $pr done 1.8; done
```