### PR TITLE
v1.7 backports 2020-11-09

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -40,7 +40,7 @@ cilium-operator [flags]
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 250)
+      --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 15m0s)
       --ipam string                               Backend to use for IPAM
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -215,7 +215,15 @@ If you intent to release a new feature release, see the
 #. Update the ``stable`` tags for ``cilium``, ``cilium-operator``, and
    ``cilium-docker-plugin`` on DockerHub.
 
-#. Update the external tools and guides to point to the released Cilium version:
+#. Check if all docker images are available before announcing the release:
+
+   ::
+
+      make -C install/kubernetes/ check-docker-images
+
+#. Update the following external tools and guides to point to the released
+   Cilium version. This step is only required on a new minor release like going
+   from ``1.8`` to ``1.9``.
 
     * `kubeadm <https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>`_
     * `kops <https://github.com/kubernetes/kops/>`_

--- a/contrib/release/check-docker-images.sh
+++ b/contrib/release/check-docker-images.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+cilium_tag="${1}"
+org="cilium"
+
+external_dependencies_docker=(
+  "envoyproxy/envoy:${HUBBLE_PROXY_VERSION}" \
+)
+
+external_dependencies_quay=(
+  "coreos/etcd:${ETCD_VERSION}" \
+)
+
+internal_dependencies=(
+  "certgen:${CERTGEN_VERSION}" \
+  "cilium-etcd-operator:${MANAGED_ETCD_VERSION}" \
+  "startup-script:${NODEINIT_VERSION}"
+  "hubble-ui:${HUBBLE_UI_VERSION}" \
+  "hubble-ui-backend:${HUBBLE_UI_VERSION}" \
+)
+
+cilium_images=(\
+  "cilium" \
+  "clustermesh-apiserver" \
+  "docker-plugin" \
+  "hubble-relay" \
+  "operator" \
+  "operator-azure" \
+  "operator-aws" \
+  "operator-generic" \
+)
+
+docker_tag_exists(){
+  local repo="${1}"
+  local tag="${2}"
+  curl --silent -f -lSL "https://index.docker.io/v1/repositories/${repo}/tags/${tag}" &> /dev/null
+}
+
+quay_tag_exists(){
+  local repo="${1}"
+  local tag="${2}"
+  curl --silent -f -lSL "https://quay.io/api/v1/repository/${repo}/tag/${tag}/images" &> /dev/null
+}
+
+for image in "${external_dependencies_docker[@]}" ; do
+  image_tag=${image#*:}
+  image_name=${image%":$image_tag"}
+  if ! docker_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "docker.io/${image} does not exist!"
+    not_found=true
+  fi
+done
+
+for image in "${external_dependencies_quay[@]}" ; do
+  image_tag=${image#*:}
+  image_name=${image%":$image_tag"}
+  if ! quay_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "quay.io/${image} does not exist!"
+    not_found=true
+  fi
+done
+
+for image in "${internal_dependencies[@]}" ; do
+  image_tag=${image#*:}
+  image_name=${org}/${image%":$image_tag"}
+  if ! docker_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "docker.io/${image_name}:${image_tag} does not exist!"
+    not_found=true
+  fi
+  if ! quay_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "quay.io/${image_name}:${image_tag} does not exist!"
+    not_found=true
+  fi
+done
+
+for image in "${cilium_images[@]}"; do
+  image_name="${org}/${image}"
+  if ! docker_tag_exists "${image_name}" "${cilium_tag}" ; then
+    echo "docker.io/${image_name}:${cilium_tag} does not exist!"
+    not_found=true
+  fi
+  if ! quay_tag_exists "${image_name}" "${cilium_tag}" ; then
+    echo "quay.io/${image_name}:${cilium_tag} does not exist!"
+    not_found=true
+  fi
+done
+
+if [[ -n "${not_found}" ]]; then
+  exit 1
+fi
+
+exit 0

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -194,10 +194,17 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 				alive, dead := ep.DNSZombies.GC()
 
 				// Alive zombie need to be added to the global cache as name->IP
-				// entries. We accumulate the names into namesToClean to ensure that
-				// the original full DNS lookup (name -> many IPs) is expired and only
-				// the active connections (name->single IP) are re-added.
-				// Note: Other DNS lookups may also use an active IP. This is fine.
+				// entries.
+				//
+				// NB: The following  comment is _no longer true_ (see
+				// DNSZombies.GC()).  We keep it to maintain the original intention
+				// of the code for future reference:
+				//    We accumulate the names into namesToClean to ensure that the
+				//    original full DNS lookup (name -> many IPs) is expired and
+				//    only the active connections (name->single IP) are re-added.
+				//    Note: Other DNS lookups may also use an active IP. This is
+				//    fine.
+				//
 				lookupTime := time.Now()
 				for _, zombie := range alive {
 					namesToClean = fqdn.KeepUniqueNames(append(namesToClean, zombie.Names...))

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -556,15 +556,16 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 					Port:         uint16(serverPort),
 				}
 			} else if serverSecID, exists := ipcache.IPIdentityCache.LookupByIP(serverIP); exists {
-				secID := d.identityAllocator.LookupIdentityByID(d.ctx, serverSecID.ID)
 				// TODO: handle IPv6
 				lr.LogRecord.DestinationEndpoint = accesslog.EndpointInfo{
 					IPv4: serverIP,
 					// IPv6:         serverEP.GetIPv6Address(),
-					Labels:       secID.Labels.GetModel(),
-					LabelsSHA256: secID.GetLabelsSHA256(),
-					Identity:     uint64(serverSecID.ID.Uint32()),
-					Port:         uint16(serverPort),
+					Identity: uint64(serverSecID.ID.Uint32()),
+					Port:     uint16(serverPort),
+				}
+				if secID := d.identityAllocator.LookupIdentityByID(d.ctx, serverSecID.ID); secID != nil {
+					lr.LogRecord.DestinationEndpoint.Labels = secID.Labels.GetModel()
+					lr.LogRecord.DestinationEndpoint.LabelsSHA256 = secID.GetLabelsSHA256()
 				}
 			}
 		},

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -42,4 +42,13 @@ update-versions:
 clean:
 	$(RM) $(QUICK_INSTALL)
 
-.phony: all clean update-versions
+	$(QUIET)\
+         HUBBLE_PROXY_VERSION=$(HUBBLE_PROXY_VERSION) \
+         HUBBLE_UI_VERSION=$(HUBBLE_UI_VERSION) \
+         MANAGED_ETCD_VERSION=$(MANAGED_ETCD_VERSION) \
+         ETCD_VERSION=$(ETCD_VERSION) \
+         NODEINIT_VERSION=$(NODEINIT_VERSION) \
+         CERTGEN_VERSION=`echo $(CERTGEN_VERSION) | egrep -o '^.*@' | sed 's/@//'` \
+         ../../contrib/release/check-docker-images.sh "v$(VERSION)"
+
+.phony: all check-docker-images clean update-versions

--- a/operator/main.go
+++ b/operator/main.go
@@ -170,7 +170,7 @@ func init() {
 	flags.Duration(option.IdentityGCRateInterval, time.Minute,
 		"Interval used for rate limiting the GC of security identities")
 	option.BindEnv(option.IdentityGCRateInterval)
-	flags.Int64(option.IdentityGCRateLimit, 250,
+	flags.Int64(option.IdentityGCRateLimit, 2500,
 		fmt.Sprintf("Maximum number of security identities that will be deleted within the %s", option.IdentityGCRateInterval))
 	option.BindEnv(option.IdentityGCRateLimit)
 	flags.DurationVar(&kvNodeGCInterval, "nodes-gc-interval", time.Minute*2, "GC interval for nodes store in the kvstore")


### PR DESCRIPTION
* #13892 -- release: add script to check presence of docker images (@aanm)
   - Minor merge conflict.
 * #13907 -- operator: increase GC Rate limit of identities to 2500 per minute (@aanm)
   - Merge conflict, flags are defined in a operator/main.go rather than
     operator/flags.go in v1.7. Fixed up manually
 * #13886 -- fqdn: Add a nil check for security id lookup (@aditighag)
 * #13914 -- fqdn: keep IPs alive if their name is alive (@kkourt)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13892 13907 13886 13914; do contrib/backporting/set-labels.py $pr done 1.7; done
```