### PR TITLE
cilium/cmd: remove unnecessary parseLabels func

### DIFF
--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -70,23 +70,12 @@ If multiple sources and / or destinations are provided, each source is tested wh
 			Usagef(cmd, "Missing destination argument")
 		}
 
-		// Parse provided labels
 		if len(src) > 0 {
-			srcSlice, err = parseLabels(src)
-			if err != nil {
-				Fatalf("Invalid source: %s", err)
-			}
-
-			srcSlices = append(srcSlices, srcSlice)
+			srcSlices = append(srcSlices, src)
 		}
 
 		if len(dst) > 0 {
-			dstSlice, err = parseLabels(dst)
-			if err != nil {
-				Fatalf("Invalid destination: %s", err)
-			}
-
-			dstSlices = append(dstSlices, dstSlice)
+			dstSlices = append(dstSlices, dst)
 		}
 
 		if len(dports) > 0 {
@@ -221,13 +210,6 @@ func appendEpLabelsToSlice(labelSlice []string, epID string) []string {
 	}
 
 	return append(labelSlice, lbls...)
-}
-
-func parseLabels(slice []string) ([]string, error) {
-	if len(slice) == 0 {
-		return nil, fmt.Errorf("No labels provided")
-	}
-	return slice, nil
 }
 
 func getSecIDFromK8s(podName string) (string, error) {


### PR DESCRIPTION
The parseLabels func merely checks for the slice passed to it not to be
empty. All call sites are already protected by "if len(slice) > 0", so
drop parseLabels entirely and directly append the checked slice to
srcSlices/dstSlices.