### PR TITLE
[v1.8] backporting: Escape commit message when used as regex

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -126,6 +126,7 @@ generate_commit_list_for_pr () {
   local entry_id
   local entry_sha
   local entry_sub
+  local entry_sub_re
   local upstream
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
@@ -152,7 +153,8 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "^$entry_sub" $REMOTE/master)"
+    entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
+    upstream="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then


### PR DESCRIPTION
Manual backport of #13756 to `v1.8` in order to simplify remaining backports using `contrib/backporting/start-backport`.

[ upstream commit 1f178f092c155c728d6fa9822ee062b2cfa9821b ]

This commit escapes the commit message when it is used as a regular
expression. Any special character of the posix extended regex
(`.^$*+?()[{\|`) is prefixed with a backslash. This fixes an issue where
`git log` would crash due to to the string being passed to `--grep` not
being a valid regex, such as e.g. in the commit messages found in
PR #13674 which contain `$`, `*` and `{`.