### PR TITLE
hubble: fix rounding behavior of MaxFlows

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -120,8 +120,8 @@ cilium-agent [flags]
       --http-retry-count uint                                Number of retries performed after a forwarded request attempt fails (default 3)
       --http-retry-timeout uint                              Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --hubble-disable-tls                                   Allow Hubble server to run on the given listen address without TLS.
+      --hubble-event-buffer-capacity int                     Capacity of Hubble events buffer. The provided value must be on less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
       --hubble-event-queue-size int                          Buffer size of the channel to receive monitor events.
-      --hubble-flow-buffer-size int                          Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
       --hubble-listen-address string                         An additional address for Hubble server to listen to, e.g. ":4244"
       --hubble-metrics strings                               List of Hubble metrics to enable.
       --hubble-metrics-server string                         Address to serve Hubble metrics on.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipmasq"
@@ -844,8 +845,12 @@ func init() {
 	flags.StringSlice(option.HubbleTLSClientCAFiles, []string{}, "Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.")
 	option.BindEnv(option.HubbleTLSClientCAFiles)
 
-	flags.Int(option.HubbleFlowBufferSize, 4095, "Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096")
+	flags.Int(option.HubbleFlowBufferSize, 0, "Maximum number of flows in Hubble's buffer.")
+	flags.MarkDeprecated(option.HubbleFlowBufferSize, fmt.Sprintf("Use %s instead.", option.HubbleEventBufferCapacity))
 	option.BindEnv(option.HubbleFlowBufferSize)
+
+	flags.Int(option.HubbleEventBufferCapacity, observeroption.Default.MaxFlows.AsInt(), "Capacity of Hubble events buffer. The provided value must be on less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535)")
+	option.BindEnv(option.HubbleEventBufferCapacity)
 
 	flags.Int(option.HubbleEventQueueSize, 0, "Buffer size of the channel to receive monitor events.")
 	option.BindEnv(option.HubbleEventQueueSize)

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -26,6 +26,8 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/pkg/crypto/certloader"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/container"
+	"github.com/cilium/cilium/pkg/hubble/math"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/hubble/monitor"
 	"github.com/cilium/cilium/pkg/hubble/observer"
@@ -111,8 +113,15 @@ func (d *Daemon) launchHubble() {
 		logger.WithError(err).Error("Failed to initialize Hubble")
 		return
 	}
+
+	maxFlows, err := getHubbleEventBufferCapacity(logger)
+	if err != nil {
+		logger.WithError(err).Error("Specified capacity for Hubble events buffer is invalid")
+		return
+	}
+
 	d.hubbleObserver, err = observer.NewLocalServer(payloadParser, logger,
-		observeroption.WithMaxFlows(option.Config.HubbleFlowBufferSize),
+		observeroption.WithMaxFlows(maxFlows),
 		observeroption.WithMonitorBuffer(option.Config.HubbleEventQueueSize),
 		observeroption.WithCiliumDaemon(d))
 	if err != nil {
@@ -331,4 +340,25 @@ func (d *Daemon) LookupSecIDByIP(ip net.IP) (id ipcache.Identity, ok bool) {
 // should only be used for reading.
 func (d *Daemon) GetK8sStore(name string) k8scache.Store {
 	return d.k8sWatcher.GetStore(name)
+}
+
+// getHubbleEventBufferCapacity returns the user configured capacity for
+// Hubble's events buffer. The deprecated flag hubble-flow-buffer-size is
+// evaluated if greater than 0, otherwise the new flag
+// hubble-event-buffer-capacity is used instead.
+func getHubbleEventBufferCapacity(logger logrus.FieldLogger) (container.Capacity, error) {
+	// check deprecated old flag for compatibility
+	// TODO: remove support for HubbleFlowBufferSize once 1.11 is out
+	if option.Config.HubbleFlowBufferSize > 0 {
+		logger.Warningf("Option '%s' is deprecated and will be removed in Cilium 1.11", option.HubbleFlowBufferSize)
+		c, err := container.NewCapacity(option.Config.HubbleFlowBufferSize)
+		if err == nil {
+			return c, nil
+		}
+		// old flag behavior was to silently round up the buffer capacity to a
+		// valid value (eg: 1500 -> 2047, 5000 -> 8191, etc) so adjust provided
+		// value to the nearest valid one for compatibility purpose
+		return container.NewCapacity((1<<math.MSB(uint64(option.Config.HubbleFlowBufferSize)) - 1))
+	}
+	return container.NewCapacity(option.Config.HubbleEventBufferCapacity)
 }

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -573,8 +573,12 @@ data:
   hubble-event-queue-size: {{ .Values.hubble.eventQueueSize | quote }}
 {{- end }}
 {{- if hasKey .Values.hubble "flowBufferSize" }}
-  # Size of the buffer to store recent flows.
+  # DEPRECATED: this block should be removed in 1.11
   hubble-flow-buffer-size: {{ .Values.hubble.flowBufferSize | quote }}
+{{- end }}
+{{- if hasKey .Values.hubble "eventBufferCapacity" }}
+  # Capacity of the buffer to store recent events.
+  hubble-event-buffer-capacity: {{ .Values.hubble.eventBufferCapacity | quote }}
 {{- end }}
 {{- if .Values.hubble.metrics.enabled }}
   # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -437,12 +437,15 @@ hubble:
   # Enable Hubble (true by default).
   enabled: true
 
-  # Buffer size of the channel Hubble uses to receive monitor events. If this value is not set,
-  # the queue size is set to the default monitor queue size.
+  # Buffer size of the channel Hubble uses to receive monitor events. If this
+  # value is not set, the queue size is set to the default monitor queue size.
   # eventQueueSize: ""
 
-  # Number of recent flows for Hubble to cache. Defaults to 4096.
-  # flowBufferSize: ""
+  # Number of recent flows for Hubble to cache. Defaults to 4095.
+  # Possible values are:
+  #   1, 3, 7, 15, 31, 63, 127, 255, 511, 1023,
+  #   2047, 4095, 8191, 16383, 32767, 65535
+  # eventBufferCapacity: "4095"
 
   # Hubble metrics configuration.
   # See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-metrics

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestRingReader_Previous(t *testing.T) {
-	ring := NewRing(15)
+	ring := NewRing(Capacity15)
 	for i := 0; i < 15; i++ {
 		ring.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
 	}
@@ -108,7 +108,7 @@ func TestRingReader_Previous(t *testing.T) {
 }
 
 func TestRingReader_Next(t *testing.T) {
-	ring := NewRing(15)
+	ring := NewRing(Capacity15)
 	for i := 0; i < 15; i++ {
 		ring.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
 	}
@@ -185,7 +185,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
-	ring := NewRing(15)
+	ring := NewRing(Capacity15)
 	for i := 0; i < 15; i++ {
 		ring.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
 	}
@@ -256,7 +256,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 }
 
 func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
-	ring := NewRing(15)
+	ring := NewRing(Capacity15)
 	reader := NewRingReader(ring, ring.LastWriteParallel())
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan *v1.Event)

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -34,7 +34,7 @@ import (
 
 func BenchmarkRingWrite(b *testing.B) {
 	entry := &v1.Event{}
-	s := NewRing(b.N)
+	s := NewRing(capacity(b.N))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -44,7 +44,7 @@ func BenchmarkRingWrite(b *testing.B) {
 
 func BenchmarkRingRead(b *testing.B) {
 	entry := &v1.Event{}
-	s := NewRing(b.N)
+	s := NewRing(capacity(b.N))
 	a := make([]*v1.Event, b.N, b.N)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -524,7 +524,7 @@ func TestRing_LastWrite(t *testing.T) {
 }
 
 func TestRingFunctionalityInParallel(t *testing.T) {
-	r := NewRing(0xf)
+	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}
@@ -569,7 +569,7 @@ func TestRingFunctionalityInParallel(t *testing.T) {
 }
 
 func TestRingFunctionalitySerialized(t *testing.T) {
-	r := NewRing(0xf)
+	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}
@@ -614,7 +614,7 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
-	r := NewRing(0xf)
+	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}
@@ -672,7 +672,8 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
-	r := NewRing(0xf)
+
+	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}
@@ -755,7 +756,7 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
-	r := NewRing(0xf)
+	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
 	}

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -27,6 +27,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser"
@@ -77,7 +78,7 @@ func TestLocalObserverServer_ServerStatus(t *testing.T) {
 	// results in the actual flow capacity of 2.
 
 	pp := noopParser(t)
-	s, err := NewLocalServer(pp, log, observeroption.WithMaxFlows(1))
+	s, err := NewLocalServer(pp, log, observeroption.WithMaxFlows(container.Capacity1))
 	require.NoError(t, err)
 	res, err := s.ServerStatus(context.Background(), &observerpb.ServerStatusRequest{})
 	require.NoError(t, err)
@@ -107,7 +108,7 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 
 	pp := noopParser(t)
 	s, err := NewLocalServer(pp, log,
-		observeroption.WithMaxFlows(numFlows),
+		observeroption.WithMaxFlows(container.Capacity127),
 		observeroption.WithMonitorBuffer(queueSize),
 	)
 	require.NoError(t, err)
@@ -147,7 +148,7 @@ func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
 
 	pp := noopParser(t)
 	s, err := NewLocalServer(pp, log,
-		observeroption.WithMaxFlows(numFlows),
+		observeroption.WithMaxFlows(container.Capacity127),
 		observeroption.WithMonitorBuffer(queueSize),
 	)
 	require.NoError(t, err)
@@ -261,7 +262,7 @@ func TestHooks(t *testing.T) {
 
 	pp := noopParser(t)
 	s, err := NewLocalServer(pp, log,
-		observeroption.WithMaxFlows(numFlows),
+		observeroption.WithMaxFlows(container.Capacity15),
 		observeroption.WithMonitorBuffer(queueSize),
 		observeroption.WithCiliumDaemon(ciliumDaemon),
 		observeroption.WithOnServerInitFunc(onServerInit),
@@ -320,7 +321,7 @@ func TestLocalObserverServer_OnFlowDelivery(t *testing.T) {
 
 	pp := noopParser(t)
 	s, err := NewLocalServer(pp, log,
-		observeroption.WithMaxFlows(numFlows),
+		observeroption.WithMaxFlows(container.Capacity127),
 		observeroption.WithMonitorBuffer(queueSize),
 		observeroption.WithOnFlowDeliveryFunc(onFlowDelivery),
 	)
@@ -383,7 +384,7 @@ func TestLocalObserverServer_OnGetFlows(t *testing.T) {
 
 	pp := noopParser(t)
 	s, err := NewLocalServer(pp, log,
-		observeroption.WithMaxFlows(numFlows),
+		observeroption.WithMaxFlows(container.Capacity127),
 		observeroption.WithMonitorBuffer(queueSize),
 		observeroption.WithOnFlowDeliveryFunc(onFlowDelivery),
 		observeroption.WithOnGetFlowsFunc(onGetFlows),

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -74,9 +74,6 @@ func TestNewLocalServer(t *testing.T) {
 }
 
 func TestLocalObserverServer_ServerStatus(t *testing.T) {
-	// (glibsm): This test is really confusing. `observeroption.WithMaxFlows(1)`
-	// results in the actual flow capacity of 2.
-
 	pp := noopParser(t)
 	s, err := NewLocalServer(pp, log, observeroption.WithMaxFlows(container.Capacity1))
 	require.NoError(t, err)
@@ -84,7 +81,7 @@ func TestLocalObserverServer_ServerStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), res.SeenFlows)
 	assert.Equal(t, uint64(0), res.NumFlows)
-	assert.Equal(t, uint64(2), res.MaxFlows)
+	assert.Equal(t, uint64(1), res.MaxFlows)
 }
 
 func TestLocalObserverServer_GetFlows(t *testing.T) {

--- a/pkg/hubble/observer/observeroption/defaults.go
+++ b/pkg/hubble/observer/observeroption/defaults.go
@@ -14,10 +14,12 @@
 
 package observeroption
 
+import "github.com/cilium/cilium/pkg/hubble/container"
+
 // Default serves only as reference point for default values. Very useful for
 // the CLI to pick these up instead of defining own defaults that need to be
 // kept in sync.
 var Default = Options{
-	MaxFlows:      131071, // 2^17-1
+	MaxFlows:      container.Capacity4095, // 4095
 	MonitorBuffer: 1024,
 }

--- a/pkg/hubble/observer/observeroption/option.go
+++ b/pkg/hubble/observer/observeroption/option.go
@@ -19,6 +19,7 @@ import (
 
 	pb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/filters"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -44,10 +45,8 @@ type Server interface {
 
 // Options stores all the configurations values for the hubble server.
 type Options struct {
-	// Both sizes should really be uint32 but it's better saved for a single
-	// refactor commit.
-	MaxFlows      int // max number of flows that can be stored in the ring buffer
-	MonitorBuffer int // buffer size for monitor payload
+	MaxFlows      container.Capacity // max number of flows that can be stored in the ring buffer
+	MonitorBuffer int                // buffer size for monitor payload
 
 	CiliumDaemon CiliumDaemon // when running inside Cilium, contains a reference to the daemon
 
@@ -142,9 +141,9 @@ func WithMonitorBuffer(size int) Option {
 }
 
 // WithMaxFlows that the ring buffer is initialized to hold.
-func WithMaxFlows(size int) Option {
+func WithMaxFlows(capacity container.Capacity) Option {
 	return func(o *Options) error {
-		o.MaxFlows = size
+		o.MaxFlows = capacity
 		return nil
 	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -806,7 +806,11 @@ const (
 	HubbleTLSClientCAFiles = "hubble-tls-client-ca-files"
 
 	// HubbleFlowBufferSize specifies the maximum number of flows in Hubble's buffer.
+	// Deprecated: please, use HubbleEventBufferCapacity instead.
 	HubbleFlowBufferSize = "hubble-flow-buffer-size"
+
+	// HubbleEventBufferCapacity specifies the capacity of Hubble events buffer.
+	HubbleEventBufferCapacity = "hubble-event-buffer-capacity"
 
 	// HubbleEventQueueSize specifies the buffer size of the channel to receive monitor events.
 	HubbleEventQueueSize = "hubble-event-queue-size"
@@ -1072,6 +1076,7 @@ var HelpFlagSections = []FlagsSection{
 			HubbleTLSKeyFile,
 			HubbleTLSClientCAFiles,
 			HubbleFlowBufferSize,
+			HubbleEventBufferCapacity,
 			HubbleEventQueueSize,
 			HubbleMetricsServer,
 			HubbleMetrics,
@@ -1953,7 +1958,11 @@ type DaemonConfig struct {
 	HubbleTLSClientCAFiles []string
 
 	// HubbleFlowBufferSize specifies the maximum number of flows in Hubble's buffer.
+	// Deprecated: please, use HubbleEventBufferCapacity instead.
 	HubbleFlowBufferSize int
+
+	// HubbleEventBufferCapacity specifies the capacity of Hubble events buffer.
+	HubbleEventBufferCapacity int
 
 	// HubbleEventQueueSize specifies the buffer size of the channel to receive monitor events.
 	HubbleEventQueueSize int
@@ -2726,6 +2735,7 @@ func (c *DaemonConfig) Populate() {
 	c.HubbleTLSKeyFile = viper.GetString(HubbleTLSKeyFile)
 	c.HubbleTLSClientCAFiles = viper.GetStringSlice(HubbleTLSClientCAFiles)
 	c.HubbleFlowBufferSize = viper.GetInt(HubbleFlowBufferSize)
+	c.HubbleEventBufferCapacity = viper.GetInt(HubbleEventBufferCapacity)
 	c.HubbleEventQueueSize = viper.GetInt(HubbleEventQueueSize)
 	if c.HubbleEventQueueSize == 0 {
 		c.HubbleEventQueueSize = getDefaultMonitorQueueSize(runtime.NumCPU())


### PR DESCRIPTION
Hubble's ring buffer effectively only supports a capacity that satisfies `n=2^i -1`.
The flag `hubble-flow-buffer-size` is very forgiving when invalid capacities are specified in that they would be rounded up to the next valid value (for example, when a user specifies a capacity of `1500`, it is effectively adjusted to `2047`).
This results in a ring buffer size that is almost always larger than what a user specifies unless it matches the constraints  `n=2^i -1` which is the only case where the actual ring buffer size would match the user specified size. As valid sizes are power of 2, the difference increases exponentially with regard to the specified size (for example, if a user specifies a size of `5000`, the actual size would end up being `8191`, etc). Note that the default is `4095`, which is a valid value and thus never rounded up.

This PR introduces a new flag, `hubble-event-buffer-capacity`, which replaces the old one. The new flag is more strict in that invalid values are now rejected. For compatibility reasons, the old flag may still be used and retains the old behavior although it is marked as deprecated and set for removal in the next version of Cilium.

This PR also fixes wrongly reported buffer capacity which was always off by one (for an actual capacity of `4095`, a capacity of `4096` was reported). Similarly, the actual reported buffer usage was off by one once the buffer was full, which is also fixed by this PR. In addition, the larger buffer size that can be specified is now `65535` (it was previously unbounded).

For more context around this issue, see issue #11650 and PR #13815 which is set to be closed in favor of this one after some discussions.

Fixes: #11650

```release-note
Fix rounding behavior when specifying a capacity for Hubble's buffer.
```