### PR TITLE
pkg/endpoint: calculate Kube API-Server lag from pod events

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -122,6 +122,10 @@ type Endpoint struct {
 	// ID of the endpoint, unique in the scope of the node
 	ID uint16
 
+	// createdAt stores the time the endpoint was created. This value is
+	// recalculated on endpoint restore.
+	createdAt time.Time
+
 	// mutex protects write operations to this endpoint structure except
 	// for the logger field which has its own mutex
 	mutex lock.RWMutex
@@ -430,6 +434,7 @@ func createEndpoint(owner regeneration.Owner, proxy EndpointProxy, allocator cac
 	ep := &Endpoint{
 		owner:           owner,
 		ID:              ID,
+		createdAt:       time.Now(),
 		proxy:           proxy,
 		ifName:          ifName,
 		OpLabels:        labels.NewOpLabels(),
@@ -2399,4 +2404,9 @@ func (e *Endpoint) setDefaultPolicyConfig() {
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
 	e.desiredPolicy.IngressPolicyEnabled = alwaysEnforce
 	e.desiredPolicy.EgressPolicyEnabled = alwaysEnforce
+}
+
+// GetCreatedAt returns the endpoint creation time.
+func (e *Endpoint) GetCreatedAt() time.Time {
+	return e.createdAt
 }

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -531,6 +531,7 @@ func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 
 func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
+	ep.createdAt = time.Now()
 	ep.containerName = r.ContainerName
 	ep.containerID = r.ContainerID
 	ep.dockerNetworkID = r.DockerNetworkID

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/bandwidth"
@@ -43,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
@@ -72,6 +74,15 @@ func (k *K8sWatcher) createPodController(getter cache.Getter, fieldSelector fiel
 				var valid bool
 				if pod := k8s.ObjTov1Pod(obj); pod != nil {
 					valid = true
+					podNSName := k8sUtils.GetObjNamespaceName(&pod.ObjectMeta)
+					// If ep is not nil then we have received the CNI event
+					// first and the k8s event afterwards, if this happens it's
+					// likely the Kube API Server is getting behind the event
+					// handling.
+					if ep := k.endpointManager.LookupPodName(podNSName); ep != nil {
+						epCreatedAt := ep.GetCreatedAt()
+						metrics.EventLagK8s.Set(time.Since(epCreatedAt).Seconds())
+					}
 					err := k.addK8sPodV1(pod)
 					k.K8sEventProcessed(metricPod, metricCreate, err == nil)
 				}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -273,6 +273,9 @@ var (
 	// EventTSK8s is the timestamp of k8s events
 	EventTSK8s = NoOpGauge
 
+	// EventLagK8s is the lag calculation for k8s Pod events.
+	EventLagK8s = NoOpGauge
+
 	// EventTSContainerd is the timestamp of docker events
 	EventTSContainerd = NoOpGauge
 
@@ -485,6 +488,7 @@ type Configuration struct {
 	PolicyImplementationDelayEnabled        bool
 	IdentityCountEnabled                    bool
 	EventTSK8sEnabled                       bool
+	EventLagK8sEnabled                      bool
 	EventTSContainerdEnabled                bool
 	EventTSAPIEnabled                       bool
 	ProxyRedirectsEnabled                   bool
@@ -786,6 +790,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, EventTSK8s)
 			c.EventTSK8sEnabled = true
+
+			EventLagK8s = prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace:   Namespace,
+				Name:        "k8s_event_lag_seconds",
+				Help:        "Lag for Kubernetes events - computed value between receiving a CNI ADD event from kubelet and a Pod event received from kube-api-server",
+				ConstLabels: prometheus.Labels{"source": LabelEventSourceK8s},
+			})
+
+			collectors = append(collectors, EventLagK8s)
+			c.EventLagK8sEnabled = true
 
 			EventTSContainerd = prometheus.NewGauge(prometheus.GaugeOpts{
 				Namespace:   Namespace,


### PR DESCRIPTION
Since Cilium receives CNI events when a pod is created, Cilium can
calculate the lag for kube-apiserver events by checking the time an
ADD event for that Pod was received and subtracting by the time the CNI
event for that pod was received.

Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/13679

```release-note
Add metric 'cilium_k8s_event_lag_seconds' for calculated lag of Kubernetes events
```
