### PR TITLE
add missing '| quote' for disableEnvoyVersionCheck

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -76,7 +76,7 @@ data:
 {{- end }}
 
 {{- if hasKey .Values "disableEnvoyVersionCheck" }}
-  disable-envoy-version-check: {{ .Values.disableEnvoyVersionCheck }}
+  disable-envoy-version-check: {{ .Values.disableEnvoyVersionCheck | quote }}
 {{- end }}
 
   # Identity allocation mode selects how identities are shared between cilium


### PR DESCRIPTION
Add's missing `| quote` to the disableEnvoryVersionCheck parameter. The rendered configMap requires quotes around boolean values.
