### PR TITLE
.github: Fix cilium project management for v1.9

### DIFF
--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -3,13 +3,13 @@ column: "In progress"
 move-to-projects-for-labels-xored:
   v1.9:
     needs-backport/1.9:
-      project: "https://github.com/cilium/cilium/projects/135"
+      project: "https://github.com/cilium/cilium/projects/137"
       column: "Needs backport from master"
     backport-pending/1.9:
-      project: "https://github.com/cilium/cilium/projects/135"
+      project: "https://github.com/cilium/cilium/projects/137"
       column: "Backport pending to v1.9"
     backport-done/1.9:
-      project: "https://github.com/cilium/cilium/projects/135"
+      project: "https://github.com/cilium/cilium/projects/137"
       column: "Backport done to v1.9"
   v1.8:
     needs-backport/1.8:


### PR DESCRIPTION
Commit a02744cbe274 ("README: update security releases") bumped the
README for v1.9.0, but missed the github actions, which meant that
labeling PRs for backport to v1.9.1 would not trigger the maintainer's
little helper to put the PRs in the appropriate project.

Bump the project to the v1.9.1 project to fix this.