### PR TITLE
Mention MTU kernel bug in frag page

### DIFF
--- a/Documentation/concepts/networking/fragmentation.rst
+++ b/Documentation/concepts/networking/fragmentation.rst
@@ -21,4 +21,17 @@ options:
 - ``--bpf-fragments-map-max``: Control the maximum number of active concurrent
   connections using IP fragmentation. For the defaults, see `bpf_map_limitations`.
 
+.. note::
+
+    When running Cilium with kube-proxy, fragmented NodePort traffic may break due
+    to a kernel bug where route MTU is not respected for forwarded packets. Cilium
+    fragments tracking requires the first logical fragment to arrive first. Due to the
+    kernel bug, additional fragmentation on the outer encapsulation layer may happen
+    that causes packet reordering and results in a failure in tracking the fragments.
+
+    The kernel bug has been `fixed <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=02a1b175b0e92d9e0fa5df3957ade8d733ceb6a0>`_
+    and backported to all maintained kernel versions. If you observe connectivity problems,
+    ensure that the kernel package on your nodes has been upgraded recently before
+    reporting an issue.
+
 .. include:: ../../beta.rst


### PR DESCRIPTION
Signed-off-by: Yuan Liu <liuyuan@google.com>

Fixes: #13349

```release-note
Mention kernel MTU bug in IPv4 fragmentation document
```
