### PR TITLE
test: add nil check to CiliumReport to prevent segfaults

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3139,6 +3139,11 @@ func (kub *Kubectl) CiliumReport(commands ...string) {
 		return
 	}
 
+	if kub == nil {
+		ginkgoext.GinkgoPrint("Skipped gathering logs due to kubectl not being initialized")
+		return
+	}
+
 	// Log gathering for Cilium should take at most 10 minutes. This ensures that
 	// the CiliumReport stage doesn't cause the entire CI to hang.
 


### PR DESCRIPTION
If kubectl fails to initialize, most test suites will try to run
CiliumReport to get cluster state, which will cause a segmentation fault
since kubectl is nil. This change will give us a bit more visibility
into these CI failures.