### PR TITLE
test: Bump migrate-svc-test image

### DIFF
--- a/test/k8sT/manifests/migrate-svc-client.yaml
+++ b/test/k8sT/manifests/migrate-svc-client.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: server
-        image: docker.io/cilium/migrate-svc-test:v0.0.1
+        image: docker.io/cilium/migrate-svc-test:v0.0.2
         imagePullPolicy: IfNotPresent
         command: [ "/client", "migrate-svc.default.svc.cluster.local.:8000" ]

--- a/test/k8sT/manifests/migrate-svc-server.yaml
+++ b/test/k8sT/manifests/migrate-svc-server.yaml
@@ -25,6 +25,6 @@ spec:
     spec:
       containers:
       - name: server
-        image: docker.io/cilium/migrate-svc-test:v0.0.1
+        image: docker.io/cilium/migrate-svc-test:v0.0.2
         imagePullPolicy: IfNotPresent
         command: [ "/server", "8000" ]


### PR DESCRIPTION
In the new version \[1\], the client sends a request to the server
every 0.5s over the long-lived connection, and it expects a reply from
the server in 1s. The change can help to catch intermittent connection
failures during Cilium upgrades. The previous version could only catch
connections failing due to RST.

\[1\]: https://github.com/cilium/migrate-svc-test/commit/edc628b2df7bd1002d3499c7f65df8c0396502ff

---

- Added the labels to backport to 1.{8,9} to improve coverage.
- Will update packer-ci-builder after this PR has been merged.