### PR TITLE
Pr/jrajahalme/test envoy ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:1177896bebde79915fe5f9092409bf0254084b4e@sha256:50fb77af2b3fa8a902bb11b26c97c2c230fba74bdb417a645bd938278a6f81df as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:6c980c60fb96e27faae370af792217316482c2ed@sha256:4c1cc322e6a76a49839b94cc3f0b088bd0c93dda6e98eefc0fd129e4b4c55157 as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -81,7 +81,8 @@ ifeq ($(NOSTRIP),)
     GO_BUILD_LDFLAGS += -s -w
 endif
 
-CILIUM_ENVOY_SHA=$(shell grep -o "FROM.*cilium/cilium-envoy:[0-9a-fA-F]*" $(ROOT_DIR)/Dockerfile | cut -d : -f 2)
+CILIUM_ENVOY_REF=$(shell grep -o "FROM .*cilium/cilium-envoy.*:[^ ]*" $(ROOT_DIR)/Dockerfile | cut -d ' ' -f 2)
+CILIUM_ENVOY_SHA=$(shell echo $(subst @,:,$(CILIUM_ENVOY_REF)) | cut -d : -f 2)
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 
 # Use git only if in a Git repo, otherwise find the files from the file system

--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -34,7 +34,7 @@ all:
 
 install:
 ifndef DISABLE_ENVOY_INSTALLATION
-	docker create -ti --name cilium-envoy quay.io/cilium/cilium-envoy:${CILIUM_ENVOY_SHA} bash
+	docker create -ti --name cilium-envoy $(CILIUM_ENVOY_REF) bash
 	docker cp cilium-envoy:/usr/bin/cilium-envoy $(BINDIR)/cilium-envoy
 	docker rm -fv cilium-envoy
 endif

--- a/tests/testsite/private
+++ b/tests/testsite/private
@@ -1,0 +1,1 @@
+This is private.

--- a/tests/testsite/public
+++ b/tests/testsite/public
@@ -1,0 +1,1 @@
+This is public.


### PR DESCRIPTION
Switch to multi-arch Envoy build, allowing Cilium to be locally installed on both x86_64 and ARM64.

This is a necessary step in making cilium images themselves support multiple architectures.

Most of our tests likely still depend on non-multi-arch images. Update the local Envoy smoke test (`tests/envoy-smoke-test.sh`) to use multi-arch images for client (`curlimages/curl`) and server (`httpd`). To make this work the test site data is now in `tests/testsite`, and the client container is started with a local query that takes forever so that we can issue `docker exec` commands on a running container.

Amend the policies in `test/envoy-smoke-test.sh` to never completely remove the policy from the endpoints. This avoids bpf compilations/loads that otherwise took place due to policy enforcement mode changing when policy was completely removed. This change halves the execution time of the test.

```release-note
Cilium now builds and installs on ARM64 machines.
```
