### PR TITLE
Add 'nilness' to golangci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,6 +48,9 @@ run:
 
 # all available settings of specific linters
 linters-settings:
+  govet:
+    enable:
+      - nilness
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.

--- a/pkg/crypto/certificatemanager/certificate_manager.go
+++ b/pkg/crypto/certificatemanager/certificate_manager.go
@@ -71,8 +71,10 @@ func (m *Manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string)
 	if ioErr == nil {
 		secrets := make(map[string][]byte, len(files))
 		for _, file := range files {
+			var bytes []byte
+
 			path := filepath.Join(certPath, file.Name())
-			bytes, ioErr := ioutil.ReadFile(path)
+			bytes, ioErr = ioutil.ReadFile(path)
 			if ioErr == nil {
 				secrets[file.Name()] = bytes
 			}

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -252,6 +252,8 @@ func leasesFallbackDiscovery(client kubernetes.Interface, conf k8sconfig.Configu
 }
 
 func updateK8sServerVersion(client kubernetes.Interface) error {
+	var ver go_version.Version
+
 	sv, err := client.Discovery().ServerVersion()
 	if err != nil {
 		return err
@@ -260,7 +262,7 @@ func updateK8sServerVersion(client kubernetes.Interface) error {
 	// Try GitVersion first. In case of error fallback to MajorMinor
 	if sv.GitVersion != "" {
 		// This is a string like "v1.9.0"
-		ver, err := versioncheck.Version(sv.GitVersion)
+		ver, err = versioncheck.Version(sv.GitVersion)
 		if err == nil {
 			updateVersion(ver)
 			return nil
@@ -268,18 +270,14 @@ func updateK8sServerVersion(client kubernetes.Interface) error {
 	}
 
 	if sv.Major != "" && sv.Minor != "" {
-		ver, err := versioncheck.Version(fmt.Sprintf("%s.%s", sv.Major, sv.Minor))
+		ver, err = versioncheck.Version(fmt.Sprintf("%s.%s", sv.Major, sv.Minor))
 		if err == nil {
 			updateVersion(ver)
 			return nil
 		}
 	}
 
-	if err != nil {
-		return fmt.Errorf("cannot parse k8s server version from %+v: %s", sv, err)
-	}
-
-	return fmt.Errorf("cannot parse k8s server version from %+v", sv)
+	return fmt.Errorf("cannot parse k8s server version from %+v: %s", sv, err)
 }
 
 // Update retrieves the version of the Kubernetes apiserver and derives the


### PR DESCRIPTION
Nilness checks for common programming errors like nil pointer dereference or degenerate nil pointer comparisons. It can find bugs, add it to the golangci target.

https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness

Add it to the CI, and fix up the couple of legitimate failures it complains about in the codebase.

Technically the two identified errors are bugs, but they do not appear to be at all severe so I see no strong motivation to backport this PR to v1.9.