### PR TITLE
helm: Add extraConfig in configmap template

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -143,6 +143,7 @@ contributors across the globe, there is almost always someone available to help.
 | externalWorkloads | object | `{"enabled":false}` | Configure external workloads support |
 | externalWorkloads.enabled | bool | `false` | Enable support for external workloads, such as VMs (false by default). |
 | extraArgs | object | `{}` | Additional agent container arguments |
+| extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
 | extraConfigmapMounts | list | `[]` | Additional agent ConfigMap mounts |
 | extraEnv | object | `{}` | Additional agent container environment variables |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -646,4 +646,8 @@ data:
   # Configure service proxy name for Cilium.
   k8s-service-proxy-name: {{ .Values.k8s.serviceProxyName | quote }}
 {{- end }}
+
+{{- if .Values.extraConfig }}
+{{ toYaml .Values.extraConfig | indent 2 }}
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -109,6 +109,15 @@ extraConfigmapMounts: []
   #   configMap: certs-configmap
   #   readOnly: true
 
+# -- extraConfig allows you to specify additional configuration parameters to be
+# included in the cilium-config configmap.
+extraConfig: {}
+#  my-config-a: "1234"
+#  my-config-b: |-
+#    test 1
+#    test 2
+#    test 3
+
 # -- Node tolerations for agent scheduling to nodes with taints
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 tolerations:


### PR DESCRIPTION
This allows users to provide additional fields in the configmap without
having them explicitly listed in the template. For example, you can do:

    % cat my-config.yaml
    extraConfig:
      my-config-a: "1234"
      my-config-b: |-
        test 1
        test 2
        test 3
    % helm install ./cilium -n kube-system -f ./my-config.yaml

to add my-config-a and my-config-b to cilium-config. This could be
useful in case the template is missing some fields.

Ref: https://github.com/cilium/cilium/pull/13317

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>