### PR TITLE
v1.7 backports 2020-10-23

### DIFF
--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -87,6 +87,16 @@ Opensuse_                  Tumbleweed, >=Leap 15.0
           Linux distribution that works well, please let us know by opening a
           GitHub issue or by creating a pull request that updates this guide.
 
+.. note:: Systemd 245 and above (``systemctl --version``) overrides ``rp_filter`` setting
+          of Cilium network interfaces. This introduces connectivity issues (see
+          `GH-10645 <https://github.com/cilium/cilium/issues/10645>`_ for details). To
+          avoid that, configure ``rp_filter`` in systemd using the following commands:
+
+          .. code:: bash
+
+              echo 'net.ipv4.conf.lxc*.rp_filter = 0' > /etc/sysctl.d/99-override_cilium_rp_filter.conf
+              systemctl restart systemd-sysctl
+
 .. _admin_kernel_version:
 
 Linux Kernel

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -120,6 +120,10 @@ type Endpoint struct {
 	// ID of the endpoint, unique in the scope of the node
 	ID uint16
 
+	// createdAt stores the time the endpoint was created. This value is
+	// recalculated on endpoint restore.
+	createdAt time.Time
+
 	// mutex protects write operations to this endpoint structure except
 	// for the logger field which has its own mutex
 	mutex lock.RWMutex
@@ -410,6 +414,7 @@ func NewEndpointWithState(owner regeneration.Owner, proxy EndpointProxy, allocat
 		owner:           owner,
 		proxy:           proxy,
 		ID:              ID,
+		createdAt:       time.Now(),
 		OpLabels:        pkgLabels.NewOpLabels(),
 		status:          NewEndpointStatus(),
 		DNSHistory:      fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
@@ -2282,4 +2287,9 @@ func (e *Endpoint) WaitUntilExposed(ctx context.Context) error {
 	case <-e.aliveCtx.Done():
 		return e.aliveCtx.Err()
 	}
+}
+
+// GetCreatedAt returns the endpoint creation time.
+func (e *Endpoint) GetCreatedAt() time.Time {
+	return e.createdAt
 }

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -471,6 +471,7 @@ func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 
 func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
+	ep.createdAt = time.Now()
 	ep.containerName = r.ContainerName
 	ep.containerID = r.ContainerID
 	ep.dockerNetworkID = r.DockerNetworkID

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -241,6 +241,9 @@ var (
 	// EventTSK8s is the timestamp of k8s events
 	EventTSK8s = NoOpGauge
 
+	// EventLagK8s is the lag calculation for k8s Pod events.
+	EventLagK8s = NoOpGauge
+
 	// EventTSContainerd is the timestamp of docker events
 	EventTSContainerd = NoOpGauge
 
@@ -447,6 +450,7 @@ type Configuration struct {
 	PolicyImplementationDelayEnabled        bool
 	IdentityCountEnabled                    bool
 	EventTSK8sEnabled                       bool
+	EventLagK8sEnabled                      bool
 	EventTSContainerdEnabled                bool
 	EventTSAPIEnabled                       bool
 	ProxyRedirectsEnabled                   bool
@@ -701,6 +705,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, EventTSK8s)
 			c.EventTSK8sEnabled = true
+
+			EventLagK8s = prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace:   Namespace,
+				Name:        "k8s_event_lag_seconds",
+				Help:        "Lag for Kubernetes events - computed value between receiving a CNI ADD event from kubelet and a Pod event received from kube-api-server",
+				ConstLabels: prometheus.Labels{"source": LabelEventSourceK8s},
+			})
+
+			collectors = append(collectors, EventLagK8s)
+			c.EventLagK8sEnabled = true
 
 			EventTSContainerd = prometheus.NewGauge(prometheus.GaugeOpts{
 				Namespace:   Namespace,


### PR DESCRIPTION
* #13702 -- pkg/endpoint: calculate Kube API-Server lag from pod events (@aanm)
 * #13717 -- docs: Add a note about systemd 245 rp_filter issue (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13702 13717; do contrib/backporting/set-labels.py $pr done 1.7; done
```