### PR TITLE
bugtool: Add lsmod

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -110,6 +110,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		fmt.Sprintf("gops stats $(pidof %s)", components.CiliumAgentName),
 		// Get list of open file descriptors managed by the agent
 		fmt.Sprintf("ls -la /proc/$(pidof %s)/fd", components.CiliumAgentName),
+		"lsmod",
 	}
 
 	if bpffsMountpoint := bpffsMountpoint(); bpffsMountpoint != "" {


### PR DESCRIPTION
Module listings can allow figuring out the availability of certain
functionality like `iptables` or `aes` modules which can be useful when
debugging certain types of problems.

Nominating for backports just for the convenience of making
debugging easier in future.