### PR TITLE
datapath: Fix clang vsn regexp

### DIFF
--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -88,7 +88,7 @@ func getClangVersion(filePath string) (go_version.Version, error) {
 	if err != nil {
 		log.WithError(err).Fatal("clang version: NOT OK")
 	}
-	res := regexp.MustCompile(`(clang version )([^ ]*)`).FindStringSubmatch(string(verOut))
+	res := regexp.MustCompile(`(clang version )([^ ]*)\n`).FindStringSubmatch(string(verOut))
 	if len(res) != 3 {
 		log.Fatalf("clang version: NOT OK: unable to get clang's version "+
 			"from: %q", string(verOut))


### PR DESCRIPTION
The clang 11 "--version" output contains multiple lines, so limit the match to a single line.

Otherwise, cilium-agent will fail with: `clang: NOT OK" error="Invalid character(s) found in patch number \"0\\nTarget:\""`