### PR TITLE
helm: Remove `type: kubernetes.io/tls` from hubble-ca-secret

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-generate-certs-ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble-generate-certs-ca-secret.yaml
@@ -5,7 +5,6 @@ kind: Secret
 metadata:
   name: hubble-ca-secret
   namespace: {{ .Release.Namespace }}
-type: kubernetes.io/tls
 data:
   ca.crt: {{ .Values.hubble.tls.ca.cert }}
   ca.key: {{ .Values.hubble.tls.ca.key }}


### PR DESCRIPTION
While `hubble-ca-secret` is technically a TLS secret, it does not
conform to the naming scheme outlined in
https://kubernetes.io/docs/concepts/services-networking/ingress/#tls

There is currently no technical reason for it to be a secret of type
`kubernetes.io/tls`. Therefore we simply remove the type for now. 
Renaming the files to be conform to `type: kubernetes.io/tls` would
require more in-depth changes, as certgen currently requires the files
to be named `ca.{crt,key}`. 

certgen itself creates the CA secrets without an explicit type if they
are absent, so this change is consent with what certgen already does.

This commit does not contain any functional changes.
