### PR TITLE
agent: Make intent of signaling channels clear and optimize memory

### DIFF
--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -78,7 +78,7 @@ func newCache(a *Allocator) cache {
 	}
 }
 
-type waitChan chan bool
+type waitChan chan struct{}
 
 // CacheMutations are the operations given to a Backend's ListAndWatch command.
 // They are called on changes to identities.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -46,7 +46,7 @@ func (b *ControllerSuite) TestUpdateRemoveController(c *C) {
 
 func (b *ControllerSuite) TestStopFunc(c *C) {
 	stopFuncRan := false
-	waitChan := make(chan bool)
+	waitChan := make(chan struct{})
 
 	mngr := Manager{}
 	mngr.UpdateController("test", ControllerParams{

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -211,7 +211,7 @@ func (s *LoaderTestSuite) testCompileFailure(c *C, ep *testutils.TestEndpoint) {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
-	exit := make(chan bool)
+	exit := make(chan struct{})
 	defer close(exit)
 	go func() {
 		select {

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -182,7 +182,7 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 	owner := newDummyOwner()
 	events := make(allocator.AllocatorEventChan, 1024)
 	watcher := identityWatcher{
-		stopChan: make(chan bool),
+		stopChan: make(chan struct{}),
 		owner:    owner,
 	}
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -237,7 +237,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 // CachingIdentityAllocator.
 func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityAllocator {
 	watcher := identityWatcher{
-		stopChan: make(chan bool),
+		stopChan: make(chan struct{}),
 		owner:    owner,
 	}
 

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -104,7 +104,7 @@ func (m *CachingIdentityAllocator) GetIdentities() IdentitiesModel {
 }
 
 type identityWatcher struct {
-	stopChan chan bool
+	stopChan chan struct{}
 	owner    IdentityAllocatorOwner
 }
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -79,7 +79,7 @@ type nodeStore struct {
 	allocationPoolSize map[Family]int
 
 	// signal for completion of restoration
-	restoreFinished  chan bool
+	restoreFinished  chan struct{}
 	restoreCloseOnce sync.Once
 
 	conf Configuration
@@ -95,7 +95,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 		allocationPoolSize: map[Family]int{},
 		conf:               conf,
 	}
-	store.restoreFinished = make(chan bool)
+	store.restoreFinished = make(chan struct{})
 	ciliumClient := k8s.CiliumClient()
 
 	t, err := trigger.NewTrigger(trigger.Parameters{

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -483,7 +483,7 @@ func (s *SharedStore) deleteSharedKey(name string) {
 }
 
 func (s *SharedStore) listAndStartWatcher() error {
-	listDone := make(chan bool)
+	listDone := make(chan struct{})
 
 	go s.watcher(listDone)
 
@@ -496,7 +496,7 @@ func (s *SharedStore) listAndStartWatcher() error {
 	return nil
 }
 
-func (s *SharedStore) watcher(listDone chan bool) {
+func (s *SharedStore) watcher(listDone chan struct{}) {
 	s.kvstoreWatcher = s.backend.ListAndWatch(s.conf.Context, s.name+"-watcher", s.conf.Prefix, watcherChanSize)
 
 	for event := range s.kvstoreWatcher.Events {

--- a/pkg/trigger/trigger.go
+++ b/pkg/trigger/trigger.go
@@ -89,7 +89,7 @@ type Trigger struct {
 	lastTrigger time.Time
 
 	// wakeupCan is used to wake up the background trigger routine
-	wakeupChan chan bool
+	wakeupChan chan struct{}
 
 	// closeChan is used to stop the background trigger routine
 	closeChan chan struct{}
@@ -116,7 +116,7 @@ func NewTrigger(p Parameters) (*Trigger, error) {
 
 	t := &Trigger{
 		params:        p,
-		wakeupChan:    make(chan bool, 1),
+		wakeupChan:    make(chan struct{}, 1),
 		closeChan:     make(chan struct{}, 1),
 		foldedReasons: newReasonStack(),
 	}
@@ -161,7 +161,7 @@ func (t *Trigger) TriggerWithReason(reason string) {
 	}
 
 	select {
-	case t.wakeupChan <- true:
+	case t.wakeupChan <- struct{}{}:
 	default:
 	}
 }


### PR DESCRIPTION
When channels are merely used for signaling purposes, use an empty
struct as the channel type since the value of the channel is never read.
Also, this can help with memory optimizations as the empty struct occupies 0 bytes of storage.

Signed-off-by: Aditi Ghag <aditi@cilium.io>
