### PR TITLE
v1.9 backports 2020-11-19

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -62,7 +62,7 @@ assignees: ''
 ## Post-release
 
 - [ ] Prepare post-release changes to master branch using `contrib/release/bump-readme.sh`
-- [ ] Update the `stable` tags for each Cilium image on Docker Hub (if applicable)
+- [ ] Update the `stable` tags for each Cilium image (`contrib/release/bump-docker-stable.sh`)
 - [ ] Update external tools and guides to point to the new Cilium version:
   - [ ] [kops]
   - [ ] [kubespray]

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,6 +63,7 @@ cilium-agent [flags]
       --disable-conntrack                                    Disable connection tracking
       --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
       --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
       --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bandwidth-manager                             Enable BPF bandwidth manager
@@ -205,7 +206,6 @@ cilium-agent [flags]
       --tofqdns-enable-dns-compression                       Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-endpoint-max-ip-per-hostname int             Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-max-deferred-connection-deletes int          Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-max-ips-per-restored-rule int                Maximum number of IPs to maintain for each restored rule (default 1000)
       --tofqdns-min-ttl int                                  The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
       --tofqdns-pre-cache string                             DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                               Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.

--- a/Documentation/concepts/networking/fragmentation.rst
+++ b/Documentation/concepts/networking/fragmentation.rst
@@ -21,4 +21,17 @@ options:
 - ``--bpf-fragments-map-max``: Control the maximum number of active concurrent
   connections using IP fragmentation. For the defaults, see `bpf_map_limitations`.
 
+.. note::
+
+    When running Cilium with kube-proxy, fragmented NodePort traffic may break due
+    to a kernel bug where route MTU is not respected for forwarded packets. Cilium
+    fragments tracking requires the first logical fragment to arrive first. Due to the
+    kernel bug, additional fragmentation on the outer encapsulation layer may happen
+    that causes packet reordering and results in a failure in tracking the fragments.
+
+    The kernel bug has been `fixed <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=02a1b175b0e92d9e0fa5df3957ade8d733ceb6a0>`_
+    and backported to all maintained kernel versions. If you observe connectivity problems,
+    ensure that the kernel package on your nodes has been upgraded recently before
+    reporting an issue.
+
 .. include:: ../../beta.rst

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -164,10 +164,11 @@ Reference steps for the template
    ``clustermesh-apiserver`` on DockerHub, for the latest version of Cilium.
    For example, if the latest version is ``1.8``, then for all patch releases
    on the ``1.8`` line, this step should be performed. Once ``1.9`` is out for
-   example, then this is no longer required for ``1.8``.
+   example, then this is no longer required for ``1.8`` or earlier releases.
 
-   **Note**, the DockerHub UI will not allow you to modify the ``stable`` tag
-   directly. You will need to delete it, and then create a new, updated one.
+   ::
+
+       contrib/release/bump-docker-stable.sh X.Y.Z
 
 #. Check if all docker images are available before announcing the release:
 

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -115,8 +115,8 @@ information on Cilium's transparent encryption, see :ref:`ebpf_datapath`.
 Encryption interface
 --------------------
 
-If direct routing is being used, an additional argument can be used to identify
-the network-facing interface. If no interface is specified, the default route
+An additional argument can be used to identify the network-facing interface.
+If direct routing is used and no interface is specified, the default route
 link is chosen by inspecting the routing tables. This will work in many cases,
 but depending on routing rules, users may need to specify the encryption
 interface as follows:
@@ -212,6 +212,11 @@ Troubleshooting
       [...]
 
  * Check for ``level=warning`` and ``level=error`` messages in the Cilium log files
+
+   * If there is a warning message similar to ``Device eth0 does not exist``,
+     use ``--set encryption.interface=ethX`` to set the encryption
+     interface.
+
  * Run a ``bash`` in a Cilium and validate the following:
 
    * Routing rules matching on fwmark:

--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -54,7 +54,7 @@ Deploy Cilium
 
 Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
    helm install cilium |CHART_RELEASE| --namespace kube-system
 

--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -59,8 +59,8 @@ this attribute can also be set via helm option ``--set labels=<values>``.
     ...
 
 
-Upon defining a custom list of labels in the ConfigMap, Cilium will override
-the default list of labels with the list provided. After saving the ConfigMap,
+Upon defining a custom list of labels in the ConfigMap, Cilium add the provided
+list of labels to the default list of labels. After saving the ConfigMap,
 restart the Cilium Agents to pickup the new labels setting.
 
 .. code-block:: bash

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -226,8 +226,9 @@ enum Verdict {
     ERROR = 3;
 }
 
-// Taken from pkg/monitor/api/drop.go. Note that non-drop reasons (i.e. values
-// less than api.DropMin) are not used here.
+// These values are shared with pkg/monitor/api/drop.go and bpf/lib/common.h.
+// Note that non-drop reasons (i.e. values less than api.DropMin) are not used
+// here.
 enum DropReason {
     // non-drop reasons
     DROP_REASON_UNKNOWN = 0;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -7,6 +7,8 @@
 #include <ep_config.h>
 #include <node_config.h>
 
+#include <bpf/verifier.h>
+
 #include <linux/icmpv6.h>
 
 #define EVENT_SOURCE LXC_ID
@@ -1147,6 +1149,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	/* Check it this is return traffic to an egress proxy.
 	 * Do not redirect again if the packet is coming from the egress proxy.
 	 */
+	relax_verifier();
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect &&
 	    !tc_index_skip_egress_proxy(ctx)) {
 		/* This is a reply, the proxy port does not need to be embedded

--- a/bpf/include/bpf/verifier.h
+++ b/bpf/include/bpf/verifier.h
@@ -4,7 +4,7 @@
 #ifndef __BPF_VERIFIER__
 #define __BPF_VERIFIER__
 
-#include "csum.h"
+#include "compiler.h"
 
 /* relax_verifier is a dummy helper call to introduce a pruning checkpoint
  * to help relax the verifier to avoid reaching complexity limits on older
@@ -13,9 +13,7 @@
 static __always_inline void relax_verifier(void)
 {
 #ifdef NEEDS_RELAX_VERIFIER
-       int foo = 0;
-
-       csum_diff(0, 0, &foo, 1, 0);
+       volatile int __maybe_unused id = get_smp_processor_id();
 #endif
 }
 

--- a/bpf/include/bpf/verifier.h
+++ b/bpf/include/bpf/verifier.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2016-2020 Authors of Cilium */
+
+#ifndef __BPF_VERIFIER__
+#define __BPF_VERIFIER__
+
+#include "csum.h"
+
+/* relax_verifier is a dummy helper call to introduce a pruning checkpoint
+ * to help relax the verifier to avoid reaching complexity limits on older
+ * kernels.
+ */
+static __always_inline void relax_verifier(void)
+{
+#ifdef NEEDS_RELAX_VERIFIER
+       int foo = 0;
+
+       csum_diff(0, 0, &foo, 1, 0);
+#endif
+}
+
+#endif /* __BPF_VERIFIER__ */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -401,8 +401,9 @@ enum {
 #define LB_LOOKUP_SCOPE_INT	1
 
 /* Cilium metrics direction for dropping/forwarding packet */
+#define METRIC_EGRESS   0
 #define METRIC_INGRESS  1
-#define METRIC_EGRESS   2
+#define METRIC_SERVICE  2
 
 /* Magic ctx->mark identifies packets origination and encryption status.
  *

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -328,6 +328,9 @@ enum {
 /* Cilium error codes, must NOT overlap with TC return codes.
  * These also serve as drop reasons for metrics,
  * where reason > 0 corresponds to -(DROP_*)
+ *
+ * These are shared with pkg/monitor/api/drop.go and api/v1/flow/flow.proto.
+ * When modifying any of the below, those files should also be updated.
  */
 #define DROP_UNUSED1		-130 /* unused */
 #define DROP_UNUSED2		-131 /* unused */
@@ -387,6 +390,9 @@ enum {
 /* Cilium metrics reasons for forwarding packets and other stats.
  * If reason is larger than below then this is a drop reason and
  * value corresponds to -(DROP_*), see above.
+ *
+ * These are shared with pkg/monitor/api/drop.go.
+ * When modifying any of the below, those files should also be updated.
  */
 #define REASON_FORWARDED		0
 #define REASON_PLAINTEXT		3
@@ -395,6 +401,8 @@ enum {
 #define REASON_LB_NO_BACKEND		6
 #define REASON_LB_REVNAT_UPDATE		7
 #define REASON_LB_REVNAT_STALE		8
+#define REASON_FRAG_PACKET		9
+#define REASON_FRAG_PACKET_UPDATE	10
 
 /* Lookup scope for externalTrafficPolicy=Local */
 #define LB_LOOKUP_SCOPE_EXT	0

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -7,6 +7,8 @@
 #include <linux/icmpv6.h>
 #include <linux/icmp.h>
 
+#include <bpf/verifier.h>
+
 #include "common.h"
 #include "utils.h"
 #include "ipv4.h"
@@ -206,6 +208,8 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 {
 	struct ct_entry *entry;
 	int reopen;
+
+	relax_verifier();
 
 	entry = map_lookup_elem(map, tuple);
 	if (entry) {
@@ -665,6 +669,8 @@ static __always_inline int ct_lookup4(const void *map,
 		}
 		goto out;
 	}
+
+	relax_verifier();
 
 	/* Lookup entry in forward direction */
 	if (dir != CT_SERVICE) {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -535,14 +535,14 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_CT_INVALID_HDR;
 
-	if (unlikely(ipv4_is_fragment(ip4)))
-		return ipv4_handle_fragment(ctx, ip4, off, dir,
-					    (struct ipv4_frag_l4ports *)&tuple->dport,
-					    has_l4_header);
-#endif
+	return ipv4_handle_fragmentation(ctx, ip4, off, dir,
+				    (struct ipv4_frag_l4ports *)&tuple->dport,
+				    has_l4_header);
+#else
 	/* load sport + dport into tuple */
 	if (ctx_load_bytes(ctx, off, &tuple->dport, 4) < 0)
 		return DROP_CT_INVALID_HDR;
+#endif
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -528,7 +528,7 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 	 * after data has been invalidated (see handle_ipv4_from_lxc())
 	 */
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
+		return DROP_CT_INVALID_HDR;
 
 	if (unlikely(ipv4_is_fragment(ip4)))
 		return ipv4_handle_fragment(ctx, ip4, off,
@@ -536,7 +536,10 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 					    has_l4_header);
 #endif
 	/* load sport + dport into tuple */
-	return ctx_load_bytes(ctx, off, &tuple->dport, 4);
+	if (ctx_load_bytes(ctx, off, &tuple->dport, 4) < 0)
+		return DROP_CT_INVALID_HDR;
+
+	return CTX_ACT_OK;
 }
 
 static __always_inline void ct4_cilium_dbg_tuple(struct __ctx_buff *ctx, __u8 type,
@@ -554,7 +557,7 @@ static __always_inline int ct_lookup4(const void *map,
 				      struct __ctx_buff *ctx, int off, int dir,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
-	int ret = CT_NEW, action = ACTION_UNSPEC;
+	int err, ret = CT_NEW, action = ACTION_UNSPEC;
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP,
 	     has_l4_header = true;
 	union tcp_flags tcp_flags = { .value = 0 };
@@ -613,9 +616,9 @@ static __always_inline int ct_lookup4(const void *map,
 		break;
 
 	case IPPROTO_TCP:
-		if (ipv4_ct_extract_l4_ports(ctx, off, tuple,
-					     &has_l4_header) < 0)
-			return DROP_CT_INVALID_HDR;
+		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, &has_l4_header);
+		if (err < 0)
+			return err;
 
 		action = ACTION_CREATE;
 
@@ -626,12 +629,12 @@ static __always_inline int ct_lookup4(const void *map,
 			if (unlikely(tcp_flags.value & (TCP_FLAG_RST|TCP_FLAG_FIN)))
 				action = ACTION_CLOSE;
 		}
-
 		break;
 
 	case IPPROTO_UDP:
-		if (ipv4_ct_extract_l4_ports(ctx, off, tuple, NULL) < 0)
-			return DROP_CT_INVALID_HDR;
+		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, NULL);
+		if (err < 0)
+			return err;
 
 		action = ACTION_CREATE;
 		break;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -517,6 +517,7 @@ ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 
 static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 						    int off,
+						    int dir __maybe_unused,
 						    struct ipv4_ct_tuple *tuple,
 						    bool *has_l4_header __maybe_unused)
 {
@@ -531,7 +532,7 @@ static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 		return DROP_CT_INVALID_HDR;
 
 	if (unlikely(ipv4_is_fragment(ip4)))
-		return ipv4_handle_fragment(ctx, ip4, off,
+		return ipv4_handle_fragment(ctx, ip4, off, dir,
 					    (struct ipv4_frag_l4ports *)&tuple->dport,
 					    has_l4_header);
 #endif
@@ -616,7 +617,7 @@ static __always_inline int ct_lookup4(const void *map,
 		break;
 
 	case IPPROTO_TCP:
-		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, &has_l4_header);
+		err = ipv4_ct_extract_l4_ports(ctx, off, dir, tuple, &has_l4_header);
 		if (err < 0)
 			return err;
 
@@ -632,7 +633,7 @@ static __always_inline int ct_lookup4(const void *map,
 		break;
 
 	case IPPROTO_UDP:
-		err = ipv4_ct_extract_l4_ports(ctx, off, tuple, NULL);
+		err = ipv4_ct_extract_l4_ports(ctx, off, dir, tuple, NULL);
 		if (err < 0)
 			return err;
 

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -7,6 +7,7 @@
 #include <linux/ip.h>
 
 #include "dbg.h"
+#include "metrics.h"
 
 struct ipv4_frag_id {
 	__be32	daddr;
@@ -107,7 +108,7 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 }
 
 static __always_inline int
-ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off,
+ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off, int dir,
 			    const struct ipv4_frag_id *frag_id,
 			    struct ipv4_frag_l4ports *ports)
 {
@@ -117,7 +118,9 @@ ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off,
 	if (ret < 0)
 		return ret;
 
-	map_update_elem(&IPV4_FRAG_DATAGRAMS_MAP, frag_id, ports, BPF_ANY);
+	if (map_update_elem(&IPV4_FRAG_DATAGRAMS_MAP, frag_id, ports, BPF_ANY))
+		update_metrics(ctx_full_len(ctx), dir, REASON_FRAG_PACKET_UPDATE);
+
 	/* Do not return an error if map update failed, as nothing prevents us
 	 * to process the current packet normally.
 	 */
@@ -126,7 +129,7 @@ ipv4_frag_register_datagram(struct __ctx_buff *ctx, int l4_off,
 
 static __always_inline int
 ipv4_handle_fragment(struct __ctx_buff *ctx,
-		     const struct iphdr *ip4, int l4_off,
+		     const struct iphdr *ip4, int l4_off, int dir,
 		     struct ipv4_frag_l4ports *ports,
 		     bool *has_l4_header)
 {
@@ -140,6 +143,8 @@ ipv4_handle_fragment(struct __ctx_buff *ctx,
 		.pad = 0,
 	};
 
+	update_metrics(ctx_full_len(ctx), dir, REASON_FRAG_PACKET);
+
 	not_first_fragment = ipv4_is_not_first_fragment(ip4);
 	if (has_l4_header)
 		*has_l4_header = !not_first_fragment;
@@ -151,7 +156,7 @@ ipv4_handle_fragment(struct __ctx_buff *ctx,
 	 * we receive). Fragment has L4 header, we can retrieve L4 ports and
 	 * create an entry in datagrams map.
 	 */
-	return ipv4_frag_register_datagram(ctx, l4_off, &frag_id, ports);
+	return ipv4_frag_register_datagram(ctx, l4_off, dir, &frag_id, ports);
 }
 #endif
 

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -340,7 +340,9 @@ bool lb4_svc_is_localredirect(const struct lb4_service *svc __maybe_unused)
 }
 
 static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
-					   int l4_off, __be16 *port,
+					   int l4_off,
+					   int dir __maybe_unused,
+					   __be16 *port,
 					   __maybe_unused struct iphdr *ip4)
 {
 	int ret;
@@ -354,7 +356,7 @@ static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 
 			if (unlikely(ipv4_is_fragment(ip4))) {
 				ret = ipv4_handle_fragment(ctx, ip4, l4_off,
-							   &ports,
+							   dir, &ports,
 							   NULL);
 				if (IS_ERR(ret))
 					return ret;
@@ -513,7 +515,8 @@ static __always_inline int lb6_extract_key(struct __ctx_buff *ctx __maybe_unused
 	ipv6_addr_copy(&key->address, addr);
 	csum_l4_offset_and_flags(tuple->nexthdr, csum_off);
 
-	return extract_l4_port(ctx, tuple->nexthdr, l4_off, &key->dport, NULL);
+	return extract_l4_port(ctx, tuple->nexthdr, l4_off, dir, &key->dport,
+			       NULL);
 }
 
 static __always_inline
@@ -1033,7 +1036,7 @@ static __always_inline int lb4_extract_key(struct __ctx_buff *ctx __maybe_unused
 	if (ipv4_has_l4_header(ip4))
 		csum_l4_offset_and_flags(ip4->protocol, csum_off);
 
-	return extract_l4_port(ctx, ip4->protocol, l4_off, &key->dport, ip4);
+	return extract_l4_port(ctx, ip4->protocol, l4_off, dir, &key->dport, ip4);
 }
 
 static __always_inline

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -354,15 +354,12 @@ static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 		if (ip4) {
 			struct ipv4_frag_l4ports ports = { };
 
-			if (unlikely(ipv4_is_fragment(ip4))) {
-				ret = ipv4_handle_fragment(ctx, ip4, l4_off,
-							   dir, &ports,
-							   NULL);
-				if (IS_ERR(ret))
-					return ret;
-				*port = ports.dport;
-				break;
-			}
+			ret = ipv4_handle_fragmentation(ctx, ip4, l4_off,
+							dir, &ports, NULL);
+			if (IS_ERR(ret))
+				return ret;
+			*port = ports.dport;
+			break;
 		}
 #endif
 		/* Port offsets for UDP and TCP are the same */

--- a/bpf/tests/ipv6_test.h
+++ b/bpf/tests/ipv6_test.h
@@ -2,8 +2,6 @@
 /* Copyright (C) 2018-2020 Authors of Cilium */
 
 #include "lib/ipv6.h"
-
-#define SKIP_UNDEF_LPM_LOOKUP_FN
 #include "lib/maps.h"
 
 static void test_ipv6_addr_clear_suffix(void)

--- a/contrib/release/bump-docker-stable.sh
+++ b/contrib/release/bump-docker-stable.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+IMAGES=(cilium hubble-relay docker-plugin operator operator-generic operator-aws operator-azure)
+
+usage() {
+    logecho "usage: $0 <VERSION>"
+    logecho "VERSION    Version to bump stable tags to"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local ersion="$(echo $1 | sed 's/^v//')"
+    local version="v$ersion"
+
+    echo -n "Set stable docker tags to $version"
+    if ! common::askyorn ; then
+        common::exit 0 "Aborting stable tag bump."
+    fi
+
+    for image in ${IMAGES[@]}; do
+        $CONTAINER_ENGINE pull docker.io/cilium/$image:$version
+    done
+
+    for image in ${IMAGES[@]}; do
+        $CONTAINER_ENGINE tag docker.io/cilium/$image:$version docker.io/cilium/$image:stable
+        $CONTAINER_ENGINE push docker.io/cilium/$image:stable
+    done
+}
+
+main "$@"

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -785,8 +785,8 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
-	flags.Int(option.ToFQDNsMaxIPsPerRestoredRule, defaults.ToFQDNsMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored rule")
-	option.BindEnv(option.ToFQDNsMaxIPsPerRestoredRule)
+	flags.Int(option.DNSMaxIPsPerRestoredRule, defaults.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
+	option.BindEnv(option.DNSMaxIPsPerRestoredRule)
 
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1264,6 +1264,10 @@ func initEnv(cmd *cobra.Command) {
 			}
 		}
 	}
+
+	if !probes.NewProbeManager().GetMisc().HaveLargeInsnLimit {
+		option.Config.NeedsRelaxVerifier = true
+	}
 }
 
 func (d *Daemon) initKVStore() {

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -300,7 +300,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		return err
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
-		option.Config.ToFQDNsMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
+		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
 		d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -61,7 +61,7 @@ spec:
               port: grpc
 {{- with .Values.hubble.relay.resources }}
           resources:
-            {{- toYaml . | trim | nindent 10 }}
+            {{- toYaml . | trim | nindent 12 }}
 {{- end }}
           volumeMounts:
           - mountPath: {{ dir .Values.hubble.socketPath }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -541,7 +541,7 @@ hubble:
       pullPolicy: IfNotPresent
 
     # Specifies the resources for the hubble-relay pods
-    # resources: {}
+    resources: {}
 
     # Number of replicas run for the hubble-relay deployment.
     replicas: 1
@@ -553,16 +553,6 @@ hubble:
     ## Annotations to be added to hubble-relay pods
     ##
     podAnnotations: {}
-
-    # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
-    #     resources:
-    #       limits:
-    #         cpu: 1000m
-    #         memory: 1024M
-    #       requests:
-    #         cpu: 100m
-    #         memory: 64Mi
-    resources: {}
 
     ## Node tolerations for pod assignment on nodes with taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3,7 +3,7 @@
 # Cilium will not change critical values to ensure continued operation
 # This is flag is not required for new installations.
 # ex: 1.7, 1.8, 1.9
-# upgradeCompatibility: 1.8
+# upgradeCompatibility: '1.8'
 
 debug:
   enabled: false

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -189,6 +189,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if option.Config.NeedsRelaxVerifier {
+		cDefinesMap["NEEDS_RELAX_VERIFIER"] = "1"
+	}
+
 	cDefinesMap["TRACE_PAYLOAD_LEN"] = fmt.Sprintf("%dULL", option.Config.TracePayloadlen)
 	cDefinesMap["MTU"] = fmt.Sprintf("%d", cfg.MtuConfig.GetDeviceMTU())
 

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -131,11 +131,17 @@ type MapTypes struct {
 	HaveStackMapType               bool `json:"have_stack_map_type"`
 }
 
+// Misc contains bools exposing miscellaneous eBPF features.
+type Misc struct {
+	HaveLargeInsnLimit bool `json:"have_large_insn_limit"`
+}
+
 // Features contains BPF feature checks returned by bpftool.
 type Features struct {
 	SystemConfig `json:"system_config"`
 	MapTypes     `json:"map_types"`
 	Helpers      map[string][]string `json:"helpers"`
+	Misc         `json:"misc"`
 }
 
 // ProbeManager is a manager of BPF feature checks.
@@ -287,6 +293,11 @@ func (p *ProbeManager) GetOptionalConfig() map[KernelParam]bool {
 // GetMapTypes returns information about supported BPF map types.
 func (p *ProbeManager) GetMapTypes() *MapTypes {
 	return &p.features.MapTypes
+}
+
+// GetMisc returns information about miscellaneous eBPF features.
+func (p *ProbeManager) GetMisc() *Misc {
+	return &p.features.Misc
 }
 
 // GetHelpers returns information about available BPF helpers for the given

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,6 +94,10 @@ const (
 	// DefaultMapPrefix is the default prefix for all BPF maps.
 	DefaultMapPrefix = "tc/globals"
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules.
+	DNSMaxIPsPerRestoredRule = 1000
+
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
 	// This is used in DaemonConfig.Populate
 	ToFQDNsMinTTL = 3600 // 1 hour in seconds
@@ -101,10 +105,6 @@ const (
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50
-
-	// ToFQDNsMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules.
-	ToFQDNsMaxIPsPerRestoredRule = 1000
 
 	// ToFQDNsMaxDeferredConnectionDeletes Maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -126,6 +126,10 @@ type DNSProxy struct {
 	// this mutex protects variables below this point
 	lock.Mutex
 
+	// usedServers is the set of DNS servers that have been allowed and used successfully.
+	// This is used to limit the number of IPs we store for restored DNS rules.
+	usedServers map[string]struct{}
+
 	// allowed tracks all allowed L7 DNS rules by endpointID, destination port,
 	// and L3 Selector. All must match for a query to be allowed.
 	//
@@ -196,6 +200,13 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 				for _, nid := range cs.GetSelections() {
 					nidIPs := p.LookupIPsBySecID(nid)
 					for _, ip := range nidIPs {
+						// Skip IPs that are allowed but have never been used,
+						// but only if at least one server has been used so far.
+						if len(p.usedServers) > 0 {
+							if _, used := p.usedServers[ip]; !used {
+								continue
+							}
+						}
 						IPs[ip] = struct{}{}
 						count++
 						if count > p.maxIPsPerRestoredDNSRule {
@@ -374,6 +385,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		LookupIPsBySecID:         lookupIPsFunc,
 		NotifyOnDNSMsg:           notifyFunc,
 		lookupTargetDNSServer:    lookupTargetDNSServer,
+		usedServers:              make(map[string]struct{}),
 		allowed:                  make(perEPAllow),
 		restored:                 make(perEPRestored),
 		restoredEPs:              make(restoredEPs),
@@ -624,6 +636,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS response")
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, &stat)
+	} else {
+		p.Lock()
+		// Add the server to the set of used DNS servers. This set is never GCd, but is limited by set
+		// of DNS server IPs that are allowed by a policy and for which successful response was received.
+		p.usedServers[targetServerIP.String()] = struct{}{}
+		p.Unlock()
 	}
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -119,9 +119,9 @@ type DNSProxy struct {
 	// helpers.go but is modified during testing.
 	lookupTargetDNSServer func(w dns.ResponseWriter) (serverIP net.IP, serverPort uint16, addrStr string, err error)
 
-	// maxIPsPerRestoredRule is the maximum number of IPs to maintain for each
-	// restored ToFQDNs rule.
-	maxIPsPerRestoredRule int
+	// maxIPsPerRestoredDNSRule is the maximum number of IPs to maintain for each
+	// restored DNS rule.
+	maxIPsPerRestoredDNSRule int
 
 	// this mutex protects variables below this point
 	lock.Mutex
@@ -194,17 +194,18 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 				count := 0
 			Loop:
 				for _, nid := range cs.GetSelections() {
-					for _, ip := range p.LookupIPsBySecID(nid) {
+					nidIPs := p.LookupIPsBySecID(nid)
+					for _, ip := range nidIPs {
 						IPs[ip] = struct{}{}
 						count++
-						if count > p.maxIPsPerRestoredRule {
+						if count > p.maxIPsPerRestoredDNSRule {
 							log.WithFields(logrus.Fields{
 								logfields.EndpointID:            endpointID,
 								logfields.Port:                  port,
 								logfields.EndpointLabelSelector: cs,
-								logfields.Limit:                 p.maxIPsPerRestoredRule,
-								"totalRules":                    len(p.LookupIPsBySecID(nid)),
-							}).Warning("Too many IPs for a rule, skipping the rest")
+								logfields.Limit:                 p.maxIPsPerRestoredDNSRule,
+								logfields.Count:                 len(nidIPs),
+							}).Warning("Too many IPs for a DNS rule, skipping the rest")
 							break Loop
 						}
 					}
@@ -358,7 +359,7 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 // notifyFunc will be called with DNS response data that is returned to a
 // requesting endpoint. Note that denied requests will not trigger this
 // callback.
-func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
+func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
 	if port == 0 {
 		log.Debug("DNS Proxy port is configured to 0. A random port will be assigned by the OS.")
 	}
@@ -377,7 +378,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		restored:                 make(perEPRestored),
 		restoredEPs:              make(restoredEPs),
 		EnableDNSCompression:     enableDNSCompression,
-		maxIPsPerRestoredRule:    maxRestoreIPs,
+		maxIPsPerRestoredDNSRule: maxRestoreDNSIPs,
 	}
 	atomic.StoreInt32(&p.rejectReply, dns.RcodeRefused)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -661,6 +661,27 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	restored3 := s.proxy.GetRules(uint16(epID3)).Sort()
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
+	// Test with limited set of allowed IPs
+	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
+
+	expected1b := restore.DNSRules{
+		53: restore.IPRules{{
+			IPs: map[string]struct{}{},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID1Selector]},
+		}, {
+			IPs: map[string]struct{}{"127.0.0.2": {}},
+			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID2Selector]},
+		}}.Sort(),
+		54: restore.IPRules{{
+			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
+		}},
+	}
+	restored1b := s.proxy.GetRules(uint16(epID1)).Sort()
+	c.Assert(restored1b, checker.DeepEquals, expected1b)
+
+	// unlimited again
+	s.proxy.usedServers = nil
+
 	s.proxy.UpdateAllowed(epID1, 53, nil)
 	s.proxy.UpdateAllowed(epID1, 54, nil)
 	_, exists := s.proxy.allowed[epID1]

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -447,6 +447,9 @@ const (
 	// Limit is a numerical limit that has been exceeded
 	Limit = "limit"
 
+	// Count is a measure being compared to the Limit
+	Count = "count"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -48,19 +48,21 @@ const (
 	// of 2**16 (2 uint8) to 2**10 (1 uint8 + 2 bits).
 	MaxEntries = 1024
 	// dirIngress and dirEgress values should match with
-	// METRIC_INGRESS and METRIC_EGRESS in bpf/lib/common.h
+	// METRIC_INGRESS, METRIC_EGRESS and METRIC_SERVICE
+	// in bpf/lib/common.h
+	dirEgress  = 0
 	dirIngress = 1
-	dirEgress  = 2
-	dirUnknown = 0
+	dirService = 2
 )
 
-// direction is the metrics direction i.e ingress (to an endpoint)
-// or egress (from an endpoint). If it's none of the above, we return
-// UNKNOWN direction.
+// direction is the metrics direction i.e ingress (to an endpoint),
+// egress (from an endpoint) or service (NodePort service being accessed from
+// outside or a ClusterIP service being accessed from inside the cluster).
+// If it's none of the above, we return UNKNOWN direction.
 var direction = map[uint8]string{
-	dirUnknown: "UNKNOWN",
-	dirIngress: "INGRESS",
 	dirEgress:  "EGRESS",
+	dirIngress: "INGRESS",
+	dirService: "SERVICE",
 }
 
 type pad3uint16 [3]uint16
@@ -123,13 +125,10 @@ func (k *Key) String() string {
 
 // MetricDirection gets the direction in human readable string format
 func MetricDirection(dir uint8) string {
-	switch dir {
-	case dirIngress:
-		return direction[dir]
-	case dirEgress:
-		return direction[dir]
+	if desc, ok := direction[dir]; ok {
+		return desc
 	}
-	return direction[dirUnknown]
+	return "UNKNOWN"
 }
 
 // Direction gets the direction in human readable string format

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -24,6 +24,7 @@ var DropMin uint8 = 130
 // DropInvalid is the Invalid packet reason.
 var DropInvalid uint8 = 2
 
+// These values are shared with bpf/lib/common.h and api/v1/flow/flow.proto.
 var errors = map[uint8]string{
 	0:   "Success",
 	2:   "Invalid packet",
@@ -33,6 +34,8 @@ var errors = map[uint8]string{
 	6:   "LB, sock cgroup: No backend entry found",
 	7:   "LB, sock cgroup: Reverse entry update failed",
 	8:   "LB, sock cgroup: Reverse entry stale",
+	9:   "Fragmented packet",
+	10:  "Fragmented packet entry update failed",
 	130: "Invalid source mac",      // Unused
 	131: "Invalid destination mac", // Unused
 	132: "Invalid source ip",

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2033,6 +2033,11 @@ type DaemonConfig struct {
 	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
 	// available.
 	CRDWaitTimeout time.Duration
+
+	// NeedsRelaxVerifier enables the relax_verifier() helper which is used
+	// to introduce state pruning points for the verifier in the datapath
+	// program.
+	NeedsRelaxVerifier bool
 }
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -384,6 +384,10 @@ const (
 	// CMDRef is the path to cmdref output directory
 	CMDRef = "cmdref"
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule = "dns-max-ips-per-restored-rule"
+
 	// ToFQDNsMinTTL is the minimum time, in seconds, to use DNS data for toFQDNs policies.
 	ToFQDNsMinTTL = "tofqdns-min-ttl"
 
@@ -393,10 +397,6 @@ const (
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
-
-	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules
-	ToFQDNsMaxIPsPerRestoredRule = "tofqdns-max-ips-per-restored-rule"
 
 	// ToFQDNsMaxDeferredConnectionDeletes defines the maximum number of IPs to
 	// retain for expired DNS lookups with still-active connections"
@@ -906,9 +906,9 @@ var HelpFlagSections = []FlagsSection{
 	{
 		Name: "DNS policy flags",
 		Flags: []string{
+			DNSMaxIPsPerRestoredRule,
 			FQDNRejectResponseCode,
 			ToFQDNsMaxIPsPerHost,
-			ToFQDNsMaxIPsPerRestoredRule,
 			ToFQDNsMinTTL,
 			ToFQDNsPreCache,
 			ToFQDNsProxyPort,
@@ -1630,6 +1630,10 @@ type DaemonConfig struct {
 	PrometheusServeAddr    string
 	ToFQDNsMinTTL          int
 
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule int
+
 	// ToFQDNsProxyPort is the user-configured global, shared, DNS listen port used
 	// by the DNS Proxy. Both UDP and TCP are handled on the same port. When it
 	// is 0 a random port will be assigned, and can be obtained from
@@ -1639,10 +1643,6 @@ type DaemonConfig struct {
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost int
-
-	// ToFQDNMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored ToFQDN rules
-	ToFQDNsMaxIPsPerRestoredRule int
 
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
@@ -2056,8 +2056,8 @@ var (
 		EnableIPv6NDP:                defaults.EnableIPv6NDP,
 		EnableL7Proxy:                defaults.EnableL7Proxy,
 		EndpointStatus:               make(map[string]struct{}),
+		DNSMaxIPsPerRestoredRule:     defaults.DNSMaxIPsPerRestoredRule,
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
-		ToFQDNsMaxIPsPerRestoredRule: defaults.ToFQDNsMaxIPsPerRestoredRule,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
 		IPAllocationTimeout:          defaults.IPAllocationTimeout,
@@ -2584,8 +2584,8 @@ func (c *DaemonConfig) Populate() {
 	c.EnableIdentityMark = viper.GetBool(EnableIdentityMark)
 
 	// toFQDNs options
+	c.DNSMaxIPsPerRestoredRule = viper.GetInt(DNSMaxIPsPerRestoredRule)
 	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
-	c.ToFQDNsMaxIPsPerRestoredRule = viper.GetInt(ToFQDNsMaxIPsPerRestoredRule)
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)
 	} else {

--- a/test/bpf/unit-test.c
+++ b/test/bpf/unit-test.c
@@ -8,6 +8,14 @@
 #include <stdlib.h>
 
 #include "lib/utils.h"
+
+/* SKIP_UNDEF_LPM_LOOKUP_FN is used to control if the LPM_LOOKUP_FN macro in
+ * lib/maps.h should be defined or not.
+ *
+ * As lib/common.h includes in turn lib/maps.h, define SKIP_UNDEF_LPM_LOOKUP_FN
+ * here since unit tests require the LPM_LOOKUP_FN macro to be defined.
+ */
+#define SKIP_UNDEF_LPM_LOOKUP_FN
 #include "lib/common.h"
 
 #include "node_config.h"

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3742,11 +3742,6 @@ func (kub *Kubectl) ciliumControllersPreFlightCheck() error {
 }
 
 func (kub *Kubectl) ciliumHealthPreFlightCheck() error {
-	if IsIntegration(CIIntegrationEKS) {
-		ginkgoext.By("Skipping cilium-health --probe in EKS")
-		return nil
-	}
-
 	ginkgoext.By("Performing Cilium health check")
 	var nodesFilter = `{.nodes[*].name}`
 	var statusFilter = `{range .nodes[*]}{.name}{"="}{.host.primary-address.http.status}{"\n"}{end}`

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -15,7 +15,9 @@
 package helpers
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -188,4 +190,13 @@ func OpenSSLShowCerts(host string, port uint16, serverName string) string {
 		serverNameFlag = fmt.Sprintf("-servername %q", serverName)
 	}
 	return fmt.Sprintf("openssl s_client -connect %s:%d %s -showcerts | openssl x509 -outform PEM", host, port, serverNameFlag)
+}
+
+// GetBPFPacketsCount returns the number of packets for a given drop reason and
+// direction by parsing BPF metrics.
+func GetBPFPacketsCount(kubectl *Kubectl, pod, reason, direction string) (int, error) {
+	cmd := fmt.Sprintf("cilium bpf metrics list | awk '/%s *%s/ {print $4}'", reason, direction)
+	res := kubectl.CiliumExecMustSucceed(context.TODO(), pod, cmd)
+
+	return strconv.Atoi(strings.TrimSpace(res.Stdout()))
 }

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -78,7 +78,6 @@ var _ = Describe("K8sHealthTest", func() {
 
 	It("checks cilium-health status between nodes", func() {
 		SkipIfIntegration(helpers.CIIntegrationFlannel)
-		SkipIfIntegration(helpers.CIIntegrationEKS)
 
 		cilium1, cilium1IP := getCilium(helpers.K8s1)
 		cilium2, cilium2IP := getCilium(helpers.K8s2)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -753,7 +753,7 @@ var _ = Describe("K8sServicesTest", func() {
 		}
 
 		// srcPod:     Name of pod sending the datagram
-		// srcPort:    Source UDP port
+		// srcPort:    Source UDP port (should be different for each doFragmentRequest invocation to allow distinct CT table entries)
 		// dstPodIP:   Receiver pod IP (for checking in CT table)
 		// dstPodPort: Receiver pod port (for checking in CT table)
 		// dstIP:      Target endpoint IP for sending the datagram
@@ -818,6 +818,9 @@ var _ = Describe("K8sServicesTest", func() {
 				countOutK8s2, _ = strconv.Atoi(strings.TrimSpace(res.Stdout()))
 			}
 
+			fragmentedPacketsBeforeK8s1, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s1, "Fragmented packet", "INGRESS")
+			fragmentedPacketsBeforeK8s2, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s2, "Fragmented packet", "INGRESS")
+
 			// Send datagram
 			By("Sending a fragmented packet from %s to endpoint %s", srcPod, net.JoinHostPort(dstIP, fmt.Sprintf("%d", dstPort)))
 			cmd := fmt.Sprintf("bash -c 'dd if=/dev/zero bs=%d count=%d | nc -u -w 1 -p %d %s %d'", blockSize, blockCount, srcPort, dstIP, dstPort)
@@ -863,6 +866,14 @@ var _ = Describe("K8sServicesTest", func() {
 				Equal([]int{countOutK8s1, countOutK8s2 + delta}),
 				Equal([]int{countOutK8s1 + delta, countOutK8s2}),
 			), "Failed to account for IPv4 fragments to %s (out)", dstIP)
+
+			fragmentedPacketsAfterK8s1, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s1, "Fragmented packet", "INGRESS")
+			fragmentedPacketsAfterK8s2, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s2, "Fragmented packet", "INGRESS")
+
+			ExpectWithOffset(2, []int{fragmentedPacketsAfterK8s1, fragmentedPacketsAfterK8s2}).To(SatisfyAny(
+				Equal([]int{fragmentedPacketsBeforeK8s1, fragmentedPacketsBeforeK8s2 + delta}),
+				Equal([]int{fragmentedPacketsBeforeK8s1 + delta, fragmentedPacketsBeforeK8s2}),
+			), "Failed to account for INGRESS IPv4 fragments in BPF metrics", dstIP)
 		}
 
 		getIPv4AddrForIface := func(nodeName, iface string) string {


### PR DESCRIPTION
* #13936 -- bpf: don't override DROP_FRAG_NOT_FOUND error (@jibi)
 * #13347 -- bpf: add metrics for fragmented ipv4 packets (@jibi)
 * #14061 -- docs: Fix helm install command in kubeadm getting started guide (@pchaigno)
 * #14064 -- docs: Fix wording around labels configuration (@joestringer)
 * #14029 -- helm/hubble-relay: fixed indentation error (@PranaviRoy)
 * #14012 -- fqdn: Fix confusion of ToFQDNs vs. DNS rules. (@jrajahalme)
 * #14019 -- helm: 'upgradeCompatibility' needs to be a string, not a float64 (@mvisonneau)
 * #13660 -- docs: encryption: interface clarifications (@kkourt)
 * #14030 -- Mention MTU kernel bug in frag page (@liuyuan10)
 * #13961 -- Revert commits that skip running tests on CI with EKS (@christarazi)
 * #13364 -- contrib: Add script to bump stable docker image tags (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13936 13347 14061 14064 14029 14012 14019 13660 14030 13961 13364; do contrib/backporting/set-labels.py $pr done 1.9; done
```