### PR TITLE
agent: Keep hostPort config consistent with nodePort

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -77,7 +77,7 @@ cilium-agent [flags]
       --enable-health-checking                               Enable connectivity health checking (default true)
       --enable-host-firewall                                 Enable host network policies (beta)
       --enable-host-legacy-routing                           Enable the legacy host forwarding model which does not bypass upper stack in host namespace
-      --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
+      --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port)
       --enable-host-reachable-services                       Enable reachability of services for host applications
       --enable-hubble                                        Enable hubble server
       --enable-identity-mark                                 Enable setting identity mark for local traffic (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -525,7 +525,7 @@ func init() {
 	flags.String(option.KubeProxyReplacementHealthzBindAddr, defaults.KubeProxyReplacementHealthzBindAddr, "The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.")
 	option.BindEnv(option.KubeProxyReplacementHealthzBindAddr)
 
-	flags.Bool(option.EnableHostPort, true, fmt.Sprintf("Enable k8s hostPort mapping feature (requires enabling %s)", option.EnableNodePort))
+	flags.Bool(option.EnableHostPort, false, fmt.Sprintf("Enable k8s hostPort mapping feature (requires enabling %s)", option.EnableNodePort))
 	option.BindEnv(option.EnableHostPort)
 
 	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium")


### PR DESCRIPTION
The current default for the `enable-host-port` config option is true.
However, the feature is enabled only when `enable-node-port` config is set to true (the default
for which is false). Hence, keep the option defaults consistent.

Signed-off-by: Aditi Ghag <aditi@cilium.io>
