### PR TITLE
Complete kube-router documentation

### DIFF
--- a/Documentation/gettingstarted/kube-router.rst
+++ b/Documentation/gettingstarted/kube-router.rst
@@ -82,7 +82,9 @@ Deploy Cilium
 In order for routing to be delegated to kube-router, tunneling/encapsulation
 must be disabled. This is done by setting the ``tunnel=disabled`` in the
 ConfigMap ``cilium-config`` or by adjusting the DaemonSet to run the
-``cilium-agent`` with the argument ``--tunnel=disabled``:
+``cilium-agent`` with the argument ``--tunnel=disabled``. Moreover, in the
+same ConfigMap, we must explicitly set ``ipam: kubernetes`` since kube-router
+pulls the pod CIDRs directly from K8s:
 
 .. code:: bash
 
@@ -92,6 +94,7 @@ ConfigMap ``cilium-config`` or by adjusting the DaemonSet to run the
     #   - vxlan (default)
     #   - geneve
     tunnel: "disabled"
+    ipam: "kubernetes"
 
 You can then install Cilium according to the instructions in section
 :ref:`ds_deploy`.


### PR DESCRIPTION
Kube-router fetches the CIDRs from Kubernetes and thus ipam: cluter-pool
configuration does not really work well. This patch clarifies this in
the kube-router documentation

Signed-off-by: Manuel Buil <mbuil@suse.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #14152 

```release-note
Complete kube-router documentation by mentioning that "ipam: kubernetes" should be used
```