### PR TITLE
checkpatch: update image tag to latest

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://cilium/cilium-checkpatch:5b099019bf0db775b33b3f32cd5ecea55dd15f21
+        uses: docker://cilium/cilium-checkpatch:f5443bb156d5ac4110ede4b501d6a2cf356d3202
   coccicheck:
     name: coccicheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the tag for the checkpatch image in order to benefit from the latest changes when running the GitHub action:

- Fix and update the issues reported by checkpatch. In particular, ignoring `GIT_COMMIT_ID` reports will avoid automatic checkpatch failures for backports.
- Allow for passing arguments directly to checkpatch.pl (not just the bash script), such as `--fix-inplace`.

See https://github.com/cilium/image-tools/pull/85.
Addresses follow-up items for https://github.com/cilium/cilium/issues/12467.
Related: https://github.com/cilium/cilium/pull/13904.