### PR TITLE
.travis: Run race detection builds on master commits only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ jobs:
       group: edge
     - arch: amd64
       name: "amd64-race"
+      if: type != pull_request
       env:
         - RACE=1
         - BASE_IMAGE=quay.io/cilium/cilium-runtime:2020-11-16@sha256:e0a7d9cc628f93f086434d633d2ac825b9d0c2fb4c2dd6d8d926b05e85515822
         - LOCKDEBUG=1
     - arch: arm64-graviton2
       name: "arm64-graviton2-race"
+      if: type != pull_request
       env:
         - RACE=1
         - BASE_IMAGE=quay.io/cilium/cilium-runtime:2020-11-16@sha256:e0a7d9cc628f93f086434d633d2ac825b9d0c2fb4c2dd6d8d926b05e85515822


### PR DESCRIPTION
We had to temporarily subscribe to Travis CI because we consumed our 10000 free credits. Our current plan however only allows for two concurrent builds. With four builds per commit, we are constantly running behind, with Travis CI builds now taking longer to be scheduled than it takes our Jenkins tests to finish. Long gone are the days when we considered Travis CI a viable smoke test...

This pull request attempts to alleviate the issue by running our race detection builds only on master commits.