### PR TITLE
[1.9] Disable checkpatch github action on release branch

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -7,16 +7,6 @@ on:
       - master
 
 jobs:
-  checkpatch:
-    name: checkpatch
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Run checkpatch.pl
-        uses: docker://cilium/cilium-checkpatch:5b099019bf0db775b33b3f32cd5ecea55dd15f21
   coccicheck:
     name: coccicheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
checkpatch consistent fails on backport PRs due to the formatting of the
upstream commit, see e.g. [1]. Since we expect changes to go through
master first where checkpatch is run and need to pass before merge,
disable the check on the 1.9 release branch.

[1] https://github.com/cilium/cilium/pull/13903/checks?check_run_id=1357642875