### PR TITLE
test: Collect object file artifacts for K8sVerifier

### DIFF
--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -6,6 +6,7 @@ spec:
   containers:
   - name: cilium-builder
     image: quay.io/cilium/cilium-builder:2020-11-16@sha256:822fd77f09703e0e06b8e2cb4b6919b842bae2dbb80a3744c99dd0a0d717eb17
+    workingDir: /cilium
     command: ["sleep"]
     args:
       - "1000h"


### PR DESCRIPTION
This PR first simplifies a little the K8sVerifier test by defining a working directory for the pod, then adds collection of all `bpf_*.o` artifacts if the test fails, to help debugging failures.