### PR TITLE
helm: Fix format issue for logOptions in ConfigMap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -512,7 +512,7 @@ data:
   log-system-load: {{ .Values.logSystemLoad | quote }}
 {{- end }}
 {{- if .Values.logOptions }}
-  log-opt: {{ toYaml .Values.logOptions | nindent 4 }}
+  log-opt: {{ .Values.logOptions | toJson | quote }}
 {{- end }}
 {{- if and .Values.sockops .Values.sockops.enabled }}
   sockops-enable: {{ .Values.sockops.enabled | quote }}


### PR DESCRIPTION
ConfigMap object supports only key-value format, this commit to
serialise lopOptions option to json string.

Closes #13831

## Testing

Testing was done locally with kind cluster with addition flag `--set logOptions.format=json`.

<details>
<summary>Set logOptions.format</summary>

```
helm upgrade -i cilium ./install/kubernetes/cilium \
    --wait \
    --namespace kube-system \
    --set nodeinit.enabled=true \
    --set kubeProxyReplacement=partial \
    --set hostServices.enabled=false \
    --set externalIPs.enabled=true \
    --set nodePort.enabled=true \
    --set hostPort.enabled=true \
    --set bpf.masquerade=false \
    --set ipam.mode=kubernetes \
    --set image.tag=latest \
    --set image.pullPolicy=Never \
    --set operator.image.tag=latest \
    --set operator.image.pullPolicy=Never \
    --set prometheus.enabled=true \
    --set operator.prometheus.enabled=true \
    --set hubble.enabled=true \
    --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}" \
    --set logOptions.format=json

# Log in json format now

$ ksyslo cilium-2g5xv 
level=info msg="Skipped reading configuration file" error="Config File \"ciliumd\" Not Found in \"[/root]\"" subsys=config
level=info msg="Memory available for map entries (0.003% of 67457114112B): 168642785B" subsys=config
level=info msg="option bpf-ct-global-tcp-max set by dynamic sizing to 591729" subsys=config
level=info msg="option bpf-ct-global-any-max set by dynamic sizing to 295864" subsys=config
level=info msg="option bpf-nat-global-max set by dynamic sizing to 591729" subsys=config
level=info msg="option bpf-neigh-global-max set by dynamic sizing to 591729" subsys=config
level=info msg="option bpf-sock-rev-map-max set by dynamic sizing to 295864" subsys=config
{"level":"info","msg":"  --agent-health-port='9876'","subsys":"daemon"}
{"level":"info","msg":"  --agent-labels=''","subsys":"daemon"}
{"level":"info","msg":"  --allow-icmp-frag-needed='true'","subsys":"daemon"}
{"level":"info","msg":"  --allow-localhost='auto'","subsys":"daemon"}
{"level":"info","msg":"  --annotate-k8s-node='true'","subsys":"daemon"}
{"level":"info","msg":"  --api-rate-limit='map[]'","subsys":"daemon"}
{"level":"info","msg":"  --auto-create-cilium-node-resource='true'","subsys":"daemon"}
{"level":"info","msg":"  --auto-direct-node-routes='false'","subsys":"daemon"}
{"level":"info","msg":"  --blacklist-conflicting-routes='false'","subsys":"daemon"}
{"level":"info","msg":"  --bpf-compile-debug='false'","subsys":"daemon"}

```

</details>



```release-note
helm: Fix format issue for logOptions in ConfigMap
```
