### PR TITLE
test: Remove use of undefined field in TLS test

### DIFF
--- a/test/k8sT/manifests/l7-policy-TLS.yaml
+++ b/test/k8sT/manifests/l7-policy-TLS.yaml
@@ -39,7 +39,6 @@ spec:
             secret:
               namespace: "default"
               name: "user-agent"
-              value: "user-agent"
   - toFQDNs:
     - matchPattern: "www.lyft.com"
     toPorts:
@@ -64,4 +63,3 @@ spec:
             secret:
               namespace: "default"
               name: "user-agent"
-              value: "user-agent"


### PR DESCRIPTION
Use of "value" field in a Secret was a remnant from feature
development that was harmless until we started rejecting CRDs with
undefined fields.

Fixes: #13382
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
