### PR TITLE
Replace remaining exit codes -1 with exit code 1

### DIFF
--- a/cilium-health/cmd/root.go
+++ b/cilium-health/cmd/root.go
@@ -51,7 +51,7 @@ var rootCmd = &cobra.Command{
 // Note: os.Exit(1) is not recoverable
 func Fatalf(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "Error: %s\n", fmt.Sprintf(msg, args...))
-	os.Exit(-1)
+	os.Exit(1)
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -59,7 +59,7 @@ func Fatalf(msg string, args ...interface{}) {
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -62,7 +62,7 @@ func main() {
 		defer pidfile.Clean()
 		if err := pidfile.Write(pidfilePath); err != nil {
 			fmt.Fprintf(os.Stderr, "cannot write pidfile: %s: %s\n", pidfilePath, err.Error())
-			os.Exit(-1)
+			os.Exit(1)
 		}
 	}
 

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -215,7 +215,7 @@ func main() {
 
 	if err := runApiserver(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -115,7 +115,7 @@ var (
 			// Open socket for using gops to get stacktraces of the agent.
 			if err := gops.Listen(gops.Options{}); err != nil {
 				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
-				os.Exit(-1)
+				os.Exit(1)
 			}
 
 			bootstrapStats.earlyInit.Start()
@@ -148,7 +148,7 @@ func Execute() {
 	interruptCh := cleaner.registerSigHandler()
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 	<-interruptCh
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -72,7 +72,7 @@ var (
 			// Open socket for using gops to get stacktraces of the operator.
 			if err := gops.Listen(gops.Options{}); err != nil {
 				fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
-				os.Exit(-1)
+				os.Exit(1)
 			}
 
 			initEnv()
@@ -157,7 +157,7 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -69,7 +69,7 @@ connected to a Docker network of type "cilium".`,
 func main() {
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -49,7 +49,7 @@ func init() {
 	// Open socket for using gops to get stacktraces in case the tests deadlock.
 	if err := gops.Listen(gops.Options{ShutdownCleanup: true}); err != nil {
 		fmt.Fprintf(os.Stderr, "unable to start gops: %s", err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 
 	for k, v := range DefaultSettings {


### PR DESCRIPTION
As [suggested by](https://github.com/cilium/cilium/pull/13761#pullrequestreview-517414234) @sayboras in #13761, this cleans up the remaining uses of exit code -1. Note that exit codes are `uint8`s, so `os.Exit(-1)` actually causes the process to exit with code 255.