### PR TITLE
runtime: specify ICMP ids on connectivity test

### DIFF
--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -16,7 +16,9 @@ package constants
 
 const (
 	// NetperfImage is the Docker image used for performance testing
-	NetperfImage = "docker.io/tgraf/netperf:v1.0"
+	// NB: this image includes netperf and a utility named xping that works
+	// like ping but it also allows to specify the ICMP id.
+	NetperfImage = "quay.io/cilium/net-test:v1.0.0"
 
 	// HttpdImage is the image used for starting an HTTP server.
 	HttpdImage = "docker.io/cilium/demo-httpd:latest"

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -62,6 +62,14 @@ func Ping6(endpoint string) string {
 	return fmt.Sprintf("ping6 -c %d %s", PingCount, endpoint)
 }
 
+func Ping6WithID(endpoint string, icmpID uint16) string {
+	return fmt.Sprintf("xping -6 -W %d -c %d -x %d %s", PingTimeout, PingCount, icmpID, endpoint)
+}
+
+func PingWithID(endpoint string, icmpID uint16) string {
+	return fmt.Sprintf("xping -W %d -c %d -x %d %s", PingTimeout, PingCount, icmpID, endpoint)
+}
+
 // Wrk runs a standard wrk test for http
 func Wrk(endpoint string) string {
 	return fmt.Sprintf("wrk -t2 -c100 -d30s -R2000 http://%s", endpoint)


### PR DESCRIPTION
The RuntimeConntrackInVethModeTest failed transiently (#12891).

The test sends pings from client->server and expects them to work, and
pings from server->client and expects them to not work (based on cilium
policies). If the ICMP ids for these two case match, current CT code
allows packets in both directions. This patch uses a modified ping
utility (called xping) that allows to specify the ICMP id when executing
a ping to produce determenistic results.

Currently, we only test the case where the ids do not match. Once the CT
code is modified to address the above issue, we can add a test where the
ids match.

Related: #12891

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>