### PR TITLE
Revert commits that skip running tests on CI with EKS

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3713,11 +3713,6 @@ func (kub *Kubectl) ciliumControllersPreFlightCheck() error {
 }
 
 func (kub *Kubectl) ciliumHealthPreFlightCheck() error {
-	if IsIntegration(CIIntegrationEKS) {
-		ginkgoext.By("Skipping cilium-health --probe in EKS")
-		return nil
-	}
-
 	ginkgoext.By("Performing Cilium health check")
 	var nodesFilter = `{.nodes[*].name}`
 	var statusFilter = `{range .nodes[*]}{.name}{"="}{.host.primary-address.http.status}{"\n"}{end}`

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -78,7 +78,6 @@ var _ = Describe("K8sHealthTest", func() {
 
 	It("checks cilium-health status between nodes", func() {
 		SkipIfIntegration(helpers.CIIntegrationFlannel)
-		SkipIfIntegration(helpers.CIIntegrationEKS)
 
 		cilium1, cilium1IP := getCilium(helpers.K8s1)
 		cilium2, cilium2IP := getCilium(helpers.K8s2)


### PR DESCRIPTION
See commit msgs.

Since https://github.com/cilium/cilium/pull/11073 has been merged, we no
longer need to skip this test when running on EKS.