### PR TITLE
test: Quarantine flakes from k8s-all CI pipeline

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -612,3 +612,14 @@ func SkipRaceDetectorEnabled() bool {
 	race := os.Getenv("RACE")
 	return race == "1" || race == "true"
 }
+
+// SkipK8sVersions returns true if the current K8s versions matched the
+// constraints passed in argument.
+func SkipK8sVersions(k8sVersions string) bool {
+	k8sVersion, err := versioncheck.Version(GetCurrentK8SEnv())
+	if err != nil {
+		return false
+	}
+	constraint := versioncheck.MustCompile(k8sVersions)
+	return constraint(k8sVersion)
+}

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -254,7 +254,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 
-		It("Check vxlan connectivity with per-endpoint routes", func() {
+		SkipItIf(func() bool {
+			// Skip K8s versions for which the test is currently flaky.
+			return helpers.SkipK8sVersions(">=1.13.0 <1.17.0") && helpers.SkipQuarantined()
+		}, "Check vxlan connectivity with per-endpoint routes", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                 "vxlan",
 				"endpointRoutes.enabled": "true",
@@ -268,7 +271,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 		})
 
-		It("Check iptables masquerading with random-fully", func() {
+		SkipItIf(func() bool {
+			// Skip K8s versions for which the test is currently flaky.
+			return helpers.SkipK8sVersions(">=1.13.0 <1.17.0") && helpers.SkipQuarantined()
+		}, "Check iptables masquerading with random-fully", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"bpf.masquerade":      "false",
 				"iptablesRandomFully": "true",


### PR DESCRIPTION
`Check vxlan connectivity with per-endpoint routes` and `Check iptables masquerading with random-fully` are currently failing on the kubernetes-all CI pipeline for most K8s versions. This pull request quarantines those tests.

The list of K8s versions to exclude was retrieved using [this CI dashboard report](https://datastudio.google.com/s/iCx91Z2LNH8).