### PR TITLE
v1.7 backports 2020-10-23

### DIFF
--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -87,10 +87,23 @@ will be used to evaluate Cilium identities:
 The above configuration would only include the following labels when evaluating
 Cilium identities:
 
-- io.kubernetes.pod.namespace=*
-- k8s-app=*
-- app=*
-- name=*
+- io.kubernetes.pod.namespace*=.*
+- k8s-app*=*
+- app*=*
+- name*=*
+
+Labels with the same prefix as defined in the configuration will also be
+considered. This lists some examples of labels that would also be evaluated for
+Cilium identities:
+
+- k8s-app-team*=*
+- app-production*=*
+- name-defined*=*
+
+When a single "inclusive label" is added to the filter, all labels not defined
+in the default list will be excluded. For example, pods running with the
+security labels ``team=team-1, env=prod`` will have the label ``env=prod``
+ignored as soon Cilium is started with the filter ``k8s:team``.
 
 Excluding Labels
 ----------------

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -52,7 +52,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 	parseBackendEntry := func(key bpf.MapKey, value bpf.MapValue) {
 		id := key.(lbmap.BackendKey).GetID()
-		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue)
+		backendMap[id] = value.DeepCopyMapValue().(lbmap.BackendValue).ToHost()
 	}
 	if err := lbmap.Backend4Map.DumpWithCallbackIfExists(parseBackendEntry); err != nil {
 		Fatalf("Unable to dump IPv4 backends table: %s", err)
@@ -65,8 +65,9 @@ func dumpSVC(serviceList map[string][]string) {
 		var entry string
 
 		svcKey := key.(lbmap.ServiceKey)
-		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.ToNetwork().String()
+		svcVal := value.(lbmap.ServiceValue).ToHost()
+		svc := svcKey.String()
+		svcKey = svcKey.ToHost()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -66,7 +66,7 @@ func dumpSVC(serviceList map[string][]string) {
 
 		svcKey := key.(lbmap.ServiceKey)
 		svcVal := value.(lbmap.ServiceValue)
-		svc := svcKey.String()
+		svc := svcKey.ToNetwork().String()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())

--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -167,7 +167,7 @@ func migrateIdentities() {
 
 		ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
 		defer cancel()
-		newID, actuallyAllocated, err := crdAllocator.Allocate(ctx, key)
+		newID, actuallyAllocated, _, err := crdAllocator.Allocate(ctx, key)
 		switch {
 		case err != nil:
 			log.WithError(err).Errorf("Cannot allocate new CRD ID for %v", key)

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -453,13 +453,21 @@ func (a *Allocator) encodeKey(key AllocatorKey) string {
 	return a.backend.Encode(key.GetKey())
 }
 
-func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpool.ID, bool, error) {
+// Return values:
+// 1. allocated ID
+// 2. whether the ID is newly allocated from kvstore
+// 3. whether this is the first owner that holds a reference to the key in
+//    localkeys store
+// 4. error in case of failure
+func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpool.ID, bool, bool, error) {
+	var firstUse bool
+
 	kvstore.Trace("Allocating key in kvstore", nil, logrus.Fields{fieldKey: key})
 
 	k := a.encodeKey(key)
 	lock, err := a.backend.Lock(ctx, key)
 	if err != nil {
-		return 0, false, err
+		return 0, false, false, err
 	}
 
 	defer lock.Unlock(context.Background())
@@ -468,7 +476,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	// node suffix
 	value, err := a.GetIfLocked(ctx, key, lock)
 	if err != nil {
-		return 0, false, err
+		return 0, false, false, err
 	}
 
 	kvstore.Trace("kvstore state is: ", nil, logrus.Fields{fieldID: value})
@@ -484,13 +492,19 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		if value != 0 {
 			// re-create master key
 			if err := a.backend.UpdateKeyIfLocked(ctx, value, key, true, lock); err != nil {
-				return 0, false, fmt.Errorf("unable to re-create missing master key '%s': %s while allocating ID: %s", key, value, err)
+				return 0, false, false, fmt.Errorf("unable to re-create missing master key '%s': %s while allocating ID: %s", key, value, err)
 			}
 		}
 	} else {
-		_, err := a.localKeys.allocate(k, key, value)
+		_, firstUse, err = a.localKeys.allocate(k, key, value)
 		if err != nil {
-			return 0, false, fmt.Errorf("unable to reserve local key '%s': %s", k, err)
+			return 0, false, false, fmt.Errorf("unable to reserve local key '%s': %s", k, err)
+		}
+
+		if firstUse {
+			log.WithField(fieldKey, k).Info("Reserved new local key")
+		} else {
+			log.WithField(fieldKey, k).Info("Reusing existing local key")
 		}
 	}
 
@@ -499,7 +513,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 		if err = a.backend.AcquireReference(ctx, value, key, lock); err != nil {
 			a.localKeys.release(k)
-			return 0, false, errors.Wrapf(err, "unable to create slave key '%s'", k)
+			return 0, false, false, errors.Wrapf(err, "unable to create slave key '%s'", k)
 		}
 
 		// mark the key as verified in the local cache
@@ -507,13 +521,13 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 			log.WithError(err).Error("BUG: Unable to verify local key")
 		}
 
-		return value, false, nil
+		return value, false, firstUse, nil
 	}
 
 	log.WithField(fieldKey, k).Debug("Allocating new master ID")
 	id, strID, unmaskedID := a.selectAvailableID()
 	if id == 0 {
-		return 0, false, fmt.Errorf("no more available IDs in configured space")
+		return 0, false, false, fmt.Errorf("no more available IDs in configured space")
 	}
 
 	kvstore.Trace("Selected available key ID", nil, logrus.Fields{fieldID: id})
@@ -523,17 +537,17 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		a.idPool.Release(unmaskedID) // This returns this ID to be re-used for other keys
 	}
 
-	oldID, err := a.localKeys.allocate(k, key, id)
+	oldID, firstUse, err := a.localKeys.allocate(k, key, id)
 	if err != nil {
 		a.idPool.Release(unmaskedID)
-		return 0, false, fmt.Errorf("unable to reserve local key '%s': %s", k, err)
+		return 0, false, false, fmt.Errorf("unable to reserve local key '%s': %s", k, err)
 	}
 
 	// Another local writer beat us to allocating an ID for the same key,
 	// start over
 	if id != oldID {
 		releaseKeyAndID()
-		return 0, false, fmt.Errorf("another writer has allocated key %s", k)
+		return 0, false, false, fmt.Errorf("another writer has allocated key %s", k)
 	}
 
 	// Check that this key has not been allocated in the cluster during our
@@ -541,11 +555,11 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	value, err = a.GetNoCache(ctx, key)
 	if err != nil {
 		releaseKeyAndID()
-		return 0, false, err
+		return 0, false, false, err
 	}
 	if value != 0 {
 		releaseKeyAndID()
-		return 0, false, fmt.Errorf("Found master key after proceeding with new allocation for %s", k)
+		return 0, false, false, fmt.Errorf("Found master key after proceeding with new allocation for %s", k)
 	}
 
 	err = a.backend.AllocateIDIfLocked(ctx, id, key, lock)
@@ -553,7 +567,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		// Creation failed. Another agent most likely beat us to allocting this
 		// ID, retry.
 		releaseKeyAndID()
-		return 0, false, fmt.Errorf("unable to allocate ID %s for key %s: %s", strID, key, err)
+		return 0, false, false, fmt.Errorf("unable to allocate ID %s for key %s: %s", strID, key, err)
 	}
 
 	// Notify pool that leased ID is now in-use.
@@ -564,7 +578,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		// exposed and may be in use by other nodes. The garbage
 		// collector will release it again.
 		releaseKeyAndID()
-		return 0, false, errors.Wrapf(err, "slave key creation failed '%s'", k)
+		return 0, false, false, errors.Wrapf(err, "slave key creation failed '%s'", k)
 	}
 
 	// mark the key as verified in the local cache
@@ -574,7 +588,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 	log.WithField(fieldKey, k).Info("Allocated new global key")
 
-	return id, true, nil
+	return id, true, firstUse, nil
 }
 
 // Allocate will retrieve the ID for the provided key. If no ID has been
@@ -582,14 +596,19 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 // most likely due to a parallel allocation of the same ID by another user,
 // allocation is re-attempted for maxAllocAttempts times.
 //
-// Returns the ID allocated to the key, if the ID had to be allocated, then
-// true is returned. An error is returned in case of failure.
-func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, bool, error) {
+// Return values:
+// 1. allocated ID
+// 2. whether the ID is newly allocated from kvstore
+// 3. whether this is the first owner that holds a reference to the key in
+//    localkeys store
+// 4. error in case of failure
+func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, bool, bool, error) {
 	var (
-		err   error
-		value idpool.ID
-		isNew bool
-		k     = a.encodeKey(key)
+		err      error
+		value    idpool.ID
+		isNew    bool
+		firstUse bool
+		k        = a.encodeKey(key)
 	)
 
 	log.WithField(fieldKey, key).Debug("Allocating key")
@@ -597,7 +616,7 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 	select {
 	case <-a.initialListDone:
 	case <-ctx.Done():
-		return 0, false, fmt.Errorf("allocation was cancelled while waiting for initial key list to be received: %s", ctx.Err())
+		return 0, false, false, fmt.Errorf("allocation was cancelled while waiting for initial key list to be received: %s", ctx.Err())
 	}
 
 	kvstore.Trace("Allocating from kvstore", nil, logrus.Fields{fieldKey: key})
@@ -617,15 +636,15 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 		if val := a.localKeys.use(k); val != idpool.NoID {
 			kvstore.Trace("Reusing local id", nil, logrus.Fields{fieldID: val, fieldKey: key})
 			a.mainCache.insert(key, val)
-			return val, false, nil
+			return val, false, false, nil
 		}
 
 		// FIXME: Add non-locking variant
-		value, isNew, err = a.lockedAllocate(ctx, key)
+		value, isNew, firstUse, err = a.lockedAllocate(ctx, key)
 		if err == nil {
 			a.mainCache.insert(key, value)
 			log.WithField(fieldKey, key).WithField(fieldID, value).Debug("Allocated key")
-			return value, isNew, nil
+			return value, isNew, firstUse, nil
 		}
 
 		scopedLog := log.WithFields(logrus.Fields{
@@ -636,7 +655,7 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 		select {
 		case <-ctx.Done():
 			scopedLog.WithError(ctx.Err()).Warning("Ongoing key allocation has been cancelled")
-			return 0, false, fmt.Errorf("key allocation cancelled: %s", ctx.Err())
+			return 0, false, false, fmt.Errorf("key allocation cancelled: %s", ctx.Err())
 		default:
 			// Do not log a warning if the error is caused by ErrIdentityNonExistent
 			// and has not reached the maxAllocAttempts
@@ -648,11 +667,11 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 		kvstore.Trace("Allocation attempt failed", err, logrus.Fields{fieldKey: key, logfields.Attempt: attempt})
 
 		if waitErr := boff.Wait(ctx); waitErr != nil {
-			return 0, false, waitErr
+			return 0, false, false, waitErr
 		}
 	}
 
-	return 0, false, err
+	return 0, false, false, err
 }
 
 // GetIfLocked returns the ID which is allocated to a key. Returns an ID of NoID if no ID

--- a/pkg/allocator/localkeys.go
+++ b/pkg/allocator/localkeys.go
@@ -51,25 +51,28 @@ func newLocalKeys() *localKeys {
 // allocate creates an entry for key in localKeys if needed and increments the
 // refcnt. The value associated with the key must match the local cache or an
 // error is returned
-func (lk *localKeys) allocate(keyString string, key AllocatorKey, val idpool.ID) (idpool.ID, error) {
+func (lk *localKeys) allocate(keyString string, key AllocatorKey, val idpool.ID) (idpool.ID, bool, error) {
 	lk.Lock()
 	defer lk.Unlock()
 
+	var firstUse bool
+
 	if k, ok := lk.keys[keyString]; ok {
 		if val != k.val {
-			return idpool.NoID, fmt.Errorf("local key already allocated with different value (%s != %s)", val, k.val)
+			return idpool.NoID, firstUse, fmt.Errorf("local key already allocated with different value (%s != %s)", val, k.val)
 		}
 
 		k.refcnt++
 		kvstore.Trace("Incremented local key refcnt", nil, logrus.Fields{fieldKey: keyString, fieldID: val, fieldRefCnt: k.refcnt})
-		return k.val, nil
+		return k.val, firstUse, nil
 	}
 
+	firstUse = true
 	k := &localKey{key: key, val: val, refcnt: 1}
 	lk.keys[keyString] = k
 	lk.ids[val] = k
 	kvstore.Trace("New local key", nil, logrus.Fields{fieldKey: keyString, fieldID: val, fieldRefCnt: 1})
-	return val, nil
+	return val, firstUse, nil
 }
 
 func (lk *localKeys) verify(key string) error {

--- a/pkg/allocator/localkeys_test.go
+++ b/pkg/allocator/localkeys_test.go
@@ -30,9 +30,10 @@ func (s *AllocatorSuite) TestLocalKeys(c *C) {
 	v := k.use(key.GetKey())
 	c.Assert(v, Equals, idpool.NoID)
 
-	v, err := k.allocate(key.GetKey(), key, val) // refcnt=1
+	v, firstUse, err := k.allocate(key.GetKey(), key, val) // refcnt=1
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, val)
+	c.Assert(firstUse, Equals, true)
 
 	c.Assert(k.verify(key.GetKey()), IsNil)
 
@@ -40,20 +41,22 @@ func (s *AllocatorSuite) TestLocalKeys(c *C) {
 	c.Assert(v, Equals, val)
 	k.release(key.GetKey()) // refcnt=1
 
-	v, err = k.allocate(key.GetKey(), key, val) // refcnt=2
+	v, firstUse, err = k.allocate(key.GetKey(), key, val) // refcnt=2
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, val)
+	c.Assert(firstUse, Equals, false)
 
-	v, err = k.allocate(key2.GetKey(), key2, val2) // refcnt=1
+	v, firstUse, err = k.allocate(key2.GetKey(), key2, val2) // refcnt=1
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, val2)
+	c.Assert(firstUse, Equals, true)
 
 	// only one of the two keys is verified yet
 	ids := k.getVerifiedIDs()
 	c.Assert(len(ids), Equals, 1)
 
 	// allocate with different value must fail
-	_, err = k.allocate(key2.GetKey(), key2, val)
+	_, _, err = k.allocate(key2.GetKey(), key2, val)
 	c.Assert(err, Not(IsNil))
 
 	k.release(key.GetKey()) // refcnt=1

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -35,15 +35,8 @@ var (
 		int(unsafe.Sizeof(Service4Value{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			svcKey, svcVal := mapKey.(*Service4Key), mapValue.(*Service4Value)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, svcKey, svcVal); err != nil {
-				return nil, nil, err
-			}
-
-			return svcKey.ToNetwork(), svcVal.ToNetwork(), nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 	Backend4Map = bpf.NewMap("cilium_lb4_backends",
 		bpf.MapTypeHash,
 		&Backend4Key{},
@@ -52,15 +45,8 @@ var (
 		int(unsafe.Sizeof(Backend4Value{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			backendVal := mapValue.(*Backend4Value)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, mapKey, backendVal); err != nil {
-				return nil, nil, err
-			}
-
-			return mapKey, backendVal.ToNetwork(), nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 	RevNat4Map = bpf.NewMap("cilium_lb4_reverse_nat",
 		bpf.MapTypeHash,
 		&RevNat4Key{},
@@ -69,15 +55,8 @@ var (
 		int(unsafe.Sizeof(RevNat4Value{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			revKey, revNat := mapKey.(*RevNat4Key), mapValue.(*RevNat4Value)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, revKey, revNat); err != nil {
-				return nil, nil, err
-			}
-
-			return revKey.ToNetwork(), revNat.ToNetwork(), nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 )
 
 // +k8s:deepcopy-gen=true
@@ -180,7 +159,8 @@ func NewService4Key(ip net.IP, port uint16, proto u8proto.U8proto, slave uint16)
 }
 
 func (k *Service4Key) String() string {
-	return fmt.Sprintf("%s:%d", k.Address, k.Port)
+	kHost := k.ToHost().(*Service4Key)
+	return net.JoinHostPort(kHost.Address.String(), fmt.Sprintf("%d", kHost.Port))
 }
 
 func (k *Service4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -35,15 +35,8 @@ var (
 		int(unsafe.Sizeof(Service6Value{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			svcKey, svcVal := mapKey.(*Service6Key), mapValue.(*Service6Value)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, svcKey, svcVal); err != nil {
-				return nil, nil, err
-			}
-
-			return svcKey.ToNetwork(), svcVal.ToNetwork(), nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 	Backend6Map = bpf.NewMap("cilium_lb6_backends",
 		bpf.MapTypeHash,
 		&Backend6Key{},
@@ -52,15 +45,8 @@ var (
 		int(unsafe.Sizeof(Backend6Value{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			backendVal := mapValue.(*Backend6Value)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, mapKey, backendVal); err != nil {
-				return nil, nil, err
-			}
-
-			return mapKey, backendVal.ToNetwork(), nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 	// RevNat6Map represents the BPF map for reverse NAT in IPv6 load balancer
 	RevNat6Map = bpf.NewMap("cilium_lb6_reverse_nat",
 		bpf.MapTypeHash,
@@ -70,15 +56,8 @@ var (
 		int(unsafe.Sizeof(RevNat6Value{})),
 		MaxEntries,
 		0, 0,
-		func(key []byte, value []byte, mapKey bpf.MapKey, mapValue bpf.MapValue) (bpf.MapKey, bpf.MapValue, error) {
-			revKey, revNat := mapKey.(*RevNat6Key), mapValue.(*RevNat6Value)
-
-			if _, _, err := bpf.ConvertKeyValue(key, value, revKey, revNat); err != nil {
-				return nil, nil, err
-			}
-
-			return revKey.ToNetwork(), revNat.ToNetwork(), nil
-		}).WithCache()
+		bpf.ConvertKeyValue,
+	).WithCache()
 )
 
 // +k8s:deepcopy-gen=true
@@ -172,7 +151,8 @@ func NewService6Key(ip net.IP, port uint16, proto u8proto.U8proto, slave uint16)
 }
 
 func (k *Service6Key) String() string {
-	return fmt.Sprintf("[%s]:%d", k.Address, k.Port)
+	kHost := k.ToHost().(*Service6Key)
+	return fmt.Sprintf("[%s]:%d", kHost.Address, kHost.Port)
 }
 
 func (k *Service6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -211,13 +211,13 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 
 	parseBackendEntries := func(key bpf.MapKey, value bpf.MapValue) {
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 
 	parseSVCEntries := func(key bpf.MapKey, value bpf.MapValue) {
-		svcKey := key.DeepCopyMapKey().(ServiceKey)
-		svcValue := value.DeepCopyMapValue().(ServiceValue)
+		svcKey := key.DeepCopyMapKey().(ServiceKey).ToHost()
+		svcValue := value.DeepCopyMapValue().(ServiceValue).ToHost()
 
 		fe := svcFrontend(svcKey, svcValue)
 
@@ -293,7 +293,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		// No need to deep copy the key because we are using the ID which
 		// is a value.
 		backendKey := key.(BackendKey)
-		backendValue := value.DeepCopyMapValue().(BackendValue)
+		backendValue := value.DeepCopyMapValue().(BackendValue).ToHost()
 		backendValueMap[backendKey.GetID()] = backendValue
 	}
 

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -51,6 +51,9 @@ type ServiceKey interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() ServiceKey
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceKey
 }
 
 // ServiceValue is the interface describing protocol independent value for services map v2.
@@ -86,6 +89,9 @@ type ServiceValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() ServiceValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() ServiceValue
 }
 
 // BackendKey is the interface describing protocol independent backend key.
@@ -114,6 +120,9 @@ type BackendValue interface {
 
 	// Convert fields to network byte order.
 	ToNetwork() BackendValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() BackendValue
 }
 
 // Backend is the interface describing protocol independent backend used by services v2.
@@ -139,6 +148,9 @@ type RevNatKey interface {
 
 	// Returns the key value
 	GetKey() uint16
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatKey
 }
 
 type RevNatValue interface {
@@ -146,6 +158,9 @@ type RevNatValue interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() RevNatValue
+
+	// ToHost converts fields to host byte order.
+	ToHost() RevNatValue
 }
 
 func svcFrontend(svcKey ServiceKey, svcValue ServiceValue) *loadbalancer.L3n4AddrID {


### PR DESCRIPTION
* #12313 -- metrics: fix negative identity count (@ArthurChiao)
 * #13244 -- lbmap: Correct issue that port info display error (@Jianlin-lv)
 * #13696 -- pkg/labelsfilter: add more unit test and rewrite docs (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 12313 13244 13696; do contrib/backporting/set-labels.py $pr done 1.7; done
```

----

Each commit had some conflicts. They all seemed rather simple, but it would be good if I get an additional set of eyes on this:

commit 9673c485a72ec93c10e2db1f4fdc8feab45d3d98

Rather trivial merge conflict where v1.7 used `errors.Wrapf` instead of
`fmt.Errorf`.

commit c5b709b22cfc0c127c7bc92d7ea2eacdc6b59179

Simple multiple merge conflicts in the `String()` functions, as v1.7 seemed
to use  `fmt.Sprintf` instead of `net.JoinHostPort`. 
 
I skipped the the changes to the `pkg/maps/lbmap/affinity.go` file,
which does not seem to exist in the v1.7 branch.

commit 682f6826bce735056a5e0d285ec0cdbb1e6cd9c8

Simple merge conflict in `String()` due to `loadbalancer.ScopeInternal`
check which is not present in `v1.7`

Skipped the changes to functions related affinity map dumping in
`pkg/maps/lbmap/lbmap.go`. They do not seem present in v1.7.

Skipped changes to `pkg/maps/lbmap/source_range.go`
and `pkg/maps/lbmap/affinity.go`, neither of which ar present in v1.7.

commit 5733f6af771c127ecc2777af4da3d2bcbb870154

Simple removal of the `labels.` references in
 `pkg/labels/filter_test.go` due to this file being part
of the `labels` package instead the `labelsfilters` package in v1.7.