### PR TITLE
ci/helpers: Delete CRDs in CleanupCiliumComponents

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	cnpv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers/logutils"
@@ -4394,6 +4395,8 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"service":            "cilium-agent hubble-metrics hubble-relay",
 			"secret":             "hubble-relay-client-certs hubble-server-certs",
 		}
+
+		crdsToDelete = synced.AllCRDResourceNames
 	)
 
 	wg.Add(len(resourcesToDelete))
@@ -4403,6 +4406,17 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			wg.Done()
 		}(resource, resourceType)
 	}
+
+	wg.Add(len(crdsToDelete))
+	for _, crd := range crdsToDelete {
+		// crd is of format `type:name`, e.g. "crd:ciliumnodes.cilium.io"
+		parts := strings.SplitN(crd, ":", 2)
+		go func(resource, resourceType string) {
+			_ = kub.DeleteResource(resourceType, resource)
+			wg.Done()
+		}(parts[1], parts[0])
+	}
+
 	wg.Wait()
 }
 


### PR DESCRIPTION
`CleanupCiliumComponents` is invoked before running the test suite in
order to remove any traces of Cilium in the existing cluster.  In
addition, PR #14165 also invokes this helper for the `K8sUpdates` test,
again with the goal to remove traces of the previous installation.

This change here ensures that besides deleting the Cilium pods,
configmaps and secrets, that we also remove the Cilium CRDs (network
policies, endpoints, etc) from the cluster, in order to avoid issues
where stale CRDs can interfere with the tests.

One such example of interference from stale CRDs is CI flake #13833,
which this change (in conjunction with PR #14165) intends to fix. By
removing the CEPs after uninstalling the old version of Cilium in the
`K8sUpdates` suite,  we ensure that `RestartUnmanagedPodsInNamespace`
(which relies on the fact that CEPs should only exist for managed pods)
does indeed restart _all_ unmanaged pods (including the pods managed by
a previous installation of Cilium).

~Draft, because needs to be based on #14165 for proper testing~