### PR TITLE
build: don't disable compiler optimizations and inlining on unstripped builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 all: precheck build postcheck
 	@echo "Build finished."
 
+debug: export NOOPT=1
 debug: export NOSTRIP=1
 debug: all
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -145,8 +145,8 @@ endif
 GO_BUILD_FLAGS += -ldflags '$(GO_BUILD_LDFLAGS) $(EXTRA_GO_BUILD_LDFLAGS)' -tags=$(call join-with-comma,$(GO_TAGS_FLAGS)) $(EXTRA_GO_BUILD_FLAGS)
 GO_TEST_FLAGS += -tags=$(call join-with-comma,$(GO_TAGS_FLAGS))
 
-ifeq ($(NOSTRIP),1)
-	GO_BUILD_FLAGS += -gcflags="all=-N -l"
+ifeq ($(NOOPT),1)
+    GO_BUILD_FLAGS += -gcflags="all=-N -l"
 endif
 
 GO_BUILD += $(GO_BUILD_FLAGS)


### PR DESCRIPTION
Commit 3e85bd59dcc8 ("build Add a debug make target") introduced a `make
debug` target which re-used the existing NOSTRIP make var. This lead to
compiler optimizations and inlining being disabled on unstripped builds
(i.e.  production builds but with debug symbols) which lead to
performance penalties, see e.g. #13889.

Fix this by introducing a separate make var to the debug build (i.e.
disabling compiler optimizations and inlining) and using
NOSTRIP solely to disable stripping of debug symbols.

Fixes #13893
Fixes: 3e85bd59dcc8 ("build Add a debug make target")