### PR TITLE
dev/protoc: Add check for protoc binary

### DIFF
--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -84,6 +84,14 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 			hint:          "See https://golangci-lint.run/usage/install/#local-installation.",
 		},
 		&binaryCheck{
+			name:          "protoc",
+			ifNotFound:    checkWarning,
+			versionArgs:   []string{"--version"},
+			versionRegexp: regexp.MustCompile(`libprotoc (\d+\.\d+\.\d+)`),
+			minVersion:    &semver.Version{Major: 3, Minor: 12, Patch: 4},
+			hint:          "https://github.com/protocolbuffers/protobuf/releases.",
+		},
+		&binaryCheck{
 			name:          "docker",
 			ifNotFound:    checkError,
 			versionArgs:   []string{"--version"},


### PR DESCRIPTION
Protoc is required to run `make generate-k8s-api`

Signed-off-by: Tam Mach <sayboras@yahoo.com>

<details>
<summary>run make dev-docter locally (ignore my local go version)</summary>

```
$ make dev-doctor
go version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )
go version go1.15.4 linux/amd64
go run ./tools/dev-doctor
RESULT   CHECK            MESSAGE
ok       os/arch          linux/amd64
ok       uname            Linux ubuntu20 5.4.0-54-generic #60-Ubuntu SMP Fri Nov 6 10:37:59 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
error    go               found /snap/go/6715/bin/go, version 1.15.4, need 1.15.5
ok       clang            found /usr/bin/clang, version 10.0.0
ok       ginkgo           found /home/tammach/go/bin/ginkgo, version 1.14.2
ok       golangci-lint    found /home/tammach/go/bin/golangci-lint, version 1.32.2
ok       protoc           found /home/tammach/go/bin/protoc, version 3.14.0
ok       docker           found /usr/bin/docker, version 19.03.8
ok       docker-compose   found /home/tammach/.local/bin/docker-compose, version 1.27.4
ok       helm             found /usr/sbin/helm, version 3.4.1
ok       vagrant          found /home/tammach/go/bin/vagrant, version 2.2.10
ok       virtualbox       found /usr/bin/VirtualBox
ok       vboxheadless     found /usr/bin/VBoxHeadless, version 6.1.10_Ubuntu
ok       pip3             found /usr/bin/pip3, version 20.0.2
ok       docker-group     user tammach in docker group

See https://docs.cilium.io/en/latest/contributing/development/dev_setup/.
exit status 1
make: *** [Makefile:616: dev-doctor] Error 1
```

```release-note
dev/protoc: Add check for protoc binary
```
