### PR TITLE
operator: increase GC Rate limit of identities to 2500 per minute

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -41,7 +41,7 @@ cilium-operator-aws [flags]
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                               Backend to use for IPAM (default "eni")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -42,7 +42,7 @@ cilium-operator-azure [flags]
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                               Backend to use for IPAM (default "azure")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -37,7 +37,7 @@ cilium-operator-generic [flags]
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -46,7 +46,7 @@ cilium-operator [flags]
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -210,7 +210,7 @@ func init() {
 		"Interval used for rate limiting the GC of security identities")
 	option.BindEnv(operatorOption.IdentityGCRateInterval)
 
-	flags.Int(operatorOption.IdentityGCRateLimit, 250,
+	flags.Int(operatorOption.IdentityGCRateLimit, 2500,
 		fmt.Sprintf("Maximum number of security identities that will be deleted within the %s", operatorOption.IdentityGCRateInterval))
 	option.BindEnv(operatorOption.IdentityGCRateLimit)
 


### PR DESCRIPTION
In cluster that have some high churn of pods being created and deleted
with different security identities, garbage collecting 250 identities
per minute might not be sufficient. Thus, we are increasing the default
limit to 2500 identities per minute.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/13816

```release-note
Increment the default value of maximum garbage collected security identities from 250 to 2500 per minute
```