### PR TITLE
doc: Update OpenShift GSG

### DIFF
--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -31,8 +31,10 @@ OpenShift Requirements
      doesn't simply pickup ``az login`` credentials. It's recommended to
      setup a dedicated service principal and use it
    - with the GCP provider ``openshift-install`` will only work with a service
-     account key, which has to be set using ``GOOGLE_APPLICATION_CREDENTIALS``
-     environment variable (e.g. ``GOOGLE_APPLICATION_CREDENTIALS=service-account.json``)
+     account key, which has to be set using ``GOOGLE_CREDENTIALS``
+     environment variable (e.g. ``GOOGLE_CREDENTIALS=service-account.json``).
+     Follow `Openshift Installer documentation <https://github.com/openshift/installer/blob/master/docs/user/gcp/iam.md>`_
+     to assign required roles to your service account.
 
 Create an OpenShift OKD Cluster
 ===============================
@@ -194,11 +196,12 @@ Please note that ``openshift-install`` doesn't support custom firewall
 rules, so you will need to use one of the following scripts if you are
 using AWS or GCP. Azure does not need additional configuration.
 
-.. note::
+.. warning::
 
-   This has to be done just after ``INFO Waiting up to 40m0s for
-   bootstrapping to complete...`` appears in the logs. It is safe to apply
-   these changes once, OpenShift will not override these.
+   **You need to execute the following command to configure firewall rules just after**
+   ``INFO Waiting up to 40m0s for bootstrapping to complete...`` **appears in the logs,
+   or the installation will fail**. It is safe to apply these changes once, OpenShift will
+   not override these.
 
 .. tabs::
 


### PR DESCRIPTION
- Use `GOOGLE_CREDENTIALS` instead of `GOOGLE_APPLICATION_CREDENTIALS`.
- Refer to https://github.com/openshift/installer/blob/master/docs/user/gcp/iam.md
  to assign appropriate roles to service account.

Ref: https://github.com/cilium/cilium/issues/13627#issuecomment-714783626

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>