### PR TITLE
tools/licensegen: include licenses that have file extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ test/gke/registry-adder.yaml
 # generated from make targets
 *.ok
 *.build_all
+LICENSE.all
 
 # Temporary files that allow build containers/VMs work without git
 # Not to be ignored by docker.

--- a/tools/licensegen/licensegen.go
+++ b/tools/licensegen/licensegen.go
@@ -6,24 +6,26 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func main() {
-	err := filepath.Walk(
-		"./vendor",
-		func(path string, info os.FileInfo, err error) error {
-			if filepath.Base(path) == "LICENSE" {
+	err := filepath.Walk("./vendor", func(path string, _ os.FileInfo, _ error) error {
+		base := filepath.Base(path)
+		ext := filepath.Ext(base)
+		if strings.TrimSuffix(base, ext) == "LICENSE" {
+			switch strings.TrimPrefix(strings.ToLower(ext), ".") {
+			case "", "code", "docs", "libyaml", "md", "txt":
 				fmt.Println("Name:", path)
-
 				lb, err := ioutil.ReadFile(path)
 				if err != nil {
 					log.Fatal(err)
 				}
 				fmt.Println("License:", string(lb))
 			}
-			return nil
-		},
-	)
+		}
+		return nil
+	})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Some projects in `vendor` use a file extension for their `LICENSE` file.
Make sure to include them as well.

A quick `find | grep` gave me the following list which I used as a basis
for file extension to include (not including `.sh` and `.go`):

    $ find vendor -iname '*license*' | grep -oiE 'license\.[a-zA-Z0-9]+' | sort | uniq
    LICENSE.code
    LICENSE.docs
    license.go
    LICENSE.libyaml
    LICENSE.md
    license.sh
    LICENSE.txt

When running `make licenses-all` again, the following previously missed
license files are now also added to `LICENSE.all`:

    vendor/github.com/aws/aws-sdk-go-v2/LICENSE.txt
    vendor/github.com/cespare/xxhash/v2/LICENSE.txt
    vendor/github.com/cpuguy83/go-md2man/v2/LICENSE.md
    vendor/github.com/fatih/color/LICENSE.md
    vendor/github.com/go-stack/stack/LICENSE.md
    vendor/github.com/hpcloud/tail/LICENSE.txt
    vendor/github.com/opencontainers/go-digest/LICENSE.code
    vendor/github.com/opencontainers/go-digest/LICENSE.docs
    vendor/github.com/russross/blackfriday/LICENSE.txt
    vendor/github.com/russross/blackfriday/v2/LICENSE.txt
    vendor/github.com/spf13/afero/LICENSE.txt
    vendor/github.com/spf13/cobra/LICENSE.txt
    vendor/go.uber.org/atomic/LICENSE.txt
    vendor/go.uber.org/multierr/LICENSE.txt
    vendor/go.uber.org/zap/LICENSE.txt
    vendor/gopkg.in/yaml.v2/LICENSE.libyaml

Ref: #13918
Fixes: 18451591a2ebc05c9d492bf8082bc0bae4eb614d