### PR TITLE
bpf: datapath: Rewite base devices setup in Go

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -17,14 +17,25 @@ package loader
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/vishvananda/netlink"
 )
 
+type baseDeviceMode string
+
 const (
+	flannelMode = baseDeviceMode("flannel")
+	ipvlanMode  = baseDeviceMode("ipvlan")
+	directMode  = baseDeviceMode("direct")
+
 	libbpfFixupMsg = "struct bpf_elf_map fixup performed due to size mismatch!"
 )
 
@@ -150,4 +161,165 @@ func RemoveTCFilters(ifName string, tcDir uint32) error {
 	}
 
 	return nil
+}
+
+func setupDev(link netlink.Link) error {
+	ifName := link.Attrs().Name
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		log.WithError(err).WithField("device", ifName).Warn("Could not set up the link")
+		return err
+	}
+
+	sysSettings := make([]sysctl.Setting, 0, 5)
+	if option.Config.EnableIPv6 {
+		sysSettings = append(sysSettings, sysctl.Setting{
+			Name: fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName), Val: "1", IgnoreErr: false})
+	}
+	if option.Config.EnableIPv4 {
+		sysSettings = append(sysSettings, []sysctl.Setting{
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.forwarding", ifName), Val: "1", IgnoreErr: false},
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName), Val: "0", IgnoreErr: false},
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.accept_local", ifName), Val: "1", IgnoreErr: false},
+			{Name: fmt.Sprintf("net.ipv4.conf.%s.send_redirects", ifName), Val: "0", IgnoreErr: false},
+		}...)
+	}
+	if err := sysctl.ApplySettings(sysSettings); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupDevs(links ...netlink.Link) error {
+	for _, link := range links {
+		if err := setupDev(link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setupVethPair(name, peerName string) error {
+	// Create the veth pair if it doesn't exist.
+	if _, err := netlink.LinkByName(name); err != nil {
+		hostMac, err := mac.GenerateRandMAC()
+		if err != nil {
+			return err
+		}
+		peerMac, err := mac.GenerateRandMAC()
+		if err != nil {
+			return err
+		}
+
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         name,
+				HardwareAddr: net.HardwareAddr(hostMac),
+			},
+			PeerName:         peerName,
+			PeerHardwareAddr: net.HardwareAddr(peerMac),
+		}
+		if err := netlink.LinkAdd(veth); err != nil {
+			return err
+		}
+	}
+
+	veth, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	if err := setupDev(veth); err != nil {
+		return err
+	}
+	peer, err := netlink.LinkByName(peerName)
+	if err != nil {
+		return err
+	}
+	if err := setupDev(peer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupIpvlan(name string, nativeLink netlink.Link) (*netlink.IPVlan, error) {
+	hostLink, err := netlink.LinkByName(name)
+	if err == nil {
+		// Ignore the error.
+		netlink.LinkDel(hostLink)
+	}
+
+	ipvlan := &netlink.IPVlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        name,
+			ParentIndex: nativeLink.Attrs().Index,
+		},
+		Mode: netlink.IPVLAN_MODE_L3,
+	}
+	if err := netlink.LinkAdd(ipvlan); err != nil {
+		return nil, err
+	}
+
+	if err := setupDev(ipvlan); err != nil {
+		return nil, err
+	}
+
+	return ipvlan, nil
+}
+
+// setupBaseDevice decides which and what kind of interfaces should be set up as
+// the first step of datapath initialization, then performs the setup (and
+// creation, if needed) of those interfaces. It returns two links and an error.
+// By default, it sets up the veth pair - cilium_host and cilium_net.
+// In flannel mode, it sets up the native interface used by flannel.
+// In ipvlan mode, it creates the cilium_host ipvlan with the native device as a
+// parent.
+func setupBaseDevice(nativeDevs []netlink.Link, mode baseDeviceMode, mtu int) (netlink.Link, netlink.Link, error) {
+	switch mode {
+	case flannelMode:
+		if err := setupDevs(nativeDevs...); err != nil {
+			return nil, nil, err
+		}
+		return nativeDevs[0], nativeDevs[0], nil
+	case ipvlanMode:
+		ipvlan, err := setupIpvlan(defaults.HostDevice, nativeDevs[0])
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := netlink.LinkSetMTU(ipvlan, mtu); err != nil {
+			return nil, nil, err
+		}
+
+		return ipvlan, ipvlan, nil
+	default:
+		if err := setupVethPair(defaults.HostDevice, defaults.SecondHostDevice); err != nil {
+			return nil, nil, err
+		}
+
+		linkHost, err := netlink.LinkByName(defaults.HostDevice)
+		if err != nil {
+			return nil, nil, err
+		}
+		linkNet, err := netlink.LinkByName(defaults.SecondHostDevice)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if err := netlink.LinkSetARPOff(linkHost); err != nil {
+			return nil, nil, err
+		}
+		if err := netlink.LinkSetARPOff(linkNet); err != nil {
+			return nil, nil, err
+		}
+
+		if err := netlink.LinkSetMTU(linkHost, mtu); err != nil {
+			return nil, nil, err
+		}
+		if err := netlink.LinkSetMTU(linkNet, mtu); err != nil {
+			return nil, nil, err
+		}
+
+		return linkHost, linkNet, nil
+	}
 }

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package loader
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
+
+	"github.com/vishvananda/netlink"
+	. "gopkg.in/check.v1"
+)
+
+type NetlinkTestSuite struct {
+	prevConfigEnableIPv4 bool
+	prevConfigEnableIPv6 bool
+}
+
+var _ = Suite(&NetlinkTestSuite{})
+
+func (s *NetlinkTestSuite) SetUpSuite(c *C) {
+	s.prevConfigEnableIPv4 = option.Config.EnableIPv4
+	s.prevConfigEnableIPv6 = option.Config.EnableIPv6
+
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = true
+}
+
+func (s *NetlinkTestSuite) TearDownSuite(c *C) {
+	option.Config.EnableIPv4 = s.prevConfigEnableIPv4
+	option.Config.EnableIPv6 = s.prevConfigEnableIPv6
+}
+
+func (s *NetlinkTestSuite) TestSetupDev(c *C) {
+	ifName := "dummy9"
+
+	dummy := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: ifName,
+		},
+	}
+	err := netlink.LinkAdd(dummy)
+	c.Assert(err, IsNil)
+
+	err = setupDev(dummy)
+	c.Assert(err, IsNil)
+
+	enabledSettings := []string{
+		fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName),
+		fmt.Sprintf("net.ipv4.conf.%s.forwarding", ifName),
+		fmt.Sprintf("net.ipv4.conf.%s.accept_local", ifName),
+	}
+	disabledSettings := []string{
+		fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName),
+		fmt.Sprintf("net.ipv4.conf.%s.send_redirects", ifName),
+	}
+	for _, setting := range enabledSettings {
+		s, err := sysctl.Read(setting)
+		c.Assert(err, IsNil)
+		c.Assert(s, Equals, "1")
+	}
+	for _, setting := range disabledSettings {
+		s, err := sysctl.Read(setting)
+		c.Assert(err, IsNil)
+		c.Assert(s, Equals, "0")
+	}
+
+	err = netlink.LinkDel(dummy)
+	c.Assert(err, IsNil)
+}

--- a/pkg/sysctl/sysctl_linux_privileged_test.go
+++ b/pkg/sysctl/sysctl_linux_privileged_test.go
@@ -115,3 +115,69 @@ func (s *SysctlLinuxPrivilegedTestSuite) TestDisableEnable(c *C) {
 		}
 	}
 }
+
+func (s *SysctlLinuxPrivilegedTestSuite) TestApplySettings(c *C) {
+	testCases := []struct {
+		settings    []Setting
+		expectedErr bool
+	}{
+		{
+			settings: []Setting{
+				{
+					Name:      "net.ipv4.ip_forward",
+					Val:       "1",
+					IgnoreErr: false,
+				},
+				{
+					Name:      "net.ipv4.conf.all.forwarding",
+					Val:       "1",
+					IgnoreErr: false,
+				},
+				{
+					Name:      "net.ipv6.conf.all.forwarding",
+					Val:       "1",
+					IgnoreErr: false,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			settings: []Setting{
+				{
+					Name:      "net.ipv4.ip_forward",
+					Val:       "1",
+					IgnoreErr: false,
+				},
+				{
+					Name:      "foo.bar",
+					Val:       "1",
+					IgnoreErr: false,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			settings: []Setting{
+				{
+					Name:      "net.ipv4.ip_forward",
+					Val:       "1",
+					IgnoreErr: false,
+				},
+				{
+					Name:      "foo.bar",
+					Val:       "1",
+					IgnoreErr: true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		err := ApplySettings(tc.settings)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}


### PR DESCRIPTION
This change removes the part of init.sh responsible for base devices
setup and remplements it in Go.

Ref: #920

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>