### PR TITLE
release: add script to check presence of docker images

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -49,6 +49,8 @@ assignees: ''
   - [operator-azure](https://hub.docker.com/repository/docker/cilium/operator-azure/builds)
   - [hubble-relay](https://hub.docker.com/repository/docker/cilium/hubble-relay/builds)
   - [clustermesh-apiserver](https://hub.docker.com/repository/docker/cilium/clustermesh-apiserver/builds)
+  - Check if all docker images are available before announcing the release
+    `make -C install/kubernetes/ check-docker-images`
 - [ ] Create helm charts artifacts in [Cilium charts] repository using
       [cilium helm release tool] for both the `vX.Y.Z` release and `vX.Y` branch
       & push to repository

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -169,6 +169,12 @@ Reference steps for the template
    **Note**, the DockerHub UI will not allow you to modify the ``stable`` tag
    directly. You will need to delete it, and then create a new, updated one.
 
+#. Check if all docker images are available before announcing the release:
+
+   ::
+
+      make -C install/kubernetes/ check-docker-images
+
 #. Update the following external tools and guides to point to the released
    Cilium version. This step is only required on a new minor release like going
    from ``1.8`` to ``1.9``.

--- a/contrib/release/check-docker-images.sh
+++ b/contrib/release/check-docker-images.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+cilium_tag="${1}"
+org="cilium"
+
+external_dependencies_docker=(
+  "envoyproxy/envoy:${HUBBLE_PROXY_VERSION}" \
+)
+
+external_dependencies_quay=(
+  "coreos/etcd:${ETCD_VERSION}" \
+)
+
+internal_dependencies=(
+  "certgen:${CERTGEN_VERSION}" \
+  "cilium-etcd-operator:${MANAGED_ETCD_VERSION}" \
+  "startup-script:${NODEINIT_VERSION}"
+  "hubble-ui:${HUBBLE_UI_VERSION}" \
+  "hubble-ui-backend:${HUBBLE_UI_VERSION}" \
+)
+
+cilium_images=(\
+  "cilium" \
+  "clustermesh-apiserver" \
+  "docker-plugin" \
+  "hubble-relay" \
+  "operator" \
+  "operator-azure" \
+  "operator-aws" \
+  "operator-generic" \
+)
+
+docker_tag_exists(){
+  local repo="${1}"
+  local tag="${2}"
+  curl --silent -f -lSL "https://index.docker.io/v1/repositories/${repo}/tags/${tag}" &> /dev/null
+}
+
+quay_tag_exists(){
+  local repo="${1}"
+  local tag="${2}"
+  curl --silent -f -lSL "https://quay.io/api/v1/repository/${repo}/tag/${tag}/images" &> /dev/null
+}
+
+for image in "${external_dependencies_docker[@]}" ; do
+  image_tag=${image#*:}
+  image_name=${image%":$image_tag"}
+  if ! docker_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "docker.io/${image} does not exist!"
+    not_found=true
+  fi
+done
+
+for image in "${external_dependencies_quay[@]}" ; do
+  image_tag=${image#*:}
+  image_name=${image%":$image_tag"}
+  if ! quay_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "quay.io/${image} does not exist!"
+    not_found=true
+  fi
+done
+
+for image in "${internal_dependencies[@]}" ; do
+  image_tag=${image#*:}
+  image_name=${org}/${image%":$image_tag"}
+  if ! docker_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "docker.io/${image_name}:${image_tag} does not exist!"
+    not_found=true
+  fi
+  if ! quay_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "quay.io/${image_name}:${image_tag} does not exist!"
+    not_found=true
+  fi
+done
+
+for image in "${cilium_images[@]}"; do
+  image_name="${org}/${image}"
+  if ! docker_tag_exists "${image_name}" "${cilium_tag}" ; then
+    echo "docker.io/${image_name}:${cilium_tag} does not exist!"
+    not_found=true
+  fi
+  if ! quay_tag_exists "${image_name}" "${cilium_tag}" ; then
+    echo "quay.io/${image_name}:${cilium_tag} does not exist!"
+    not_found=true
+  fi
+done
+
+if [[ -n "${not_found}" ]]; then
+  exit 1
+fi
+
+exit 0

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -96,4 +96,14 @@ clean:
 docs:
 	$(QUIET)$(HELM_DOCS)
 
+check-docker-images:
+	$(QUIET)\
+         HUBBLE_PROXY_VERSION=$(HUBBLE_PROXY_VERSION) \
+         HUBBLE_UI_VERSION=$(HUBBLE_UI_VERSION) \
+         MANAGED_ETCD_VERSION=$(MANAGED_ETCD_VERSION) \
+         ETCD_VERSION=$(ETCD_VERSION) \
+         NODEINIT_VERSION=$(NODEINIT_VERSION) \
+         CERTGEN_VERSION=`echo $(CERTGEN_VERSION) | egrep -o '^.*@' | sed 's/@//'` \
+         ../../contrib/release/check-docker-images.sh "v$(VERSION)"
+
 .PHONY: all clean docs experimental-install lint quick-install update-versions


### PR DESCRIPTION
To check if images are published across all repositories the
`check-docker-images.sh` script will be able to perform this check of a
particular release.

Signed-off-by: André Martins <andre@cilium.io>