### PR TITLE
bpf: move metrics to new cilium_metrics_v2 map

### DIFF
--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -19,6 +19,15 @@ struct bpf_elf_map __section_maps ENDPOINTS_MAP = {
 	.flags		= CONDITIONAL_PREALLOC,
 };
 
+struct bpf_elf_map __section_maps OLD_METRICS_MAP = {
+	.type		= BPF_MAP_TYPE_PERCPU_HASH,
+	.size_key	= sizeof(struct metrics_key),
+	.size_value	= sizeof(struct metrics_value),
+	.pinning	= PIN_GLOBAL_NS,
+	.max_elem	= METRICS_MAP_SIZE,
+	.flags		= CONDITIONAL_PREALLOC,
+};
+
 struct bpf_elf_map __section_maps METRICS_MAP = {
 	.type		= BPF_MAP_TYPE_PERCPU_HASH,
 	.size_key	= sizeof(struct metrics_key),

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -75,7 +75,8 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define ENDPOINTS_MAP test_cilium_lxc
 #define EVENTS_MAP test_cilium_events
 #define SIGNAL_MAP test_cilium_signals
-#define METRICS_MAP test_cilium_metrics
+#define OLD_METRICS_MAP test_cilium_metrics
+#define METRICS_MAP test_cilium_metrics_v2
 #define POLICY_CALL_MAP test_cilium_policy
 #define SOCK_OPS_MAP test_sock_ops_map
 #define IPCACHE_MAP test_cilium_ipcache

--- a/pkg/bpf/map_test.go
+++ b/pkg/bpf/map_test.go
@@ -39,6 +39,7 @@ func (s *BPFTestSuite) TestExtractCommonName(c *C) {
 	c.Assert(extractCommonName("cilium_lb4_services"), Equals, "lb4_services")
 	c.Assert(extractCommonName("cilium_lxc"), Equals, "lxc")
 	c.Assert(extractCommonName("cilium_metrics"), Equals, "metrics")
+	c.Assert(extractCommonName("cilium_metrics_v2"), Equals, "metrics")
 	c.Assert(extractCommonName("cilium_policy"), Equals, "policy")
 	c.Assert(extractCommonName("cilium_policy_1157"), Equals, "policy")
 	c.Assert(extractCommonName("cilium_policy_reserved_1"), Equals, "policy")

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -138,6 +138,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["TUNNEL_ENDPOINT_MAP_SIZE"] = fmt.Sprintf("%d", tunnel.MaxEntries)
 	cDefinesMap["ENDPOINTS_MAP"] = lxcmap.MapName
 	cDefinesMap["ENDPOINTS_MAP_SIZE"] = fmt.Sprintf("%d", lxcmap.MaxEntries)
+	cDefinesMap["OLD_METRICS_MAP"] = metricsmap.OldMapName
 	cDefinesMap["METRICS_MAP"] = metricsmap.MapName
 	cDefinesMap["METRICS_MAP_SIZE"] = fmt.Sprintf("%d", metricsmap.MaxEntries)
 	cDefinesMap["POLICY_MAP_SIZE"] = fmt.Sprintf("%d", policymap.MaxEntries)

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -50,6 +50,7 @@ var ignoredELFPrefixes = []string{
 	"cilium_lb",                  // Global
 	"cilium_lxc",                 // Global
 	"cilium_metrics",             // Global
+	"cilium_metrics_v2",          // Global
 	"cilium_nodeport_neigh",      // All nodeport neigh maps
 	"cilium_policy",              // All policy maps
 	"cilium_proxy",               // Global

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -183,7 +183,7 @@ function load_sockops_prog {
 		cilium_metrics cilium_tunnel_map cilium_encrypt_state		\
 		cilium_lb6_reverse_nat cilium_lb6_services cilium_lb6_backends	\
 		cilium_lb4_reverse_nat cilium_lb4_services cilium_lb4_backends	\
-		cilium_events"
+		cilium_events cilium_metrics_v2"
 
 	map_args=""
 	for map in $ALL_MAPS; do


### PR DESCRIPTION
With commit 38ab8f0 ("bpf: add support for SERVICE metrics") the format used to encode BPF metrics in the `cilium_metrics` map has changed.

Specifically, the set of constants used to encode the direction of a given metric has changed from

```c
  #define METRIC_INGRESS  1
  #define METRIC_EGRESS   2
```

to

```c
  #define METRIC_EGRESS   0
  #define METRIC_INGRESS  1
  #define METRIC_SERVICE  2
```

Since after an upgrade the `cilium_metrics` map is not deleted, upgrading from a version which uses the old directions encoding to a version which uses the new one causes the `cilium bpf metrics list` command to report incorrect metrics, as all the keys already present in the map will be interpreted according to the new format.

This commit fixes this by introducing a new map for metrics, `cilium_metrics_v2`, while also keeping the old one (`cilium_metrics`).

This allows to mitigate the upgrade impact by merging together the eventual items of the old map, after they have been rewritten to match the new format, with the new map ones.

This also partially mitigates the downgrade impact, as downgrading to a version which does not use the new direction scheme will not cause `cilium bpf metrics list` to report invalid metrics, although all the metrics collected with the new format in `cilium_metrics_v2` will be lost.
