### PR TITLE
Add pressure metric for bpf maps

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -228,6 +228,7 @@ Name                                       Labels                               
 ========================================== ===================================================================== ========================================================
 ``bpf_syscall_duration_seconds``           ``operation``, ``outcome``                                            Duration of eBPF system call performed
 ``bpf_map_ops_total``                      ``mapName`` (deprecated), ``map_name``, ``operation``, ``outcome``    Number of eBPF map operations performed. ``mapName`` is deprecated and will be removed in 1.10. Use ``map_name`` instead.
+``bpf_map_pressure``                       ``map_name``                                                          Map pressure defined as fill-up ratio of the map. Policy maps are exceptionally reported only when ratio is over 0.1.
 ``bpf_maps_virtual_memory_max_bytes``                                                                            Max memory used by eBPF maps installed in the system
 ``bpf_progs_virtual_memory_max_bytes``                                                                           Max memory used by eBPF programs installed in the system
 ========================================== ===================================================================== ========================================================

--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1590659986961,
+  "iteration": 1606309591568,
   "links": [],
   "panels": [
     {
@@ -647,9 +647,9 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
+        "h": 6,
+        "w": 12,
+        "x": 0,
         "y": 11
       },
       "hiddenSeries": false,
@@ -755,13 +755,110 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Fill percentage of BPF maps, tagged by map name",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "hiddenSeries": false,
+      "id": 194,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "cilium_bpf_map_pressure",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "BPF map pressure",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:230",
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": "1.0",
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:231",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 155,
       "panels": [],
@@ -786,7 +883,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "hiddenSeries": false,
       "id": 152,
@@ -887,7 +984,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 17
+        "y": 18
       },
       "hiddenSeries": false,
       "id": 153,
@@ -988,7 +1085,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 24
       },
       "hiddenSeries": false,
       "id": 156,
@@ -1089,7 +1186,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 24
       },
       "hiddenSeries": false,
       "id": 157,
@@ -1190,7 +1287,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 159,
@@ -1291,7 +1388,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 158,
@@ -1381,7 +1478,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 36
       },
       "id": 72,
       "panels": [],
@@ -1401,7 +1498,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 37
       },
       "id": 144,
       "links": [],
@@ -1427,7 +1524,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 146,
@@ -1529,7 +1626,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 145,
@@ -1631,7 +1728,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "hiddenSeries": false,
       "id": 140,
@@ -1732,7 +1829,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 46
       },
       "hiddenSeries": false,
       "id": 148,
@@ -1831,7 +1928,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 51
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 142,
@@ -1932,7 +2029,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 51
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 147,
@@ -2033,7 +2130,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 51
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 143,
@@ -2129,7 +2226,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 58
       },
       "id": 182,
       "links": [],
@@ -2156,7 +2253,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 59
       },
       "hiddenSeries": false,
       "id": 184,
@@ -2259,7 +2356,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 58
+        "y": 59
       },
       "hiddenSeries": false,
       "id": 186,
@@ -2361,7 +2458,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 63
+        "y": 64
       },
       "hiddenSeries": false,
       "id": 188,
@@ -2462,7 +2559,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 63
+        "y": 64
       },
       "hiddenSeries": false,
       "id": 190,
@@ -2563,7 +2660,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 69
       },
       "hiddenSeries": false,
       "id": 192,
@@ -2657,7 +2754,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 75
       },
       "id": 47,
       "links": [],
@@ -2683,7 +2780,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 75
+        "y": 76
       },
       "hiddenSeries": false,
       "id": 81,
@@ -2780,7 +2877,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 75
+        "y": 76
       },
       "hiddenSeries": false,
       "id": 111,
@@ -2900,7 +2997,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 81
+        "y": 82
       },
       "hiddenSeries": false,
       "id": 56,
@@ -3066,7 +3163,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 81
+        "y": 82
       },
       "hiddenSeries": false,
       "id": 128,
@@ -3232,7 +3329,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 87
+        "y": 88
       },
       "hiddenSeries": false,
       "id": 129,
@@ -3398,7 +3495,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 87
+        "y": 88
       },
       "hiddenSeries": false,
       "id": 130,
@@ -3550,7 +3647,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 93
+        "y": 94
       },
       "hiddenSeries": false,
       "id": 87,
@@ -3656,7 +3753,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 93
+        "y": 94
       },
       "hiddenSeries": false,
       "id": 79,
@@ -3753,7 +3850,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 98
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 106,
@@ -3850,7 +3947,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 98
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 89,
@@ -3963,7 +4060,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 39,
@@ -4063,7 +4160,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 103
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 93,
@@ -4186,7 +4283,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 108
+        "y": 109
       },
       "hiddenSeries": false,
       "id": 113,
@@ -4286,7 +4383,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 108
+        "y": 109
       },
       "hiddenSeries": false,
       "id": 91,
@@ -4404,7 +4501,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 113
+        "y": 114
       },
       "id": 28,
       "links": [],
@@ -4434,7 +4531,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 114
+        "y": 115
       },
       "hiddenSeries": false,
       "id": 53,
@@ -4554,7 +4651,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 114
+        "y": 115
       },
       "hiddenSeries": false,
       "id": 37,
@@ -4656,7 +4753,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 119
+        "y": 120
       },
       "hiddenSeries": false,
       "id": 94,
@@ -4780,7 +4877,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 119
+        "y": 120
       },
       "hiddenSeries": false,
       "id": 114,
@@ -4882,7 +4979,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 124
+        "y": 125
       },
       "hiddenSeries": false,
       "id": 104,
@@ -5018,7 +5115,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 124
+        "y": 125
       },
       "hiddenSeries": false,
       "id": 66,
@@ -5134,7 +5231,7 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 129
+        "y": 130
       },
       "hiddenSeries": false,
       "id": 33,
@@ -5243,7 +5340,7 @@
         "h": 5,
         "w": 6,
         "x": 6,
-        "y": 129
+        "y": 130
       },
       "hiddenSeries": false,
       "id": 100,
@@ -5371,7 +5468,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 129
+        "y": 130
       },
       "hiddenSeries": false,
       "id": 102,
@@ -5507,7 +5604,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 134
+        "y": 135
       },
       "hiddenSeries": false,
       "id": 85,
@@ -5649,7 +5746,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 134
+        "y": 135
       },
       "hiddenSeries": false,
       "id": 123,
@@ -5757,7 +5854,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 139
+        "y": 140
       },
       "hiddenSeries": false,
       "id": 117,
@@ -5873,7 +5970,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 144
+        "y": 145
       },
       "id": 73,
       "links": [],
@@ -5900,7 +5997,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 145
+        "y": 146
       },
       "hiddenSeries": false,
       "id": 55,
@@ -6000,7 +6097,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 145
+        "y": 146
       },
       "hiddenSeries": false,
       "id": 115,
@@ -6104,7 +6201,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 154
+        "y": 155
       },
       "hiddenSeries": false,
       "id": 49,
@@ -6214,7 +6311,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 154
+        "y": 155
       },
       "hiddenSeries": false,
       "id": 51,
@@ -6307,7 +6404,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 159
+        "y": 160
       },
       "id": 74,
       "links": [],
@@ -6337,7 +6434,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 160
+        "y": 161
       },
       "hiddenSeries": false,
       "id": 70,
@@ -6458,7 +6555,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 160
+        "y": 161
       },
       "hiddenSeries": false,
       "id": 68,
@@ -6564,7 +6661,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 165
+        "y": 166
       },
       "id": 60,
       "links": [],
@@ -6590,7 +6687,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 166
+        "y": 167
       },
       "hiddenSeries": false,
       "id": 163,
@@ -6691,7 +6788,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 166
+        "y": 167
       },
       "hiddenSeries": false,
       "id": 165,
@@ -6792,7 +6889,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 173
+        "y": 174
       },
       "hiddenSeries": false,
       "id": 168,
@@ -6893,7 +6990,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 173
+        "y": 174
       },
       "hiddenSeries": false,
       "id": 166,
@@ -6994,7 +7091,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 181
+        "y": 182
       },
       "hiddenSeries": false,
       "id": 172,
@@ -7094,7 +7191,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 181
+        "y": 182
       },
       "hiddenSeries": false,
       "id": 174,
@@ -7193,7 +7290,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 187
+        "y": 188
       },
       "hiddenSeries": false,
       "id": 175,
@@ -7292,7 +7389,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 187
+        "y": 188
       },
       "hiddenSeries": false,
       "id": 173,
@@ -7391,7 +7488,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 195
+        "y": 196
       },
       "hiddenSeries": false,
       "id": 108,
@@ -7494,7 +7591,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 195
+        "y": 196
       },
       "hiddenSeries": false,
       "id": 119,
@@ -7597,7 +7694,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 202
+        "y": 203
       },
       "hiddenSeries": false,
       "id": 109,
@@ -7700,7 +7797,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 202
+        "y": 203
       },
       "hiddenSeries": false,
       "id": 122,
@@ -7799,7 +7896,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 209
+        "y": 210
       },
       "hiddenSeries": false,
       "id": 118,
@@ -7898,7 +7995,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 209
+        "y": 210
       },
       "hiddenSeries": false,
       "id": 120,
@@ -7997,7 +8094,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 216
+        "y": 217
       },
       "hiddenSeries": false,
       "id": 121,

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -368,7 +368,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 1,
-      "iteration": 1590659986961,
+      "iteration": 1606309591568,
       "links": [],
       "panels": [
         {
@@ -999,9 +999,9 @@ data:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
-            "w": 8,
-            "x": 8,
+            "h": 6,
+            "w": 12,
+            "x": 0,
             "y": 11
           },
           "hiddenSeries": false,
@@ -1107,13 +1107,110 @@ data:
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "description": "Fill percentage of BPF maps, tagged by map name",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "hiddenSeries": false,
+          "id": 194,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "cilium_bpf_map_pressure",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BPF map pressure",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:230",
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": "1.0",
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:231",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
           "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 16
+            "y": 17
           },
           "id": 155,
           "panels": [],
@@ -1138,7 +1235,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 152,
@@ -1239,7 +1336,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 153,
@@ -1340,7 +1437,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 156,
@@ -1441,7 +1538,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 157,
@@ -1542,7 +1639,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 159,
@@ -1643,7 +1740,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 158,
@@ -1733,7 +1830,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 36
           },
           "id": 72,
           "panels": [],
@@ -1753,7 +1850,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 36
+            "y": 37
           },
           "id": 144,
           "links": [],
@@ -1779,7 +1876,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 146,
@@ -1881,7 +1978,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 145,
@@ -1983,7 +2080,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 140,
@@ -2084,7 +2181,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 148,
@@ -2183,7 +2280,7 @@ data:
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 51
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 142,
@@ -2284,7 +2381,7 @@ data:
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 51
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 147,
@@ -2385,7 +2482,7 @@ data:
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 51
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 143,
@@ -2481,7 +2578,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 58
           },
           "id": 182,
           "links": [],
@@ -2508,7 +2605,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 184,
@@ -2611,7 +2708,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 186,
@@ -2713,7 +2810,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 63
+            "y": 64
           },
           "hiddenSeries": false,
           "id": 188,
@@ -2814,7 +2911,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 63
+            "y": 64
           },
           "hiddenSeries": false,
           "id": 190,
@@ -2915,7 +3012,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 69
           },
           "hiddenSeries": false,
           "id": 192,
@@ -3009,7 +3106,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 74
+            "y": 75
           },
           "id": 47,
           "links": [],
@@ -3035,7 +3132,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 76
           },
           "hiddenSeries": false,
           "id": 81,
@@ -3132,7 +3229,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 76
           },
           "hiddenSeries": false,
           "id": 111,
@@ -3252,7 +3349,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 56,
@@ -3418,7 +3515,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 128,
@@ -3584,7 +3681,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 87
+            "y": 88
           },
           "hiddenSeries": false,
           "id": 129,
@@ -3750,7 +3847,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 87
+            "y": 88
           },
           "hiddenSeries": false,
           "id": 130,
@@ -3902,7 +3999,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 93
+            "y": 94
           },
           "hiddenSeries": false,
           "id": 87,
@@ -4008,7 +4105,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 93
+            "y": 94
           },
           "hiddenSeries": false,
           "id": 79,
@@ -4105,7 +4202,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 106,
@@ -4202,7 +4299,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 89,
@@ -4315,7 +4412,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 103
+            "y": 104
           },
           "hiddenSeries": false,
           "id": 39,
@@ -4415,7 +4512,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 103
+            "y": 104
           },
           "hiddenSeries": false,
           "id": 93,
@@ -4538,7 +4635,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 108
+            "y": 109
           },
           "hiddenSeries": false,
           "id": 113,
@@ -4638,7 +4735,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 108
+            "y": 109
           },
           "hiddenSeries": false,
           "id": 91,
@@ -4756,7 +4853,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 113
+            "y": 114
           },
           "id": 28,
           "links": [],
@@ -4786,7 +4883,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 114
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 53,
@@ -4906,7 +5003,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 114
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 37,
@@ -5008,7 +5105,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 119
+            "y": 120
           },
           "hiddenSeries": false,
           "id": 94,
@@ -5132,7 +5229,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 119
+            "y": 120
           },
           "hiddenSeries": false,
           "id": 114,
@@ -5234,7 +5331,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 124
+            "y": 125
           },
           "hiddenSeries": false,
           "id": 104,
@@ -5370,7 +5467,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 124
+            "y": 125
           },
           "hiddenSeries": false,
           "id": 66,
@@ -5486,7 +5583,7 @@ data:
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 129
+            "y": 130
           },
           "hiddenSeries": false,
           "id": 33,
@@ -5595,7 +5692,7 @@ data:
             "h": 5,
             "w": 6,
             "x": 6,
-            "y": 129
+            "y": 130
           },
           "hiddenSeries": false,
           "id": 100,
@@ -5723,7 +5820,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 129
+            "y": 130
           },
           "hiddenSeries": false,
           "id": 102,
@@ -5859,7 +5956,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 134
+            "y": 135
           },
           "hiddenSeries": false,
           "id": 85,
@@ -6001,7 +6098,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 134
+            "y": 135
           },
           "hiddenSeries": false,
           "id": 123,
@@ -6109,7 +6206,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 139
+            "y": 140
           },
           "hiddenSeries": false,
           "id": 117,
@@ -6225,7 +6322,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 144
+            "y": 145
           },
           "id": 73,
           "links": [],
@@ -6252,7 +6349,7 @@ data:
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 145
+            "y": 146
           },
           "hiddenSeries": false,
           "id": 55,
@@ -6352,7 +6449,7 @@ data:
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 145
+            "y": 146
           },
           "hiddenSeries": false,
           "id": 115,
@@ -6456,7 +6553,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 154
+            "y": 155
           },
           "hiddenSeries": false,
           "id": 49,
@@ -6566,7 +6663,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 154
+            "y": 155
           },
           "hiddenSeries": false,
           "id": 51,
@@ -6659,7 +6756,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 159
+            "y": 160
           },
           "id": 74,
           "links": [],
@@ -6689,7 +6786,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 160
+            "y": 161
           },
           "hiddenSeries": false,
           "id": 70,
@@ -6810,7 +6907,7 @@ data:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 160
+            "y": 161
           },
           "hiddenSeries": false,
           "id": 68,
@@ -6916,7 +7013,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 165
+            "y": 166
           },
           "id": 60,
           "links": [],
@@ -6942,7 +7039,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 166
+            "y": 167
           },
           "hiddenSeries": false,
           "id": 163,
@@ -7043,7 +7140,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 166
+            "y": 167
           },
           "hiddenSeries": false,
           "id": 165,
@@ -7144,7 +7241,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 173
+            "y": 174
           },
           "hiddenSeries": false,
           "id": 168,
@@ -7245,7 +7342,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 173
+            "y": 174
           },
           "hiddenSeries": false,
           "id": 166,
@@ -7346,7 +7443,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 181
+            "y": 182
           },
           "hiddenSeries": false,
           "id": 172,
@@ -7446,7 +7543,7 @@ data:
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 181
+            "y": 182
           },
           "hiddenSeries": false,
           "id": 174,
@@ -7545,7 +7642,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 187
+            "y": 188
           },
           "hiddenSeries": false,
           "id": 175,
@@ -7644,7 +7741,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 187
+            "y": 188
           },
           "hiddenSeries": false,
           "id": 173,
@@ -7743,7 +7840,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 195
+            "y": 196
           },
           "hiddenSeries": false,
           "id": 108,
@@ -7846,7 +7943,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 195
+            "y": 196
           },
           "hiddenSeries": false,
           "id": 119,
@@ -7949,7 +8046,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 202
+            "y": 203
           },
           "hiddenSeries": false,
           "id": 109,
@@ -8052,7 +8149,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 202
+            "y": 203
           },
           "hiddenSeries": false,
           "id": 122,
@@ -8151,7 +8248,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 209
+            "y": 210
           },
           "hiddenSeries": false,
           "id": 118,
@@ -8250,7 +8347,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 209
+            "y": 210
           },
           "hiddenSeries": false,
           "id": 120,
@@ -8349,7 +8446,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 216
+            "y": 217
           },
           "hiddenSeries": false,
           "id": 121,

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -315,7 +315,8 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.updateStrategy | object | `{"type":"RollingUpdate"}` | preflight update strategy |
 | preflight.validateCNPs | bool | `true` | By default we should always validate the installed CNPs before upgrading Cilium. This will make sure the user will have the policies deployed in the cluster with the right schema. |
 | priorityClassName | string | `""` |  |
-| prometheus | object | `{"enabled":false,"port":9090,"serviceMonitor":{"enabled":false}}` | Configure prometheus metrics on the configured port at /metrics |
+| prometheus | object | `{"enabled":false,"metrics":null,"port":9090,"serviceMonitor":{"enabled":false}}` | Configure prometheus metrics on the configured port at /metrics |
+| prometheus.metrics | string | `nil` | Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics |
 | prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | proxy | object | `{"prometheus":{"enabled":true,"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
 | proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -146,6 +146,14 @@ data:
   {{- if .Values.proxy.prometheus.enabled }}
   proxy-prometheus-port: "{{ .Values.proxy.prometheus.port }}"
   {{- end }}
+  {{- if .Values.prometheus.metrics }}
+  # Metrics that should be enabled or disabled from the default metric
+  # list. (+metric_foo to enable metric_foo , -metric_bar to disable
+  # metric_bar).
+  metrics: {{- range .Values.prometheus.metrics }}
+    {{ . }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.operator.prometheus.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -920,6 +920,11 @@ prometheus:
     # -- Specify the Kubernetes namespace where Prometheus expects to find
     # service monitors configured.
     # namespace: ""
+  # -- Metrics that should be enabled or disabled from the default metric
+  # list. (+metric_foo to enable metric_foo , -metric_bar to disable
+  # metric_bar).
+  # ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics
+  metrics: ~
 
 # -- Configure Istio proxy options.
 proxy:

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/eppolicymap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -822,6 +823,8 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 		// Also reset the in-memory state of the realized state as the
 		// BPF map content is guaranteed to be empty right now.
 		e.realizedPolicy.PolicyMapState = make(policy.MapState)
+		e.initPolicyMapPressureMetric()
+		e.updatePolicyMapPressureMetric()
 	}
 
 	// Only generate & populate policy map if a security identity is set up for
@@ -1076,6 +1079,27 @@ func (e *Endpoint) SkipStateClean() {
 	e.unlock()
 }
 
+func (e *Endpoint) initPolicyMapPressureMetric() {
+	if !option.Config.MetricsConfig.BPFMapPressure {
+		return
+	}
+
+	if e.policyMapPressureGauge != nil {
+		return
+	}
+
+	e.policyMapPressureGauge = metrics.NewBPFMapPressureGauge(e.policyMap.NonPrefixedName(), policymap.PressureMetricThreshold)
+}
+
+func (e *Endpoint) updatePolicyMapPressureMetric() {
+	if e.policyMapPressureGauge == nil {
+		return
+	}
+
+	value := float64(len(e.realizedPolicy.PolicyMapState)) / float64(e.policyMap.MapInfo.MaxEntries)
+	e.policyMapPressureGauge.Set(value)
+}
+
 // The bool pointed by hadProxy, if not nil, will be set to 'true' if
 // the deleted entry had a proxy port assigned to it.  *hadProxy is
 // not otherwise changed (e.g., it is never set to 'false').
@@ -1110,6 +1134,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool, had
 
 	// Operation was successful, remove from realized state.
 	delete(e.realizedPolicy.PolicyMapState, keyToDelete)
+	e.updatePolicyMapPressureMetric()
 
 	e.policyDebug(logrus.Fields{
 		logfields.BPFMapKey:   keyToDelete,
@@ -1145,6 +1170,7 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry,
 
 	// Operation was successful, add to realized state.
 	e.realizedPolicy.PolicyMapState[keyToAdd] = entry
+	e.updatePolicyMapPressureMetric()
 
 	e.policyDebug(logrus.Fields{
 		logfields.BPFMapKey:   keyToAdd,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -194,6 +194,10 @@ type Endpoint struct {
 	// reference to all policy related BPF
 	policyMap *policymap.PolicyMap
 
+	// policyMapPressureGauge is a metric to track and report the pressure over
+	// policyMap.
+	policyMapPressureGauge *metrics.GaugeWithThreshold
+
 	// Options determine the datapath configuration of the endpoint.
 	Options *option.IntOptions
 

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -65,7 +65,7 @@ var ThrottleMap = bpf.NewMap(
 	MapSize,
 	bpf.BPF_F_NO_PREALLOC, 0,
 	bpf.ConvertKeyValue,
-).WithCache()
+).WithCache().WithPressureMetric()
 
 func Update(Id uint16, Bps uint64) error {
 	return ThrottleMap.Update(

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -170,7 +170,7 @@ func NewMap(name string) *Map {
 			MaxEntries,
 			bpf.BPF_F_NO_PREALLOC, 0,
 			bpf.ConvertKeyValue,
-		).WithCache(),
+		).WithCache().WithPressureMetric(),
 		deleteSupport: true,
 	}
 }

--- a/pkg/maps/ipmasq/ipmasq.go
+++ b/pkg/maps/ipmasq/ipmasq.go
@@ -56,7 +56,7 @@ var IPMasq4Map = bpf.NewMap(
 	MaxEntries,
 	bpf.BPF_F_NO_PREALLOC, 0,
 	bpf.ConvertKeyValue,
-).WithCache()
+).WithCache().WithPressureMetric()
 
 type IPMasqBPFMap struct{}
 

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -48,7 +48,7 @@ func initAffinity(params InitParams) {
 		MaxEntries,
 		0, 0,
 		bpf.ConvertKeyValue,
-	).WithCache()
+	).WithCache().WithPressureMetric()
 
 	if params.IPv4 {
 		Affinity4Map = bpf.NewMap(

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -73,7 +73,7 @@ func initSVC(params InitParams) {
 			MaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 		Backend4Map = bpf.NewMap(Backend4MapName,
 			bpf.MapTypeHash,
 			&Backend4Key{},
@@ -83,7 +83,7 @@ func initSVC(params InitParams) {
 			MaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 		RevNat4Map = bpf.NewMap(RevNat4MapName,
 			bpf.MapTypeHash,
 			&RevNat4Key{},
@@ -93,7 +93,7 @@ func initSVC(params InitParams) {
 			MaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 	}
 
 	if params.IPv6 {
@@ -106,7 +106,7 @@ func initSVC(params InitParams) {
 			MaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 		Backend6Map = bpf.NewMap(Backend6MapName,
 			bpf.MapTypeHash,
 			&Backend6Key{},
@@ -116,7 +116,7 @@ func initSVC(params InitParams) {
 			MaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 		RevNat6Map = bpf.NewMap(RevNat6MapName,
 			bpf.MapTypeHash,
 			&RevNat6Key{},
@@ -126,7 +126,7 @@ func initSVC(params InitParams) {
 			MaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 	}
 }
 
@@ -469,7 +469,7 @@ func CreateSockRevNat4Map() error {
 		0,
 		0,
 		bpf.ConvertKeyValue,
-	)
+	).WithPressureMetric()
 	_, err := sockRevNat4Map.Create()
 	return err
 }

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -395,7 +395,7 @@ func CreateSockRevNat6Map() error {
 		0,
 		0,
 		bpf.ConvertKeyValue,
-	)
+	).WithPressureMetric()
 	_, err := sockRevNat6Map.Create()
 	return err
 }

--- a/pkg/maps/lbmap/maglev.go
+++ b/pkg/maps/lbmap/maglev.go
@@ -144,7 +144,7 @@ func newOuterMaglevMap(name string, innerMap *bpf.Map) *bpf.Map {
 		MaxEntries,
 		0, uint32(innerMap.GetFd()),
 		bpf.ConvertKeyValue,
-	)
+	).WithPressureMetric()
 }
 
 func updateMaglevTable(ipv6 bool, revNATID uint16, backendIDs []uint16) error {

--- a/pkg/maps/lbmap/source_range.go
+++ b/pkg/maps/lbmap/source_range.go
@@ -159,7 +159,7 @@ func initSourceRange(params InitParams) {
 			MaxEntries,
 			bpf.BPF_F_NO_PREALLOC, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 	}
 
 	if params.IPv6 {
@@ -171,7 +171,7 @@ func initSourceRange(params InitParams) {
 			MaxEntries,
 			bpf.BPF_F_NO_PREALLOC, 0,
 			bpf.ConvertKeyValue,
-		).WithCache()
+		).WithCache().WithPressureMetric()
 	}
 }
 

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -45,7 +45,7 @@ var (
 		MaxEntries,
 		0, 0,
 		bpf.ConvertKeyValue,
-	).WithCache()
+	).WithCache().WithPressureMetric()
 )
 
 // MAC is the __u64 representation of a MAC address.

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -45,6 +45,10 @@ const (
 	// are allowed. In the datapath, this is represented with the value 0 in the
 	// port field of map elements.
 	AllPorts = uint16(0)
+
+	// PressureMetricThreshold sets the threshold over which map pressure will
+	// be reported for the policy map.
+	PressureMetricThreshold = 0.1
 )
 
 type policyFlag uint8

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -51,7 +51,7 @@ func NewTunnelMap(name string) *Map {
 		MaxEntries,
 		0, 0,
 		bpf.ConvertKeyValue,
-	).WithCache(),
+	).WithCache().WithPressureMetric(),
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package metrics
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *MetricsSuite) TestGaugeWithThreshold(c *C) {
+	threshold := 1.0
+	underThreshold := threshold - 0.5
+	overThreshold := threshold + 0.5
+	gauge := NewGaugeWithThreshold(
+		"test_metric",
+		"test_subsystem",
+		"test_metric",
+		map[string]string{
+			"test_label": "test_value",
+		},
+		threshold,
+	)
+
+	metrics, err := registry.Gather()
+	c.Assert(err, IsNil)
+	initMetricLen := len(metrics)
+
+	gauge.Set(underThreshold)
+	metrics, err = registry.Gather()
+	c.Assert(err, IsNil)
+	c.Assert(metrics, HasLen, initMetricLen)
+	c.Assert(GetGaugeValue(gauge.gauge), Equals, underThreshold)
+
+	gauge.Set(overThreshold)
+	metrics, err = registry.Gather()
+	c.Assert(err, IsNil)
+	c.Assert(metrics, HasLen, initMetricLen+1)
+	c.Assert(GetGaugeValue(gauge.gauge), Equals, overThreshold)
+
+	gauge.Set(threshold)
+	metrics, err = registry.Gather()
+	c.Assert(err, IsNil)
+	c.Assert(metrics, HasLen, initMetricLen)
+	c.Assert(GetGaugeValue(gauge.gauge), Equals, threshold)
+
+	gauge.Set(overThreshold)
+	metrics, err = registry.Gather()
+	c.Assert(err, IsNil)
+	c.Assert(metrics, HasLen, initMetricLen+1)
+	c.Assert(GetGaugeValue(gauge.gauge), Equals, overThreshold)
+
+	gauge.Set(underThreshold)
+	metrics, err = registry.Gather()
+	c.Assert(err, IsNil)
+	c.Assert(metrics, HasLen, initMetricLen)
+	c.Assert(GetGaugeValue(gauge.gauge), Equals, underThreshold)
+}


### PR DESCRIPTION
Adds a metric to tell the fill percentage from 0 to 1 of selected maps
filled from userspace. Selected maps are those non LRU filled from
userspace.

This metric is a Prometheus const label gauge that is registered and
unregistered dynamically for each map when over/under a threshold
respectively. By default the threshold is 0.0 for all tracked maps.

As other metrics, this one can be enabled or disabled globally via
command line and is disabled by default.

This metric takes advantage of the existing cache mechanism for maps
to count the current number of entries on each map. For those maps that
already have this cache enabled, there is no change in this regard. For
those that don't, this caching mechanism is partially enabled to track a
key-only cache, which is the case for ` cilium_lb4_reverse_sk`,
`cilium_lb6_reverse_sk`, `cilium_lb4_maglev` and `cilium_lb6_maglev`
maps.

The policy map is an exceptional case. For this map threshold is set to
0.1 to avoid flooding Prometheus with reports. The metric is tracked
from the endpoint instead of the map in this case as the endpoint is
already caching this data while the map does not.

**Release note**
```release-note
Add new `cilium_bpf_map_pressure` metric measuring the fill-up ratio of selected BPF maps.
```