### PR TITLE
docs: Add az login command to AKS getting started guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -23,8 +23,13 @@ and clustermesh.
 Prerequisites
 =============
 
-Ensure that you have the `Azure Cloud CLI 
-<https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest>`_ installed.
+Ensure that you have the `Azure Cloud CLI
+<https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest>`_
+installed and log in to Azure with:
+
+.. code:: bash
+
+    az login
 
 To verify, confirm that the following command displays the set of available
 Kubernetes versions.


### PR DESCRIPTION
This makes the AKS getting started guide assume even less knowledge of AKS by making an implicitly-needed command explicit.
