### PR TITLE
helm/cilium-configmap: added checks to deduplicate keys

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -295,13 +295,6 @@ data:
   # container image names
   sidecar-istio-proxy-image: "{{ .Values.proxy.sidecarImageRegex }}"
 
-  # Encapsulation mode for communication between nodes
-  # Possible values:
-  #   - disabled
-  #   - vxlan (default)
-  #   - geneve
-  tunnel: {{ .Values.tunnel }}
-
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: {{ .Values.cluster.name }}
 
@@ -311,12 +304,17 @@ data:
   cluster-id: "{{ .Values.cluster.id }}"
 {{- end }}
 
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
 {{- if .Values.gke.enabled }}
-
-  ipam: "kubernetes"
   tunnel: "disabled"
   enable-endpoint-routes: "true"
   enable-local-node-route: "false"
+{{- else }}
+  tunnel: {{ .Values.tunnel }}
 {{- end }}
 
 {{- if .Values.eni }}
@@ -612,9 +610,8 @@ data:
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: {{ .Values.disableIptablesFeederRules | join " " | quote }}
 {{- end }}
-{{- if ne $ipam "hostscope" }}
   ipam: {{ $ipam | quote }}
-{{- end }}
+
 {{- if eq $ipam "cluster-pool" }}
 {{- if .Values.ipv4.enabled }}
   cluster-pool-ipv4-cidr: {{ .Values.ipam.operator.clusterPoolIPv4PodCIDR | quote }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -119,18 +119,18 @@ data:
   # container image names
   sidecar-istio-proxy-image: "cilium/istio_proxy"
 
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  cluster-id: ""
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
   tunnel: vxlan
-
-  # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: default
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
-  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
-  cluster-id: ""
   # Enables L7 proxy for L7 policy enforcement and visibility
   enable-l7-proxy: "true"
 

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -98,18 +98,18 @@ data:
   # container image names
   sidecar-istio-proxy-image: "cilium/istio_proxy"
 
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  cluster-id: ""
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
   tunnel: vxlan
-
-  # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: default
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
-  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
-  cluster-id: ""
   # Enables L7 proxy for L7 policy enforcement and visibility
   enable-l7-proxy: "true"
 


### PR DESCRIPTION

1. This PR adds a check around line 303, so that the `tunnel` key is set here only if `.Values.gke.enabled=false`,
https://github.com/cilium/cilium/blob/f66515219c21041f17d424cb8f2ca2b1b81c4687/install/kubernetes/cilium/templates/cilium-configmap.yaml#L303
otherwise if `.Values.gke.enabled=true`, the `tunnel` key is set by this block
https://github.com/cilium/cilium/blob/f66515219c21041f17d424cb8f2ca2b1b81c4687/install/kubernetes/cilium/templates/cilium-configmap.yaml#L314-L320

2. Also to deduplicate `ipam` key, we are removing it from this block
https://github.com/cilium/cilium/blob/f66515219c21041f17d424cb8f2ca2b1b81c4687/install/kubernetes/cilium/templates/cilium-configmap.yaml#L314-L320
along with the condition around line 616 here
https://github.com/cilium/cilium/blob/f66515219c21041f17d424cb8f2ca2b1b81c4687/install/kubernetes/cilium/templates/cilium-configmap.yaml#L615-L617
so that `ipam` is either _set explicitly by the user_ **or** _takes the default value of_ `"cluster-pool"`.
https://github.com/cilium/cilium/blob/f66515219c21041f17d424cb8f2ca2b1b81c4687/install/kubernetes/cilium/templates/cilium-configmap.yaml#L34


Fixes: #13999 

Signed-off-by: Pranavi Roy <pranavi@accuknox.com>