### PR TITLE
Docker: Multi-arch & cross-compile build with docker buildx

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -16,6 +16,7 @@ Brenden
 Broadcom
 Brouer
 Bugtool
+Buildx
 CIDR
 CIDRs
 CRD
@@ -42,6 +43,7 @@ Datapath
 Deathstar
 Dinan
 Dockerfile
+Dockerfiles
 Elasticsearch
 FIt
 Facebook
@@ -247,6 +249,7 @@ browsable
 bugfix
 bugfixes
 bugtool
+buildx
 bytecode
 cBPF
 callee

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ JOB_BASE_NAME ?= cilium_test
 
 GO_VERSION := $(shell cat GO_VERSION)
 GO_MAJOR_AND_MINOR_VERSION := $(shell sed 's/\([0-9]\+\).\([0-9]\+\).\([0-9]\+\)/\1.\2/' GO_VERSION)
-GOARCH := $(shell $(GO) env GOARCH)
 
 DOCKER_FLAGS ?=
 

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -15,7 +15,20 @@ clean-build:
 
 veryclean: clean-build
 
-BUILDKIT_DOCKERFILE_FILTER := | sed -e "1s|^\#.*|\# syntax = docker/dockerfile:experimental|" -e "s|^RUN\(.*\)make|RUN --mount=type=cache,target=/root/.cache/go-build\1make|"
+#
+# Transform classic Dockerfiles by:
+# 1. Add the experimental syntax moniker to the first line
+# 2. Add go build caching to all RUN..make and RUN..go instructions
+#
+# Notes:
+# - These regexes need to be compatible with both GNU sed (Linux) and old AT&T sed (macOS).
+#   That's why we're using '-E' instead of '-r'.
+# - Since we're in a Makefile, all '#' and '$' characters need escaping as '\#' and '$$', respectively.
+# - We use '!' as the separator in the 's' commands as we need '/' and '|' within the expressions.
+#
+BUILDKIT_DOCKERFILE_FILTER := | sed -E \
+			   -e "1s!^\#.*!\# syntax = docker/dockerfile:experimental!" \
+			   -e "s!^RUN(.*)( make| go )!RUN --mount=type=cache,target=/root/.cache/go-build\1\2!"
 
 # Check that files needed for git-less build are up-to-date
 build-context-update: GIT_VERSION

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -1,12 +1,34 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+.PHONY: builder-info
+# nothing by default
+builder-info:
+
+DOCKER_BUILDER := default
+
 ifdef DOCKER_BUILDKIT
 
 BUILD_DIR := _build
 
 # Export with value expected by docker
 export DOCKER_BUILDKIT=1
+
+# Docker Buildx support. If DOCKER_BUILDX is defined, a builder instance 'cross'
+# on the local node is configured for amd64 and arm64 platform targets. 
+ifdef DOCKER_BUILDX
+CONTAINER_ENGINE := docker buildx
+DOCKER_PLATFORMS := linux/arm64,linux/amd64
+DOCKER_FLAGS += --push --platform $(DOCKER_PLATFORMS)
+DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
+ifeq ($(DOCKER_BUILDER),default)
+    BUILDER_SETUP := $(shell docker buildx rm cross || true && docker buildx create --name cross --platform $(DOCKER_PLATFORMS) --use)
+    DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
+endif
+endif
+
+builder-info:
+	@echo "Using Docker Buildx builder \"$(DOCKER_BUILDER)\" with build flags \"$(DOCKER_FLAGS)\"."
 
 # Clean the build directory and cache
 clean-build:
@@ -19,6 +41,7 @@ veryclean: clean-build
 # Transform classic Dockerfiles by:
 # 1. Add the experimental syntax moniker to the first line
 # 2. Add go build caching to all RUN..make and RUN..go instructions
+# 3. Apply FROM options from comments to the next FROM line (e.g., "# FROM --platform=$BUILDPLATFORM")
 #
 # Notes:
 # - These regexes need to be compatible with both GNU sed (Linux) and old AT&T sed (macOS).
@@ -28,7 +51,8 @@ veryclean: clean-build
 #
 BUILDKIT_DOCKERFILE_FILTER := | sed -E \
 			   -e "1s!^\#.*!\# syntax = docker/dockerfile:experimental!" \
-			   -e "s!^RUN(.*)( make| go )!RUN --mount=type=cache,target=/root/.cache/go-build\1\2!"
+			   -e "s!^RUN(.*)( make| go )!RUN --mount=type=cache,target=/root/.cache/go-build\1\2!" \
+			   -e '/^\# FROM --[a-z][a-z-]*=.*$$/{$$!{N; s!^\# FROM (.*)\nFROM !FROM \1 !; };}'
 
 # Check that files needed for git-less build are up-to-date
 build-context-update: GIT_VERSION
@@ -59,7 +83,9 @@ _build/%ockerfile.dockerignore: $(GIT_IGNORE_FILES) Makefile.buildkit
 _build/%ockerfile: %ockerfile _build/%ockerfile.dockerignore force
 	@-mkdir -p $(dir $@)
 	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
+ifeq ($(DOCKER_BUILDER),default)
 	@-grep "^FROM " $@ | cut -d ' ' -f2 | grep -v -e "scratch" -e "[\$$_{}]" | xargs -P4 -n1 docker pull
+endif
 
 #
 # Optionally make a shallow clone of the repo to explicitly exclude

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -22,6 +22,7 @@ LIBDIR?=$(PREFIX)/lib
 LOCALSTATEDIR?=/var
 RUNDIR?=/var/run
 CONFDIR?=/etc
+export GOARCH ?= $(shell $(GO) env GOARCH)
 
 INSTALL = install
 
@@ -29,12 +30,12 @@ CONTAINER_ENGINE?=docker
 
 # Set DOCKER_DEV_ACCOUNT with "cilium" by default
 ifeq ($(DOCKER_DEV_ACCOUNT),)
-    DOCKER_DEV_ACCOUNT="cilium"
+    DOCKER_DEV_ACCOUNT=cilium
 endif
 
 # Set DOCKER_IMAGE_TAG with "latest" by default
 ifeq ($(DOCKER_IMAGE_TAG),)
-    DOCKER_IMAGE_TAG="latest"
+    DOCKER_IMAGE_TAG=latest
 endif
 
 ifeq ($(shell uname -m),aarch64)
@@ -121,9 +122,13 @@ else
     endif
 endif
 
-
 GO_BUILD = CGO_ENABLED=0 $(GO) build
-GO_BUILD_WITH_CGO = CGO_ENABLED=1 $(GO) build
+# Currently crosscompiling only enabled for arm64 targets
+CGO_CC =
+ifeq ($(GOARCH),arm64)
+    CGO_CC = CC=aarch64-linux-gnu-gcc
+endif
+GO_BUILD_WITH_CGO = CGO_ENABLED=1 $(CGO_CC) $(GO) build
 
 ifneq ($(RACE),)
     GO_BUILD_FLAGS += -race

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -3,18 +3,82 @@
 
 UTC_DATE=$(shell date -u "+%Y-%m-%d")
 DOCKER_REGISTRY ?= quay.io
+ifeq ($(findstring /,$(DOCKER_DEV_ACCOUNT)),/)
+    # DOCKER_DEV_ACCOUNT already contains '/', assume it specifies a registry
+    IMAGE_REPOSITORY := $(DOCKER_DEV_ACCOUNT)
+else
+    IMAGE_REPOSITORY := $(DOCKER_REGISTRY)/$(DOCKER_DEV_ACCOUNT)
+endif
 
-docker-cilium-image-for-developers:
-	# DOCKER_BUILDKIT allows for faster build as well as the ability to use
-	# a dedicated dockerignore file per Dockerfile.
-	$(QUIET)DOCKER_BUILDKIT=1 $(CONTAINER_ENGINE) build \
+#
+# Template for Docker images. Paramaters are:
+# $(1) image target name
+# $(2) Dockerfile name
+# $(3) image name stem (e.g., cilium, cilium-operator, etc)
+# $(4) image tag
+# $(5) manifest target name
+#
+define DOCKER_IMAGE_TEMPLATE
+.PHONY: $(1)
+$(1): GIT_VERSION $(BUILD_DIR)/$(2) build-context-update builder-info
+	$(eval IMAGE_NAME := $(subst %,$$$$*,$(3))$(UNSTRIPPED))
+	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/$(subst %,$$*,$(2)) \
 		$(DOCKER_FLAGS) \
-		--build-arg LOCKDEBUG=${RACE}\
+		--build-arg NOSTRIP=${NOSTRIP} \
+		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg RACE=${RACE}\
-		--build-arg V=\
-		--build-arg LIBNETWORK_PLUGIN=\
-		-t $(DOCKER_DEV_ACCOUNT)/cilium-dev:latest . -f ./cilium-dev.Dockerfile
+		--build-arg V=${V} \
+		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
+		-t $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4) $(DOCKER_BUILD_DIR)
+ifneq ($(DOCKER_BUILDER),default)
+  ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
+	@echo 'Define "DOCKER_FLAGS=--push" to push the build results.'
+  else
+	docker buildx imagetools inspect $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4)
+	@echo '^^^ Images pushed, multi-arch manifest should be above. ^^^'
+  endif
+else
+	$(QUIET)$(CONTAINER_ENGINE) tag $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4) $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4) cilium/$(IMAGE_NAME):$(4)
+	@echo "Push like this when ready:"
+	@echo "${CONTAINER_ENGINE} push $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4)-${GOARCH}"
 
+.PHONY: $(5)
+$(5): $(BUILD_DIR)/$(2)
+	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh $(IMAGE_NAME) $(4)
+	$(QUIET) contrib/scripts/push_manifest.sh $(IMAGE_NAME) $(4)
+endif
+
+$(1)-unstripped: NOSTRIP=1
+$(1)-unstripped: UNSTRIPPED=-unstripped
+$(1)-unstripped: docker-cilium-image
+endef
+
+# docker-cilium-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-cilium-image,Dockerfile,cilium,$(DOCKER_IMAGE_TAG),docker-cilium-manifest))
+
+# dev-docker-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-image,Dockerfile,cilium-dev,$(DOCKER_IMAGE_TAG),docker-cilium-dev-manifest))
+
+# docker-plugin-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-plugin-image,cilium-docker-plugin.Dockerfile,docker-plugin,$(DOCKER_IMAGE_TAG),docker-plugin-manifest))
+
+# docker-hubble-relay-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-hubble-relay-image,hubble-relay.Dockerfile,hubble-relay,$(DOCKER_IMAGE_TAG),docker-hubble-relay-manifest))
+
+# docker-clustermesh-apiserver-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-clustermesh-apiserver-image,clustermesh-apiserver.Dockerfile,clustermesh-apiserver,$(DOCKER_IMAGE_TAG),docker-clustermesh-apiserver-manifest))
+
+# docker-operator-images.
+# We eat the ending of "operator" in to the stem ('%') to allow this pattern
+# to build also 'docker-operator-image', where the stem would be empty otherwise.
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-opera%-image,cilium-opera%.Dockerfile,opera%,$(DOCKER_IMAGE_TAG),docker-opera%-manifest))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image,cilium-opera%.Dockerfile,cilium-opera%,$(DOCKER_IMAGE_TAG),dev-docker-opera%-manifest))
+
+#
+# docker-*-all targets are mainly used from the CI
+#
 docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all
 
 docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped
@@ -23,172 +87,30 @@ docker-operator-images-all: docker-operator-image docker-operator-aws-image dock
 
 docker-operator-images-all-unstripped: docker-operator-image-unstripped docker-operator-aws-image-unstripped docker-operator-azure-image-unstripped docker-operator-generic-image-unstripped
 
-docker-cilium-image: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/Dockerfile \
-		$(DOCKER_FLAGS) \
-		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEBUG} \
-		--build-arg RACE=${RACE}\
-		--build-arg V=${V} \
-		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
-		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-t cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
-	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push cilium/cilium$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
-docker-cilium-image-unstripped: NOSTRIP=1
-docker-cilium-image-unstripped: UNSTRIPPED=-unstripped
-docker-cilium-image-unstripped: docker-cilium-image
+docker-image-runtime: builder-info
+	cd contrib/packaging/docker && $(CONTAINER_ENGINE) build $(DOCKER_FLAGS) -t $(IMAGE_REPOSITORY)/cilium-runtime:$(UTC_DATE) -f Dockerfile.runtime .
 
-docker-cilium-manifest:
-	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium $(DOCKER_IMAGE_TAG)
-	$(QUIET) contrib/scripts/push_manifest.sh cilium $(DOCKER_IMAGE_TAG)
-
-dev-docker-image: GIT_VERSION $(BUILD_DIR)/Dockerfile build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/Dockerfile \
-		$(DOCKER_FLAGS) \
-		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEBUG} \
-		--build-arg RACE=${RACE}\
-		--build-arg V=${V} \
-		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
-		-t $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
-	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push $(DOCKER_DEV_ACCOUNT)/cilium-dev$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
-
-dev-docker-image-unstripped: NOSTRIP=1
-dev-docker-image-unstripped: UNSTRIPPED=-unstripped
-dev-docker-image-unstripped: dev-docker-image
-
-docker-cilium-dev-manifest:
-	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium-dev $(DOCKER_IMAGE_TAG)
-	$(QUIET) contrib/scripts/push_manifest.sh cilium-dev $(DOCKER_IMAGE_TAG)
-
-# Build cilium-operator images.
-# We eat the ending of "operator" in to the stem ('%') to allow this pattern
-# to build also 'docker-operator-image', where the stem would be empty otherwise
-docker-opera%-image: GIT_VERSION $(BUILD_DIR)/cilium-opera%.Dockerfile build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build \
-		$(DOCKER_FLAGS) \
-		--build-arg BASE_IMAGE=${BASE_IMAGE} \
-		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEBUG} \
-		--build-arg RACE=${RACE}\
-		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f $(BUILD_DIR)/cilium-opera$*.Dockerfile \
-		-t cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
-	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push cilium/opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
-
-docker-operator-image-unstripped: NOSTRIP=1
-docker-operator-image-unstripped: UNSTRIPPED=-unstripped
-docker-operator-image-unstripped: docker-operator-image
-
-dev-docker-opera%-image: GIT_VERSION $(BUILD_DIR)/cilium-opera%.Dockerfile build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build \
-		$(DOCKER_FLAGS) \
-		--build-arg BASE_IMAGE=${BASE_IMAGE} \
-		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEBUG} \
-		--build-arg RACE=${RACE}\
-		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f $(BUILD_DIR)/cilium-opera$*.Dockerfile \
-		-t $(DOCKER_DEV_ACCOUNT)/cilium-opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag $(DOCKER_DEV_ACCOUNT)/cilium-opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_DEV_ACCOUNT)/cilium-opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag $(DOCKER_DEV_ACCOUNT)/cilium-opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_DEV_ACCOUNT)/cilium-opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
-	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push $(DOCKER_DEV_ACCOUNT)/cilium-opera$*$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
-
-dev-docker-operator-image-unstripped: NOSTRIP=1
-dev-docker-operator-image-unstripped: UNSTRIPPED=-unstripped
-dev-docker-operator-image-unstripped: dev-docker-operator-image
-
-docker-operator-manifest:
-	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh operator $(DOCKER_IMAGE_TAG)
-	$(QUIET) contrib/scripts/push_manifest.sh operator $(DOCKER_IMAGE_TAG)
-
-docker-plugin-image: GIT_VERSION $(BUILD_DIR)/cilium-docker-plugin.Dockerfile build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build \
-		$(DOCKER_FLAGS) \
-		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEBUG} \
-		--build-arg RACE=${RACE}\
-		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f $(BUILD_DIR)/cilium-docker-plugin.Dockerfile \
-		-t cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
-	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push cilium/docker-plugin$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
-
-docker-plugin-image-unstripped: NOSTRIP=1
-docker-plugin-image-unstripped: UNSTRIPPED=-unstripped
-docker-plugin-image-unstripped: docker-plugin-image
-
-docker-plugin-manifest:
-	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh docker-plugin $(DOCKER_IMAGE_TAG)
-	$(QUIET) contrib/scripts/push_manifest.sh docker-plugin $(DOCKER_IMAGE_TAG)
-
-docker-image-runtime:
-	cd contrib/packaging/docker && $(CONTAINER_ENGINE) build $(DOCKER_FLAGS) --build-arg ARCH=$(GOARCH) -t cilium/cilium-runtime:$(UTC_DATE) -f Dockerfile.runtime .
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-runtime:$(UTC_DATE) cilium/cilium-runtime:$(UTC_DATE)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-runtime:$(UTC_DATE) $(DOCKER_REGISTRY)/cilium/cilium-runtime:$(UTC_DATE)-${GOARCH}
+ifeq ($(DOCKER_BUILDER),default)
+	$(QUIET)$(CONTAINER_ENGINE) tag $(IMAGE_REPOSITORY)/cilium-runtime:$(UTC_DATE) $(IMAGE_REPOSITORY)/cilium-runtime:$(UTC_DATE)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag $(IMAGE_REPOSITORY)/cilium-runtime:$(UTC_DATE) cilium/cilium-runtime:$(UTC_DATE)
 
 docker-cilium-runtime-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium-runtime $(UTC_DATE)
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-runtime $(UTC_DATE)
+endif
 
-docker-image-builder:
-	$(QUIET)$(CONTAINER_ENGINE) build $(DOCKER_FLAGS) --build-arg ARCH=$(GOARCH) -t cilium/cilium-builder:$(UTC_DATE) -f Dockerfile.builder .
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-builder:$(UTC_DATE) cilium/cilium-builder:$(UTC_DATE)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium-builder:$(UTC_DATE) $(DOCKER_REGISTRY)/cilium/cilium-builder:$(UTC_DATE)-${GOARCH}
+
+docker-image-builder: builder-info
+	$(QUIET)$(CONTAINER_ENGINE) build $(DOCKER_FLAGS) -t $(IMAGE_REPOSITORY)/cilium-builder:$(UTC_DATE) -f Dockerfile.builder .
+
+ifeq ($(DOCKER_BUILDER),default)
+	$(QUIET)$(CONTAINER_ENGINE) tag $(IMAGE_REPOSITORY)/cilium-builder:$(UTC_DATE) $(IMAGE_REPOSITORY)/cilium-builder:$(UTC_DATE)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) tag $(IMAGE_REPOSITORY)/cilium-builder:$(UTC_DATE) cilium/cilium-builder:$(UTC_DATE)
 
 docker-cilium-builder-manifest:
 	@$(ECHO_CHECK) contrib/scripts/push_manifest.sh cilium-builder $(UTC_DATE)
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-builder $(UTC_DATE)
+endif
 
-docker-hubble-relay-image: $(BUILD_DIR)/hubble-relay.Dockerfile build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build \
-		$(DOCKER_FLAGS) \
-		--build-arg BASE_IMAGE=${BASE_IMAGE} \
-		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEBUG} \
-		--build-arg RACE=${RACE}\
-		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f $(BUILD_DIR)/hubble-relay.Dockerfile \
-		-t cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
-	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push cilium/hubble-relay$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
-
-docker-hubble-relay-image-unstripped: NOSTRIP=1
-docker-hubble-relay-image-unstripped: UNSTRIPPED=-unstripped
-docker-hubble-relay-image-unstripped: docker-hubble-relay-image
-
-docker-clustermesh-apiserver-image: $(BUILD_DIR)/clustermesh-apiserver.Dockerfile build-context-update
-	$(QUIET)$(CONTAINER_ENGINE) build \
-		$(DOCKER_FLAGS) \
-		--build-arg BASE_IMAGE=${BASE_IMAGE} \
-		--build-arg NOSTRIP=${NOSTRIP} \
-		--build-arg LOCKDEBUG=${LOCKDEBUG} \
-		--build-arg RACE=${RACE}\
-		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
-		-f $(BUILD_DIR)/clustermesh-apiserver.Dockerfile \
-		-t cilium/clustermesh-apiserver$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_BUILD_DIR)
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/clustermesh-apiserver$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) cilium/clustermesh-apiserver$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/clustermesh-apiserver$(UNSTRIPPED):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/cilium/clustermesh-apiserver$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)
-	@echo "Push like this when ready:"
-	@echo "${CONTAINER_ENGINE} push cilium/clustermesh-apiserver$(UNSTRIPPED):$(DOCKER_IMAGE_TAG)-${GOARCH}"
-
-docker-clustermesh-apiserver-image-unstripped: NOSTRIP=1
-docker-clustermesh-apiserver-image-unstripped: UNSTRIPPED=-unstripped
-docker-clustermesh-apiserver-image-unstripped: docker-clustermesh-apiserver-image
-
-.PHONY: docker-image-runtime docker-image-builder docker-cilium-manifest docker-cilium-dev-manifest docker-operator-manifest docker-plugin-manifest docker-cilium-runtime-manifest docker-cilium-builder-manifest
+.PHONY: docker-image-runtime docker-image-builder cilium-runtime-manifest docker-cilium-builder-manifest

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -1,5 +1,9 @@
 # (first line comment needed for DOCKER_BUILDKIT use)
 #
+# Cross-compile go, FROM comment must right before the FROM line for
+# the parameter to be applied on BuildKit builds.
+#
+# FROM --platform=$BUILDPLATFORM
 FROM docker.io/library/golang:1.15.7 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
@@ -9,7 +13,10 @@ WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker
 ARG LOCKDEBUG
 ARG RACE
 ARG NOSTRIP
-RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN make GOARCH=$TARGETARCH NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE
 
 FROM scratch
 ARG CILIUM_SHA=""

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -2,6 +2,10 @@
 #
 ARG BASE_IMAGE=scratch
 
+# Cross-compile go, FROM comment must be located right before the FROM
+# line for the parameter to be applied on BuildKit builds.
+#
+# FROM --platform=$BUILDPLATFORM
 FROM docker.io/library/golang:1.15.7 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
@@ -13,9 +17,12 @@ WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG RACE
-RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cilium-operator-azure
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN make GOARCH=$TARGETARCH NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cilium-operator-azure
 WORKDIR /go/src/github.com/cilium/cilium
-RUN make licenses-all
+RUN make GOARCH=$TARGETARCH licenses-all
 
 FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
@@ -25,7 +32,11 @@ RUN apk --update add ca-certificates
 FROM docker.io/library/golang:1.15.7 as gops
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
-RUN go get -d github.com/google/gops && \
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN GOARCH=$TARGETARCH && [ "$GOARCH" != "arm64" ] || CC="aarch64-linux-gnu-gcc" && \
+    go get -d github.com/google/gops && \
     cd /go/src/github.com/google/gops && \
     git checkout -b v0.3.14 v0.3.14 && \
     git --no-pager remote -v && \

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -2,6 +2,10 @@
 #
 ARG BASE_IMAGE=scratch
 
+# Cross-compile go, FROM comment must be located right before the FROM
+# line for the parameter to be applied on BuildKit builds.
+#
+# FROM --platform=$BUILDPLATFORM
 FROM docker.io/library/golang:1.15.7 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
@@ -13,9 +17,12 @@ WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG RACE
-RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cilium-operator-generic
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN make GOARCH=$TARGETARCH NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cilium-operator-generic
 WORKDIR /go/src/github.com/cilium/cilium
-RUN make licenses-all
+RUN make GOARCH=$TARGETARCH licenses-all
 
 FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
@@ -25,7 +32,11 @@ RUN apk --update add ca-certificates
 FROM docker.io/library/golang:1.15.7 as gops
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
-RUN go get -d github.com/google/gops && \
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN GOARCH=$TARGETARCH && [ "$GOARCH" != "arm64" ] || CC="aarch64-linux-gnu-gcc" && \
+    go get -d github.com/google/gops && \
     cd /go/src/github.com/google/gops && \
     git checkout -b v0.3.14 v0.3.14 && \
     git --no-pager remote -v && \

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -2,6 +2,10 @@
 #
 ARG BASE_IMAGE=scratch
 
+# Cross-compile go, FROM comment must be located right before the FROM
+# line for the parameter to be applied on BuildKit builds.
+#
+# FROM --platform=$BUILDPLATFORM
 FROM docker.io/library/golang:1.15.7 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
@@ -13,9 +17,12 @@ WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG RACE
-RUN make RACE=$RACE NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG cilium-operator
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN make GOARCH=$TARGETARCH RACE=$RACE NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG cilium-operator
 WORKDIR /go/src/github.com/cilium/cilium
-RUN make licenses-all
+RUN make GOARCH=$TARGETARCH licenses-all
 
 FROM docker.io/library/alpine:3.12.0 as certs
 ARG CILIUM_SHA=""
@@ -25,7 +32,11 @@ RUN apk --update add ca-certificates
 FROM docker.io/library/golang:1.15.7 as gops
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
-RUN go get -d github.com/google/gops && \
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN GOARCH=$TARGETARCH && [ "$GOARCH" != "arm64" ] || CC="aarch64-linux-gnu-gcc" && \
+    go get -d github.com/google/gops && \
     cd /go/src/github.com/google/gops && \
     git checkout -b v0.3.14 v0.3.14 && \
     git --no-pager remote -v && \

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -43,13 +43,13 @@ RUN go get -d github.com/google/gops && \
 # LLVM, bpftool, iproute2 and loopback for runtime image (cilium/packaging repo)
 #
 FROM runtime-base as tools
-ARG ARCH=amd64
 WORKDIR /tmp
 # when updating this version, also run `images/scripts/update-cni-version.sh <v>`
 # to update images/runtime/cni-version.sh
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl ca-certificates xz-utils binutils && \
+      ARCH=$(uname -m) && [ "$ARCH" != "aarch64" ] || ARCH="arm64" && [ "$ARCH" != "x86_64" ] || ARCH="amd64" && \
     curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-${ARCH}-v0.9.0.tgz -o cni-plugins-linux-${ARCH}-v0.9.0.tgz && \
     curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-${ARCH}-v0.9.0.tgz.sha512 -o cni-plugins-linux-${ARCH}-v0.9.0.tgz.sha512 && \
     sha512sum -c cni-plugins-linux-${ARCH}-v0.9.0.tgz.sha512 && \

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -2,6 +2,10 @@
 #
 ARG BASE_IMAGE=scratch
 
+# Cross-compile go, FROM comment must be located right before the FROM
+# line for the parameter to be applied on BuildKit builds.
+#
+# FROM --platform=$BUILDPLATFORM
 FROM docker.io/library/golang:1.15.7 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
@@ -10,7 +14,8 @@ WORKDIR /go/src/github.com/cilium/cilium/hubble-relay
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG RACE
-RUN make RACE=${RACE} NOSTRIP=${NOSTRIP} LOCKDEBUG=${LOCKDEBUG}
+ARG TARGETARCH
+RUN make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} LOCKDEBUG=${LOCKDEBUG}
 WORKDIR /go/src/github.com/cilium/cilium
 RUN make licenses-all
 
@@ -22,7 +27,11 @@ RUN apk --update add ca-certificates
 FROM docker.io/library/golang:1.15.7 as gops
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
-RUN go get -d github.com/google/gops && \
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+#
+ARG TARGETARCH
+RUN GOARCH=$TARGETARCH && [ "$GOARCH" != "arm64" ] || CC="aarch64-linux-gnu-gcc" && \
+    go get -d github.com/google/gops && \
     cd /go/src/github.com/google/gops && \
     git checkout -b v0.3.14 v0.3.14 && \
     git --no-pager remote -v && \


### PR DESCRIPTION
Note that this PR adds functionality that currently already exists in `images/`
to the main Dockerfiles.

Add support for Docker BuildX multi-arch builds for arm64 and amd64 to
Cilium runtime, builder, and release images. Add Go cross-compilation
support to Cilium release images to make the arm64 builds faster on
amd64 hosts.

If both DOCKER_BUILDKIT=1 and DOCKER_BUILDX=1 are defined, the
makefiles create a cross-compilation builder instance ('cross') and
switch buildx to use it.

Images depend on each other, so the images normally should be built in
a specific order.

0. Export variables

$ export DOCKER_BUILDKIT=1
$ export DOCKER_BUILDX=1
$ export DOCKER_REGISTRY=docker.io
$ export DOCKER_DEV_ACCOUNT=your-account

1. Runtime

$ make docker-image-runtime
$ docker buildx imagetools inspect ${DOCKER_REGISTRY}/${DOCKER_DEV_ACCOUNT}/cilium-runtime:2020-11-30

Then update the runtime image references in other Dockerfiles

2. Builder

$ make docker-image-builder
$ docker buildx imagetools inspect ${DOCKER_REGISTRY}/${DOCKER_DEV_ACCOUNT}/cilium-builder:2020-12-01

Update the main Cilium Dockerfile with the new builder reference

3. Hubble

Hubble builds via buildx QEMU integration, unless you have an ARM machine added to your buildx builder.

- Check out hubble branch pr/jrajahalme/docker-buildx-support

$ export IMAGE_REPOSITORY=${DOCKER_REGISTRY}/${DOCKER_DEV_ACCOUNT}
$ IMAGE_TAG=v0.7.1x CONTAINER_ENGINE="docker buildx" DOCKER_FLAGS="--push --platform=linux/arm64,linux/amd64" make image

$ docker buildx imagetools inspect ${IMAGE_REPOSITORY}/hubble:v0.7.1x

Update the main Cilium Dockerfile with the new Hubble reference

4. Cilium release images

Cilium Dockerfiles are modified for cross-compilation based on the multi-arch support in the Cilium builder image:

$ make docker-images-all
