### PR TITLE
install: Disable operator HA for quick/experimental install YAMLs

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -21,7 +21,8 @@ DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_PULLPOLICY_REGEX := '\([pP]ullPolicy:\) .*'
 QUICK_OPTIONS := \
-    --set hubble.tls.enabled=false
+    --set hubble.tls.enabled=false \
+    --set operator.replicas=1
 EXPERIMENTAL_OPTIONS := \
     --set hubble.enabled=true \
     --set hubble.listenAddress=":4244" \
@@ -30,7 +31,8 @@ EXPERIMENTAL_OPTIONS := \
     --set hubble.metrics.enabled="{dns,drop,tcp,flow,icmp,http}" \
     --set hubble.relay.enabled=true \
     --set hubble.ui.enabled=true \
-    --set localRedirectPolicy=true
+    --set localRedirectPolicy=true \
+    --set operator.replicas=1
 
 DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 	--workdir /src/install/kubernetes \

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -957,7 +957,7 @@ spec:
   # We support HA mode only for Kubernetes version > 1.14
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       io.cilium/app: operator

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -604,7 +604,7 @@ spec:
   # We support HA mode only for Kubernetes version > 1.14
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       io.cilium/app: operator


### PR DESCRIPTION
Users who have HA as a requirement can deploy more explicitly via helm
and specify the number of replicas they require (`--set operator.replicas`).
Set the default to 1 for the quick installs for trying Cilium out, since those
YAMLs are more likely to be used in 1-node clusters.

Fixes: #14089 