### PR TITLE
dnsproxy: print total number of rules if too many

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -203,6 +203,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 								logfields.Port:                  port,
 								logfields.EndpointLabelSelector: cs,
 								logfields.Limit:                 p.maxIPsPerRestoredRule,
+								"totalRules":                    len(p.LookupIPsBySecID(nid)),
 							}).Warning("Too many IPs for a rule, skipping the rest")
 							break Loop
 						}


### PR DESCRIPTION
GetRules() will not process more than 1000 rules per port.
Print how many are the total rules in the message.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>
