### PR TITLE
labelsfilter: add reserved labels to default identity label list

### DIFF
--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -23,6 +23,7 @@ By default, Cilium evaluates the following labels:
 =================================== ==================================================
 Label                               Description
 ----------------------------------- --------------------------------------------------
+``reserved:.*``                     Include all ``reserved`` labels
 ``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
 ``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
 ``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -504,7 +504,7 @@ func (mgr *EndpointManager) AddHostEndpoint(ctx context.Context, owner regenerat
 	// Give the endpoint a security identity
 	newCtx, cancel := context.WithTimeout(ctx, launchTime)
 	defer cancel()
-	ep.UpdateLabels(newCtx, epLabels, nil, true)
+	ep.UpdateLabels(newCtx, epLabels, epLabels, true)
 	if errors.Is(newCtx.Err(), context.DeadlineExceeded) {
 		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for host endpoint")
 	}


### PR DESCRIPTION
Fix #14100

When using custom identity-relevant-label-list in whitelist mode, if
`reserved:host` (or `reserved:.*`) label is not included in the custom
list, the `cilium_host` endpoint will lose its `reserved:host` label.

When rolling back the default configuration, that is, removing the specified
label list and restarting the agent, cilium agent will raise errors like
following:

```
level=warning msg="Regeneration of endpoint failed" .. error="Exposing new BPF failed: invalid LXC MAC: invalid MAC address "
level=error msg="endpoint regeneration failed" ..  error="Exposing new BPF failed: invalid LXC MAC: invalid MAC address "
```

And subsequently, all pods' traffic on this node will be interrupted.

This is because the agent relies on this label to distinguish `cilium_host`
endpoint from normal endpoints, and the former has no `lxcMAC`.
Add reserved labels to the default label list could solve the problem.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>