### PR TITLE
v1.6 backports 2020-11-03

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1874,7 +1874,11 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 	done := make(chan struct{})
 	controllerName := fmt.Sprintf("resolve-labels-%s/%s", e.GetK8sNamespace(), e.GetK8sPodName())
 	go func() {
-		<-done
+		select {
+		case <-done:
+		case <-e.aliveCtx.Done():
+			return
+		}
 		e.controllers.RemoveController(controllerName)
 	}()
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1894,7 +1894,7 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 				close(done)
 				return nil
 			},
-			RunInterval: 30 * time.Second,
+			Context: e.aliveCtx,
 		},
 	)
 }


### PR DESCRIPTION
* #13683 -- endpoint: Fix goroutine leak when EP is deleted (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13683; do contrib/backporting/set-labels.py $pr done 1.6; done
```