### PR TITLE
ci: Print hint to fix auto-generated file checks

### DIFF
--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           go mod tidy
           go mod vendor
-          git diff --exit-code
+          git diff --exit-code || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
 
   golangci:
     name: lint

--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           make -C examples/kubernetes/connectivity-check fmt
           make -C examples/kubernetes/connectivity-check all
-          git diff --exit-code
+          git diff --exit-code || (echo "please run 'make -C examples/kubernetes/connectivity-check all' and submit your changes"; exit 1)
 
       - name: Enable IPv6 in docker
         run: |

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Run helm-docs
         run: |
           make -C install/kubernetes docs
-          git diff --exit-code
+          git diff --exit-code || (echo "please run 'make -C install/kubernetes docs' and submit your changes"; exit 1)
 
   quick-install:
     strategy:
@@ -63,7 +63,7 @@ jobs:
       - name: Check ${{ matrix.target.template }}
         run: |
           make -C install/kubernetes ${{ matrix.target.name }}
-          git diff --exit-code
+          git diff --exit-code || (echo "please run 'make -C install/kubernetes ${{ matrix.target.name }}' and submit your changes"; exit 1)
 
   conformance-test:
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
         run: |
           make -C examples/kubernetes/connectivity-check fmt
           make -C examples/kubernetes/connectivity-check all
-          git diff --exit-code
+          git diff --exit-code || (echo "please run 'make -C examples/kubernetes/connectivity-check all' and submit your changes"; exit 1)
 
       - name: Build docker images
         run: |


### PR DESCRIPTION
## Description

ci(gha): Print hint to fix generated file check

This commit is to print steps on how to fix github action check for
generated files. This will surely help new contributors to have
better experience and reduce feedback loop.

Suggested by: Kornilios Kourtis <kornilios@isovalent.com>

Signed-off-by: Tam Mach <sayboras@yahoo.com>

## Testing

Testing was done by one dummy change in one of the file https://github.com/cilium/cilium/pull/13718/checks?check_run_id=1296840070

```diff
@@ -690,7 +690,3 @@ spec:
       - configMap:
           name: cilium-config
         name: cilium-config-path
-
-
-
please run 'make -C install/kubernetes quick-install' and submit your changes
Error: Process completed with exit code 1.
```

```release-note
ci: Print hint to fix auto-generated file checks
```
