### PR TITLE
Pre-allocate slices with known size

### DIFF
--- a/pkg/hubble/filters/fqdn.go
+++ b/pkg/hubble/filters/fqdn.go
@@ -88,7 +88,7 @@ func filterByFQDNs(fqdnPatterns []string, getFQDNs func(*v1.Event) []string) (Fi
 // The filter function returns true if and only if the DNS query field matches any of
 // the regular expressions.
 func filterByDNSQueries(queryPatterns []string) (FilterFunc, error) {
-	var queries []*regexp.Regexp
+	queries := make([]*regexp.Regexp, 0, len(queryPatterns))
 	for _, pattern := range queryPatterns {
 		query, err := regexp.Compile(pattern)
 		if err != nil {

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -288,7 +288,7 @@ nextFlow:
 }
 
 func logFilters(filters []*flowpb.FlowFilter) string {
-	var s []string
+	s := make([]string, 0, len(filters))
 	for _, f := range filters {
 		s = append(s, f.String())
 	}

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -322,7 +322,7 @@ func decodeDNS(flowType accesslog.FlowType, dns *accesslog.LogRecordDNS) *pb.Lay
 
 func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP) *pb.Layer7_Http {
 	var headers []*pb.HTTPHeader
-	var keys []string
+	keys := make([]string, 0, len(http.Headers))
 	for key := range http.Headers {
 		keys = append(keys, key)
 	}

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -513,7 +513,7 @@ func (rpm *Manager) upsertService(config *LRPConfig, frontendMapping *feMapping)
 		L3n4Addr: *frontendMapping.feAddr,
 		ID:       lb.ID(0),
 	}
-	var backendAddrs []lb.Backend
+	backendAddrs := make([]lb.Backend, 0, len(frontendMapping.podBackends))
 	for _, be := range frontendMapping.podBackends {
 		backendAddrs = append(backendAddrs, lb.Backend{
 			NodeName: nodeTypes.GetName(),

--- a/pkg/redirectpolicy/redirectpolicy.go
+++ b/pkg/redirectpolicy/redirectpolicy.go
@@ -112,7 +112,7 @@ type feMapping struct {
 }
 
 func (feM *feMapping) GetModel() *models.FrontendMapping {
-	var bes []*models.LRPBackend
+	bes := make([]*models.LRPBackend, 0, len(feM.podBackends))
 	for _, be := range feM.podBackends {
 		bes = append(bes, be.GetModel())
 	}
@@ -360,7 +360,7 @@ func (config *LRPConfig) GetModel() *models.LRPSpec {
 		lrpType = "svc"
 	}
 
-	var feMappingModelArray []*models.FrontendMapping
+	feMappingModelArray := make([]*models.FrontendMapping, 0, len(config.frontendMappings))
 	for _, feM := range config.frontendMappings {
 		feMappingModelArray = append(feMappingModelArray, feM.GetModel())
 	}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -531,12 +531,12 @@ func (m *ManagerTestSuite) TestLocalRedirectLocalBackendSelection(c *C) {
 	localBackend.NodeName = nodeTypes.GetName()
 	localBackends := []lb.Backend{localBackend}
 	// Create two remote backends.
-	var remoteBackends []lb.Backend
+	remoteBackends := make([]lb.Backend, 0, len(backends2))
 	for _, backend := range backends2 {
 		backend.NodeName = "not-" + nodeTypes.GetName()
 		remoteBackends = append(remoteBackends, backend)
 	}
-	var allBackends []lb.Backend
+	allBackends := make([]lb.Backend, 0, 1+len(remoteBackends))
 	allBackends = append(allBackends, localBackend)
 	allBackends = append(allBackends, remoteBackends...)
 
@@ -576,12 +576,12 @@ func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
 	localBackend.NodeName = nodeTypes.GetName()
 	localBackends := []lb.Backend{localBackend}
 	// Create two remote backends.
-	var remoteBackends []lb.Backend
+	remoteBackends := make([]lb.Backend, 0, len(backends2))
 	for _, backend := range backends2 {
 		backend.NodeName = "not-" + nodeTypes.GetName()
 		remoteBackends = append(remoteBackends, backend)
 	}
-	var allBackends []lb.Backend
+	allBackends := make([]lb.Backend, 0, 1+len(remoteBackends))
 	allBackends = append(allBackends, localBackend)
 	allBackends = append(allBackends, remoteBackends...)
 


### PR DESCRIPTION
Pre-allocate slices with known size in a few more places, as found by `github.com/alexkohler/prealloc`.

As discussed previously, this check can't be run by default as part of e.g. `golangci-lint` target due to the possibility of false positives (see #10806 and #10913). Thus - as done for the previous release - run `prealloc` against the whole tree once before the release and then review/fix the reported issues, which this PR does.