### PR TITLE
.github: Add action to build all BPF permutations

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -25,3 +25,28 @@ jobs:
       - uses: docker://cilium/coccicheck:1.0
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
+  build_all:
+    name: build datapath
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v2
+        with:
+          path: $HOME/.clang
+          key: llvm-10.0
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "10.0"
+          directory: $HOME/.clang
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build all BPF datapath permutations
+        env:
+          V: 0
+        run: |
+          make --quiet -C bpf build_all || (echo "Run 'make -C bpf build_all' locally to investigate build breakages"; exit 1)

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-.PHONY: all build_all subdirs install clean
+.PHONY: all bpf_all build_all subdirs install clean
 
 SUBDIRS = sockops
 
@@ -15,12 +15,14 @@ TARGET=cilium-map-migrate cilium-probe-kernel-hz
 include ./Makefile.bpf
 
 ifeq ("$(PKG_BUILD)","")
-all: $(BPF) $(TARGET) subdirs
+all: $(TARGET) bpf_all
+
+bpf_all: $(BPF) subdirs
 
 build_all: force
 	@touch $(BUILD_PERMUTATIONS_DEP)
 	@$(ECHO_CHECK)/*.c BUILD_PERMUTATIONS=1
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) all BUILD_PERMUTATIONS=1
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) bpf_all BUILD_PERMUTATIONS=1
 
 BUILD_PERMUTATIONS ?= ""
 


### PR DESCRIPTION
Use "make -C bpf build_all" to validate the buildability of the datapath
in a variety of permutations of input configurations.