### PR TITLE
v1.7 backport 2020-11-11

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -33,7 +33,7 @@ preflight:
 # global groups all configuration options that have effect on all sub-charts
 global:
   # registry is the address of the registry and orgnization for all container images
-  registry: docker.io/cilium
+  registry: quay.io/cilium
 
   # tag is the container image tag to use
   tag: v1.7.11

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -429,7 +429,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:v1.7.11"
+        image: "quay.io/cilium/cilium:v1.7.11"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -492,7 +492,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:v1.7.11"
+        image: "quay.io/cilium/cilium:v1.7.11"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -684,7 +684,7 @@ spec:
               key: identity-allocation-mode
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/operator:v1.7.11"
+        image: "quay.io/cilium/operator:v1.7.11"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -63,6 +63,13 @@ pipeline {
                 }
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage('Make Cilium images and prepare gke cluster') {
             parallel {
                 stage('Make Cilium images') {

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -63,6 +63,13 @@ pipeline {
                 sh '/usr/local/bin/cleanup || true'
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage('Make Cilium images') {
             environment {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
@@ -115,10 +122,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -142,10 +151,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -246,10 +257,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -273,10 +286,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -376,10 +391,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -61,6 +61,13 @@ pipeline {
                }
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage('Make Cilium images') {
             environment {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
@@ -111,9 +118,11 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
-                            sh 'cd ${TESTDIR}; timeout 30m vagrant up runtime --provision'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
+                                sh 'cd ${TESTDIR}; timeout 30m vagrant up runtime --provision'
+                            }
                         }
                     }
                     post {
@@ -141,9 +150,11 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            dir("${TESTDIR}") {
-                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                dir("${TESTDIR}") {
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }
@@ -168,9 +179,11 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            dir("${TESTDIR}") {
-                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                dir("${TESTDIR}") {
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,6 +1,5 @@
 # -*- mode: ruby -*-
-# vi: set ft=ruby
-Vagrant.require_version ">= 2.2.0"
+# vi: set ft=ruby Vagrant.require_version ">= 2.2.0"
 
 # The source of truth for vagrant box versions.
 # Sets SERVER_BOX, SERVER_VERSION, NETNEXT_SERVER_BOXET and NEXT_SERVER_VERSION
@@ -26,6 +25,8 @@ $PRELOAD_VM = ENV['PRELOAD_VM'] || "false"
 $SKIP_K8S_PROVISION = ENV['SKIP_K8S_PROVISION'] || "false"
 $NO_CILIUM_ON_NODE = ENV['NO_CILIUM_ON_NODE'] || ""
 $KUBEPROXY = (ENV['KUBEPROXY'] || "1")
+$DOCKER_LOGIN = ENV['DOCKER_LOGIN'] || ""
+$DOCKER_PASSWORD = ENV['DOCKER_PASSWORD'] || ""
 
 # RAM and CPU settings
 $MEMORY = (ENV['VM_MEMORY'] || "4096").to_i
@@ -132,7 +133,10 @@ Vagrant.configure("2") do |config|
                           "CILIUM_REGISTRY" => "#{$CILIUM_REGISTRY}",
                           "PRELOAD_VM" => "#{$PRELOAD_VM}",
                           "SKIP_K8S_PROVISION" => "#{$SKIP_K8S_PROVISION}",
-                          "KUBEPROXY" => "#{$KUBEPROXY}"}
+                          "KUBEPROXY" => "#{$KUBEPROXY}",
+                          "DOCKER_LOGIN" => "#{$DOCKER_LOGIN}",
+                          "DOCKER_PASSWORD" => "#{$DOCKER_PASSWORD}"
+                }
             end
         end
     end

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -218,7 +218,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), "Unable to install helm repository")
 
 		By("Cleaning Cilium state")
-		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "cilium", oldImageVersion, "docker.io/cilium")
+		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "cilium", oldImageVersion, "quay.io/cilium")
 
 		By("Deploying Cilium %s", oldHelmChartVersion)
 

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if ! [[ -z $DOCKER_LOGIN && -z $DOCKER_PASSWORD ]]; then
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_LOGIN}" --password-stdin
+fi
+
 HOST=$(hostname)
 export HELM_VERSION="3.1.1"
 export TOKEN="258062.5d84c017c9b2796c"

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if ! [[ -z $DOCKER_LOGIN && -z $DOCKER_PASSWORD ]]; then
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_LOGIN}" --password-stdin
+fi
+
 HOST=$(hostname)
 PROVISIONSRC="/tmp/provision"
 


### PR DESCRIPTION
v1.7 backports 2020-11-11

 * #13937 -- change default docker image repository from docker.io to quay.io (@aanm)
 * #13969 -- ci: log in to docker in vagrant boxes (@nebril)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13937 13969; do contrib/backporting/set-labels.py $pr done 1.7; done
```
