### PR TITLE
helm: 'logOptions' needs to be a string, not a hash

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -792,8 +792,10 @@ localRedirectPolicy: false
 # labels: ""
 
 # logOptions allows you to define logging options. eg:
-# logOptions:
-#   format: json
+# logOptions: |
+#   {
+#     "format": "json"
+#   }
 
 # logSytemLoad enables logging of system load
 logSystemLoad: false


### PR DESCRIPTION
Make it more evident for end users by amending the comment regarding how to configure `logOptions`