### PR TITLE
pkg/k8s: keep resource version when watching CRDs

### DIFF
--- a/pkg/k8s/watchers/crd.go
+++ b/pkg/k8s/watchers/crd.go
@@ -370,7 +370,8 @@ func tableToCRDList(t *slim_metav1beta1.Table) *slim_apiextensions_v1beta1.Custo
 	for _, row := range t.Rows {
 		crd := slim_apiextensions_v1beta1.CustomResourceDefinition{
 			ObjectMeta: slim_metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s", row.Cells[idx]),
+				Name:            fmt.Sprintf("%s", row.Cells[idx]),
+				ResourceVersion: t.ListMeta.GetResourceVersion(),
 			},
 		}
 
@@ -414,7 +415,8 @@ func tableToPomList(t *slim_metav1.Table) *slim_metav1.PartialObjectMetadataList
 	for _, row := range t.Rows {
 		pom := slim_metav1.PartialObjectMetadata{
 			ObjectMeta: slim_metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s", row.Cells[idx]),
+				Name:            fmt.Sprintf("%s", row.Cells[idx]),
+				ResourceVersion: t.ListMeta.GetResourceVersion(),
 			},
 		}
 


### PR DESCRIPTION
In Kubernetes watchers, we need to keep the resource version of objects
so the watchers can keep track of the newest changes of a particular
object otherwise any event received from Kubernetes will be considered
"new".

Signed-off-by: André Martins <andre@cilium.io>