### PR TITLE
cilium/cmd: Replace exit code -1 with exit code 1

### DIFF
--- a/Documentation/cmdref/cilium_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium_preflight_validate-cnp.md
@@ -9,7 +9,7 @@ Validate Cilium Network Policies deployed in the cluster
 Before upgrading Cilium it is recommended to run this validation checker
 to make sure the policies deployed are valid. The validator will verify if all policies
 deployed in the cluster are valid, in case they are not, an error is printed and the
-has an exit code -1 is returned.
+has an exit code 1 is returned.
 
 ```
 cilium preflight validate-cnp [flags]

--- a/cilium/cmd/metrics_list.go
+++ b/cilium/cmd/metrics_list.go
@@ -58,7 +58,6 @@ var MetricsListCmd = &cobra.Command{
 			fmt.Fprintf(w, "%s\t%s\t%f\n", metric.Name, label, metric.Value)
 		}
 		w.Flush()
-		os.Exit(0)
 	},
 }
 

--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -42,12 +42,12 @@ var validateCNP = &cobra.Command{
 	Long: `Before upgrading Cilium it is recommended to run this validation checker
 to make sure the policies deployed are valid. The validator will verify if all policies
 deployed in the cluster are valid, in case they are not, an error is printed and the
-has an exit code -1 is returned.`,
+has an exit code 1 is returned.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := validateCNPs()
 		if err != nil {
 			log.Error(err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 	},
 }

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -46,7 +46,7 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
In two cases, cilium could exit with code -1, which gets converted to
255. Instead, always exit with code 1 in the event of failure. Also,
remove an unnecessary os.Exit(0).
