### PR TITLE
v1.8 backports 2020-11-13

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -189,6 +189,7 @@ cilium-agent [flags]
       --tofqdns-enable-dns-compression                Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-endpoint-max-ip-per-hostname int      Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-max-deferred-connection-deletes int   Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-max-ips-per-restored-rule int         Maximum number of IPs to maintain for each restored rule (default 1000)
       --tofqdns-min-ttl int                           The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
       --tofqdns-pre-cache string                      DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                        Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 UTC_DATE=$(shell date -u "+%Y-%m-%d")
+DOCKER_REGISTRY ?= quay.io
 
 docker-cilium-image-for-developers:
 	# DOCKER_BUILDKIT allows for faster build as well as the ability to use
@@ -33,6 +34,7 @@ docker-image-no-clean: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		-t cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
 	@echo "Push like this when ready:"
 	@echo "${CONTAINER_ENGINE} push cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
@@ -52,7 +54,7 @@ dev-docker-image: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
 		-t $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
 	@echo "Push like this when ready:"
 	@echo "${CONTAINER_ENGINE} push $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
@@ -74,6 +76,8 @@ docker-opera%-image: GIT_VERSION $(BUILD_DIR)/cilium-opera%.Dockerfile build-con
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		-f $(BUILD_DIR)/cilium-opera$*.Dockerfile \
 		-t cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
+	$(QUIET)$(CONTAINER_ENGINE) tag cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
 	@echo "Push like this when ready:"
 	@echo "${CONTAINER_ENGINE} push cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
@@ -93,6 +97,7 @@ docker-plugin-image: GIT_VERSION $(BUILD_DIR)/cilium-docker-plugin.Dockerfile bu
 		-f $(BUILD_DIR)/cilium-docker-plugin.Dockerfile \
 		-t cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
 	@echo "Push like this when ready:"
 	@echo "${CONTAINER_ENGINE} push cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
@@ -107,6 +112,7 @@ docker-plugin-manifest:
 docker-image-runtime:
 	cd contrib/packaging/docker && $(CONTAINER_ENGINE) build --build-arg ARCH=$(GOARCH) -t cilium/cilium-runtime:$(UTC_DATE) -f Dockerfile.runtime .
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-runtime:$(UTC_DATE) cilium/cilium-runtime:$(UTC_DATE)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-runtime:$(UTC_DATE) $(DOCKER_REGISTRY)/cilium/cilium-runtime:$(UTC_DATE)-${GOARCH}
 
 docker-cilium-runtime-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium-runtime $(UTC_DATE)
@@ -115,6 +121,7 @@ docker-cilium-runtime-manifest:
 docker-image-builder:
 	$(QUIET)$(CONTAINER_ENGINE) build --build-arg ARCH=$(GOARCH) -t cilium/cilium-builder:$(UTC_DATE) -f Dockerfile.builder .
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-builder:$(UTC_DATE) cilium/cilium-builder:$(UTC_DATE)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-builder:$(UTC_DATE) $(DOCKER_REGISTRY)/cilium/cilium-builder:$(UTC_DATE)-${GOARCH}
 
 docker-cilium-builder-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium-builder $(UTC_DATE)
@@ -127,6 +134,7 @@ docker-hubble-relay-image: $(BUILD_DIR)/hubble-relay.Dockerfile build-context-up
 		-f $(BUILD_DIR)/hubble-relay.Dockerfile \
 		-t cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
 	@echo "Push like this when ready:"
 	@echo "${CONTAINER_ENGINE} push cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -753,6 +753,9 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
+	flags.Int(option.ToFQDNsMaxIPsPerRestoredRule, defaults.ToFQDNsMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored rule")
+	option.BindEnv(option.ToFQDNsMaxIPsPerRestoredRule)
+
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -311,7 +311,9 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	if err != nil {
 		return err
 	}
-	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID, d.notifyOnDNSMsg)
+	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
+		option.Config.ToFQDNsMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
+		d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -85,7 +85,7 @@ global:
   imagePullSecrets:
     # - name: "image-pull-secret"
   # registry is the address of the registry and organization for all container images
-  registry: docker.io/cilium
+  registry: quay.io/cilium
 
   # tag is the container image tag to use
   tag: v1.8.5

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -577,7 +577,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:v1.8.5"
+        image: "quay.io/cilium/cilium:v1.8.5"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -645,7 +645,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:v1.8.5"
+        image: "quay.io/cilium/cilium:v1.8.5"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -747,7 +747,7 @@ spec:
       serviceAccountName: hubble-relay
       containers:
         - name: hubble-relay
-          image: "docker.io/cilium/hubble-relay:v1.8.5"
+          image: "quay.io/cilium/hubble-relay:v1.8.5"
           imagePullPolicy: IfNotPresent
           command:
             - "hubble-relay"
@@ -900,7 +900,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator-generic:v1.8.5"
+        image: "quay.io/cilium/operator-generic:v1.8.5"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -432,7 +432,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:v1.8.5"
+        image: "quay.io/cilium/cilium:v1.8.5"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -495,7 +495,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "docker.io/cilium/cilium:v1.8.5"
+        image: "quay.io/cilium/cilium:v1.8.5"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -648,7 +648,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "docker.io/cilium/operator-generic:v1.8.5"
+        image: "quay.io/cilium/operator-generic:v1.8.5"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -78,6 +78,13 @@ pipeline {
                 }
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage('Make Cilium images and prepare gke cluster') {
             parallel {
                 stage('Make Cilium images') {

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -110,6 +110,13 @@ pipeline {
                }
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage('Make Cilium images') {
             environment {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
@@ -177,9 +184,11 @@ pipeline {
                     )}"""
             }
             steps {
-                retry(3) {
-                    dir("${TESTDIR}") {
-                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    retry(3) {
+                        dir("${TESTDIR}") {
+                            sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
+                        }
                     }
                 }
             }

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -73,6 +73,13 @@ pipeline {
                 sh '/usr/local/bin/cleanup || true'
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage('Make Cilium images') {
             environment {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
@@ -125,10 +132,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -152,10 +161,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -256,10 +267,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -283,10 +296,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -386,10 +401,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }
@@ -413,10 +430,12 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 20, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
                                 }
                             }
                         }

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -94,6 +94,13 @@ pipeline {
                 }
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage ("Copy code and boot vms"){
             options {
                 timeout(time: 30, unit: 'MINUTES')
@@ -108,11 +115,13 @@ pipeline {
             steps {
                 sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                 sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                retry(3) {
-                    timeout(time: 30, unit: 'MINUTES'){
-                        dir("${TESTDIR}") {
-                            sh 'vagrant destroy runtime --force'
-                            sh 'KERNEL=$(python get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    retry(3) {
+                        timeout(time: 30, unit: 'MINUTES'){
+                            dir("${TESTDIR}") {
+                                sh 'vagrant destroy runtime --force'
+                                sh 'KERNEL=$(python get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
+                            }
                         }
                     }
                 }

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -75,6 +75,13 @@ pipeline {
                }
             }
         }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
         stage('Make Cilium images') {
             environment {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
@@ -125,9 +132,11 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
-                            sh 'cd ${TESTDIR}; timeout 30m vagrant up runtime --provision'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
+                                sh 'cd ${TESTDIR}; timeout 30m vagrant up runtime --provision'
+                            }
                         }
                     }
                     post {
@@ -155,9 +164,11 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            dir("${TESTDIR}") {
-                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                dir("${TESTDIR}") {
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }
@@ -182,9 +193,11 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        retry(3) {
-                            dir("${TESTDIR}") {
-                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                dir("${TESTDIR}") {
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 45m ./vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -158,7 +158,7 @@ func LookupElementFromPointers(fd int, structPtr unsafe.Pointer, sizeOfStruct ui
 	}
 
 	if ret != 0 || err != 0 {
-		return fmt.Errorf("Unable to lookup element in map with file descriptor %d: %s", fd, err)
+		return fmt.Errorf("Unable to lookup element in map with file descriptor %d: %w", fd, err)
 	}
 
 	return nil

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -107,6 +107,10 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50
 
+	// ToFQDNsMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored ToFQDN rules.
+	ToFQDNsMaxIPsPerRestoredRule = 1000
+
 	// ToFQDNsMaxDeferredConnectionDeletes Maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes = 10000

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -202,6 +202,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 								logfields.Port:                  port,
 								logfields.EndpointLabelSelector: cs,
 								logfields.Limit:                 p.maxIPsPerRestoredRule,
+								"totalRules":                    len(p.LookupIPsBySecID(nid)),
 							}).Warning("Too many IPs for a rule, skipping the rest")
 							break Loop
 						}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -193,7 +193,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
-	proxy, err := StartDNSProxy("", 0, true, // any address, any port, enable compression
+	proxy, err := StartDNSProxy("", 0, true, 1000, // any address, any port, enable compression, max 1000 restore IPs
 		// LookupEPByIP
 		func(ip net.IP) (*endpoint.Endpoint, error) {
 			if s.restoring {

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -173,6 +173,7 @@ type NodesPodCIDRManager struct {
 
 type CIDRAllocator interface {
 	fmt.Stringer
+
 	Occupy(cidr *net.IPNet) error
 	AllocateNext() (*net.IPNet, error)
 	Release(cidr *net.IPNet) error
@@ -866,20 +867,21 @@ func (n *NodesPodCIDRManager) allocateNext(nodeName string) (*nodeCIDRs, bool, e
 }
 
 func getCIDRAllocatorsInfo(cidrAllocators []CIDRAllocator, netTypes string) string {
-	var cidrAllocatorsInfo bytes.Buffer
-	cidrAllocatorsLength := len(cidrAllocators)
-	if cidrAllocatorsLength == 0 {
+	var buf bytes.Buffer
+
+	length := len(cidrAllocators)
+	if length == 0 {
 		return "[]"
 	}
 
 	for index, cidrAllocator := range cidrAllocators {
-		cidrAllocatorsInfo.WriteString(fmt.Sprintf("%s", cidrAllocator.String()))
-		if index < cidrAllocatorsLength-1 {
-			cidrAllocatorsInfo.WriteString(fmt.Sprintf(", "))
+		buf.WriteString(fmt.Sprintf("%s", cidrAllocator.String()))
+		if index < length-1 {
+			buf.WriteString(", ")
 		}
 	}
 
-	return fmt.Sprintf("[%s]", cidrAllocatorsInfo.String())
+	return fmt.Sprintf("[%s]", buf.String())
 }
 
 // allocateFirstFreeCIDR allocates the first CIDR available from the slice of

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -427,6 +427,9 @@ const (
 	// performed
 	Reason = "reason"
 
+	// Limit is a numerical limit that has been exceeded
+	Limit = "limit"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -540,33 +540,27 @@ func GC(m *Map, filter *GCFilter) int {
 // CT_INGRESS CT entry. See the unit test TestOrphanNatGC for more examples.
 //
 // The function only handles 1-3 cases, the 4. case is TODO(brb).
-func PurgeOrphanNATEntries(ctMap *Map) *NatGCStats {
+func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 	if option.Config.NodePortMode == option.NodePortModeDSR ||
 		option.Config.NodePortMode == option.NodePortModeHybrid {
 		return nil
 	}
 
-	natMap := mapInfo[ctMap.mapType].natMap
+	// Both CT maps should point to the same natMap, so use the first one
+	// to determine natMap
+	natMap := mapInfo[ctMapTCP.mapType].natMap
 	if natMap == nil {
 		return nil
 	}
 
-	isCTMapTCP := ctMap.mapType == mapTypeIPv4TCPLocal ||
-		ctMap.mapType == mapTypeIPv6TCPLocal ||
-		ctMap.mapType == mapTypeIPv4TCPGlobal ||
-		ctMap.mapType == mapTypeIPv6TCPGlobal
 	stats := newNatGCStats(natMap)
-
 	cb := func(key bpf.MapKey, value bpf.MapValue) {
 		natKey := key.(nat.NatKey)
 		natVal := value.(nat.NatEntry)
 
-		// In opposite to the CT maps, TCP and UDP entries are stored in the same
-		// SNAT map. Therefore, to avoid a case when the given ctMap does not
-		// store entries of the given natKey.NextHeader proto, we should return
-		// early. Otherwise, the natKey entries will be removed, which is wrong.
-		if (natKey.GetNextHeader() == u8proto.TCP) != isCTMapTCP {
-			return
+		ctMap := ctMapAny
+		if natKey.GetNextHeader() == u8proto.TCP {
+			ctMap = ctMapTCP
 		}
 
 		if natKey.GetFlags()&tuple.TUPLE_F_IN == 1 { // natKey is r(everse)tuple

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -16,6 +16,7 @@ package ctmap
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -34,8 +35,10 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
+	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -103,6 +106,10 @@ type NatMap interface {
 	Open() error
 	Close() error
 	DeleteMapping(key tuple.TupleKey) error
+	DumpWithCallback(bpf.DumpCallback) error
+	DumpReliablyWithCallback(bpf.DumpCallback, *bpf.DumpStats) error
+	Delete(bpf.MapKey) error
+	DumpStats() *bpf.DumpStats
 }
 
 type mapAttributes struct {
@@ -506,6 +513,83 @@ func GC(m *Map, filter *GCFilter) int {
 	}
 
 	return doGC(m, filter)
+}
+
+// PurgeOrphanNATEntries removes orphan SNAT entries. We call an SNAT entry
+// orphan if it does not have a corresponding CT entry.
+//
+// This can happen when the CT entry is removed by the LRU eviction which
+// happens when the CT map becomes full.
+//
+// PurgeOrphanNATEntries() is triggered by the datapath via the GC signaling
+// mechanism. When the datapath SNAT fails to find free mapping after
+// SNAT_SIGNAL_THRES attempts, it sends the signal via the perf ring buffer.
+// The consumer of the buffer invokes the function.
+//
+// The SNAT is being used for the following cases:
+// 1. By NodePort BPF on an intermediate node before fwd'ing request from outside
+//     to a destination node.
+// 2. A packet from local endpoint sent to outside (BPF-masq).
+// 3. A packet from a host local application (i.e. running in the host netns)
+//    This is needed to prevent SNAT from hijacking such connections.
+// 4. By DSR on a backend node to SNAT responses with service IP+port before
+//    sending to a client.
+//
+// In the case of 1-3, we always create a CT_EGRESS CT entry. This allows the
+// CT GC to remove corresponding SNAT entries. In the case of 4, will create
+// CT_INGRESS CT entry. See the unit test TestOrphanNatGC for more examples.
+//
+// The function only handles 1-3 cases, the 4. case is TODO(brb).
+func PurgeOrphanNATEntries(ctMap *Map) *NatGCStats {
+	if option.Config.NodePortMode == option.NodePortModeDSR ||
+		option.Config.NodePortMode == option.NodePortModeHybrid {
+		return nil
+	}
+
+	natMap := mapInfo[ctMap.mapType].natMap
+	if natMap == nil {
+		return nil
+	}
+
+	isCTMapTCP := ctMap.mapType == mapTypeIPv4TCPLocal ||
+		ctMap.mapType == mapTypeIPv6TCPLocal ||
+		ctMap.mapType == mapTypeIPv4TCPGlobal ||
+		ctMap.mapType == mapTypeIPv6TCPGlobal
+	stats := newNatGCStats(natMap)
+
+	cb := func(key bpf.MapKey, value bpf.MapValue) {
+		natKey := key.(nat.NatKey)
+		natVal := value.(nat.NatEntry)
+
+		// In opposite to the CT maps, TCP and UDP entries are stored in the same
+		// SNAT map. Therefore, to avoid a case when the given ctMap does not
+		// store entries of the given natKey.NextHeader proto, we should return
+		// early. Otherwise, the natKey entries will be removed, which is wrong.
+		if (natKey.GetNextHeader() == u8proto.TCP) != isCTMapTCP {
+			return
+		}
+
+		if natKey.GetFlags()&tuple.TUPLE_F_IN == 1 { // natKey is r(everse)tuple
+			ctKey := egressCTKeyFromIngressNatKeyAndVal(natKey, natVal)
+			if _, err := ctMap.Lookup(ctKey); errors.Is(err, unix.ENOENT) {
+				// No CT entry is found, so delete SNAT for both original and
+				// reverse flows
+				oNatKey := oNatKeyFromReverse(natKey, natVal)
+				if err := natMap.Delete(oNatKey); err == nil {
+					stats.EgressDeleted += 1
+				}
+				if err := natMap.Delete(natKey); err == nil {
+					stats.IngressDeleted += 1
+				}
+			} else {
+				stats.IngressAlive += 1
+			}
+		}
+	}
+
+	natMap.DumpReliablyWithCallback(cb, stats.DumpStats)
+
+	return &stats
 }
 
 // Flush runs garbage collection for map m with the name mapType, deleting all

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -38,6 +38,12 @@ func Test(t *testing.T) {
 	TestingT(t)
 }
 
+func (k *CTMapTestSuite) SetUpSuite(c *C) {
+	bpf.CheckOrMountFS("", false)
+	err := bpf.ConfigureResourceLimits()
+	c.Assert(err, IsNil)
+}
+
 func (k *CTMapTestSuite) Benchmark_MapUpdate(c *C) {
 	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal)
 	_, err := m.OpenOrCreate()
@@ -98,13 +104,9 @@ func (k *CTMapTestSuite) Benchmark_MapUpdate(c *C) {
 // TestCtGcIcmp tests whether ICMP NAT entries are removed upon a removal of
 // their CT entry (GH#12625).
 func (k *CTMapTestSuite) TestCtGcIcmp(c *C) {
-	bpf.CheckOrMountFS("", false)
-	err := bpf.ConfigureResourceLimits()
-	c.Assert(err, IsNil)
-
 	// Init maps
 	natMap := nat.NewMap("cilium_nat_any4_test", true, 1000)
-	_, err = natMap.OpenOrCreate()
+	_, err := natMap.OpenOrCreate()
 	c.Assert(err, IsNil)
 	defer natMap.Map.Unpin()
 
@@ -206,6 +208,230 @@ func (k *CTMapTestSuite) TestCtGcIcmp(c *C) {
 	c.Assert(stats.aliveEntries, Equals, uint32(0))
 	c.Assert(stats.deleted, Equals, uint32(1))
 
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+}
+
+// TestOrphanNat checks whether dangling NAT entries are GC'd (GH#12686)
+func (k *CTMapTestSuite) TestOrphanNatGC(c *C) {
+	// Init maps
+	natMap := nat.NewMap("cilium_nat_any4_test", true, 1000)
+	_, err := natMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer natMap.Map.Unpin()
+
+	ctMapName := MapNameAny4Global + "_test"
+	setupMapInfo(mapTypeIPv4AnyGlobal, ctMapName,
+		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
+		100, natMap)
+	ctMap := newMap(ctMapName, mapTypeIPv4AnyGlobal)
+	_, err = ctMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctMap.Map.Unpin()
+
+	ctTCPMapName := MapNameTCP4Global + "_test"
+	setupMapInfo(mapTypeIPv4TCPGlobal, ctTCPMapName,
+		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
+		100, natMap)
+	ctTCPMap := newMap(ctTCPMapName, mapTypeIPv4TCPGlobal)
+	_, err = ctTCPMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctTCPMap.Map.Unpin()
+
+	// Create the following entries and check that SNAT entries are NOT GC-ed
+	// (as we have the CT entry which they belong to):
+	//
+	// - Host local traffic (no SNAT):
+	//		CT:		UDP OUT 10.23.32.45:54864 -> 10.23.53.48:8472
+	//		NAT:	UDP IN  10.23.53.48:8472 -> 10.23.32.45:54865 XLATE_DST 10.23.32.45:54864
+	//	 			UDP OUT 10.23.32.45:54864 -> 10.23.53.48:8472 XLATE_SRC 10.23.32.45:54865
+	//
+	// The example above covers other SNAT cases. E.g. (not used in unit tests below, just
+	// to show for completion):
+	//
+	// - NodePort request from outside (subject to NodePort SNAT):
+	// 		CT: 	TCP OUT 192.168.34.1:63000 -> 10.0.1.99:80
+	// 		NAT: 	TCP IN 10.0.1.99:80 -> 10.0.0.134:63000 XLATE_DST 192.168.34.1:63000
+	// 		NAT: 	TCP OUT 192.168.34.1:63000 -> 10.0.1.99:80 XLATE_SRC 10.0.0.134:63000
+	//
+	// - Local endpoint request to outside (subject to BPF-masq):
+	//		CT: 	TCP OUT 10.0.1.99:34520 -> 1.1.1.1:80
+	//		NAT: 	TCP IN 1.1.1.1:80 -> 10.0.2.15:34520 XLATE_DST 10.0.1.99:34520
+	//				TCP OUT 10.0.1.99:34520 -> 1.1.1.1:80 XLATE_SRC 10.0.2.15:34520
+
+	ctKey := &CtKey4Global{
+		tuple.TupleKey4Global{
+			tuple.TupleKey4{
+				DestAddr:   types.IPv4{10, 23, 32, 45},
+				SourceAddr: types.IPv4{10, 23, 53, 48},
+				SourcePort: 0x50d6,
+				DestPort:   0x1821,
+				NextHeader: u8proto.UDP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	ctVal := &CtEntry{
+		TxPackets: 1,
+		TxBytes:   216,
+		Lifetime:  37459,
+	}
+	err = bpf.UpdateElement(ctMap.Map.GetFd(), unsafe.Pointer(ctKey),
+		unsafe.Pointer(ctVal), 0)
+	c.Assert(err, IsNil)
+
+	natKey := &nat.NatKey4{
+		tuple.TupleKey4Global{
+			tuple.TupleKey4{
+				SourceAddr: types.IPv4{10, 23, 32, 45},
+				DestAddr:   types.IPv4{10, 23, 53, 48},
+				SourcePort: 0x50d6,
+				DestPort:   0x1821,
+				NextHeader: u8proto.UDP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	natVal := &nat.NatEntry4{
+		Created:   37400,
+		HostLocal: 1,
+		Addr:      types.IPv4{10, 23, 32, 45},
+		Port:      0x51d6,
+	}
+	err = bpf.UpdateElement(natMap.Map.GetFd(), unsafe.Pointer(natKey),
+		unsafe.Pointer(natVal), 0)
+	c.Assert(err, IsNil)
+	natKey = &nat.NatKey4{
+		tuple.TupleKey4Global{
+			tuple.TupleKey4{
+				DestAddr:   types.IPv4{10, 23, 32, 45},
+				SourceAddr: types.IPv4{10, 23, 53, 48},
+				DestPort:   0x51d6,
+				SourcePort: 0x1821,
+				NextHeader: u8proto.UDP,
+				Flags:      tuple.TUPLE_F_IN,
+			},
+		},
+	}
+	natVal = &nat.NatEntry4{
+		Created:   37400,
+		HostLocal: 1,
+		Addr:      types.IPv4{10, 23, 32, 45},
+		Port:      0x50d6,
+	}
+	err = bpf.UpdateElement(natMap.Map.GetFd(), unsafe.Pointer(natKey),
+		unsafe.Pointer(natVal), 0)
+	c.Assert(err, IsNil)
+
+	ctKeyTCP := &CtKey4Global{
+		tuple.TupleKey4Global{
+			tuple.TupleKey4{
+				DestAddr:   types.IPv4{10, 23, 32, 45},
+				SourceAddr: types.IPv4{10, 23, 53, 48},
+				SourcePort: 0x50d6,
+				DestPort:   0x1821,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	err = bpf.UpdateElement(ctTCPMap.Map.GetFd(), unsafe.Pointer(ctKeyTCP),
+		unsafe.Pointer(ctVal), 0)
+	c.Assert(err, IsNil)
+
+	// UDP SNAT entries should not be removed when the TCP CT map is given
+	stats := PurgeOrphanNATEntries(ctTCPMap)
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressDeleted, Equals, uint32(0))
+
+	stats = PurgeOrphanNATEntries(ctMap)
+	c.Assert(stats.IngressAlive, Equals, uint32(1))
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressDeleted, Equals, uint32(0))
+	// Check that both entries haven't removed
+	buf := make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 2)
+
+	// Now remove the CT entry which should remove both NAT entries
+	err = bpf.DeleteElement(ctMap.Map.GetFd(), unsafe.Pointer(ctKey))
+	c.Assert(err, IsNil)
+	stats = PurgeOrphanNATEntries(ctMap)
+	c.Assert(stats.IngressDeleted, Equals, uint32(1))
+	c.Assert(stats.IngressAlive, Equals, uint32(0))
+	c.Assert(stats.EgressDeleted, Equals, uint32(1))
+	// Check that both orphan NAT entries have been removed
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+
+	// Create only CT_INGRESS NAT entry which should be removed
+	err = bpf.UpdateElement(natMap.Map.GetFd(), unsafe.Pointer(natKey),
+		unsafe.Pointer(natVal), 0)
+	c.Assert(err, IsNil)
+
+	stats = PurgeOrphanNATEntries(ctMap)
+	c.Assert(stats.IngressDeleted, Equals, uint32(1))
+	c.Assert(stats.EgressDeleted, Equals, uint32(0))
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+
+	// Let's check IPv6
+
+	natMapV6 := nat.NewMap("cilium_nat_any6_test", false, 1000)
+	_, err = natMapV6.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer natMapV6.Map.Unpin()
+
+	ctMapAnyName = MapNameAny6Global + "_test"
+	setupMapInfo(mapTypeIPv6AnyGlobal, ctMapAnyName,
+		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
+		100, natMapV6)
+	ctMapAnyV6 := newMap(ctMapAnyName, mapTypeIPv6AnyGlobal)
+	_, err = ctMapAnyV6.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctMapAnyV6.Map.Unpin()
+
+	ctMapTCPName = MapNameTCP6Global + "_test"
+	setupMapInfo(mapTypeIPv6TCPGlobal, ctMapTCPName,
+		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
+		100, natMapV6)
+	ctMapTCPV6 := newMap(ctMapTCPName, mapTypeIPv6TCPGlobal)
+	_, err = ctMapTCP.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctMapTCPV6.Map.Unpin()
+
+	natKeyV6 := &nat.NatKey6{
+		tuple.TupleKey6Global{
+			tuple.TupleKey6{
+				SourceAddr: types.IPv6{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				DestAddr:   types.IPv6{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+				SourcePort: 0x50d6,
+				DestPort:   0x1821,
+				NextHeader: u8proto.UDP,
+				Flags:      tuple.TUPLE_F_IN,
+			},
+		},
+	}
+	natValV6 := &nat.NatEntry6{
+		Created:   37400,
+		HostLocal: 1,
+		Addr:      types.IPv6{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+		Port:      0x51d6,
+	}
+	err = bpf.UpdateElement(natMapV6.Map.GetFd(), unsafe.Pointer(natKeyV6),
+		unsafe.Pointer(natValV6), 0)
+	c.Assert(err, IsNil)
+
+	stats = PurgeOrphanNATEntries(ctMapTCPV6, ctMapAnyV6)
+	c.Assert(stats.IngressDeleted, Equals, uint32(1))
+	c.Assert(stats.EgressDeleted, Equals, uint32(0))
 	buf = make(map[string][]string)
 	err = natMap.Map.Dump(buf)
 	c.Assert(err, IsNil)

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -86,3 +86,25 @@ func (t *CTMapTestSuite) TestCalculateInterval(c *C) {
 	c.Assert(calculateInterval(bpf.MapTypeLRUHash, 24*time.Hour, 0.01), Equals, defaults.ConntrackGCMaxLRUInterval)
 	c.Assert(calculateInterval(bpf.MapTypeHash, 24*time.Hour, 0.01), Equals, defaults.ConntrackGCMaxInterval)
 }
+
+func (t *CTMapTestSuite) TestFilterMapsByProto(c *C) {
+	maps := []*Map{
+		newMap("tcp4", mapTypeIPv4TCPGlobal),
+		newMap("any4", mapTypeIPv4AnyGlobal),
+		newMap("tcp6", mapTypeIPv6TCPGlobal),
+		newMap("any6", mapTypeIPv6AnyGlobal),
+	}
+
+	ctMapTCP, ctMapAny := FilterMapsByProto(maps, CTMapIPv4)
+	c.Assert(ctMapTCP.mapType, Equals, mapTypeIPv4TCPGlobal)
+	c.Assert(ctMapAny.mapType, Equals, mapTypeIPv4AnyGlobal)
+
+	ctMapTCP, ctMapAny = FilterMapsByProto(maps, CTMapIPv6)
+	c.Assert(ctMapTCP.mapType, Equals, mapTypeIPv6TCPGlobal)
+	c.Assert(ctMapAny.mapType, Equals, mapTypeIPv6AnyGlobal)
+
+	maps = maps[0:2] // remove ipv6 maps
+	ctMapTCP, ctMapAny = FilterMapsByProto(maps, CTMapIPv6)
+	c.Assert(ctMapTCP, IsNil)
+	c.Assert(ctMapAny, IsNil)
+}

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -49,6 +49,7 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 		var wakeup = make(chan signal.SignalData)
 		ipv4Orig := ipv4
 		ipv6Orig := ipv6
+		triggeredBySignal := false
 		for {
 			var (
 				maxDeleteRatio float64
@@ -87,14 +88,14 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 			}
 
 			if len(eps) > 0 || initialScan {
-				mapType, maxDeleteRatio = runGC(nil, ipv4, ipv6, createGCFilter(initialScan, restoredEndpoints, emitEntryCB))
+				mapType, maxDeleteRatio = runGC(nil, ipv4, ipv6, triggeredBySignal, createGCFilter(initialScan, restoredEndpoints, emitEntryCB))
 			}
 			for _, e := range eps {
 				if !e.ConntrackLocal() {
 					// Skip because GC was handled above.
 					continue
 				}
-				runGC(e, ipv4, ipv6, &ctmap.GCFilter{RemoveExpired: true, EmitCTEntryCB: emitEntryCB})
+				runGC(e, ipv4, ipv6, triggeredBySignal, &ctmap.GCFilter{RemoveExpired: true, EmitCTEntryCB: emitEntryCB})
 			}
 
 			// Mark the CT GC as over in each EP DNSZombies instance
@@ -111,9 +112,11 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 				signal.MuteChannel(signal.SignalWakeGC)
 			}
 
+			triggeredBySignal = false
 			signal.UnmuteChannel(signal.SignalWakeGC)
 			select {
 			case x := <-wakeup:
+				triggeredBySignal = true
 				ipv4 = false
 				ipv6 = false
 				if x == signal.SignalProtoV4 {
@@ -154,7 +157,7 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 // The provided endpoint is optional; if it is provided, then its map will be
 // garbage collected and any failures will be logged to the endpoint log.
 // Otherwise it will garbage-collect the global map and use the global log.
-func runGC(e *endpoint.Endpoint, ipv4, ipv6 bool, filter *ctmap.GCFilter) (mapType bpf.MapType, maxDeleteRatio float64) {
+func runGC(e *endpoint.Endpoint, ipv4, ipv6, triggeredBySignal bool, filter *ctmap.GCFilter) (mapType bpf.MapType, maxDeleteRatio float64) {
 	var maps []*ctmap.Map
 
 	if e == nil {
@@ -195,6 +198,17 @@ func runGC(e *endpoint.Endpoint, ipv4, ipv6 bool, filter *ctmap.GCFilter) (mapTy
 				logfields.Path: path,
 				"count":        deleted,
 			}).Debug("Deleted filtered entries from map")
+		}
+
+		if triggeredBySignal {
+			stats := ctmap.PurgeOrphanNATEntries(m)
+			if stats != nil && (stats.EgressDeleted != 0 || stats.IngressDeleted != 0) {
+				log.WithFields(logrus.Fields{
+					"ingressDeleted": stats.IngressDeleted,
+					"egressDeleted":  stats.EgressDeleted,
+					"ingressAlive":   stats.IngressAlive,
+				}).Info("Deleted orphan SNAT entries from map")
+			}
 		}
 	}
 

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -122,3 +122,19 @@ func (s *gcStats) finish() {
 	metrics.ConntrackGCDuration.WithLabelValues(family, proto, status).Observe(duration.Seconds())
 	metrics.ConntrackGCKeyFallbacks.WithLabelValues(family, proto).Add(float64(s.KeyFallback))
 }
+
+type NatGCStats struct {
+	*bpf.DumpStats
+
+	IngressAlive   uint32
+	IngressDeleted uint32
+	EgressDeleted  uint32
+	// It's not possible with the current PurgeOrphanNATEntries implementation
+	// to correctly count EgressAlive, so skip it
+}
+
+func newNatGCStats(m NatMap) NatGCStats {
+	return NatGCStats{
+		DumpStats: m.DumpStats(),
+	}
+}

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -107,6 +107,37 @@ func (m mapType) isTCP() bool {
 	return false
 }
 
+type CTMapIPVersion int
+
+const (
+	CTMapIPv4 CTMapIPVersion = iota
+	CTMapIPv6
+)
+
+// FilterMapsByProto filters the given CT maps by the given IP version, and
+// returns two maps - one for TCP and one for any protocol.
+func FilterMapsByProto(maps []*Map, ipVsn CTMapIPVersion) (ctMapTCP *Map, ctMapAny *Map) {
+	for _, m := range maps {
+		switch ipVsn {
+		case CTMapIPv4:
+			switch m.mapType {
+			case mapTypeIPv4TCPLocal, mapTypeIPv4TCPGlobal:
+				ctMapTCP = m
+			case mapTypeIPv4AnyLocal, mapTypeIPv4AnyGlobal:
+				ctMapAny = m
+			}
+		case CTMapIPv6:
+			switch m.mapType {
+			case mapTypeIPv6TCPLocal, mapTypeIPv6TCPGlobal:
+				ctMapTCP = m
+			case mapTypeIPv6AnyLocal, mapTypeIPv6AnyGlobal:
+				ctMapAny = m
+			}
+		}
+	}
+	return
+}
+
 type CtKey interface {
 	bpf.MapKey
 

--- a/pkg/maps/ctmap/utils.go
+++ b/pkg/maps/ctmap/utils.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctmap
+
+import (
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/tuple"
+)
+
+// NOTE: the function does NOT copy addr fields, so it's not safe to
+// reuse the returned natKey.
+func oNatKeyFromReverse(k nat.NatKey, v nat.NatEntry) nat.NatKey {
+	natKey, ok := k.(*nat.NatKey4)
+	if ok { // ipv4
+		natVal := v.(*nat.NatEntry4)
+		return &nat.NatKey4{TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: natVal.Addr,
+				SourcePort: natVal.Port,
+				DestAddr:   natKey.SourceAddr,
+				DestPort:   natKey.SourcePort,
+				NextHeader: natKey.NextHeader,
+				Flags:      tuple.TUPLE_F_OUT,
+			}}}
+	}
+
+	{ // ipv6
+		natKey := k.(*nat.NatKey6)
+		natVal := v.(*nat.NatEntry6)
+		return &nat.NatKey6{TupleKey6Global: tuple.TupleKey6Global{
+			TupleKey6: tuple.TupleKey6{
+				SourceAddr: natVal.Addr,
+				SourcePort: natVal.Port,
+				DestAddr:   natKey.SourceAddr,
+				DestPort:   natKey.SourcePort,
+				NextHeader: natKey.NextHeader,
+				Flags:      tuple.TUPLE_F_OUT,
+			}}}
+	}
+}
+
+// NOTE: the function does NOT copy addr fields, so it's not safe to
+// reuse the returned ctKey.
+func egressCTKeyFromIngressNatKeyAndVal(k nat.NatKey, v nat.NatEntry) bpf.MapKey {
+	natKey, ok := k.(*nat.NatKey4)
+	if ok { // ipv4
+		natVal := v.(*nat.NatEntry4)
+		return &tuple.TupleKey4Global{TupleKey4: tuple.TupleKey4{
+			// Workaround #5848
+			SourceAddr: natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
+			DestAddr:   natVal.Addr,
+			SourcePort: natVal.Port,
+			NextHeader: natKey.NextHeader,
+			Flags:      tuple.TUPLE_F_OUT,
+		}}
+	}
+
+	{ // ipv6
+		natKey := k.(*nat.NatKey6)
+		natVal := v.(*nat.NatEntry6)
+		return &tuple.TupleKey6Global{TupleKey6: tuple.TupleKey6{
+			// Workaround #5848
+			SourceAddr: natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
+			DestAddr:   natVal.Addr,
+			SourcePort: natVal.Port,
+			NextHeader: natKey.NextHeader,
+			Flags:      tuple.TUPLE_F_OUT,
+		}}
+	}
+}

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -119,7 +119,21 @@ func NewMap(name string, v4 bool, entries int) *Map {
 	}
 }
 
-func doDumpEntries(m NatMap) (string, error) {
+func (m *Map) Delete(k bpf.MapKey) error {
+	return (&m.Map).Delete(k)
+}
+
+func (m *Map) DumpStats() *bpf.DumpStats {
+	return bpf.NewDumpStats(&m.Map)
+}
+
+func (m *Map) DumpReliablyWithCallback(cb bpf.DumpCallback, stats *bpf.DumpStats) error {
+	return (&m.Map).DumpReliablyWithCallback(cb, stats)
+}
+
+// DoDumpEntries iterates through Map m and writes the values of the
+// nat entries in m to a string.
+func DoDumpEntries(m NatMap) (string, error) {
 	var buffer bytes.Buffer
 
 	nsecStart, _ := bpf.GetMtime()
@@ -138,7 +152,7 @@ func doDumpEntries(m NatMap) (string, error) {
 // DumpEntries iterates through Map m and writes the values of the
 // nat entries in m to a string.
 func (m *Map) DumpEntries() (string, error) {
-	return doDumpEntries(m)
+	return DoDumpEntries(m)
 }
 
 type gcStats struct {

--- a/pkg/maps/nat/nat_mock.go
+++ b/pkg/maps/nat/nat_mock.go
@@ -48,7 +48,7 @@ func (m *NatMockMap) Path() (string, error) {
 // DumpEntries iterates through Map m and writes the values of the ct entries
 // in m to a string.
 func (m *NatMockMap) DumpEntries() (string, error) {
-	return doDumpEntries(m)
+	return DoDumpEntries(m)
 }
 
 // DumpWithCallback runs the callback on each entry of the mock map.

--- a/pkg/maps/nat/types.go
+++ b/pkg/maps/nat/types.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/tuple"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 type NatKey interface {
@@ -36,6 +37,9 @@ type NatKey interface {
 
 	// GetFlags flags containing the direction of the TupleKey.
 	GetFlags() uint8
+
+	// GetNextHeader returns the proto of the NatKey
+	GetNextHeader() u8proto.U8proto
 }
 
 // NatKey4 is needed to provide NatEntry type to Lookup values
@@ -76,6 +80,10 @@ func (k *NatKey4) ToHost() NatKey {
 // GetKeyPtr returns the unsafe.Pointer for k.
 func (k *NatKey4) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
+func (k *NatKey4) GetNextHeader() u8proto.U8proto {
+	return k.NextHeader
+}
+
 // NatKey6 is needed to provide NatEntry type to Lookup values
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapKey
@@ -113,3 +121,7 @@ func (k *NatKey6) ToHost() NatKey {
 
 // GetKeyPtr returns the unsafe.Pointer for k.
 func (k *NatKey6) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+
+func (k *NatKey6) GetNextHeader() u8proto.U8proto {
+	return k.NextHeader
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -380,6 +380,10 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
 
+	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored ToFQDN rules
+	ToFQDNsMaxIPsPerRestoredRule = "tofqdns-max-ips-per-restored-rule"
+
 	// ToFQDNsMaxDeferredConnectionDeletes defines the maximum number of IPs to
 	// retain for expired DNS lookups with still-active connections"
 	ToFQDNsMaxDeferredConnectionDeletes = "tofqdns-max-deferred-connection-deletes"
@@ -863,6 +867,7 @@ var HelpFlagSections = []FlagsSection{
 			ToFQDNsEnablePoller,
 			ToFQDNsEnablePollerEvents,
 			ToFQDNsMaxIPsPerHost,
+			ToFQDNsMaxIPsPerRestoredRule,
 			ToFQDNsMinTTL,
 			ToFQDNsPreCache,
 			ToFQDNsProxyPort,
@@ -1572,6 +1577,10 @@ type DaemonConfig struct {
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost int
 
+	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored ToFQDN rules
+	ToFQDNsMaxIPsPerRestoredRule int
+
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes int
@@ -1936,6 +1945,7 @@ var (
 		EnableL7Proxy:                defaults.EnableL7Proxy,
 		EndpointStatus:               make(map[string]struct{}),
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
+		ToFQDNsMaxIPsPerRestoredRule: defaults.ToFQDNsMaxIPsPerRestoredRule,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
 		IPAllocationTimeout:          defaults.IPAllocationTimeout,
@@ -2452,6 +2462,7 @@ func (c *DaemonConfig) Populate() {
 	c.ToFQDNsEnablePoller = viper.GetBool(ToFQDNsEnablePoller)
 	c.ToFQDNsEnablePollerEvents = viper.GetBool(ToFQDNsEnablePollerEvents)
 	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
+	c.ToFQDNsMaxIPsPerRestoredRule = viper.GetInt(ToFQDNsMaxIPsPerRestoredRule)
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)
 	} else {

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,6 +1,5 @@
 # -*- mode: ruby -*-
-# vi: set ft=ruby
-Vagrant.require_version ">= 2.2.0"
+# vi: set ft=ruby Vagrant.require_version ">= 2.2.0"
 
 # The source of truth for vagrant box versions.
 # Sets SERVER_BOX, SERVER_VERSION, NETNEXT_SERVER_BOXET and NEXT_SERVER_VERSION
@@ -27,6 +26,8 @@ $PRELOAD_VM = ENV['PRELOAD_VM'] || "false"
 $SKIP_K8S_PROVISION = ENV['SKIP_K8S_PROVISION'] || "false"
 $NO_CILIUM_ON_NODE = ENV['NO_CILIUM_ON_NODE'] || ""
 $KUBEPROXY = (ENV['KUBEPROXY'] || "1")
+$DOCKER_LOGIN = ENV['DOCKER_LOGIN'] || ""
+$DOCKER_PASSWORD = ENV['DOCKER_PASSWORD'] || ""
 
 # RAM and CPU settings
 $MEMORY = (ENV['VM_MEMORY'] || "4096").to_i
@@ -141,7 +142,10 @@ Vagrant.configure("2") do |config|
                           "CILIUM_REGISTRY" => "#{$CILIUM_REGISTRY}",
                           "PRELOAD_VM" => "#{$PRELOAD_VM}",
                           "SKIP_K8S_PROVISION" => "#{$SKIP_K8S_PROVISION}",
-                          "KUBEPROXY" => "#{$KUBEPROXY}"}
+                          "KUBEPROXY" => "#{$KUBEPROXY}",
+                          "DOCKER_LOGIN" => "#{$DOCKER_LOGIN}",
+                          "DOCKER_PASSWORD" => "#{$DOCKER_PASSWORD}"
+                }
             end
         end
     end

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -245,13 +245,13 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		cleanupCiliumState(filepath.Join(kubectl.BasePath(), helpers.HelmTemplate), newHelmChartVersion, "", newImageVersion, "")
 
 		By("Cleaning Cilium state (%s)", oldImageVersion)
-		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "cilium", oldImageVersion, "docker.io/cilium")
+		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "cilium", oldImageVersion, "quay.io/cilium")
 
 		By("Deploying Cilium %s", oldHelmChartVersion)
 
 		opts := map[string]string{
 			"global.tag":      oldImageVersion,
-			"global.registry": "docker.io/cilium",
+			"global.registry": "quay.io/cilium",
 			"agent.image":     "cilium",
 			"operator.image":  "operator",
 		}

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if ! [[ -z $DOCKER_LOGIN && -z $DOCKER_PASSWORD ]]; then
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_LOGIN}" --password-stdin
+fi
+
 HOST=$(hostname)
 export HELM_VERSION="3.1.1"
 export TOKEN="258062.5d84c017c9b2796c"

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if ! [[ -z $DOCKER_LOGIN && -z $DOCKER_PASSWORD ]]; then
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_LOGIN}" --password-stdin
+fi
+
 HOST=$(hostname)
 PROVISIONSRC="/tmp/provision"
 

--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -29,7 +29,7 @@ import (
 const (
 	// The privileged unit tests can take more than 4 minutes, the default
 	// timeout for helper commands.
-	privilegedUnitTestTimeout = 8 * time.Minute
+	privilegedUnitTestTimeout = 16 * time.Minute
 )
 
 var _ = Describe("RuntimePrivilegedUnitTests", func() {


### PR DESCRIPTION
 * #13937 -- change default docker image repository from docker.io to quay.io (@aanm)
 * #13916 -- ipam/allocator: Fix nil check on node CIDR (@christarazi)
 * #13944 -- test: Increase timeout on privileged unit tests (@pchaigno)
 * #13969 -- ci: log in to docker in vagrant boxes (@nebril)
 * #13992 -- fqdn: Make maximum number of IPs per restored rule configurable (@jrajahalme)
 * #13912 -- ctmap: GC orphan SNAT entries (@brb)
 * #13991 -- dnsproxy: print total number of rules if too many (@kkourt)
 * #13994 -- Hubble-Relay: proxy metadata from originating client (@nathanjsweet)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13937 13916 13944 13969 13992 13912 13991 13994; do contrib/backporting/set-labels.py $pr done 1.8; done
```