### PR TITLE
hubble: avoid rounding up power of 2 specified flows buffer capacity

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -121,7 +121,7 @@ cilium-agent [flags]
       --http-retry-timeout uint                              Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --hubble-disable-tls                                   Allow Hubble server to run on the given listen address without TLS.
       --hubble-event-queue-size int                          Buffer size of the channel to receive monitor events.
-      --hubble-flow-buffer-size int                          Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
+      --hubble-flow-buffer-size int                          Maximum number of flows in Hubble's buffer. If the number is not a power of 2, the buffer size gets rounded up to the next power of 2, e.g. 3000 => 4096 (default 4096)
       --hubble-listen-address string                         An additional address for Hubble server to listen to, e.g. ":4244"
       --hubble-metrics strings                               List of Hubble metrics to enable.
       --hubble-metrics-server string                         Address to serve Hubble metrics on.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -309,6 +309,11 @@ Annotations:
 -----------------
 
 * Cilium has bumped the minimal Kubernetes version supported to v1.12.0.
+* Provided value to set the size of Hubble's buffer for flows is no longer
+  rounded up to the next power of 2 minus 1 when it is a power of 2
+  (for example: 2048 -> 4095). If you changed the default for
+  ``hubble.flowBufferSize`` to be a power of 2 value, the actual buffer
+  capacity will be halved after the upgrade.
 * Connections between Hubble server and Hubble Relay instances is now secured
   via mutual TLS (mTLS) by default. Users who have opted to enable Hubble Relay
   in v1.8 (a beta feature) will experience disruptions of the Hubble Relay

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -844,7 +844,7 @@ func init() {
 	flags.StringSlice(option.HubbleTLSClientCAFiles, []string{}, "Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.")
 	option.BindEnv(option.HubbleTLSClientCAFiles)
 
-	flags.Int(option.HubbleFlowBufferSize, 4095, "Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096")
+	flags.Int(option.HubbleFlowBufferSize, 4096, "Maximum number of flows in Hubble's buffer. If the number is not a power of 2, the buffer size gets rounded up to the next power of 2, e.g. 3000 => 4096")
 	option.BindEnv(option.HubbleFlowBufferSize)
 
 	flags.Int(option.HubbleEventQueueSize, 0, "Buffer size of the channel to receive monitor events.")

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -441,7 +441,9 @@ hubble:
   # the queue size is set to the default monitor queue size.
   # eventQueueSize: ""
 
-  # Number of recent flows for Hubble to cache. Defaults to 4096.
+  # Number of recent flows for Hubble to cache. Defaults to 4096. The actual
+  # value, when not a power of 2 already, gets rounded up to the next power of
+  # 2 (eg: 3000 -> 4096).
   # flowBufferSize: ""
 
   # Hubble metrics configuration.

--- a/pkg/hubble/observer/observeroption/defaults.go
+++ b/pkg/hubble/observer/observeroption/defaults.go
@@ -18,6 +18,6 @@ package observeroption
 // the CLI to pick these up instead of defining own defaults that need to be
 // kept in sync.
 var Default = Options{
-	MaxFlows:      131071, // 2^17-1
+	MaxFlows:      4096,
 	MonitorBuffer: 1024,
 }


### PR DESCRIPTION
The ring buffer has an actual capacity of `2^n-1`. Thus, to avoid power of 2 specified capacity to be rounded up (eg `1024 -> 2047`), subtract one to the provided capacity when the provided value is a power of 2 as this probably best reflects the actual user's intent.

Fixes: #11650