### PR TITLE
make: Fix dev-docker-image make target

### DIFF
--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -46,7 +46,7 @@ _build/%ockerfile.dockerignore: $(GIT_IGNORE_FILES) Makefile.buildkit
 _build/%ockerfile: %ockerfile _build/%ockerfile.dockerignore force
 	@-mkdir -p $(dir $@)
 	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
-	@-grep "^FROM " $@ | cut -d ' ' -f2 | grep -v -e "scratch" -e "[$$_{}]" | xargs -P4 -n1 docker pull
+	@-grep "^FROM " $@ | cut -d ' ' -f2 | grep -v -e "scratch" -e "[\$$_{}]" | xargs -P4 -n1 docker pull
 
 #
 # Optionally make a shallow clone of the repo to explicitly exclude


### PR DESCRIPTION
The pull of docker images during the dev-docker-image make target would
previously mess up because of a lack of escaping of the $ in the grep
statement, resulting in this message:

```
   $ make dev-docker-image                                                                                            [315/979]
   "docker pull" requires exactly 1 argument.
   See 'docker pull --help'.

   Usage:  docker pull [OPTIONS] NAME[:TAG|@DIGEST]

   Pull an image or a repository from a registry
   [+] Building 6.2s (16/24)
   ...
```

Fix it to ensure that environment variables are not used for pulling
docker images, but that the grep statement doesn't exclude all of the
other legitimate docker image targets.

Fixes: 8a5bc179e08a ("build: Suppress warnings about invalid image names")