### PR TITLE
docs: GKE setup example with encryption and direct routing

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -85,6 +85,30 @@ to GKE, with VXLAN tunneling:
       --set encryption.enabled=true \\
       --set encryption.nodeEncryption=false
 
+On GKE, Cilium can also be deployed with direct routing instead of tunneling.
+This requires us to enable the GKE integration and specify the native routing
+CIDR. As a bonus, node encryption (for transparently encrypting node-to-node
+traffic) can be enabled as well. See :ref:`node_to_node_encryption` below.
+
+.. note::
+
+    This example builds on the steps outlined in :ref:`k8s_install_gke`.
+
+.. parsed-literal::
+
+    export NATIVE_CIDR="$(gcloud container clusters describe $CLUSTER_NAME --zone $CLUSTER_ZONE --format 'value(clusterIpv4Cidr)')"
+    helm install cilium |CHART_RELEASE| \\
+      --namespace cilium \\
+      --set nodeinit.enabled=true \\
+      --set nodeinit.reconfigureKubelet=true \\
+      --set nodeinit.removeCbrBridge=true \\
+      --set cni.binPath=/home/kubernetes/bin \\
+      --set gke.enabled=true \\
+      --set ipam.mode=kubernetes \\
+      --set nativeRoutingCIDR=$NATIVE_CIDR \\
+      --set encryption.enabled=true \\
+      --set encryption.nodeEncryption=true
+
 At this point the Cilium managed nodes will be using IPsec for all traffic. For further
 information on Cilium's transparent encryption, see :ref:`ebpf_datapath`.
 
@@ -100,6 +124,8 @@ interface as follows:
 .. code:: bash
 
     --set encryption.interface=ethX
+
+.. _node_to_node_encryption:
 
 Node to node encryption
 -----------------------

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -19,6 +19,11 @@ distributed, but that is not shown here.
 
 .. note::
 
+    ``Secret`` resources need to be deployed in the same namespace as Cilium!
+    In our example, we use ``kube-system``.
+
+.. note::
+
     The encryption feature is stable in combination with the direct-routing and
     ENI datapath mode. In combination with encapsulation/tunneling, the feature
     is still in beta phase.
@@ -71,13 +76,13 @@ to GKE, with VXLAN tunneling:
 .. parsed-literal::
 
     helm install cilium |CHART_RELEASE| \\
-      --namespace cilium \
-      --set nodeinit.enabled=true \
-      --set nodeinit.reconfigureKubelet=true \
-      --set nodeinit.removeCbrBridge=true \
-      --set cni.binPath=/home/kubernetes/bin \
-      --set tunnel=vxlan \
-      --set encryption.enabled=true \
+      --namespace cilium \\
+      --set nodeinit.enabled=true \\
+      --set nodeinit.reconfigureKubelet=true \\
+      --set nodeinit.removeCbrBridge=true \\
+      --set cni.binPath=/home/kubernetes/bin \\
+      --set tunnel=vxlan \\
+      --set encryption.enabled=true \\
       --set encryption.nodeEncryption=false
 
 At this point the Cilium managed nodes will be using IPsec for all traffic. For further
@@ -168,6 +173,9 @@ Cilium agent will default to KEYID of zero if its not specified in the secret.
 
 Troubleshooting
 ===============
+
+ * If the ``cilium`` Pods fail to start after enabling encryption, double-check if
+   the IPSec ``Secret`` and Cilium are deployed in the same namespace together.
 
  * Make sure that the Cilium pods have kvstore connectivity:
 


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/12123.

Found a minor documentation bug while adding this example. The instructions drop the IPSec keys in the `kube-system` namespace, but the vxlan example deploys into `cilium`.

```release-note
Fixed encryption + VXLAN example, added encryption + Direct Routing example for GKE.
```
