### PR TITLE
helm/hubble-relay: fixed indentation error

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -61,7 +61,7 @@ spec:
               port: grpc
 {{- with .Values.hubble.relay.resources }}
           resources:
-            {{- toYaml . | trim | nindent 10 }}
+            {{- toYaml . | trim | nindent 12 }}
 {{- end }}
           volumeMounts:
           - mountPath: {{ dir .Values.hubble.socketPath }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -538,7 +538,7 @@ hubble:
       pullPolicy: Always
 
     # Specifies the resources for the hubble-relay pods
-    # resources: {}
+    resources: {}
 
     # Number of replicas run for the hubble-relay deployment.
     replicas: 1
@@ -550,16 +550,6 @@ hubble:
     ## Annotations to be added to hubble-relay pods
     ##
     podAnnotations: {}
-
-    # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
-    #     resources:
-    #       limits:
-    #         cpu: 1000m
-    #         memory: 1024M
-    #       requests:
-    #         cpu: 100m
-    #         memory: 64Mi
-    resources: {}
 
     ## Node tolerations for pod assignment on nodes with taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
Signed-off-by: Pranavi Roy <pranvyr@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Previously, customizing resources for hubble-relay-deployment via helm produced validation errors due to smaller indentation width. This PR increases the indentation width by 2, so as to not write the resource requests on the same level as 'resources'.

Also, couldn't find similar instance anywhere else.

Fixes: #14000
