### PR TITLE
test: Quarantine K8sUpdates on GKE

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -106,7 +106,7 @@ var _ = Describe("K8sUpdates", func() {
 		ExpectAllPodsTerminated(kubectl)
 	})
 
-	It("Tests upgrade and downgrade from a Cilium stable image to master", func() {
+	SkipItIf(helpers.SkipGKEQuarantined, "Tests upgrade and downgrade from a Cilium stable image to master", func() {
 		var assertUpgradeSuccessful func()
 		assertUpgradeSuccessful, cleanupCallback =
 			InstallAndValidateCiliumUpgrades(


### PR DESCRIPTION
GKE builds have been failing since K8sUpdates was unquarantined. Tests running after K8sUpdates appear to be randomly failing, properly due to some improperly cleaned up shared resource. This pull request re-quarantines K8sUpdates on GKE to fix the GKE build while we investigate this.

Related: #13898