### PR TITLE
test: Switch from Cilium test logger to Ginkgo

### DIFF
--- a/test/helpers/vagrant.go
+++ b/test/helpers/vagrant.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
-	"github.com/cilium/cilium/test/logger"
 
 	"github.com/onsi/ginkgo"
 	"github.com/sirupsen/logrus"
@@ -85,7 +84,7 @@ func GetVagrantSSHMetadata(vmName string) ([]byte, error) {
 	debugVms := func() {
 		cmd := getCmd("vagrant status --machine-readable")
 		output, _ := cmd.CombinedOutput()
-		fmt.Fprintf(&logger.TestLogWriter, "Vagrant status on failure:\n%s\n", output)
+		ginkgoext.Failf("Vagrant status on failure:\n%s\n", output)
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -99,7 +98,7 @@ func GetVagrantSSHMetadata(vmName string) ([]byte, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		fmt.Fprintf(&logger.TestLogWriter, "cmd='%s %s'\noutput:\n%s\nstderr:\n%s\n",
+		ginkgoext.GinkgoPrint("cmd='%s %s'\noutput:\n%s\nstderr:\n%s\n",
 			cmd.Path, strings.Join(cmd.Args, " "), stdout.String(), stderr.String())
 		debugVms()
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

When executing ginkgo according to the instructions: https://docs.cilium.io/en/v1.9.0-rc2/contributing/testing/e2e/#running-end-to-end-tests-in-other-environments-via-ssh, something was not working and the only output I was getting was:

`FAIL: Cannot connect to vmName  'k8s1-1.18'`

After changing the logs using this patch, I could see that the real error was:

`cat: ssh-config: No such file or directory`

It seems that `fmt.Fprintf(&logger.TestLogWriter...` function does not print the logs anywhere as I could not see that message in the output
