### PR TITLE
test: Don't wait for network to schedule test-verifier

### DIFF
--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -34,4 +34,6 @@ spec:
   tolerations:
   - key: "node.kubernetes.io/not-ready"
     operator: "Exists"
+  - key: "node.kubernetes.io/unreachable"
+    operator: "Exists"
   hostNetwork: true


### PR DESCRIPTION
The `test-verifier` pod needs to run when Cilium is uninstall and therefore shouldn't wait for the network to be ready to be scheduled to a node.

Fixes: #12658
Fixes: #14071