### PR TITLE
Services support for external workloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,9 +68,9 @@ test/cilium-istioctl
 # generated test files
 test/k8sT/manifests/cnp-second-namespaces.yaml
 test/cilium.conf.ginkgo
-test/provision/externalworkload-client-ca.crt
-test/provision/externalworkload-client-tls.crt
-test/provision/externalworkload-client-tls.key
+external-workload-ca.crt
+external-workload-tls.crt
+external-workload-tls.key
 
 # GKE temporary files
 test/gke/cluster-name

--- a/contrib/k8s/extract-external-workload-certs.sh
+++ b/contrib/k8s/extract-external-workload-certs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# TLS certs path defaults to the current directory
+TLS_PATH=${TLS_PATH:-.}
+
+echo "Extracting external workload TLS config from Kubernetes secrets in to ${TLS_PATH}"
+kubectl -n kube-system get secret clustermesh-apiserver-ca-cert -o jsonpath="{.data['ca\.crt']}" | base64 --decode >"${TLS_PATH}"/external-workload-ca.crt
+kubectl -n kube-system get secret clustermesh-apiserver-client-cert -o jsonpath="{.data['tls\.crt']}" | base64 --decode >"${TLS_PATH}"/external-workload-tls.crt
+kubectl -n kube-system get secret clustermesh-apiserver-client-cert -o jsonpath="{.data['tls\.key']}" | base64 --decode >"${TLS_PATH}"/external-workload-tls.key

--- a/contrib/k8s/install-external-workload.sh
+++ b/contrib/k8s/install-external-workload.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -e
+set -x
+shopt -s extglob
+
+if [ -z "$CLUSTER_ADDR" ] ; then
+    echo "CLUSTER_ADDR must be defined to the IP:PORT at which the clustermesh-apiserver is reachable."
+    exit 1
+fi
+
+CILIUM_IMAGE=${CILIUM_IMAGE:-cilium/cilium:latest}
+
+# TLS certs path defaults to the current directory
+TLS_PATH=${TLS_PATH:-.}
+
+port='@(6553[0-5]|655[0-2][0-9]|65[0-4][0-9][0-9]|6[0-4][0-9][0-9][0-9]|[1-5][0-9][0-9][0-9][0-9]|[1-9][0-9][0-9][0-9]|[1-9][0-9][0-9]|[1-9][0-9]|[1-9])'
+byte='@(25[0-5]|2[0-4][0-9]|[1][0-9][0-9]|[1-9][0-9]|[0-9])'
+ipv4="$byte\.$byte\.$byte\.$byte"
+
+# Default port is for a HostPort service
+case "$CLUSTER_ADDR" in
+    \[+([0-9a-fA-F:])\]:$port)
+	CLUSTER_PORT=${CLUSTER_ADDR##\[*\]:}
+	CLUSTER_IP=${CLUSTER_ADDR#\[}
+	CLUSTER_IP=${CLUSTER_IP%\]:*}
+	;;
+    [^[]$ipv4:$port)
+	CLUSTER_PORT=${CLUSTER_ADDR##*:}
+	CLUSTER_IP=${CLUSTER_ADDR%:*}
+	;;
+    *:*)
+	echo "Malformed CLUSTER_ADDR: $CLUSTER_ADDR"
+	exit 1
+	;;
+    *)
+	CLUSTER_PORT=32379
+	CLUSTER_IP=$CLUSTER_ADDR
+	;;
+esac
+
+CA_CRT="${TLS_PATH}/external-workload-ca.crt"
+TLS_CRT="${TLS_PATH}/external-workload-tls.crt"
+TLS_KEY="${TLS_PATH}/external-workload-tls.key"
+
+if [[ ! ( -f $CA_CRT && -f $TLS_CRT && -f $TLS_KEY ) ]]; then
+    echo "Client certificates not found. These can be extracted from your Kubernetes"
+    echo "cluster with 'contrib/k8s/extract-external-workload-certs.sh'"
+    exit 1
+fi
+
+sudo mkdir -p /var/lib/cilium/etcd
+sudo cp "$CA_CRT" /var/lib/cilium/etcd/ca.crt
+sudo cp "$TLS_CRT" /var/lib/cilium/etcd/tls.crt
+sudo cp "$TLS_KEY" /var/lib/cilium/etcd/tls.key
+sudo tee /var/lib/cilium/etcd/config.yaml <<EOF >/dev/null
+---
+trusted-ca-file: /var/lib/cilium/etcd/ca.crt
+cert-file: /var/lib/cilium/etcd/tls.crt
+key-file: /var/lib/cilium/etcd/tls.key
+endpoints:
+- https://clustermesh-apiserver.cilium.io:$CLUSTER_PORT
+EOF
+
+CILIUM_OPTS=" --join-cluster --enable-host-reachable-services"
+CILIUM_OPTS+=" --kvstore etcd --kvstore-opt etcd.config=/var/lib/cilium/etcd/config.yaml"
+if [ -n "$HOST_IP" ] ; then
+    CILIUM_OPTS+=" --ipv4-node $HOST_IP"
+fi
+if [ -n "$DEBUG" ] ; then
+    CILIUM_OPTS+=" --debug"
+fi
+
+DOCKER_OPTS=" -d --log-driver syslog --restart always"
+DOCKER_OPTS+=" --privileged --network host --cap-add NET_ADMIN --cap-add SYS_MODULE"
+DOCKER_OPTS+=" --volume /var/lib/cilium/etcd:/var/lib/cilium/etcd"
+DOCKER_OPTS+=" --volume /var/run/cilium:/var/run/cilium"
+DOCKER_OPTS+=" --volume /boot:/boot"
+DOCKER_OPTS+=" --volume /lib/modules:/lib/modules"
+DOCKER_OPTS+=" --volume /sys/fs/bpf:/sys/fs/bpf"
+DOCKER_OPTS+=" --volume /run/xtables.lock:/run/xtables.lock"
+DOCKER_OPTS+=" --add-host clustermesh-apiserver.cilium.io:$CLUSTER_IP"
+
+if [ -n "$(docker ps -a -q -f name=cilium)" ]; then
+    echo "Shutting down running Cilium agent"
+    sudo docker rm -f cilium || true
+fi
+
+echo "Launching Cilium agent..."
+sudo docker run --name cilium $DOCKER_OPTS cilium/cilium:latest cilium-agent $CILIUM_OPTS
+
+# Copy Cilium CLI
+sudo docker cp cilium:/usr/bin/cilium /usr/bin/cilium
+
+# Wait for cilium agent to become available
+cilium_started=false
+for ((i = 0 ; i < 24; i++)); do
+    if cilium status --brief > /dev/null 2>&1; then
+        cilium_started=true
+        break
+    fi
+    sleep 5s
+    echo "Waiting for Cilium daemon to come up..."
+done
+
+if [ "$cilium_started" = true ] ; then
+    echo 'Cilium successfully started!'
+else
+    >&2 echo 'Timeout waiting for Cilium to start.'
+    exit 1
+fi
+
+# Wait for kube-dns service to become available
+kubedns=""
+for ((i = 0 ; i < 24; i++)); do
+    kubedns=$(cilium service list get -o jsonpath='{[?(@.spec.frontend-address.port==53)].spec.frontend-address.ip}')
+    if [ -n "$kubedns" ] ; then
+        break
+    fi
+    sleep 5s
+    echo "Waiting for kube-dns service to come available..."
+done
+
+if [ -n "$kubedns" ] ; then
+    echo "updating /etc/resolv.conf with kube-dns IP $kubedns"
+
+    sudo tee /etc/resolv.conf <<EOF >/dev/null
+nameserver $kubedns
+EOF
+else
+    >&2 echo "kube-dns not found."
+    exit 1
+fi

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -79,6 +79,7 @@ import (
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
+	serviceStore "github.com/cilium/cilium/pkg/service/store"
 	"github.com/cilium/cilium/pkg/sockops"
 	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -605,6 +606,9 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		// This can override node addressing config, so do this before starting IPAM
 		log.WithField(logfields.NodeName, nodeTypes.GetName()).Debug("Calling JoinCluster()")
 		d.nodeDiscovery.JoinCluster(nodeTypes.GetName())
+
+		// Start services watcher
+		serviceStore.JoinClusterServices(&d.k8sWatcher.K8sSvcCache)
 	}
 
 	// Start IPAM

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -31,9 +31,7 @@ EXPERIMENTAL_OPTIONS := \
     --set hubble.relay.enabled=true \
     --set hubble.ui.enabled=true \
     --set localRedirectPolicy=true \
-    --set bandwidthManager=true \
-    --set externalWorkloads.enabled=true \
-    --set clustermesh.apiserver.tls.auto.method="cronJob"
+    --set bandwidthManager=true
 
 DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 	--workdir /src/install/kubernetes \

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -66,6 +66,7 @@ Helm chart for Cilium
 | clustermesh.apiserver.tolerations | list | `[]` |  |
 | clustermesh.apiserver.updateStrategy.rollingUpdate.maxUnavailable | int | `1` |  |
 | clustermesh.apiserver.updateStrategy.type | string | `"RollingUpdate"` |  |
+| clustermesh.useAPIServer | bool | `false` |  |
 | cni.binPath | string | `"/opt/cni/bin"` |  |
 | cni.chainingMode | string | `"none"` |  |
 | cni.confFileMountPath | string | `"/tmp/cni-configuration"` |  |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-admin-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent (not .Values.preflight.enabled) (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) }}
+{{- if and .Values.agent (not .Values.preflight.enabled) (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) }}
 {{- if or (and (.Values.clustermesh.apiserver.tls.auto.enabled) (eq .Values.clustermesh.apiserver.tls.auto.method "helm")) (and .Values.clustermesh.apiserver.tls.admin.cert .Values.clustermesh.apiserver.tls.admin.key) }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-ca-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and  .Values.agent (not .Values.preflight.enabled) (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) }}
+{{- if and  .Values.agent (not .Values.preflight.enabled) (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) }}
 {{- if or (and .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm")) (and .Values.clustermesh.apiserver.tls.ca.cert .Values.clustermesh.apiserver.tls.ca.key) }}
 ---
 apiVersion: v1

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) .Values.serviceAccounts.clustermeshApiserver.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
   - namespaces
   - services
   verbs:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) .Values.serviceAccounts.clustermeshApiserver.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) }}
+{{- if (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-cronjob.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.clustermesh.apiserver.tls.auto.schedule }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.clustermesh.apiserver.tls.auto.schedule }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-job.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-role.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-remote-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent (not .Values.preflight.enabled) (not (eq .Values.cluster.name "default")) }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.clustermesh.useAPIServer }}
 {{- if or (and (.Values.clustermesh.apiserver.tls.auto.enabled) (eq .Values.clustermesh.apiserver.tls.auto.method "helm")) (and .Values.clustermesh.apiserver.tls.remote.cert .Values.clustermesh.apiserver.tls.remote.key) }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent (not .Values.preflight.enabled) (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) }}
+{{- if and .Values.agent (not .Values.preflight.enabled) (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) }}
 {{- if or (and (.Values.clustermesh.apiserver.tls.auto.enabled) (eq .Values.clustermesh.apiserver.tls.auto.method "helm")) (and .Values.clustermesh.apiserver.tls.server.cert .Values.clustermesh.apiserver.tls.server.key) }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-service.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) }}
+{{- if (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled (not (eq .Values.cluster.name "default"))) .Values.serviceAccounts.clustermeshApiserver.create -}}
+{{- if and (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1370,8 +1370,11 @@ enableCriticalPriorityClass: true
 # AArch64 as the images do not currently ship a version of Envoy.
 #disableEnvoyVersionCheck: false
 
-# clustermesh-apiserver is created if externalWorkloads are enabled or if cluster.name != "default".
+# clustermesh-apiserver is created if externalWorkloads are enabled or clustermesh.useAPIServer is not false
 clustermesh:
+  # Deploy clustermesh-apiserver for clustermesh
+  useAPIServer: false
+
   apiserver:
     image:
       repository: quay.io/cilium/clustermesh-apiserver

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -13,20 +13,6 @@ metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-# Source: cilium/templates/clustermesh-apiserver-generate-certs-serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: clustermesh-apiserver-generate-certs
-  namespace: kube-system
----
-# Source: cilium/templates/clustermesh-apiserver-serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: clustermesh-apiserver
-  namespace: kube-system
----
 # Source: cilium/templates/hubble-generate-certs-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -464,49 +450,6 @@ rules:
   - get
   - update
 ---
-# Source: cilium/templates/clustermesh-apiserver-clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: clustermesh-apiserver
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - list
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnodes
-  - ciliumnodes/status
-  - ciliumexternalworkloads
-  - ciliumexternalworkloads/status
-  - ciliumidentities
-  - ciliumidentities/status
-  - ciliumendpoints
-  - ciliumendpoints/status
-  verbs:
-  - '*'
----
 # Source: cilium/templates/hubble-generate-certs-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -639,20 +582,6 @@ subjects:
   name: cilium-operator
   namespace: kube-system
 ---
-# Source: cilium/templates/clustermesh-apiserver-clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: clustermesh-apiserver
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: clustermesh-apiserver
-subjects:
-- kind: ServiceAccount
-  name: clustermesh-apiserver
-  namespace: kube-system
----
 # Source: cilium/templates/hubble-generate-certs-clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -695,55 +624,6 @@ subjects:
   namespace: kube-system
   name: hubble-ui
 ---
-# Source: cilium/templates/clustermesh-apiserver-generate-certs-role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: clustermesh-apiserver-generate-certs
-  namespace: kube-system
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    resourceNames:
-      - clustermesh-apiserver-ca-cert
-    verbs:
-      - get
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    resourceNames:
-      - clustermesh-apiserver-server-cert
-      - clustermesh-apiserver-admin-cert
-      - clustermesh-apiserver-remote-cert
-      - clustermesh-apiserver-client-cert
-    verbs:
-      - update
----
-# Source: cilium/templates/clustermesh-apiserver-generate-certs-rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: clustermesh-apiserver-generate-certs
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: clustermesh-apiserver-generate-certs
-subjects:
-- kind: ServiceAccount
-  name: clustermesh-apiserver-generate-certs
-  namespace: kube-system
----
 # Source: cilium/templates/cilium-agent-service.yaml
 kind: Service
 apiVersion: v1
@@ -765,22 +645,6 @@ spec:
     targetPort: hubble-metrics
   selector:
     k8s-app: cilium
----
-# Source: cilium/templates/clustermesh-apiserver-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: "clustermesh-apiserver"
-  namespace: kube-system
-  labels:
-    k8s-app: clustermesh-apiserver
-spec:
-  type: NodePort
-  selector:
-    k8s-app: clustermesh-apiserver
-  ports:
-  - port: 2379
-    nodePort: 32379
 ---
 # Source: cilium/templates/hubble-relay-service.yaml
 kind: Service
@@ -1174,153 +1038,6 @@ spec:
           name: cilium-config
         name: cilium-config-path
 ---
-# Source: cilium/templates/clustermesh-apiserver-deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: clustermesh-apiserver
-  labels:
-    k8s-app: clustermesh-apiserver
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      k8s-app: clustermesh-apiserver
-  strategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        k8s-app: clustermesh-apiserver
-    spec:
-      restartPolicy: Always
-      serviceAccount: clustermesh-apiserver
-      initContainers:
-      - name: etcd-init
-        image: quay.io/coreos/etcd:v3.4.13
-        imagePullPolicy: Always
-        env:
-        - name: ETCDCTL_API
-          value: "3"
-        - name: HOSTNAME_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        command: ["/bin/sh", "-c"]
-        args:
-        - >
-          rm -rf /var/run/etcd/*;
-          export ETCDCTL_API=3;
-          /usr/local/bin/etcd --data-dir=/var/run/etcd --name=clustermesh-apiserver --listen-client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster-token=clustermesh-apiserver --initial-cluster-state=new --auto-compaction-retention=1 &
-          export rootpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
-          echo $rootpw | etcdctl --interactive=false user add root;
-          etcdctl user grant-role root root;
-          export vmpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
-          echo $vmpw | etcdctl --interactive=false user add externalworkload;
-          etcdctl role add externalworkload;
-          etcdctl role grant-permission externalworkload --from-key read '';
-          etcdctl role grant-permission externalworkload readwrite --prefix cilium/state/noderegister/v1/;
-          etcdctl role grant-permission externalworkload readwrite --prefix cilium/.initlock/;
-          etcdctl user grant-role externalworkload externalworkload;
-          export remotepw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
-          echo $remotepw | etcdctl --interactive=false user add remote;
-          etcdctl role add remote;
-          etcdctl role grant-permission remote --from-key read '';
-          etcdctl user grant-role remote remote;
-          etcdctl auth enable;
-          exit
-        volumeMounts:
-        - mountPath: /var/run/etcd
-          name: etcd-data-dir
-      containers:
-      - name: etcd
-        image: quay.io/coreos/etcd:v3.4.13
-        imagePullPolicy: Always
-        env:
-        - name: ETCDCTL_API
-          value: "3"
-        - name: HOSTNAME_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        command:
-          - /usr/local/bin/etcd
-        args:
-          - --data-dir=/var/run/etcd
-          - --name=clustermesh-apiserver
-          - --client-cert-auth
-          - --trusted-ca-file=/var/lib/etcd-secrets/ca.crt
-          - --cert-file=/var/lib/etcd-secrets/tls.crt
-          - --key-file=/var/lib/etcd-secrets/tls.key
-          - --listen-client-urls=https://127.0.0.1:2379,https://$(HOSTNAME_IP):2379
-          - --advertise-client-urls=https://$(HOSTNAME_IP):2379
-          - --initial-cluster-token=clustermesh-apiserver
-          - --auto-compaction-retention=1
-        volumeMounts:
-        - mountPath: /var/lib/etcd-secrets
-          name: etcd-server-secrets
-          readOnly: true
-        - mountPath: /var/run/etcd
-          name: etcd-data-dir
-      - name: "apiserver"
-        image: quay.io/cilium/clustermesh-apiserver:latest
-        imagePullPolicy: Always
-        command:
-          - /usr/bin/clustermesh-apiserver
-        args:
-          - --cluster-name=$(CLUSTER_NAME)
-          - --kvstore-opt
-          - etcd.config=/var/lib/cilium/etcd-config.yaml
-        env:
-        - name: CLUSTER_NAME
-          valueFrom:
-            configMapKeyRef:
-              key: cluster-name
-              name: cilium-config
-        - name: CLUSTER_ID
-          valueFrom:
-            configMapKeyRef:
-              key: cluster-id
-              name: cilium-config
-              optional: true
-        - name: IDENTITY_ALLOCATION_MODE
-          valueFrom:
-            configMapKeyRef:
-              key: identity-allocation-mode
-              name: cilium-config
-        volumeMounts:
-        - mountPath: /var/lib/cilium/etcd-secrets
-          name: etcd-admin-client
-          readOnly: true
-      volumes:
-      - name: etcd-server-secrets
-        projected:
-          defaultMode: 0420
-          sources:
-          - secret:
-              name: clustermesh-apiserver-ca-cert
-              items:
-              - key: ca.crt
-                path: ca.crt
-          - secret:
-              name: clustermesh-apiserver-server-cert
-      - name: etcd-admin-client
-        projected:
-          defaultMode: 0420
-          sources:
-          - secret:
-              name: clustermesh-apiserver-ca-cert
-              items:
-              - key: ca.crt
-                path: ca.crt
-          - secret:
-              name: clustermesh-apiserver-admin-cert
-      - name: etcd-data-dir
-        emptyDir: {}
----
 # Source: cilium/templates/hubble-relay-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -1480,40 +1197,6 @@ spec:
         - name: hubble-ui-envoy-yaml
           configMap:
             name: hubble-ui-envoy
----
-# Source: cilium/templates/clustermesh-apiserver-generate-certs-job.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: clustermesh-apiserver-generate-certs
-  namespace: kube-system
-  labels:
-    k8s-app: clustermesh-apiserver-generate-certs
-spec:
-  template:
-    metadata:
-      labels:
-        k8s-app: clustermesh-apiserver-generate-certs
-    spec:
-      serviceAccount: clustermesh-apiserver-generate-certs
-      serviceAccountName: clustermesh-apiserver-generate-certs
-      containers:
-        - name: certgen
-          image: quay.io/cilium/certgen:v0.1.3@sha256:460fdcbabfa08b435dbee455e88add1ec54761ca2693e1d9885408ff55ed7f8e
-          imagePullPolicy: Always
-          command:
-            - "/usr/bin/cilium-certgen"
-          args:
-            - "--cilium-namespace=kube-system"
-            - "--clustermesh-apiserver-ca-cert-reuse-secret"
-            - "--clustermesh-apiserver-ca-cert-generate"
-            - "--clustermesh-apiserver-server-cert-generate"
-            - "--clustermesh-apiserver-admin-cert-generate"
-            - "--clustermesh-apiserver-client-cert-generate"
-            - "--clustermesh-apiserver-remote-cert-generate"
-      hostNetwork: true
-      restartPolicy: OnFailure
-  ttlSecondsAfterFinished: 1800
 ---
 # Source: cilium/templates/hubble-generate-certs-job.yaml
 apiVersion: batch/v1

--- a/operator/main.go
+++ b/operator/main.go
@@ -340,7 +340,7 @@ func onOperatorStartLeading(ctx context.Context) {
 
 	if kvstoreEnabled() {
 		if operatorOption.Config.SyncK8sServices {
-			operatorWatchers.StartSynchronizingServices()
+			operatorWatchers.StartSynchronizingServices(true)
 		}
 
 		var goopts *kvstore.ExtraOptions

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -48,6 +48,7 @@ var (
 	// k8s.
 	k8sSvcCacheSynced = make(chan struct{})
 	kvs               *store.SharedStore
+	sharedOnly        bool
 )
 
 func k8sServiceHandler() {
@@ -66,7 +67,7 @@ func k8sServiceHandler() {
 			"shared":               event.Service.Shared,
 		}).Debug("Kubernetes service definition changed")
 
-		if !event.Service.Shared {
+		if sharedOnly && !event.Service.Shared {
 			// The annotation may have been added, delete an eventual existing service
 			kvs.DeleteLocalKey(context.TODO(), &svc)
 			return
@@ -91,8 +92,12 @@ func k8sServiceHandler() {
 }
 
 // StartSynchronizingServices starts a controller for synchronizing services from k8s to kvstore
-func StartSynchronizingServices() {
+// 'shared' specifies whether only shared services are synchronized. If 'false' then all services
+// will be synchronized. For clustermesh we only need to synchronize shared services, while for
+// VM support we need to sync all the services.
+func StartSynchronizingServices(shared bool) {
 	log.Info("Starting to synchronize k8s services to kvstore...")
+	sharedOnly = shared
 
 	serviceOptsModifier, err := utils.GetServiceListOptionsModifier()
 	if err != nil {

--- a/operator/watchers/logfields.go
+++ b/operator/watchers/logfields.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchers
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "watchers")

--- a/pkg/service/store/logfields.go
+++ b/pkg/service/store/logfields.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "service")

--- a/test/provision/externalworkload_extract_k8s_certs.sh
+++ b/test/provision/externalworkload_extract_k8s_certs.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-
-echo "Extracting VM TLS config from Kubernetes secrets"
-kubectl -n kube-system get secret clustermesh-apiserver-ca-cert -o jsonpath="{.data['ca\.crt']}" | base64 --decode >${DIR}/externalworkload-client-ca.crt
-kubectl -n kube-system get secret clustermesh-apiserver-client-cert -o jsonpath="{.data['tls\.crt']}" | base64 --decode >${DIR}/externalworkload-client-tls.crt
-kubectl -n kube-system get secret clustermesh-apiserver-client-cert -o jsonpath="{.data['tls\.key']}" | base64 --decode >${DIR}/externalworkload-client-tls.key

--- a/test/provision/externalworkload_install.sh
+++ b/test/provision/externalworkload_install.sh
@@ -1,61 +1,9 @@
 #!/bin/bash
 set -e
-set -x
 
-# IP address at which the clustermesh-apiserver service is reachable at
-# Default to the address of k8s1
-CLUSTER_IP=${CLUSTER_IP:-"192.168.36.11"}
-
-# IP address of the VM itself. This is needed due to avoid Cilium selecting the "10.0.2.15"
-# each vagrant VM has as the first address. Default to the address of the runtime VM
-VM_IP=${VM_IP:-"192.168.36.10"}
-
-PROVISIONSRC="/tmp/provision"
-
-CA_CRT="${PROVISIONSRC}/externalworkload-client-ca.crt"
-TLS_CRT="${PROVISIONSRC}/externalworkload-client-tls.crt"
-TLS_KEY="${PROVISIONSRC}/externalworkload-client-tls.key"
-
-if [[ ! ( -f $CA_CRT && -f $TLS_CRT && -f $TLS_KEY ) ]]; then
-    echo "Client certificates not found. These can be extracted from your Kubernetes"
-    echo "cluster with 'test/provision/externalworkload_extract_k8s_certs.sh'"
-    exit 1
-fi
-
-sudo mkdir -p /var/lib/cilium/etcd
-sudo cp $CA_CRT /var/lib/cilium/etcd/ca.crt
-sudo cp $TLS_CRT /var/lib/cilium/etcd/tls.crt
-sudo cp $TLS_KEY /var/lib/cilium/etcd/tls.key
-sudo tee /var/lib/cilium/etcd/config.yaml <<EOF
----
-trusted-ca-file: /var/lib/cilium/etcd/ca.crt
-cert-file: /var/lib/cilium/etcd/tls.crt
-key-file: /var/lib/cilium/etcd/tls.key
-endpoints:
-- https://clustermesh-apiserver.cilium.io:32379
-EOF
-
-CILIUM_OPTS=" --debug --ipv4-node $VM_IP"
-CILIUM_OPTS+=" --join-cluster"
-CILIUM_OPTS+=" --kvstore etcd --kvstore-opt etcd.config=/var/lib/cilium/etcd/config.yaml"
+cd /home/vagrant/go/src/github.com/cilium/cilium
 
 # Build docker image
-DOCKER_BUILDKIT=1 make -C /home/vagrant/go/src/github.com/cilium/cilium dev-docker-image
+DOCKER_BUILDKIT=1 make docker-cilium-image
 
-# Etcd TLS config needs hostname IP mapping
-CLUSTER_HOST="clustermesh-apiserver.cilium.io:$CLUSTER_IP"
-
-DOCKER_OPTS=" -d --log-driver syslog --restart always"
-DOCKER_OPTS+=" --privileged --network host --cap-add NET_ADMIN --cap-add SYS_MODULE"
-DOCKER_OPTS+=" --volume /var/lib/cilium/etcd:/var/lib/cilium/etcd"
-DOCKER_OPTS+=" --volume /var/run/cilium:/var/run/cilium"
-DOCKER_OPTS+=" --volume /boot:/boot"
-DOCKER_OPTS+=" --volume /lib/modules:/lib/modules"
-DOCKER_OPTS+=" --volume /sys/fs/bpf:/sys/fs/bpf"
-DOCKER_OPTS+=" --volume /run/xtables.lock:/run/xtables.lock"
-DOCKER_OPTS+=" --add-host $CLUSTER_HOST"
-
-sudo docker run --name cilium $DOCKER_OPTS cilium/cilium-dev:latest cilium-agent $CILIUM_OPTS
-
-# Copy Cilium CLI
-sudo docker cp cilium:/usr/bin/cilium /usr/bin/cilium
+CLUSTER_ADDR=192.168.36.11:32379 HOST_IP=192.168.36.10 CILIUM_IMAGE=cilium/cilium:latest contrib/k8s/install-external-workload.sh

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -15,8 +15,7 @@ sudo systemctl restart ssh
 
 if [[ "${PROVISION_EXTERNAL_WORKLOAD}" == "false" ]]; then
     "${PROVISIONSRC}"/compile.sh
+    "${PROVISIONSRC}"/wait-cilium.sh
 else
     "${PROVISIONSRC}"/externalworkload_install.sh
 fi
-
-"${PROVISIONSRC}"/wait-cilium.sh


### PR DESCRIPTION
Refactor operator's services watcher to be usable also from `clustermesh-apiserver`. Make Cilium agent sync services from kvstore in `join-cluster` mode. Use `cilium service` to locate `kube-dns` and overwrite VM's `/etc/resolv.conf` with it.

None of this should affect any other functionality, so this should be safe to merge.

In `pkg/k8s/service_cache.go`, function `correlateEndpoints()` a check for `option.Config.ClusterName` is removed. This is required as cluster services synced from the k8s cluster will have the same cluster name as the external endpoint has, as it is conceptually in the same cluster as the k8s cluster it joined. Clustermesh call paths have the same check so it is still not possible for a clustermesh to re-introduce backends for it's own cluster via external endpoints.

'experimental-install.yaml' is changed to not configure support for external workloads, so an explicit helm option is required. Also, a new helm value `clustermesh.useAPIServer` is added and `clustermesh-apiserver` is only deployed if that or `externalWorkloads.enabled` is `true`, both default to `false`. This avoids surprising existing users of clustermesh with a new deployment.

Scripts are added to `contrib/k8s` to extract TLS certs as well as to install Cilium agent onto a VM with docker. Service access requires `--enable-host-reachable-services`, which does not work on older kernels. We could soften this requirement by not requiring that service access from VM is usable. Currently kube-dns is accessed via it's ClusterIP service, though.

TODO:
- [ ] CI test(s)
- [x] GSG

For later PRs:
- [ ] Handle headless services (== no frontends)
- [ ] test with IPv6 instead of IPv4
- [ ] test with direct routing modes, remove the need for IPAM setup in this case
- [ ] check if tunneling can be done without any IPAM (i.e., w/o creating `cilium_host` device)
- [ ] pass policy from cluster to the VMs
- [ ] enforce policy in VMs

Fixes: #13666

Test setup consists of two VMs, one running with k8s (`k8s1`), one running without k8s (`runtime`). Setup steps:

1. `cd cilium/test`
2. Start `k8s1`:
`VM_CPUS=6 VM_MEMORY=5120 K8S_NODES=1 ./vagrant-local-start.sh`
 - This may take a long time for the 1st run, as a vagrant box is packaged (into `test/.vagrant/k8s-box-package.box`). Subsequent runs will be faster. This packaging removes the need to pull test images for later runs of `./vagrant-local-start.sh`.
3. `vagrant ssh k8s1-1.19`
4. `cd ~/go/src/github.com/cilium/cilium`
5. `DOCKER_BUILDKIT=1 make docker-cilium-image docker-operator-generic-image docker-clustermesh-apiserver-image`
6. `helm install cilium install/kubernetes/cilium --namespace kube-system --set externalWorkloads.enabled=true --set image.pullPolicy=IfNotPresent --set operator.image.pullPolicy=IfNotPresent --set preflight.image.pullPolicy=IfNotPresent --set clustermesh.apiserver.image.pullPolicy=IfNotPresent --set debug.enabled=true`
7. Apply the CiliumExternalWorkload CRD for VM named `runtime`: `kubectl apply -f clustermesh-apiserver/test/runtime.yaml`
8. Extract the TLS client keys to be used by the VM that is started up in the next step:
`contrib/k8s/extract-external-workload-certs.sh`
9. In another terminal, change to `test` directory in your Cilium repo and start the `runtime` VM:
`PROVISION_EXTERNAL_WORKLOAD=1 PRELOAD_VM=false KERNEL=419 VM_CPUS=6 VM_MEMORY=4096 ./vagrant-local-start-runtime.sh`
10. `vagrant ssh runtime`
11. Check that etcd has connected successfully, observe the first line of:
`cilium status`
You should see something like:
`etcd: 1/1 connected, lease-ID=7c02748328e75f57, lock lease-ID=7c02748328e75f59, has-quorum=true: 192.168.36.11:32379 - 3.4.13 (Leader)`
12. Check that cluster DNS works: `nslookup clustermesh-apiserver.kube-system.svc.cluster.local`
13. Ping the backend IP of `clustermesh-apiserver` service:
`ping $(cilium service list get -o jsonpath='{[?(@.spec.flags.name=="clustermesh-apiserver")].spec.backend-addresses[0].ip}')`
14. The ping should keep running also when the following CCNP is applied in `k8s1` (e.g., `kubectl apply -n kube-system -f clustermesh-apiserver/test/testccnp.yaml`):
```
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: test-ccnp
  namespace: kube-system
spec:
  endpointSelector:
    matchLabels:
      k8s-app: clustermesh-apiserver
  ingress:
  - fromEndpoints:
    - matchLabels:
        io.kubernetes.pod.name: runtime
  - toPorts:
    - ports:
      - port: "2379"
        protocol: TCP
```
15. The ping should stop if you delete these lines from the policy and re-apply:
```
  - fromEndpoints:
    - matchLabels:
        io.kubernetes.pod.name: runtime
```
16. `kubectl get cep` should show an entry for `runtime` with `IDENTITY ID` and `IPV4` set.
17. `kubectl get cew` should show an entry for `runtime` with matching `CILIUM ID` and `IP`.
