### PR TITLE
[v1.9] hubble/observer: use event timestamp when a time range is set

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -374,7 +374,7 @@ func (r *flowsReader) Next(ctx context.Context) (*observerpb.GetFlowsResponse, e
 		}
 
 		if r.timeRange {
-			ts, err := ptypes.Timestamp(e.GetFlow().GetTime())
+			ts, err := ptypes.Timestamp(e.Timestamp)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Manually cherry-picked fix from #14168

When r.timeRange is set but the received event is not a v1.Flow (i.e.
e.GetFlow() is nil), v1.Flow(nil).GetTime() will return nil and lead to
a panic. So far, this wasn't triggered in CI because the only other
option for e.Event.(type) was *flowpb.LostEvent. These are very uncommon
and hard to trigger in CI, thus the failure was not observed to far.

Fix this by using e.Timestamp consistently which is always set.

Reference: https://github.com/cilium/cilium/pull/14168#issuecomment-734386525
Reference: https://github.com/cilium/cilium/pull/14168#issuecomment-734405743
Fixes: f40c4ce4ad65 ("hubble: Import server-side Hubble code")

```release-note
Fix potential panic in Hubble when applying time range on non-flow events, e.g. LostEvent.
```
