### PR TITLE
Documentation: Fix Loadbalancer Guide for Clustermesh

### DIFF
--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -99,6 +99,8 @@ using their internal IPs):
         name: cilium-etcd-external
         annotations:
           cloud.google.com/load-balancer-type: "Internal"
+          # if all the clusters are in the same region you can comment out this annotation
+          networking.gke.io/internal-load-balancer-allow-global-access: "true"
       spec:
         type: LoadBalancer
         ports:

--- a/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
+++ b/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
@@ -4,6 +4,8 @@ metadata:
   name: cilium-etcd-external
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
+    # if all the clusters are in the same region you can comment out this annotation
+    networking.gke.io/internal-load-balancer-allow-global-access: "true"
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
Inter regional deployments on GKE do not work unless
the internal loadbalancer has "global access" turned on.

Fixes: #13740

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>
