### PR TITLE
v1.9 backports 2020-11-10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ test/gke/registry-adder.yaml
 # generated from make targets
 *.ok
 *.build_all
+LICENSE.all
 
 # Temporary files that allow build containers/VMs work without git
 # Not to be ignored by docker.

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -46,7 +46,7 @@ _build/%ockerfile.dockerignore: $(GIT_IGNORE_FILES) Makefile.buildkit
 _build/%ockerfile: %ockerfile _build/%ockerfile.dockerignore force
 	@-mkdir -p $(dir $@)
 	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
-	@-grep "^FROM " $@ | cut -d ' ' -f2 | grep -v -e "scratch" -e "[$$_{}]" | xargs -P4 -n1 docker pull
+	@-grep "^FROM " $@ | cut -d ' ' -f2 | grep -v -e "scratch" -e "[\$$_{}]" | xargs -P4 -n1 docker pull
 
 #
 # Optionally make a shallow clone of the repo to explicitly exclude

--- a/tools/licensegen/licensegen.go
+++ b/tools/licensegen/licensegen.go
@@ -6,24 +6,26 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func main() {
-	err := filepath.Walk(
-		"./vendor",
-		func(path string, info os.FileInfo, err error) error {
-			if filepath.Base(path) == "LICENSE" {
+	err := filepath.Walk("./vendor", func(path string, _ os.FileInfo, _ error) error {
+		base := filepath.Base(path)
+		ext := filepath.Ext(base)
+		if strings.TrimSuffix(base, ext) == "LICENSE" {
+			switch strings.TrimPrefix(strings.ToLower(ext), ".") {
+			case "", "code", "docs", "libyaml", "md", "txt":
 				fmt.Println("Name:", path)
-
 				lb, err := ioutil.ReadFile(path)
 				if err != nil {
 					log.Fatal(err)
 				}
 				fmt.Println("License:", string(lb))
 			}
-			return nil
-		},
-	)
+		}
+		return nil
+	})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
* #13956 -- make: Fix dev-docker-image make target (@joestringer)
 * #13967 -- tools/licensegen: include licenses that have file extension (@Rolinh)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13956 13967; do contrib/backporting/set-labels.py $pr done 1.9; done
```