### PR TITLE
test: Use stable tags instead of :latest

### DIFF
--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: docker.io/digitalwonderland/zookeeper
+        image: docker.io/cilium/zookeeper:1.0
         ports:
         - containerPort: 2181
 ---

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -21,7 +21,7 @@ const (
 	NetperfImage = "quay.io/cilium/net-test:v1.0.0"
 
 	// HttpdImage is the image used for starting an HTTP server.
-	HttpdImage = "docker.io/cilium/demo-httpd:latest"
+	HttpdImage = "docker.io/cilium/demo-httpd:1.0"
 
 	// DNSSECContainerImage is the image used for starting a DNSSec client.
 	DNSSECContainerImage = "docker.io/cilium/dnssec-client:v0.2"
@@ -30,7 +30,7 @@ const (
 	BindContainerImage = "docker.io/cilium/docker-bind:v0.3"
 
 	// KafkaClientImage is the image used for Kafka clients.
-	KafkaClientImage = "docker.io/cilium/kafkaclient2:latest"
+	KafkaClientImage = "docker.io/cilium/kafkaclient2:1.0"
 
 	// Zookeeper image is the image used for running Zookeeper.
 	ZookeeperImage = "docker.io/digitalwonderland/zookeeper:latest"

--- a/test/k8sT/manifests/demo-named-port.yaml
+++ b/test/k8sT/manifests/demo-named-port.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-httpd:latest
+        image: docker.io/cilium/demo-httpd:1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -83,7 +83,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: app-frontend
-        image: docker.io/cilium/demo-client:latest
+        image: docker.io/cilium/demo-client:1.0
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args:
@@ -112,7 +112,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: app-frontend
-        image: docker.io/cilium/demo-client:latest
+        image: docker.io/cilium/demo-client:1.0
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args:

--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-httpd:latest
+        image: docker.io/cilium/demo-httpd:1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -82,7 +82,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: app-frontend
-        image: docker.io/cilium/demo-client:latest
+        image: docker.io/cilium/demo-client:1.0
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args:
@@ -111,7 +111,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: app-frontend
-        image: docker.io/cilium/demo-client:latest
+        image: docker.io/cilium/demo-client:1.0
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args:

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-client:latest
+        image: docker.io/cilium/demo-client:1.0
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args:

--- a/test/k8sT/manifests/demo_ds_local.yaml
+++ b/test/k8sT/manifests/demo_ds_local.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-client:latest
+        image: docker.io/cilium/demo-client:1.0
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args:

--- a/test/k8sT/manifests/externalIPs/apps/app2.yaml
+++ b/test/k8sT/manifests/externalIPs/apps/app2.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-httpd:latest
+        image: docker.io/cilium/demo-httpd:1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/test/k8sT/manifests/externalIPs/apps/app3.yaml
+++ b/test/k8sT/manifests/externalIPs/apps/app3.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-httpd:latest
+        image: docker.io/cilium/demo-httpd:1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/test/k8sT/manifests/external_pod.yaml
+++ b/test/k8sT/manifests/external_pod.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   containers:
   - name: app-reach-services
-    image: docker.io/cilium/demo-client:latest
+    image: docker.io/cilium/demo-client:1.0
     imagePullPolicy: IfNotPresent
     command: [ "bash", "-c", "while true; do sleep 5; done" ]

--- a/test/k8sT/manifests/http-clients.yaml
+++ b/test/k8sT/manifests/http-clients.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: http-client
-        image: quay.io/isovalent/wrk2:latest
+        image: quay.io/isovalent/wrk2:1.0
         ports:
         - containerPort: 80

--- a/test/k8sT/manifests/http-deployment.yaml
+++ b/test/k8sT/manifests/http-deployment.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:latest
+        image: docker.io/library/nginx:1.19.4
         ports:
         - containerPort: 80

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -17,9 +17,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: kafka
-        # Normally we would specify an exact version of the image instead of
-        # 'latest', but this is the only tagged version on Dockerhub.
-        image: docker.io/spotify/kafkaproxy:latest
+        image: docker.io/cilium/kafkaproxy:1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9092
@@ -83,7 +81,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: empire-hq
-        image: docker.io/cilium/kafkaclient:latest
+        image: docker.io/cilium/kafkaclient:1.0
         imagePullPolicy: IfNotPresent
       nodeSelector:
         "cilium.io/ci-node": k8s1
@@ -110,7 +108,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: empire-outpost-8888
-        image: docker.io/cilium/kafkaclient:latest
+        image: docker.io/cilium/kafkaclient:1.0
         imagePullPolicy: IfNotPresent
 ---
 apiVersion: apps/v1
@@ -134,7 +132,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: empire-outpost-9999
-        image: docker.io/cilium/kafkaclient:latest
+        image: docker.io/cilium/kafkaclient:1.0
         imagePullPolicy: IfNotPresent
 ---
 apiVersion: apps/v1
@@ -156,5 +154,5 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: empire-backup
-        image: docker.io/cilium/kafkaclient:latest
+        image: docker.io/cilium/kafkaclient:1.0
         imagePullPolicy: IfNotPresent

--- a/test/k8sT/manifests/lrp-test.yaml
+++ b/test/k8sT/manifests/lrp-test.yaml
@@ -71,7 +71,7 @@ metadata:
 spec:
   containers:
   - name: web
-    image: docker.io/cilium/demo-client:latest
+    image: docker.io/cilium/demo-client:1.0
     imagePullPolicy: IfNotPresent
     command: [ "sleep" ]
     args:
@@ -89,7 +89,7 @@ metadata:
 spec:
   containers:
   - name: web
-    image: docker.io/cilium/demo-client:latest
+    image: docker.io/cilium/demo-client:1.0
     imagePullPolicy: IfNotPresent
     command: [ "sleep" ]
     args:

--- a/test/k8sT/manifests/netcat-ds.yaml
+++ b/test/k8sT/manifests/netcat-ds.yaml
@@ -16,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: netcat
-        image: docker.io/cilium/demo-client:latest
+        image: docker.io/cilium/demo-client:1.0
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args:

--- a/test/k8sT/manifests/test-cli.yaml
+++ b/test/k8sT/manifests/test-cli.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: netperf
-    image: docker.io/cilium/netperf:latest
+    image: docker.io/cilium/netperf:1.0
   nodeSelector:
     "cilium.io/ci-node": k8s1
 ---
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
   - name: netperf
-    image: docker.io/cilium/netperf:latest
+    image: docker.io/cilium/netperf:1.0
   nodeSelector:
     "cilium.io/ci-node": k8s1
 ---
@@ -33,6 +33,6 @@ metadata:
 spec:
   containers:
   - name: netperf
-    image: docker.io/cilium/netperf:latest
+    image: docker.io/cilium/netperf:1.0
   nodeSelector:
     "cilium.io/ci-node": k8s1

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -458,7 +458,7 @@ EOF
 
 # Create world network
 docker network create --subnet=192.168.9.0/24 outside
-docker run --net outside --ip 192.168.9.10 --restart=always -d docker.io/cilium/demo-httpd:latest
-docker run --net outside --ip 192.168.9.11 --restart=always -d docker.io/cilium/demo-httpd:latest
+docker run --net outside --ip 192.168.9.10 --restart=always -d docker.io/cilium/demo-httpd:1.0
+docker run --net outside --ip 192.168.9.11 --restart=always -d docker.io/cilium/demo-httpd:1.0
 
 sudo touch /etc/provision_finished

--- a/test/standalone/microk8s-static-pods.sh
+++ b/test/standalone/microk8s-static-pods.sh
@@ -61,7 +61,7 @@ metadata:
 spec:
   containers:
     - name: web
-      image: nginx
+      image: docker.io/library/nginx:1.19.4
       ports:
         - name: web
           containerPort: 80


### PR DESCRIPTION
We use the `latest` tag for several of the Docker images in tests. That has two drawbacks: (1) unless `imagePullPolicy` is specified, we always attempts to pull the image and (2) we will start using new `latest` images as soon as they are available, which can cause our tests to flake.

This pull request avoids such use of `latest` to prefer an equivalent stable tag. When a stable tag did not already exist, `1.0` was created. When a source code repository existed for the image, a `1.0` GitHub release was created. When the source code wasn't available, the `1.0` image tag is simply a copy of current `latest` tag.

Fixes: #4483