### PR TITLE
fqdn: Delay ipcache upserts until policies have been updated

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -67,7 +67,7 @@ const (
 	dnsSourceConnection = "connection"
 )
 
-func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator *secIDCache.CachingIdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, error) {
+func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator *secIDCache.CachingIdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, map[string]*identity.Identity, error) {
 	var err error
 
 	// Used to track identities which are allocated in calls to
@@ -76,6 +76,7 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 	// This is best effort, as releasing can fail as well.
 	usedIdentities := make([]*identity.Identity, 0)
 	selectorIdentitySliceMapping := make(map[policyApi.FQDNSelector][]*identity.Identity)
+	newlyAllocatedIdentities := map[string]*identity.Identity{}
 
 	// Allocate identities for each IPNet and then map to selector
 	for selector, selectorIPs := range selectorsWithIPsToUpdate {
@@ -84,17 +85,17 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 			"ips":          selectorIPs,
 		}).Debug("getting identities for IPs associated with FQDNSelector")
 		var currentlyAllocatedIdentities []*identity.Identity
-		if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs); err != nil {
+		if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs, newlyAllocatedIdentities); err != nil {
 			identityAllocator.ReleaseSlice(context.TODO(), nil, usedIdentities)
 			log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 				"failed to allocate identities for IPs")
-			return nil, err
+			return nil, nil, err
 		}
 		usedIdentities = append(usedIdentities, currentlyAllocatedIdentities...)
 		selectorIdentitySliceMapping[selector] = currentlyAllocatedIdentities
 	}
 
-	return selectorIdentitySliceMapping, nil
+	return selectorIdentitySliceMapping, newlyAllocatedIdentities, nil
 }
 
 func (d *Daemon) updateSelectorCacheFQDNs(ctx context.Context, selectors map[policyApi.FQDNSelector][]*identity.Identity, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup) {
@@ -340,16 +341,16 @@ func (d *Daemon) updateDNSDatapathRules() error {
 // updateSelectors propagates the mapping of FQDNSelector to identity, as well
 // as the set of FQDNSelectors which have no IPs which correspond to them
 // (usually due to TTL expiry), down to policy layer managed by this daemon.
-func (d *Daemon) updateSelectors(ctx context.Context, selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, err error) {
+func (d *Daemon) updateSelectors(ctx context.Context, selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
 	// Convert set of selectors with IPs to update to set of selectors
 	// with identities corresponding to said IPs.
-	selectorsIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate, d.identityAllocator)
+	selectorsIdentities, newlyAllocatedIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate, d.identityAllocator)
 	if err != nil {
-		return &sync.WaitGroup{}, err
+		return &sync.WaitGroup{}, nil, err
 	}
 
 	// Update mapping in selector cache with new identities.
-	return d.updateSelectorCacheFQDNs(ctx, selectorsIdentities, selectorsWithoutIPs), nil
+	return d.updateSelectorCacheFQDNs(ctx, selectorsIdentities, selectorsWithoutIPs), newlyAllocatedIdentities, nil
 }
 
 // pollerResponseNotify handles update events for updates from the poller. It
@@ -612,7 +613,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		defer updateCancel()
 		updateStart := time.Now()
 
-		wg, err := d.dnsNameManager.UpdateGenerateDNS(updateCtx, lookupTime, map[string]*fqdn.DNSIPRecords{
+		wg, newlyAllocatedIdentities, err := d.dnsNameManager.UpdateGenerateDNS(updateCtx, lookupTime, map[string]*fqdn.DNSIPRecords{
 			qname: {
 				IPs: responseIPs,
 				TTL: int(TTL),
@@ -638,6 +639,10 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			logfields.EndpointID: ep.GetID(),
 			"qname":              qname,
 		}).Debug("Waited for endpoints to regenerate due to a DNS response")
+
+		// Add new identities to the ipcache after the wait for the policy updates above
+		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+
 		endMetric()
 	}
 

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -287,7 +287,11 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		}
 	}
 
-	if _, err := ipcache.AllocateCIDRs(prefixes); err != nil {
+	// TODO: Collect new identities to be upserted to the ipcache only after all endpoints have
+	// been regenerated below. This would make sure that any CIDRs in the policy would be first
+	// pushed to the endpoint policies and then to the ipcache to avoid traffic mapping to an ID
+	// that the endpoint policy maps do not know about yet.
+	if _, err := ipcache.AllocateCIDRs(prefixes, nil); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		metrics.PolicyImportErrors.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -287,11 +288,12 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		}
 	}
 
-	// TODO: Collect new identities to be upserted to the ipcache only after all endpoints have
-	// been regenerated below. This would make sure that any CIDRs in the policy would be first
-	// pushed to the endpoint policies and then to the ipcache to avoid traffic mapping to an ID
-	// that the endpoint policy maps do not know about yet.
-	if _, err := ipcache.AllocateCIDRs(prefixes, nil); err != nil {
+	// Any newly allocated identities MUST be upserted to the ipcache if no error is returned.
+	// With SelectiveRegeneration this is postponed to the rule reaction queue to be done
+	// after the affected endpoints have been regenerated, otherwise new identities are
+	// upserted to the ipcache before we return.
+	newlyAllocatedIdentities := make(map[string]*identity.Identity)
+	if _, err := ipcache.AllocateCIDRs(prefixes, newlyAllocatedIdentities); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		metrics.PolicyImportErrors.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
@@ -401,12 +403,16 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		// select any at all). The "reacting" to rule updates enqueues events
 		// for all endpoints. Once all endpoints have events queued up, this
 		// function will return.
-
+		//
+		// With selective regeneration upserting CIDRs to ipcache is performed after
+		// endpoint regeneration and serialized with the corresponding ipcache deletes via
+		// the policy reaction queue.
 		r := &PolicyReactionEvent{
 			wg:                &policySelectionWG,
 			epsToBumpRevision: endpointsToBumpRevision,
 			endpointsToRegen:  endpointsToRegen,
 			newRev:            newRev,
+			upsertIdentities:  newlyAllocatedIdentities,
 		}
 
 		ev := eventqueue.NewEvent(r)
@@ -420,6 +426,10 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	} else {
 		// Regenerate all endpoints unconditionally.
 		d.TriggerPolicyUpdates(false, "policy rules added")
+		// TODO: Remove 'enable-selective-regeneration' agent option.  Without selective
+		// regeneration we retain the old behavior of upserting new identities to ipcache
+		// before endpoint policy maps have been updated.
+		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
 	}
 
 	return
@@ -433,6 +443,8 @@ type PolicyReactionEvent struct {
 	epsToBumpRevision *policy.EndpointSet
 	endpointsToRegen  *policy.EndpointSet
 	newRev            uint64
+	upsertIdentities  map[string]*identity.Identity // deferred CIDR identity upserts, if any
+	releasePrefixes   []*net.IPNet                  // deferred CIDR identity deletes, if any
 }
 
 // Handle implements pkg/eventqueue/EventHandler interface.
@@ -440,15 +452,24 @@ func (r *PolicyReactionEvent) Handle(res chan interface{}) {
 	// Wait until we have calculated which endpoints need to be selected
 	// across multiple goroutines.
 	r.wg.Wait()
-	reactToRuleUpdates(r.epsToBumpRevision, r.endpointsToRegen, r.newRev)
+	reactToRuleUpdates(r.epsToBumpRevision, r.endpointsToRegen, r.newRev, r.upsertIdentities, r.releasePrefixes)
 }
 
 // reactToRuleUpdates does the following:
 // * regenerate all endpoints in epsToRegen
 // * bump the policy revision of all endpoints not in epsToRegen, but which are
 //   in allEps, to revision rev.
-func reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev uint64) {
+// * wait for the regenerations to be finished
+// * upsert or delete CIDR identities to the ipcache, as needed.
+func reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev uint64, upsertIdentities map[string]*identity.Identity, releasePrefixes []*net.IPNet) {
 	var enqueueWaitGroup sync.WaitGroup
+
+	// Release CIDR identities before regenerations have been started, if any. This makes sure
+	// the stale identities are not used in policy map classifications after we regenerate the
+	// endpoints below.
+	if len(releasePrefixes) != 0 {
+		ipcache.ReleaseCIDRs(releasePrefixes)
+	}
 
 	// Bump revision of endpoints which don't need to be regenerated.
 	epsToBumpRevision.ForEachGo(&enqueueWaitGroup, func(epp policy.Endpoint) {
@@ -477,6 +498,13 @@ func reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev u
 	})
 
 	enqueueWaitGroup.Wait()
+
+	// Upsert new identities after regeneration has completed, if any. This makes sure the
+	// policy maps are ready to classify packets using the newly allocated identities before
+	// they are upserted to the ipcache here.
+	if upsertIdentities != nil {
+		ipcache.UpsertGeneratedIdentities(upsertIdentities)
+	}
 }
 
 // PolicyDeleteEvent is a wrapper around deletion of policy rules with a given
@@ -580,7 +608,6 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 	// not appropriately performing garbage collection.
 	prefixes := policy.GetCIDRPrefixes(rules)
 	log.WithField("prefixes", prefixes).Debug("Policy deleted via API, found prefixes...")
-	ipcache.ReleaseCIDRs(prefixes)
 
 	prefixesChanged := d.prefixLengths.Delete(prefixes)
 	if !bpfIPCache.BackedByLPM() && prefixesChanged {
@@ -592,11 +619,16 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 	}
 
 	if option.Config.SelectiveRegeneration {
+		// With selective regeneration releasing prefixes from ipcache is serialized with
+		// the corresponding ipcache upserts via the policy reaction queue. Execution order
+		// w.r.t. to endpoint regenerations remains the same, endpoints are regenerated
+		// after any prefixes have been removed from the ipcache.
 		r := &PolicyReactionEvent{
 			wg:                &policySelectionWG,
 			epsToBumpRevision: epsToBumpRevision,
 			endpointsToRegen:  endpointsToRegen,
 			newRev:            rev,
+			releasePrefixes:   prefixes,
 		}
 
 		ev := eventqueue.NewEvent(r)
@@ -608,6 +640,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 			log.WithField(logfields.PolicyRevision, rev).Errorf("enqueue of RuleReactionEvent failed: %s", err)
 		}
 	} else {
+		ipcache.ReleaseCIDRs(prefixes)
 		d.TriggerPolicyUpdates(true, "policy rules deleted")
 	}
 

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/miekg/dns"
 )
@@ -50,7 +51,7 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error)
+	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error)
 
 	// PollerResponseNotify is used when the poller receives DNS data in response
 	// to a successful poll.

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -113,7 +114,10 @@ func (poller *DNSPoller) LookupUpdateDNS(ctx context.Context) error {
 		poller.config.PollerResponseNotify(lookupTime, qname, response)
 	}
 
-	_, err := poller.ruleManager.UpdateGenerateDNS(ctx, lookupTime, updatedDNSIPs)
+	_, newlyAllocatedIdentities, err := poller.ruleManager.UpdateGenerateDNS(ctx, lookupTime, updatedDNSIPs)
+	if err == nil {
+		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+	}
 	return err
 }
 

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/miekg/dns"
 
@@ -143,8 +144,8 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
 				},
 
-				UpdateSelectors: func(context.Context, map[api.FQDNSelector][]net.IP, []api.FQDNSelector) (*sync.WaitGroup, error) {
-					return &sync.WaitGroup{}, nil
+				UpdateSelectors: func(context.Context, map[api.FQDNSelector][]net.IP, []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
+					return &sync.WaitGroup{}, nil, nil
 				},
 			}
 

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -136,7 +136,12 @@ func (n *NameManager) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector
 		"ips":          selectorIPs,
 	}).Debug("getting identities for IPs associated with FQDNSelector")
 	var currentlyAllocatedIdentities []*identity.Identity
-	if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs); err != nil {
+	// TODO: Consider if upserts to ipcache should be delayed until endpoint policies have been
+	// updated. This is the path from policy updates rather than for DNS proxy results. Hence
+	// any existing IPs would typically already have been pushed to the ipcache as they would
+	// not be newly allocated. We need the 'allocation' here to get a reference count on the
+	// allocations.
+	if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs, nil); err != nil {
 		log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 			"failed to allocate identities for IPs")
 		return nil
@@ -168,8 +173,8 @@ func NewNameManager(config Config) *NameManager {
 	}
 
 	if config.UpdateSelectors == nil {
-		config.UpdateSelectors = func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, namesMissingIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
-			return &sync.WaitGroup{}, nil
+		config.UpdateSelectors = func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
+			return &sync.WaitGroup{}, nil, nil
 		}
 	}
 
@@ -200,9 +205,8 @@ func (n *NameManager) GetDNSNames() (dnsNames []string) {
 }
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
-// have changed for a name, store which rules must be updated in rulesToUpdate,
-// regenerate them, and emit via UpdateSelectors.
-func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, err error) {
+// have changed for a name they will be reflected in updatedDNSIPs.
+func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
 	n.Mutex.Lock()
 	defer n.Mutex.Unlock()
 
@@ -228,6 +232,8 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 // ForceGenerateDNS unconditionally regenerates all rules that refer to DNS
 // names in namesToRegen. These names are FQDNs and toFQDNs.matchPatterns or
 // matchNames that match them will cause these rules to regenerate.
+// Note: This is used only when DNS entries are cleaned up, not when new results
+// are ingested.
 func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []string) (wg *sync.WaitGroup, err error) {
 	n.Mutex.Lock()
 	defer n.Mutex.Unlock()
@@ -247,9 +253,10 @@ func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []strin
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
 	}
 
-	// emit the new rules
-	return n.config.
-		UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
+	// Emit the new rules.
+	// Ignore newly allocated IDs (2nd result) as this is only used for deletes.
+	wg, _, err = n.config.UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
+	return wg, err
 }
 
 func (n *NameManager) CompleteBootstrap() {

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/miekg/dns"
 
@@ -51,11 +52,11 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil
+				return &sync.WaitGroup{}, nil, nil
 			},
 		})
 	)
@@ -70,7 +71,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
@@ -82,7 +83,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
@@ -103,11 +104,11 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil
+				return &sync.WaitGroup{}, nil, nil
 			},
 		})
 	)
@@ -123,14 +124,14 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
@@ -143,7 +144,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -39,26 +39,44 @@ var (
 // AllocateCIDRs attempts to allocate identities for a list of CIDRs. If any
 // allocation fails, all allocations are rolled back and the error is returned.
 // When an identity is freshly allocated for a CIDR, it is added to the
-// ipcache.
-func AllocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
-	return allocateCIDRs(prefixes)
+// ipcache if 'newlyAllocatedIdentities' is 'nil', otherwise the newly allocated
+// identities are placed in 'newlyAllocatedIdentities' and it is the caller's
+// responsibility to upsert them into ipcache by calling UpsertGeneratedIdentities().
+func AllocateCIDRs(prefixes []*net.IPNet, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
+	return allocateCIDRs(prefixes, newlyAllocatedIdentities)
 }
 
 // AllocateCIDRsForIPs attempts to allocate identities for a list of CIDRs. If
 // any allocation fails, all allocations are rolled back and the error is
 // returned. When an identity is freshly allocated for a CIDR, it is added to
-// the ipcache.
-func AllocateCIDRsForIPs(prefixes []net.IP) ([]*identity.Identity, error) {
-	return allocateCIDRs(ip.GetCIDRPrefixesFromIPs(prefixes))
+// the ipcache if 'newlyAllocatedIdentities' is 'nil', otherwise the newly allocated
+// identities are placed in 'newlyAllocatedIdentities' and it is the caller's
+// responsibility to upsert them into ipcache by calling UpsertGeneratedIdentities().
+func AllocateCIDRsForIPs(prefixes []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
+	return allocateCIDRs(ip.GetCIDRPrefixesFromIPs(prefixes), newlyAllocatedIdentities)
 }
 
-func allocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
+func UpsertGeneratedIdentities(newlyAllocatedIdentities map[string]*identity.Identity) {
+	for prefixString, id := range newlyAllocatedIdentities {
+		IPIdentityCache.Upsert(prefixString, nil, 0, nil, Identity{
+			ID:     id.ID,
+			Source: source.Generated,
+		})
+	}
+}
+
+func allocateCIDRs(prefixes []*net.IPNet, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
 	// maintain list of used identities to undo on error
 	var usedIdentities []*identity.Identity
 
-	// maintain list of newly allocated identities to update ipcache
 	allocatedIdentities := map[string]*identity.Identity{}
-	newlyAllocatedIdentities := map[string]*identity.Identity{}
+	// Maintain list of newly allocated identities to update ipcache,
+	// but upsert them to ipcache only if no map was given by the caller.
+	upsert := false
+	if newlyAllocatedIdentities == nil {
+		upsert = true
+		newlyAllocatedIdentities = map[string]*identity.Identity{}
+	}
 
 	for _, prefix := range prefixes {
 		if prefix == nil {
@@ -92,12 +110,10 @@ func allocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
 
 	allocatedIdentitiesSlice := make([]*identity.Identity, 0, len(allocatedIdentities))
 
-	// Only upsert into ipcache if identity wasn't allocated before.
-	for prefixString, id := range newlyAllocatedIdentities {
-		IPIdentityCache.Upsert(prefixString, nil, 0, nil, Identity{
-			ID:     id.ID,
-			Source: source.Generated,
-		})
+	// Only upsert into ipcache if identity wasn't allocated
+	// before and the caller does not care doing this
+	if upsert {
+		UpsertGeneratedIdentities(newlyAllocatedIdentities)
 	}
 
 	for _, id := range allocatedIdentities {

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -127,7 +127,12 @@ func generateToCidrFromEndpoint(
 		if err != nil {
 			return err
 		}
-		if _, err := ipcache.AllocateCIDRs(prefixes); err != nil {
+		// TODO: Collect new identities to be upserted to the ipcache only after all
+		// endpoints have been regenerated later. This would make sure that any CIDRs in the
+		// policy would be first pushed to the endpoint policies and then to the ipcache to
+		// avoid traffic mapping to an ID that the endpoint policy maps do not know about
+		// yet.
+		if _, err := ipcache.AllocateCIDRs(prefixes, nil); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Add a map for newly allocated identities to ipcache.AllocateCIDR
functions that the caller can use to insert the IPs to the IP cache later,
after affected endpoint policy maps have been updated.

Use this new functionality on the DNS proxy and policy update code
paths, that makes sure that new policy map entries are in place before
an IP received from a DNS server or a CIDR included in a policy is placed
in IP cache. This is really straightforward as the logic for waiting was
already in place.

The DNS poller path still inserts in to IP cache before policies
have been updated.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
