### PR TITLE
test: Reduce build durations

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2301,7 +2301,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 			"kubeProxyReplacement": "strict",
 		}
 
-		if GetCurrentIntegration() != CIIntegrationGKE {
+		if DoesNotRunOnGKE() {
 			nodeIP, err := kub.GetNodeIPByLabel(K8s1, false)
 			if err != nil {
 				return fmt.Errorf("Cannot retrieve Node IP for k8s1: %s", err)

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -529,6 +529,16 @@ func DoesNotRunOnNetNextOr419Kernel() bool {
 	return !RunsOnNetNextOr419Kernel()
 }
 
+// RunsOnGKE returns true if the tests are running on GKE.
+func RunsOnGKE() bool {
+	return GetCurrentIntegration() == CIIntegrationGKE
+}
+
+// DoesNotRunOnGKE is the complement function of DoesNotRunOnGKE.
+func DoesNotRunOnGKE() bool {
+	return !RunsOnGKE()
+}
+
 // DoesNotHaveHosts returns a function which returns true if a CI job
 // has less VMs than the given count.
 func DoesNotHaveHosts(count int) func() bool {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -239,10 +239,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		}, 600)
 
-		It("Check connectivity with Geneve encapsulation", func() {
-			// Geneve is currently not supported on GKE
-			SkipIfIntegration(helpers.CIIntegrationGKE)
-
+		// Geneve is currently not supported on GKE
+		SkipItIf(helpers.RunsOnGKE, "Check connectivity with Geneve encapsulation", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel": "geneve",
 			}, DeployCiliumOptionsAndDNS)
@@ -284,15 +282,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	Context("DirectRouting", func() {
-		BeforeEach(func() {
-			switch {
-			case helpers.IsIntegration(helpers.CIIntegrationGKE):
-			default:
-				Skip("DirectRouting without AutoDirectNodeRoutes not supported")
-			}
-		})
-
+	// DirectRouting without AutoDirectNodeRoutes not supported outside of GKE.
+	SkipContextIf(helpers.DoesNotRunOnGKE, "DirectRouting", func() {
 		It("Check connectivity with direct routing", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                 "disabled",

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -25,95 +25,96 @@ import (
 )
 
 var _ = Describe("K8sHealthTest", func() {
+	SkipContextIf(helpers.DoesNotRunOnGKE, "cilium-health", func() {
+		var (
+			kubectl        *helpers.Kubectl
+			ciliumFilename string
+		)
 
-	var (
-		kubectl        *helpers.Kubectl
-		ciliumFilename string
-	)
+		BeforeAll(func() {
+			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-	BeforeAll(func() {
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+		})
 
-		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
-	})
+		AfterFailed(func() {
+			kubectl.CiliumReport("cilium endpoint list")
+		})
 
-	AfterFailed(func() {
-		kubectl.CiliumReport("cilium endpoint list")
-	})
+		JustAfterEach(func() {
+			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		})
 
-	JustAfterEach(func() {
-		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-	})
+		AfterEach(func() {
+			ExpectAllPodsTerminated(kubectl)
+		})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
+		AfterAll(func() {
+			UninstallCiliumFromManifest(kubectl, ciliumFilename)
+			kubectl.CloseSSHClient()
+		})
 
-	AfterAll(func() {
-		UninstallCiliumFromManifest(kubectl, ciliumFilename)
-		kubectl.CloseSSHClient()
-	})
+		getCilium := func(node string) (pod, ip string) {
+			pod, err := kubectl.GetCiliumPodOnNodeWithLabel(node)
+			Expect(err).Should(BeNil())
 
-	getCilium := func(node string) (pod, ip string) {
-		pod, err := kubectl.GetCiliumPodOnNodeWithLabel(node)
-		Expect(err).Should(BeNil())
+			res, err := kubectl.Get(
+				helpers.CiliumNamespace,
+				fmt.Sprintf("pod %s", pod)).Filter("{.status.podIP}")
+			Expect(err).Should(BeNil())
+			ip = res.String()
 
-		res, err := kubectl.Get(
-			helpers.CiliumNamespace,
-			fmt.Sprintf("pod %s", pod)).Filter("{.status.podIP}")
-		Expect(err).Should(BeNil())
-		ip = res.String()
-
-		return pod, ip
-	}
-
-	checkIP := func(pod, ip string) {
-		jsonpath := "{.nodes[*].host.primary-address.ip}"
-		ciliumCmd := fmt.Sprintf("cilium-health status -o jsonpath='%s'", jsonpath)
-
-		err := kubectl.CiliumExecUntilMatch(pod, ciliumCmd, ip)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Never saw cilium-health ip %s in pod %s", ip, pod)
-	}
-
-	It("checks cilium-health status between nodes", func() {
-		SkipIfIntegration(helpers.CIIntegrationFlannel)
-
-		cilium1, cilium1IP := getCilium(helpers.K8s1)
-		cilium2, cilium2IP := getCilium(helpers.K8s2)
-
-		By("checking that cilium API exposes health instances")
-		checkIP(cilium1, cilium1IP)
-		checkIP(cilium1, cilium2IP)
-		checkIP(cilium2, cilium1IP)
-		checkIP(cilium2, cilium2IP)
-
-		By("checking that `cilium-health --probe` succeeds")
-		healthCmd := "cilium-health status --probe -o json"
-		status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd)
-		Expect(status.Stdout()).ShouldNot(ContainSubstring("error"))
-
-		apiPaths := []string{
-			"endpoint.icmp",
-			"endpoint.http",
-			"host.primary-address.icmp",
-			"host.primary-address.http",
+			return pod, ip
 		}
-		for node := 0; node <= 1; node++ {
-			healthCmd := "cilium-health status -o json"
-			status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd, "Cannot retrieve health status")
-			for _, path := range apiPaths {
-				filter := fmt.Sprintf("{.nodes[%d].%s}", node, path)
-				By("checking API response for %q", filter)
-				data, err := status.Filter(filter)
-				Expect(err).To(BeNil(), "cannot retrieve filter %q from health output", filter)
-				Expect(data.String()).Should(Not((BeEmpty())))
-				statusFilter := fmt.Sprintf("{.nodes[%d].%s.status}", node, path)
-				By("checking API status response for %q", statusFilter)
-				data, err = status.Filter(statusFilter)
-				Expect(err).To(BeNil(), "cannot retrieve filter %q from health output", statusFilter)
-				Expect(data.String()).Should(BeEmpty())
+
+		checkIP := func(pod, ip string) {
+			jsonpath := "{.nodes[*].host.primary-address.ip}"
+			ciliumCmd := fmt.Sprintf("cilium-health status -o jsonpath='%s'", jsonpath)
+
+			err := kubectl.CiliumExecUntilMatch(pod, ciliumCmd, ip)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Never saw cilium-health ip %s in pod %s", ip, pod)
+		}
+
+		It("Checks status between nodes", func() {
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
+
+			cilium1, cilium1IP := getCilium(helpers.K8s1)
+			cilium2, cilium2IP := getCilium(helpers.K8s2)
+
+			By("checking that cilium API exposes health instances")
+			checkIP(cilium1, cilium1IP)
+			checkIP(cilium1, cilium2IP)
+			checkIP(cilium2, cilium1IP)
+			checkIP(cilium2, cilium2IP)
+
+			By("checking that `cilium-health --probe` succeeds")
+			healthCmd := "cilium-health status --probe -o json"
+			status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd)
+			Expect(status.Stdout()).ShouldNot(ContainSubstring("error"))
+
+			apiPaths := []string{
+				"endpoint.icmp",
+				"endpoint.http",
+				"host.primary-address.icmp",
+				"host.primary-address.http",
 			}
-		}
-	}, 30)
+			for node := 0; node <= 1; node++ {
+				healthCmd := "cilium-health status -o json"
+				status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd, "Cannot retrieve health status")
+				for _, path := range apiPaths {
+					filter := fmt.Sprintf("{.nodes[%d].%s}", node, path)
+					By("checking API response for %q", filter)
+					data, err := status.Filter(filter)
+					Expect(err).To(BeNil(), "cannot retrieve filter %q from health output", filter)
+					Expect(data.String()).Should(Not((BeEmpty())))
+					statusFilter := fmt.Sprintf("{.nodes[%d].%s.status}", node, path)
+					By("checking API status response for %q", statusFilter)
+					data, err = status.Filter(statusFilter)
+					Expect(err).To(BeNil(), "cannot retrieve filter %q from health output", statusFilter)
+					Expect(data.String()).Should(BeEmpty())
+				}
+			}
+		}, 30)
+	})
 })

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -960,7 +960,7 @@ var _ = Describe("K8sServicesTest", func() {
 				}...)
 			}
 
-			if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
+			if helpers.RunsOnGKE() {
 				// Testing LoadBalancer types subject to bpf_sock.
 				lbIP, err := kubectl.GetLoadBalancerIP(helpers.DefaultNamespace, "test-lb", 60*time.Second)
 				Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")

--- a/test/k8sT/cli.go
+++ b/test/k8sT/cli.go
@@ -25,123 +25,125 @@ import (
 )
 
 var _ = Describe("K8sCLI", func() {
-	var kubectl *helpers.Kubectl
-	var ciliumFilename string
-
-	BeforeAll(func() {
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
-		ExpectCiliumReady(kubectl)
-	})
-
-	AfterAll(func() {
-		UninstallCiliumFromManifest(kubectl, ciliumFilename)
-	})
-
-	JustAfterEach(func() {
-		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-	})
-
-	SkipContextIf(helpers.DoesNotRunOnGKE, "Identity CLI testing", func() {
-		const (
-			manifestYAML = "test-cli.yaml"
-			fooID        = "foo"
-			fooSHA       = "a83c739e630049e46b9ac6883dc2682b31bf8472b09c8bb81d87092a51d14ddf"
-			fooNode      = "k8s1"
-			// These labels are automatically added to all pods in the default namespace.
-			defaultLabels = "k8s:io.cilium.k8s.policy.cluster=default " +
-				"k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default"
-		)
-
-		var (
-			cliManifest string
-			ciliumPod   string
-			err         error
-			identity    int64
-		)
+	SkipContextIf(helpers.DoesNotRunOnGKE, "CLI", func() {
+		var kubectl *helpers.Kubectl
+		var ciliumFilename string
 
 		BeforeAll(func() {
-			cliManifest = helpers.ManifestGet(kubectl.BasePath(), manifestYAML)
-			res := kubectl.ApplyDefault(cliManifest)
-			res.ExpectSuccess("Unable to apply %s", cliManifest)
-			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l id", helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "The pods were not ready after timeout")
+			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-			ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel(fooNode)
-			Expect(err).Should(BeNil())
-
-			err := kubectl.WaitForCEPIdentity(helpers.DefaultNamespace, fooID)
-			Expect(err).Should(BeNil())
-
-			ep, err := kubectl.GetCiliumEndpoint(helpers.DefaultNamespace, fooID)
-			Expect(err).Should(BeNil(), fmt.Sprintf("Unable to get CEP for pod %s", fooID))
-			identity = ep.Identity.ID
+			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+			ExpectCiliumReady(kubectl)
 		})
 
 		AfterAll(func() {
-			_ = kubectl.Delete(cliManifest)
-			ExpectAllPodsTerminated(kubectl)
+			UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		})
 
-		It("Test labelsSHA256", func() {
-			cmd := fmt.Sprintf("cilium identity get %d -o json", identity)
-			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
-			res.ExpectSuccess()
-			out, err := res.Filter("{[0].labelsSHA256}")
-			Expect(err).Should(BeNil(), "Error getting SHA from identity")
-			Expect(out.String()).Should(Equal(fooSHA))
+		JustAfterEach(func() {
+			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		})
 
-		It("Test identity list", func() {
-			By("Testing 'cilium identity list' for an endpoint's identity")
-			cmd := fmt.Sprintf("cilium identity list k8s:id=%s %s", fooID, defaultLabels)
-			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
-			res.ExpectSuccess(fmt.Sprintf("Unable to get identity list output for label k8s:id=%s %s", fooID, defaultLabels))
+		Context("Identity CLI testing", func() {
+			const (
+				manifestYAML = "test-cli.yaml"
+				fooID        = "foo"
+				fooSHA       = "a83c739e630049e46b9ac6883dc2682b31bf8472b09c8bb81d87092a51d14ddf"
+				fooNode      = "k8s1"
+				// These labels are automatically added to all pods in the default namespace.
+				defaultLabels = "k8s:io.cilium.k8s.policy.cluster=default " +
+					"k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default"
+			)
 
-			resSingleOut := res.SingleOut()
-			containsIdentity := strings.Contains(resSingleOut, fmt.Sprintf("%d", identity))
-			Expect(containsIdentity).To(BeTrue(), "Identity %d of endpoint %s not in 'cilium identity list' output", identity, resSingleOut)
+			var (
+				cliManifest string
+				ciliumPod   string
+				err         error
+				identity    int64
+			)
 
-			By("Testing 'cilium identity list' for reserved identities")
-			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium identity list")
-			res.ExpectSuccess("Unable to get identity list output")
-			resSingleOut = res.SingleOut()
+			BeforeAll(func() {
+				cliManifest = helpers.ManifestGet(kubectl.BasePath(), manifestYAML)
+				res := kubectl.ApplyDefault(cliManifest)
+				res.ExpectSuccess("Unable to apply %s", cliManifest)
+				err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l id", helpers.HelperTimeout)
+				Expect(err).Should(BeNil(), "The pods were not ready after timeout")
 
-			reservedIdentities := []string{"health", "host", "world", "init"}
-			for _, id := range reservedIdentities {
-				By("Checking that reserved identity '%s' is in 'cilium identity list' output", id)
-				containsReservedIdentity := strings.Contains(resSingleOut, id)
-				Expect(containsReservedIdentity).To(BeTrue(), "Reserved identity '%s' not in 'cilium identity list' output", id)
-			}
+				ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel(fooNode)
+				Expect(err).Should(BeNil())
+
+				err := kubectl.WaitForCEPIdentity(helpers.DefaultNamespace, fooID)
+				Expect(err).Should(BeNil())
+
+				ep, err := kubectl.GetCiliumEndpoint(helpers.DefaultNamespace, fooID)
+				Expect(err).Should(BeNil(), fmt.Sprintf("Unable to get CEP for pod %s", fooID))
+				identity = ep.Identity.ID
+			})
+
+			AfterAll(func() {
+				_ = kubectl.Delete(cliManifest)
+				ExpectAllPodsTerminated(kubectl)
+			})
+
+			It("Test labelsSHA256", func() {
+				cmd := fmt.Sprintf("cilium identity get %d -o json", identity)
+				res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
+				res.ExpectSuccess()
+				out, err := res.Filter("{[0].labelsSHA256}")
+				Expect(err).Should(BeNil(), "Error getting SHA from identity")
+				Expect(out.String()).Should(Equal(fooSHA))
+			})
+
+			It("Test identity list", func() {
+				By("Testing 'cilium identity list' for an endpoint's identity")
+				cmd := fmt.Sprintf("cilium identity list k8s:id=%s %s", fooID, defaultLabels)
+				res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
+				res.ExpectSuccess(fmt.Sprintf("Unable to get identity list output for label k8s:id=%s %s", fooID, defaultLabels))
+
+				resSingleOut := res.SingleOut()
+				containsIdentity := strings.Contains(resSingleOut, fmt.Sprintf("%d", identity))
+				Expect(containsIdentity).To(BeTrue(), "Identity %d of endpoint %s not in 'cilium identity list' output", identity, resSingleOut)
+
+				By("Testing 'cilium identity list' for reserved identities")
+				res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium identity list")
+				res.ExpectSuccess("Unable to get identity list output")
+				resSingleOut = res.SingleOut()
+
+				reservedIdentities := []string{"health", "host", "world", "init"}
+				for _, id := range reservedIdentities {
+					By("Checking that reserved identity '%s' is in 'cilium identity list' output", id)
+					containsReservedIdentity := strings.Contains(resSingleOut, id)
+					Expect(containsReservedIdentity).To(BeTrue(), "Reserved identity '%s' not in 'cilium identity list' output", id)
+				}
+			})
 		})
-	})
 
-	SkipContextIf(helpers.DoesNotRunOnGKE, "stdout/stderr testing", func() {
-		var (
-			ciliumPod string
-			err       error
-		)
+		Context("stdout/stderr testing", func() {
+			var (
+				ciliumPod string
+				err       error
+			)
 
-		BeforeAll(func() {
-			ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel("k8s1")
-			Expect(err).Should(BeNil())
-		})
+			BeforeAll(func() {
+				ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel("k8s1")
+				Expect(err).Should(BeNil())
+			})
 
-		It("Root command help should print to stdout", func() {
-			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium help")
-			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium [command] --help\" for more information about a command."))
-		})
+			It("Root command help should print to stdout", func() {
+				res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium help")
+				Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium [command] --help\" for more information about a command."))
+			})
 
-		It("Subcommand help should print to stdout", func() {
-			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium help bpf")
-			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium bpf [command] --help\" for more information about a command."))
-		})
+			It("Subcommand help should print to stdout", func() {
+				res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium help bpf")
+				Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium bpf [command] --help\" for more information about a command."))
+			})
 
-		It("Failed subcommand should print help to stdout", func() {
-			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium endpoint confi 173")
-			Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium endpoint [command] --help\" for more information about a command."))
+			It("Failed subcommand should print help to stdout", func() {
+				res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium endpoint confi 173")
+				Expect(res.Stdout()).Should(ContainSubstring("Use \"cilium endpoint [command] --help\" for more information about a command."))
+			})
 		})
 	})
 })

--- a/test/k8sT/cli.go
+++ b/test/k8sT/cli.go
@@ -44,9 +44,7 @@ var _ = Describe("K8sCLI", func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	SkipContextIf(func() bool {
-		return !helpers.IsIntegration(helpers.CIIntegrationGKE)
-	}, "Identity CLI testing", func() {
+	SkipContextIf(helpers.DoesNotRunOnGKE, "Identity CLI testing", func() {
 		const (
 			manifestYAML = "test-cli.yaml"
 			fooID        = "foo"
@@ -120,9 +118,7 @@ var _ = Describe("K8sCLI", func() {
 		})
 	})
 
-	SkipContextIf(func() bool {
-		return !helpers.IsIntegration(helpers.CIIntegrationGKE)
-	}, "stdout/stderr testing", func() {
+	SkipContextIf(helpers.DoesNotRunOnGKE, "stdout/stderr testing", func() {
 		var (
 			ciliumPod string
 			err       error

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -32,129 +32,109 @@ import (
 )
 
 var _ = Describe("K8sHubbleTest", func() {
-
-	var (
-		kubectl        *helpers.Kubectl
-		ciliumFilename string
-		k8s1NodeName   string
-		ciliumPodK8s1  string
-
-		hubbleRelayNamespace = helpers.CiliumNamespace
-		hubbleRelayService   = "hubble-relay"
-		hubbleRelayAddress   string
-
-		demoPath string
-
-		app1Service    = "app1-service"
-		app1Labels     = "id=app1,zgroup=testapp"
-		apps           = []string{helpers.App1, helpers.App2, helpers.App3}
-		prometheusPort = "9091"
-	)
-
-	addVisibilityAnnotation := func(ns, podLabels, direction, port, l4proto, l7proto string) {
-		visibilityAnnotation := fmt.Sprintf("<%s/%s/%s/%s>", direction, port, l4proto, l7proto)
-		By("Adding visibility annotation %s on pod with labels %s", visibilityAnnotation, podLabels)
-
-		// Prints <node>=<ns>/<podname> for each pod the annotation was applied to
-		res := kubectl.Exec(fmt.Sprintf("%s annotate pod -n %s -l %s %s=%q"+
-			" -o 'jsonpath={.spec.nodeName}={.metadata.namespace}/{.metadata.name}{\"\\n\"}'",
-			helpers.KubectlCmd,
-			ns, app1Labels,
-			annotation.ProxyVisibility, visibilityAnnotation))
-		res.ExpectSuccess("adding proxy visibility annotation failed")
-
-		// For each pod, check that the Cilium proxy-statistics contain the new annotation
-		expectedProxyState := strings.ToLower(visibilityAnnotation)
-		for node, podName := range res.KVOutput() {
-			ciliumPod, err := kubectl.GetCiliumPodOnNode(node)
-			Expect(err).To(BeNil())
-
-			// Extract annotation from endpoint model of pod. It does not have the l4proto, so we insert it manually.
-			cmd := fmt.Sprintf("cilium endpoint get pod-name:%s"+
-				" -o jsonpath='{range [*].status.policy.proxy-statistics[*]}<{.location}/{.port}/%s/{.protocol}>{\"\\n\"}{end}'",
-				podName, strings.ToLower(l4proto))
-			err = kubectl.CiliumExecUntilMatch(ciliumPod, cmd, expectedProxyState)
-			Expect(err).To(BeNil(), "timed out waiting for endpoint to regenerate for visibility annotation")
-		}
-	}
-
-	removeVisibilityAnnotation := func(ns, podLabels string) {
-		By("Removing visibility annotation on pod with labels %s", app1Labels)
-		res := kubectl.Exec(fmt.Sprintf("%s annotate pod -n %s -l %s %s-", helpers.KubectlCmd, ns, podLabels, annotation.ProxyVisibility))
-		res.ExpectSuccess("removing proxy visibility annotation failed")
-	}
-
-	hubbleObserveUntilMatch := func(hubblePod, args, filter, expected string, timeout time.Duration) {
-		hubbleObserve := func() bool {
-			res := kubectl.HubbleObserve(hubblePod, args)
-			res.ExpectSuccess("hubble observe invocation failed: %q", res.OutputPrettyPrint())
-
-			lines, err := res.FilterLines(filter)
-			Expect(err).Should(BeNil(), "hubble observe: invalid filter: %q", filter)
-
-			for _, line := range lines {
-				if line.String() == expected {
-					return true
-				}
-			}
-
-			return false
-		}
-
-		Eventually(hubbleObserve, timeout).Should(BeTrue(),
-			"hubble observe: filter %q never matched expected string %q", filter, expected)
-	}
-
-	BeforeAll(func() {
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		k8s1NodeName, _ = kubectl.GetNodeInfo(helpers.K8s1)
-
-		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
-
-		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-			"hubble.metrics.enabled": `"{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"`,
-			"hubble.relay.enabled":   "true",
-		})
-
-		var err error
-		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
-		Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
-
-		ExpectHubbleRelayReady(kubectl, hubbleRelayNamespace)
-		hubbleRelayIP, hubbleRelayPort, err := kubectl.GetServiceHostPort(hubbleRelayNamespace, hubbleRelayService)
-		Expect(err).Should(BeNil(), "Cannot get service %s", hubbleRelayService)
-		Expect(govalidator.IsIP(hubbleRelayIP)).Should(BeTrue(), "hubbleRelayIP is not an IP")
-		hubbleRelayAddress = net.JoinHostPort(hubbleRelayIP, strconv.Itoa(hubbleRelayPort))
-	})
-
-	AfterFailed(func() {
-		kubectl.CiliumReport("cilium endpoint list")
-	})
-
-	JustAfterEach(func() {
-		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-	})
-
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
-	AfterAll(func() {
-		kubectl.DeleteHubbleRelay(hubbleRelayNamespace)
-		UninstallCiliumFromManifest(kubectl, ciliumFilename)
-		kubectl.CloseSSHClient()
-	})
-
-	Context("Hubble Observe", func() {
+	// We want to run Hubble tests both with and without our kube-proxy
+	// replacement, as the trace events depend on it. We thus run the tests
+	// on GKE and our 4.9 pipeline.
+	SkipContextIf(helpers.RunsOnNetNextOr419Kernel, "Hubble Observe", func() {
 		var (
+			kubectl        *helpers.Kubectl
+			ciliumFilename string
+			k8s1NodeName   string
+			ciliumPodK8s1  string
+
+			hubbleRelayNamespace = helpers.CiliumNamespace
+			hubbleRelayService   = "hubble-relay"
+			hubbleRelayAddress   string
+
+			demoPath string
+
+			app1Service    = "app1-service"
+			app1Labels     = "id=app1,zgroup=testapp"
+			apps           = []string{helpers.App1, helpers.App2, helpers.App3}
+			prometheusPort = "9091"
+
 			namespaceForTest string
 			appPods          map[string]string
 			app1ClusterIP    string
 			app1Port         int
 		)
 
+		addVisibilityAnnotation := func(ns, podLabels, direction, port, l4proto, l7proto string) {
+			visibilityAnnotation := fmt.Sprintf("<%s/%s/%s/%s>", direction, port, l4proto, l7proto)
+			By("Adding visibility annotation %s on pod with labels %s", visibilityAnnotation, podLabels)
+
+			// Prints <node>=<ns>/<podname> for each pod the annotation was applied to
+			res := kubectl.Exec(fmt.Sprintf("%s annotate pod -n %s -l %s %s=%q"+
+				" -o 'jsonpath={.spec.nodeName}={.metadata.namespace}/{.metadata.name}{\"\\n\"}'",
+				helpers.KubectlCmd,
+				ns, app1Labels,
+				annotation.ProxyVisibility, visibilityAnnotation))
+			res.ExpectSuccess("adding proxy visibility annotation failed")
+
+			// For each pod, check that the Cilium proxy-statistics contain the new annotation
+			expectedProxyState := strings.ToLower(visibilityAnnotation)
+			for node, podName := range res.KVOutput() {
+				ciliumPod, err := kubectl.GetCiliumPodOnNode(node)
+				Expect(err).To(BeNil())
+
+				// Extract annotation from endpoint model of pod. It does not have the l4proto, so we insert it manually.
+				cmd := fmt.Sprintf("cilium endpoint get pod-name:%s"+
+					" -o jsonpath='{range [*].status.policy.proxy-statistics[*]}<{.location}/{.port}/%s/{.protocol}>{\"\\n\"}{end}'",
+					podName, strings.ToLower(l4proto))
+				err = kubectl.CiliumExecUntilMatch(ciliumPod, cmd, expectedProxyState)
+				Expect(err).To(BeNil(), "timed out waiting for endpoint to regenerate for visibility annotation")
+			}
+		}
+
+		removeVisibilityAnnotation := func(ns, podLabels string) {
+			By("Removing visibility annotation on pod with labels %s", app1Labels)
+			res := kubectl.Exec(fmt.Sprintf("%s annotate pod -n %s -l %s %s-", helpers.KubectlCmd, ns, podLabels, annotation.ProxyVisibility))
+			res.ExpectSuccess("removing proxy visibility annotation failed")
+		}
+
+		hubbleObserveUntilMatch := func(hubblePod, args, filter, expected string, timeout time.Duration) {
+			hubbleObserve := func() bool {
+				res := kubectl.HubbleObserve(hubblePod, args)
+				res.ExpectSuccess("hubble observe invocation failed: %q", res.OutputPrettyPrint())
+
+				lines, err := res.FilterLines(filter)
+				Expect(err).Should(BeNil(), "hubble observe: invalid filter: %q", filter)
+
+				for _, line := range lines {
+					if line.String() == expected {
+						return true
+					}
+				}
+
+				return false
+			}
+
+			Eventually(hubbleObserve, timeout).Should(BeTrue(),
+				"hubble observe: filter %q never matched expected string %q", filter, expected)
+		}
+
 		BeforeAll(func() {
+			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+			k8s1NodeName, _ = kubectl.GetNodeInfo(helpers.K8s1)
+
+			demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+
+			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"hubble.metrics.enabled": `"{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"`,
+				"hubble.relay.enabled":   "true",
+			})
+
+			var err error
+			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
+
+			ExpectHubbleRelayReady(kubectl, hubbleRelayNamespace)
+			hubbleRelayIP, hubbleRelayPort, err := kubectl.GetServiceHostPort(hubbleRelayNamespace, hubbleRelayService)
+			Expect(err).Should(BeNil(), "Cannot get service %s", hubbleRelayService)
+			Expect(govalidator.IsIP(hubbleRelayIP)).Should(BeTrue(), "hubbleRelayIP is not an IP")
+			hubbleRelayAddress = net.JoinHostPort(hubbleRelayIP, strconv.Itoa(hubbleRelayPort))
+
 			namespaceForTest = helpers.GenerateNamespaceForTest("")
 			kubectl.NamespaceDelete(namespaceForTest)
 			res := kubectl.NamespaceCreate(namespaceForTest)
@@ -163,7 +143,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			res = kubectl.Apply(helpers.ApplyOptions{FilePath: demoPath, Namespace: namespaceForTest})
 			res.ExpectSuccess("could not create resource")
 
-			err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
+			err = kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "test pods are not ready after timeout")
 
 			appPods = helpers.GetAppPods(apps, namespaceForTest, kubectl, "id")
@@ -171,9 +151,25 @@ var _ = Describe("K8sHubbleTest", func() {
 			Expect(err).To(BeNil(), "unable to find service in %q namespace", namespaceForTest)
 		})
 
+		AfterFailed(func() {
+			kubectl.CiliumReport("cilium endpoint list")
+		})
+
+		JustAfterEach(func() {
+			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		})
+
+		AfterEach(func() {
+			ExpectAllPodsTerminated(kubectl)
+		})
+
 		AfterAll(func() {
 			kubectl.Delete(demoPath)
 			kubectl.NamespaceDelete(namespaceForTest)
+
+			kubectl.DeleteHubbleRelay(hubbleRelayNamespace)
+			UninstallCiliumFromManifest(kubectl, ciliumFilename)
+			kubectl.CloseSSHClient()
 		})
 
 		It("Test L3/L4 Flow", func() {


### PR DESCRIPTION
Summary of commits:
1. Adds some helper functions to help in subsequent commits.
3. Limits K8sHubble to run on GKE and 4.9 only.
2. Limits K8sIdentity and K8sHealth to run on GKE only.
4. and 5. Avoid installing Cilium for tests that are skipped or quarantined.