### PR TITLE
vendor: Fix cilium/arping goroutine leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 	github.com/blang/semver v3.5.0+incompatible
-	github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753
+	github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.3.0
 	github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc60193
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753 h1:E0nVFaPUX3dO9zU8dUx15lahVRlpTfP/c6/BzLjNiwc=
-github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
+github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5 h1:4f4AuCR25RFRemzNgw1FK0ZBSr9KgJVn5MiVA9K7HpI=
+github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
 github.com/cilium/client-go v0.0.0-20201116093811-e3ac748c004a h1:8dnqGLxNuoLqXzg0o+DgCLfHZf2wZKJwxozq6fhaSEg=
 github.com/cilium/client-go v0.0.0-20201116093811-e3ac748c004a/go.mod h1:ZrEy7+wj9PjH5VMBCuu/BDlvtUAku0oVFk4MmnW9mWA=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=

--- a/vendor/github.com/cilium/arping/arping.go
+++ b/vendor/github.com/cilium/arping/arping.go
@@ -72,6 +72,7 @@ import (
 var (
 	// ErrTimeout error
 	ErrTimeout = errors.New("timeout")
+	ErrSize = errors.New("truncated")
 
 	verboseLog = log.New(ioutil.Discard, "", 0)
 	timeout    = 1 * time.Second
@@ -147,7 +148,7 @@ func PingOverIface(dstIP net.IP, iface net.Interface) (net.HardwareAddr, time.Du
 		}
 		for {
 			// receive arp response
-			response, receiveTime, err := req.receive()
+			response, receiveTime, err := req.receive(timeout)
 
 			if err != nil {
 				select {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753
+# github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5
 ## explicit
 github.com/cilium/arping
 # github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e


### PR DESCRIPTION
This fixes a privileged runtime test failure caused by leaked goroutines on arpings with no response.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Fixed Goroutine leak for unresponded ARP pings.
```
