### PR TITLE
bpf: fix disable PolicyVerdictNotification broken

### DIFF
--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -77,9 +77,11 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 }
 #else
 static __always_inline void
-send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst_port,
-			   __u8 proto, __u8 dir, __u8 is_ipv6, int verdict,
-			   __u8 match_type)
+send_policy_verdict_notify(struct __ctx_buff *ctx __maybe_unused,
+			   __u32 remote_label __maybe_unused, __u16 dst_port __maybe_unused,
+			   __u8 proto __maybe_unused, __u8 dir __maybe_unused,
+			   __u8 is_ipv6 __maybe_unused, int verdict __maybe_unused,
+			   __u8 match_type __maybe_unused, __u8 is_audited __maybe_unused)
 {
 }
 #endif /* POLICY_VERDICT_NOTIFY */


### PR DESCRIPTION
Disable endpoints' policy verdict notification, e.g. via CLI
`cilium endpoint config <ep_id> PolicyVerdictNotification=false` has broken,
with compiler complaning about unused variables as well as function signature
mismatch.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>