### PR TITLE
helm: 'upgradeCompatibility' needs to be a string, not a float64

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3,7 +3,7 @@
 # Cilium will not change critical values to ensure continued operation
 # This is flag is not required for new installations.
 # ex: 1.7, 1.8, 1.9
-# upgradeCompatibility: 1.8
+# upgradeCompatibility: '1.8'
 
 debug:
   enabled: false


### PR DESCRIPTION
Makes it more evident for end users by amending the comment regarding how to configure `upgradeCompatibility`