### PR TITLE
docker: include v1.9 suffix in cilium-builder tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-11-09@sha256:401d3bc1464c1daf54f4205aea936cb3fb90f0ae00c03e2146ebf2a9d23d5651 as builder
+FROM quay.io/cilium/cilium-builder:2020-11-09-v1.9@sha256:401d3bc1464c1daf54f4205aea936cb3fb90f0ae00c03e2146ebf2a9d23d5651 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2020-11-09@sha256:401d3bc1464c1daf54f4205aea936cb3fb90f0ae00c03e2146ebf2a9d23d5651"
+    image: "quay.io/cilium/cilium-builder:2020-11-09-v1.9@sha256:401d3bc1464c1daf54f4205aea936cb3fb90f0ae00c03e2146ebf2a9d23d5651"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
Note that this does not influence which image is used as long as the SHA
is correct. This just helps humans to understand which tag is used.

Fixes: cf199a03f5ef ("Update Go to 1.15.4")
Reported-by: André Martins <andre@cilium.io>