### PR TITLE
test: disable fqdn connectivity test during restart

### DIFF
--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -138,7 +138,6 @@ var _ = Describe("K8sFQDNTest", func() {
 		}()
 
 		connectivityTest := func() {
-
 			By("Testing that connection from %q to %q should work",
 				appPods[helpers.App2], worldTarget)
 			res := kubectl.ExecPodCmd(
@@ -203,9 +202,15 @@ var _ = Describe("K8sFQDNTest", func() {
 			helpers.CurlFail(worldInvalidTargetIP))
 		res.ExpectFail("%q can connect when it should not work", helpers.App2)
 
-		// Re-run connectivity test while Cilium is still restarting. This should succeed as the same
-		// DNS names were used in a connectivity test before the restart.
-		connectivityTest()
+		// This test is failing consistently in quarantine, see #11213. Disable it for now
+		// to verify the rest of the test is running stable in quarantine. Once this is the
+		// case we could move the rest of the test out of quarantine and quarantine only
+		// this part.
+		if false {
+			// Re-run connectivity test while Cilium is still restarting. This should succeed as the same
+			// DNS names were used in a connectivity test before the restart.
+			connectivityTest()
+		}
 
 		channelClosed = true
 		close(quit)


### PR DESCRIPTION
From the focused testing in #13896 it seems that the connectivity test
only fails during restart on kernel 4.9. However, when run as part of
the full test suite, the connectivity check also seems to fail on e.g.
GKE and 4.19. Thus, disable the connectivity test during restart
altogether.
    
If this turns out to make the test stable in quarantine we could as a
follow-up move the "Restart Cilium validate that FQDN is still working"
test out of quarantine and only restrict the restart connectivity test
to quarantine.

For #11213