### PR TITLE
cilium/cmd: mark tests as unprivileged

### DIFF
--- a/cilium/cmd/bpf_ipcache_get_test.go
+++ b/cilium/cmd/bpf_ipcache_get_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build privileged_tests
+// +build !privileged_tests
 
 package cmd
 

--- a/cilium/cmd/helpers_test.go
+++ b/cilium/cmd/helpers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build privileged_tests
+// +build !privileged_tests
 
 package cmd
 
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"path"
 	"sort"
-	"testing"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
@@ -29,8 +28,6 @@ import (
 
 	. "gopkg.in/check.v1"
 )
-
-func Test(t *testing.T) { TestingT(t) }
 
 type CMDHelpersSuite struct{}
 


### PR DESCRIPTION
Commit 4eb58b80a640 ("cmd: mark tests as privileged") marked these as
privileged, but the BPF functionality no longer seems to be imported by
these tests so they run just fine as unprivileged tests.