### PR TITLE
docs: Fix hint for updating cmdref

### DIFF
--- a/Documentation/check-cmdref.sh
+++ b/Documentation/check-cmdref.sh
@@ -9,6 +9,6 @@ cmdref_dir="${script_dir}/cmdref"
 
 if ! git diff --quiet -- "${cmdref_dir}" ; then
     git --no-pager diff "${cmdref_dir}"
-    echo "HINT: to fix this, run 'make -C Documentation update-cmdref ; git commit Documentation/cmdref --message \"docs: Update cmdref\"'"
+    echo "HINT: to fix this, run 'make -C Documentation update-cmdref'"
     exit 1
 fi


### PR DESCRIPTION
We don't want separate commits just for updating cmdref. Also, each commit has to be compilable (think of git-bisect).
