### PR TITLE
test: Increase timeout on privileged unit tests

### DIFF
--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -29,7 +29,7 @@ import (
 const (
 	// The privileged unit tests can take more than 4 minutes, the default
 	// timeout for helper commands.
-	privilegedUnitTestTimeout = 8 * time.Minute
+	privilegedUnitTestTimeout = 16 * time.Minute
 )
 
 var _ = Describe("RuntimePrivilegedUnitTests", func() {


### PR DESCRIPTION
Flakes on privileged unit tests with `context deadline exceeded` are becoming a bit more common. There seem to be [a lot of variations](https://github.com/cilium/cilium/issues/12862#issuecomment-674085848) in actual duration of those tests, with a long tail of high durations.

This pull request doubles the timeout value in an effort to reduce flakes.

Fixes: #12862