### PR TITLE
docs: Improve DNS port documentation

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -525,6 +525,12 @@ IPs to be allowed are selected via:
   * ``*`` alone matches all names, and inserts all cached DNS IPs into this
     rule.
 
+The example below allows all DNS traffic on port 53 to the DNS service and
+intercepts it via the `DNS Proxy`_. If using a non-standard DNS port for
+a DNS application behind a Kubernetes service, the port must match the backend
+port. When the application makes a request for my-remote-service.com, Cilium
+learns the IP address and will allow traffic due to the match on the name under
+the ``toFQDNs.matchName`` rule.
 
 Example
 ~~~~~~~


### PR DESCRIPTION
Some users had expressed confusion when using non-standard ports in
conjunction with DNS policy. Clarify that when there is a k8s service,
the CoreDNS / kube-dns port must be the backend port.

Related: #13308