### PR TITLE
ci/docker: Add !operator dir into Dockerfile.dockerignore

### DIFF
--- a/images/cilium/Dockerfile.dockerignore
+++ b/images/cilium/Dockerfile.dockerignore
@@ -25,6 +25,7 @@
 !/contrib/packaging/docker
 !/daemon
 !/envoy
+!/operator/option
 !/pkg
 !/plugins/cilium-cni
 !/proxylib


### PR DESCRIPTION
## Description

This commit is to add operator directory in Dockerfile.dockerignore file to fix below issue

```
../pkg/aws/endpoints/resolver.go:18:2: cannot find package "." in:
#12 9.053       /go/src/github.com/cilium/cilium/operator/option
```

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Full log can be found here https://github.com/cilium/cilium/runs/1417805368

## Testing
Testing was done locally only as I just realise that image job in github action is kicked off only for master and tag (maybe we don't want to override the image in docker registries)

<details>
<summary>make -C images cilium-image</summary>

```shell script
$ make -C images cilium-image
make: Entering directory '/home/tammach/go/src/github.com/cilium/cilium/images'
ROOT_CONTEXT=true scripts/build-image.sh cilium-dev images/cilium linux/amd64,linux/arm64 "type=image" "$(cat .buildx_builder)" docker.io/cilium
will build cilium-dev:80e7f0642-dev as it has dev suffix
building cilium-dev:80e7f0642-dev
+ run_buildx
+ build_args=("--platform=${platform}" "--builder=${builder}" "--file=${image_dir}/Dockerfile")
+ '[' true = false ']'
+ build_args+=("${root_dir}")
+ '[' false = true ']'
+ docker buildx build --output=type=image --tag docker.io/cilium/cilium-dev:80e7f0642-dev --platform=linux/amd64,linux/arm64 --builder= --file=images/cilium/Dockerfile /home/tammach/go/src/github.com/cilium/cilium
WARN[0000] invalid non-bool value for BUILDX_NO_DEFAULT_LOAD:  
[+] Building 32.3s (26/26) FINISHED                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 75B                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 35B                                                                                                                         0.0s
 => resolve image config for docker.io/docker/dockerfile:1.1-experimental                                                                                4.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1.1-experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44           0.0s
 => => resolve docker.io/docker/dockerfile:1.1-experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44                      0.0s
 => [linux/arm64 internal] load metadata for docker.io/cilium/cilium-runtime-dev:bf6abb13718b26668af89df742b7c91507154a97                                3.8s
 => [linux/arm64 internal] load metadata for docker.io/cilium/cilium-builder-dev:5c69f48a672124827e6513db5f560f60b4a476ba                                3.7s
 => [linux/amd64 internal] load metadata for docker.io/cilium/cilium-runtime-dev:bf6abb13718b26668af89df742b7c91507154a97                                3.8s
 => [linux/amd64 internal] load metadata for docker.io/cilium/cilium-builder-dev:5c69f48a672124827e6513db5f560f60b4a476ba                                3.8s
 => CACHED [linux/amd64 stage-1 1/4] FROM docker.io/cilium/cilium-runtime-dev:bf6abb13718b26668af89df742b7c91507154a97@sha256:4eeb5f3b1327250585b833188  0.0s
 => => resolve docker.io/cilium/cilium-runtime-dev:bf6abb13718b26668af89df742b7c91507154a97@sha256:4eeb5f3b1327250585b8331883823343ce64a4818b8959f25262  0.0s
 => CACHED [linux/amd64 builder 1/4] FROM docker.io/cilium/cilium-builder-dev:5c69f48a672124827e6513db5f560f60b4a476ba@sha256:5e8dc417a3209df3dc9b247b6  0.0s
 => => resolve docker.io/cilium/cilium-builder-dev:5c69f48a672124827e6513db5f560f60b4a476ba@sha256:5e8dc417a3209df3dc9b247b66f891aff61d2978e6550e47a4c7  0.0s
 => [internal] load build context                                                                                                                        3.8s
 => => transferring context: 615.17MB                                                                                                                    3.8s
 => CACHED [linux/arm64 stage-1 1/4] FROM docker.io/cilium/cilium-runtime-dev:bf6abb13718b26668af89df742b7c91507154a97@sha256:4eeb5f3b1327250585b833188  0.0s
 => => resolve docker.io/cilium/cilium-runtime-dev:bf6abb13718b26668af89df742b7c91507154a97@sha256:4eeb5f3b1327250585b8331883823343ce64a4818b8959f25262  0.0s
 => CACHED [linux/arm64 builder 1/4] FROM docker.io/cilium/cilium-builder-dev:5c69f48a672124827e6513db5f560f60b4a476ba@sha256:5e8dc417a3209df3dc9b247b6  0.0s
 => => resolve docker.io/cilium/cilium-builder-dev:5c69f48a672124827e6513db5f560f60b4a476ba@sha256:5e8dc417a3209df3dc9b247b66f891aff61d2978e6550e47a4c7  0.0s
 => [linux/amd64 builder 2/4] RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=t  12.3s
 => [linux/arm64 builder 2/4] RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=t  12.3s
 => [linux/amd64 builder 3/4] RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium   cd /go/src/github.com/cilium/cilium/plugins/cil  0.2s
 => [linux/arm64 builder 3/4] RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium   cd /go/src/github.com/cilium/cilium/plugins/cil  0.1s
 => [linux/arm64 builder 4/4] RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium   cd /go/src/github.com/cilium/cilium/contrib/pac  0.2s 
 => [linux/amd64 builder 4/4] RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium   cd /go/src/github.com/cilium/cilium/contrib/pac  0.1s 
 => [linux/arm64 stage-1 2/4] COPY --from=builder /out/linux/arm64 /                                                                                     0.7s 
 => [linux/amd64 stage-1 2/4] COPY --from=builder /out/linux/amd64 /                                                                                     0.7s 
 => [linux/arm64 stage-1 3/4] WORKDIR /home/cilium                                                                                                       0.0s 
 => [linux/amd64 stage-1 3/4] WORKDIR /home/cilium                                                                                                       0.1s 
 => [linux/arm64 stage-1 4/4] RUN groupadd -f cilium   && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc                                 0.2s 
 => [linux/amd64 stage-1 4/4] RUN groupadd -f cilium   && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc                                 0.2s 
 => exporting to image                                                                                                                                   6.5s 
 => => exporting layers                                                                                                                                  6.4s 
 => => exporting manifest sha256:071eb779e484e4b4370711a91e308a9e408ec869dc1d54bdace698d478d9c0f9                                                        0.0s
 => => exporting config sha256:3ed26b0da3cd719ca5a81fbe2c725aa5c1a0422e9c49897ed4612f5f7f1e77de                                                          0.0s
 => => exporting manifest sha256:b1389e24cba6c03d84e936200d17093439b249b41c85f5abb9f977f5a70e0806                                                        0.0s
 => => exporting config sha256:37a3d2ffcd6656410cc84720e50db2767d3049825aca444833f5c5facb4a0735                                                          0.0s
 => => exporting manifest list sha256:349b9fd3f0c5a8b715bd3a4a822ecb243f3952f5339dcb0e88c75f5b95b1bd17                                                   0.0s
make: Leaving directory '/home/tammach/go/src/github.com/cilium/cilium/images'

```

</details>


```release-note
ci/docker: Add operator dir into Dockerfile.dockerignore
```



