### PR TITLE
pkg/endpoint: Readd GetRealizedPolicyRuleLabelsForKey

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -873,3 +873,24 @@ func (e *Endpoint) UpdateBandwidthPolicy(annoCB AnnotationsResolverCB) {
 	}
 	<-ch
 }
+
+// GetRealizedPolicyRuleLabelsForKey returns the list of policy rule labels
+// which match a given flow key (in host byte-order). The returned
+// LabelArrayList is shallow-copied and therefore must not be mutated.
+// This function explicitly exported to be accessed by code outside of the
+// Cilium source code tree and for testing.
+func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
+	derivedFrom labels.LabelArrayList,
+	revision uint64,
+	ok bool,
+) {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	entry, ok := e.realizedPolicy.PolicyMapState[key]
+	if !ok {
+		return nil, 0, false
+	}
+
+	return entry.DerivedFromRules, e.policyRevision, true
+}

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -29,6 +29,8 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -513,6 +515,9 @@ type FakeEndpointInfo struct {
 	PodName      string
 	PodNamespace string
 	Labels       []string
+
+	PolicyMap      map[policy.Key]labels.LabelArrayList
+	PolicyRevision uint64
 }
 
 // GetID returns the ID of the endpoint.
@@ -538,4 +543,13 @@ func (e *FakeEndpointInfo) GetK8sNamespace() string {
 // GetLabels returns the labels of the endpoint.
 func (e *FakeEndpointInfo) GetLabels() []string {
 	return e.Labels
+}
+
+func (e *FakeEndpointInfo) GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
+	derivedFrom labels.LabelArrayList,
+	revision uint64,
+	ok bool,
+) {
+	derivedFrom, ok = e.PolicyMap[key]
+	return derivedFrom, e.PolicyRevision, ok
 }


### PR DESCRIPTION
This brings back the GetRealizedPolicyRuleLabelsForKey helper which is
used by external client code and was accidentally removed as unused.
This commit also extends the Hubble unit tests to invoke it, to avoid
another accidental removal.

Fixes: 0ba1967d9ec0 ("pkg/endpoint: remove unused functions")
