### PR TITLE
murmur3: Inline rotl64 and fmix64 helper functions

### DIFF
--- a/pkg/murmur3/murmur3.go
+++ b/pkg/murmur3/murmur3.go
@@ -40,17 +40,17 @@ func Hash128(data []byte, seed uint32) (uint64, uint64) {
 		k2 := tmp[1]
 
 		k1 *= c1
-		k1 = rotl64(k1, 31)
+		k1 = (k1 << 31) | (k1 >> 33)
 		k1 *= c2
 		h1 ^= k1
-		h1 = rotl64(h1, 27)
+		h1 = (h1 << 27) | (h1 >> 37)
 		h1 += h2
 		h1 = h1*5 + 0x52dce729
 		k2 *= c2
-		k2 = rotl64(k2, 33)
+		k2 = (k2 << 33) | (k2 >> 31)
 		k2 *= c1
 		h2 ^= k2
-		h2 = rotl64(h2, 31)
+		h2 = (h2 << 31) | (h2 >> 33)
 		h2 += h1
 		h2 = h2*5 + 0x38495ab5
 	}
@@ -82,7 +82,7 @@ func Hash128(data []byte, seed uint32) (uint64, uint64) {
 	case 9:
 		k2 ^= uint64(tail[8]) << 0
 		k2 *= c2
-		k2 = rotl64(k2, 33)
+		k2 = (k2 << 33) | (k2 >> 31)
 		k2 *= c1
 		h2 ^= k2
 		fallthrough
@@ -110,7 +110,7 @@ func Hash128(data []byte, seed uint32) (uint64, uint64) {
 	case 1:
 		k1 ^= uint64(tail[0]) << 0
 		k1 *= c1
-		k1 = rotl64(k1, 31)
+		k1 = (k1 << 31) | (k1 >> 33)
 		k1 *= c2
 		h1 ^= k1
 	}
@@ -119,24 +119,18 @@ func Hash128(data []byte, seed uint32) (uint64, uint64) {
 	h2 ^= uint64(len(data))
 	h1 += h2
 	h2 += h1
-	h1 = fmix64(h1)
-	h2 = fmix64(h2)
+	h1 ^= h1 >> 33
+	h1 *= 0xff51afd7ed558ccd
+	h1 ^= h1 >> 33
+	h1 *= 0xc4ceb9fe1a85ec53
+	h1 ^= h1 >> 33
+	h2 ^= h2 >> 33
+	h2 *= 0xff51afd7ed558ccd
+	h2 ^= h2 >> 33
+	h2 *= 0xc4ceb9fe1a85ec53
+	h2 ^= h2 >> 33
 	h1 += h2
 	h2 += h1
 
 	return h1, h2
-}
-
-func rotl64(x uint64, r int8) uint64 {
-	return (x << r) | (x >> (64 - r))
-}
-
-func fmix64(k uint64) uint64 {
-	k ^= k >> 33
-	k *= 0xff51afd7ed558ccd
-	k ^= k >> 33
-	k *= 0xc4ceb9fe1a85ec53
-	k ^= k >> 33
-
-	return k
 }


### PR DESCRIPTION
From the "go tool objdump daemon/cilium-agent" we can see that both
functions are not inlined:
```
murmur3.go:113 0x27c46f4 48891424   MOVQ DX, 0(SP)
murmur3.go:113 0x27c46f8 c64424081f MOVB $0x1f, 0x8(SP)
murmur3.go:113 0x27c46fd 0f1f00     NOPL 0(AX)
murmur3.go:113 0x27c4700 e87b050000 CALL github.com/cilium/cilium/pkg/murmur3.rotl64(SB)
[..]
murmur3.go:121 0x27c4779 4801c8     ADDQ CX, AX
murmur3.go:121 0x27c477c 4889442448 MOVQ AX, 0x48(SP)
murmur3.go:122 0x27c4781 488b442450 MOVQ 0x50(SP), AX
murmur3.go:122 0x27c4786 48890424   MOVQ AX, 0(SP)
murmur3.go:122 0x27c478a e871050000 CALL github.com/cilium/cilium/pkg/murmur3.fmix64(SB)
```

Inlining both gives us the following tiny speed up:

```
MaglevTestSuite.BenchmarkGetMaglevTable 10 179665966 ns/op (BEFORE)
MaglevTestSuite.BenchmarkGetMaglevTable 10 179610754 ns/op (AFTER)
```