### PR TITLE
install/kubernetes: add check-docker-images target to phony targets

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -106,4 +106,4 @@ check-docker-images:
          CERTGEN_VERSION=`echo $(CERTGEN_VERSION) | egrep -o '^.*@' | sed 's/@//'` \
          ../../contrib/release/check-docker-images.sh "v$(VERSION)"
 
-.PHONY: all clean docs experimental-install lint quick-install update-versions
+.PHONY: all check-docker-images clean docs experimental-install lint quick-install update-versions


### PR DESCRIPTION
Fixes: 73be2c15ced2 ("release: add script to check presence of docker images")
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

Note: no need for backport to 1.7 and 1.8, fixed up in backport PRs #13950 and #13951 as part of conflict resolution.