### PR TITLE
test/k8sT/manifests: use image hash with cilium-builder image

### DIFF
--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:2020-10-20
+    image: quay.io/cilium/cilium-builder:2020-11-09@sha256:b276e14e2aefe4ac51c1fc48a8f3e3cea815b85c46d8fbecb97c6be96e041523
     command: ["sleep"]
     args:
       - "1000h"


### PR DESCRIPTION
Tags can be arbitrarily changed without the user noticing, potentially
making the tag point to a completely different image. Instead, reference
the cilium-builder image by its unique sha256 hash which is already done
in all other places using the image.

While at it, also bump the image to the latest version which was bumped
to Go 1.15.4 in #13945.

Fixes: 417cded995a7 ("test: Move RuntimeVerifier to K8sVerifier")

Note that the manifests in the `v1.8` and `v1.9` release branches already use the image hash.