### PR TITLE
test: Use NFS by default in test VMs

### DIFF
--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         PROJ_PATH = "src/github.com/cilium/cilium"
         VM_MEMORY = "8192"
         VM_CPUS = "4"
+        NFS = "0"
         GINKGO_TIMEOUT="150m"
         DEFAULT_KERNEL="""${sh(
             returnStdout: true,

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -128,6 +128,7 @@ pipeline {
                         TESTED_SUITE="runtime"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                        NFS="0"
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -227,6 +228,7 @@ pipeline {
                         TESTED_SUITE="runtime"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                        NFS="0"
                     }
                     steps {
                         sh 'cd ${TESTDIR}; ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -14,7 +14,7 @@ $BUILD_NUMBER = ENV['BUILD_NUMBER'] || "0"
 $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.19"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
-$NFS = ENV['NFS']=="1"? true : false
+$NFS = ENV['NFS']=="0"? false : true
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")


### PR DESCRIPTION
The new K8sVerifier test compiles some Cilium binaries inside the VM, which can lead to `interrupted system call` errors. Using NFS should fix it by speeding up the filesystem accesses.

This pull request switches the test VMs to use NFS by default, thereby enabling NFS in our CI.