### PR TITLE
daemon, config: regenerate endpoint datapath on agent config change

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -133,6 +134,8 @@ type Daemon struct {
 
 	mtuConfig     mtu.Configuration
 	policyTrigger *trigger.Trigger
+
+	datapathRegenTrigger *trigger.Trigger
 
 	// datapath is the underlying datapath implementation to use to
 	// implement all aspects of an agent
@@ -434,6 +437,20 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		return nil, nil, err
 	}
 	d.policyTrigger = t
+
+	// Reuse policyTriggerMetrics and PolicyTriggerInterval here since
+	// this is only triggered by agent configuration changes for now
+	// and should be counted in policyTriggerMetrics.
+	regenerationTrigger, err := trigger.NewTrigger(trigger.Parameters{
+		Name:            "datapath-regeneration",
+		MetricsObserver: &policyTriggerMetrics{},
+		MinInterval:     option.Config.PolicyTriggerInterval,
+		TriggerFunc:     d.datapathRegen,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	d.datapathRegenTrigger = regenerationTrigger
 
 	debug.RegisterStatusObject("k8s-service-cache", &d.k8sWatcher.K8sSvcCache)
 	debug.RegisterStatusObject("ipam", d.ipam)
@@ -795,6 +812,9 @@ func (d *Daemon) Close() {
 	if d.policyTrigger != nil {
 		d.policyTrigger.Shutdown()
 	}
+	if d.datapathRegenTrigger != nil {
+		d.datapathRegenTrigger.Shutdown()
+	}
 	d.nodeDiscovery.Close()
 }
 
@@ -819,6 +839,27 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 		RegenerationLevel: regeneration.RegenerateWithDatapathLoad,
 	}
 	return d.endpointManager.RegenerateAllEndpoints(regenRequest), nil
+}
+
+func (d *Daemon) datapathRegen(reasons []string) {
+	reason := strings.Join(reasons, ", ")
+
+	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
+		Reason:            reason,
+		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+	}
+	d.endpointManager.RegenerateAllEndpoints(regenerationMetadata)
+}
+
+// TriggerDatapathRegen triggers datapath rewrite for every daemon's endpoint.
+// This is only called after agent configuration changes for now. Policy revision
+// needs to be increased on PolicyEnforcement mode change.
+func (d *Daemon) TriggerDatapathRegen(force bool, reason string) {
+	if force {
+		log.Debug("PolicyEnforcement mode changed, increasing policy revision to enforce policy recalculation")
+		d.policy.BumpRevision()
+	}
+	d.datapathRegenTrigger.TriggerWithReason(reason)
 }
 
 func changedOption(key string, value option.OptionSetting, data interface{}) {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/hubble/observer"
 	"github.com/cilium/cilium/pkg/identity"
@@ -92,6 +93,10 @@ import (
 const (
 	// AutoCIDR indicates that a CIDR should be allocated
 	AutoCIDR = "auto"
+
+	// ConfigModifyQueueSize is the size of the event queue for serializing
+	// configuration updates to the daemon
+	ConfigModifyQueueSize = 10
 )
 
 // Daemon is the cilium daemon that is in charge of perform all necessary plumbing,
@@ -164,6 +169,9 @@ type Daemon struct {
 	redirectPolicyManager *redirectpolicy.Manager
 
 	apiLimiterSet *rate.APILimiterSet
+
+	// event queue for serializing configuration updates to the daemon.
+	configModifyQueue *eventqueue.EventQueue
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
@@ -332,6 +340,9 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		endpointCreations: newEndpointCreationManager(),
 		apiLimiterSet:     apiLimiterSet,
 	}
+
+	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)
+	d.configModifyQueue.Run()
 
 	d.svc = service.NewService(&d)
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -448,7 +448,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		ctmap.WriteBPFMacros(fw, nil)
 	}
 
-	if option.Config.PolicyAuditMode {
+	// option.Config.Opts.Opts stores agent mutable config options. We check PolicyAuditMode
+	// by its value instead of option.Config.PolicyAuditMode since PolicyAuditMode can be changed
+	// by cilium CLI/API at runtime and need to be written to bpf header files.
+	if val, ok := option.Config.Opts.Opts[option.PolicyAuditMode]; ok && val != option.OptionDisabled {
 		cDefinesMap["POLICY_AUDIT_MODE"] = "1"
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -692,6 +692,17 @@ func (e *Endpoint) applyOptsLocked(opts option.OptionMap) bool {
 	return changed
 }
 
+// ApplyOpts tries to lock endpoint, applies the given options to the
+// endpoint's options and returns true if there were any options changed.
+func (e *Endpoint) ApplyOpts(opts option.OptionMap) (bool, error) {
+	if err := e.lockAlive(); err != nil {
+		return false, err
+	}
+	defer e.unlock()
+	changed := e.applyOptsLocked(opts)
+	return changed, nil
+}
+
 // forcePolicyComputation ensures that upon the next policy calculation for this
 // Endpoint, that no short-circuiting of said operation occurs.
 func (e *Endpoint) forcePolicyComputation() {

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -16,12 +16,16 @@ package endpoint
 
 import "fmt"
 
+var (
+	ErrEndpointDeleted = fmt.Errorf("lock failed: endpoint is in the process of being removed")
+)
+
 // lockAlive returns error if endpoint was removed, locks underlying mutex otherwise
 func (e *Endpoint) lockAlive() error {
 	e.mutex.Lock()
 	if e.IsDisconnecting() {
 		e.mutex.Unlock()
-		return fmt.Errorf("lock failed: endpoint is in the process of being removed")
+		return ErrEndpointDeleted
 	}
 	return nil
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -432,6 +432,17 @@ func (mgr *EndpointManager) RegenerateAllEndpoints(regenMetadata *regeneration.E
 	return &wg
 }
 
+// OverrideEndpointOpts applies the given options to all endpoints.
+func (mgr *EndpointManager) OverrideEndpointOpts(om option.OptionMap) {
+	for _, ep := range mgr.GetEndpoints() {
+		if _, err := ep.ApplyOpts(om); err != nil && !errors.Is(err, endpoint.ErrEndpointDeleted) {
+			log.WithError(err).WithFields(logrus.Fields{
+				"ep": ep.GetID(),
+			}).Error("Override endpoint options failed")
+		}
+	}
+}
+
 // HasGlobalCT returns true if the endpoints have a global CT, false otherwise.
 func (mgr *EndpointManager) HasGlobalCT() bool {
 	eps := mgr.GetEndpoints()


### PR DESCRIPTION
Right now changing some agent options like `PolicyAuditMode` from
cilium CLI succeeds but doesn't affect datapath, e.g.:
# cilium config PolicyAuditMode=true
This patch fixes this by applying agent config changes to endpoint
header file and triggering endpoint datapath regeneration.

Fixes: #13902
Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>