### PR TITLE
v1.8 backports 2020-11-19

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -57,6 +57,7 @@ cilium-agent [flags]
       --disable-conntrack                             Disable connection tracking
       --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings         Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int             Maximum number of IPs to maintain for each restored DNS rule (default 1000)
       --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
       --enable-api-rate-limit                         Enables the use of the API rate limiting configuration
       --enable-auto-protect-node-port-range           Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
@@ -189,7 +190,6 @@ cilium-agent [flags]
       --tofqdns-enable-dns-compression                Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-endpoint-max-ip-per-hostname int      Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-max-deferred-connection-deletes int   Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-max-ips-per-restored-rule int         Maximum number of IPs to maintain for each restored rule (default 1000)
       --tofqdns-min-ttl int                           The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
       --tofqdns-pre-cache string                      DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                        Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.

--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -54,7 +54,7 @@ Deploy Cilium
 
 Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
    helm install cilium |CHART_RELEASE| --namespace kube-system
 

--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -57,8 +57,8 @@ and insert a line to define the labels to include or exclude.
     ...
 
 
-Upon defining a custom list of labels in the ConfigMap, Cilium will override
-the default list of labels with the list provided. After saving the ConfigMap,
+Upon defining a custom list of labels in the ConfigMap, Cilium add the provided
+list of labels to the default list of labels. After saving the ConfigMap,
 restart the Cilium Agents to pickup the new labels setting.
 
 .. code-block:: bash

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -388,16 +388,19 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 				/* When SNAT is enabled on traffic ingressing
 				 * into Cilium, all traffic from the world will
 				 * have a source IP of the host. It will only
-				 * actually be from the host if
-				 * "srcid_from_proxy" (passed into this
-				 * function) reports the src as the host. So we
-				 * can ignore the ipcache if it reports the
-				 * source as HOST_ID.
+				 * actually be from the host if "srcid_from_proxy"
+				 * (passed into this function) reports the src as
+				 * the host. So we can ignore the ipcache if it
+				 * reports the source as HOST_ID.
 				 */
 #ifndef ENABLE_EXTRA_HOST_DEV
-				if (from_host && *sec_label != HOST_ID)
-#endif
+				if (*sec_label != HOST_ID)
 					srcid_from_ipcache = *sec_label;
+#else
+				if ((*sec_label != HOST_ID &&
+				     !from_host) || from_host)
+					srcid_from_ipcache = *sec_label;
+#endif /* ENABLE_EXTRA_HOST_DEV */
 			}
 		}
 		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -753,8 +753,8 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
-	flags.Int(option.ToFQDNsMaxIPsPerRestoredRule, defaults.ToFQDNsMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored rule")
-	option.BindEnv(option.ToFQDNsMaxIPsPerRestoredRule)
+	flags.Int(option.DNSMaxIPsPerRestoredRule, defaults.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
+	option.BindEnv(option.DNSMaxIPsPerRestoredRule)
 
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -312,7 +312,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		return err
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
-		option.Config.ToFQDNsMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
+		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
 		d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,6 +94,10 @@ const (
 	// DefaultMapPrefix is the default prefix for all BPF maps.
 	DefaultMapPrefix = "tc/globals"
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules.
+	DNSMaxIPsPerRestoredRule = 1000
+
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
 	// This or ToFQDNsMinTTLPoller is used in DaemonConfig.Populate
 	ToFQDNsMinTTL = 3600 // 1 hour in seconds
@@ -106,10 +110,6 @@ const (
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50
-
-	// ToFQDNsMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules.
-	ToFQDNsMaxIPsPerRestoredRule = 1000
 
 	// ToFQDNsMaxDeferredConnectionDeletes Maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -655,6 +655,27 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	restored3 := s.proxy.GetRules(uint16(epID3)).Sort()
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
+	// Test with limited set of allowed IPs
+	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
+
+	expected1b := restore.DNSRules{
+		53: restore.IPRules{{
+			IPs: map[string]struct{}{},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID1Selector]},
+		}, {
+			IPs: map[string]struct{}{"127.0.0.2": {}},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID2Selector]},
+		}}.Sort(),
+		54: restore.IPRules{{
+			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
+		}},
+	}
+	restored1b := s.proxy.GetRules(uint16(epID1)).Sort()
+	c.Assert(restored1b, checker.DeepEquals, expected1b)
+
+	// unlimited again
+	s.proxy.usedServers = nil
+
 	s.proxy.UpdateAllowed(epID1, 53, nil)
 	s.proxy.UpdateAllowed(epID1, 54, nil)
 	_, exists := s.proxy.allowed[epID1]

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -656,6 +656,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
 	// Test with limited set of allowed IPs
+	oldUsed := s.proxy.usedServers
 	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
 
 	expected1b := restore.DNSRules{
@@ -674,7 +675,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored1b, checker.DeepEquals, expected1b)
 
 	// unlimited again
-	s.proxy.usedServers = nil
+	s.proxy.usedServers = oldUsed
 
 	s.proxy.UpdateAllowed(epID1, 53, nil)
 	s.proxy.UpdateAllowed(epID1, 54, nil)

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -430,6 +430,9 @@ const (
 	// Limit is a numerical limit that has been exceeded
 	Limit = "limit"
 
+	// Count is a measure being compared to the Limit
+	Count = "count"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -364,6 +364,10 @@ const (
 	// CMDRef is the path to cmdref output directory
 	CMDRef = "cmdref"
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule = "dns-max-ips-per-restored-rule"
+
 	// ToFQDNsMinTTL is the minimum time, in seconds, to use DNS data for toFQDNs policies.
 	ToFQDNsMinTTL = "tofqdns-min-ttl"
 
@@ -379,10 +383,6 @@ const (
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
-
-	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules
-	ToFQDNsMaxIPsPerRestoredRule = "tofqdns-max-ips-per-restored-rule"
 
 	// ToFQDNsMaxDeferredConnectionDeletes defines the maximum number of IPs to
 	// retain for expired DNS lookups with still-active connections"
@@ -863,11 +863,11 @@ var HelpFlagSections = []FlagsSection{
 	{
 		Name: "DNS policy flags",
 		Flags: []string{
+			DNSMaxIPsPerRestoredRule,
 			FQDNRejectResponseCode,
 			ToFQDNsEnablePoller,
 			ToFQDNsEnablePollerEvents,
 			ToFQDNsMaxIPsPerHost,
-			ToFQDNsMaxIPsPerRestoredRule,
 			ToFQDNsMinTTL,
 			ToFQDNsPreCache,
 			ToFQDNsProxyPort,
@@ -1560,6 +1560,10 @@ type DaemonConfig struct {
 	PrometheusServeAddr    string
 	ToFQDNsMinTTL          int
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule int
+
 	// ToFQDNsProxyPort is the user-configured global, shared, DNS listen port used
 	// by the DNS Proxy. Both UDP and TCP are handled on the same port. When it
 	// is 0 a random port will be assigned, and can be obtained from
@@ -1576,10 +1580,6 @@ type DaemonConfig struct {
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost int
-
-	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules
-	ToFQDNsMaxIPsPerRestoredRule int
 
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
@@ -1944,8 +1944,8 @@ var (
 		EnableIPv6:                   defaults.EnableIPv6,
 		EnableL7Proxy:                defaults.EnableL7Proxy,
 		EndpointStatus:               make(map[string]struct{}),
+		DNSMaxIPsPerRestoredRule:     defaults.DNSMaxIPsPerRestoredRule,
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
-		ToFQDNsMaxIPsPerRestoredRule: defaults.ToFQDNsMaxIPsPerRestoredRule,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
 		IPAllocationTimeout:          defaults.IPAllocationTimeout,
@@ -2461,8 +2461,8 @@ func (c *DaemonConfig) Populate() {
 	// avoids confusion about dropped connections.
 	c.ToFQDNsEnablePoller = viper.GetBool(ToFQDNsEnablePoller)
 	c.ToFQDNsEnablePollerEvents = viper.GetBool(ToFQDNsEnablePollerEvents)
+	c.DNSMaxIPsPerRestoredRule = viper.GetInt(DNSMaxIPsPerRestoredRule)
 	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
-	c.ToFQDNsMaxIPsPerRestoredRule = viper.GetInt(ToFQDNsMaxIPsPerRestoredRule)
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)
 	} else {


### PR DESCRIPTION
* #13884 -- cilium: fix redirect limits on multi dev case (@borkmann)
 * #14061 -- docs: Fix helm install command in kubeadm getting started guide (@pchaigno)
 * #14064 -- docs: Fix wording around labels configuration (@joestringer)
 * #14012 -- fqdn: Fix confusion of ToFQDNs vs. DNS rules. (@jrajahalme)
 * #14085 -- fqdn: Fix unit test (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13884 14061 14064 14012 14085; do contrib/backporting/set-labels.py $pr done 1.8; done
```