### PR TITLE
Adds a new option to skip socket lb when in pod ns

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -45,6 +45,7 @@ cilium-agent [flags]
       --bpf-lb-mode string                                   BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
       --bpf-lb-rss-ipv4-src-cidr string                      BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
       --bpf-lb-rss-ipv6-src-cidr string                      BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
+      --bpf-lb-sock-hostns-only                              Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
       --bpf-map-dynamic-size-ratio float                     Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
       --bpf-nat-global-max int                               Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-neigh-global-max int                             Maximum number of entries for the global BPF neighbor table (default 524288)

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -31,6 +31,15 @@ proxy, but that will only work if mTLS is not used.
    other GSGs. 5 GB and 4 CPUs should be enough for this GSG
    (``--vm=true --memory=5120 --cpus=4``).
 
+.. note::
+
+   If Cilium is deployed in kube-proxy-free mode, you need to set
+   ``--bpf-lb-sock-hostns-only: true`` in the deployment yaml
+   directly or via ``loadBalancer.hostNamespaceOnly`` option with Helm.
+   Without this option, when Cilium does service resolution via
+   socket load balancing, Istio sidecar will be bypassed, resulting
+   in loss of Istio features including encryption and telemetry.
+
 Step 2: Install cilium-istioctl
 ===============================
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -495,6 +495,30 @@ mode would look as follows:
 
 .. _XDP acceleration:
 
+Socket LoadBalancer Bypass in Pod Namespace
+*******************************************
+
+Cilium has built-in support for bypassing the socket-level LoadBalancer and falling back
+to the tc LoadBalancer at the veth interface when a custom redirection/operation relies
+on the original ClusterIP within pod namespace (e.g., Istio side-car).
+
+Setting ``loadBalancer.hostNamespaceOnly=true`` enables this bypassing mode. When enabled,
+this circumvents socket rewrite in the ``connect()`` and ``sendmsg()`` syscall bpf hook and
+will pass the original packet to next stage of operation (e.g., stack in
+``per-endpoint-routing`` mode) and re-enables service lookup in the tc bpf program.
+
+A Helm example configuration in a kube-proxy-free environment with socket LB bypass
+looks as follows:
+
+.. parsed-literal::
+
+    helm install cilium |CHART_RELEASE| \\
+        --namespace kube-system \\
+        --set tunnel=disabled \\
+        --set autoDirectNodeRoutes=true \\
+        --set kubeProxyReplacement=strict \\
+        --set loadBalancer.hostNamespaceOnly=true
+
 LoadBalancer & NodePort XDP Acceleration
 ****************************************
 

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -185,6 +185,7 @@ Cilium Feature                              Minimum Kernel Version
 Full support for :ref:`session-affinity`    >= 5.7
 BPF-based proxy redirection                 >= 5.7
 BPF-based host routing                      >= 5.10
+Socket-level LB bypass                      >= 5.7
 =========================================== ===============================
 
 .. _req_kvstore:

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -341,6 +341,9 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	bool backend_from_affinity = false;
 	__u32 backend_id = 0;
 
+	if (is_defined(ENABLE_HOST_XLATE_ONLY) && !in_hostns)
+		return -ENXIO;
+
 	if (!udp_only && !sock_proto_enabled(ctx->protocol))
 		return -ENOTSUP;
 
@@ -938,6 +941,9 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
 	__u32 backend_id = 0;
+
+	if (is_defined(ENABLE_HOST_XLATE_ONLY) && !in_hostns)
+		return -ENXIO;
 
 	if (!udp_only && !sock_proto_enabled(ctx->protocol))
 		return -ENOTSUP;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -353,6 +353,9 @@ func init() {
 	flags.String(option.EgressMasqueradeInterfaces, "", "Limit egress masquerading to interface selector")
 	option.BindEnv(option.EgressMasqueradeInterfaces)
 
+	flags.Bool(option.BPFSocketLBHostnsOnly, false, "Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.")
+	option.BindEnv(option.BPFSocketLBHostnsOnly)
+
 	flags.Bool(option.EnableHostReachableServices, false, "Enable reachability of services for host applications")
 	option.BindEnv(option.EnableHostReachableServices)
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -393,6 +393,27 @@ func initKubeProxyReplacementOptions() (bool, error) {
 		}
 	}
 
+	if option.Config.BPFSocketLBHostnsOnly {
+		if !option.Config.EnableHostReachableServices {
+			option.Config.BPFSocketLBHostnsOnly = false
+			log.Warnf("%s only takes effect when %s is true", option.BPFSocketLBHostnsOnly, option.EnableHostReachableServices)
+		} else {
+			found := false
+			if helpers := probesManager.GetHelpers("cgroup_sock_addr"); helpers != nil {
+				if _, ok := helpers["bpf_get_netns_cookie"]; ok {
+					found = true
+				}
+			}
+			if !found {
+				option.Config.BPFSocketLBHostnsOnly = false
+				log.Warn("Without network namespace cookie lookup functionality, BPF datapath " +
+					"cannot distinguish root and non-root namespace, skipping socket-level " +
+					"loadbalancing will not work. Istio routing chains will be missed. " +
+					"Needs kernel version >= 5.7")
+			}
+		}
+	}
+
 	return strict, nil
 }
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -480,6 +480,10 @@ data:
   enable-local-redirect-policy: {{ .Values.localRedirectPolicy | quote }}
 {{- end }}
 
+{{- if hasKey .Values.loadBalancer "hostNamespaceOnly" }}
+  bpf-lb-sock-hostns-only: {{ .Values.loadBalancer.hostNamespaceOnly | quote }}
+{{- end }}
+
 {{- if hasKey .Values "nativeRoutingCIDR" }}
   ipv4-native-routing-cidr: {{ .Values.nativeRoutingCIDR }}
 {{- else if hasKey .Values "ipv4NativeRoutingCIDR" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1010,6 +1010,9 @@ monitor:
   # used to pass a service IP and port to remote backend
   # dsrDispatch: opt
 
+  # -- Disable socket lb for non-root ns. This is used to enable Istio routing rules.
+  # hostNamespaceOnly: false
+
 # -- Configure N-S k8s service loadbalancing
 nodePort:
   # -- Enable the Cilium NodePort service implementation.

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -236,6 +236,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_EGRESS_GATEWAY"] = "1"
 	}
 
+	if option.Config.BPFSocketLBHostnsOnly {
+		cDefinesMap["ENABLE_HOST_XLATE_ONLY"] = "1"
+	}
+
 	if option.Config.EnableHostReachableServices {
 		if option.Config.EnableHostServicesTCP {
 			cDefinesMap["ENABLE_HOST_SERVICES_TCP"] = "1"
@@ -243,7 +247,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.EnableHostServicesUDP {
 			cDefinesMap["ENABLE_HOST_SERVICES_UDP"] = "1"
 		}
-		if option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP {
+		if option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP && !option.Config.BPFSocketLBHostnsOnly {
 			cDefinesMap["ENABLE_HOST_SERVICES_FULL"] = "1"
 		}
 		if option.Config.EnableHostServicesPeer {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -446,6 +446,9 @@ const (
 	// EnableHostReachableServices is the name of the EnableHostReachableServices option
 	EnableHostReachableServices = "enable-host-reachable-services"
 
+	// BPFSocketLBHostnsOnly is the name of the BPFSocketLBHostnsOnly option
+	BPFSocketLBHostnsOnly = "bpf-lb-sock-hostns-only"
+
 	// HostReachableServicesProtos is the name of the HostReachableServicesProtos option
 	HostReachableServicesProtos = "host-reachable-services-protos"
 
@@ -1400,6 +1403,7 @@ type DaemonConfig struct {
 	// CLI options
 
 	BPFRoot                       string
+	BPFSocketLBHostnsOnly         bool
 	CGroupRoot                    string
 	BPFCompileDebug               string
 	CompilerFlags                 []string
@@ -2371,6 +2375,7 @@ func (c *DaemonConfig) Populate() {
 	c.DevicePreFilter = viper.GetString(PrefilterDevice)
 	c.DisableCiliumEndpointCRD = viper.GetBool(DisableCiliumEndpointCRDName)
 	c.EgressMasqueradeInterfaces = viper.GetString(EgressMasqueradeInterfaces)
+	c.BPFSocketLBHostnsOnly = viper.GetBool(BPFSocketLBHostnsOnly)
 	c.EnableHostReachableServices = viper.GetBool(EnableHostReachableServices)
 	c.EnableRemoteNodeIdentity = viper.GetBool(EnableRemoteNodeIdentity)
 	c.K8sHeartbeatTimeout = viper.GetDuration(K8sHeartbeatTimeout)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -491,6 +491,95 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		})
 	})
 
+	SkipContextIf(func() bool {
+		return helpers.RunsWithKubeProxy() || helpers.DoesNotRunOnNetNextKernel()
+	}, "Checks connectivity when skipping socket lb in pod ns", func() {
+		var (
+			demoDSYAML string
+			demoYAML   string
+		)
+
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.hostNamespaceOnly": "true",
+			})
+			demoDSYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
+			res := kubectl.ApplyDefault(demoDSYAML)
+			res.ExpectSuccess("Unable to apply %s", demoDSYAML)
+			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+			res = kubectl.ApplyDefault(demoYAML)
+			res.ExpectSuccess("unable to apply %s", demoYAML)
+			waitPodsDs()
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
+			Expect(err).Should(BeNil())
+		})
+
+		AfterAll(func() {
+			_ = kubectl.Delete(demoDSYAML)
+			_ = kubectl.Delete(demoYAML)
+			ExpectAllPodsTerminated(kubectl)
+		})
+
+		It("Checks ClusterIP connectivity on the same node", func() {
+			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, serviceName)
+			Expect(err).Should(BeNil(), "Cannot get service %s", serviceName)
+			Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+
+			// Test that socket lb doesn't kick in, aka we see service VIP in monitor trace.
+			// Note that cilium monitor won't capture service VIP if run with Istio.
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
+			monitorRes, monitorCancel := kubectl.MonitorStart(ciliumPodK8s1)
+			defer func() {
+				monitorCancel()
+				helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), "skip-socket-lb-connectivity-same-node.log")
+			}()
+
+			httpSVCURL := fmt.Sprintf("http://%s/", clusterIP)
+			tftpSVCURL := fmt.Sprintf("tftp://%s/hello", clusterIP)
+
+			// Test connectivbity from root ns
+			status := kubectl.ExecInHostNetNS(context.TODO(), k8s1NodeName,
+				helpers.CurlFail(httpSVCURL))
+			status.ExpectSuccess("cannot curl to service IP from host")
+			status = kubectl.ExecInHostNetNS(context.TODO(), k8s1NodeName,
+				helpers.CurlFail(tftpSVCURL))
+			status.ExpectSuccess("cannot curl to service IP from host")
+
+			// Test connectivity from pod ns
+			testCurlFromPods("id=app2", httpSVCURL, 10, 0)
+			testCurlFromPods("id=app2", tftpSVCURL, 10, 0)
+
+			monitorRes.ExpectContains(clusterIP, "Service VIP not seen in monitor trace, indicating socket lb still in effect")
+		})
+
+		It("Checks ClusterIP connectivity across nodes", func() {
+			service := "testds-service"
+
+			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, service)
+			Expect(err).Should(BeNil(), "Cannot get services %s", service)
+			Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+
+			// Test that socket lb doesn't kick in, aka we see service VIP in monitor output.
+			// Note that cilium monitor won't capture service VIP if run with Istio.
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
+			monitorRes, monitorCancel := kubectl.MonitorStart(ciliumPodK8s1)
+			defer func() {
+				monitorCancel()
+				helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), "skip-socket-lb-connectivity-across-nodes.log")
+			}()
+
+			url := fmt.Sprintf("http://%s/", clusterIP)
+			testCurlFromPods(testDSClient, url, 10, 0)
+
+			url = fmt.Sprintf("tftp://%s/hello", clusterIP)
+			testCurlFromPods(testDSClient, url, 10, 0)
+
+			monitorRes.ExpectContains(clusterIP, "Service VIP not seen in monitor trace, indicating socket lb still in effect")
+		})
+	})
+
 	Context("Checks service across nodes", func() {
 
 		var (


### PR DESCRIPTION
This is for compatibility with Istio in kube-proxy free mode.
Currently, even though Istio would still get all traffic within pod
namespace, but the original service VIP is lost during socket lb,
causing it to miss all Istio routing chains and therefore bypassing
all Istio functionalities.

This adds a new option to bypass socket lb in pod namespace. When
enabled, service resolution for connection from pod namespaces will be
handled in bpf_lxc at veth. For host-namespaced pods, socket lb kept as
is.

Signed-off-by: Weilong Cui <cuiwl@google.com>
