### PR TITLE
operator: wait for endpoints to sync to use cache

### DIFF
--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -186,9 +186,12 @@ func startSynchronizingServices() {
 		cache.WaitForCacheSync(wait.NeverStop, svcController.HasSynced)
 		swgSvcs.Stop()
 		swgSvcs.Wait()
-		close(k8sSvcCacheSynced)
 
 		cache.WaitForCacheSync(wait.NeverStop, endpointController.HasSynced)
+
+		// Have to wait for endpoints to sync too otherwise readers may have to
+		// wait too long to acquire a RLock
+		close(k8sSvcCacheSynced)
 	}()
 
 	go func() {


### PR DESCRIPTION
Wait for endpoints to sync before marking the k8s service cache as synced.

Otherwise the custom dialer for etcd may hit its deadline while waiting to take a RLock on the global service cache because endpoints are still being updated.

Fixes: #13454 
