### PR TITLE
Misc. cleanups in hubble and monitor packages

### DIFF
--- a/pkg/hubble/observer/types/types.go
+++ b/pkg/hubble/observer/types/types.go
@@ -42,7 +42,7 @@ type MonitorEvent struct {
 type AgentEvent struct {
 	// Type is a monitorAPI.MessageType* value
 	Type int
-	// Message is the agent message, e.g. accesslog.LogRecord, monitorAPI.AgentNotify
+	// Message is the agent message, e.g. accesslog.LogRecord, monitorAPI.AgentNotifyMessage
 	Message interface{}
 }
 

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -441,7 +441,7 @@ type TimeNotification struct {
 // StartMessage constructs an agent notification message when the agent starts
 func StartMessage(t time.Time) AgentNotifyMessage {
 	notification := TimeNotification{
-		Time: t.String(),
+		Time: t.Format(time.RFC3339Nano),
 	}
 
 	return AgentNotifyMessage{

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -193,9 +193,9 @@ type AgentNotify struct {
 	Text string
 }
 
-// AgentNotify is a notification from the agent. It is similar to AgentNotify,
-// but the notification is an unencoded struct. See the *Message constructors
-// in this package for possible values.
+// AgentNotifyMessage is a notification from the agent. It is similar to
+// AgentNotify, but the notification is an unencoded struct. See the *Message
+// constructors in this package for possible values.
 type AgentNotifyMessage struct {
 	Type         AgentNotification
 	Notification interface{}
@@ -438,7 +438,7 @@ type TimeNotification struct {
 	Time string `json:"time"`
 }
 
-// AgentStartMessage constructs an agent notification message when the agent starts
+// StartMessage constructs an agent notification message when the agent starts
 func StartMessage(t time.Time) AgentNotifyMessage {
 	notification := TimeNotification{
 		Time: t.String(),

--- a/pkg/monitor/api/types_test.go
+++ b/pkg/monitor/api/types_test.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -160,5 +159,11 @@ func (s *MonitorAPISuite) TestStartMessage(c *C) {
 	repr, err := msg.ToJSON()
 	c.Assert(err, IsNil)
 	c.Assert(repr.Type, Equals, AgentNotifyStart)
-	c.Assert(repr.Text, Equals, fmt.Sprintf(`{"time":"%s"}`, t.String()))
+
+	var timeNotification TimeNotification
+	json.Unmarshal([]byte(repr.Text), &timeNotification)
+	parsedTS, err := time.Parse(time.RFC3339Nano, timeNotification.Time)
+	c.Assert(err, IsNil)
+	// Truncate with duration <=0 will strip any monotonic clock reading
+	c.Assert(parsedTS.Equal(t.Truncate(0)), Equals, true)
 }


### PR DESCRIPTION
Small godoc comment fixes and preparatory factoring for successive PRs. See individual commits for details.

The last commit might need closer inspection as I'm not sure whether this would break API:

```
    monitor/api: format agent start timestamp in RFC3339Nano format
    
    time.Time.String() may include a monotonic clock reading, e.g. when t is
    time.Now() which is e.g. the case for the agent start timestamp. The
    godoc for time.Time.String [1] states:
    
      If the time has a monotonic clock reading, the returned string
      includes a final field "m=±<value>", where value is the monotonic
      clock reading formatted as a decimal number of seconds.
    
      [1] https://golang.org/pkg/time/#Time.String
    
    The format including the monotonic clock reading is hard to decode
    because there is no predefined format string in the stdlib time package.
    Also, the monotonic clock reading isn't really useful for the agent
    start timestamp, the walltime clock should be enough. Thus, format the
    timestamp string in RFC3339Nano format which can easily be decoded using
    time.Parse(time.RFC3339Nano, t), e.g in the hubble API parser.
```