### PR TITLE
ci: skip tests involving L7 proxy if race detector is enabled

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -639,3 +639,10 @@ func SkipQuarantined() bool {
 func SkipGKEQuarantined() bool {
 	return SkipQuarantined() && IsIntegration(CIIntegrationGKE)
 }
+
+// SkipRaceDetectorEnabled returns whether tests failing with race detector
+// enabled should be skipped.
+func SkipRaceDetectorEnabled() bool {
+	race := os.Getenv("RACE")
+	return race == "1" || race == "true"
+}

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -64,7 +64,8 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 		kubectl.CloseSSHClient()
 	})
 
-	Context("Kafka Policy Tests", func() {
+	// Tests involving the L7 proxy do not work when built with -race, see issue #13757.
+	SkipContextIf(helpers.SkipRaceDetectorEnabled, "Kafka Policy Tests", func() {
 		createTopicCmd := func(topic string) string {
 			return fmt.Sprintf("/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --create "+
 				"--zookeeper localhost:2181 --replication-factor 1 "+

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1031,7 +1031,8 @@ var _ = Describe("K8sPolicyTest", func() {
 				validateL3L4(denyAll)
 			})
 
-			It("Verifies that a CNP with L7 HTTP rules can be replaced with L7 Kafka rules", func() {
+			// Tests involving the L7 proxy do not work when built with -race, see issue #13757.
+			SkipItIf(helpers.SkipRaceDetectorEnabled, "Verifies that a CNP with L7 HTTP rules can be replaced with L7 Kafka rules", func() {
 				By("Installing L7 Policy")
 
 				// This HTTP policy was already validated in the
@@ -1063,8 +1064,8 @@ var _ = Describe("K8sPolicyTest", func() {
 			})
 		})
 
-		Context("Traffic redirections to proxy", func() {
-
+		// Tests involving the L7 proxy do not work when built with -race, see issue #13757.
+		SkipContextIf(helpers.SkipRaceDetectorEnabled, "Traffic redirections to proxy", func() {
 			var (
 				// track which app1 pod we care about, and its corresponding
 				// cilium pod.

--- a/test/runtime/cassandra.go
+++ b/test/runtime/cassandra.go
@@ -16,6 +16,7 @@ package RuntimeTest
 
 import (
 	"fmt"
+
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	"github.com/cilium/cilium/test/helpers/constants"
@@ -126,7 +127,7 @@ var _ = Describe("RuntimeCassandra", func() {
 		vm.ReportFailed("cilium policy get")
 	})
 
-	It("Tests policy allowing all actions", func() {
+	SkipItIf(helpers.SkipRaceDetectorEnabled, "Tests policy allowing all actions", func() {
 		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-cassandra-allow-all.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Failed to import policy")
 
@@ -147,7 +148,7 @@ var _ = Describe("RuntimeCassandra", func() {
 		r.ExpectContains("alice", "Did not get inserted data in select")
 	})
 
-	It("Tests policy disallowing Insert action", func() {
+	SkipItIf(helpers.SkipRaceDetectorEnabled, "Tests policy disallowing Insert action", func() {
 
 		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-cassandra-no-insert-posts.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Failed to import policy")
@@ -169,5 +170,4 @@ var _ = Describe("RuntimeCassandra", func() {
 		r.ExpectContains("alice", "Did not get inserted data in select")
 		r.ExpectDoesNotContain("bob", "Got value on select that should not have been inserted")
 	})
-
 })

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -158,7 +158,7 @@ var _ = Describe("RuntimeKafka", func() {
 		vm.ReportFailed("cilium policy get")
 	})
 
-	It("Kafka Policy Ingress", func() {
+	SkipItIf(helpers.SkipRaceDetectorEnabled, "Kafka Policy Ingress", func() {
 		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-kafka.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 
@@ -190,7 +190,7 @@ var _ = Describe("RuntimeKafka", func() {
 		monitorRes.ExpectContains("verdict Denied offsetfetch topic disallowTopic => 29")
 	})
 
-	It("Kafka Policy Role Egress", func() {
+	SkipItIf(helpers.SkipRaceDetectorEnabled, "Kafka Policy Role Egress", func() {
 		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-kafka-Role.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Expected nil got %s while importing policy Policies-kafka-Role.json", err)
 


### PR DESCRIPTION
Running tests involving the L7 proxy fail when using the race detector, so skip them in that case.

See individual commit for details.

Fixes #13753 
Fixes #13757