### PR TITLE
hubble/parser: Always preserve datapath numeric identity

### DIFF
--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -66,6 +66,7 @@ func TestL34Decode(t *testing.T) {
 			if ip.Equal(net.ParseIP("10.16.236.178")) {
 				return &testutils.FakeEndpointInfo{
 					ID:           1234,
+					Identity:     5678,
 					PodName:      "pod-10.16.236.178",
 					PodNamespace: "default",
 				}, true
@@ -97,6 +98,8 @@ func TestL34Decode(t *testing.T) {
 		OnLookupSecIDByIP: func(ip net.IP) (ipcache.Identity, bool) {
 			// pretend IP belongs to a pod on a remote node
 			if ip.String() == "192.168.33.11" {
+				// This numeric identity will be ignored because the above
+				// TraceNotify event already contains the source identity
 				return ipcache.Identity{
 					ID:     1234,
 					Source: source.Unspec,
@@ -137,6 +140,7 @@ func TestL34Decode(t *testing.T) {
 	assert.Equal(t, "remote", f.GetSource().GetNamespace())
 	assert.Equal(t, "service-1234", f.GetSourceService().GetName())
 	assert.Equal(t, "remote", f.GetSourceService().GetNamespace())
+	assert.Equal(t, uint32(1), f.GetSource().GetIdentity())
 
 	assert.Equal(t, []string(nil), f.GetDestinationNames())
 	assert.Equal(t, "10.16.236.178", f.GetIP().GetDestination())
@@ -145,6 +149,7 @@ func TestL34Decode(t *testing.T) {
 	assert.Equal(t, "default", f.GetDestination().GetNamespace())
 	assert.Equal(t, "service-4321", f.GetDestinationService().GetName())
 	assert.Equal(t, "default", f.GetDestinationService().GetNamespace())
+	assert.Equal(t, uint32(5678), f.GetDestination().GetIdentity())
 
 	assert.Equal(t, int32(api.MessageTypeTrace), f.GetEventType().GetType())
 	assert.Equal(t, int32(api.TraceFromHost), f.GetEventType().GetSubType())
@@ -846,7 +851,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 
 	v0 := monitor.TraceNotifyV0{
 		Type:     byte(api.MessageTypeTrace),
-		SrcLabel: 456, // overwritten by ep.Identity
+		SrcLabel: 456, // takes precedence over ep.Identity
 		Version:  monitor.TraceNotifyVersion0,
 	}
 
@@ -867,7 +872,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(ep.ID), f.Source.ID)
-	assert.Equal(t, uint32(ep.Identity), f.Source.Identity)
+	assert.Equal(t, uint32(v0.SrcLabel), f.Source.Identity)
 	assert.Equal(t, ep.PodNamespace, f.Source.Namespace)
 	assert.Equal(t, ep.Labels, f.Source.Labels)
 	assert.Equal(t, ep.PodName, f.Source.PodName)


### PR DESCRIPTION
This introduces a check that we do not overwrite the numeric security
identity provided by the datapath trace point. Only if the datapath did
not provide an identity (i.e. in `FROM_LXC` trace points) do we want to
fall back on the identity from the user-space IPCache.

The datapath identity and the identity returned by `LookupSecIDByIP` may
differ if the identity has changed between the time the trace event has
been generated and the time Hubble observes it. By preserving what the
datapath originally observed, we ensure that we have the same
information as the datapath had when it made the policy decision for
this flow.
