### PR TITLE
v1.9 backport 2020-11-20

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -828,11 +828,12 @@ While communicating on this port, the only API endpoints allowed will be ``GET
 
         .. literalinclude:: ../../examples/policies/l7/http/http.json
 
+.. _kafka_policy:
 
 Kafka (beta)
 ------------
 
-.. note:: Kafka support is currently in beta phase.
+.. include:: ../beta.rst
 
 PortRuleKafka is a list of Kafka protocol constraints. All fields are optional,
 if all fields are empty or missing, the rule will match all Kafka messages.

--- a/Documentation/policy/visibility.rst
+++ b/Documentation/policy/visibility.rst
@@ -92,4 +92,8 @@ Limitations
 
 * Visibility annotations do not apply if rules are imported which select the pod
   which is annotated.
-* Proxylib parsers are not supported.
+* Proxylib parsers are not supported, including Kafka. To gain visibility on
+  these protocols, you must create a network policy that allows all of the
+  traffic at L7, either by following :ref:`l7_policy`
+  (:ref:`Kafka <kafka_policy>`) or the :ref:`envoy` proxylib extensions guide.
+  This limitation is tracked by `GH-14072 <https://github.com/cilium/cilium/issues/14072>`_.

--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,9 @@ generate-health-api: api/v1/health/openapi.yaml
 	@# sort goimports automatically
 	-$(QUIET) find api/v1/health/ -type f -name "*.go" -print | PATH="$(PWD)/tools:$(PATH)" xargs goimports -w
 
+generate-hubble-api: api/v1/flow/flow.proto api/v1/peer/peer.proto api/v1/observer/observer.proto api/v1/relay/relay.proto
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C api/v1
+
 generate-k8s-api:
 	$(call generate_k8s_protobuf,$\
 	github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1$(comma)$\
@@ -603,5 +606,5 @@ update-images-go-version:
 	$(QUIET) $(MAKE) -C images update-golang-image
 	@echo "Updated go version in image Dockerfiles to $(GO_VERSION)"
 
-.PHONY: build-context-update clean-build clean clean-container force generate-api generate-health-api install licenses-all veryclean
+.PHONY: build-context-update clean-build clean clean-container force generate-api generate-health-api generate-hubble-api install licenses-all veryclean
 force :;

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -329,8 +329,9 @@ func (Verdict) EnumDescriptor() ([]byte, []int) {
 	return file_flow_flow_proto_rawDescGZIP(), []int{4}
 }
 
-// Taken from pkg/monitor/api/drop.go. Note that non-drop reasons (i.e. values
-// less than api.DropMin) are not used here.
+// These values are shared with pkg/monitor/api/drop.go and bpf/lib/common.h.
+// Note that non-drop reasons (i.e. values less than api.DropMin) are not used
+// here.
 type DropReason int32
 
 const (

--- a/contrib/scripts/check-api-code-gen.sh
+++ b/contrib/scripts/check-api-code-gen.sh
@@ -28,13 +28,16 @@ make generate-api
 # Generate all health-api files
 make generate-health-api
 
+# Generate all hubble api files
+make generate-hubble-api
+
 # Check for diff
 diff="$(git diff)"
 
 if [ -n "$diff" ]; then
 	echo "Ungenerated api source code:"
 	echo "$diff"
-	echo "Please run make generate-api generate-health-api and submit your changes"
+	echo "Please run `make generate-api generate-health-api generate-hubble-api` and submit your changes"
 	exit 1
 fi
 

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -21,7 +21,8 @@ DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_PULLPOLICY_REGEX := '\([pP]ullPolicy:\) .*'
 QUICK_OPTIONS := \
-    --set hubble.tls.enabled=false
+    --set hubble.tls.enabled=false \
+    --set operator.replicas=1
 EXPERIMENTAL_OPTIONS := \
     --set hubble.enabled=true \
     --set hubble.listenAddress=":4244" \
@@ -31,7 +32,8 @@ EXPERIMENTAL_OPTIONS := \
     --set hubble.relay.enabled=true \
     --set hubble.ui.enabled=true \
     --set localRedirectPolicy=true \
-    --set bandwidthManager=true
+    --set bandwidthManager=true \
+    --set operator.replicas=1
 
 DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 	--workdir /src/install/kubernetes \

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -957,7 +957,7 @@ spec:
   # We support HA mode only for Kubernetes version > 1.14
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       io.cilium/app: operator

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -604,7 +604,7 @@ spec:
   # We support HA mode only for Kubernetes version > 1.14
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       io.cilium/app: operator

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -18,6 +18,7 @@ package linux
 
 import (
 	"net"
+	"runtime"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -27,9 +28,12 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/netns"
 	nodeaddressing "github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"gopkg.in/check.v1"
 )
@@ -941,6 +945,112 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 	if s.enableIPv6 {
 		c.Assert(lookupFakeRoute(c, linuxNodeHandler, ip6Alloc1), check.Equals, true)
 	}
+}
+
+func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
+	// 1. Test whether another node in the same L2 subnet can be arpinged.
+	//    The other node is in the different netns reachable via the veth pair.
+	//
+	//      +--------------+     +--------------+
+	//      |  host netns  |     |    netns0    |
+	//      |              |     |    nodev1    |
+	//      |         veth0+-----+veth1         |
+	//      | 9.9.9.249/29 |     | 9.9.9.250/29 |
+	//      +--------------+     +--------------+
+
+	// Setup
+	veth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+		PeerName:  "veth1",
+	}
+	err := netlink.LinkAdd(veth)
+	c.Assert(err, check.IsNil)
+	defer netlink.LinkDel(veth)
+	veth0, err := netlink.LinkByName("veth0")
+	c.Assert(err, check.IsNil)
+	veth1, err := netlink.LinkByName("veth1")
+	c.Assert(err, check.IsNil)
+	_, ipnet, err := net.ParseCIDR("9.9.9.252/29")
+	ip0 := net.ParseIP("9.9.9.249")
+	ip1 := net.ParseIP("9.9.9.250")
+	ipnet.IP = ip0
+	addr := &netlink.Addr{IPNet: ipnet}
+	netlink.AddrAdd(veth0, addr)
+	c.Assert(err, check.IsNil)
+	err = netlink.LinkSetUp(veth0)
+	c.Assert(err, check.IsNil)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	netns0, err := netns.ReplaceNetNSWithName("test-arping-netns0")
+	c.Assert(err, check.IsNil)
+	defer netns0.Close()
+	err = netlink.LinkSetNsFd(veth1, int(netns0.Fd()))
+	c.Assert(err, check.IsNil)
+	netns0.Do(func(ns.NetNS) error {
+		veth1, err := netlink.LinkByName("veth1")
+		c.Assert(err, check.IsNil)
+		ipnet.IP = ip1
+		addr = &netlink.Addr{IPNet: ipnet}
+		netlink.AddrAdd(veth1, addr)
+		c.Assert(err, check.IsNil)
+		err = netlink.LinkSetUp(veth1)
+		c.Assert(err, check.IsNil)
+		return nil
+	})
+
+	prevDRDev := option.Config.DirectRoutingDevice
+	defer func() { option.Config.DirectRoutingDevice = prevDRDev }()
+	option.Config.DirectRoutingDevice = "veth0"
+	prevNP := option.Config.EnableNodePort
+	defer func() { option.Config.EnableNodePort = prevNP }()
+	option.Config.EnableNodePort = true
+	dpConfig := DatapathConfiguration{HostDevice: "veth0"}
+
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing).(*linuxNodeHandler)
+	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
+
+	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
+		EnableEncapsulation: false,
+		EnableIPv4:          s.enableIPv4,
+		EnableIPv6:          s.enableIPv6,
+	})
+	c.Assert(err, check.IsNil)
+
+	nodev1 := nodeTypes.Node{
+		Name:        "node1",
+		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, ip1}},
+	}
+	err = linuxNodeHandler.NodeAdd(nodev1)
+	c.Assert(err, check.IsNil)
+
+	// Check whether an arp entry for nodev1 IP addr (=veth1) was added
+	neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found := false
+	for _, n := range neighs {
+		if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, check.Equals, true)
+
+	// Remove nodev1, and check whether the arp entry was removed
+	err = linuxNodeHandler.NodeDelete(nodev1)
+	c.Assert(err, check.IsNil)
+
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found = false
+	for _, n := range neighs {
+		if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, check.Equals, false)
 }
 
 func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config datapath.LocalNodeConfiguration) {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -662,6 +662,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
 	// Test with limited set of allowed IPs
+	oldUsed := s.proxy.usedServers
 	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
 
 	expected1b := restore.DNSRules{
@@ -680,7 +681,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored1b, checker.DeepEquals, expected1b)
 
 	// unlimited again
-	s.proxy.usedServers = nil
+	s.proxy.usedServers = oldUsed
 
 	s.proxy.UpdateAllowed(epID1, 53, nil)
 	s.proxy.UpdateAllowed(epID1, 54, nil)

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -18,12 +18,25 @@ import "context"
 
 // SetupDummy sets up kvstore for tests
 func SetupDummy(dummyBackend string) {
+	setupDummyWithConfigOpts(dummyBackend, nil)
+}
+
+// setupDummyWithConfigOpts sets up the dummy kvstore for tests but also
+// configures the module with the provided opts.
+func setupDummyWithConfigOpts(dummyBackend string, opts map[string]string) {
 	module := getBackend(dummyBackend)
 	if module == nil {
 		log.Panicf("Unknown dummy kvstore backend %s", dummyBackend)
 	}
 
 	module.setConfigDummy()
+
+	if opts != nil {
+		err := module.setConfig(opts)
+		if err != nil {
+			log.WithError(err).Panic("Unable to set config options for kvstore backend module")
+		}
+	}
 
 	if err := initClient(context.TODO(), module, nil); err != nil {
 		log.WithError(err).Panic("Unable to initialize kvstore client")

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1285,6 +1285,7 @@ func (e *etcdClient) DeleteIfLocked(ctx context.Context, key string, lock KVLock
 	defer func() { Trace("DeleteIfLocked", err, logrus.Fields{fieldKey: key}) }()
 
 	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
 	opDel := client.OpDelete(key)
 	cmp := lock.Comparator().(client.Cmp)
 	txnReply, err := e.client.Txn(ctx).If(cmp).Then(opDel).Commit()

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -194,6 +194,9 @@ const (
 	// NetNSName is a name of a network namespace
 	NetNSName = "netNSName"
 
+	// HardwareAddr is L2 addr of a network iface
+	HardwareAddr = "hardwareAddr"
+
 	// Hash is a hash of something
 	Hash = "hash"
 
@@ -313,6 +316,9 @@ const (
 
 	// Line is a line number within a file
 	Line = "line"
+
+	// LinkIndex is a network iface index
+	LinkIndex = "linkIndex"
 
 	// Object is used when "%+v" printing Go objects for debug or error handling.
 	// It is often paired with logfields.Repr to render the object.

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -91,6 +91,9 @@ const (
 
 	metricsAlive   = "alive"
 	metricsDeleted = "deleted"
+
+	metricsIngress = "ingress"
+	metricsEgress  = "egress"
 )
 
 type action int
@@ -555,7 +558,13 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 		return nil
 	}
 
-	stats := newNatGCStats(natMap)
+	family := gcFamilyIPv4
+	if ctMapTCP.mapType.isIPv6() {
+		family = gcFamilyIPv6
+	}
+	stats := newNatGCStats(natMap, family)
+	defer stats.finish()
+
 	cb := func(key bpf.MapKey, value bpf.MapValue) {
 		natKey := key.(nat.NatKey)
 		natVal := value.(nat.NatEntry)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -178,6 +178,9 @@ const (
 
 	// LabelVersion is the label for the version number
 	LabelVersion = "version"
+
+	// LabelDirection is the label for traffic direction
+	LabelDirection = "direction"
 )
 
 var (
@@ -897,7 +900,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "drop_count_total",
 				Help:      "Total dropped packets, tagged by drop reason and ingress/egress direction",
 			},
-				[]string{"reason", "direction"})
+				[]string{"reason", LabelDirection})
 
 			collectors = append(collectors, DropCount)
 			c.DropCountEnabled = true
@@ -908,7 +911,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "drop_bytes_total",
 				Help:      "Total dropped bytes, tagged by drop reason and ingress/egress direction",
 			},
-				[]string{"reason", "direction"})
+				[]string{"reason", LabelDirection})
 
 			collectors = append(collectors, DropBytes)
 			c.DropBytesEnabled = true
@@ -919,7 +922,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "forward_count_total",
 				Help:      "Total forwarded packets, tagged by ingress/egress direction",
 			},
-				[]string{"direction"})
+				[]string{LabelDirection})
 
 			collectors = append(collectors, ForwardCount)
 			c.NoOpCounterVecEnabled = true
@@ -930,7 +933,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "forward_bytes_total",
 				Help:      "Total forwarded bytes, tagged by ingress/egress direction",
 			},
-				[]string{"direction"})
+				[]string{LabelDirection})
 
 			collectors = append(collectors, ForwardBytes)
 			c.ForwardBytesEnabled = true

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -347,6 +347,9 @@ var (
 	// ConntrackGCSize the number of entries in the conntrack table
 	ConntrackGCSize = NoOpGaugeVec
 
+	// NatGCSize the number of entries in the nat table
+	NatGCSize = NoOpGaugeVec
+
 	// ConntrackGCDuration the duration of the conntrack GC process in milliseconds.
 	ConntrackGCDuration = NoOpObserverVec
 
@@ -983,6 +986,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, ConntrackGCSize)
 			c.ConntrackGCSizeEnabled = true
+
+			NatGCSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemDatapath,
+				Name:      "nat_gc_entries",
+				Help: "The number of alive and deleted nat entries at the end " +
+					"of a garbage collector run labeled by datapath family.",
+			}, []string{LabelDatapathFamily, LabelDirection, LabelStatus})
+
+			collectors = append(collectors, NatGCSize)
 
 		case Namespace + "_" + SubsystemDatapath + "_conntrack_gc_duration_seconds":
 			ConntrackGCDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -34,4 +34,6 @@ spec:
   tolerations:
   - key: "node.kubernetes.io/not-ready"
     operator: "Exists"
+  - key: "node.kubernetes.io/unreachable"
+    operator: "Exists"
   hostNetwork: true


### PR DESCRIPTION
v1.9 backports 2020-11-20

 * #14091 -- build, ci: extend API checks to include Hubble API (@tklauser)
 * #14085 -- fqdn: Fix unit test (@jrajahalme)
 * #14074 -- test: Don't wait for network to schedule test-verifier (@pchaigno)
 * #14070 -- node: Misc neighbor related changes (@brb)
 * #12832 -- metrics: add cilium_datapath_nat_gc_entries (@ArthurChiao)
 * #14102 -- install: Disable operator HA for quick/experimental install YAMLs (@joestringer)
 * #14073 -- docs: Improve visibility limitations docs (@joestringer)
 * #14063 -- kvstore: add tests for etcd ratelimiter implementation (@fristonio)
 * #14078 -- ipam: Remove unnecessary deep copies (@christarazi)

```upstream-prs
$ for pr in 14091 14085 14074 14070 12832 14102 14073 14063 14078 14083; do contrib/backporting/set-labels.py $pr done 1.9; done
```