### PR TITLE
alignchecker: git should not ignore bpf_foo.o

### DIFF
--- a/pkg/alignchecker/.gitignore
+++ b/pkg/alignchecker/.gitignore
@@ -1,0 +1,1 @@
+!testdata/bpf_foo.o


### PR DESCRIPTION
For better or for worse, we include `pkg/alignchecker/testdata/bpf_foo.o` into our tree so it should not be ignored by git.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>

