### PR TITLE
hubble: allow to filter agent events

### DIFF
--- a/pkg/hubble/api/v1/interface.go
+++ b/pkg/hubble/api/v1/interface.go
@@ -24,7 +24,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
-// Flow is an interface matching pb.Flow
+// Flow is an interface matching flowpb.Flow.
 type Flow interface {
 	proto.Message
 	GetTime() *timestamp.Timestamp
@@ -50,7 +50,7 @@ type Flow interface {
 	GetDropReasonDesc() flowpb.DropReason
 }
 
-// This ensures that the protobuf definition implements the interface
+// This ensures that the protobuf definition implements the interface.
 var _ Flow = &flowpb.Flow{}
 
 // EndpointInfo defines readable fields of a Cilium endpoint.
@@ -61,3 +61,12 @@ type EndpointInfo interface {
 	GetK8sNamespace() string
 	GetLabels() []string
 }
+
+// AgentEvent is an interface matching flowpb.AgentEvent.
+type AgentEvent interface {
+	proto.Message
+	GetType() flowpb.AgentEventType
+}
+
+// This ensures that the protobuf definition implements the interface.
+var _ AgentEvent = &flowpb.AgentEvent{}

--- a/pkg/hubble/api/v1/types.go
+++ b/pkg/hubble/api/v1/types.go
@@ -39,3 +39,15 @@ func (ev *Event) GetFlow() Flow {
 	}
 	return nil
 }
+
+// GetAgentEvent returns the decoded agent event, or nil if there is no event.
+func (ev *Event) GetAgentEvent() AgentEvent {
+	if ev == nil || ev.Event == nil {
+		// returns typed nil so getter methods still work
+		return (*pb.AgentEvent)(nil)
+	}
+	if f, ok := ev.Event.(AgentEvent); ok {
+		return f
+	}
+	return nil
+}

--- a/pkg/hubble/filters/event_type_test.go
+++ b/pkg/hubble/filters/event_type_test.go
@@ -1,0 +1,146 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package filters
+
+import (
+	"context"
+	"testing"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+)
+
+func TestEventTypeFilter(t *testing.T) {
+	type args struct {
+		f  []*flowpb.FlowFilter
+		ev []*v1.Event
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    []bool
+	}{
+		{
+			name: "drop without subtype",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						EventType: []*flowpb.EventTypeFilter{
+							{
+								Type: monitorAPI.MessageTypeDrop,
+							},
+						},
+					},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{}},
+					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop}}},
+					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop, SubType: 2}}},
+					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeCapture}}},
+					{Event: &flowpb.AgentEvent{}},
+					{Event: &flowpb.LostEvent{}},
+				},
+			},
+			want: []bool{
+				false,
+				true,
+				true,
+				false,
+				false,
+				true, // always want lost events
+			},
+		},
+		{
+			name: "drop with subtype",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						EventType: []*flowpb.EventTypeFilter{
+							{
+								Type:         monitorAPI.MessageTypeDrop,
+								MatchSubType: true,
+								SubType:      2, // invalid packet
+							},
+						},
+					},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{}},
+					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop}}},
+					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop, SubType: 2}}},
+					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeCapture}}},
+					{Event: &flowpb.AgentEvent{}},
+					{Event: &flowpb.LostEvent{}},
+				},
+			},
+			want: []bool{
+				false,
+				false,
+				true,
+				false,
+				false,
+				true, // always want lost events
+			},
+		},
+		{
+			name: "agent event",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						EventType: []*flowpb.EventTypeFilter{
+							{
+								Type: monitorAPI.MessageTypeAgent,
+							},
+						},
+					},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{}},
+					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{}}},
+					{Event: &flowpb.AgentEvent{}},
+					{Event: &flowpb.AgentEvent{Type: flowpb.AgentEventType_ENDPOINT_CREATED}},
+					{Event: &flowpb.AgentEvent{Type: flowpb.AgentEventType_IPCACHE_UPSERTED}},
+					{Event: &flowpb.LostEvent{}},
+				},
+			},
+			want: []bool{
+				false,
+				false,
+				true,
+				true,
+				true,
+				true, // always want lost events
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&EventTypeFilter{}})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildFilterList() with EventTypeFilter: error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i, ev := range tt.args.ev {
+				if filterResult := fl.MatchOne(ev); filterResult != tt.want[i] {
+					t.Errorf("for event %d (%v) got %v, want %v", i, ev, filterResult, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/hubble/filters/fqdn_test.go
+++ b/pkg/hubble/filters/fqdn_test.go
@@ -217,7 +217,7 @@ func TestFQDNFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&FQDNFilter{}})
 			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildFilterList(context.Background(), ) error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("BuildFilterList() with FQDNFilter: error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			for i, ev := range tt.args.ev {

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -397,18 +397,20 @@ func (r *flowsReader) Next(ctx context.Context) (*observerpb.GetFlowsResponse, e
 			}
 		}
 
+		if !filters.Apply(r.whitelist, r.blacklist, e) {
+			continue
+		}
+
 		switch ev := e.Event.(type) {
 		case *flowpb.Flow:
-			if filters.Apply(r.whitelist, r.blacklist, e) {
-				r.flowsCount++
-				return &observerpb.GetFlowsResponse{
-					Time:     ev.GetTime(),
-					NodeName: ev.GetNodeName(),
-					ResponseTypes: &observerpb.GetFlowsResponse_Flow{
-						Flow: ev,
-					},
-				}, nil
-			}
+			r.flowsCount++
+			return &observerpb.GetFlowsResponse{
+				Time:     ev.GetTime(),
+				NodeName: ev.GetNodeName(),
+				ResponseTypes: &observerpb.GetFlowsResponse_Flow{
+					Flow: ev,
+				},
+			}, nil
 		case *flowpb.LostEvent:
 			return &observerpb.GetFlowsResponse{
 				Time:     e.Timestamp,


### PR DESCRIPTION
This PR allows to apply filters on all event types and to filter agent events specifically. Previously (with #14168 in place), agent events were always returned leading to them being interleaved with flow events in Hubble CLI output.

See cilium/hubble#442 for the respective Hubble CLI PR, adding support for `hubble observe -t agent`.