### PR TITLE
helm: Backport `agent.extraHostPathMounts`

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -264,6 +264,14 @@ spec:
           name: kube-config
           readOnly: true
 {{- end}}
+{{- range .Values.extraHostPathMounts }}
+        - mountPath: {{ .mountPath }}
+          name: {{ .name }}
+          readOnly: {{ .readOnly }}
+{{- if .mountPropagation }}
+          mountPropagation: {{ .mountPropagation }}
+{{- end }}
+{{- end }}
 {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
         command: ["cilium"]
@@ -416,6 +424,14 @@ spec:
           path: {{ .Values.global.nodeinit.bootstrapFile }}
           type: FileOrCreate
         name: cilium-bootstrap-file
+{{- end }}
+{{- range .Values.extraHostPathMounts }}
+      - name: {{ .name }}
+        hostPath:
+          path: {{ .hostPath }}
+{{- if .hostPathType }}
+          type: {{ .hostPathType }}
+{{- end }}
 {{- end }}
 {{- if .Values.global.etcd.enabled }}
         # To read the etcd config stored in config maps

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -32,3 +32,12 @@ initResources:
 ##
 tolerations:
 - operator: Exists
+
+# Additional agent hostPath mounts
+extraHostPathMounts: []
+  # - name: host-mnt-data
+  #   mountPath: /host/mnt/data
+  #   hostPath: /mnt/data
+  #   hostPathType: Directory
+  #   readOnly: true
+  #   mountPropagation: HostToContainer


### PR DESCRIPTION
This PR backports `extraHostPathMounts` Helm parameter that was added in 1.9 to 1.8, as it is needed for OpenShift to bind mount iptables binaries from the hosts. It's relatively simple configuration parameter, and backporting is scoped only to the agent subchart.