### PR TITLE
bpf: Replace CALLS_MAP symbol in compile-tested binaries

### DIFF
--- a/bpf/netdev_config.h
+++ b/bpf/netdev_config.h
@@ -12,3 +12,4 @@
 #define ENCAP_IFINDEX 1
 #define SECLABEL 2
 #define SECLABEL_NB 0xfffff
+#define CALLS_MAP test_cilium_calls_65535


### PR DESCRIPTION
Because we don't define `CALLS_MAP` for several programs, the binaries end up with `CALLS_MAP` as the actual map name:

    $ for f in $(ls bpf/*.o); do ( readelf -s $f | grep -q CALLS_MAP ) && echo $f; done
    bpf/bpf_alignchecker.o
    bpf/bpf_network.o
    bpf/bpf_overlay.o
    bpf/bpf_xdp.o

That can lead to warnings when trying to load the programs with `test/bpf/verifier-test.sh`. This pull request fixes it:

    $ for f in $(ls bpf/*.o); do ( readelf -s $f | grep -q CALLS_MAP ) && echo $f; done
    bpf/bpf_alignchecker.o