### PR TITLE
helm: Correct nodeSelector values

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -352,6 +352,12 @@ The following metrics have been removed:
 
 .. _1.9_upgrade_notes:
 
+1.9.1 Upgrade Notes
+-------------------
+
+* Helm option ``nodeSelector`` is removed, please use the option for respective component
+  (e.g. ``operator.nodeSelector``, ``etc.nodeSelector`` and ``preflight.nodeSelector``) instead.
+
 1.9 Upgrade Notes
 -----------------
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -236,7 +236,6 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.bindProtection | bool | `true` | Port range to use for NodePort services. range: "30000,32767" -- Set to true to prevent applications binding to service ports. |
 | nodePort.enableHealthCheck | bool | `true` | Enable healthcheck nodePort server for NodePort services |
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
-| nodeSelector | object | `{}` | Node labels for agent pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraArgs | object | `{}` |  |

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
@@ -75,7 +75,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
-{{- with .Values.nodeSelector }}
+{{- with .Values.etcd.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -203,7 +203,7 @@ spec:
 {{- end }}
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
-{{- with .Values.nodeSelector }}
+{{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccount: cilium-pre-flight
       serviceAccountName: cilium-pre-flight
       terminationGracePeriodSeconds: 1
-{{- with .Values.nodeSelector }}
+{{- with .Values.preflight.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -117,10 +117,6 @@ tolerations:
   #   value: "value"
   #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
-# -- Node labels for agent pod assignment
-# ref: https://kubernetes.io/docs/user-guide/node-selection/
-nodeSelector: {}
-
 # -- Annotations to be added to agent pods
 podAnnotations: {}
 


### PR DESCRIPTION
This commit is to use the correct nodeSelectors in etc, operator and
preflight templates.

Add deprecated note for .Values.nodeSelector option.

Closes #14005

```release-note
helm: Correct nodeSelector values
```
