### PR TITLE
daemon: Don't check XDPDevice in DevicePreFilter case

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1046,12 +1046,6 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.DevicePreFilter != "undefined" {
-		if option.Config.XDPDevice != "undefined" &&
-			option.Config.XDPDevice != option.Config.DevicePreFilter {
-			log.Fatalf("Cannot set Prefilter device: mismatch between NodePort device %s and Prefilter device %s",
-				option.Config.XDPDevice, option.Config.DevicePreFilter)
-		}
-
 		option.Config.XDPDevice = option.Config.DevicePreFilter
 		if err := loader.SetXDPMode(option.Config.ModePreFilter); err != nil {
 			scopedLog.WithError(err).Fatal("Cannot set prefilter XDP mode")


### PR DESCRIPTION
Deriving `XDPDevice` from `DevicePreFilter` happens before `XDPDevice` can be set from NodePort devices: the former happens in `initEnv()`, while the latter in `NewDaemon() -> finishKubeProxyReplacementInit()`; `NewDaemon()` is called after `initEnv()`. Therefore, remove the redundant check for the device mismatch.

OT: we really need an init system in `daemon/cmd`.