### PR TITLE
cilium: Node to node encryption is not supported with vxlan

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -105,7 +105,15 @@ In order to enable node-to-node encryption, add:
 
     [...]
     --set encryption.enabled=true \
-    --set encryption.nodeEncryption=true
+    --set encryption.nodeEncryption=true \
+    --set tunnel=disabled
+
+.. note::
+
+    Node to node encryption feature is tested and supported with direct routing
+    modes. Using with encapsulation/tunneling is not currently tested or supported.
+
+    Support with tunneling mode is tracked at `#13663 <https://github.com/cilium/cilium/issues/13663>`_.
 
 Validate the Setup
 ==================


### PR DESCRIPTION
We do not currently support node to node encryption nor do we test it.
I've heard folks have gotten mixed results with deploying it. At least
when used with GKE it appears to be failing. For upcoming release lets
make a note in the Documentation.

When the feature is officially supported we can delete the node.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>