### PR TITLE
docs: ipam - update Azure Private IP link

### DIFF
--- a/Documentation/concepts/networking/ipam/azure.rst
+++ b/Documentation/concepts/networking/ipam/azure.rst
@@ -12,7 +12,7 @@ Azure IPAM (beta)
 
 The Azure IPAM allocator is specific to Cilium deployments running in the Azure
 cloud and performs IP allocation based on `Azure Private IP addresses
-<https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm#private-ip-addresses>`__.
+<https://docs.microsoft.com/en-us/azure/virtual-network/private-ip-addresses>`__.
 
 The architecture ensures that only a single operator communicates with the
 Azure API to avoid rate-limiting issues in large clusters. A pre-allocation


### PR DESCRIPTION
This was split off into its own page, the old link just points to the 'public IP addresses' page now.

```release-note
Updated the link to Azure Private IP documentation, which was split off into a page of its own.
```
