### PR TITLE
fqdn: Make maximum number of IPs per restored rule configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -168,6 +168,7 @@ cilium-agent [flags]
       --tofqdns-enable-poller-events                  Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
       --tofqdns-endpoint-max-ip-per-hostname int      Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-max-deferred-connection-deletes int   Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-max-ips-per-restored-rule int                Maximum number of IPs to maintain for each restored rule (default 1000)
       --tofqdns-min-ttl int                           The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 600 when --tofqdns-enable-poller, 3600 otherwise)
       --tofqdns-pre-cache string                      DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                        Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -722,6 +722,9 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
+	flags.Int(option.ToFQDNsMaxIPsPerRestoredRule, defaults.ToFQDNsMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored rule")
+	option.BindEnv(option.ToFQDNsMaxIPsPerRestoredRule)
+
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)
 

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -311,7 +311,9 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	if err != nil {
 		return err
 	}
-	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression, d.lookupEPByIP, d.lookupSecIDByIP, d.lookupIPsBySecID, d.notifyOnDNSMsg)
+	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
+		option.Config.ToFQDNsMaxIPsPerRestoredRule, d.lookupEPByIP, d.lookupSecIDByIP, d.lookupIPsBySecID,
+		d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -96,6 +96,10 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50
 
+	// ToFQDNsMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored ToFQDN rules.
+	ToFQDNsMaxIPsPerRestoredRule = 1000
+
 	// ToFQDNsMaxDeferredConnectionDeletes Maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes = 10000

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -189,7 +189,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
-	proxy, err := StartDNSProxy("", 0, true, // any address, any port, enable compression
+	proxy, err := StartDNSProxy("", 0, true, 1000, // any address, any port, enable compression, max 1000 restore IPs
 		// LookupEPByIP
 		func(ip net.IP) (*endpoint.Endpoint, error) {
 			if s.restoring {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -390,6 +390,9 @@ const (
 	// performed
 	Reason = "reason"
 
+	// Limit is a numerical limit that has been exceeded
+	Limit = "limit"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -378,6 +378,10 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
 
+	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored ToFQDN rules
+	ToFQDNsMaxIPsPerRestoredRule = "tofqdns-max-ips-per-restored-rule"
+
 	// ToFQDNsMaxDeferredConnectionDeletes defines the maximum number of IPs to
 	// retain for expired DNS lookups with still-active connections"
 	ToFQDNsMaxDeferredConnectionDeletes = "tofqdns-max-deferred-connection-deletes"
@@ -1224,6 +1228,10 @@ type DaemonConfig struct {
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost int
 
+	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored ToFQDN rules
+	ToFQDNsMaxIPsPerRestoredRule int
+
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes int
@@ -1545,6 +1553,7 @@ var (
 		EnableL7Proxy:                defaults.EnableL7Proxy,
 		EndpointStatus:               make(map[string]struct{}),
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
+		ToFQDNsMaxIPsPerRestoredRule: defaults.ToFQDNsMaxIPsPerRestoredRule,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
 		IPAllocationTimeout:          defaults.IPAllocationTimeout,
@@ -2048,6 +2057,7 @@ func (c *DaemonConfig) Populate() {
 	c.ToFQDNsEnablePoller = viper.GetBool(ToFQDNsEnablePoller)
 	c.ToFQDNsEnablePollerEvents = viper.GetBool(ToFQDNsEnablePollerEvents)
 	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
+	c.ToFQDNsMaxIPsPerRestoredRule = viper.GetInt(ToFQDNsMaxIPsPerRestoredRule)
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)
 	} else {

--- a/test/gke/clean-cluster.sh
+++ b/test/gke/clean-cluster.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# We leak istio pods for an unknown reason (these tests do cleanup). This may
+# be related to timeouts or other failures. In any case, we delete them here to
+# be sure.
+
+echo "deleting istio-system namespace and contents"
+kubectl delete ns istio-system --force --grace-period=0
+# Delete sidecar injection namespace label in case it was left behind
+kubectl label --overwrite namespace default istio-injection-
+
+echo "deleting cilium-monitoring namespace and contents"
+kubectl delete ns cilium-monitoring --force --grace-period=0
+
+echo "deleting cilium namespace and contents"
+kubectl delete ns cilium --force --grace-period=0
+
+echo "deleting all crds"
+kubectl delete crds --all
+
+# because of https://github.com/kubernetes/kubernetes/issues/60807 , we may end up with garbage terminating
+# namespaces leftovers after tests. This is a hacky workaround
+# '\[[^]]*\]' below matches a pair of square brackets with anything in between, not containing a closing square bracket
+kubectl get ns | \
+	awk '/Terminating/ {print $1}' | \
+   	xargs -n 1 bash -c 'if [ "$#" -ne 1 ]; then exit 0; fi; kubectl get ns -o json $1 | tr -d "\n" | sed "s/\"finalizers\": \[[^]]*\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/$1/finalize -f -' -
+
+# Note: This can be removed once GKE stops having the issue with namespaces no
+# deleting.
+# because of the hack above, we may end up with orphaned pods etc. We need to
+# delete any here. We do this after the hack above to simplify the logic (i.e.
+# don't look for the terminating namespaces twice). We also cannot rely on the
+# list of terminating namespaces because another run deleted them, leaving
+# orphans.
+# The commands mimic the DeleteAllInNamespace function in test/helpers/kubectl.go
+
+# Get all namespaces that exist. Terminating ones have been cleared above.
+NAMESPACES=$(kubectl get ns -o jsonpath='{range .items[*]}{@.metadata.name}{" "}')
+
+# Get all namespaced types in the k8s system
+TYPES=$(kubectl api-resources --namespaced=true --verbs=delete -o name | tr '\n' ',' | sed -e 's/,$//')
+
+# Get all objects of namespaced types
+# We use '|' to delimit namespace and type/name since / is already used
+OBJECTS=$(kubectl get $TYPES --all-namespaces -o jsonpath="{range .items[*]}{@.metadata.namespace}{'|'}{@.kind}{'/'}{@.metadata.name}{' '}{end}")
+
+# For each object, check if the namespace it is in exists. If the namespace
+# does not, delete the object.
+for pair in $OBJECTS; do
+  IFS='|' read ns obj <<<"$pair"
+  #echo "Checking if $ns/$obj ($pair) is present in $NAMESPACES"
+  if ! $(echo "$NAMESPACES" | grep -q "$ns" - ) ; then
+    echo "Object $obj in $ns is a namespace orphan; deleting"
+    kubectl delete -n $ns $obj --force --grace-period=0
+  elif [ "$ns" == "default" ] ; then
+    echo "Deleting object $obj in $ns"
+    kubectl delete -n $ns $obj --force --grace-period=0
+  fi
+done

--- a/test/gke/lock.yaml
+++ b/test/gke/lock.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lock
+  namespace: cilium-ci-lock
 spec:
   replicas: 0
   selector:

--- a/test/gke/locking.sh
+++ b/test/gke/locking.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# based on https://stackoverflow.com/a/1985512/563158
+
+LOCKFILE="/var/lock/$(basename "$0")"
+LOCKFD=99
+
+_lock()             { flock -"$1" "$LOCKFD";  }
+_no_more_locking()  { _lock u; _lock xn && rm -f "$LOCKFILE";  }
+_prepare_locking()  { eval "exec $LOCKFD>\"$LOCKFILE\""; trap _no_more_locking EXIT;  }
+
+_prepare_locking
+
+lock()            { _lock x;  }   # obtain a lock
+unlock()            { _lock u;  }   # drop a lock

--- a/test/gke/registry-ip.sh
+++ b/test/gke/registry-ip.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "$(${script_dir}/../print-node-ip.sh):$(cat ${script_dir}/registry_port)"

--- a/test/gke/resize-cluster.sh
+++ b/test/gke/resize-cluster.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2020 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# this script sets management cluster nodepool cnrm object nodecount and resizes the cluster via gcloud cli
+
+if [ ! "$#" -eq 2 ] ; then
+  echo "$0 supports exactly 2 arguments - desired node count and cluster uri"
+  exit 1
+fi
+
+project="cilium-ci"
+# this is only needs to be set as some of gcloud commands requires it,
+# but as this script uses resource URIs clusters in all locations are
+# going to be discovered and used
+region="us-west1"
+
+node_count=${1}
+cluster_uri=${2}
+cluster_name=${cluster_uri##*/}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export KUBECONFIG="${script_dir}/resize-kubeconfig"
+gcloud container clusters get-credentials --project "${project}" --region "europe-west4" management-cluster-0
+
+kubectl get containernodepools.container.cnrm.cloud.google.com ${cluster_name} -n test-clusters -o yaml | sed "s/nodeCount:.*$/nodeCount: ${node_count}/g" | kubectl replace -f -
+
+gcloud container clusters get-credentials --project "${project}" --region "${region}" "${cluster_uri}"
+
+node_pools=($(gcloud container node-pools list --project "${project}" --region "${region}" --cluster "${cluster_uri}" --format="value(name)"))
+if [ "${#node_pools[@]}" -ne 1 ] ; then
+  echo "expected 1 node pool, found ${#node_pools[@]}"
+  exit 1
+fi
+
+gcloud container clusters resize --project "${project}" --region "${region}" --node-pool "${node_pools[0]}" --num-nodes ${node_count} --quiet "${cluster_uri}"

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -1,48 +1,76 @@
 #!/bin/bash
 
+test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+project="cilium-ci"
+# this is only needs to be set as some of gcloud commands requires it,
+# but as this script uses resource URIs clusters in all locations are
+# going to be discovered and used
+region="us-west1"
+
 set -e
 
 locked=1
 
-zone=europe-west4-a
-export KUBECONFIG=gke-kubeconfig
+export KUBECONFIG="${script_dir}/gke-kubeconfig"
 
 while [ $locked -ne 0 ]; do
-    rm gke-kubeconfig || true
+    rm -f "${KUBECONFIG}"
     echo "selecting random cluster"
-    cluster=$(gcloud container clusters list --zone europe-west4-a | grep cilium-ci | sort -R | head -n 1 | awk '{print $1}')
+    for cluster_uri in $(gcloud container clusters list --project "${project}" --filter="name ~ ^cilium-ci-" --uri | sort -R); do
 
-    echo "getting kubeconfig for $cluster"
-    gcloud container clusters get-credentials --zone $zone $cluster
+	echo "checking whether cluster ${cluster_uri} has any node pools"
+	node_pools=$(gcloud container node-pools list --project "${project}" --region "${region}" --cluster "${cluster_uri}" --format="value(name)")
+	if [ -z "${node_pools}" ]; then
+		echo "no nodepools found, selecting another cluster"
+		continue
+	fi
 
-    echo "aquiring cluster lock"
-    set +e
-    kubectl create -f lock.yaml
+	echo "getting kubeconfig for ${cluster_uri} (will store in ${KUBECONFIG})"
+	gcloud container clusters get-credentials --project "${project}" --region "${region}" "${cluster_uri}"
 
-    kubectl annotate deployment lock lock=1
-    locked=$?
-    echo $locked
-    set -e
+	echo "acquiring cluster lock"
+	set +e
+	kubectl create namespace cilium-ci-lock
+	kubectl create -f "${script_dir}/lock.yaml"
+
+	kubectl annotate deployment -n cilium-ci-lock lock lock=1
+	locked=$?
+	echo $locked
+	if [ -n "${BUILD_URL+x}" ] && [ $locked -eq 0 ] ; then
+	    kubectl annotate deployment -n cilium-ci-lock lock --overwrite "jenkins-build-url=${BUILD_URL}"
+	fi
+	set -e
+	if [ $locked -eq 0 ] ; then
+	   break
+	fi
+    done
 done
 
-echo "lock acquired on cluster $cluster"
-# cluster-name is used in get-cluster-version.sh, which runs after this in CI.
-echo $cluster > cluster-name
+echo "lock acquired on cluster ${cluster_uri}"
+echo "${cluster_uri}" > "${script_dir}/cluster-uri"
+gcloud container clusters describe --project "${project}" --region "${region}" --format='value(name)' "${cluster_uri}" > "${script_dir}/cluster-name"
+gcloud container clusters describe --project "${project}" --region "${region}" --format='value(currentMasterVersion)' "${cluster_uri}" \
+  | sed -E 's/([0-9]+\.[0-9]+)\..*/\1/' | tr -d '\n' > "${script_dir}/cluster-version"
+
+echo "cleaning cluster before tests"
+${script_dir}/clean-cluster.sh
 
 echo "creating cilium ns"
 kubectl create ns cilium || true
 
-echo "scaling $cluster to 2"
-yes | gcloud container clusters resize $cluster --node-pool default-pool --num-nodes 2 --zone $zone
+echo "scaling ${cluster_uri} to 2"
+${script_dir}/resize-cluster.sh 2 ${cluster_uri}
 
 echo "labeling nodes"
 index=1
 for node in $(kubectl get nodes --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
 do
-    kubectl label node $node cilium.io/ci-node=k8s$index
+    kubectl label node $node cilium.io/ci-node=k8s$index --overwrite
     index=$((index+1))
 done
 
 echo "adding node registry as trusted"
-helm template registry-adder ../k8sT/manifests/registry-adder-gke --set IP="$(../print-node-ip.sh)" > registry-adder.yaml
-kubectl apply -f registry-adder.yaml
+helm template registry-adder "${test_dir}/k8sT/manifests/registry-adder-gke" --set IP="$(${script_dir}/registry-ip.sh)" > "${script_dir}/registry-adder.yaml"
+kubectl apply -f "${script_dir}/registry-adder.yaml"

--- a/test/gke/start-registry.sh
+++ b/test/gke/start-registry.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+set -x
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./locking.sh
+source "${script_dir}"/locking.sh
+
+docker run -d \
+	--restart=always \
+	-v /opt/registry/certs:/certs \
+	-e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
+	-e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+	-e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+	-p 443 \
+	registry:2 > "${script_dir}"/registry_container
+
+docker inspect "$(cat "${script_dir}"/registry_container)" | jq -r '.[0]["NetworkSettings"]["Ports"]["443/tcp"][0]["HostPort"]' > "${script_dir}"/registry_port
+
+
+lock
+cat /etc/docker/daemon.json | jq -r ". + {\"insecure-registries\": (.[\"insecure-registries\"] + [\"$("${script_dir}"/registry-ip.sh)\"])}" > daemon.json
+mv daemon.json /etc/docker/daemon.json
+# make docker reload configuration
+pgrep dockerd | xargs kill -SIGHUP
+unlock

--- a/test/gke/stop-registry.sh
+++ b/test/gke/stop-registry.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+docker rm -f "$(cat ${script_dir}/registry_container)"


### PR DESCRIPTION
Only count the number of IPs for each FQDN selector/rule when storing
rules for restoration, rather than ignoring later rules on a port
after previous rules have hit the maximum number of IPs.

Make the maximum number of IPs per restored rule configurable with the
new option '--tofqdns-max-ips-per-restored-rule' (default 1000).

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
FQDN rule restoration IP limit has been made configurable (`--tofqdns-max-ips-per-restored-rule`, default 1000). 
```
