### PR TITLE
Centralize building of the aws.Config object

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
+	"github.com/cilium/cilium/pkg/aws/endpoints"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/types"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -26,6 +27,8 @@ import (
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
@@ -51,6 +54,25 @@ func NewClient(ec2Client *ec2.Client, metrics MetricsAPI, rateLimit float64, bur
 		limiter:        helpers.NewApiLimiter(metrics, rateLimit, burst),
 		subnetsFilters: subnetsFilters,
 	}
+}
+
+// NewConfig returns a new aws.Config configured with the correct region + endpoint resolver
+func NewConfig() (aws.Config, error) {
+	cfg, err := external.LoadDefaultAWSConfig()
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("unable to load AWS configuration: %w", err)
+	}
+
+	metadataClient := ec2metadata.New(cfg)
+	instance, err := metadataClient.GetInstanceIdentityDocument(context.TODO())
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("unable to retrieve instance identity document: %w", err)
+	}
+
+	cfg.Region = instance.Region
+	cfg.EndpointResolver = aws.EndpointResolverFunc(endpoints.Resolver)
+
+	return cfg, nil
 }
 
 // NewSubnetsFilters transforms a map of tags and values and a slice of subnets

--- a/pkg/aws/eni/limits/limits.go
+++ b/pkg/aws/eni/limits/limits.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 	"strings"
 
+	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/lock"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
@@ -345,11 +345,10 @@ func UpdateFromUserDefinedMappings(m map[string]string) (err error) {
 // UpdateFromEC2API updates limits from the EC2 API via calling
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html.
 func UpdateFromEC2API(ctx context.Context) error {
-	cfg, err := external.LoadDefaultAWSConfig()
+	cfg, err := ec2shim.NewConfig()
 	if err != nil {
-		return fmt.Errorf("unable to load AWS configuration: %s", err)
+		return err
 	}
-
 	ec2Client := ec2.New(cfg)
 
 	instanceTypeInfos := []ec2.InstanceTypeInfo{}


### PR DESCRIPTION
When running the ENI IPAM an operator does not need to pass any region env var flag for the AWS SDK to configure it's client because we read it from the ec2 metadata endpoint. If the same operator wants to run with `--update-ec2-apdater-limit-via-api=true` then the `cilium-operator` will fail to construct the ec2 client because a valid region was not passed.

I removed the logging that was identifying that we connected to the ec2 metadata (mostly because we do not have a logger in the package where I moved this). Happy to add it back and construct a logger there but did not think it provides a lot of value IMO.

I think in the future we should use the `ec2.NewClient` method to get the client for the ENI limits updater so we get bought into the same metrics + QPS pipeline as well.

```release-note
Centralize building of the aws.Config object
```
