### PR TITLE
cilium: Drop encryption with tunnel support beta tag

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -7,7 +7,7 @@
 .. _encryption:
 
 ************************************
-Transparent Encryption (stable/beta)
+Transparent Encryption
 ************************************
 
 This guide explains how to configure Cilium to use IPsec based transparent
@@ -21,12 +21,6 @@ distributed, but that is not shown here.
 
     ``Secret`` resources need to be deployed in the same namespace as Cilium!
     In our example, we use ``kube-system``.
-
-.. note::
-
-    The encryption feature is stable in combination with the direct-routing and
-    ENI datapath mode. In combination with encapsulation/tunneling, the feature
-    is still in beta phase.
 
 .. note::
 


### PR DESCRIPTION
Encryption with tunnel support has been working for some time and we've
never dropped the beta tag. Lets drop it now for v1.10 seeing its in
use and working as expected.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>