### PR TITLE
helm/hubble-ui: fixed ingress configuration on EKS clusters

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -11,7 +11,7 @@ Return the appropriate apiVersion for ingress.
 {{- define "ingress.apiVersion" -}}
 {{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare ">=1.14-0, <1.19.0" .Capabilities.KubeVersion.Version -}}
+{{- else if semverCompare ">=1.14-0, <1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- else if semverCompare "^1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1" -}}


### PR DESCRIPTION
On EKS clusters, the interpolated value of `.Capabilities.KubeVersion.Version` is assimilated as a prerelease per its semver syntax, eg: `v1.18.8-eks-7c9bda`. With this change, we are fixing the compute of the `ingress.apiVersion` template parameter when deploying over EKS clusters.

Fixes: #14018
