### PR TITLE
docs: disable k3s network policy enforcement

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -42,7 +42,7 @@ replace the variables with values from your environment:
 
 .. parsed-literal::
 
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--no-flannel' K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--disable-network-policy --no-flannel' K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
 
 Should you encounter any issues during the installation, please refer to the
 :ref:`troubleshooting_k8s` section and / or seek help on the `Slack channel`.


### PR DESCRIPTION
If not defined, k3s has a network policy enforcer with the help of
iptables rules. With `--disable-network-policy` this functionality is
disabled and the enforcement is performed by Cilium.

Running k3s without `disable-network-policy` will make k3s to insert
iptables rules which will conflict with iptables rules installed by
Cilium. This will make packets from host to not be marked by iptables
and therefore Cilium will never consider them has "host" causing host
traffic to be denied by Cilium.

Fixes: f85d3142ab2b ("Implements documentation to install Cilium on k3s")
Signed-off-by: André Martins <andre@cilium.io>


Fixes: https://github.com/cilium/cilium/issues/13615

```release-note
Fixed installation instructions for K3s and Kubernetes Network Policy enforcement
```
