### PR TITLE
bpf: revert changes to metrics directions contants

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -409,9 +409,9 @@ enum {
 #define LB_LOOKUP_SCOPE_INT	1
 
 /* Cilium metrics direction for dropping/forwarding packet */
-#define METRIC_EGRESS   0
 #define METRIC_INGRESS  1
-#define METRIC_SERVICE  2
+#define METRIC_EGRESS   2
+#define METRIC_SERVICE  3
 
 /* Magic ctx->mark identifies packets origination and encryption status.
  *

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -109,11 +109,11 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 
 static __always_inline int
 ipv4_handle_fragmentation(struct __ctx_buff *ctx,
-			  const struct iphdr *ip4, int l4_off, int dir,
+			  const struct iphdr *ip4, int l4_off, int ct_dir,
 			  struct ipv4_frag_l4ports *ports,
 			  bool *has_l4_header)
 {
-	int ret;
+	int ret, dir;
 	bool is_fragment, not_first_fragment;
 
 	struct ipv4_frag_id frag_id = {
@@ -125,6 +125,7 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 	};
 
 	is_fragment = ipv4_is_fragment(ip4);
+	dir = ct_to_metrics_dir(ct_dir);
 
 	if (unlikely(is_fragment)) {
 		update_metrics(ctx_full_len(ctx), dir, REASON_FRAG_PACKET);

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -42,4 +42,23 @@ static __always_inline void update_metrics(__u32 bytes, __u8 direction,
 	}
 }
 
+/**
+ * ct_to_metrics_dir
+ * @direction:	1: Ingress 2: Egress 3: Service
+ * Convert a CT direction into the corresponding one for metrics.
+ */
+static __always_inline __u8 ct_to_metrics_dir(__u8 ct_dir)
+{
+	switch (ct_dir) {
+	case CT_INGRESS:
+		return METRIC_INGRESS;
+	case CT_EGRESS:
+		return METRIC_EGRESS;
+	case CT_SERVICE:
+		return METRIC_SERVICE;
+	default:
+		return 0;
+	}
+}
+
 #endif /* __LIB_METRICS__ */

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -50,9 +50,10 @@ const (
 	// dirIngress and dirEgress values should match with
 	// METRIC_INGRESS, METRIC_EGRESS and METRIC_SERVICE
 	// in bpf/lib/common.h
-	dirEgress  = 0
+	dirUnknown = 0
 	dirIngress = 1
-	dirService = 2
+	dirEgress  = 2
+	dirService = 3
 )
 
 // direction is the metrics direction i.e ingress (to an endpoint),
@@ -60,8 +61,9 @@ const (
 // outside or a ClusterIP service being accessed from inside the cluster).
 // If it's none of the above, we return UNKNOWN direction.
 var direction = map[uint8]string{
-	dirEgress:  "EGRESS",
+	dirUnknown: "UNKNOWN",
 	dirIngress: "INGRESS",
+	dirEgress:  "EGRESS",
 	dirService: "SERVICE",
 }
 
@@ -141,7 +143,7 @@ func MetricDirection(dir uint8) string {
 	if desc, ok := direction[dir]; ok {
 		return desc
 	}
-	return "UNKNOWN"
+	return direction[dirUnknown]
 }
 
 // Direction gets the direction in human readable string format


### PR DESCRIPTION
This commit partially reverts commit 38ab8f0 ("bpf: add support for
SERVICE metrics") by bringing the `METRIC_INGRESS` and `METRIC_EGRESS`
constants back to their original values.

In addition to that, it introduces the `ct_to_metrics_dir` helper which
allows to convert a CT direction into the corresponding metric one.

This mitigates any upgrade/downgrade impact caused by having keys with 2
different formats on the metrics map.

Fixes: #14175