### PR TITLE
operator: add identity GC metrics

### DIFF
--- a/operator/flags.go
+++ b/operator/flags.go
@@ -242,7 +242,7 @@ func init() {
 	flags.Duration(operatorOption.NodesGCInterval, 2*time.Minute, "GC interval for nodes store in the kvstore")
 	option.BindEnv(operatorOption.NodesGCInterval)
 
-	flags.String(operatorOption.OperatorPrometheusServeAddr, ":6942", "Address to serve Prometheus metrics")
+	flags.String(operatorOption.OperatorPrometheusServeAddr, operatorOption.PrometheusServeAddr, "Address to serve Prometheus metrics")
 	option.BindEnv(operatorOption.OperatorPrometheusServeAddr)
 
 	flags.String(operatorOption.OperatorAPIServeAddr, "localhost:9234", "Address to serve API requests")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -23,6 +23,9 @@ import (
 const (
 	// EndpointGCIntervalDefault is the default time for the CEP GC
 	EndpointGCIntervalDefault = 5 * time.Minute
+
+	// PrometheusServeAddr is the default server address for operator metrics
+	PrometheusServeAddr = ":6942"
 )
 
 const (

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -181,8 +181,8 @@ func (d *dummyBackend) RunLocksGC(_ context.Context, _ map[string]kvstore.Value)
 	return nil, nil
 }
 
-func (d *dummyBackend) RunGC(context.Context, *rate.Limiter, map[string]uint64) (map[string]uint64, error) {
-	return nil, nil
+func (d *dummyBackend) RunGC(context.Context, *rate.Limiter, map[string]uint64) (map[string]uint64, *GCStats, error) {
+	return nil, nil, nil
 }
 
 func (d *dummyBackend) Status() (string, error) {

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -126,8 +126,8 @@ func (c *crdBackend) RunLocksGC(_ context.Context, _ map[string]kvstore.Value) (
 	return nil, nil
 }
 
-func (c *crdBackend) RunGC(context.Context, *rate.Limiter, map[string]uint64) (map[string]uint64, error) {
-	return nil, nil
+func (c *crdBackend) RunGC(context.Context, *rate.Limiter, map[string]uint64) (map[string]uint64, *allocator.GCStats, error) {
+	return nil, nil, nil
 }
 
 // UpdateKey refreshes the reference that this node is using this key->ID

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -272,10 +272,10 @@ func (s *AllocatorSuite) TestGC(c *C) {
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 
 	keysToDelete := map[string]uint64{}
-	keysToDelete, err = allocator.RunGC(rateLimiter, keysToDelete)
+	keysToDelete, _, err = allocator.RunGC(rateLimiter, keysToDelete)
 	c.Assert(err, IsNil)
 	c.Assert(len(keysToDelete), Equals, 1)
-	keysToDelete, err = allocator.RunGC(rateLimiter, keysToDelete)
+	keysToDelete, _, err = allocator.RunGC(rateLimiter, keysToDelete)
 	c.Assert(err, IsNil)
 	c.Assert(len(keysToDelete), Equals, 0)
 
@@ -353,7 +353,7 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	staleKeysPreviousRound := map[string]uint64{}
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 	// running the GC should not evict any entries
-	staleKeysPreviousRound, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
+	staleKeysPreviousRound, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
 	c.Assert(err, IsNil)
 
 	v, err := kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
@@ -366,9 +366,9 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	}
 
 	// running the GC should evict all entries
-	staleKeysPreviousRound, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
+	staleKeysPreviousRound, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
 	c.Assert(err, IsNil)
-	_, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
+	_, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
 	c.Assert(err, IsNil)
 
 	v, err = kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))


### PR DESCRIPTION
operator: add new metric cilium_operator_identity_gc_entries_total

This patch adds identity GC stats to cilium-operator's metric list,
which allows users to track the identity GC activities,
e.g. deleted & alive identities during each GC run.

Preview:

```
$ curl <cilium-operator-ip>:6942/metrics 2>/dev/null | grep identity
# HELP cilium_operator_identity_gc_entries_total The number of alive and deleted identity entries at the end of a garbage collector run
# TYPE cilium_operator_identity_gc_total gauge
cilium_operator_identity_gc_entries_total{status="alive"} 157
cilium_operator_identity_gc_entries_total{status="deleted"} 0
```

```release-note
Add metrics for identity garbage collection in cilium-operator
```