### PR TITLE
v1.9 backports 2020-11-12

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -13,6 +13,8 @@ TEST_ARTIFACTS += ./test.test
 
 GINKGO = $(QUIET) ginkgo
 
+REGISTRY_CREDENTIALS ?= "${DOCKER_LOGIN}:${DOCKER_PASSWORD}"
+
 all: build
 
 build:
@@ -27,13 +29,13 @@ build:
 test: run k8s
 
 run:
-	ginkgo --focus "Runtime" -v -- --cilium.provision=$(PROVISION)
+	ginkgo --focus "Runtime" -v -- --cilium.provision=$(PROVISION) --cilium.registryCredenitals=$(REGISTRY_CREDENTIALS)
 
 k8s:
-	ginkgo --focus "K8s" -v -- --cilium.provision=$(PROVISION)
+	ginkgo --focus "K8s" -v -- --cilium.provision=$(PROVISION) --cilium.registryCredenitals=$(REGISTRY_CREDENTIALS)
 
 nightly:
-	ginkgo --focus "Nightly" -v -- --cilium.provision=$(PROVISION)
+	ginkgo --focus "Nightly" -v -- --cilium.provision=$(PROVISION) --cilium.registryCredenitals=$(REGISTRY_CREDENTIALS)
 
 clean:
 	@$(ECHO_CLEAN)

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -21,6 +21,11 @@ import (
 	"time"
 )
 
+const (
+	RegistryDomain     = "docker.io"
+	RegistrySecretName = "regcred"
+)
+
 // CiliumTestConfigType holds all of the configurable elements of the testsuite
 type CiliumTestConfigType struct {
 	Reprovision bool
@@ -43,6 +48,7 @@ type CiliumTestConfigType struct {
 	ProvisionK8s        bool
 	Timeout             time.Duration
 	Kubeconfig          string
+	RegistryCredentials string
 	Benchmarks          bool
 	// Multinode enables the running of tests that involve more than one
 	// node. If false, some tests will silently skip multinode checks.
@@ -90,6 +96,8 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies timeout for test run")
 	flagset.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",
 		"Kubeconfig to be used for k8s tests")
+	flagset.StringVar(&c.RegistryCredentials, "cilium.registryCredentials", "",
+		"Registry credentials to be used to download images")
 	flagset.BoolVar(&c.Benchmarks, "cilium.benchmarks", false,
 		"Specifies benchmark tests should be run which may increase test time")
 	flagset.BoolVar(&c.Multinode, "cilium.multinode", true,


### PR DESCRIPTION
* #13959 -- Add Registry Credentials to Tests (@nathanjsweet)

Once this PR is merged, you can update the PR labels via:

```upstream-prs
$ for pr in 13959; do contrib/backporting/set-labels.py $pr done 1.9; done
```