### PR TITLE
redirectpolicy: Check lrp type before restoring lrp service

### DIFF
--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -449,10 +449,12 @@ func (rpm *Manager) notifyPolicyBackendDelete(config *LRPConfig, frontendMapping
 			log.WithError(err).Errorf("Local redirect service for policy (%v)"+
 				" with frontend (%v) not deleted", config.id, frontendMapping.feAddr)
 		}
-		if restored := rpm.svcCache.EnsureService(*config.serviceID, lock.NewStoppableWaitGroup()); restored {
-			log.WithFields(logrus.Fields{
-				logfields.K8sSvcID: *config.serviceID,
-			}).Info("Restored service")
+		if config.lrpType == lrpConfigTypeSvc {
+			if restored := rpm.svcCache.EnsureService(*config.serviceID, lock.NewStoppableWaitGroup()); restored {
+				log.WithFields(logrus.Fields{
+					logfields.K8sSvcID: *config.serviceID,
+				}).Info("Restored service")
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes the regression caused by commit b553f49, whereby not checking the lrp type before restoring clusterIP service would lead to nil pointer access for `addressMatcher` lrps that don't have the `serviceID` field set in the lrp config. As there is no backing k8s service for such lrps, they don't need restore.

Here is the stack trace - 

level=info msg="Observed a panic: \"invalid memory address or nil pointer dereference\" (runtime error: invalid memory address or nil pointer dereference)" subsys=klog
level=info msg="goroutine 171 [running]:" subsys=klog
:
level=info msg="\t/usr/local/go/src/runtime/panic.go:969 +0x1b9" subsys=klog
level=info msg="github.com/cilium/cilium/pkg/redirectpolicy.(*Manager).notifyPolicyBackendDelete(0xc000706480, 0xc0009790e0, 0xc000d8d2c0)" subsys=klog
**level=info msg="\t/go/src/github.com/cilium/cilium/pkg/redirectpolicy/manager.go:452 +0x316" subsys=klog**
level=info msg="github.com/cilium/cilium/pkg/redirectpolicy.(*Manager).deletePolicyBackends(0xc000706480, 0xc0009790e0, 0xc00038ec80, 0x10, 0xc00038ec65, 0x7)" subsys=klog
level=info msg="\t/go/src/github.com/cilium/cilium/pkg/redirectpolicy/manager.go:427 +0x1c5" subsys=klog
level=info msg="github.com/cilium/cilium/pkg/redirectpolicy.(*Manager).OnUpdatePodLocked(0xc000706480, 0xc000de5d40, 0x3ad0001)" subsys=klog
level=info msg="\t/go/src/github.com/cilium/cilium/pkg/redirectpolicy/manager.go:277 +0x3af" subsys=klog
level=info msg="github.com/cilium/cilium/pkg/redirectpolicy.(*Manager).OnUpdatePod(0xc000706480, 0xc000de5d40, 0xc000cd0000)" subsys=klog


Fixes: [b553f49](https://github.com/cilium/cilium/commit/b553f492df0c7e3188fafe870973f3345700c83b)
Fixes: #13736 

[1] https://github.com/cilium/cilium/blob/master/pkg/redirectpolicy/manager.go#L452