### PR TITLE
Consistently use structured logging for errors

### DIFF
--- a/cilium/cmd/bpf_ipcache_get.go
+++ b/cilium/cmd/bpf_ipcache_get.go
@@ -105,9 +105,8 @@ func getLPMValue(ip net.IP, entries map[string][]string) (interface{}, bool) {
 	lpmEntries := make([]lpmEntry, 0, len(entries))
 	for cidr, identity := range entries {
 		currIP, subnet, err := net.ParseCIDR(cidr)
-
 		if err != nil {
-			log.Warnf("unable to parse ipcache entry '%s' as a CIDR: %s", cidr, err)
+			log.WithError(err).Warnf("unable to parse ipcache entry %q as a CIDR", cidr)
 			continue
 		}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -543,7 +543,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			log.Fatalf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)
 		}
 		if err := node.InitBPFMasqueradeAddrs(option.Config.Devices); err != nil {
-			log.Fatalf("Failed to determine BPF masquerade IPv4 addrs: %s", err)
+			log.WithError(err).Fatal("Failed to determine BPF masquerade IPv4 addrs")
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		log.Fatalf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.Masquerade, option.EnableBPFMasquerade)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1083,8 +1083,7 @@ func initEnv(cmd *cobra.Command) {
 
 	monitorAggregationLevel, err := option.ParseMonitorAggregationLevel(option.Config.MonitorAggregation)
 	if err != nil {
-		log.WithError(err).Fatalf("Failed to parse %s: %s",
-			option.MonitorAggregationName, err)
+		log.WithError(err).Fatalf("Failed to parse %s", option.MonitorAggregationName)
 	}
 	option.Config.Opts.SetValidated(option.MonitorAggregation, monitorAggregationLevel)
 
@@ -1094,7 +1093,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if err := identity.AddUserDefinedNumericIdentitySet(option.Config.FixedIdentityMapping); err != nil {
-		log.Fatalf("Invalid fixed identities provided: %s", err)
+		log.WithError(err).Fatal("Invalid fixed identities provided")
 	}
 
 	if !option.Config.EnableIPv4 && !option.Config.EnableIPv6 {

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -140,7 +140,7 @@ func initKubeProxyReplacementOptions() (strict bool) {
 					option.MaglevTableSize, option.Config.MaglevTableSize, supportedPrimes)
 			}
 			if err := maglev.InitMaglevSeeds(option.Config.MaglevHashSeed); err != nil {
-				log.Fatalf("Failed to initialize maglev hash seeds: %s", err)
+				log.WithError(err).Fatalf("Failed to initialize maglev hash seeds")
 			}
 		}
 	}
@@ -167,7 +167,7 @@ func initKubeProxyReplacementOptions() (strict bool) {
 				log.Fatal(err)
 			} else {
 				disableNodePort()
-				log.Warn(fmt.Sprintf("%s. Disabling BPF NodePort.", err))
+				log.WithError(err).Warn("Disabling BPF NodePort.")
 			}
 		}
 	}

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -406,7 +406,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	}
 	err = d.SendNotification(monitorAPI.PolicyUpdateMessage(len(sourceRules), labels, newRev))
 	if err != nil {
-		logger.WithField(logfields.PolicyRevision, newRev).Warn("Failed to send policy update as monitor notification")
+		logger.WithError(err).WithField(logfields.PolicyRevision, newRev).Warn("Failed to send policy update as monitor notification")
 	}
 
 	if option.Config.SelectiveRegeneration {
@@ -430,7 +430,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		// order.
 		_, err := d.policy.RuleReactionQueue.Enqueue(ev)
 		if err != nil {
-			log.WithField(logfields.PolicyRevision, newRev).Errorf("enqueue of RuleReactionEvent failed: %s", err)
+			log.WithError(err).WithField(logfields.PolicyRevision, newRev).Error("enqueue of RuleReactionEvent failed")
 		}
 	} else {
 		// Regenerate all endpoints unconditionally.
@@ -627,7 +627,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 		// order.
 		_, err := d.policy.RuleReactionQueue.Enqueue(ev)
 		if err != nil {
-			log.WithField(logfields.PolicyRevision, rev).Errorf("enqueue of RuleReactionEvent failed: %s", err)
+			log.WithError(err).WithField(logfields.PolicyRevision, rev).Error("enqueue of RuleReactionEvent failed")
 		}
 	} else {
 		d.TriggerPolicyUpdates(true, "policy rules deleted")
@@ -635,7 +635,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 
 	err := d.SendNotification(monitorAPI.PolicyDeleteMessage(deleted, labels.GetModel(), rev))
 	if err != nil {
-		log.WithField(logfields.PolicyRevision, rev).Warn("Failed to send policy update as monitor notification")
+		log.WithError(err).WithField(logfields.PolicyRevision, rev).Warn("Failed to send policy update as monitor notification")
 	}
 
 	return

--- a/operator/api.go
+++ b/operator/api.go
@@ -72,7 +72,7 @@ func startServer(shutdownSignal <-chan struct{}, allSystemsGo <-chan struct{}, a
 					log.WithError(err).Error("apiserver shutdown")
 				}
 			case err := <-errCh:
-				log.Warnf("Unable to start status api: %s", err)
+				log.WithError(err).Warn("Unable to start status api")
 			}
 		}()
 		log.Infof("Starting apiserver on address %s", addr)
@@ -81,7 +81,7 @@ func startServer(shutdownSignal <-chan struct{}, allSystemsGo <-chan struct{}, a
 	for err := range errs {
 		nServers--
 		if nServers == 0 {
-			log.Fatalf("Unable to start status api: %s", err)
+			log.WithError(err).Fatal("Unable to start status api")
 		}
 	}
 }

--- a/pkg/azure/api/metadata.go
+++ b/pkg/azure/api/metadata.go
@@ -64,7 +64,7 @@ func getMetadataString(ctx context.Context, path string) (string, error) {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Errorf("Failed to close body for request %s: %+v", url, err)
+			log.WithError(err).Errorf("Failed to close body for request %s", url)
 		}
 	}()
 

--- a/pkg/fqdn/dnsproxy/udp.go
+++ b/pkg/fqdn/dnsproxy/udp.go
@@ -120,7 +120,7 @@ func bindUDP(addr string, ipv4, ipv6 bool) *net.IPConn {
 	// Mark outgoing packets as proxy egress return traffic (0x0b00)
 	conn, err := listenConfig(0xb00, ipv4, ipv6).ListenPacket(context.Background(), "ip:udp", addr)
 	if err != nil {
-		log.Errorf("bindUDP failed for address %s: %s", addr, err)
+		log.WithError(err).Errorf("bindUDP failed for address %s", addr)
 		return nil
 	}
 	return conn.(*net.IPConn)

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -508,7 +508,7 @@ func CreateCustomDialer(b ServiceIPGetter, log *logrus.Entry) func(s string, dur
 			}
 			log.Debugf("custom dialer based on k8s service backend is dialing to %q", s)
 		} else {
-			log.Errorf("Unable to parse etcd service URL %s", err)
+			log.WithError(err).Error("Unable to parse etcd service URL")
 		}
 		return net.Dial("tcp", s)
 	}

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -249,7 +249,7 @@ func (k *K8sWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP) error {
 	ctrlName := cnp.GetControllerName()
 	err := k8sCM.RemoveControllerAndWait(ctrlName)
 	if err != nil {
-		log.Debugf("Unable to remove controller %s: %s", ctrlName, err)
+		log.WithError(err).Debugf("Unable to remove controller %s", ctrlName)
 	}
 
 	_, err = k.policyManager.PolicyDelete(cnp.GetIdentityLabels())
@@ -318,7 +318,7 @@ func (k *K8sWatcher) updateCiliumNetworkPolicyV2(ciliumNPClient clientset.Interf
 				if oldCtrlName != newCtrlName {
 					err := k8sCM.RemoveController(oldCtrlName)
 					if err != nil {
-						log.Debugf("Unable to remove controller %s: %s", oldCtrlName, err)
+						log.WithError(err).Debugf("Unable to remove controller %s", oldCtrlName)
 					}
 				}
 				k.updateCiliumNetworkPolicyV2AnnotationsOnly(ciliumNPClient, ciliumV2Store, newRuleCpy)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -449,7 +449,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, false, svc.Labels, true)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
-				log.Errorf("Unable to repopulate egress policies from ToService rules: %v", err)
+				log.WithError(err).Error("Unable to repopulate egress policies from ToService rules")
 				break
 			} else if result.NumToServicesRules > 0 {
 				// Only trigger policy updates if ToServices rules are in effect
@@ -468,7 +468,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, true, svc.Labels, true)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
-				log.Errorf("Unable to depopulate egress policies from ToService rules: %v", err)
+				log.WithError(err).Error("Unable to depopulate egress policies from ToService rules")
 				break
 			} else if result.NumToServicesRules > 0 {
 				// Only trigger policy updates if ToServices rules are in effect

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -42,7 +42,7 @@ func setOpts(opts map[string]string, supportedOpts backendOptions) error {
 
 		if opt.validate != nil {
 			if err := opt.validate(val); err != nil {
-				log.Errorf("invalid value for key %s: %s", key, err)
+				log.WithError(err).Errorf("invalid value for key %s", key)
 				errors++
 			}
 		}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2326,7 +2326,7 @@ func ReadDirConfig(dirName string) (map[string]interface{}, error) {
 		if f.Mode()&os.ModeSymlink == 0 {
 			absFileName, err := filepath.EvalSymlinks(fName)
 			if err != nil {
-				log.Warnf("Unable to read configuration file %q: %s", absFileName, err)
+				log.WithError(err).Warnf("Unable to read configuration file %q", absFileName)
 				continue
 			}
 			fName = absFileName
@@ -2334,7 +2334,7 @@ func ReadDirConfig(dirName string) (map[string]interface{}, error) {
 
 		f, err = os.Stat(fName)
 		if err != nil {
-			log.Warnf("Unable to read configuration file %q: %s", fName, err)
+			log.WithError(err).Warnf("Unable to read configuration file %q", fName)
 			continue
 		}
 		if f.Mode().IsDir() {
@@ -2343,7 +2343,7 @@ func ReadDirConfig(dirName string) (map[string]interface{}, error) {
 
 		b, err := ioutil.ReadFile(fName)
 		if err != nil {
-			log.Warnf("Unable to read configuration file %q: %s", fName, err)
+			log.WithError(err).Warnf("Unable to read configuration file %q", fName)
 			continue
 		}
 		m[f.Name()] = string(bytes.TrimSpace(b))
@@ -3090,13 +3090,13 @@ func InitConfig(programName, configName string) func() {
 			}
 
 			if m, err := ReadDirConfig(Config.ConfigDir); err != nil {
-				log.Fatalf("Unable to read configuration directory %s: %s", Config.ConfigDir, err)
+				log.WithError(err).Fatalf("Unable to read configuration directory %s", Config.ConfigDir)
 			} else {
 				// replace deprecated fields with new fields
 				ReplaceDeprecatedFields(m)
 				err := MergeConfig(m)
 				if err != nil {
-					log.Fatalf("Unable to merge configuration: %s", err)
+					log.WithError(err).Fatal("Unable to merge configuration")
 				}
 			}
 		}
@@ -3116,7 +3116,7 @@ func InitConfig(programName, configName string) func() {
 			log.WithField(logfields.Path, Config.ConfigFile).
 				Fatal("Error reading config file")
 		} else {
-			log.WithField(logfields.Reason, err).Info("Skipped reading configuration file")
+			log.WithError(err).Info("Skipped reading configuration file")
 		}
 	}
 }

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -224,7 +224,7 @@ func (driver *driver) updateRoutes(addressing *models.NodeAddressing) {
 
 	if driver.conf.Addressing.IPV6 != nil && driver.conf.Addressing.IPV6.Enabled {
 		if routes, err := connector.IPv6Routes(driver.conf.Addressing, int(driver.conf.RouteMTU)); err != nil {
-			log.Fatalf("Unable to generate IPv6 routes: %s", err)
+			log.WithError(err).Fatal("Unable to generate IPv6 routes")
 		} else {
 			for _, r := range routes {
 				driver.routes = append(driver.routes, newLibnetworkRoute(r))
@@ -236,7 +236,7 @@ func (driver *driver) updateRoutes(addressing *models.NodeAddressing) {
 
 	if driver.conf.Addressing.IPV4 != nil && driver.conf.Addressing.IPV4.Enabled {
 		if routes, err := connector.IPv4Routes(driver.conf.Addressing, int(driver.conf.RouteMTU)); err != nil {
-			log.Fatalf("Unable to generate IPv4 routes: %s", err)
+			log.WithError(err).Fatal("Unable to generate IPv4 routes")
 		} else {
 			for _, r := range routes {
 				driver.routes = append(driver.routes, newLibnetworkRoute(r))

--- a/proxylib/accesslog/client.go
+++ b/proxylib/accesslog/client.go
@@ -62,7 +62,7 @@ func (cl *Client) connect() *net.UnixConn {
 	log.Debugf("Accesslog: Connecting to Cilium access log socket: %s", cl.path)
 	conn, err := net.DialUnix("unixpacket", nil, &net.UnixAddr{Name: cl.path, Net: "unixpacket"})
 	if err != nil {
-		log.Errorf("Accesslog: DialUnix() failed: %v", err)
+		log.WithError(err).Error("Accesslog: DialUnix() failed")
 		return nil
 	}
 
@@ -78,14 +78,14 @@ func (cl *Client) Log(pblog *cilium.LogEntry) {
 		// Encode
 		logmsg, err := proto.Marshal(pblog)
 		if err != nil {
-			log.Errorf("Accesslog: Protobuf marshaling error: %v", err)
+			log.WithError(err).Error("Accesslog: Protobuf marshaling error")
 			return
 		}
 
 		// Write
 		_, err = conn.Write(logmsg)
 		if err != nil {
-			log.Errorf("Accesslog: Write() failed: %v", err)
+			log.WithError(err).Error("Accesslog: Write() failed")
 			atomic.StoreUint32(&cl.connected, 0) // Mark connection as broken
 		}
 	} else {


### PR DESCRIPTION
When reporting errors in log messages, use structured logging
(`WithError`) instead of including them in the message.