### PR TITLE
Remove Cilium CNI configuration during agent preStop

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -17,13 +17,7 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 	done
 	CNI_CONF_NAME=${CNI_CONF_NAME:-04-flannel-cilium-cni.conflist}
 	;;
-"generic-veth")
-	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
-	;;
-"portmap")
-	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
-	;;
-"aws-cni")
+"generic-veth"|"portmap"|"aws-cni")
 	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
 	;;
 *)

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -30,6 +30,13 @@ HOST_PREFIX=${HOST_PREFIX:-/host}
 BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 
+# .conf/.conflist/.json (undocumented) are read by kubelet/dockershim's CNI implementation.
+# Remove any active Cilium CNI configurations to prevent scheduling Pods during agent
+# downtime. Configs belonging to other CNI implementations have already been renamed
+# to *.cilium_bak during agent startup.
+echo "Removing active Cilium CNI configurations from ${HOST_PREFIX}/etc/cni/net.d..."
+find "${HOST_PREFIX}/etc/cni/net.d" -maxdepth 1 -regextype egrep -regex '\.\/.*cilium.*\.(conf|conflist|json)' -delete
+
 echo "Removing ${CNI_DIR}/bin/cilium-cni..."
 rm -f "${CNI_DIR}/bin/${BIN_NAME}"
 rm -f "${CNI_DIR}/bin/${BIN_NAME}.old"


### PR DESCRIPTION
Ran `shellcheck` on both scripts and applied the suggestions. We could probably add this to CI as it will catch common pitfalls.

<!-- Description of change -->

As I understand it, this cleanup step was previously omitted to prevent Pods being successfully scheduled by other CNI plugins installed on the node during a Cilium upgrade, since K8s can't tell the difference between a Cilium uninstall and an agent restart.

It turns out that, since we remove the CNI binary during agent shutdown, the Cilium CNI plugin is skipped anyway, and Pod creation continues using the node/cloud's next working CNI plugin in the list. As such, it doesn't look like an effective way of blocking scheduling during an upgrade, and we should rely on cordoning nodes instead. DaemonSets can schedule Pods on cordoned nodes no problem.

Fixes: https://github.com/cilium/cilium/issues/13152

```release-note
Remove Cilium CNI config from node when the CIlium agent Pod is stopped.
```

WDYT?