### PR TITLE
pkg/hubble/container: Add meaningful RingBuffer benchmark

### DIFF
--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -33,9 +33,11 @@ import (
 	"go.uber.org/goleak"
 )
 
+const benchmarkCapacity = Capacity4095
+
 func BenchmarkRingWrite(b *testing.B) {
 	entry := &v1.Event{}
-	s := NewRing(capacity(b.N))
+	s := NewRing(benchmarkCapacity)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -45,8 +47,8 @@ func BenchmarkRingWrite(b *testing.B) {
 
 func BenchmarkRingRead(b *testing.B) {
 	entry := &v1.Event{}
-	s := NewRing(capacity(b.N))
-	a := make([]*v1.Event, b.N, b.N)
+	s := NewRing(benchmarkCapacity)
+	a := make([]*v1.Event, b.N)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		s.Write(entry)


### PR DESCRIPTION
AFAICT Hubble's `pkg/hubble/container.RingBuffer` does not support any way to read all messages written to it. This PR exists to hopefully demonstrate that I'm wrong :)

tl;dr How you do make Hubble's current `RingBuffer` reliably deliver events?

@Rolinh and I are reviewing Hubble's ring buffer code. I'm trying to write a benchmark/test for the existing code so we can compare alternative implementations.

The current benchmarks only test writes to the ring buffer, they do not test that events are received by readers. Although the ring buffer performs well in these benchmarks (around 20ns/op on my machine), `cat > /dev/null` has equivalent functionality and better performance.

Therefore, I want to create a benchmark/test that measures both writes and reads, roughly:
1. Create a `RingBuffer`.
2. Create M readers.
3. Write N events to the `RingBuffer`.
4. Stop all readers.
5. Verify that all readers have received N events.

I am currently unable to do step 5.

See the code in this PR for my best attempt so far. You can run the benchmark by running

    go test -benchmem -run=^$ github.com/cilium/cilium/pkg/hubble/container -bench ^(BenchmarkReadBufferOneReader)$

The readers use new `RingReader`s  created before any events are written to the ring buffer and use `NextFollow`. However, after running the benchmark, the readers have not received any events.

What changes are needed to the benchmark code to make all readers receive all events? Is such a thing even possible with the current `RingBuffer` implementation?

Note that `go test -bench` first runs the benchmark with `b.N == 1`, this is the failure you see. I have not tried with larger `b.N`.

For the curious, the WIP branch for a replacement ring buffer with a new internal API is [here](https://github.com/cilium/cilium/compare/pr/twpayne/hubble-recent-events-buffer) and has a working equivalent benchmark to the one I'm trying to create here.