### PR TITLE
helm: Fix format issue for logOptions in ConfigMap

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -471,7 +471,7 @@ data:
   log-system-load: {{ .Values.global.logSystemLoad | quote }}
 {{- end }}
 {{- if .Values.global.logOptions }}
-  log-opt: {{ toYaml .Values.global.logOptions | nindent 4 }}
+  log-opt: {{ .Values.global.logOptions | toJson | quote }}
 {{- end }}
 {{- if and .Values.global.sockops .Values.global.sockops.enabled }}
   sockops-enable: {{ .Values.global.sockops.enabled | quote }}


### PR DESCRIPTION
ConfigMap object supports only key-value format, this commit to
serialise lopOptions option to json string.

Closes #13831

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
helm: Fix format issue for logOptions in ConfigMap
```
