### PR TITLE
endpoint: Fix typo in CT clean logic

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -763,11 +763,11 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 			if !option.Config.DryMode {
 				ipv4 := option.Config.EnableIPv4
 				ipv6 := option.Config.EnableIPv6
-				created := ctmap.Exists(nil, ipv4, ipv6)
+				exists := ctmap.Exists(nil, ipv4, ipv6)
 				if e.ConntrackLocal() {
-					created = ctmap.Exists(e, ipv4, ipv6)
+					exists = ctmap.Exists(e, ipv4, ipv6)
 				}
-				if created {
+				if exists {
 					e.scrubIPsInConntrackTable()
 				}
 			}


### PR DESCRIPTION
This is a purely cosmetic change. The IPs of the endpoint will only be
scrubbed if the CT map already exists, but the variable was named
'created' which is misleading (the opposite meaning).

Basic build validation should be sufficient for this patch as there are
no functional changes.