### PR TITLE
contrib/script: To add script for kind cluster

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Copyright 2017-2020 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -o pipefail
+
+# Sample usages
+# ./contrib/scripts/kind.sh
+# IPv6=1 ./contrib/scripts/kind.sh
+# NO_BUILD=1 ./contrib/scripts/kind.sh
+# NO_PROVISION=1 ./contrib/scripts/kind.sh
+
+# Enable IPv6 mode. By default using IPv4
+export 'IPv6'="${IPv6:0}"
+# Set NO_BUILD=1 to avoid building docker images again
+export 'NO_BUILD'="${NO_BUILD:0}"
+# Set NO_PROVISION=1 to use existing kind cluster
+export 'NO_PROVISION'="${NO_PROVISION:0}"
+
+function help() {
+  printf "Run with default values:\n\t./contrib/scripts/kind.sh\n\n"
+  printf "Using existing docker images:\n\t./contrib/scripts/kind.sh\n\n"
+  printf "Using existing cluster:\n\tNO_PROVISION=1 ./contrib/scripts/kind.sh\n\n"
+  exit 1
+}
+
+# Build cilium and cilium operator docker images
+if [[ "${NO_BUILD}" -ne "1" ]]; then
+  make -j docker-cilium-image docker-operator-generic-image
+fi
+
+# Provision kind cluster if required
+if [[ "${NO_PROVISION}" -ne "1" ]]; then
+  kind delete cluster
+  # clean up previous kind network
+  docker system prune -f
+
+  if [[ "${IPv6}" -ne "1" ]]; then
+    kind_config_file=.github/kind-config.yaml
+  else
+    kind_config_file=.github/kind-config-ipv6.yaml
+  fi
+
+  kind create cluster --config="$kind_config_file"
+fi
+
+# Load images into kind cluster
+kind load docker-image cilium/cilium:latest
+kind load docker-image cilium/operator-generic:latest
+
+# Install cilium with helm, similar to what we have in smoketest
+if [[ "${IPv6}" -ne "1" ]]; then
+  helm upgrade -i cilium ./install/kubernetes/cilium \
+    --wait \
+    --namespace kube-system \
+    --set nodeinit.enabled=true \
+    --set kubeProxyReplacement=partial \
+    --set hostServices.enabled=false \
+    --set externalIPs.enabled=true \
+    --set nodePort.enabled=true \
+    --set hostPort.enabled=true \
+    --set bpf.masquerade=false \
+    --set ipam.mode=kubernetes \
+    --set image.tag=latest \
+    --set image.pullPolicy=Never \
+    --set operator.image.tag=latest \
+    --set operator.image.pullPolicy=Never \
+    --set prometheus.enabled=true \
+    --set operator.prometheus.enabled=true \
+    --set hubble.enabled=true \
+    --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}"
+else
+  helm upgrade -i cilium ./install/kubernetes/cilium \
+    --wait \
+    --namespace kube-system \
+    --set nodeinit.enabled=true \
+    --set kubeProxyReplacement=strict \
+    --set ipam.mode=kubernetes \
+    --set image.tag=latest \
+    --set image.pullPolicy=Never \
+    --set operator.image.tag=latest \
+    --set operator.image.pullPolicy=Never \
+    --set ipv6.enabled=true \
+    --set ipv4.enabled=false \
+    --set tunnel=disabled \
+    --set autoDirectNodeRoutes=true \
+    --set prometheus.enabled=true \
+    --set operator.prometheus.enabled=true \
+    --set hubble.enabled=true \
+    --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}"
+fi
+
+kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=60s
+kubectl wait --for condition=Established crd/ciliumnetworkpolicies.cilium.io --timeout=60s
+
+# Run connectivity check
+if [[ "${IPv6}" -ne "1" ]]; then
+  kubectl apply -f examples/kubernetes/connectivity-check/connectivity-check.yaml
+else
+  kubectl apply -f examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+fi


### PR DESCRIPTION
This commit is to add the script to bring up kind cluster with cilium.
Most of the options and steps are similar as smoke-test in github
action. Hence, it will help to some capacity to debug any failure in
smoke test as well.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

**PS**: Sorry, I just remembered that you have similar PR https://github.com/cilium/cilium/pull/12527 after 
created this, I can close this one as well /cc @christarazi 

## Testing
I used this one for quite sometimes as part of local development, some sample run can be found as below

<details>
<summary> NO_BUILD=1 IPv6=1 ./contrib/scripts/kind.sh</summary>

```shell script
$ NO_BUILD=1 IPv6=1 ./contrib/scripts/kind.sh
Deleting cluster "kind" ...
Deleted Networks:
kind

Total reclaimed space: 2.885GB
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.19.1) 🖼 
 ✓ Preparing nodes 📦 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing StorageClass 💾 
 ✓ Joining worker nodes 🚜 
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
Image: "cilium/cilium:latest" with ID "sha256:0c1d192b31a884752703d81126f284ca9e9f415793b5815de230372bf8445fcd" not yet present on node "kind-control-plane", loading...
Image: "cilium/cilium:latest" with ID "sha256:0c1d192b31a884752703d81126f284ca9e9f415793b5815de230372bf8445fcd" not yet present on node "kind-worker", loading...
Image: "cilium/operator-generic:latest" with ID "sha256:6d307105932393dbb92dc9c787cb18a510ed5b53c760a81908df4b4936c391c1" not yet present on node "kind-control-plane", loading...
Image: "cilium/operator-generic:latest" with ID "sha256:6d307105932393dbb92dc9c787cb18a510ed5b53c760a81908df4b4936c391c1" not yet present on node "kind-worker", loading...
Release "cilium" does not exist. Installing it now.
NAME: cilium
LAST DEPLOYED: Thu Oct 29 00:02:08 2020
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
You have successfully installed Cilium with Hubble.

Your release version is 1.8.90.

For any further help, visit https://docs.cilium.io/en/v1.8/gettinghelp
pod/cilium-8jpsq condition met
pod/cilium-node-init-8fmll condition met
pod/cilium-node-init-r22f2 condition met
pod/cilium-operator-c4855965d-mrlpc condition met
pod/cilium-operator-c4855965d-xtjqc condition met
pod/cilium-r9m4b condition met
pod/coredns-f9fd979d6-nn5pl condition met
pod/coredns-f9fd979d6-sr6dc condition met
pod/etcd-kind-control-plane condition met
pod/kube-apiserver-kind-control-plane condition met
pod/kube-controller-manager-kind-control-plane condition met
pod/kube-proxy-898xb condition met
pod/kube-proxy-9q4x8 condition met
pod/kube-scheduler-kind-control-plane condition met
customresourcedefinition.apiextensions.k8s.io/ciliumnetworkpolicies.cilium.io condition met
deployment.apps/echo-a created
deployment.apps/echo-b created
deployment.apps/echo-b-host created
deployment.apps/pod-to-a created
deployment.apps/pod-to-external-1111 created
deployment.apps/pod-to-a-denied-cnp created
deployment.apps/pod-to-a-allowed-cnp created
deployment.apps/pod-to-external-fqdn-allow-google-cnp created
deployment.apps/pod-to-b-multi-node-clusterip created
deployment.apps/pod-to-b-multi-node-headless created
deployment.apps/host-to-b-multi-node-clusterip created
deployment.apps/host-to-b-multi-node-headless created
deployment.apps/pod-to-b-multi-node-nodeport created
deployment.apps/pod-to-b-intra-node-nodeport created
service/echo-a created
service/echo-b created
service/echo-b-headless created
service/echo-b-host-headless created
ciliumnetworkpolicy.cilium.io/pod-to-a-denied-cnp created
ciliumnetworkpolicy.cilium.io/pod-to-a-allowed-cnp created
ciliumnetworkpolicy.cilium.io/pod-to-external-fqdn-allow-google-cnp created

```

</details>

<details>
<summary>NO_BUILD=1 ./contrib/scripts/kind.sh</summary>

```shell scripts
$ NO_BUILD=1 ./contrib/scripts/kind.sh    
Deleting cluster "kind" ...
Deleted Networks:
kind

Total reclaimed space: 0B
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.19.1) 🖼 
 ✓ Preparing nodes 📦 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing StorageClass 💾 
 ✓ Joining worker nodes 🚜 
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Thanks for using kind! 😊
Image: "cilium/cilium:latest" with ID "sha256:0c1d192b31a884752703d81126f284ca9e9f415793b5815de230372bf8445fcd" not yet present on node "kind-worker", loading...
Image: "cilium/cilium:latest" with ID "sha256:0c1d192b31a884752703d81126f284ca9e9f415793b5815de230372bf8445fcd" not yet present on node "kind-control-plane", loading...
Image: "cilium/operator-generic:latest" with ID "sha256:6d307105932393dbb92dc9c787cb18a510ed5b53c760a81908df4b4936c391c1" not yet present on node "kind-worker", loading...
Image: "cilium/operator-generic:latest" with ID "sha256:6d307105932393dbb92dc9c787cb18a510ed5b53c760a81908df4b4936c391c1" not yet present on node "kind-control-plane", loading...
Release "cilium" does not exist. Installing it now.
NAME: cilium
LAST DEPLOYED: Thu Oct 29 00:07:18 2020
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
You have successfully installed Cilium with Hubble.

Your release version is 1.8.90.

For any further help, visit https://docs.cilium.io/en/v1.8/gettinghelp
pod/cilium-4nmkl condition met
pod/cilium-node-init-cw82x condition met
pod/cilium-node-init-sr25f condition met
pod/cilium-operator-c4855965d-cclsm condition met
pod/cilium-operator-c4855965d-ksg9l condition met
pod/cilium-vq66w condition met
pod/coredns-f9fd979d6-7vjmx condition met
pod/coredns-f9fd979d6-xlfhf condition met
pod/etcd-kind-control-plane condition met
pod/kube-apiserver-kind-control-plane condition met
pod/kube-controller-manager-kind-control-plane condition met
pod/kube-proxy-czxtb condition met
pod/kube-proxy-jmmvx condition met
pod/kube-scheduler-kind-control-plane condition met
customresourcedefinition.apiextensions.k8s.io/ciliumnetworkpolicies.cilium.io condition met
deployment.apps/echo-a created
deployment.apps/echo-b created
deployment.apps/echo-b-host created
deployment.apps/pod-to-a created
deployment.apps/pod-to-external-1111 created
deployment.apps/pod-to-a-denied-cnp created
deployment.apps/pod-to-a-allowed-cnp created
deployment.apps/pod-to-external-fqdn-allow-google-cnp created
deployment.apps/pod-to-b-multi-node-clusterip created
deployment.apps/pod-to-b-multi-node-headless created
deployment.apps/host-to-b-multi-node-clusterip created
deployment.apps/host-to-b-multi-node-headless created
deployment.apps/pod-to-b-multi-node-nodeport created
deployment.apps/pod-to-b-intra-node-nodeport created
service/echo-a created
service/echo-b created
service/echo-b-headless created
service/echo-b-host-headless created
ciliumnetworkpolicy.cilium.io/pod-to-a-denied-cnp created
ciliumnetworkpolicy.cilium.io/pod-to-a-allowed-cnp created
ciliumnetworkpolicy.cilium.io/pod-to-external-fqdn-allow-google-cnp created
```
</details>

<details>
<summary>NO_BUILD=1 NO_PROVISION=1 ./contrib/scripts/kind.sh</summary>

```shell script
$ NO_BUILD=1 NO_PROVISION=1 ./contrib/scripts/kind.sh
Release "cilium" has been upgraded. Happy Helming!
NAME: cilium
LAST DEPLOYED: Thu Oct 29 00:10:51 2020
NAMESPACE: kube-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
You have successfully installed Cilium with Hubble.

Your release version is 1.8.90.

For any further help, visit https://docs.cilium.io/en/v1.8/gettinghelp
pod/cilium-4nmkl condition met
pod/cilium-node-init-cw82x condition met
pod/cilium-node-init-sr25f condition met
pod/cilium-operator-c4855965d-cclsm condition met
pod/cilium-operator-c4855965d-ksg9l condition met
pod/cilium-vq66w condition met
pod/coredns-f9fd979d6-7vjmx condition met
pod/coredns-f9fd979d6-xlfhf condition met
pod/etcd-kind-control-plane condition met
pod/kube-apiserver-kind-control-plane condition met
pod/kube-controller-manager-kind-control-plane condition met
pod/kube-proxy-czxtb condition met
pod/kube-proxy-jmmvx condition met
pod/kube-scheduler-kind-control-plane condition met
customresourcedefinition.apiextensions.k8s.io/ciliumnetworkpolicies.cilium.io condition met
deployment.apps/echo-a configured
deployment.apps/echo-b configured
deployment.apps/echo-b-host configured
deployment.apps/pod-to-a configured
deployment.apps/pod-to-external-1111 configured
deployment.apps/pod-to-a-denied-cnp configured
deployment.apps/pod-to-a-allowed-cnp configured
deployment.apps/pod-to-external-fqdn-allow-google-cnp configured
deployment.apps/pod-to-b-multi-node-clusterip configured
deployment.apps/pod-to-b-multi-node-headless configured
deployment.apps/host-to-b-multi-node-clusterip configured
deployment.apps/host-to-b-multi-node-headless configured
deployment.apps/pod-to-b-multi-node-nodeport configured
deployment.apps/pod-to-b-intra-node-nodeport configured
service/echo-a unchanged
service/echo-b unchanged
service/echo-b-headless unchanged
service/echo-b-host-headless configured
ciliumnetworkpolicy.cilium.io/pod-to-a-denied-cnp unchanged
ciliumnetworkpolicy.cilium.io/pod-to-a-allowed-cnp unchanged
ciliumnetworkpolicy.cilium.io/pod-to-external-fqdn-allow-google-cnp unchanged
```

</details>

```release-note
contrib/script: To add script for kind cluster
```
