### PR TITLE
Fix for IPVLAN after init.sh partial rewrite in Go

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -277,11 +277,12 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	devices := make([]netlink.Link, 0, len(option.Config.Devices))
 	if len(option.Config.Devices) != 0 {
 		for _, device := range option.Config.Devices {
-			_, err := netlink.LinkByName(device)
+			link, err := netlink.LinkByName(device)
 			if err != nil {
 				log.WithError(err).WithField("device", device).Warn("Link does not exist")
 				return err
 			}
+			devices = append(devices, link)
 		}
 		args[initArgDevices] = strings.Join(option.Config.Devices, ";")
 	} else if option.Config.IsFlannelMasterDeviceSet() {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2322,18 +2322,25 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		addIfNotOverwritten(options, "hostFirewall", "true")
 	}
 
+	defaultIface, err := kub.GetDefaultIface()
+	if err != nil {
+		return err
+	}
+
 	if !RunsWithKubeProxy() || options["hostFirewall"] == "true" {
 		// Set devices
 		privateIface, err := kub.GetPrivateIface()
 		if err != nil {
 			return err
 		}
-		defaultIface, err := kub.GetDefaultIface()
-		if err != nil {
-			return err
-		}
+
 		devices := fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface)
 		addIfNotOverwritten(options, "devices", devices)
+	}
+
+	switch options["datapathMode"] {
+	case "ipvlan":
+		addIfNotOverwritten(options, "ipvlan.masterDevice", defaultIface)
 	}
 
 	if len(config.CiliumTestConfig.RegistryCredentials) > 0 {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -319,6 +319,35 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
+	SkipContextIf(func() bool {
+		return helpers.GetCurrentIntegration() != ""
+	}, "IPVLAN", func() {
+		It("Check connectivity with IPVLAN", func() {
+			options := map[string]string{
+				"tunnel":              "disabled",
+				"datapathMode":        "ipvlan",
+				"ipvlan.masterDevice": "eth0",
+			}
+			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
+
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+		})
+
+		It("Check connecitivity with IPVLAN in pure L3 mode", func() {
+			options := map[string]string{
+				"tunnel":               "disabled",
+				"autoDirectNodeRoutes": "true",
+				"datapathMode":         "ipvlan",
+				"ipvlan.masterDevice":  "eth0",
+				"installIptablesRules": "false",
+				"l7Proxy.enabled":      "false",
+			}
+			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
+
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+		})
+	})
+
 	Context("AutoDirectNodeRoutes", func() {
 		BeforeEach(func() {
 			SkipIfIntegration(helpers.CIIntegrationFlannel)


### PR DESCRIPTION
My previous PR #13915 introduced a regression in IPVLAN mode. This PR contains the fix and enables IPVLAN in CI.