### PR TITLE
ci: skip k8s Kafka/L7 tests if race detector is enabled

### DIFF
--- a/test/helpers/norace.go
+++ b/test/helpers/norace.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !race
+
+package helpers
+
+// isRaceDetectorBuild is true in case the test suite was built with the Go race
+// detector enabled.
+const isRaceDetectorEnabled = false

--- a/test/helpers/race.go
+++ b/test/helpers/race.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build race
+
+package helpers
+
+// isRaceDetectorBuild is true in case the test suite was built with the Go race
+// detector enabled.
+const isRaceDetectorEnabled = true

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -639,3 +639,9 @@ func SkipQuarantined() bool {
 func SkipGKEQuarantined() bool {
 	return SkipQuarantined() && IsIntegration(CIIntegrationGKE)
 }
+
+// SkipRaceDetectorEnabled returns whether test should be skipped in case the
+// test suire was build with the Go race detector enabled.
+func SkipRaceDetectorEnabled() bool {
+	return isRaceDetectorEnabled
+}

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !race
+
 package k8sTest
 
 import (

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1031,7 +1031,8 @@ var _ = Describe("K8sPolicyTest", func() {
 				validateL3L4(denyAll)
 			})
 
-			It("Verifies that a CNP with L7 HTTP rules can be replaced with L7 Kafka rules", func() {
+			// Tests involving the L7 proxy do not work when built with -race, see issue #13757.
+			SkipItIf(helpers.SkipRaceDetectorEnabled, "Verifies that a CNP with L7 HTTP rules can be replaced with L7 Kafka rules", func() {
 				By("Installing L7 Policy")
 
 				// This HTTP policy was already validated in the
@@ -1063,8 +1064,8 @@ var _ = Describe("K8sPolicyTest", func() {
 			})
 		})
 
-		Context("Traffic redirections to proxy", func() {
-
+		// Tests involving the L7 proxy do not work when built with -race, see issue #13757.
+		SkipContextIf(helpers.SkipRaceDetectorEnabled, "Traffic redirections to proxy", func() {
 			var (
 				// track which app1 pod we care about, and its corresponding
 				// cilium pod.


### PR DESCRIPTION
K8s tests involving the L7 proxy fail when using the race detector, so
skip them in that case.

Fixes #13757