### PR TITLE
build, ci: extend API checks to include Hubble API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,9 @@ generate-health-api: api/v1/health/openapi.yaml
 	@# sort goimports automatically
 	-$(QUIET) find api/v1/health/ -type f -name "*.go" -print | PATH="$(PWD)/tools:$(PATH)" xargs goimports -w
 
+generate-hubble-api: api/v1/flow/flow.proto api/v1/peer/peer.proto api/v1/observer/observer.proto api/v1/relay/relay.proto
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C api/v1
+
 generate-k8s-api:
 	$(call generate_k8s_protobuf,$\
 	github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1$(comma)$\
@@ -612,5 +615,5 @@ dev-doctor:
 	$(QUIET)$(GO) version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )
 	$(QUIET)$(GO) run ./tools/dev-doctor
 
-.PHONY: build-context-update clean-build clean clean-container dev-doctor force generate-api generate-health-api install licenses-all veryclean
+.PHONY: build-context-update clean-build clean clean-container dev-doctor force generate-api generate-health-api generate-hubble-api install licenses-all veryclean
 force :;

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -329,8 +329,9 @@ func (Verdict) EnumDescriptor() ([]byte, []int) {
 	return file_flow_flow_proto_rawDescGZIP(), []int{4}
 }
 
-// Taken from pkg/monitor/api/drop.go. Note that non-drop reasons (i.e. values
-// less than api.DropMin) are not used here.
+// These values are shared with pkg/monitor/api/drop.go and bpf/lib/common.h.
+// Note that non-drop reasons (i.e. values less than api.DropMin) are not used
+// here.
 type DropReason int32
 
 const (

--- a/contrib/scripts/check-api-code-gen.sh
+++ b/contrib/scripts/check-api-code-gen.sh
@@ -28,13 +28,16 @@ make generate-api
 # Generate all health-api files
 make generate-health-api
 
+# Generate all hubble api files
+make generate-hubble-api
+
 # Check for diff
 diff="$(git diff)"
 
 if [ -n "$diff" ]; then
 	echo "Ungenerated api source code:"
 	echo "$diff"
-	echo "Please run make generate-api generate-health-api and submit your changes"
+	echo "Please run `make generate-api generate-health-api generate-hubble-api` and submit your changes"
 	exit 1
 fi
 


### PR DESCRIPTION
Similar to the existing infrastructure to detect OpenAPI based changes,
detect whether any of the Hubble API file need to be regenerated.

This change also includes regeneration of `api/v1/flow/flow.pb.go` which
was previously missed and the GitHub action would otherwise fail.