### PR TITLE
pkg/k8s: trim spaces from loadBalancerSourceRanges

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -117,9 +117,14 @@ func ParseService(svc *slim_corev1.Service, nodeAddressing datapath.NodeAddressi
 			loadBalancerIPs = append(loadBalancerIPs, ip.IP)
 		}
 	}
+	lbSrcRanges := make([]string, 0, len(svc.Spec.LoadBalancerSourceRanges))
+	for _, cidrString := range svc.Spec.LoadBalancerSourceRanges {
+		cidrStringTrimmed := strings.TrimSpace(cidrString)
+		lbSrcRanges = append(lbSrcRanges, cidrStringTrimmed)
+	}
 
 	svcInfo := NewService(clusterIP, svc.Spec.ExternalIPs, loadBalancerIPs,
-		svc.Spec.LoadBalancerSourceRanges, headless, trafficPolicy,
+		lbSrcRanges, headless, trafficPolicy,
 		uint16(svc.Spec.HealthCheckNodePort), svc.Labels, svc.Spec.Selector,
 		svc.GetNamespace(), svcType)
 	svcInfo.IncludeExternal = getAnnotationIncludeExternal(svc)


### PR DESCRIPTION
Similarly to what is being done in upstream kube-proxy [1], but
unfortunately without explaining why, loadBalancerSourceRanges might
contain spaces which prevents the CIDR from being parsed correctly.

[1] https://github.com/kubernetes/kubernetes/pull/94107

Fixes: 31956817bbd4 ("k8s: Add and parse LoadBalancerSourceRanges field")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Trim spaces from loadBalancerSourceRanges when parsing its values.
```