### PR TITLE
fqdn: Optimize KeepUniqueNames

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -257,13 +257,12 @@ func (c *DNSCache) cleanupExpiredEntries(expires time.Time) (affectedNames []str
 		if entries, exists := c.forward[name]; exists {
 			affectedNames = append(affectedNames, name)
 			for ip, entry := range c.removeExpired(entries, c.lastCleanup, time.Time{}) {
-				affectedNames = append(affectedNames, name)
 				removed[ip] = append(removed[ip], entry)
 			}
 		}
 	}
 
-	return KeepUniqueNames(affectedNames), removed
+	return affectedNames, removed
 }
 
 // cleanupOverLimitEntries returns the names that has reached the max number of

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -129,18 +129,42 @@ func prepareMatchName(matchName string) string {
 	return strings.ToLower(dns.Fqdn(matchName))
 }
 
-// KeepUniqueNames it gets a array of strings and return a new array of strings
-// with the unique names.
+// KeepUniqueNames removes duplicate names from the given slice while
+// maintaining order. The returned slice re-uses the memory of the
+// input slice.
 func KeepUniqueNames(names []string) []string {
-	result := []string{}
-	entries := map[string]bool{}
-
-	for _, item := range names {
-		if _, ok := entries[item]; ok {
-			continue
+	deleted := 0
+	namesLen := len(names)
+	// Use naive O(n^2) in-place algorithm for shorter slices,
+	// avoiding all memory allocations.  Limit of 48 names has
+	// been experimentally derived. For shorter slices N^2 search
+	// is upto 5 times faster than using a map. At 48 both
+	// implementations are roughly the same speed.  Above 48 the
+	// exponential kicks in and the naive loop becomes slower.
+	if namesLen < 48 {
+	Loop:
+		for i := 0; i < namesLen; i++ {
+			current := i - deleted
+			for j := 0; j < current; j++ {
+				if names[i] == names[j] {
+					deleted++
+					continue Loop
+				}
+			}
+			names[current] = names[i]
 		}
-		entries[item] = true
-		result = append(result, item)
+	} else {
+		// Use map
+		entries := make(map[string]struct{}, namesLen)
+		for i := 0; i < namesLen; i++ {
+			if _, ok := entries[names[i]]; ok {
+				deleted++
+				continue
+			}
+			entries[names[i]] = struct{}{}
+			names[i-deleted] = names[i]
+		}
 	}
-	return result
+	// truncate slice to leave off the duplicates
+	return names[:namesLen-deleted]
 }

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -17,6 +17,8 @@
 package fqdn
 
 import (
+	"fmt"
+	"math/rand"
 	"net"
 	"time"
 
@@ -41,19 +43,53 @@ var (
 )
 
 func (ds *DNSCacheTestSuite) TestKeepUniqueNames(c *C) {
+	r := rand.New(rand.NewSource(99))
+
+	data := make([]string, 48)
+	uniq := []string{}
+	for i := 0; i < len(data); i++ {
+		rnd := r.Float64()
+		// Duplicate name with 10% probability
+		if i > 0 && rnd < 0.1 {
+			data[i] = data[int(float64(i-1)*r.Float64())]
+		} else {
+			data[i] = fmt.Sprintf("a%d.domain.com", i)
+			uniq = append(uniq, data[i])
+		}
+	}
+
 	testData := []struct {
 		argument []string
 		expected []string
 	}{
+		{[]string{"a"}, []string{"a"}},
+		{[]string{"a", "a"}, []string{"a"}},
+		{[]string{"a", "b"}, []string{"a", "b"}},
+		{[]string{"a", "b", "b"}, []string{"a", "b"}},
 		{[]string{"a", "b", "c"}, []string{"a", "b", "c"}},
 		{[]string{"a", "b", "a", "c"}, []string{"a", "b", "c"}},
 		{[]string{""}, []string{""}},
 		{[]string{}, []string{}},
+		{data, uniq},
 	}
 
 	for _, item := range testData {
 		val := KeepUniqueNames(item.argument)
 		c.Assert(val, checker.DeepEquals, item.expected)
+	}
+}
+
+// Note: each "op" works on size things
+func (ds *DNSCacheTestSuite) BenchmarkKeepUniqueNames(c *C) {
+	c.StopTimer()
+	data := make([]string, 48)
+	for i := 0; i < len(data); i++ {
+		data[i] = fmt.Sprintf("a%d.domain.com", i)
+	}
+	c.StartTimer()
+
+	for i := 0; i < c.N; i++ {
+		KeepUniqueNames(data)
 	}
 }
 


### PR DESCRIPTION
Not sure if this is of any actual significance, but KeepUniqueNames()
is called from couple of places. Modify it to filter out duplicates in
place so that no memory allocations are needed.

Using naive search for duplicates instead of a map is about 5x faster
for small sets of names.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
