### PR TITLE
Add fuzzer with OSS-fuzz build script

### DIFF
--- a/test/fuzzing/fuzz.go
+++ b/test/fuzzing/fuzz.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package fuzz
+
+import (
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+func Fuzz(data []byte) int {
+	label := labels.NewLabel("test", "label", "1")
+	err := label.UnmarshalJSON(data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -1,0 +1,3 @@
+#/bin/bash -eu
+
+compile_go_fuzzer github.com/cilium/cilium/tests/fuzz Fuzz fuzz


### PR DESCRIPTION
This PR adds a fuzzer implemented with the go-fuzz fuzzing engine. Furthermore a build script is added to set up continuous fuzzing by way of OSS-fuzz.

Fuzzing is a way of testing programs wherby pseudo-random data is passed to a target application with the goal of finding bugs and vulnerabilities. In this fuzzer, the entrypoint to Cilium is the `UnmarshalJSON` implementatin in the `labels` package.

Integrating Cilium into OSS-fuzz allows Google to run all fuzzers in the Cilium project continuously free of charge. If bugs are found, maintainers get notified with detailed bug reports that include stack trace and reproducible test case. The service is offered free of charge to open source project with an implied expectation that bugs are fixed, and it has contributed to finding vulnerabilities in major open source projects like Kubernetes.

If there is interest in integrating Cilium, I will be happy to complete the integration on the OSS-fuzz side. For this at least one maintainer email address is needed.

Signed-off-by: AdamKorcz <adam@adalogics.com>
