### PR TITLE
backporting: Update labels by default when submitting backport

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -51,9 +51,9 @@ hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
-echo -n "Set labels for all PRs above? [y/N] "
+echo -n "Set labels for all PRs above? [Y/n] "
 read set_all_labels
-if [ "$set_all_labels" = "y" ]; then
+if [ "$set_all_labels" != "n" ]; then
     for pr in $prs; do
         $DIR/set-labels.py $pr pending $BRANCH;
     done


### PR DESCRIPTION
When submitting the backport PR using `submit-backport`, the script proposes to update the labels (i.e., remove `needs-backport/X` and add `backport-pending/X`):

    Sending pull request...
    Everything up-to-date
    https://github.com/cilium/cilium/pull/13700

    Updating labels for PRs 13383 13608 12975

    Set labels for all PRs above? [y/N] y
    Setting labels for PR 13383... ✓
    Setting labels for PR 13608... ✓
    Setting labels for PR 12975... ✓

The choice defaults to not updating the labels. That may give the wrong impression that it is an optional step---and if you're like me, when you're unsure what an optional step does, you skip it. We should default to setting the labels because we later rely on the labels being set (e.g., when we update them after the PR is merged).

This pull request changes it to the following:

    Sending pull request...
    Everything up-to-date
    https://github.com/cilium/cilium/pull/13700

    Updating labels for PRs 13383 13608 12975

    Set labels for all PRs above? [Y/n]
    Setting labels for PR 13383... ✓
    Setting labels for PR 13608... ✓
    Setting labels for PR 12975... ✓
