### PR TITLE
install: Remove 1.9 RC workaround

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -3,9 +3,6 @@
 
 include ../../Makefile.defs
 
-# Workaround until we branch for v1.9
-VERSION := 1.8.90
-
 HUBBLE_PROXY_VERSION := "v1.14.5"
 HUBBLE_UI_VERSION := "v0.7.3"
 MANAGED_ETCD_VERSION := "v2.0.7"

--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cilium
 home: https://cilium.io/
-version: 1.8.90
-appVersion: 1.8.90
+version: 1.9.90
+appVersion: 1.9.90
 description: Helm chart for Cilium
 keywords:
 sources:

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -1,6 +1,6 @@
 # cilium
 
-![Version: 1.8.90](https://img.shields.io/badge/Version-1.8.90-informational?style=flat-square) ![AppVersion: 1.8.90](https://img.shields.io/badge/AppVersion-1.8.90-informational?style=flat-square)
+![Version: 1.9.90](https://img.shields.io/badge/Version-1.9.90-informational?style=flat-square) ![AppVersion: 1.9.90](https://img.shields.io/badge/AppVersion-1.9.90-informational?style=flat-square)
 
 Helm chart for Cilium
 


### PR DESCRIPTION
This reverts commit dae3d3cb6a4789ae980eacfa22426d3527e4a11f, which
allows updating to the correct development versions for 1.10.x.