### PR TITLE
backporting: Clean tmp files after backport with conflicts

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -3,6 +3,14 @@ set -e
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
+cleanup () {
+  if [ -n "$TMPF" ]; then
+    rm $TMPF
+  fi
+}
+
+trap cleanup EXIT
+
 cherry_pick () {
   CID=$1
   BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
@@ -19,7 +27,6 @@ cherry_pick () {
   git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,$p' >> $TMPF
   echo "Applying: $(git log -1 --oneline $FULL_ID)"
   git am --quiet -3 --signoff $TMPF
-  rm $TMPF
 }
 
 main () {


### PR DESCRIPTION
During the backport process, when cherry-picking commits to backport, the cherry-pick script may fail if there are conflicts. In that case, the temporary file (`cp.XXXXX`) holding the backported commit is not clean up.

This commit fixes it to clean the temporary file even in case of failure, while preserving the error code from `git am`.