### PR TITLE
v1.7 backports 2020-10-22

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -51,9 +51,9 @@ hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
-echo -n "Set labels for all PRs above? [y/N] "
+echo -n "Set labels for all PRs above? [Y/n] "
 read set_all_labels
-if [ "$set_all_labels" = "y" ]; then
+if [ "$set_all_labels" != "n" ]; then
     for pr in $prs; do
         $DIR/set-labels.py $pr pending $BRANCH;
     done

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -198,8 +198,11 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 
 		restore, err := d.validateEndpoint(ep)
 		if err != nil {
-			scopedLog.WithError(err).Warningf("Unable to restore endpoint, ignoring")
-			failed++
+			// Disconnected EPs are not failures, clean them silently below
+			if !ep.IsDisconnecting() {
+				scopedLog.WithError(err).Warningf("Unable to restore endpoint, ignoring")
+				failed++
+			}
 		}
 		if !restore {
 			if clean {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1531,7 +1531,8 @@ type MetadataResolverCB func(ns, podName string) (identityLabels labels.Labels, 
 // will handle updates (such as pkg/k8s/watchers informers).
 func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 	done := make(chan struct{})
-	controllerName := fmt.Sprintf("resolve-labels-%s", e.GetK8sNamespaceAndPodName())
+	const controllerPrefix = "resolve-labels"
+	controllerName := fmt.Sprintf("%s-%s", controllerPrefix, e.GetK8sNamespaceAndPodName())
 	go func() {
 		select {
 		case <-done:
@@ -1547,7 +1548,7 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 				ns, podName := e.GetK8sNamespace(), e.GetK8sPodName()
 				identityLabels, info, _, err := resolveMetadata(ns, podName)
 				if err != nil {
-					e.Logger(controllerName).WithError(err).Warning("Unable to fetch kubernetes labels")
+					e.Logger(controllerPrefix).WithError(err).Warning("Unable to fetch kubernetes labels")
 					return err
 				}
 				e.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1019,7 +1019,12 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 	}
 
 	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
-		identitymanager.Remove(e.SecurityIdentity)
+		// Restored endpoint may be created with a reserved identity of 5
+		// (init), which is not registered in the identity manager and
+		// therefore doesn't need to be removed.
+		if e.SecurityIdentity.ID != identity.ReservedIdentityInit {
+			identitymanager.Remove(e.SecurityIdentity)
+		}
 
 		releaseCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 		defer cancel()

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -151,7 +151,7 @@ func (e *Endpoint) Unexpose(mgr endpointManager) <-chan struct{} {
 			//
 			// Avoid irritating warning messages.
 			state := ep.GetState()
-			if state != StateRestoring && state != StateDisconnecting {
+			if state != StateRestoring && state != StateDisconnecting && state != StateDisconnected {
 				log.WithError(err).WithField("state", state).Warning("Unable to release endpoint ID")
 			}
 		}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -283,6 +283,7 @@ func (mgr *EndpointManager) ReleaseID(ep *endpoint.Endpoint) error {
 
 // WaitEndpointRemoved waits until all operations associated with Remove of
 // the endpoint have been completed.
+// Note: only used for unit tests
 func (mgr *EndpointManager) WaitEndpointRemoved(ep *endpoint.Endpoint) {
 	<-ep.Unexpose(mgr)
 }


### PR DESCRIPTION
* #10974 -- endpoint: Avoid logging about disconnected EPs during restore (@jrajahalme)
 * #13667 -- endpoint: Avoid benign error messages on restoration (@pchaigno)
 * #13703 -- backporting: Update labels by default when submitting backport (@pchaigno)
 * #13699 -- pkg/endpoint: reduce cardinality of prometheus labels (@aanm)

Skipped:

 * #12313 -- metrics: fix negative identity count (@ArthurChiao)
 * #13244 -- lbmap: Correct issue that port info display error (@Jianlin-lv)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10974 13667 13703 13699; do contrib/backporting/set-labels.py $pr done 1.7; done
```