### PR TITLE
checkpatch: update image tag to latest

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://cilium/cilium-checkpatch:f5443bb156d5ac4110ede4b501d6a2cf356d3202
+        uses: docker://cilium/cilium-checkpatch:71bf805000d58c07c45eb6e436640a4dc0ca6c84
   coccicheck:
     name: coccicheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the tag for the checkpatch image in order to benefit from the latest changes when running the GitHub actions: The latest image suppresses reports for `FILE_PATH_CHANGES` to avoid checkpatch to complain when files are added or moved under bpf/ directory.

See discussion at https://github.com/cilium/cilium/pull/14088#issuecomment-731035505.
Image updated in https://github.com/cilium/image-tools/pull/87.

No CI checks required.