### PR TITLE
v1.9 backports 2020-12-02

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -333,7 +333,7 @@ Annotations:
 -------------------
 
 * Helm option ``nodeSelector`` is removed, please use the option for respective component
-  (e.g. ``operator.nodeSelector``, ``etc.nodeSelector`` and ``preflight.nodeSelector``) instead.
+  (e.g. ``operator.nodeSelector``, ``etcd.nodeSelector`` and ``preflight.nodeSelector``) instead.
 
 1.9 Upgrade Notes
 -----------------

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -7,6 +7,8 @@
 #include <node_config.h>
 #include <ep_config.h>
 
+#define IS_BPF_HOST
+
 #define EVENT_SOURCE HOST_EP_ID
 
 /* These are configuration options which have a default value in their

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -409,9 +409,9 @@ enum {
 #define LB_LOOKUP_SCOPE_INT	1
 
 /* Cilium metrics direction for dropping/forwarding packet */
-#define METRIC_EGRESS   0
 #define METRIC_INGRESS  1
-#define METRIC_SERVICE  2
+#define METRIC_EGRESS   2
+#define METRIC_SERVICE  3
 
 /* Magic ctx->mark identifies packets origination and encryption status.
  *

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -7,7 +7,7 @@
 /* Only compile in if host firewall is enabled and file is included from
  * bpf_host.
  */
-#if defined(ENABLE_HOST_FIREWALL) && defined(HOST_EP_ID)
+#if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
 
 # include "policy.h"
 # include "policy_log.h"
@@ -421,5 +421,5 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id)
 	return CTX_ACT_OK;
 }
 # endif /* ENABLE_IPV4 */
-#endif /* ENABLE_HOST_FIREWALL && HOST_EP_ID */
+#endif /* ENABLE_HOST_FIREWALL && IS_BPF_HOST */
 #endif /* __LIB_HOST_FIREWALL_H_ */

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -109,11 +109,11 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 
 static __always_inline int
 ipv4_handle_fragmentation(struct __ctx_buff *ctx,
-			  const struct iphdr *ip4, int l4_off, int dir,
+			  const struct iphdr *ip4, int l4_off, int ct_dir,
 			  struct ipv4_frag_l4ports *ports,
 			  bool *has_l4_header)
 {
-	int ret;
+	int ret, dir;
 	bool is_fragment, not_first_fragment;
 
 	struct ipv4_frag_id frag_id = {
@@ -125,6 +125,7 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 	};
 
 	is_fragment = ipv4_is_fragment(ip4);
+	dir = ct_to_metrics_dir(ct_dir);
 
 	if (unlikely(is_fragment)) {
 		update_metrics(ctx_full_len(ctx), dir, REASON_FRAG_PACKET);

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -42,4 +42,23 @@ static __always_inline void update_metrics(__u32 bytes, __u8 direction,
 	}
 }
 
+/**
+ * ct_to_metrics_dir
+ * @direction:	1: Ingress 2: Egress 3: Service
+ * Convert a CT direction into the corresponding one for metrics.
+ */
+static __always_inline __u8 ct_to_metrics_dir(__u8 ct_dir)
+{
+	switch (ct_dir) {
+	case CT_INGRESS:
+		return METRIC_INGRESS;
+	case CT_EGRESS:
+		return METRIC_EGRESS;
+	case CT_SERVICE:
+		return METRIC_SERVICE;
+	default:
+		return 0;
+	}
+}
+
 #endif /* __LIB_METRICS__ */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -771,7 +771,7 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 {
 	int ifindex = 0;
 	int ret = 0;
-#if defined(ENABLE_HOST_FIREWALL) && defined(HOST_EP_ID)
+#if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
 	/* We only enforce the host policies if nodeport.h is included from
 	 * bpf_host.
 	 */
@@ -793,7 +793,10 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	return ctx_redirect(ctx, ifindex, 0);
 }
 
-declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+			       is_defined(ENABLE_IPV6)),
+			 __and(is_defined(ENABLE_HOST_FIREWALL),
+			       is_defined(IS_BPF_HOST))),
 		    CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT)
 int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 {
@@ -1492,7 +1495,7 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 {
 	int ifindex = 0;
 	int ret = 0;
-#if defined(ENABLE_HOST_FIREWALL) && defined(HOST_EP_ID)
+#if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
 	/* We only enforce the host policies if nodeport.h is included from
 	 * bpf_host.
 	 */
@@ -1514,7 +1517,10 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 	return ctx_redirect(ctx, ifindex, 0);
 }
 
-declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+			       is_defined(ENABLE_IPV6)),
+			 __and(is_defined(ENABLE_HOST_FIREWALL),
+			       is_defined(IS_BPF_HOST))),
 		    CILIUM_CALL_IPV4_ENCAP_NODEPORT_NAT)
 int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 {
@@ -1532,14 +1538,20 @@ static __always_inline int nodeport_nat_fwd(struct __ctx_buff *ctx)
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+					      is_defined(ENABLE_IPV6)),
+					__and(is_defined(ENABLE_HOST_FIREWALL),
+					      is_defined(IS_BPF_HOST))),
 				   CILIUM_CALL_IPV4_ENCAP_NODEPORT_NAT,
 				   tail_handle_nat_fwd_ipv4);
 		break;
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+					      is_defined(ENABLE_IPV6)),
+					__and(is_defined(ENABLE_HOST_FIREWALL),
+					      is_defined(IS_BPF_HOST))),
 				   CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT,
 				   tail_handle_nat_fwd_ipv6);
 		break;

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -493,7 +493,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	}
 
 	// Perform an early probe on the underlying kernel on whether BandwidthManager
-	// can be supported or not. This needs to be done before detectNativeDevices()
+	// can be supported or not. This needs to be done before handleNativeDevices()
 	// as BandwidthManager needs these to be available for setup.
 	bandwidth.ProbeBandwidthManager()
 
@@ -502,7 +502,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	// This is because the device detection requires self (Cilium)Node object,
 	// and the k8s service watcher depends on option.Config.EnableNodePort flag
 	// which can be modified after the device detection.
-	detectNativeDevices(isKubeProxyReplacementStrict)
+	handleNativeDevices(isKubeProxyReplacementStrict)
 	finishKubeProxyReplacementInit(isKubeProxyReplacementStrict)
 
 	// Launch the K8s watchers in parallel as we continue to process other

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -280,8 +280,8 @@ func initKubeProxyReplacementOptions() (strict bool) {
 	return
 }
 
-// detectNativeDevices tries to detect bpf_host devices (if needed).
-func detectNativeDevices(strict bool) {
+// handleNativeDevices tries to detect bpf_host devices (if needed).
+func handleNativeDevices(strict bool) {
 	detectNodePortDevs := len(option.Config.Devices) == 0 &&
 		(option.Config.EnableNodePort || option.Config.EnableHostFirewall || option.Config.EnableBandwidthManager)
 	detectDirectRoutingDev := option.Config.EnableNodePort &&
@@ -304,6 +304,22 @@ func detectNativeDevices(strict bool) {
 				l = l.WithField(logfields.DirectRoutingDevice, option.Config.DirectRoutingDevice)
 			}
 			l.Info("Using auto-derived devices for BPF node port")
+		}
+	} else if option.Config.EnableNodePort { // both --devices and --direct-routing-device are specified by user
+		// Check whether the DirectRoutingDevice (if specified) is
+		// defined within devices and if not, add it.
+		if option.Config.DirectRoutingDevice != "" {
+			directDev := option.Config.DirectRoutingDevice
+			directDevFound := false
+			for _, iface := range option.Config.Devices {
+				if iface == directDev {
+					directDevFound = true
+					break
+				}
+			}
+			if !directDevFound {
+				option.Config.Devices = append(option.Config.Devices, directDev)
+			}
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 	github.com/blang/semver v3.5.0+incompatible
-	github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753
+	github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
 	github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc60193
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753 h1:E0nVFaPUX3dO9zU8dUx15lahVRlpTfP/c6/BzLjNiwc=
-github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
+github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5 h1:4f4AuCR25RFRemzNgw1FK0ZBSr9KgJVn5MiVA9K7HpI=
+github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
 github.com/cilium/client-go v0.0.0-20201116093811-e3ac748c004a h1:8dnqGLxNuoLqXzg0o+DgCLfHZf2wZKJwxozq6fhaSEg=
 github.com/cilium/client-go v0.0.0-20201116093811-e3ac748c004a/go.mod h1:ZrEy7+wj9PjH5VMBCuu/BDlvtUAku0oVFk4MmnW9mWA=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -948,6 +948,9 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 }
 
 func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	// 1. Test whether another node in the same L2 subnet can be arpinged.
 	//    The other node is in the different netns reachable via the veth pair.
 	//
@@ -979,9 +982,6 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = netlink.LinkSetUp(veth0)
 	c.Assert(err, check.IsNil)
-
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 
 	netns0, err := netns.ReplaceNetNSWithName("test-arping-netns0")
 	c.Assert(err, check.IsNil)
@@ -1052,98 +1052,172 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	}
 	c.Assert(found, check.Equals, false)
 
-	// 2. Add another node which is reachable from the host only via nodev1 (gw).
-	//    Arping should ping veth1 IP addr instead of veth3.
+	// Setup routine for the 2. test
+	setupRemoteNode := func(vethName, vethPeerName, netnsName, vethCIDR, vethIPAddr,
+		vethPeerIPAddr string) (cleanup func(), errRet error) {
+
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: vethName},
+			PeerName:  vethPeerName,
+		}
+		errRet = netlink.LinkAdd(veth)
+		if errRet != nil {
+			return nil, err
+		}
+		cleanup1 := func() { netlink.LinkDel(veth) }
+		cleanup = cleanup1
+
+		veth2, err := netlink.LinkByName(vethName)
+		if err != nil {
+			errRet = err
+			return
+		}
+		veth3, err := netlink.LinkByName(vethPeerName)
+		if err != nil {
+			errRet = err
+			return
+		}
+		netns1, err := netns.ReplaceNetNSWithName(netnsName)
+		if err != nil {
+			errRet = err
+			return
+		}
+		cleanup = func() {
+			cleanup1()
+			netns1.Close()
+		}
+		if errRet = netlink.LinkSetNsFd(veth2, int(netns0.Fd())); errRet != nil {
+			return
+		}
+		if errRet = netlink.LinkSetNsFd(veth3, int(netns1.Fd())); errRet != nil {
+			return
+		}
+
+		ip, ipnet, err := net.ParseCIDR(vethCIDR)
+		ip2 := net.ParseIP(vethIPAddr)
+		ip3 := net.ParseIP(vethPeerIPAddr)
+		ipnet.IP = ip2
+
+		if errRet = netns0.Do(func(ns.NetNS) error {
+			addr = &netlink.Addr{IPNet: ipnet}
+			if err := netlink.AddrAdd(veth2, addr); err != nil {
+				return err
+			}
+			if err := netlink.LinkSetUp(veth2); err != nil {
+				return err
+			}
+			if err := netlink.LinkSetUp(veth2); err != nil {
+				return err
+			}
+			return nil
+		}); errRet != nil {
+			return
+		}
+
+		ipnet.IP = ip
+		route := &netlink.Route{
+			Dst: ipnet,
+			Gw:  ip1,
+		}
+		if errRet = netlink.RouteAdd(route); errRet != nil {
+			return
+		}
+
+		if errRet = netns1.Do(func(ns.NetNS) error {
+			veth3, err := netlink.LinkByName(vethPeerName)
+			if err != nil {
+				return err
+			}
+			ipnet.IP = ip3
+			addr = &netlink.Addr{IPNet: ipnet}
+			if err := netlink.AddrAdd(veth3, addr); err != nil {
+				return err
+			}
+			if err := netlink.LinkSetUp(veth3); err != nil {
+				return err
+			}
+
+			_, ipnet, err := net.ParseCIDR("9.9.9.248/29")
+			if err != nil {
+				return err
+			}
+			route := &netlink.Route{
+				Dst: ipnet,
+				Gw:  ip2,
+			}
+			if err := netlink.RouteAdd(route); err != nil {
+				return err
+			}
+			return nil
+		}); errRet != nil {
+			return
+		}
+
+		return
+	}
+
+	// 2. Add two nodes which are reachable from the host only via nodev1 (gw).
+	//    Arping should ping veth1 IP addr instead of veth3 or veth5.
 	//
 	//      +--------------+     +--------------+     +--------------+
 	//      |  host netns  |     |    netns0    |     |    netns1    |
 	//      |              |     |    nodev1    |     |    nodev2    |
-	//      |              |     |  8.8.8.250/29|     |              |
+	//      |              |     |  8.8.8.249/29|     |              |
 	//      |              |     |           |  |     |              |
 	//      |         veth0+-----+veth1    veth2+-----+veth3         |
 	//      |          |   |     |   |          |     | |            |
 	//      | 9.9.9.249/29 |     |9.9.9.250/29  |     | 8.8.8.250/29 |
-	//      +--------------+     +--------------+     +--------------+
+	//      +--------------+     |         veth4+-+   +--------------+
+	//                           |           |  | |   +--------------+
+	//                           | 7.7.7.249/29 | |   |    netns2    |
+	//                           +--------------+ |   |    nodev3    |
+	//                                            |   |              |
+	//                                            +---+veth5         |
+	//                                                | |            |
+	//                                                | 7.7.7.250/29 |
+	//                                                +--------------+
 
-	// Setup
-	veth = &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{Name: "veth2"},
-		PeerName:  "veth3",
-	}
-	err = netlink.LinkAdd(veth)
+	cleanup1, err := setupRemoteNode("veth2", "veth3", "test-arping-netns1",
+		"8.8.8.248/29", "8.8.8.249", "8.8.8.250")
 	c.Assert(err, check.IsNil)
-	defer netlink.LinkDel(veth)
-
-	veth2, err := netlink.LinkByName("veth2")
+	defer cleanup1()
+	cleanup2, err := setupRemoteNode("veth4", "veth5", "test-arping-netns2",
+		"7.7.7.248/29", "7.7.7.249", "7.7.7.250")
 	c.Assert(err, check.IsNil)
-	veth3, err := netlink.LinkByName("veth3")
-	c.Assert(err, check.IsNil)
-	netns1, err := netns.ReplaceNetNSWithName("test-arping-netns1")
-	c.Assert(err, check.IsNil)
-	defer netns1.Close()
-	err = netlink.LinkSetNsFd(veth2, int(netns0.Fd()))
-	c.Assert(err, check.IsNil)
-	err = netlink.LinkSetNsFd(veth3, int(netns1.Fd()))
-	c.Assert(err, check.IsNil)
+	defer cleanup2()
 
-	ip, ipnet, err := net.ParseCIDR("8.8.8.248/29")
-	ip2 := net.ParseIP("8.8.8.249")
-	ip3 := net.ParseIP("8.8.8.250")
-	ipnet.IP = ip2
-
-	netns0.Do(func(ns.NetNS) error {
-		addr = &netlink.Addr{IPNet: ipnet}
-		netlink.AddrAdd(veth2, addr)
-		c.Assert(err, check.IsNil)
-		err = netlink.LinkSetUp(veth2)
-		c.Assert(err, check.IsNil)
-		err = netlink.LinkSetUp(veth2)
-		c.Assert(err, check.IsNil)
-		return nil
-
-	})
-
-	ipnet.IP = ip
-	route := &netlink.Route{
-		Dst: ipnet,
-		Gw:  ip1,
-	}
-	err = netlink.RouteAdd(route)
-	c.Assert(err, check.IsNil)
-
-	netns1.Do(func(ns.NetNS) error {
-		veth3, err := netlink.LinkByName("veth3")
-		c.Assert(err, check.IsNil)
-		ipnet.IP = ip3
-		addr = &netlink.Addr{IPNet: ipnet}
-		netlink.AddrAdd(veth3, addr)
-		c.Assert(err, check.IsNil)
-		err = netlink.LinkSetUp(veth3)
-		c.Assert(err, check.IsNil)
-
-		_, ipnet, err := net.ParseCIDR("9.9.9.248/29")
-		c.Assert(err, check.IsNil)
-		route := &netlink.Route{
-			Dst: ipnet,
-			Gw:  ip2,
-		}
-		err = netlink.RouteAdd(route)
-		c.Assert(err, check.IsNil)
-
-		return nil
-	})
-
+	node2IP := net.ParseIP("8.8.8.250")
 	nodev2 := nodeTypes.Node{
 		Name:        "node2",
-		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, ip3}},
+		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, node2IP}},
 	}
-	err = linuxNodeHandler.NodeAdd(nodev2)
-	c.Assert(err, check.IsNil)
+	c.Assert(linuxNodeHandler.NodeAdd(nodev2), check.IsNil)
 
+	node3IP := net.ParseIP("7.7.7.250")
+	nodev3 := nodeTypes.Node{
+		Name:        "node3",
+		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, node3IP}},
+	}
+	c.Assert(linuxNodeHandler.NodeAdd(nodev3), check.IsNil)
+
+	nextHop := net.ParseIP("9.9.9.250")
+	// Check that both node{2,3} are via nextHop (gw)
 	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
 	c.Assert(err, check.IsNil)
 	found = false
-	nextHop := net.ParseIP("9.9.9.250")
+	for _, n := range neighs {
+		if n.IP.Equal(nextHop) && n.State == netlink.NUD_PERMANENT {
+			found = true
+		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
+			c.ExpectFailure("node{2,3} should not be in the same L2")
+		}
+	}
+	c.Assert(found, check.Equals, true)
+
+	// Check that removing node2 will not remove nextHop, as it is still used by node3
+	c.Assert(linuxNodeHandler.NodeDelete(nodev2), check.IsNil)
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	found = false
 	for _, n := range neighs {
 		if n.IP.Equal(nextHop) && n.State == netlink.NUD_PERMANENT {
 			found = true
@@ -1151,6 +1225,19 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}
 	}
 	c.Assert(found, check.Equals, true)
+
+	// However, removing node3 should remove the neigh entry for nextHop
+	c.Assert(linuxNodeHandler.NodeDelete(nodev3), check.IsNil)
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found = false
+	for _, n := range neighs {
+		if n.IP.Equal(nextHop) && n.State == netlink.NUD_PERMANENT {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, check.Equals, false)
 }
 
 func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config datapath.LocalNodeConfiguration) {

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -50,9 +50,10 @@ const (
 	// dirIngress and dirEgress values should match with
 	// METRIC_INGRESS, METRIC_EGRESS and METRIC_SERVICE
 	// in bpf/lib/common.h
-	dirEgress  = 0
+	dirUnknown = 0
 	dirIngress = 1
-	dirService = 2
+	dirEgress  = 2
+	dirService = 3
 )
 
 // direction is the metrics direction i.e ingress (to an endpoint),
@@ -60,8 +61,9 @@ const (
 // outside or a ClusterIP service being accessed from inside the cluster).
 // If it's none of the above, we return UNKNOWN direction.
 var direction = map[uint8]string{
-	dirEgress:  "EGRESS",
+	dirUnknown: "UNKNOWN",
 	dirIngress: "INGRESS",
+	dirEgress:  "EGRESS",
 	dirService: "SERVICE",
 }
 
@@ -128,7 +130,7 @@ func MetricDirection(dir uint8) string {
 	if desc, ok := direction[dir]; ok {
 		return desc
 	}
-	return "UNKNOWN"
+	return direction[dirUnknown]
 }
 
 // Direction gets the direction in human readable string format

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	cnpv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers/logutils"
@@ -4389,6 +4390,8 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"service":            "cilium-agent hubble-metrics hubble-relay",
 			"secret":             "hubble-relay-client-certs hubble-server-certs",
 		}
+
+		crdsToDelete = synced.AllCRDResourceNames
 	)
 
 	wg.Add(len(resourcesToDelete))
@@ -4398,6 +4401,17 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			wg.Done()
 		}(resource, resourceType)
 	}
+
+	wg.Add(len(crdsToDelete))
+	for _, crd := range crdsToDelete {
+		// crd is of format `type:name`, e.g. "crd:ciliumnodes.cilium.io"
+		parts := strings.SplitN(crd, ":", 2)
+		go func(resource, resourceType string) {
+			_ = kub.DeleteResource(resourceType, resource)
+			wg.Done()
+		}(parts[1], parts[0])
+	}
+
 	wg.Wait()
 }
 

--- a/vendor/github.com/cilium/arping/arping.go
+++ b/vendor/github.com/cilium/arping/arping.go
@@ -72,6 +72,7 @@ import (
 var (
 	// ErrTimeout error
 	ErrTimeout = errors.New("timeout")
+	ErrSize = errors.New("truncated")
 
 	verboseLog = log.New(ioutil.Discard, "", 0)
 	timeout    = 1 * time.Second
@@ -147,7 +148,7 @@ func PingOverIface(dstIP net.IP, iface net.Interface) (net.HardwareAddr, time.Du
 		}
 		for {
 			// receive arp response
-			response, receiveTime, err := req.receive()
+			response, receiveTime, err := req.receive(timeout)
 
 			if err != nil {
 				select {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cilium/arping v1.0.1-0.20201009104213-b546132ab753
+# github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5
 ## explicit
 github.com/cilium/arping
 # github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e


### PR DESCRIPTION
 * #14217 -- bpf: revert changes to metrics directions contants (@jibi)
 * #14214 -- docs: Correct typo in upgrade notes (@sayboras)
 * #14201 -- node: Handle arpinging when remote node is in different L2 (@brb)
 * #14054 -- kpr: ensure DirectRoutingDevice is in devices (@kkourt)
 * #14222 -- vendor: Fix cilium/arping goroutine leak (@jrajahalme)
 * #14187 -- ci/helpers: Delete CRDs in CleanupCiliumComponents (@gandro)
 * #14232 --  bpf: Fix program size issue with host firewall in IPv4-only mode (@pchaigno) 

Taken out:

 * #14193 -- bpf: optimize dsr and add ipip support for lb-only (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14217 14214 14201 14054 14222 14187 14232; do contrib/backporting/set-labels.py $pr done 1.9; done
```