### PR TITLE
install/kubernetes: Allow update of "remote" secret

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-role.yaml
@@ -27,6 +27,7 @@ rules:
     resourceNames:
       - clustermesh-apiserver-server-cert
       - clustermesh-apiserver-admin-cert
+      - clustermesh-apiserver-remote-cert
       - clustermesh-apiserver-client-cert
     verbs:
       - update

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -717,6 +717,7 @@ rules:
     resourceNames:
       - clustermesh-apiserver-server-cert
       - clustermesh-apiserver-admin-cert
+      - clustermesh-apiserver-remote-cert
       - clustermesh-apiserver-client-cert
     verbs:
       - update


### PR DESCRIPTION
clustermesh-apiserver certificate generation job need the permission
to update also the "remote" secret, in addition to "client", "server",
and "admin".

Fixes: #13666
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
