### PR TITLE
docs: Add gsg cross-link for cluster-pool IPAM

### DIFF
--- a/Documentation/concepts/networking/ipam/cluster-pool.rst
+++ b/Documentation/concepts/networking/ipam/cluster-pool.rst
@@ -38,6 +38,13 @@ Field                  Description
 ``Spec.IPAM.PodCIDRs`` IPv4 and/or IPv6 PodCIDR range
 ====================== ==============================
 
+*************
+Configuration
+*************
+
+For a practical tutorial on how to enable this mode in Cilium, see
+:ref:`gsg_ipam_crd_cluster_pool`.
+
 ***************
 Troubleshooting
 ***************


### PR DESCRIPTION
There was previously only a one-way link from the configuration guide
to the concepts section. Add a link the other way.