### PR TITLE
docs: Add a note about systemd 245 rp_filter issue

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -98,6 +98,16 @@ RancherOS_                 >= 1.5.5
           Linux distribution that works well, please let us know by opening a
           GitHub issue or by creating a pull request that updates this guide.
 
+.. note:: Systemd 245 and above (``systemctl --version``) overrides ``rp_filter`` setting
+          of Cilium network interfaces. This introduces connectivity issues (see
+          `GH-10645 <https://github.com/cilium/cilium/issues/10645>`_ for details). To
+          avoid that, configure ``rp_filter`` in systemd using the following commands:
+
+          .. code:: bash
+
+              echo 'net.ipv4.conf.lxc*.rp_filter = 0' > /etc/sysctl.d/99-override_cilium_rp_filter.conf
+              systemctl restart systemd-sysctl
+
 .. _admin_kernel_version:
 
 Linux Kernel


### PR DESCRIPTION
This doc change removes `release-blocker` note from https://github.com/cilium/cilium/issues/10645.