### PR TITLE
helm: fix usage of `hostPath` and add `hostPathType` in `extraHostPathMounts`

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -446,7 +446,10 @@ spec:
 {{- range .Values.extraHostPathMounts }}
       - name: {{ .name }}
         hostPath:
-          path: {{ .mountPath }}
+          path: {{ .hostPath }}
+{{- if .hostPathType }}
+          type: {{ .hostPathType }}
+{{- end }}
 {{- end }}
 {{- if .Values.etcd.enabled }}
         # To read the etcd config stored in config maps

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -243,6 +243,9 @@ spec:
 {{- range .Values.operator.extraHostPathMounts }}
       - name: {{ .name }}
         hostPath:
-          path: {{ .mountPath }}
+          path: {{ .hostPath }}
+{{- if .hostPathType }}
+          type: {{ .hostPathType }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -95,9 +95,10 @@ extraInitContainers: []
 
 # -- Additional agent hostPath mounts
 extraHostPathMounts: []
-  # - name: textfile-dir
-  #   mountPath: /srv/txt_collector
-  #   hostPath: /var/lib/agent
+  # - name: host-mnt-data
+  #   mountPath: /host/mnt/data
+  #   hostPath: /mnt/data
+  #   hostPathType: Directory
   #   readOnly: true
   #   mountPropagation: HostToContainer
 
@@ -1084,9 +1085,10 @@ operator:
 
   # -- Additional cilium-operator hostPath mounts
   extraHostPathMounts: []
-    # - name: textfile-dir
-    #   mountPath: /srv/txt_collector
-    #   hostPath: /var/lib/cilium-operator
+    # - name: host-mnt-data
+    #   mountPath: /host/mnt/data
+    #   hostPath: /mnt/data
+    #   hostPathType: Directory
     #   readOnly: true
     #   mountPropagation: HostToContainer
 


### PR DESCRIPTION
- fix reference for host-side path, use `hostPath` instead of `mountPath`
- add `type`

Fixes: #14132