### PR TITLE
Adds pod annotation to manage iptables NOTRACK rules.

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -476,6 +476,13 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			}
 			return p.Annotations[bandwidth.EgressBandwidth], nil
 		})
+		ep.UpdateNoTrackRules(func(ns, podName string) (noTrackPort string, err error) {
+			p, err := d.k8sWatcher.GetCachedPod(ns, podName)
+			if err != nil {
+				return "", err
+			}
+			return p.Annotations[annotation.NoTrack], nil
+		})
 	}
 
 	regenTriggered := ep.UpdateLabels(ctx, addLabels, infoLabels, true)

--- a/examples/kubernetes-local-redirect/node-local-dns.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns.yaml
@@ -107,6 +107,7 @@ spec:
       labels:
         k8s-app: node-local-dns
       annotations:
+        io.cilium.no-track-port: "53"
         prometheus.io/port: "9253"
         prometheus.io/scrape: "true"
     spec:

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -65,4 +65,9 @@ const (
 	// pod is redirected to the proxy for the given port / protocol in the
 	// annotation
 	ProxyVisibility = Prefix + ".proxy-visibility"
+
+	// NoTrack is the annotation name used to store the port and protocol
+	// that we should bypass kernel conntrack for a given pod. This applies for
+	// both TCP and UDP connection. Current use case is NodeLocalDNS.
+	NoTrack = Prefix + ".no-track-port"
 )


### PR DESCRIPTION
This adds handler of a new pod annotation `no-track-port: <port-number>`. When this annotation is in place, 5 NOTRACK rules are automatically inserted into the root-ns iptables for the pod at the port specified. The 5 rules are:

- NOTRACK in filter table, INPUT chain (ingress)
- NOTRACK in raw table, PREROUTING chain (ingress)
- NOTRACK in raw table, OUTPUT chain (ingress)
- NOTRACK in raw table, OUTPUT chain (egress)
- NOTRACK in filter table, OUTPUT chain (egress)

The effect of these rules is essentially all traffic going to/from that specified port will skip kernel conntrack. One particular use case is to achieve feature parity with nodelocaldns (https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0030-nodelocal-dns-cache.md#iptables-notrack).

The rules are managed via a new event type `EndpointNoTrackEvent` at endpoint creation/deletion time and in pod watcher (when annotation changes).

Fixes: #13686 
