### PR TITLE
nodeinit: remove nodeinit.expectAzureVnet Helm option and behaviour

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -66,7 +66,6 @@ Deploy Cilium release via Helm:
      --set cni.chainingMode=generic-veth \\
      --set cni.customConf=true \\
      --set nodeinit.enabled=true \\
-     --set nodeinit.expectAzureVnet=true \\
      --set cni.configMap=cni-configuration \\
      --set tunnel=disabled \\
      --set masquerade=false

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -162,18 +162,6 @@ spec:
               ip -4 a
               ip -6 a
 
-{{- if or .Values.expectAzureVnet .Values.azure.enabled }}
-              # Azure specific: Transparent bridge mode is required in order
-              # for proxy-redirection to work
-              until [ -f /var/run/azure-vnet.json ]; do
-                echo waiting for azure-vnet to be created
-                sleep 1s
-              done
-              if [ -f /var/run/azure-vnet.json ]; then
-                sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
-              fi
-{{- end }}
-
 {{- if .Values.nodeinit.removeCbrBridge }}
               if ip link show cbr0; then
                 echo "Detected cbr0 bridge. Deleting interface..."


### PR DESCRIPTION
Commit 0b70117b9 ("AKS: Fix dynamic reconfiguration of bridge mode") and preceding commits would modify an internal state file of the azure-vnet CNI plugin. This is potentially dangerous, because:

- azure-vnet uses a lockfile to coordinate access to this state file between independent invocations.
- The format of the state file is not controlled by us and subject to change.
- How this state file is used can change between versions of azure-vnet.

After investigating some reports of connectivity issues, it turns out that:

- Modifying the state file directly isn't necessary. azure-vnet obeys the mode it's given in its CNI configuration, regardless of the mode recorded in the state file.
- Changing the mode directly _in the state file_ from `bridge` to `transparent` causes azure-vnet to forget cleaning up static ARP entries for deleted Pods that were previously created in bridge mode before Cilium was deployed. This can cause addresses of Pods previously scheduled on the node to become unroutable on said node.
- Waiting for the state file to appear causes a deadlock on newly-created nodes in a cluster where Cilium is already running, for example, when scaling out a node pool. azure-vnet only creates the state file when it gets its first CNI `ADD` event, which will never happen with the CNI configurations Cilium installs.

```release-note
No longer wait for and modify `/var/run/azure-vnet.json`.
```

---

This should contribute to solving https://github.com/cilium/cilium/issues/12113.

- [ ] Test whether transparent (Envoy and DNS) proxying doesn't regress.