### PR TITLE
hubble: Fix dropped flows not showing up in Hubble UI

### DIFF
--- a/pkg/hubble/filters/reply.go
+++ b/pkg/hubble/filters/reply.go
@@ -27,7 +27,12 @@ func filterByReplyField(replyParams []bool) FilterFunc {
 		}
 		switch f := ev.Event.(type) {
 		case v1.Flow:
-			if f.GetIsReply() == nil {
+			// FIXME: For dropped flows, we handle `is_reply=unknown` as
+			// `is_reply=false`. This is for compatibility with older clients
+			// (such as Hubble UI) which assume this filter applies to the
+			// deprecated `reply` field, where dropped flows always have
+			// `reply=false`.
+			if f.GetIsReply() == nil && f.GetVerdict() != flowpb.Verdict_DROPPED {
 				return false
 			}
 

--- a/pkg/hubble/filters/reply_test.go
+++ b/pkg/hubble/filters/reply_test.go
@@ -106,6 +106,14 @@ func Test_filterByReplyField(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "drop implies reply=false",
+			args: args{
+				f:  []*flowpb.FlowFilter{{Reply: []bool{false}}},
+				ev: &v1.Event{Event: &flowpb.Flow{Verdict: flowpb.Verdict_DROPPED, IsReply: nil}},
+			},
+			want: true,
+		},
+		{
 			name: "no-match",
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{true}}},

--- a/pkg/hubble/metrics/port-distribution/handler.go
+++ b/pkg/hubble/metrics/port-distribution/handler.go
@@ -54,6 +54,8 @@ func (h *portDistributionHandler) Status() string {
 }
 
 func (h *portDistributionHandler) ProcessFlow(flow v1.Flow) {
+	// if we are not certain if a flow is a reply (i.e. flow.GetIsReply() == nil)
+	// we do not want to consider its destination port for the metric
 	skipReply := flow.GetIsReply() == nil || flow.GetIsReply().GetValue()
 	if flow.GetVerdict() != flowpb.Verdict_FORWARDED || flow.GetL4() == nil || skipReply {
 		return


### PR DESCRIPTION
The changes introduced in 0507c62 accidentally broke Hubble
UI in that it would not display dropped flows anymore. The cause
for this is that Hubble UI sets a filter on `reply=false`, which with
the above commit did now never matches dropped flows anymore.

This PR adds a workaround in the filter logic, where we restore the
old behavior of treating `is_reply=unknown` as `is_reply=false` for
dropped flows.

Additionally, the assumptions around the `is_reply` logic are made
a bit more explicit. As a result, we now assume that a forwarded
`PolicyVerdictNotify` always has `is_reply=false`.

Unit tests are added to ensure the new changes in behavior. I have also
manually verified that this fixes the display of dropped flows in Hubble UI
against `master`. 