### PR TITLE
test: Avoid use of install with NFS

### DIFF
--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
         PROJ_PATH = "src/github.com/cilium/cilium"
         VM_MEMORY = "8192"
         VM_CPUS = "4"
-        NFS = "0"
         GINKGO_TIMEOUT="150m"
         DEFAULT_KERNEL="""${sh(
             returnStdout: true,

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -128,7 +128,6 @@ pipeline {
                         TESTED_SUITE="runtime"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        NFS="0"
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -228,7 +227,6 @@ pipeline {
                         TESTED_SUITE="runtime"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        NFS="0"
                     }
                     steps {
                         sh 'cd ${TESTDIR}; ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -334,8 +334,14 @@ func (s *SSHMeta) RenderTemplateToFile(filename string, tmplt string, perm os.Fi
 		return err
 	}
 
-	cmd := fmt.Sprintf("install -m %o <(echo '%s') %s\n", perm, content, filepath.Join(s.basePath, filename))
+	dst := filepath.Join(s.basePath, filename)
+	cmd := fmt.Sprintf("echo '%s' > %s", content, dst)
 	res := s.Exec(cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("%s", res.CombineOutput())
+	}
+	cmd = fmt.Sprintf("chmod %o %s", perm, dst)
+	res = s.Exec(cmd)
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}


### PR DESCRIPTION
Running the Runtime tests in CI with NFS enabled currently fails because `install` reports a permission error when trying to change permissions of `cilium.conf.ginkgo`. This pull request switches `install` for `chmod` which works fine.

The reason for this error is that `install` relies on the `fsetxattr(2)` system call to change the permissions and, as pointed by @qmonnet, there is [no support for Extended File Attributes in NFS](https://tools.ietf.org/html/rfc8276). `install` therefore fails whereas `chmod`, which relies on `fchmodat(2)`, works fine.

That bug wasn't found when running the Runtime test with NFS locally because, for local tests, a different implementation of
`RenderTemplateToFile()` is used, one that does not rely on `install`.

I tested this by provisioning a Packet node with our Terraform script, checking Runtime tests pass with the patch and fail without.