### PR TITLE
ipam/allocator: Fix nil check on node CIDR

### DIFF
--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -173,6 +173,7 @@ type NodesPodCIDRManager struct {
 
 type CIDRAllocator interface {
 	fmt.Stringer
+
 	Occupy(cidr *net.IPNet) error
 	AllocateNext() (*net.IPNet, error)
 	Release(cidr *net.IPNet) error
@@ -866,20 +867,21 @@ func (n *NodesPodCIDRManager) allocateNext(nodeName string) (*nodeCIDRs, bool, e
 }
 
 func getCIDRAllocatorsInfo(cidrAllocators []CIDRAllocator, netTypes string) string {
-	var cidrAllocatorsInfo bytes.Buffer
-	cidrAllocatorsLength := len(cidrAllocators)
-	if cidrAllocatorsLength == 0 {
+	var buf bytes.Buffer
+
+	length := len(cidrAllocators)
+	if length == 0 {
 		return "[]"
 	}
 
 	for index, cidrAllocator := range cidrAllocators {
-		cidrAllocatorsInfo.WriteString(fmt.Sprintf("%s", cidrAllocator.String()))
-		if index < cidrAllocatorsLength-1 {
-			cidrAllocatorsInfo.WriteString(fmt.Sprintf(", "))
+		buf.WriteString(fmt.Sprintf("%s", cidrAllocator.String()))
+		if index < length-1 {
+			buf.WriteString(", ")
 		}
 	}
 
-	return fmt.Sprintf("[%s]", cidrAllocatorsInfo.String())
+	return fmt.Sprintf("[%s]", buf.String())
 }
 
 // allocateFirstFreeCIDR allocates the first CIDR available from the slice of

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -849,9 +849,10 @@ func (n *NodesPodCIDRManager) allocateNext(nodeName string) (*nodeCIDRs, bool, e
 		}
 	}()
 
-	var v4CIDR, v6CIDR *net.IPNet
-
-	nCIDRs := &nodeCIDRs{}
+	var (
+		cidrs          nodeCIDRs
+		v4CIDR, v6CIDR *net.IPNet
+	)
 
 	// Only allocate a v4 CIDR if the v4CIDR allocator is available
 	if len(n.v4CIDRAllocators) != 0 {
@@ -859,21 +860,25 @@ func (n *NodesPodCIDRManager) allocateNext(nodeName string) (*nodeCIDRs, bool, e
 		if err != nil {
 			return nil, false, err
 		}
-		revertStack.Push(revertFunc)
+
 		log.WithField("CIDR", v4CIDR).Debug("v4 allocated CIDR")
-		nCIDRs.v4PodCIDRs = []*net.IPNet{v4CIDR}
+		cidrs.v4PodCIDRs = []*net.IPNet{v4CIDR}
+
+		revertStack.Push(revertFunc)
 	}
 	if len(n.v6CIDRAllocators) != 0 {
 		revertFunc, v6CIDR, err = allocateFirstFreeCIDR(n.v6CIDRAllocators)
 		if err != nil {
 			return nil, false, err
 		}
-		revertStack.Push(revertFunc)
+
 		log.WithField("CIDR", v6CIDR).Debug("v6 allocated CIDR")
-		nCIDRs.v6PodCIDRs = []*net.IPNet{v6CIDR}
+		cidrs.v6PodCIDRs = []*net.IPNet{v6CIDR}
+
+		revertStack.Push(revertFunc)
 	}
 
-	if nCIDRs == nil {
+	if cidrs.v4PodCIDRs == nil && cidrs.v6PodCIDRs == nil {
 		return nil, false, ErrNoAllocators{
 			name: nodeName,
 			v4:   getCIDRAllocatorsInfo(n.v4CIDRAllocators, v4AllocatorType),
@@ -881,10 +886,9 @@ func (n *NodesPodCIDRManager) allocateNext(nodeName string) (*nodeCIDRs, bool, e
 		}
 	}
 
-	n.nodes[nodeName] = nCIDRs
+	n.nodes[nodeName] = &cidrs
 
-	return nCIDRs, true, nil
-
+	return &cidrs, true, nil
 }
 
 func getCIDRAllocatorsInfo(cidrAllocators []CIDRAllocator, netTypes string) string {

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -1248,7 +1248,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_allocateNext(c *C) {
 		args          args
 		nodeCIDRs     *nodeCIDRs
 		wantAllocated bool
-		wantErr       bool
+		wantErr       error
 	}{
 		{
 			name: "test-1 - should not allocate anything because the node had previously allocated CIDRs",
@@ -1280,7 +1280,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_allocateNext(c *C) {
 				v6PodCIDRs: mustNewCIDRs("fd00::/80"),
 			},
 			wantAllocated: false,
-			wantErr:       false,
+			wantErr:       nil,
 		},
 		{
 			name: "test-2 - should allocate both CIDRs",
@@ -1338,7 +1338,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_allocateNext(c *C) {
 				v6PodCIDRs: mustNewCIDRs("fd00::/80"),
 			},
 			wantAllocated: true,
-			wantErr:       false,
+			wantErr:       nil,
 		},
 		{
 			name: "test-3 - the v6 allocator is full!",
@@ -1389,7 +1389,25 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_allocateNext(c *C) {
 				nodeName: "node-1",
 			},
 			wantAllocated: false,
-			wantErr:       true,
+			wantErr:       &ErrAllocatorFull{},
+		},
+		{
+			name: "test-4 - no allocators!",
+			testSetup: func() *fields {
+				return &fields{
+					v4ClusterCIDRs: []CIDRAllocator{},
+					nodes:          map[string]*nodeCIDRs{},
+				}
+			},
+			args: args{
+				nodeName: "node-1",
+			},
+			wantAllocated: false,
+			wantErr: ErrNoAllocators{
+				name: "node-1",
+				v4:   "[]",
+				v6:   "[]",
+			},
 		},
 	}
 
@@ -1401,8 +1419,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_allocateNext(c *C) {
 			nodes:            tt.fields.nodes,
 		}
 		nodeCIDRs, gotAllocated, err := n.allocateNext(tt.args.nodeName)
-		gotErr := err != nil
-		c.Assert(gotErr, checker.Equals, tt.wantErr, Commentf("Test Name: %s", tt.name))
+		c.Assert(err, checker.DeepEquals, tt.wantErr, Commentf("Test Name: %s", tt.name))
 		c.Assert(nodeCIDRs, checker.DeepEquals, tt.nodeCIDRs, Commentf("Test Name: %s", tt.name))
 		c.Assert(gotAllocated, checker.Equals, tt.wantAllocated, Commentf("Test Name: %s", tt.name))
 


### PR DESCRIPTION
See commit msgs.

Fixes: ef6ecbdb61 ("add error log When ipam allocate nodecidr failure")
Fixes: https://github.com/cilium/cilium/pull/13299

```release-note
Fix bug in cluster-pool IPAM mode where the user is never alerted of a node CIDR allocation failure
```