### PR TITLE
v1.8 backports 2020-11-23

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -543,67 +543,58 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 }
 
-func neighborLog(spec, iface string, err error, ip *net.IP, hwAddr *net.HardwareAddr, link int) {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.Reason: spec,
-		"Interface":      iface,
-		logfields.IPAddr: ip,
-		"HardwareAddr":   hwAddr,
-		"LinkIndex":      link,
-	})
-
-	if err != nil {
-		scopedLog.WithError(err).Error("insertNeighbor failed")
-	} else {
-		scopedLog.Debug("insertNeighbor")
-	}
-}
-
+// Must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName string) {
 	if newNode.IsLocal() {
 		return
 	}
 
 	ciliumIPv4 := newNode.GetNodeIP(false)
-	var hwAddr net.HardwareAddr
-	link := 0
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.Interface: ifaceName,
+		logfields.IPAddr:    ciliumIPv4,
+	})
 
 	iface, err := net.InterfaceByName(ifaceName)
 	if err != nil {
-		neighborLog("insertNeightbor InterfaceByName", ifaceName, err, &ciliumIPv4, &hwAddr, link)
+		scopedLog.WithError(err).Error("Failed to retrieve iface by name")
 		return
 	}
 
 	_, err = arping.FindIPInNetworkFromIface(ciliumIPv4, *iface)
 	if err != nil {
-		neighborLog("insertNeightbor IP not L2 reachable", ifaceName, nil, &ciliumIPv4, &hwAddr, link)
+		scopedLog.WithError(err).Error("IP is not L2 reachable")
 		return
 	}
 
 	linkAttr, err := netlink.LinkByName(ifaceName)
 	if err != nil {
-		neighborLog("insertNeightbor LinkByName", ifaceName, err, &ciliumIPv4, &hwAddr, link)
+		scopedLog.WithError(err).Error("Failed to retrieve iface by name (netlink)")
 		return
 	}
-	link = linkAttr.Attrs().Index
+	link := linkAttr.Attrs().Index
 
-	if hwAddr, _, err := arping.PingOverIface(ciliumIPv4, *iface); err == nil {
-		neigh := netlink.Neigh{
-			LinkIndex:    link,
-			IP:           ciliumIPv4,
-			HardwareAddr: hwAddr,
-			State:        netlink.NUD_PERMANENT,
-		}
-		err := netlink.NeighSet(&neigh)
-		neighborLog("insertNeighbor NeighSet", ifaceName, err, &ciliumIPv4, &hwAddr, link)
-		if err == nil {
-			n.neighByNode[newNode.Identity()] = &neigh
-			if option.Config.NodePortHairpin {
-				neighborsmap.NeighRetire(ciliumIPv4)
-			}
-		}
-	} else {
-		neighborLog("insertNeighbor arping failed", ifaceName, err, &ciliumIPv4, &hwAddr, link)
+	hwAddr, _, err := arping.PingOverIface(ciliumIPv4, *iface)
+	if err != nil {
+		scopedLog.WithError(err).Error("arping failed")
+		return
+	}
+	scopedLog = scopedLog.WithField(logfields.HardwareAddr, hwAddr)
+
+	neigh := netlink.Neigh{
+		LinkIndex:    link,
+		IP:           ciliumIPv4,
+		HardwareAddr: hwAddr,
+		State:        netlink.NUD_PERMANENT,
+	}
+	if err := netlink.NeighSet(&neigh); err != nil {
+		scopedLog.WithError(err).Error("Failed to insert neighbor")
+		return
+	}
+
+	n.neighByNode[newNode.Identity()] = &neigh
+	if option.Config.NodePortHairpin {
+		neighborsmap.NeighRetire(ciliumIPv4)
 	}
 }
 
@@ -615,14 +606,15 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 
 	if err := netlink.NeighDel(neigh); err != nil {
 		log.WithFields(logrus.Fields{
-			logfields.IPAddr: neigh.IP,
-			"HardwareAddr":   neigh.HardwareAddr,
-			"LinkIndex":      neigh.LinkIndex,
+			logfields.IPAddr:       neigh.IP,
+			logfields.HardwareAddr: neigh.HardwareAddr,
+			logfields.LinkIndex:    neigh.LinkIndex,
 		}).WithError(err).Warn("Failed to remove neighbor entry")
-	} else {
-		if option.Config.NodePortHairpin {
-			neighborsmap.NeighRetire(neigh.IP)
-		}
+		return
+	}
+
+	if option.Config.NodePortHairpin {
+		neighborsmap.NeighRetire(neigh.IP)
 	}
 }
 

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -18,6 +18,7 @@ package linux
 
 import (
 	"net"
+	"runtime"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -27,9 +28,12 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/netns"
 	nodeaddressing "github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"gopkg.in/check.v1"
 )
@@ -941,6 +945,112 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 	if s.enableIPv6 {
 		c.Assert(lookupFakeRoute(c, linuxNodeHandler, ip6Alloc1), check.Equals, true)
 	}
+}
+
+func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
+	// 1. Test whether another node in the same L2 subnet can be arpinged.
+	//    The other node is in the different netns reachable via the veth pair.
+	//
+	//      +--------------+     +--------------+
+	//      |  host netns  |     |    netns0    |
+	//      |              |     |    nodev1    |
+	//      |         veth0+-----+veth1         |
+	//      | 9.9.9.249/29 |     | 9.9.9.250/29 |
+	//      +--------------+     +--------------+
+
+	// Setup
+	veth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+		PeerName:  "veth1",
+	}
+	err := netlink.LinkAdd(veth)
+	c.Assert(err, check.IsNil)
+	defer netlink.LinkDel(veth)
+	veth0, err := netlink.LinkByName("veth0")
+	c.Assert(err, check.IsNil)
+	veth1, err := netlink.LinkByName("veth1")
+	c.Assert(err, check.IsNil)
+	_, ipnet, err := net.ParseCIDR("9.9.9.252/29")
+	ip0 := net.ParseIP("9.9.9.249")
+	ip1 := net.ParseIP("9.9.9.250")
+	ipnet.IP = ip0
+	addr := &netlink.Addr{IPNet: ipnet}
+	netlink.AddrAdd(veth0, addr)
+	c.Assert(err, check.IsNil)
+	err = netlink.LinkSetUp(veth0)
+	c.Assert(err, check.IsNil)
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	netns0, err := netns.ReplaceNetNSWithName("test-arping-netns0")
+	c.Assert(err, check.IsNil)
+	defer netns0.Close()
+	err = netlink.LinkSetNsFd(veth1, int(netns0.Fd()))
+	c.Assert(err, check.IsNil)
+	netns0.Do(func(ns.NetNS) error {
+		veth1, err := netlink.LinkByName("veth1")
+		c.Assert(err, check.IsNil)
+		ipnet.IP = ip1
+		addr = &netlink.Addr{IPNet: ipnet}
+		netlink.AddrAdd(veth1, addr)
+		c.Assert(err, check.IsNil)
+		err = netlink.LinkSetUp(veth1)
+		c.Assert(err, check.IsNil)
+		return nil
+	})
+
+	prevDRDev := option.Config.DirectRoutingDevice
+	defer func() { option.Config.DirectRoutingDevice = prevDRDev }()
+	option.Config.DirectRoutingDevice = "veth0"
+	prevNP := option.Config.EnableNodePort
+	defer func() { option.Config.EnableNodePort = prevNP }()
+	option.Config.EnableNodePort = true
+	dpConfig := DatapathConfiguration{HostDevice: "veth0"}
+
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing).(*linuxNodeHandler)
+	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
+
+	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
+		EnableEncapsulation: false,
+		EnableIPv4:          s.enableIPv4,
+		EnableIPv6:          s.enableIPv6,
+	})
+	c.Assert(err, check.IsNil)
+
+	nodev1 := nodeTypes.Node{
+		Name:        "node1",
+		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, ip1}},
+	}
+	err = linuxNodeHandler.NodeAdd(nodev1)
+	c.Assert(err, check.IsNil)
+
+	// Check whether an arp entry for nodev1 IP addr (=veth1) was added
+	neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found := false
+	for _, n := range neighs {
+		if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, check.Equals, true)
+
+	// Remove nodev1, and check whether the arp entry was removed
+	err = linuxNodeHandler.NodeDelete(nodev1)
+	c.Assert(err, check.IsNil)
+
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found = false
+	for _, n := range neighs {
+		if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, check.Equals, false)
 }
 
 func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config datapath.LocalNodeConfiguration) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -192,6 +192,9 @@ const (
 	// NetNSName is a name of a network namespace
 	NetNSName = "netNSName"
 
+	// HardwareAddr is L2 addr of a network iface
+	HardwareAddr = "hardwareAddr"
+
 	// Hash is a hash of something
 	Hash = "hash"
 
@@ -302,6 +305,9 @@ const (
 
 	// Line is a line number within a file
 	Line = "line"
+
+	// LinkIndex is a network iface index
+	LinkIndex = "linkIndex"
 
 	// Object is used when "%+v" printing Go objects for debug or error handling.
 	// It is often paired with logfields.Repr to render the object.

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -91,6 +91,9 @@ const (
 
 	metricsAlive   = "alive"
 	metricsDeleted = "deleted"
+
+	metricsIngress = "ingress"
+	metricsEgress  = "egress"
 )
 
 type action int
@@ -553,7 +556,13 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 		return nil
 	}
 
-	stats := newNatGCStats(natMap)
+	family := gcFamilyIPv4
+	if ctMapTCP.mapType.isIPv6() {
+		family = gcFamilyIPv6
+	}
+	stats := newNatGCStats(natMap, family)
+	defer stats.finish()
+
 	cb := func(key bpf.MapKey, value bpf.MapValue) {
 		natKey := key.(nat.NatKey)
 		natVal := value.(nat.NatEntry)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -315,6 +315,9 @@ var (
 	// ConntrackGCSize the number of entries in the conntrack table
 	ConntrackGCSize = NoOpGaugeVec
 
+	// NatGCSize the number of entries in the nat table
+	NatGCSize = NoOpGaugeVec
+
 	// ConntrackGCDuration the duration of the conntrack GC process in milliseconds.
 	ConntrackGCDuration = NoOpObserverVec
 
@@ -898,6 +901,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, ConntrackGCSize)
 			c.ConntrackGCSizeEnabled = true
+
+			NatGCSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemDatapath,
+				Name:      "nat_gc_entries",
+				Help: "The number of alive and deleted nat entries at the end " +
+					"of a garbage collector run labeled by datapath family.",
+			}, []string{LabelDatapathFamily, LabelDirection, LabelStatus})
+
+			collectors = append(collectors, NatGCSize)
 
 		case Namespace + "_" + SubsystemDatapath + "_conntrack_gc_duration_seconds":
 			ConntrackGCDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -173,6 +173,9 @@ const (
 
 	// LabelVersion is the label for the version number
 	LabelVersion = "version"
+
+	// LabelDirection is the label for traffic direction
+	LabelDirection = "direction"
 )
 
 var (
@@ -812,7 +815,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "drop_count_total",
 				Help:      "Total dropped packets, tagged by drop reason and ingress/egress direction",
 			},
-				[]string{"reason", "direction"})
+				[]string{"reason", LabelDirection})
 
 			collectors = append(collectors, DropCount)
 			c.DropCountEnabled = true
@@ -823,7 +826,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "drop_bytes_total",
 				Help:      "Total dropped bytes, tagged by drop reason and ingress/egress direction",
 			},
-				[]string{"reason", "direction"})
+				[]string{"reason", LabelDirection})
 
 			collectors = append(collectors, DropBytes)
 			c.DropBytesEnabled = true
@@ -834,7 +837,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "forward_count_total",
 				Help:      "Total forwarded packets, tagged by ingress/egress direction",
 			},
-				[]string{"direction"})
+				[]string{LabelDirection})
 
 			collectors = append(collectors, ForwardCount)
 			c.NoOpCounterVecEnabled = true
@@ -845,7 +848,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "forward_bytes_total",
 				Help:      "Total forwarded bytes, tagged by ingress/egress direction",
 			},
-				[]string{"direction"})
+				[]string{LabelDirection})
 
 			collectors = append(collectors, ForwardBytes)
 			c.ForwardBytesEnabled = true

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -34,4 +34,6 @@ spec:
   tolerations:
   - key: "node.kubernetes.io/not-ready"
     operator: "Exists"
+  - key: "node.kubernetes.io/unreachable"
+    operator: "Exists"
   hostNetwork: true


### PR DESCRIPTION
* #14074 -- test: Don't wait for network to schedule test-verifier (@pchaigno)
 * #14070 -- node: Misc neighbor related changes (@brb)
 * #12832 -- metrics: add cilium_datapath_nat_gc_entries (@ArthurChiao)

 Skipping:

 * #14091 -- build, ci: extend API checks to include Hubble API (@tklauser)
   * Note: This one seems to depend on another PR
     (https://github.com/cilium/cilium/pull/12673). Unsure if we want to bring
     that infastructure into the v1.8 branch.
 * #14085 -- fqdn: Fix unit test (@jrajahalme)
   * Note: Depends on pending backport PR
     https://github.com/cilium/cilium/pull/14012

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14074 14070 12832; do contrib/backporting/set-labels.py $pr done 1.8; done
```