### PR TITLE
bpf: Don't compile unused BPF sections

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -25,6 +25,11 @@
 # undef ENABLE_HOST_FIREWALL
 #endif
 
+/* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_ECHO_REPLY section in
+ * the bpf_lxc object file.
+ */
+#define SKIP_ICMPV6_ECHO_HANDLING
+
 #include "lib/common.h"
 #include "lib/edt.h"
 #include "lib/arp.h"

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -9,6 +9,16 @@
 
 #define IS_BPF_OVERLAY 1
 
+/* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
+ * bpf_lxc object file.
+ */
+#define SKIP_ICMPV6_NS_HANDLING
+
+/* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_ECHO_REPLY section in
+ * the bpf_lxc object file.
+ */
+#define SKIP_ICMPV6_ECHO_HANDLING
+
 #include "lib/tailcall.h"
 #include "lib/common.h"
 #include "lib/edt.h"

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -10,6 +10,22 @@
 
 #define SKIP_POLICY_MAP 1
 
+/* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
+ * bpf_lxc object file.
+ */
+#define SKIP_ICMPV6_NS_HANDLING
+
+/* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED section
+ * in the bpf_lxc object file. This is needed for all callers of
+ * ipv6_local_delivery, which calls into the IPv6 L3 handling.
+ */
+#define SKIP_ICMPV6_HOPLIMIT_HANDLING
+
+/* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_ECHO_REPLY section in
+ * the bpf_lxc object file.
+ */
+#define SKIP_ICMPV6_ECHO_HANDLING
+
 #include "lib/common.h"
 #include "lib/maps.h"
 #include "lib/eps.h"

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -124,6 +124,7 @@ static __always_inline int __icmp6_send_echo_reply(struct __ctx_buff *ctx,
 	return icmp6_send_reply(ctx, nh_off);
 }
 
+#ifndef SKIP_ICMPV6_ECHO_HANDLING
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_ECHO_REPLY)
 int tail_icmp6_send_echo_reply(struct __ctx_buff *ctx)
 {
@@ -136,6 +137,7 @@ int tail_icmp6_send_echo_reply(struct __ctx_buff *ctx)
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, direction);
 	return ret;
 }
+#endif
 
 /*
  * icmp6_send_echo_reply
@@ -325,10 +327,11 @@ static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 }
 #endif
 
+#ifndef SKIP_ICMPV6_HOPLIMIT_HANDLING
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED)
 int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx __maybe_unused)
 {
-#ifdef BPF_HAVE_CHANGE_TAIL
+# ifdef BPF_HAVE_CHANGE_TAIL
 	int ret, nh_off = ctx_load_meta(ctx, 0);
 	__u8 direction  = ctx_load_meta(ctx, 1);
 
@@ -338,10 +341,11 @@ int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx __maybe_unused)
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 					      direction);
 	return ret;
-#else
+# else
 	return 0;
-#endif
+# endif
 }
+#endif
 
 /*
  * icmp6_send_time_exceeded
@@ -393,6 +397,7 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 	return ACTION_UNKNOWN_ICMP6_NS;
 }
 
+#ifndef SKIP_ICMPV6_NS_HANDLING
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_HANDLE_ICMP6_NS)
 int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
 {
@@ -405,6 +410,7 @@ int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, direction);
 	return ret;
 }
+#endif
 
 /*
  * icmp6_handle_ns


### PR DESCRIPTION
When we load a BPF program in the kernel, `tc` loads the entire object file, meaning it attempts to load each BPF program found in the object file. In some cases (e.g., ICMPv6 code in `bpf_xdp.o`), we include BPF program as sections in the object file even though we never tail call to them.

This commit fixes it by ensuring we only compile those sections if they are needed. This also fixes a failure to load `bpf_xdp` on 4.19 when compiled with our `MAX_LB_OPTIONS` options combination: `ENABLE_IPV4 ENABLE_IPV6 ENABLE_HOST_SERVICES_TCP ENABLE_HOST_SERVICES_UDP ENABLE_IPSEC`.