### PR TITLE
test: Enable K8sVerifier on 4.19 and net-next CI

### DIFF
--- a/test/k8sT/Verifier.go
+++ b/test/k8sT/Verifier.go
@@ -92,12 +92,25 @@ var _ = Describe("K8sVerifier", func() {
 		kubectl.DeleteResource("pod", podName)
 	})
 
-	SkipItIf(helpers.RunsOnNetNextOr419Kernel, "Runs the kernel verifier against the BPF datapath", func() {
+	It("Runs the kernel verifier against Cilium's BPF datapath", func() {
 		By("Building BPF objects from the tree")
 		res := kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "make -C bpf V=0")
 		res.ExpectSuccess("Expected compilation of the BPF objects to succeed")
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "make -C tools/maptool/")
 		res.ExpectSuccess("Expected compilation of maptool to succeed")
+
+		if helpers.RunsOn419Kernel() {
+			// On 4.19, we need to remove global data sections before loading
+			// those programs. The libbpf version used in our bpftool (which
+			// loads these two programs), rejects global data.
+			By("Remove global data section")
+			for _, prog := range []string{"bpf/sockops/bpf_sockops.o", "bpf/sockops/bpf_redir.o"} {
+				cmd := "llvm-objcopy --remove-section=.debug_info --remove-section=.BTF --remove-section=.data /cilium/%s /cilium/%s"
+				res := kubectl.ExecPodCmd(helpers.DefaultNamespace, podName,
+					fmt.Sprintf(cmd, prog, prog))
+				res.ExpectSuccess(fmt.Sprintf("Expected deletion of object file sections from %s to succeed.", prog))
+			}
+		}
 
 		By("Running the verifier test script")
 		cmd := fmt.Sprintf("test/%s", script)


### PR DESCRIPTION
Pull request #13927 fixed `verifier-test.sh`, used in K8sVerifier, for bpf-next kernels. We can therefore enable K8sVerifier on our net-next pipeline.

To enable K8sVerifier on our 4.19 pipeline, we also need to remove global data sections from the object files loaded with bpftool. Otherwise, since bpftool relies on libbpf, it complains with:

    libbpf: kernel doesn't support global data

This is achieved by using llvm-objcopy, now included in the cilium-builder image.

Updates: #10798