### PR TITLE
kvstore: add tests for etcd ratelimiter implementation

### DIFF
--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -18,12 +18,25 @@ import "context"
 
 // SetupDummy sets up kvstore for tests
 func SetupDummy(dummyBackend string) {
+	setupDummyWithConfigOpts(dummyBackend, nil)
+}
+
+// setupDummyWithConfigOpts sets up the dummy kvstore for tests but also
+// configures the module with the provided opts.
+func setupDummyWithConfigOpts(dummyBackend string, opts map[string]string) {
 	module := getBackend(dummyBackend)
 	if module == nil {
 		log.Panicf("Unknown dummy kvstore backend %s", dummyBackend)
 	}
 
 	module.setConfigDummy()
+
+	if opts != nil {
+		err := module.setConfig(opts)
+		if err != nil {
+			log.WithError(err).Panic("Unable to set config options for kvstore backend module")
+		}
+	}
 
 	if err := initClient(context.TODO(), module, nil); err != nil {
 		log.WithError(err).Panic("Unable to initialize kvstore client")

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1285,6 +1285,7 @@ func (e *etcdClient) DeleteIfLocked(ctx context.Context, key string, lock KVLock
 	defer func() { Trace("DeleteIfLocked", err, logrus.Fields{fieldKey: key}) }()
 
 	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
 	opDel := client.OpDelete(key)
 	cmp := lock.Comparator().(client.Cmp)
 	txnReply, err := e.client.Txn(ctx).If(cmp).Then(opDel).Commit()


### PR DESCRIPTION
Increase unit tests coverage for `pkg/kvstore`.
This Pull Request adds tests to cover rate limiter functionality for etcd kvstore backend.
Fixes #11916