### PR TITLE
bpf: Fix program size issue with host firewall in IPv4-only mode

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -7,6 +7,8 @@
 #include <node_config.h>
 #include <ep_config.h>
 
+#define IS_BPF_HOST
+
 #define EVENT_SOURCE HOST_EP_ID
 
 /* These are configuration options which have a default value in their

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -7,7 +7,7 @@
 /* Only compile in if host firewall is enabled and file is included from
  * bpf_host.
  */
-#if defined(ENABLE_HOST_FIREWALL) && defined(HOST_EP_ID)
+#if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
 
 # include "policy.h"
 # include "policy_log.h"
@@ -421,5 +421,5 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id)
 	return CTX_ACT_OK;
 }
 # endif /* ENABLE_IPV4 */
-#endif /* ENABLE_HOST_FIREWALL && HOST_EP_ID */
+#endif /* ENABLE_HOST_FIREWALL && IS_BPF_HOST */
 #endif /* __LIB_HOST_FIREWALL_H_ */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -817,7 +817,7 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 {
 	int ifindex = 0;
 	int ret = 0;
-#if defined(ENABLE_HOST_FIREWALL) && defined(HOST_EP_ID)
+#if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
 	/* We only enforce the host policies if nodeport.h is included from
 	 * bpf_host.
 	 */
@@ -839,7 +839,10 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	return ctx_redirect(ctx, ifindex, 0);
 }
 
-declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+			       is_defined(ENABLE_IPV6)),
+			 __and(is_defined(ENABLE_HOST_FIREWALL),
+			       is_defined(IS_BPF_HOST))),
 		    CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT)
 int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 {
@@ -1596,7 +1599,7 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 {
 	int ifindex = 0;
 	int ret = 0;
-#if defined(ENABLE_HOST_FIREWALL) && defined(HOST_EP_ID)
+#if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
 	/* We only enforce the host policies if nodeport.h is included from
 	 * bpf_host.
 	 */
@@ -1618,7 +1621,10 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 	return ctx_redirect(ctx, ifindex, 0);
 }
 
-declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+			       is_defined(ENABLE_IPV6)),
+			 __and(is_defined(ENABLE_HOST_FIREWALL),
+			       is_defined(IS_BPF_HOST))),
 		    CILIUM_CALL_IPV4_ENCAP_NODEPORT_NAT)
 int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 {
@@ -1636,14 +1642,20 @@ static __always_inline int nodeport_nat_fwd(struct __ctx_buff *ctx)
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+					      is_defined(ENABLE_IPV6)),
+					__and(is_defined(ENABLE_HOST_FIREWALL),
+					      is_defined(IS_BPF_HOST))),
 				   CILIUM_CALL_IPV4_ENCAP_NODEPORT_NAT,
 				   tail_handle_nat_fwd_ipv4);
 		break;
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+					      is_defined(ENABLE_IPV6)),
+					__and(is_defined(ENABLE_HOST_FIREWALL),
+					      is_defined(IS_BPF_HOST))),
 				   CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT,
 				   tail_handle_nat_fwd_ipv6);
 		break;


### PR DESCRIPTION
Running Cilium in IPv4-only mode with the host firewall and our kube-proxy replacement enabled causes program `to-netdev` from `bpf_host` to have an excessive size (>4096 instructions):

    level=warning msg="Prog section 'to-netdev' rejected: Argument list too long (7)!" subsys=datapath-loader
    level=warning msg=" - Type:         3" subsys=datapath-loader
    level=warning msg=" - Attach Type:  0" subsys=datapath-loader
    level=warning msg=" - Instructions: 4179 (83 over limit)" subsys=datapath-loader
    level=warning msg=" - License:      GPL" subsys=datapath-loader

The section in question consists in particular of the host firewall enforcement and the NAT+service handling via `nodeport_nat_fwd()`. That last function is only split into several programs via tail calls when both IPv4 and IPv6 are enabled.

To reduce the program size, this pull request also splits `nodeport_nat_fwd()` into several BPF programs via tail calls when the host firewall is enabled. We also need to check for `HOST_EP_ID` to only split if we're calling `nodeport_nat_fwd()` from `bpf_host`.

Fixes: https://github.com/cilium/cilium/issues/14231