### PR TITLE
kvstore: Fix event watcher serialization

### DIFF
--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -320,10 +320,10 @@ func (c *consulClient) Watch(ctx context.Context, w *Watcher) {
 		sleepTime := 1 * time.Millisecond
 
 		qo.WaitIndex = nextIndex
-		pairs, q, err := c.KV().List(w.prefix, qo)
+		pairs, q, err := c.KV().List(w.Prefix, qo)
 		if err != nil {
 			sleepTime = 5 * time.Second
-			Trace("List of Watch failed", err, logrus.Fields{fieldPrefix: w.prefix, fieldWatcher: w.name})
+			Trace("List of Watch failed", err, logrus.Fields{fieldPrefix: w.Prefix, fieldWatcher: w.Name})
 		}
 
 		if q != nil {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -929,7 +929,7 @@ func (e *etcdClient) Watch(ctx context.Context, w *Watcher) {
 
 	scopedLog := e.getLogger().WithFields(logrus.Fields{
 		fieldWatcher: w,
-		fieldPrefix:  w.prefix,
+		fieldPrefix:  w.Prefix,
 	})
 
 	err := <-e.Connected(ctx)
@@ -950,7 +950,7 @@ reList:
 		}
 
 		e.limiter.Wait(ctx)
-		res, err := e.client.Get(ctx, w.prefix, client.WithPrefix(),
+		res, err := e.client.Get(ctx, w.Prefix, client.WithPrefix(),
 			client.WithSerializable())
 		if err != nil {
 			scopedLog.WithError(Hint(err)).Warn("Unable to list keys before starting watcher")
@@ -1010,7 +1010,7 @@ reList:
 		scopedLog.WithField(fieldRev, nextRev).Debug("Starting to watch a prefix")
 
 		e.limiter.Wait(ctx)
-		etcdWatch := e.client.Watch(ctx, w.prefix,
+		etcdWatch := e.client.Watch(ctx, w.Prefix,
 			client.WithPrefix(), client.WithRev(nextRev))
 		for {
 			select {

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -70,10 +70,10 @@ type stopChan chan struct{}
 // Watcher represents a KVstore watcher
 type Watcher struct {
 	// Events is the channel to which change notifications will be sent to
-	Events EventChan
+	Events EventChan `json:"-"`
 
-	name      string
-	prefix    string
+	Name      string `json:"name"`
+	Prefix    string `json:"prefix"`
 	stopWatch stopChan
 
 	// stopOnce guarantees that Stop() is only called once
@@ -85,8 +85,8 @@ type Watcher struct {
 
 func newWatcher(name, prefix string, chanSize int) *Watcher {
 	w := &Watcher{
-		name:      name,
-		prefix:    prefix,
+		Name:      name,
+		Prefix:    prefix,
 		Events:    make(EventChan, chanSize),
 		stopWatch: make(stopChan),
 	}
@@ -98,7 +98,7 @@ func newWatcher(name, prefix string, chanSize int) *Watcher {
 
 // String returns the name of the wather
 func (w *Watcher) String() string {
-	return w.name
+	return w.Name
 }
 
 // ListAndWatch creates a new watcher which will watch the specified prefix for


### PR DESCRIPTION
When using the watcher in log messages with JSON-based logging, logrus
would give up on trying to generate the log message and print this to
the logs instead:

    Failed to obtain reader, failed to marshal fields to JSON, json:
    unsupported type: kvstore.EventChan

Fix it by fixing the JSON serialization tags to the structure to avoid
serializing fields that don't make sense to be serialized, and to export
the fields that do make sense to be serialized.

Manually tested by applying this diff:

    diff --git a/pkg/kvstore/base_test.go b/pkg/kvstore/base_test.go
    index e9ee7da296bf..eb5a3548039b 100644
    --- a/pkg/kvstore/base_test.go
    +++ b/pkg/kvstore/base_test.go
    @@ -292,3 +292,10 @@ func (s *BaseTests) TestListAndWatch(c *C) {

            w.Stop()
     }
    +
    +func (s *BaseTests) TestFoo(c *C) {
    +       w := ListAndWatch(context.TODO(), "testWatcher2", "foo2/", 100)
    +       c.Assert(c, Not(IsNil))
    +
    +       log.WithField(fieldWatcher, w).Fatal("Stopped watcher")
    +}
    diff --git a/pkg/logging/logging.go b/pkg/logging/logging.go
    index 9989e8db0280..6a651c0c87f4 100644
    --- a/pkg/logging/logging.go
    +++ b/pkg/logging/logging.go
    @@ -50,7 +50,7 @@ const (

            // DefaultLogFormat is the string representation of the default logrus.Formatter
            // we want to use (possible values: text or json)
    -       DefaultLogFormat LogFormat = LogFormatText
    +       DefaultLogFormat LogFormat = LogFormatJSON
     )

     var (

Fixes: #14028