### PR TITLE
fqdn: Fix confusion of ToFQDNs vs. DNS rules.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,6 +63,7 @@ cilium-agent [flags]
       --disable-conntrack                                    Disable connection tracking
       --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
       --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
       --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bandwidth-manager                             Enable BPF bandwidth manager
@@ -205,7 +206,6 @@ cilium-agent [flags]
       --tofqdns-enable-dns-compression                       Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-endpoint-max-ip-per-hostname int             Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-max-deferred-connection-deletes int          Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-max-ips-per-restored-rule int                Maximum number of IPs to maintain for each restored rule (default 1000)
       --tofqdns-min-ttl int                                  The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
       --tofqdns-pre-cache string                             DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                               Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -786,8 +786,8 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
-	flags.Int(option.ToFQDNsMaxIPsPerRestoredRule, defaults.ToFQDNsMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored rule")
-	option.BindEnv(option.ToFQDNsMaxIPsPerRestoredRule)
+	flags.Int(option.DNSMaxIPsPerRestoredRule, defaults.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
+	option.BindEnv(option.DNSMaxIPsPerRestoredRule)
 
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -300,7 +300,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		return err
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
-		option.Config.ToFQDNsMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
+		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
 		d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,6 +94,10 @@ const (
 	// DefaultMapPrefix is the default prefix for all BPF maps.
 	DefaultMapPrefix = "tc/globals"
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules.
+	DNSMaxIPsPerRestoredRule = 1000
+
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
 	// This is used in DaemonConfig.Populate
 	ToFQDNsMinTTL = 3600 // 1 hour in seconds
@@ -101,10 +105,6 @@ const (
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50
-
-	// ToFQDNsMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules.
-	ToFQDNsMaxIPsPerRestoredRule = 1000
 
 	// ToFQDNsMaxDeferredConnectionDeletes Maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -126,6 +126,10 @@ type DNSProxy struct {
 	// this mutex protects variables below this point
 	lock.Mutex
 
+	// usedServers is the set of DNS servers that have been allowed and used successfully.
+	// This is used to limit the number of IPs we store for restored DNS rules.
+	usedServers map[string]struct{}
+
 	// allowed tracks all allowed L7 DNS rules by endpointID, destination port,
 	// and L3 Selector. All must match for a query to be allowed.
 	//
@@ -196,6 +200,13 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 				for _, nid := range cs.GetSelections() {
 					nidIPs := p.LookupIPsBySecID(nid)
 					for _, ip := range nidIPs {
+						// Skip IPs that are allowed but have never been used,
+						// but only if at least one server has been used so far.
+						if len(p.usedServers) > 0 {
+							if _, used := p.usedServers[ip]; !used {
+								continue
+							}
+						}
 						IPs[ip] = struct{}{}
 						count++
 						if count > p.maxIPsPerRestoredDNSRule {
@@ -374,6 +385,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		LookupIPsBySecID:         lookupIPsFunc,
 		NotifyOnDNSMsg:           notifyFunc,
 		lookupTargetDNSServer:    lookupTargetDNSServer,
+		usedServers:              make(map[string]struct{}),
 		allowed:                  make(perEPAllow),
 		restored:                 make(perEPRestored),
 		restoredEPs:              make(restoredEPs),
@@ -624,6 +636,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS response")
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, &stat)
+	} else {
+		p.Lock()
+		// Add the server to the set of used DNS servers. This set is never GCd, but is limited by set
+		// of DNS server IPs that are allowed by a policy and for which successful response was received.
+		p.usedServers[targetServerIP.String()] = struct{}{}
+		p.Unlock()
 	}
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -119,9 +119,9 @@ type DNSProxy struct {
 	// helpers.go but is modified during testing.
 	lookupTargetDNSServer func(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error)
 
-	// maxIPsPerRestoredRule is the maximum number of IPs to maintain for each
-	// restored ToFQDNs rule.
-	maxIPsPerRestoredRule int
+	// maxIPsPerRestoredDNSRule is the maximum number of IPs to maintain for each
+	// restored DNS rule.
+	maxIPsPerRestoredDNSRule int
 
 	// this mutex protects variables below this point
 	lock.Mutex
@@ -194,17 +194,18 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 				count := 0
 			Loop:
 				for _, nid := range cs.GetSelections() {
-					for _, ip := range p.LookupIPsBySecID(nid) {
+					nidIPs := p.LookupIPsBySecID(nid)
+					for _, ip := range nidIPs {
 						IPs[ip] = struct{}{}
 						count++
-						if count > p.maxIPsPerRestoredRule {
+						if count > p.maxIPsPerRestoredDNSRule {
 							log.WithFields(logrus.Fields{
 								logfields.EndpointID:            endpointID,
 								logfields.Port:                  port,
 								logfields.EndpointLabelSelector: cs,
-								logfields.Limit:                 p.maxIPsPerRestoredRule,
-								"totalRules":                    len(p.LookupIPsBySecID(nid)),
-							}).Warning("Too many IPs for a rule, skipping the rest")
+								logfields.Limit:                 p.maxIPsPerRestoredDNSRule,
+								logfields.Count:                 len(nidIPs),
+							}).Warning("Too many IPs for a DNS rule, skipping the rest")
 							break Loop
 						}
 					}
@@ -358,7 +359,7 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 // notifyFunc will be called with DNS response data that is returned to a
 // requesting endpoint. Note that denied requests will not trigger this
 // callback.
-func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
+func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
 	if port == 0 {
 		log.Debug("DNS Proxy port is configured to 0. A random port will be assigned by the OS.")
 	}
@@ -377,7 +378,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		restored:                 make(perEPRestored),
 		restoredEPs:              make(restoredEPs),
 		EnableDNSCompression:     enableDNSCompression,
-		maxIPsPerRestoredRule:    maxRestoreIPs,
+		maxIPsPerRestoredDNSRule: maxRestoreDNSIPs,
 	}
 	atomic.StoreInt32(&p.rejectReply, dns.RcodeRefused)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -661,6 +661,27 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	restored3 := s.proxy.GetRules(uint16(epID3)).Sort()
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
+	// Test with limited set of allowed IPs
+	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
+
+	expected1b := restore.DNSRules{
+		53: restore.IPRules{{
+			IPs: map[string]struct{}{},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID1Selector]},
+		}, {
+			IPs: map[string]struct{}{"127.0.0.2": {}},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID2Selector]},
+		}}.Sort(),
+		54: restore.IPRules{{
+			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
+		}},
+	}
+	restored1b := s.proxy.GetRules(uint16(epID1)).Sort()
+	c.Assert(restored1b, checker.DeepEquals, expected1b)
+
+	// unlimited again
+	s.proxy.usedServers = nil
+
 	s.proxy.UpdateAllowed(epID1, 53, nil)
 	s.proxy.UpdateAllowed(epID1, 54, nil)
 	_, exists := s.proxy.allowed[epID1]

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -447,6 +447,9 @@ const (
 	// Limit is a numerical limit that has been exceeded
 	Limit = "limit"
 
+	// Count is a measure being compared to the Limit
+	Count = "count"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -384,6 +384,10 @@ const (
 	// CMDRef is the path to cmdref output directory
 	CMDRef = "cmdref"
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule = "dns-max-ips-per-restored-rule"
+
 	// ToFQDNsMinTTL is the minimum time, in seconds, to use DNS data for toFQDNs policies.
 	ToFQDNsMinTTL = "tofqdns-min-ttl"
 
@@ -393,10 +397,6 @@ const (
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
-
-	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules
-	ToFQDNsMaxIPsPerRestoredRule = "tofqdns-max-ips-per-restored-rule"
 
 	// ToFQDNsMaxDeferredConnectionDeletes defines the maximum number of IPs to
 	// retain for expired DNS lookups with still-active connections"
@@ -910,9 +910,9 @@ var HelpFlagSections = []FlagsSection{
 	{
 		Name: "DNS policy flags",
 		Flags: []string{
+			DNSMaxIPsPerRestoredRule,
 			FQDNRejectResponseCode,
 			ToFQDNsMaxIPsPerHost,
-			ToFQDNsMaxIPsPerRestoredRule,
 			ToFQDNsMinTTL,
 			ToFQDNsPreCache,
 			ToFQDNsProxyPort,
@@ -1635,6 +1635,10 @@ type DaemonConfig struct {
 	PrometheusServeAddr    string
 	ToFQDNsMinTTL          int
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule int
+
 	// ToFQDNsProxyPort is the user-configured global, shared, DNS listen port used
 	// by the DNS Proxy. Both UDP and TCP are handled on the same port. When it
 	// is 0 a random port will be assigned, and can be obtained from
@@ -1644,10 +1648,6 @@ type DaemonConfig struct {
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost int
-
-	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules
-	ToFQDNsMaxIPsPerRestoredRule int
 
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
@@ -2060,8 +2060,8 @@ var (
 		EnableIPv6NDP:                defaults.EnableIPv6NDP,
 		EnableL7Proxy:                defaults.EnableL7Proxy,
 		EndpointStatus:               make(map[string]struct{}),
+		DNSMaxIPsPerRestoredRule:     defaults.DNSMaxIPsPerRestoredRule,
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
-		ToFQDNsMaxIPsPerRestoredRule: defaults.ToFQDNsMaxIPsPerRestoredRule,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
 		IPAllocationTimeout:          defaults.IPAllocationTimeout,
@@ -2588,8 +2588,8 @@ func (c *DaemonConfig) Populate() {
 	c.EnableIdentityMark = viper.GetBool(EnableIdentityMark)
 
 	// toFQDNs options
+	c.DNSMaxIPsPerRestoredRule = viper.GetInt(DNSMaxIPsPerRestoredRule)
 	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
-	c.ToFQDNsMaxIPsPerRestoredRule = viper.GetInt(ToFQDNsMaxIPsPerRestoredRule)
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)
 	} else {


### PR DESCRIPTION
Restored DNS proxy rules are DNS rules, not ToFQDNs rules. Change the cilium command line argument introduced in #13992 to reflect this.

Keep only used DNS server IPs in restored rules returned by GetRules().

Fixes: #13991
Fixes: #13992
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
