### PR TITLE
bpf: add IPV4_LOCAL_DELIVERY tail call

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -507,8 +507,12 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			return CTX_ACT_OK;
 #endif
 
-		return ipv4_local_delivery(ctx, ETH_HLEN, secctx, ip4, ep,
-					   METRIC_INGRESS, from_host);
+		ctx_store_meta(ctx, CB_SRC_IDENTITY, secctx);
+		ctx_store_meta(ctx, CB_METRIC_DIRECTION, METRIC_EGRESS);
+		ctx_store_meta(ctx, CB_FROM_HOST, from_host);
+
+		ep_tail_call(ctx, CILIUM_CALL_IPV4_LOCAL_DELIVERY);
+		return DROP_MISSED_TAIL_CALL;
 	}
 
 #ifdef ENCAP_IFINDEX

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -673,8 +673,13 @@ ct_recreate4:
 			}
 #endif /* ENABLE_ROUTING */
 			policy_clear_mark(ctx);
-			return ipv4_local_delivery(ctx, l3_off, SECLABEL, ip4,
-						   ep, METRIC_EGRESS, false);
+
+			ctx_store_meta(ctx, CB_SRC_IDENTITY, SECLABEL);
+			ctx_store_meta(ctx, CB_METRIC_DIRECTION, METRIC_EGRESS);
+			ctx_store_meta(ctx, CB_FROM_HOST, false);
+
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_LOCAL_DELIVERY);
+			return DROP_MISSED_TAIL_CALL;
 		}
 	}
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -220,8 +220,12 @@ not_esp:
 		if (ep->flags & ENDPOINT_F_HOST)
 			goto to_host;
 
-		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, ip4, ep,
-					   METRIC_INGRESS, false);
+		ctx_store_meta(ctx, CB_SRC_IDENTITY, *identity);
+		ctx_store_meta(ctx, CB_METRIC_DIRECTION, METRIC_INGRESS);
+		ctx_store_meta(ctx, CB_FROM_HOST, false);
+
+		ep_tail_call(ctx, CILIUM_CALL_IPV4_LOCAL_DELIVERY);
+		return DROP_MISSED_TAIL_CALL;
 	}
 
 to_host:

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -81,7 +81,8 @@
 #define CILIUM_CALL_IPV4_FROM_HOST		22
 #define CILIUM_CALL_IPV6_FROM_HOST		23
 #define CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT	24
-#define CILIUM_CALL_SIZE			25
+#define CILIUM_CALL_IPV4_LOCAL_DELIVERY		25
+#define CILIUM_CALL_SIZE			26
 
 typedef __u64 mac_t;
 
@@ -502,17 +503,23 @@ enum {
 #define	CB_SVC_PORT		CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_PROXY_MAGIC		CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL	/* Alias, non-overlapping */
+#define CB_SRC_IDENTITY		CB_SRC_LABEL
+
 	CB_IFINDEX,
 #define	CB_SVC_ADDR_V4		CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_SVC_ADDR_V6_1	CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_ENCRYPT_IDENTITY	CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
+#define CB_METRIC_DIRECTION     CB_IFINDEX
+
 	CB_POLICY,
 #define	CB_SVC_ADDR_V6_2	CB_POLICY	/* Alias, non-overlapping */
+
 	CB_NAT46_STATE,
 #define CB_NAT			CB_NAT46_STATE	/* Alias, non-overlapping */
 #define	CB_SVC_ADDR_V6_3	CB_NAT46_STATE	/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_NAT46_STATE	/* Alias, non-overlapping */
+
 	CB_CT_STATE,
 #define	CB_SVC_ADDR_V6_4	CB_CT_STATE	/* Alias, non-overlapping */
 #define	CB_ENCRYPT_DST		CB_CT_STATE	/* Alias, non-overlapping,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -19,8 +19,6 @@
 #include "trace.h"
 #include "host_firewall.h"
 
-#define CB_SRC_IDENTITY	0
-
 #ifdef ENABLE_NODEPORT
  /* Define dummy values to make bpf_{lxc,overlay}.c to compile */
 #ifndef NATIVE_DEV_IFINDEX

--- a/test/bpf/check-complexity.sh
+++ b/test/bpf/check-complexity.sh
@@ -50,9 +50,10 @@ function annotate_section_names {
 	    -e "s/\(section '2\/22'\)/\1 (tail_call IPV4_FROM_HOST)/" \
 	    -e "s/\(section '2\/23'\)/\1 (tail_call IPV6_FROM_HOST)/" \
 	    -e "s/\(section '2\/24'\)/\1 (tail_call IPV6_ENCAP_NODEPORT_NAT)/"
+	    -e "s/\(section '2\/25'\)/\1 (tail_call IPV4_LOCAL_DELIVERY)/"
 }
 
-if ! grep -q "CILIUM_CALL_SIZE.*25" "$BPFDIR/lib/common.h" ; then
+if ! grep -q "CILIUM_CALL_SIZE.*26" "$BPFDIR/lib/common.h" ; then
 	echo "This script is out of date compared to CILIUM_CALL_SIZE." 1>&2
 	exit 1
 fi


### PR DESCRIPTION
Move the logic to handle IPv4 local delivery into a separate tail call
to reduce the complexity of the datapath.

Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>

For context: I'm trying to extract some pieces from https://github.com/cilium/cilium/pull/13347 in order to make it easier to review it and test it