### PR TITLE
ci: push cilium-test-dev image to quay, accept tags in the test script

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -75,6 +75,9 @@ jobs:
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD  }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME  }}
+          REGISTRIES: "docker.io/cilium quay.io/cilium"
         with:
           entrypoint: make
           args: -C images cilium-test-image PUSH=true

--- a/images/cilium-test/cilium-test-gke.sh
+++ b/images/cilium-test/cilium-test-gke.sh
@@ -23,11 +23,14 @@ done
 kubectl create ns cilium || true
 
 CILIUM_IMAGE="${1}"
-CILIUM_OPERATOR_IMAGE="${2}"
-HUBBLE_RELAY_IMAGE="${3}"
-FOCUS="${4:-K8s*}"
+CILIUM_IMAGE_TAG="${2}"
+CILIUM_OPERATOR_IMAGE="${3}"
+CILIUM_OPERATOR_IMAGE_TAG="${4}"
+HUBBLE_RELAY_IMAGE="${5}"
+HUBBLE_RELAY_IMAGE_TAG="${6}"
+FOCUS="${7:-K8s*}"
 
-export CILIUM_IMAGE CILIUM_OPERATOR_IMAGE HUBBLE_RELAY_IMAGE FOCUS
+export CILIUM_IMAGE CILIUM_IMAGE_TAG CILIUM_OPERATOR_IMAGE CILIUM_OPERATOR_IMAGE_TAG HUBBLE_RELAY_IMAGE HUBBLE_RELAY_IMAGE_TAG FOCUS
 
 shift 4
 
@@ -47,6 +50,9 @@ cilium-test \
   -cilium.provision=false \
   -cilium.kubeconfig="${KUBECONFIG}" \
   -cilium.image="${CILIUM_IMAGE}" \
+  -cilium.tag="${CILIUM_IMAGE_TAG}" \
   -cilium.operator-image="${CILIUM_OPERATOR_IMAGE}" \
+  -cilium.operator-tag="${CILIUM_OPERATOR_IMAGE_TAG}" \
   -cilium.hubble-relay-image="${HUBBLE_RELAY_IMAGE}" \
+  -cilium.hubble-relay-tag="${HUBBLE_RELAY_IMAGE_TAG}" \
   -cilium.passCLIEnvironment=true


### PR DESCRIPTION
We want to have this image on quay because of docker rate limiting