### PR TITLE
docs: Add how to remove kube-proxy from existing clusters

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -50,7 +50,7 @@ installation of the ``kube-proxy`` add-on:
     in kubeadm, therefore the below workaround for manually removing the ``kube-proxy`` DaemonSet and
     cleaning the corresponding iptables rules after kubeadm initialization is still necessary (`kubeadm#1733 <https://github.com/kubernetes/kubeadm/issues/1733>`__).
 
-    Initialize control-plane as first step with a given pod network CIDR:
+    Initialize control-plane as first step:
 
     .. code:: bash
 
@@ -61,6 +61,15 @@ installation of the ``kube-proxy`` add-on:
     .. code:: bash
 
       kubectl -n kube-system delete ds kube-proxy
+      iptables-restore <(iptables-save | grep -v KUBE)
+
+For existing installations with ``kube-proxy`` running as a DaemonSet, remove it
+by using the following commands:
+
+.. code:: bash
+
+      kubectl -n kube-system delete ds kube-proxy
+      # Run on each node:
       iptables-restore <(iptables-save | grep -v KUBE)
 
 Afterwards, join worker nodes by specifying the control-plane node IP address and


### PR DESCRIPTION
Some users thought that it's not possible to remove kube-proxy from
existing installations. So, add instructions how to do that.

Also, remove the ask for specify a podCIDR (no longer needed) - fixes d131945388a486d70c008623c21c4f6923b13ab2.