### PR TITLE
test: quarantine flaking datapathconfig tests on 1.17

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -256,7 +256,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		SkipItIf(func() bool {
 			// Skip K8s versions for which the test is currently flaky.
-			return helpers.SkipK8sVersions(">=1.13.0 <1.17.0") && helpers.SkipQuarantined()
+			return helpers.SkipK8sVersions(">=1.13.0 <1.18.0") && helpers.SkipQuarantined()
 		}, "Check vxlan connectivity with per-endpoint routes", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                 "vxlan",
@@ -274,7 +274,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		SkipItIf(func() bool {
 			// Skip K8s versions for which the test is currently flaky.
-			return helpers.SkipK8sVersions(">=1.13.0 <1.17.0") && helpers.SkipQuarantined()
+			return helpers.SkipK8sVersions(">=1.13.0 <1.18.0") && helpers.SkipQuarantined()
 		}, "Check iptables masquerading with random-fully", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"bpf.masquerade":      "false",


### PR DESCRIPTION
this change extends quarantine for k8s-all job to 1.17 k8s version,
which will help us checking whether 1.18 job actually fails due to these
flakes.