### PR TITLE
kpr: ensure DirectRoutingDevice is in devices

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -491,7 +491,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	}
 
 	// Perform an early probe on the underlying kernel on whether BandwidthManager
-	// can be supported or not. This needs to be done before detectNativeDevices()
+	// can be supported or not. This needs to be done before handleNativeDevices()
 	// as BandwidthManager needs these to be available for setup.
 	bandwidth.ProbeBandwidthManager()
 
@@ -500,7 +500,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	// This is because the device detection requires self (Cilium)Node object,
 	// and the k8s service watcher depends on option.Config.EnableNodePort flag
 	// which can be modified after the device detection.
-	detectNativeDevices(isKubeProxyReplacementStrict)
+	handleNativeDevices(isKubeProxyReplacementStrict)
 	finishKubeProxyReplacementInit(isKubeProxyReplacementStrict)
 
 	// Launch the K8s watchers in parallel as we continue to process other


### PR DESCRIPTION
As reported by #14052, there can be a panic if the congfigured
DirectRoutingDevice is not included in devices. (InitNodePortAddrs() is
called with option.Config.Devices.)

~Fix this by checking that the specified is included and fail otherwise
since this is probably a user error.~

docs state that:
 If the direct routing device does not exist within devices, Cilium
 will add the device to the latter list.

so this patch adds the device to the list.


Fixes #14052

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>

