### PR TITLE
build: bpf: Fix cross-compilation of gcc targets

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -27,8 +27,8 @@ HOST_CC    ?= gcc
 HOST_STRIP ?= strip
 
 ifeq ($(IMAGE_CROSS_TARGET_PLATFORM),linux/arm64)
-  HOST_CC ?= aarch64-linux-gnu-gcc
-  HOST_STRIP ?= aarch64-linux-gnu-strip
+  HOST_CC = aarch64-linux-gnu-gcc
+  HOST_STRIP = aarch64-linux-gnu-strip
 endif
 
 # Define all at the top here so that Makefiles which include this one will hit


### PR DESCRIPTION
Due to usage of ?=, the attempt to override HOST_CC and HOST_STRIP
variables (when IMAGE_CROSS_TARGET_PLATFORM == linux/arm64) was
ineffecting, because values of those variables were already set. Using =
fixes that.

Ref: #13650
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

```release-note
build: bpf: Fix cross-compilation of gcc targets
```
