### PR TITLE
docs: Fix shell session highlighting

### DIFF
--- a/Documentation/concepts/kubernetes/requirements.rst
+++ b/Documentation/concepts/kubernetes/requirements.rst
@@ -52,7 +52,7 @@ Mounted eBPF filesystem
         Some distributions mount the bpf filesystem automatically. Check if the
         bpf filesystem is mounted by running the command.
 
-        .. code:: shell-session
+        .. code-block:: shell-session
 
                   mount | grep /sys/fs/bpf
                   # if present should output, e.g. "none on /sys/fs/bpf type bpf"...

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -450,7 +450,7 @@ running agent. Debugging of an individual endpoint can be enabled by running
 ``cilium endpoint config ID debug=true``. Running ``cilium monitor -v`` will
 print the normal form of monitor output along with debug messages:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ cilium endpoint config 731 debug=true
    Endpoint 731 configuration updated successfully
@@ -471,7 +471,7 @@ print the normal form of monitor output along with debug messages:
 
 Passing ``-v -v`` supports deeper detail, for example:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ cilium endpoint config 3978 debug=true
     Endpoint 3978 configuration updated successfully

--- a/Documentation/gettingstarted/bird.rst
+++ b/Documentation/gettingstarted/bird.rst
@@ -35,7 +35,7 @@ should be very similar.
 Install bird
 ##################
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ yum install -y bird2
 
@@ -45,7 +45,7 @@ Install bird
 
 Test the installation:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ birdc show route
     BIRD 2.0.6 ready.
@@ -162,7 +162,7 @@ Below is the a reference configuration for fulfilling the above purposes:
 Save the above file as ``/etc/bird.conf``, and replace the placeholders with
 your own:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     sed -i 's/{{ NODE_IP }}/<your node ip>/g'                /etc/bird.conf
     sed -i 's/{{ POD_CIDR }}/<your pod cidr>/g'              /etc/bird.conf
@@ -175,7 +175,7 @@ your own:
 
 Restart ``bird`` and check the logs:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ systemctl restart bird
 
@@ -188,7 +188,7 @@ Restart ``bird`` and check the logs:
 
 Verify the changes, you should get something like this:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ birdc show route
     BIRD 2.0.6 ready.
@@ -199,7 +199,7 @@ Verify the changes, you should get something like this:
 This indicates that the PodCIDR ``10.5.48.0/24`` on this node has been
 successfully imported into BIRD.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ birdc show protocols all uplink0 | grep -A 3 -e "Description" -e "stats"
      Description:    BGP uplink 0
@@ -265,7 +265,7 @@ is a detection protocol designed to accelerate path failure detection.
 
 Verify, you should see something like this:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ birdc show bfd sessions
     BIRD 2.0.6 ready.
@@ -300,7 +300,7 @@ See the user manual for more detailed information.
 You need to check the ECMP correctness on physical network (Core router in the
 above scenario):
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     CORE01# show ip route 10.5.2.0
     IP Route Table for VRF "default"

--- a/Documentation/gettingstarted/host-firewall.rst
+++ b/Documentation/gettingstarted/host-firewall.rst
@@ -55,7 +55,7 @@ In this guide, we will apply host policies only to nodes with the label
 ``node-access=ssh``. We thus first need to attach that label to a node in the
 cluster.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ export NODE_NAME=k8s1
     $ kubectl label node $NODE_NAME node-access=ssh
@@ -75,7 +75,7 @@ validate the impact of host policies before enforcing them. When Policy Audit
 Mode is enabled, no network policy is enforced so this setting is *not
 recommended for production deployment*.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ CILIUM_NAMESPACE=kube-system
     $ CILIUM_POD_NAME=$(kubectl -n $CILIUM_NAMESPACE get pods -l "k8s-app=cilium" -o jsonpath="{.items[?(@.spec.nodeName=='$NODE_NAME')].metadata.name}")
@@ -101,7 +101,7 @@ the outside of the cluster, except if those pods are host-networking pods.
 
 To apply this policy, run:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ kubectl create -f \ |SCM_WEB|\/examples/policies/host/demo-host-policy.yaml
     ciliumclusterwidenetworkpolicy.cilium.io/demo-host-policy created
@@ -110,7 +110,7 @@ The host is represented as a special endpoint, with label ``reserved:host``, in
 the output of command ``cilium endpoint list``. You can therefore inspect the
 status of the policy using that command.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium endpoint list
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4           STATUS
@@ -133,7 +133,7 @@ disallowed by the policy won't be dropped. They will however be reported by
 adjust the host policy to your environment, to avoid unexpected connection
 breakages.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium monitor -t policy-verdict --related-to $HOST_EP_ID
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 6, proto 1, ingress, action allow, match L3-Only, 192.168.33.12 -> 192.168.33.11 EchoRequest
@@ -163,14 +163,14 @@ Once you are confident all required communication to the host from outside the
 cluster are allowed, you can disable policy audit mode to enforce the host
 policy.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium endpoint config $HOST_EP_ID PolicyAuditMode=Disabled
     Endpoint 3353 configuration updated successfully
 
 Ingress host policies should now appear as enforced:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium endpoint list
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4           STATUS
@@ -186,7 +186,7 @@ Ingress host policies should now appear as enforced:
 
 Communications not explicitly allowed by the host policy will now be dropped:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ kubectl -n $CILIUM_NAMESPACE exec $CILIUM_POD_NAME -- cilium monitor -t policy-verdict --related-to $HOST_EP_ID
     Policy verdict log: flow 0x0 local EP ID 1687, remote ID 2, proto 6, ingress, action deny, match none, 10.0.2.2:49038 -> 10.0.2.15:21 tcp SYN
@@ -195,7 +195,7 @@ Communications not explicitly allowed by the host policy will now be dropped:
 Clean Up
 ========
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl delete ccnp demo-host-policy
    $ kubectl label node $NODE_NAME node-access-

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -60,7 +60,7 @@ AKS cluster:
 
 To verify, you should see AKS in the name of the nodes when you run:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
     $ kubectl get nodes
     NAME                                STATUS   ROLES   AGE   VERSION

--- a/Documentation/gettingstarted/k8s-install-azure-cni-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-validate.rst
@@ -3,7 +3,7 @@ Validate the Installation
 
 You can monitor as Cilium and all required components are being installed:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl -n cilium get pods --watch
    cilium-2twr9                      0/1     Init:0/2            0          17s
@@ -15,7 +15,7 @@ You can monitor as Cilium and all required components are being installed:
 
 It may take a couple of minutes for all components to come up:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    cilium-operator-f8bd5cd96-tvdn6   1/1     Running             0          25s
    cilium-operator-f8bd5cd96-qdspd   1/1     Running             0          26s

--- a/Documentation/gettingstarted/k8s-install-connectivity-test.rst
+++ b/Documentation/gettingstarted/k8s-install-connectivity-test.rst
@@ -20,7 +20,7 @@ service load-balancing and various network policy combinations. The pod name
 indicates the connectivity variant and the readiness and liveness gate
 indicates success or failure of the test:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl get pods -n cilium-test
    NAME                                                     READY   STATUS    RESTARTS   AGE

--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -50,7 +50,7 @@ Now, create configuration files:
    The sample output below is showing the AWS provider, but
    it should work the same way with other providers.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ openshift-install create install-config --dir "${CLUSTER_NAME}"
    ? SSH Public Key ~/.ssh/id_rsa.pub
@@ -172,7 +172,7 @@ Create the cluster:
    The sample output below is showing the AWS provider, but
    it should work the same way with other providers.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ openshift-install create cluster --dir "${CLUSTER_NAME}"
    WARNING   Discarding the Bootstrap Ignition Config that was provided in the target directory because its dependencies are dirty and it needs to be regenerated

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -31,7 +31,7 @@ Kubernetes
 An initial overview of Cilium can be retrieved by listing all pods to verify
 whether all pods have the status ``Running``:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl -n kube-system get pods -l k8s-app=cilium
    NAME           READY     STATUS    RESTARTS   AGE
@@ -53,7 +53,7 @@ If a particular Cilium pod is not in running state, the status and health of
 the agent on that node can be retrieved by running ``cilium status`` in the
 context of that pod:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl -n kube-system exec -ti cilium-2hq5z -- cilium status
    KVStore:                Ok   etcd: 1/1 connected: http://demo-etcd-lab--a.etcd.tgraf.test1.lab.corp.isovalent.link:2379 - 3.2.5 (Leader)
@@ -78,7 +78,7 @@ of all nodes in the cluster:
 
 ... and run ``cilium status`` on all nodes:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ ./k8s-cilium-exec.sh cilium status
    KVStore:                Ok   Etcd: http://127.0.0.1:2379 - (Leader) 3.1.10
@@ -123,7 +123,7 @@ Generic
 When logged in a host running Cilium, the cilium CLI can be invoked directly,
 e.g.:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ cilium status
    KVStore:                Ok   etcd: 1/1 connected: https://192.168.33.11:2379 - 3.2.7 (Leader)
@@ -158,7 +158,7 @@ The Hubble CLI is part of the Cilium container image and can be accessed via
 to flows which either originated or terminated in the ``default/tiefighter`` pod
 in the last three minutes:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl exec -n kube-system cilium-77lk6 -- hubble observe --since 3m --pod default/tiefighter
    Jun  2 11:14:46.041   default/tiefighter:38314                  kube-system/coredns-66bff467f8-ktk8c:53   to-endpoint   FORWARDED   UDP
@@ -184,7 +184,7 @@ in the last three minutes. The numeric security identity can then be used
 together with the Cilium CLI to obtain more information about why a particular
 flow was dropped:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl exec -n kube-system cilium-77lk6 -- \
        hubble observe --since 3m --type drop --from-pod default/xwing -o json | \
@@ -220,7 +220,7 @@ Ensure Hubble is running correctly
 To ensure the Hubble client can connect to the Hubble server running inside
 Cilium, you may use the ``hubble status`` command:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ hubble status
    Healthcheck (via unix:///var/run/cilium/hubble.sock): Ok
@@ -234,7 +234,7 @@ to set the ``hubble.enabled=true`` value.
 To check if Hubble is enabled in your deployment, you may look for the
 following output in ``cilium status``:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ cilium status
    ...
@@ -281,7 +281,7 @@ command:
 
 This command should return an output similar to the following:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    Healthcheck (via localhost:4245): Ok
    Max Flows: 16384
@@ -339,7 +339,7 @@ The pod name indicates the connectivity
 variant and the readiness and liveness gate indicates success or failure of the
 test:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl get pods -n cilium-test
    NAME                                                    READY   STATUS    RESTARTS   AGE
@@ -361,7 +361,7 @@ test:
 Information about test failures can be determined by describing a failed test
 pod
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl describe pod pod-to-b-intra-node-hostport
      Warning  Unhealthy  6s (x6 over 56s)   kubelet, agent1    Readiness probe failed: curl: (7) Failed to connect to echo-b-host-headless port 40000: Connection refused
@@ -383,7 +383,7 @@ cluster and through each node using different protocols to determine the health
 status of each path and protocol. At any point in time, cilium-health may be
 queried for the connectivity status of the last probe.
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl -n kube-system exec -ti cilium-2hq5z -- cilium-health status
    Probe time:   2018-06-16T09:51:58Z
@@ -422,7 +422,7 @@ the networking level. The tool
 drops happen. Following is an example output (use ``kubectl exec`` as in
 previous examples if running with Kubernetes):
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ kubectl -n kube-system exec -ti cilium-2hq5z -- cilium monitor --type drop
    Listening for events on 2 CPUs with 64x4096 of shared memory
@@ -483,7 +483,7 @@ selecting the respective pods will not be applied. See the section
 You can run the following script to list the pods which are *not* managed by
 Cilium:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ ./contrib/k8s/k8s-unmanaged.sh
    kube-system/cilium-hqpk7
@@ -770,7 +770,7 @@ were started before Cilium was deployed.
 
 **Example:**
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    $ curl -sLO releases.cilium.io/v1.1.0/tools/k8s-unmanaged.sh
    $ ./k8s-unmanaged.sh
@@ -845,7 +845,7 @@ namespace can be changed via ``k8s-namespace`` and ``k8s-label`` respectively.
 If you want to capture the archive from a Kubernetes pod, then the process is a
 bit different
 
-.. code:: shell-session
+.. code-block:: shell-session
 
    # First we need to get the Cilium pod
    $ kubectl get pods --namespace kube-system


### PR DESCRIPTION
`.. code:: shell-session` does not work to provide syntax highlighting for shell sessions, this needs to be `.. code-block:: shell-session`.

Fix it tree-wide.

Before:

![image](https://user-images.githubusercontent.com/1243336/96902814-d6921c80-1449-11eb-8047-ff0664032c11.png)


After:

![image](https://user-images.githubusercontent.com/1243336/96902556-85822880-1449-11eb-8ecc-4b59d5653d09.png)

/cc @qmonnet @pchaigno @twpayne  (tagging for knowledge spread, not to call anyone out).