### PR TITLE
[v1.7] contrib: Sort authors without depending on locale

### DIFF
--- a/contrib/scripts/extract_authors.sh
+++ b/contrib/scripts/extract_authors.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Ensure sort order doesn't depend on locale
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 function extract_authors() {
 	authors=$(git shortlog --summary | awk '{$1=""; print $0}' | sed -e 's/^ //')
 	IFS=$'\n'
@@ -14,4 +18,4 @@ function extract_authors() {
 	done
 }
 
-extract_authors | uniq | sort
+extract_authors | sort -u


### PR DESCRIPTION
This is a partial backport of
https://github.com/cilium/cilium/pull/13106.

This commit was cherry-picked from https://github.com/cilium/cilium/pull/13802
(v1.8).