### PR TITLE
Makefile: Simplify to run faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,13 @@ ifdef LIBNETWORK_PLUGIN
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
 endif
 
-GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(GO_LIST) -e ./...))
+GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(GO_LIST) -find -e ./...))
 GOFILES ?= $(GOFILES_EVAL)
 TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell echo $(GOFILES) | \
 	sed 's/ /\n/g' | \
 	grep -v '/api/v1\|/vendor\|/contrib\|/$(BUILD_DIR)/' | \
-	grep -v -P 'test(?!/helpers/logutils)'))
+	grep -v '/test'))
+TESTPKGS_EVAL += "test/helpers/logutils"
 TESTPKGS ?= $(TESTPKGS_EVAL)
 GOLANG_SRCFILES := $(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor | sort | uniq)
 K8S_CRD_EVAL := $(addprefix $(ROOT_DIR)/,$(shell git ls-files $(ROOT_DIR)/examples/crds | grep -v .gitignore | tr "\n" ' '))

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -109,7 +109,7 @@ ifeq ($(GO111MODULE),on)
     GO_TEST_FLAGS += -mod=vendor
     GO_CLEAN_FLAGS += -mod=vendor
 else
-    GO_MAJOR_VERSION_GE_1 := $(shell expr `$(GO) version | grep -E 'go[0-9]{1}+' -o | sed 's/go//g'` \>= 1)
+    GO_MAJOR_VERSION_GE_1 := $(shell expr `$(GO) version | grep -E 'go[0-9]+' -o | sed 's/go//g'` \>= 1)
     ifeq ($(GO_MAJOR_VERSION_GE_1),1)
         GO_MINOR_VERSION_GE_13 := $(shell expr `$(GO) version | grep -E 'go[^ ]+' -o | sed 's/go1.//g'` \>= 13)
         ifeq ($(GO_MINOR_VERSION_GE_13),1)


### PR DESCRIPTION
Avoid using grep options that are not supported on macOS. This
eliminates errors like this:

    grep: repetition-operator operand invalid
    expr: syntax error
    usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
            [-e pattern] [-f file] [--binary-files=value] [--color=when]
            [--context[=num]] [--directories=action] [--label] [--line-buffered]
            [--null] [pattern] [file ...]

Make 'go list' faster by adding '-find' option that eliminates
resolution of some state we are not using:

     "The -find flag causes list to identify the named packages but not
     resolve their dependencies: the Imports and Deps lists will be empty."

This makes 'make nothing' to run about twice as fast as before,
especially in the dev VM.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
