### PR TITLE
k8s: Only wait for the needed CRDs

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -547,7 +547,7 @@ func runServer(cmd *cobra.Command) {
 		if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 			log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 		}
-		synced.SyncCRDs(context.TODO(), &synced.Resources{}, &synced.APIGroups{})
+		synced.SyncCRDs(context.TODO(), synced.AllCRDResourceNames, &synced.Resources{}, &synced.APIGroups{})
 		ciliumK8sClient = k8s.CiliumClient()
 	}
 


### PR DESCRIPTION
Agent does not depend on the CiliumExternalWorkload CRD, so do not
sync & wait for that.

Also remove unnecessary wait for CRDs that always happened after the
sync & wait was already done.

Fixes: #13666
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
