### PR TITLE
fqdn: Fix unit test

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -662,6 +662,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
 	// Test with limited set of allowed IPs
+	oldUsed := s.proxy.usedServers
 	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
 
 	expected1b := restore.DNSRules{
@@ -680,7 +681,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored1b, checker.DeepEquals, expected1b)
 
 	// unlimited again
-	s.proxy.usedServers = nil
+	s.proxy.usedServers = oldUsed
 
 	s.proxy.UpdateAllowed(epID1, 53, nil)
 	s.proxy.UpdateAllowed(epID1, 54, nil)


### PR DESCRIPTION
Setting usedServers to nil caused write to nil map on other tests.

Fixes: #14012 
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
