### PR TITLE
pkg/maps: fix interface implementation for SourceRangeKey{4,6}

### DIFF
--- a/pkg/maps/lbmap/source_range.go
+++ b/pkg/maps/lbmap/source_range.go
@@ -55,7 +55,7 @@ type SourceRangeKey4 struct {
 func (k *SourceRangeKey4) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *SourceRangeKey4) NewValue() bpf.MapValue    { return &SourceRangeValue{} }
 func (k *SourceRangeKey4) String() string            { return fmt.Sprintf("%s", k.Address) }
-func (k *SourceRangeKey4) ToNetwork() *SourceRangeKey4 {
+func (k *SourceRangeKey4) ToNetwork() SourceRangeKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in
 	// the SVC BPF maps
@@ -64,7 +64,7 @@ func (k *SourceRangeKey4) ToNetwork() *SourceRangeKey4 {
 }
 
 // ToHost returns the key in the host byte order
-func (k *SourceRangeKey4) ToHost() *SourceRangeKey4 {
+func (k *SourceRangeKey4) ToHost() SourceRangeKey {
 	h := *k
 	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
 	return &h
@@ -96,7 +96,7 @@ type SourceRangeKey6 struct {
 func (k *SourceRangeKey6) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *SourceRangeKey6) NewValue() bpf.MapValue    { return &SourceRangeValue{} }
 func (k *SourceRangeKey6) String() string            { return fmt.Sprintf("%s", k.Address) }
-func (k *SourceRangeKey6) ToNetwork() *SourceRangeKey6 {
+func (k *SourceRangeKey6) ToNetwork() SourceRangeKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in
 	// the SVC BPF maps
@@ -105,7 +105,7 @@ func (k *SourceRangeKey6) ToNetwork() *SourceRangeKey6 {
 }
 
 // ToHost returns the key in the host byte order
-func (k *SourceRangeKey6) ToHost() *SourceRangeKey6 {
+func (k *SourceRangeKey6) ToHost() SourceRangeKey {
 	h := *k
 	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
 	return &h


### PR DESCRIPTION
The interface SourceRangeKey should implement the ToNetwork() and
ToHost() methods by returning a SourceRangeKey and not a pointer for the
implementation structure.

Fixes: 945a852cfe62 ("lbmap: Add SourceRange maps")
Fixes: 682f6826bce7 ("lbmap: Optimize lbmap byte order related code")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/13824

```release-note
Fix panic on cilium-agent startup when restoring LB source range maps
```
