### PR TITLE
Remove the beta status note for Hubble Relay/UI

### DIFF
--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -109,11 +109,6 @@ Relay and Hubble's graphical UI.
                   --set hubble.relay.enabled=true \\
                   --set hubble.ui.enabled=true
 
-.. note::
-
-    Please note that Hubble Relay and Hubble UI are currently in beta status
-    and are not yet recommended for production use.
-
 Validate the Installation
 =========================
 


### PR DESCRIPTION
They are both GA in 1.9.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>