### PR TITLE
bpf: don't override DROP_FRAG_NOT_FOUND error

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -528,7 +528,7 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 	 * after data has been invalidated (see handle_ipv4_from_lxc())
 	 */
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
+		return DROP_CT_INVALID_HDR;
 
 	if (unlikely(ipv4_is_fragment(ip4)))
 		return ipv4_handle_fragment(ctx, ip4, off,
@@ -536,7 +536,10 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 					    has_l4_header);
 #endif
 	/* load sport + dport into tuple */
-	return ctx_load_bytes(ctx, off, &tuple->dport, 4);
+	if (ctx_load_bytes(ctx, off, &tuple->dport, 4) < 0)
+		return DROP_CT_INVALID_HDR;
+
+	return CTX_ACT_OK;
 }
 
 static __always_inline void ct4_cilium_dbg_tuple(struct __ctx_buff *ctx, __u8 type,
@@ -554,7 +557,7 @@ static __always_inline int ct_lookup4(const void *map,
 				      struct __ctx_buff *ctx, int off, int dir,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
-	int ret = CT_NEW, action = ACTION_UNSPEC;
+	int err, ret = CT_NEW, action = ACTION_UNSPEC;
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP,
 	     has_l4_header = true;
 	union tcp_flags tcp_flags = { .value = 0 };
@@ -613,9 +616,9 @@ static __always_inline int ct_lookup4(const void *map,
 		break;
 
 	case IPPROTO_TCP:
-		if (ipv4_ct_extract_l4_ports(ctx, off, tuple,
-					     &has_l4_header) < 0)
-			return DROP_CT_INVALID_HDR;
+		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, &has_l4_header);
+		if (err < 0)
+			return err;
 
 		action = ACTION_CREATE;
 
@@ -626,12 +629,12 @@ static __always_inline int ct_lookup4(const void *map,
 			if (unlikely(tcp_flags.value & (TCP_FLAG_RST|TCP_FLAG_FIN)))
 				action = ACTION_CLOSE;
 		}
-
 		break;
 
 	case IPPROTO_UDP:
-		if (ipv4_ct_extract_l4_ports(ctx, off, tuple, NULL) < 0)
-			return DROP_CT_INVALID_HDR;
+		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, NULL);
+		if (err < 0)
+			return err;
 
 		action = ACTION_CREATE;
 		break;


### PR DESCRIPTION
`ipv4_ct_extract_l4_ports()` can return different error codes, but we
currently ignore them and just override whichever error code is returned
with a generic `DROP_CT_INVALID_HDR`, making metrics less accurate.

This commit fixes this behaviour so that `ct_lookup4()` will return, in
case of an error, the original error code returned by
`ipv4_ct_extract_l4_ports()`.
