### PR TITLE
backporting: Properly escape commit message when used as regex

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -126,6 +126,7 @@ generate_commit_list_for_pr () {
   local entry_id
   local entry_sha
   local entry_sub
+  local entry_sub_re
   local upstream
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
@@ -152,7 +153,8 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "^$entry_sub" $REMOTE/master)"
+    entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
+    upstream="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then


### PR DESCRIPTION
This change escapes the commit message when it is used as a regular
expression. Any special character of the posix extended regex
(`.^$*+?()[{\|`) is now prefixed with a backslash. This fixes an issue where
`git log` would crash due to to the string being passed to `--grep` not
being a valid regex, such as e.g. in the commit messages found in
PR #13674 which contain `$`, `*` and `{`.

Example of a failure when processing commit c0b8a82366f573470afe62bdce4463bd8a56174d:
```
++ git log -F --since=1year --pretty=%H --no-merges --extended-regexp --grep '^docs: use $API_SERVER_{IP,PORT} vars in kube-proxy-free GSG' origin/master
fatal: command line, '^docs: use $API_SERVER_{IP,PORT} vars in kube-proxy-free GSG': Invalid content of \{\}
```

With the fix applied:

```
+ entry_sub='docs: use $API_SERVER_{IP,PORT} vars in kube-proxy-free GSG'
++ sed 's/[.^$*+?()[{\|]/\\&/g'
+ entry_sub_re='^docs: use \$API_SERVER_\{IP,PORT} vars in kube-proxy-free GSG'
++ git log -F --since=1year --pretty=%H --no-merges --extended-regexp --grep '^docs: use \$API_SERVER_\{IP,PORT} vars in kube-proxy-free GSG' origin/master
+ upstream=11282c7cde428a01dd9295c77937350ffb1b9fd7
```

---

Additional note: For some reason, even with the fix, `check-stable` still is not able to correlate the commits in the above PR, but I'm 99% sure this is unrelated to the escaping issue addressed here.

Thanks to the fix in this PR, `check-stable` now finds the correct upstream commit instead of crashing. But due to differences in line numbers (maybe due to the rebase done by GitHub), the computed `git patch-id` between the upstream sha and the master sha still don't match.

---

I'm also marking this for backport to 1.7-1.9, such that users who are initiating backport from a release branch will use the updated scripts as well.