### PR TITLE
docs: Fix wording around labels configuration

### DIFF
--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -59,8 +59,8 @@ this attribute can also be set via helm option ``--set labels=<values>``.
     ...
 
 
-Upon defining a custom list of labels in the ConfigMap, Cilium will override
-the default list of labels with the list provided. After saving the ConfigMap,
+Upon defining a custom list of labels in the ConfigMap, Cilium add the provided
+list of labels to the default list of labels. After saving the ConfigMap,
 restart the Cilium Agents to pickup the new labels setting.
 
 .. code-block:: bash


### PR DESCRIPTION
`ParseLabelPrefixCfg()` appends the user-specified list to the user-specified file for labels. By default, the file is empty, which
`readLabelPrefixCfgFrom()` interprets as "use the default list". This means that by default, when the user specifies a set of labels, it will append to the default list rather than replacing it.

/cc @ArthurChiao 