### PR TITLE
option: avoid error on dynamic NAT table size if CT map sizes are static

### DIFF
--- a/Documentation/concepts/ebpf/maps.rst
+++ b/Documentation/concepts/ebpf/maps.rst
@@ -38,6 +38,14 @@ line options for ``cilium-agent``. A given capacity can be set using
 ``--bpf-nat-global-max``, ``--bpf-neigh-global-max``, ``--bpf-policy-map-max``,
 ``--bpf-fragments-map-max`` and ``--bpf-lb-map-max``.
 
+.. Note::
+
+   In case the ``--bpf-ct-global-tcp-max`` and/or ``--bpf-ct-global-any-max``
+   are specified, the NAT table size (``--bpf-nat-global-max``) must not exceed
+   2/3 of the combined CT table size (TCP + UDP). This will automatically be set
+   if either ``--bpf-nat-global-max`` is not explicitly set or if dynamic BPF
+   map sizing is used (see below).
+
 Using the ``--bpf-map-dynamic-size-ratio`` flag, the upper capacity limits of
 several large BPF maps are determined at agent startup based on the given ratio
 of the total system memory. For example, a given ratio of 0.0025 leads to 0.25%

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3055,6 +3055,14 @@ func (c *DaemonConfig) calculateDynamicBPFMapSizes(totalMemory uint64, dynamicSi
 			getEntries(NATMapEntriesGlobalDefault, LimitTableAutoNatGlobalMin, LimitTableMax)
 		log.Infof("option %s set by dynamic sizing to %v",
 			NATMapEntriesGlobalName, c.NATMapEntriesGlobal)
+		if c.NATMapEntriesGlobal > c.CTMapEntriesGlobalTCP+c.CTMapEntriesGlobalAny {
+			// CT table size was specified manually, make sure that the NAT table size
+			// does not exceed maximum CT table size. See
+			// (*DaemonConfig).checkMapSizeLimits.
+			c.NATMapEntriesGlobal = (c.CTMapEntriesGlobalTCP + c.CTMapEntriesGlobalAny) * 2 / 3
+			log.Warningf("option %s would exceed maximum determined by CT table sizes, capping to %v",
+				NATMapEntriesGlobalName, c.NATMapEntriesGlobal)
+		}
 	} else {
 		log.Debugf("option %s set by user to %v", NATMapEntriesGlobalName, c.NATMapEntriesGlobal)
 	}

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -919,6 +919,22 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 				SockRevNatMapSize: LimitTableMax,
 			},
 		},
+		{
+			name:        "dynamic size NAT size above limit with static CT sizes (issue #13843)",
+			totalMemory: 128 * GiB,
+			ratio:       0.0025,
+			want: sizes{
+				CTMapSizeTCP:      524288,
+				CTMapSizeAny:      262144,
+				NATMapSize:        (524288 + 262144) * 2 / 3,
+				NeighMapSize:      524288,
+				SockRevNatMapSize: 607062,
+			},
+			preTestRun: func() {
+				viper.Set(CTMapEntriesGlobalTCPName, 524288)
+				viper.Set(CTMapEntriesGlobalAnyName, 262144)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
If the CT map sizes are configured statically, depending on system
memory and the dynamic ration it might happen that the dynamically
determined size for the NAT table exceeds
(CTMapTCPSize+CTMapAnySize)*2/3 which is leads to an error in
`(*DaemonConfig).checkMapSizeLimits`:

```
Invalid daemon configuration: specified NAT tables size 1185960 must not exceed maximum CT table size 786432
```

Fix this by already capping the dynamically determined NAT table size in
`(*DaemonConfig).calculateDynamicBPFMapSizes` accordingly.

Fixes: #13843
Fixes: 0316bc205d21 ("daemon: add option to dynamically size BPF maps based on system memory")
Reported-by: Timo Reimann on Slack

```release-note
Fix dynamic NAT table size calculation if CT map sizes are configured statically.
```
