### PR TITLE
node: Fix ineffectual assignment

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1094,6 +1094,10 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}
 
 		ip, ipnet, err := net.ParseCIDR(vethCIDR)
+		if err != nil {
+			errRet = err
+			return
+		}
 		ip2 := net.ParseIP(vethIPAddr)
 		ip3 := net.ParseIP(vethPeerIPAddr)
 		ipnet.IP = ip2


### PR DESCRIPTION
```
/home/travis/gopath/src/github.com/cilium/cilium/pkg/datapath/linux/node_linux_test.go:1096:14: ineffectual assignment to err
```

Reported-by: André Martins <andre@cilium.io>
Fix: b78b3b7f25 ("node: Refcount neighbour entries")