### PR TITLE
.dockerignore: add *.box files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -85,3 +85,6 @@ test/gke/registry-adder.yaml
 
 # In GIT but ignored for docker
 hack/
+
+# be forgiving to users that run add_vagrant_box.sh without -t
+*.box


### PR DESCRIPTION
By default, `test/packet/scripts/add_vagrant_box.sh` uses `.` as the
destination directory which might lead to large `*.box` files in the
cilium source directory. Instruct docker to ignore these files.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>