### PR TITLE
loader: Use netlink lib instead of tc binary to delete filters

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1365,7 +1365,7 @@ func runDaemon() {
 	if option.Config.IsFlannelMasterDeviceSet() && option.Config.FlannelUninstallOnExit {
 		cleanup.DeferTerminationCleanupFunction(cleaner.cleanUPWg, cleaner.cleanUPSig, func() {
 			d.compilationMutex.Lock()
-			d.Datapath().Loader().DeleteDatapath(context.Background(), option.FlannelMasterDevice, "egress")
+			loader.RemoveTCFilters(option.FlannelMasterDevice, netlink.HANDLE_MIN_EGRESS)
 			d.compilationMutex.Unlock()
 		})
 	}

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -120,10 +120,6 @@ func (f *fakeLoader) EndpointHash(cfg datapath.EndpointConfiguration) (string, e
 	panic("implement me")
 }
 
-func (f *fakeLoader) DeleteDatapath(ctx context.Context, ifName, direction string) error {
-	panic("implement me")
-}
-
 func (f *fakeLoader) Unload(ep datapath.Endpoint) {
 }
 

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -30,7 +30,6 @@ type Loader interface {
 	CompileOrLoad(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
 	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
 	EndpointHash(cfg EndpointConfiguration) (string, error)
-	DeleteDatapath(ctx context.Context, ifName, direction string) error
 	Unload(ep Endpoint)
 	Reinitialize(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr IptablesManager, p Proxy) error
 }

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -251,14 +251,10 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			directions = append(directions, dirEgress)
 			objPaths = append(objPaths, netdevObjPath)
 		} else {
-			hasDatapath, err := l.HasDatapath(ctx, device, dirEgress)
+			// Remove any previously attached device from egress path if BPF
+			// NodePort and host firewall are disabled.
+			err := RemoveTCFilters(device, netlink.HANDLE_MIN_EGRESS)
 			if err != nil {
-				log.WithField("device", device).Error(err)
-			}
-			if hasDatapath || err != nil {
-				// Remove any previously attached device from egress path if BPF
-				// NodePort and host firewall are disabled.
-				err := l.DeleteDatapath(ctx, device, dirEgress)
 				log.WithField("device", device).Error(err)
 			}
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadinfo"
@@ -46,6 +47,7 @@ import (
 
 	"github.com/google/renameio"
 	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
@@ -1008,7 +1010,7 @@ func (e *Endpoint) deleteMaps() []error {
 // veth interface.
 func (e *Endpoint) DeleteBPFProgramLocked() error {
 	e.getLogger().Debug("deleting bpf program from endpoint")
-	return e.owner.Datapath().Loader().DeleteDatapath(context.TODO(), e.ifName, "ingress")
+	return loader.RemoveTCFilters(e.ifName, netlink.HANDLE_MIN_INGRESS)
 }
 
 // garbageCollectConntrack will run the ctmap.GC() on either the endpoint's


### PR DESCRIPTION
This commit replaces the `DeleteDatapath` method which called the `tc` binary by a new `RemoveTCFilters` function which relies on the netlink library.