### PR TITLE
daemon: Disable parts of Cilium API in LB mode

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1537,7 +1537,6 @@ func runDaemon() {
 }
 
 func (d *Daemon) instantiateAPI() *restapi.CiliumAPIAPI {
-
 	swaggerSpec, err := loads.Analyzed(server.SwaggerJSON, "")
 	if err != nil {
 		log.WithError(err).Fatal("Cannot load swagger spec")
@@ -1558,47 +1557,49 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPIAPI {
 	restAPI.DaemonGetConfigHandler = NewGetConfigHandler(d)
 	restAPI.DaemonPatchConfigHandler = NewPatchConfigHandler(d)
 
-	// /endpoint/
-	restAPI.EndpointGetEndpointHandler = NewGetEndpointHandler(d)
+	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		// /endpoint/
+		restAPI.EndpointGetEndpointHandler = NewGetEndpointHandler(d)
 
-	// /endpoint/{id}
-	restAPI.EndpointGetEndpointIDHandler = NewGetEndpointIDHandler(d)
-	restAPI.EndpointPutEndpointIDHandler = NewPutEndpointIDHandler(d)
-	restAPI.EndpointPatchEndpointIDHandler = NewPatchEndpointIDHandler(d)
-	restAPI.EndpointDeleteEndpointIDHandler = NewDeleteEndpointIDHandler(d)
+		// /endpoint/{id}
+		restAPI.EndpointGetEndpointIDHandler = NewGetEndpointIDHandler(d)
+		restAPI.EndpointPutEndpointIDHandler = NewPutEndpointIDHandler(d)
+		restAPI.EndpointPatchEndpointIDHandler = NewPatchEndpointIDHandler(d)
+		restAPI.EndpointDeleteEndpointIDHandler = NewDeleteEndpointIDHandler(d)
 
-	// /endpoint/{id}config/
-	restAPI.EndpointGetEndpointIDConfigHandler = NewGetEndpointIDConfigHandler(d)
-	restAPI.EndpointPatchEndpointIDConfigHandler = NewPatchEndpointIDConfigHandler(d)
+		// /endpoint/{id}config/
+		restAPI.EndpointGetEndpointIDConfigHandler = NewGetEndpointIDConfigHandler(d)
+		restAPI.EndpointPatchEndpointIDConfigHandler = NewPatchEndpointIDConfigHandler(d)
 
-	// /endpoint/{id}/labels/
-	restAPI.EndpointGetEndpointIDLabelsHandler = NewGetEndpointIDLabelsHandler(d)
-	restAPI.EndpointPatchEndpointIDLabelsHandler = NewPatchEndpointIDLabelsHandler(d)
+		// /endpoint/{id}/labels/
+		restAPI.EndpointGetEndpointIDLabelsHandler = NewGetEndpointIDLabelsHandler(d)
+		restAPI.EndpointPatchEndpointIDLabelsHandler = NewPatchEndpointIDLabelsHandler(d)
 
-	// /endpoint/{id}/log/
-	restAPI.EndpointGetEndpointIDLogHandler = NewGetEndpointIDLogHandler(d)
+		// /endpoint/{id}/log/
+		restAPI.EndpointGetEndpointIDLogHandler = NewGetEndpointIDLogHandler(d)
 
-	// /endpoint/{id}/healthz
-	restAPI.EndpointGetEndpointIDHealthzHandler = NewGetEndpointIDHealthzHandler(d)
+		// /endpoint/{id}/healthz
+		restAPI.EndpointGetEndpointIDHealthzHandler = NewGetEndpointIDHealthzHandler(d)
 
-	// /identity/
-	restAPI.PolicyGetIdentityHandler = newGetIdentityHandler(d)
-	restAPI.PolicyGetIdentityIDHandler = newGetIdentityIDHandler(d.identityAllocator)
+		// /identity/
+		restAPI.PolicyGetIdentityHandler = newGetIdentityHandler(d)
+		restAPI.PolicyGetIdentityIDHandler = newGetIdentityIDHandler(d.identityAllocator)
 
-	// /identity/endpoints
-	restAPI.PolicyGetIdentityEndpointsHandler = newGetIdentityEndpointsIDHandler(d)
+		// /identity/endpoints
+		restAPI.PolicyGetIdentityEndpointsHandler = newGetIdentityEndpointsIDHandler(d)
 
-	// /policy/
-	restAPI.PolicyGetPolicyHandler = newGetPolicyHandler(d.policy)
-	restAPI.PolicyPutPolicyHandler = newPutPolicyHandler(d)
-	restAPI.PolicyDeletePolicyHandler = newDeletePolicyHandler(d)
-	restAPI.PolicyGetPolicySelectorsHandler = newGetPolicyCacheHandler(d)
+		// /policy/
+		restAPI.PolicyGetPolicyHandler = newGetPolicyHandler(d.policy)
+		restAPI.PolicyPutPolicyHandler = newPutPolicyHandler(d)
+		restAPI.PolicyDeletePolicyHandler = newDeletePolicyHandler(d)
+		restAPI.PolicyGetPolicySelectorsHandler = newGetPolicyCacheHandler(d)
 
-	// /policy/resolve/
-	restAPI.PolicyGetPolicyResolveHandler = NewGetPolicyResolveHandler(d)
+		// /policy/resolve/
+		restAPI.PolicyGetPolicyResolveHandler = NewGetPolicyResolveHandler(d)
 
-	// /lrp/
-	restAPI.ServiceGetLrpHandler = NewGetLrpHandler(d.redirectPolicyManager)
+		// /lrp/
+		restAPI.ServiceGetLrpHandler = NewGetLrpHandler(d.redirectPolicyManager)
+	}
 
 	// /service/{id}/
 	restAPI.ServiceGetServiceIDHandler = NewGetServiceIDHandler(d.svc)
@@ -1613,10 +1614,12 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPIAPI {
 	restAPI.PrefilterDeletePrefilterHandler = NewDeletePrefilterHandler(d)
 	restAPI.PrefilterPatchPrefilterHandler = NewPatchPrefilterHandler(d)
 
-	// /ipam/{ip}/
-	restAPI.IpamPostIpamHandler = NewPostIPAMHandler(d)
-	restAPI.IpamPostIpamIPHandler = NewPostIPAMIPHandler(d)
-	restAPI.IpamDeleteIpamIPHandler = NewDeleteIPAMIPHandler(d)
+	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		// /ipam/{ip}/
+		restAPI.IpamPostIpamHandler = NewPostIPAMHandler(d)
+		restAPI.IpamPostIpamIPHandler = NewPostIPAMIPHandler(d)
+		restAPI.IpamDeleteIpamIPHandler = NewDeleteIPAMIPHandler(d)
+	}
 
 	// /debuginfo
 	restAPI.DaemonGetDebuginfoHandler = NewGetDebugInfoHandler(d)
@@ -1628,11 +1631,13 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPIAPI {
 	// metrics
 	restAPI.MetricsGetMetricsHandler = NewGetMetricsHandler(d)
 
-	// /fqdn/cache
-	restAPI.PolicyGetFqdnCacheHandler = NewGetFqdnCacheHandler(d)
-	restAPI.PolicyDeleteFqdnCacheHandler = NewDeleteFqdnCacheHandler(d)
-	restAPI.PolicyGetFqdnCacheIDHandler = NewGetFqdnCacheIDHandler(d)
-	restAPI.PolicyGetFqdnNamesHandler = NewGetFqdnNamesHandler(d)
+	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		// /fqdn/cache
+		restAPI.PolicyGetFqdnCacheHandler = NewGetFqdnCacheHandler(d)
+		restAPI.PolicyDeleteFqdnCacheHandler = NewDeleteFqdnCacheHandler(d)
+		restAPI.PolicyGetFqdnCacheIDHandler = NewGetFqdnCacheIDHandler(d)
+		restAPI.PolicyGetFqdnNamesHandler = NewGetFqdnNamesHandler(d)
+	}
 
 	// /ip/
 	restAPI.PolicyGetIPHandler = NewGetIPHandler()


### PR DESCRIPTION
The reason for this commit is to avoid exposing an API for entities that
do not exist in LB-only mode such as endpoints and identity. Otherwise,
the logs will get polluted with useless messages such as:

```
level=info msg="Delete endpoint request" id="container-id:905e9520571d56b77fb01c8ab01f4f306092f2b6234fa8c5b7538dcfa0a03d11" subsys=daemon
level=info msg="API call has been processed" error="endpoint not found" name=endpoint-delete processingDuration="12.37µs" subsys=rate totalDuration="68.216µs" uuid=34c79b54-298f-11eb-969d-0cc47a03f925 waitDurationTotal="41.669µs"
level=info msg="Processing API request with rate limiter" name=endpoint-delete parallelRequests=4 subsys=rate uuid=34d60724-298f-11eb-969d-0cc47a03f925
level=info msg="API request released by rate limiter" name=endpoint-delete parallelRequests=4 subsys=rate uuid=34d60724-298f-11eb-969d-0cc47a03f925 waitDurationTotal="39.987µs"
```

Fixes: https://github.com/cilium/cilium/issues/14086

```release-note
Avoid exposing full Cilium API in LB-only mode
```