### PR TITLE
fqdn: pass CIDR matcher to (*DNSZombieMappings).DumpAlive

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -727,12 +727,7 @@ func extractDNSLookups(endpoints []*endpoint.Endpoint, CIDRStr, matchPatternStr 
 			})
 		}
 
-		for _, delete := range ep.DNSZombies.DumpAlive() {
-			// only proceed if any IP matches the cidr selector
-			if !cidrMatcher(delete.IP) {
-				continue
-			}
-
+		for _, delete := range ep.DNSZombies.DumpAlive(cidrMatcher) {
 			for _, name := range delete.Names {
 				if !nameMatcher(name) {
 					continue


### PR DESCRIPTION
The only caller of (*DNSZombieMappings).DumpAlive takes the returned
slice and proceeds only if its IP matches. Rather than potentially
wasting memory by returning zombie mappings which aren't used further,
pass the matcher function and call it to determine whether the mapping
should be included in the result.

Also add a test to verify the functionality.