### PR TITLE
bandwidth: adjust version to 5.1 in log message

### DIFF
--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -67,7 +67,7 @@ func ProbeBandwidthManager() {
 		}
 	}
 	if !kernelGood {
-		log.Warn("BPF bandwidth manager needs kernel 5.0 or newer. Disabling the feature.")
+		log.Warn("BPF bandwidth manager needs kernel 5.1 or newer. Disabling the feature.")
 		option.Config.EnableBandwidthManager = false
 		return
 	}


### PR DESCRIPTION
The version in the log message was not adjusted when the version check
was changed from 5.0+ to 5.1+.

Fixes: bf3a103465dc ("cilium: make bandwidth manager dependent on 5.1+")