### PR TITLE
pkg: Use strings.Builder instead of bytes.Buffer where possible

### DIFF
--- a/pkg/command/output.go
+++ b/pkg/command/output.go
@@ -15,11 +15,11 @@
 package command
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/util/jsonpath"
@@ -86,13 +86,13 @@ func DumpJSONToSlice(data interface{}, jsonPath string) ([]byte, error) {
 		return nil, err
 	}
 
-	buf := new(bytes.Buffer)
-	if err := parser.Execute(buf, data); err != nil {
+	var sb strings.Builder
+	if err := parser.Execute(&sb, data); err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't parse jsonpath expression: '%s'\n", err)
 		return nil, err
 
 	}
-	return buf.Bytes(), nil
+	return []byte(sb.String()), nil
 }
 
 // dumpJSON dump the data variable to the stdout as json.

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -15,7 +15,6 @@
 package podcidr
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -892,21 +891,16 @@ func (n *NodesPodCIDRManager) allocateNext(nodeName string) (*nodeCIDRs, bool, e
 }
 
 func getCIDRAllocatorsInfo(cidrAllocators []CIDRAllocator, netTypes string) string {
-	var buf bytes.Buffer
-
-	length := len(cidrAllocators)
-	if length == 0 {
-		return "[]"
-	}
-
-	for index, cidrAllocator := range cidrAllocators {
-		buf.WriteString(fmt.Sprintf("%s", cidrAllocator.String()))
-		if index < length-1 {
-			buf.WriteString(", ")
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for i, cidrAllocator := range cidrAllocators {
+		if i > 0 {
+			sb.WriteString(", ")
 		}
+		sb.WriteString(cidrAllocator.String())
 	}
-
-	return fmt.Sprintf("[%s]", buf.String())
+	sb.WriteByte(']')
+	return sb.String()
 }
 
 // allocateFirstFreeCIDR allocates the first CIDR available from the slice of

--- a/pkg/k8s/slim/k8s/apis/labels/selector.go
+++ b/pkg/k8s/slim/k8s/apis/labels/selector.go
@@ -16,7 +16,6 @@
 package labels
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 	"strconv"
@@ -274,48 +273,48 @@ func (lsel internalSelector) Empty() bool {
 // Requirement. If called on an invalid Requirement, an error is
 // returned. See NewRequirement for creating a valid Requirement.
 func (r *Requirement) String() string {
-	var buffer bytes.Buffer
+	var sb strings.Builder
 	if r.operator == selection.DoesNotExist {
-		buffer.WriteString("!")
+		sb.WriteString("!")
 	}
-	buffer.WriteString(r.key)
+	sb.WriteString(r.key)
 
 	switch r.operator {
 	case selection.Equals:
-		buffer.WriteString("=")
+		sb.WriteString("=")
 	case selection.DoubleEquals:
-		buffer.WriteString("==")
+		sb.WriteString("==")
 	case selection.NotEquals:
-		buffer.WriteString("!=")
+		sb.WriteString("!=")
 	case selection.In:
-		buffer.WriteString(" in ")
+		sb.WriteString(" in ")
 	case selection.NotIn:
-		buffer.WriteString(" notin ")
+		sb.WriteString(" notin ")
 	case selection.GreaterThan:
-		buffer.WriteString(">")
+		sb.WriteString(">")
 	case selection.LessThan:
-		buffer.WriteString("<")
+		sb.WriteString("<")
 	case selection.Exists, selection.DoesNotExist:
-		return buffer.String()
+		return sb.String()
 	}
 
 	switch r.operator {
 	case selection.In, selection.NotIn:
-		buffer.WriteString("(")
+		sb.WriteString("(")
 	}
 	if len(r.strValues) == 1 {
-		buffer.WriteString(r.strValues[0])
+		sb.WriteString(r.strValues[0])
 	} else { // only > 1 since == 0 prohibited by NewRequirement
 		// normalizes value order on output, without mutating the in-memory selector representation
 		// also avoids normalization when it is not required, and ensures we do not mutate shared data
-		buffer.WriteString(strings.Join(safeSort(r.strValues), ","))
+		sb.WriteString(strings.Join(safeSort(r.strValues), ","))
 	}
 
 	switch r.operator {
 	case selection.In, selection.NotIn:
-		buffer.WriteString(")")
+		sb.WriteString(")")
 	}
-	return buffer.String()
+	return sb.String()
 }
 
 // safeSort sort input strings without modification

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -15,7 +15,6 @@
 package ctmap
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +22,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -261,20 +261,20 @@ type EmitCTEntryCBFunc func(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHd
 // DoDumpEntries iterates through Map m and writes the values of the ct entries
 // in m to a string.
 func DoDumpEntries(m CtMap) (string, error) {
-	var buffer bytes.Buffer
+	var sb strings.Builder
 
 	cb := func(k bpf.MapKey, v bpf.MapValue) {
 		// No need to deep copy as the values are used to create new strings
 		key := k.(CtKey)
-		if !key.ToHost().Dump(&buffer, true) {
+		if !key.ToHost().Dump(&sb, true) {
 			return
 		}
 		value := v.(*CtEntry)
-		buffer.WriteString(value.String())
+		sb.WriteString(value.String())
 	}
-	// DumpWithCallback() must be called before buffer.String().
+	// DumpWithCallback() must be called before sb.String().
 	err := m.DumpWithCallback(cb)
-	return buffer.String(), err
+	return sb.String(), err
 }
 
 // DumpEntries iterates through Map m and writes the values of the ct entries

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -15,8 +15,8 @@
 package ctmap
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -147,8 +147,8 @@ type CtKey interface {
 	// ToHost converts fields to host byte order.
 	ToHost() CtKey
 
-	// Dump contents of key to buffer. Returns true if successful.
-	Dump(buffer *bytes.Buffer, reverse bool) bool
+	// Dump contents of key to sb. Returns true if successful.
+	Dump(sb *strings.Builder, reverse bool) bool
 
 	// GetFlags flags containing the direction of the CtKey.
 	GetFlags() uint8
@@ -194,9 +194,9 @@ func (k *CtKey4) String() string {
 // GetKeyPtr returns the unsafe.Pointer for k.
 func (k *CtKey4) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
-// Dump writes the contents of key to buffer and returns true if the value for
-// next header in the key is nonzero.
-func (k *CtKey4) Dump(buffer *bytes.Buffer, reverse bool) bool {
+// Dump writes the contents of key to sb and returns true if the value for next
+// header in the key is nonzero.
+func (k *CtKey4) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrDest string
 
 	if k.NextHeader == 0 {
@@ -211,23 +211,23 @@ func (k *CtKey4) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.SourcePort,
 			k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.DestPort,
 			k.SourcePort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true
@@ -281,9 +281,9 @@ func (k *CtKey4Global) String() string {
 // GetKeyPtr returns the unsafe.Pointer for k.
 func (k *CtKey4Global) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
-// Dump writes the contents of key to buffer and returns true if the
-// value for next header in the key is nonzero.
-func (k *CtKey4Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
+// Dump writes the contents of key to sb and returns true if the value for next
+// header in the key is nonzero.
+func (k *CtKey4Global) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrSource, addrDest string
 
 	if k.NextHeader == 0 {
@@ -300,23 +300,23 @@ func (k *CtKey4Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true
@@ -362,9 +362,9 @@ func (k *CtKey6) String() string {
 // GetKeyPtr returns the unsafe.Pointer for k.
 func (k *CtKey6) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
-// Dump writes the contents of key to buffer and returns true if the value for
-// next header in the key is nonzero.
-func (k *CtKey6) Dump(buffer *bytes.Buffer, reverse bool) bool {
+// Dump writes the contents of key to sb and returns true if the value for next
+// header in the key is nonzero.
+func (k *CtKey6) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrDest string
 
 	if k.NextHeader == 0 {
@@ -379,23 +379,23 @@ func (k *CtKey6) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.SourcePort,
 			k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.DestPort,
 			k.SourcePort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true
@@ -451,9 +451,9 @@ func (k *CtKey6Global) String() string {
 // GetKeyPtr returns the unsafe.Pointer for k.
 func (k *CtKey6Global) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
-// Dump writes the contents of key to buffer and returns true if the
-// value for next header in the key is nonzero.
-func (k *CtKey6Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
+// Dump writes the contents of key to sb and returns true if the value for next
+// header in the key is nonzero.
+func (k *CtKey6Global) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrSource, addrDest string
 
 	if k.NextHeader == 0 {
@@ -470,23 +470,23 @@ func (k *CtKey6Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true
@@ -534,41 +534,41 @@ const (
 )
 
 func (c *CtEntry) flagsString() string {
-	var buffer bytes.Buffer
+	var sb strings.Builder
 
-	buffer.WriteString(fmt.Sprintf("Flags=%#04x [ ", c.Flags))
+	sb.WriteString(fmt.Sprintf("Flags=%#04x [ ", c.Flags))
 	if (c.Flags & RxClosing) != 0 {
-		buffer.WriteString("RxClosing ")
+		sb.WriteString("RxClosing ")
 	}
 	if (c.Flags & TxClosing) != 0 {
-		buffer.WriteString("TxClosing ")
+		sb.WriteString("TxClosing ")
 	}
 	if (c.Flags & Nat64) != 0 {
-		buffer.WriteString("Nat64 ")
+		sb.WriteString("Nat64 ")
 	}
 	if (c.Flags & LBLoopback) != 0 {
-		buffer.WriteString("LBLoopback ")
+		sb.WriteString("LBLoopback ")
 	}
 	if (c.Flags & SeenNonSyn) != 0 {
-		buffer.WriteString("SeenNonSyn ")
+		sb.WriteString("SeenNonSyn ")
 	}
 	if (c.Flags & NodePort) != 0 {
-		buffer.WriteString("NodePort ")
+		sb.WriteString("NodePort ")
 	}
 	if (c.Flags & ProxyRedirect) != 0 {
-		buffer.WriteString("ProxyRedirect ")
+		sb.WriteString("ProxyRedirect ")
 	}
 	if (c.Flags & DSR) != 0 {
-		buffer.WriteString("DSR ")
+		sb.WriteString("DSR ")
 	}
 
 	unknownFlags := c.Flags
 	unknownFlags &^= MaxFlags - 1
 	if unknownFlags != 0 {
-		buffer.WriteString(fmt.Sprintf("Unknown=%#04x ", unknownFlags))
+		sb.WriteString(fmt.Sprintf("Unknown=%#04x ", unknownFlags))
 	}
-	buffer.WriteString("]")
-	return buffer.String()
+	sb.WriteString("]")
+	return sb.String()
 }
 
 // String returns the readable format

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -15,8 +15,8 @@
 package nat
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -134,19 +134,19 @@ func (m *Map) DumpReliablyWithCallback(cb bpf.DumpCallback, stats *bpf.DumpStats
 // DoDumpEntries iterates through Map m and writes the values of the
 // nat entries in m to a string.
 func DoDumpEntries(m NatMap) (string, error) {
-	var buffer bytes.Buffer
+	var sb strings.Builder
 
 	nsecStart, _ := bpf.GetMtime()
 	cb := func(k bpf.MapKey, v bpf.MapValue) {
 		key := k.(NatKey)
-		if !key.ToHost().Dump(&buffer, false) {
+		if !key.ToHost().Dump(&sb, false) {
 			return
 		}
 		val := v.(NatEntry)
-		buffer.WriteString(val.ToHost().Dump(key, nsecStart))
+		sb.WriteString(val.ToHost().Dump(key, nsecStart))
 	}
 	err := m.DumpWithCallback(cb)
-	return buffer.String(), err
+	return sb.String(), err
 }
 
 // DumpEntries iterates through Map m and writes the values of the

--- a/pkg/maps/nat/types.go
+++ b/pkg/maps/nat/types.go
@@ -15,7 +15,7 @@
 package nat
 
 import (
-	"bytes"
+	"strings"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -32,8 +32,8 @@ type NatKey interface {
 	// ToHost converts fields to host byte order.
 	ToHost() NatKey
 
-	// Dump contents of key to buffer. Returns true if successful.
-	Dump(buffer *bytes.Buffer, reverse bool) bool
+	// Dump contents of key to sb. Returns true if successful.
+	Dump(sb *strings.Builder, reverse bool) bool
 
 	// GetFlags flags containing the direction of the TupleKey.
 	GetFlags() uint8

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -15,9 +15,9 @@
 package policymap
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -343,16 +343,16 @@ func (pm *PolicyMap) String() string {
 }
 
 func (pm *PolicyMap) Dump() (string, error) {
-	var buffer bytes.Buffer
+	var sb strings.Builder
 	entries, err := pm.DumpToSlice()
 	if err != nil {
 		return "", err
 	}
 	for _, entry := range entries {
-		buffer.WriteString(fmt.Sprintf("%20s: %s\n",
+		sb.WriteString(fmt.Sprintf("%20s: %s\n",
 			entry.Key.String(), entry.PolicyEntry.String()))
 	}
-	return buffer.String(), nil
+	return sb.String(), nil
 }
 
 func (pm *PolicyMap) DumpToSlice() (PolicyEntriesDump, error) {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -15,8 +15,8 @@
 package policy
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/identity"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -281,7 +281,7 @@ func mergeIngressPortProto(policyCtx PolicyContext, ctx *SearchContext, endpoint
 }
 
 func traceL3(ctx *SearchContext, peerEndpoints api.EndpointSelectorSlice, direction string, isDeny bool) {
-	var result bytes.Buffer
+	var result strings.Builder
 
 	// Requirements will be cloned into every selector, only trace them once.
 	if len(peerEndpoints[0].MatchExpressions) > 0 {

--- a/pkg/tuple/ipv4.go
+++ b/pkg/tuple/ipv4.go
@@ -15,8 +15,8 @@
 package tuple
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -71,9 +71,9 @@ func (k *TupleKey4) String() string {
 	return fmt.Sprintf("%s:%d, %d, %d, %d", k.DestAddr, k.SourcePort, k.DestPort, k.NextHeader, k.Flags)
 }
 
-// Dump writes the contents of key to buffer and returns true if the value for
-// next header in the key is nonzero.
-func (k TupleKey4) Dump(buffer *bytes.Buffer, reverse bool) bool {
+// Dump writes the contents of key to sb and returns true if the value for next
+// header in the key is nonzero.
+func (k TupleKey4) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrDest string
 
 	if k.NextHeader == 0 {
@@ -88,23 +88,23 @@ func (k TupleKey4) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.SourcePort,
 			k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.DestPort,
 			k.SourcePort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true
@@ -150,9 +150,9 @@ func (k *TupleKey4Global) ToHost() TupleKey {
 	}
 }
 
-// Dump writes the contents of key to buffer and returns true if the
+// Dump writes the contents of key to sb and returns true if the
 // value for next header in the key is nonzero.
-func (k TupleKey4Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
+func (k TupleKey4Global) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrSource, addrDest string
 
 	if k.NextHeader == 0 {
@@ -169,23 +169,23 @@ func (k TupleKey4Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true

--- a/pkg/tuple/ipv6.go
+++ b/pkg/tuple/ipv6.go
@@ -15,8 +15,8 @@
 package tuple
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -71,9 +71,9 @@ func (k *TupleKey6) String() string {
 	return fmt.Sprintf("[%s]:%d, %d, %d, %d", k.DestAddr, k.SourcePort, k.DestPort, k.NextHeader, k.Flags)
 }
 
-// Dump writes the contents of key to buffer and returns true if the value for
-// next header in the key is nonzero.
-func (k TupleKey6) Dump(buffer *bytes.Buffer, reverse bool) bool {
+// Dump writes the contents of key to sb and returns true if the value for next
+// header in the key is nonzero.
+func (k TupleKey6) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrDest string
 
 	if k.NextHeader == 0 {
@@ -88,23 +88,23 @@ func (k TupleKey6) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.SourcePort,
 			k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.DestPort,
 			k.SourcePort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true
@@ -149,9 +149,9 @@ func (k *TupleKey6Global) ToHost() TupleKey {
 	}
 }
 
-// Dump writes the contents of key to buffer and returns true if the value for
-// next header in the key is nonzero.
-func (k TupleKey6Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
+// Dump writes the contents of key to sb and returns true if the value for next
+// header in the key is nonzero.
+func (k TupleKey6Global) Dump(sb *strings.Builder, reverse bool) bool {
 	var addrSource, addrDest string
 
 	if k.NextHeader == 0 {
@@ -168,23 +168,23 @@ func (k TupleKey6Global) Dump(buffer *bytes.Buffer, reverse bool) bool {
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
-		buffer.WriteString(fmt.Sprintf("%s IN [%s]:%d -> [%s]:%d ",
+		sb.WriteString(fmt.Sprintf("%s IN [%s]:%d -> [%s]:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s OUT [%s]:%d -> [%s]:%d ",
+		sb.WriteString(fmt.Sprintf("%s OUT [%s]:%d -> [%s]:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
 		)
 	}
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
-		buffer.WriteString("related ")
+		sb.WriteString("related ")
 	}
 
 	if k.Flags&TUPLE_F_SERVICE != 0 {
-		buffer.WriteString("service ")
+		sb.WriteString("service ")
 	}
 
 	return true

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -15,7 +15,7 @@
 package tuple
 
 import (
-	"bytes"
+	"strings"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -38,8 +38,8 @@ type TupleKey interface {
 	// ToHost converts fields to host byte order.
 	ToHost() TupleKey
 
-	// Dumps contents of key to buffer. Returns true if successful.
-	Dump(buffer *bytes.Buffer, reverse bool) bool
+	// Dumps contents of key to sb. Returns true if successful.
+	Dump(sb *strings.Builder, reverse bool) bool
 
 	// Returns flags containing the direction of the tuple key.
 	GetFlags() uint8


### PR DESCRIPTION
strings.Builder is optimized for building strings and performs a little
better than bytes.Buffer.
