### PR TITLE
cocinelle: add git and golang to Dockerfile

### DIFF
--- a/contrib/coccinelle/Dockerfile
+++ b/contrib/coccinelle/Dockerfile
@@ -1,16 +1,18 @@
-FROM docker.io/library/alpine:3.11
+FROM docker.io/library/golang:1.15.5-alpine3.12 as builder
 
 LABEL maintainer="maintainer@cilium.io"
 
 ENV COCCINELLE_VERSION 1.0.8
 
+RUN apk add git
+
 RUN apk add -t .build_apks curl autoconf automake gcc libc-dev ocaml ocaml-dev ocaml-ocamldoc ocaml-findlib && \
-    apk add make python bash && \
+    apk add make python3 bash && \
     curl -sS -L https://github.com/coccinelle/coccinelle/archive/$COCCINELLE_VERSION.tar.gz -o coccinelle.tar.gz && \
     tar xvzf coccinelle.tar.gz && rm coccinelle.tar.gz && \
     cd coccinelle-$COCCINELLE_VERSION && \
     ./autogen && \
-    ./configure --disable-ocaml --disable-pcre-syntax && \
+    ./configure --disable-ocaml --disable-pcre-syntax --with-python=python3 && \
     make && make install-spatch install-python && \
     cd .. && rm -r coccinelle-$COCCINELLE_VERSION && \
     strip `which spatch` && \

--- a/contrib/coccinelle/aligned.cocci
+++ b/contrib/coccinelle/aligned.cocci
@@ -54,7 +54,7 @@ x << rule.x;
 p << rule.p;
 @@
 
-print "* file %s: missing __align_stack_8 on %s on line %s" % (p[0].file, x, p[0].line)
+print("* file %s: missing __align_stack_8 on %s on line %s" % (p[0].file, x, p[0].line))
 cnt += 1
 
 
@@ -62,8 +62,8 @@ cnt += 1
 @@
 
 if cnt > 0:
-  print """Use the following command to fix the above issues:
+  print("""Use the following command to fix the above issues:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                  \\
     -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/aligned.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
-"""
+""")

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -57,7 +57,7 @@ x << rule.x;
 p << rule.p;
 @@
 
-print "* file %s: variable %s on line %s should be declared constant" % (p[0].file, x, p[0].line)
+print("* file %s: variable %s on line %s should be declared constant" % (p[0].file, x, p[0].line))
 cnt += 1
 
 
@@ -65,8 +65,8 @@ cnt += 1
 @@
 
 if cnt > 0:
-  print """Use the following command to fix the above issues:
+  print("""Use the following command to fix the above issues:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                \\
     -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/const.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
-"""
+""")

--- a/contrib/coccinelle/null.cocci
+++ b/contrib/coccinelle/null.cocci
@@ -21,4 +21,4 @@ E << r.E;
 p << r.p;
 @@
 
-print "* file: %s deref of NULL value %s on line %s" % (p[0].file,E,p[0].line)
+print("* file: %s deref of NULL value %s on line %s" % (p[0].file,E,p[0].line))

--- a/contrib/coccinelle/tail_calls.cocci
+++ b/contrib/coccinelle/tail_calls.cocci
@@ -91,7 +91,7 @@ symbol ret;
 p << rule.p;
 @@
 
-print "* file %s: DROP_MISSED_TAIL_CALL missing after tail call on line %s" % (p[0].file, p[0].line)
+print("* file %s: DROP_MISSED_TAIL_CALL missing after tail call on line %s" % (p[0].file, p[0].line))
 cnt += 1
 
 
@@ -99,7 +99,7 @@ cnt += 1
 @@
 
 if cnt > 0:
-  print """Unlogged tail calls found. Please fix and use the following command to check:
+  print("""Unlogged tail calls found. Please fix and use the following command to check:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
     -it docker.io/cilium/coccicheck make -C bpf coccicheck\n
-"""
+""")


### PR DESCRIPTION
_bpf/Makefile_ include _Makefile.defs_ which call both go and git. Before this patch in the `coccicheck` GitHub action we have:

    make: Entering directory '/github/workspace/bpf'
    /bin/bash: git: command not found
    /bin/bash: go: command not found
    expr: syntax error

Update to alpine-3.12 and Python 3 on the way.