### PR TITLE
test: get cilium pods inside background closure

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1161,11 +1161,16 @@ func (kub *Kubectl) MonitorEndpointStart(pod string, epID int64) (res *CmdRes, c
 // five seconds.
 func (kub *Kubectl) BackgroundReport(commands ...string) (context.CancelFunc, error) {
 	backgroundCtx, cancel := context.WithCancel(context.Background())
-	pods, err := kub.GetCiliumPods()
-	if err != nil {
-		return cancel, fmt.Errorf("Cannot retrieve cilium pods: %s", err)
-	}
 	retrieveInfo := func() {
+		pods, err := kub.GetCiliumPods()
+		if err != nil {
+			kub.Logger().Infof("failed to retrieve cilium pods: %s", err)
+			return
+		}
+		if len(pods) == 0 {
+			kub.Logger().Infof("no cilium pods found")
+			return
+		}
 		for _, pod := range pods {
 			for _, cmd := range commands {
 				kub.CiliumExecContext(context.TODO(), pod, cmd)


### PR DESCRIPTION
BackgroundReport dumps the result of the given cilium command (e.g.,
uptime) every 5 seconds. The name of the cilium pods are retrieved once
at the beginning. This has the problem that if the names of the cilium
pods change, spurious messages like the following will appear on the
logs:

```
time="2020-11-17T00:15:08Z" level=error msg="Error executing command 'kubectl exec -n kube-system cilium-nr2hm -- uptime'" error="exit status 1"
cmd: "kubectl exec -n kube-system cilium-nr2hm -- uptime" exitCode: 1 duration: 64.011551ms stdout:

err:
exit status 1
stderr:
Error from server (NotFound): pods "cilium-nr2hm" not found
```

Fix this by retrieving the names of the pods within the closure, rather
than only at the beginning.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>
