### PR TITLE
Fix a typo in terminology documentation

### DIFF
--- a/Documentation/concepts/terminology.rst
+++ b/Documentation/concepts/terminology.rst
@@ -293,7 +293,7 @@ Node
 
 Cilium refers to a node as an individual member of a cluster. Each node must be
 running the ``cilium-agent`` and will operate in a mostly autonomous manner.
-Synchronization of state between Cilium agent's running on different nodes is
+Synchronization of state between Cilium agents running on different nodes is
 kept to a minimum for simplicity and scale. It occurs exclusively via the
 Key-Value store or with packet metadata.
 


### PR DESCRIPTION
Signed-off-by: Didier Durand <durand.didier@gmail.com>

this is a re-opening of https://github.com/cilium/cilium/pull/14172 now with proper sign-off
