### PR TITLE
maglev: Convert permutation 2D array to 1D

### DIFF
--- a/pkg/maglev/maglev.go
+++ b/pkg/maglev/maglev.go
@@ -60,15 +60,14 @@ func getOffsetAndSkip(backend string, m uint64) (uint64, uint64) {
 	return offset, skip
 }
 
-func getPermutation(backends []string, m uint64) [][]uint64 {
-	perm := make([][]uint64, len(backends))
+func getPermutation(backends []string, m uint64) []uint64 {
+	perm := make([]uint64, len(backends)*int(m))
 
 	for i, backend := range backends {
 		offset, skip := getOffsetAndSkip(backend, m)
-		perm[i] = make([]uint64, m)
-		perm[i][0] = offset % m
+		perm[i*int(m)] = offset % m
 		for j := uint64(1); j < m; j++ {
-			perm[i][j] = (perm[i][j-1] + skip) % m
+			perm[i*int(m)+int(j)] = (perm[i*int(m)+int(j-1)] + skip) % m
 		}
 	}
 
@@ -94,10 +93,10 @@ func GetLookupTable(backends []string, m uint64) []int {
 
 	for n := uint64(0); n < m; n++ {
 		i := int(n) % l
-		c := perm[i][next[i]]
+		c := perm[i*int(m)+next[i]]
 		for entry[c] >= 0 {
 			next[i] += 1
-			c = perm[i][next[i]]
+			c = perm[i*int(m)+next[i]]
 		}
 		entry[c] = i
 		next[i] += 1


### PR DESCRIPTION
As identified by Glib, writing to the permutation 2D array takes the longest:

```
9.64s 9.97s (flat, cum) 70.26% of Total
[..]
510ms 510ms 71: for j := uint64(1); j < m; j++ {
300ms 300ms 72:         old = perm[i][j-1]
400ms 420ms 73:         val = (old + skip) % m
8.16s 8.16s 74:         perm[i][j] = val
```

Converting 2D to 1D the permutation array gives us the following
speedup:
```
MaglevTestSuite.BenchmarkGetMaglevTable 10 179852399 ns/op (BEFORE)
MaglevTestSuite.BenchmarkGetMaglevTable 10 165438307 ns/op (AFTER)
```

Signed-off-by: Glib Smaga <code@gsmaga.com>
Signed-off-by: Martynas Pumputis <m@lambda.lt>