### PR TITLE
ci/github: Replace set-env command by echo

### DIFF
--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -87,7 +87,7 @@ jobs:
           sudo chmod +x bin/protoc && sudo cp bin/protoc /usr/local/bin
       - name: Set GOPATH
         run: |
-          echo "##[set-env name=GOPATH;]$GITHUB_WORKSPACE"
+          echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
         shell: bash
       - name: Check k8s generated files
         run: |


### PR DESCRIPTION
Related to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Signed-off-by: Tam Mach <sayboras@yahoo.com>

More information can be found [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)

```release-note
ci/github: Replace set-env command by echo command
```
