### PR TITLE
test: Unquarantine K8sUpdates under GKE

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -589,43 +588,10 @@ func GetNodeWithoutCilium() string {
 	return os.Getenv("NO_CILIUM_ON_NODE")
 }
 
-// ContainerURLRE matches and splits container image URLs. The protocol and tag
-// are optional.
-// Note: The groups can be simplified but that is less readable.
-// Group #    Contains
-//    1       http protocol
-//    2       registry domain
-//    3       registry path
-//    4       - tag w/ ":"
-//    5       tag
-var containerURLRE = regexp.MustCompile(`(https?://)?([^/]+)/([^:]+)(:(.+))?`)
-
-// SplitContainerURL returns url split into the registry (with protocol), image
-// path and tag.
-// If this split is successful success is true.
-// Note: tag may be empty when not present. success is true in this case.
-func SplitContainerURL(url string) (registry, image, tag string, success bool) {
-	parts := containerURLRE.FindStringSubmatch(url)
-	if parts == nil {
-		return "", "", "", false
-	}
-
-	registryProto := parts[1]
-	registryDomain := parts[2]
-	registry = registryProto + registryDomain
-
-	image = parts[3]
-	tag = parts[5]
-
-	return registry, image, tag, true
-}
-
 // GetLatestImageVersion infers which docker tag should be used
 func GetLatestImageVersion() string {
-	_, _, tag, success := SplitContainerURL(config.CiliumTestConfig.CiliumImage)
-
-	if success && len(tag) > 0 {
-		return tag
+	if len(config.CiliumTestConfig.CiliumTag) > 0 {
+		return config.CiliumTestConfig.CiliumTag
 	}
 	return "latest"
 }

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -106,7 +106,7 @@ var _ = Describe("K8sUpdates", func() {
 		ExpectAllPodsTerminated(kubectl)
 	})
 
-	SkipItIf(helpers.SkipGKEQuarantined, "Tests upgrade and downgrade from a Cilium stable image to master", func() {
+	It("Tests upgrade and downgrade from a Cilium stable image to master", func() {
 		var assertUpgradeSuccessful func()
 		assertUpgradeSuccessful, cleanupCallback =
 			InstallAndValidateCiliumUpgrades(


### PR DESCRIPTION
On GKE, we use the commit hash instead of `latest` as the Docker image tag. Therefore, `GetLatestImageVersion()` should retrieve the correct tag from the appropriate ginkgo flag. #13259 changed that flag from `-cilium.image` (tag was passed as part of the full image reference) to `-cilium.tag` but failed to update the `GetLatestImageVersion()` accordingly.

This bug results in the following messages during the K8sUpdates test on GKE:

    Cilium "1.8.90" did not become ready in time

with an `ImagePullBackOff` error on the Cilium image. This pull request fixes it.

Fixes: #13259
Fixes: #13276