### PR TITLE
daemon: Allow to specify dev to inherit IP addr for LB devs

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -35,6 +35,7 @@ cilium-agent [flags]
       --bpf-fragments-map-max int                            Maximum number of entries in fragments tracking map (default 8192)
       --bpf-lb-acceleration string                           BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
       --bpf-lb-algorithm string                              BPF load balancing algorithm ("random", "maglev") (default "random")
+      --bpf-lb-dev-ip-addr-inherit string                    Device name which IP addr is inherited by devices running LB BPF program (--devices)
       --bpf-lb-dsr-dispatch string                           BPF load balancing DSR dispatch method ("opt", "ipip") (default "opt")
       --bpf-lb-maglev-hash-seed string                       Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                        Maglev per service backend table size (parameter M) (default 16381)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -269,6 +269,9 @@ func init() {
 	flags.String(option.DirectRoutingDevice, "", "Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)")
 	option.BindEnv(option.DirectRoutingDevice)
 
+	flags.String(option.LBDevInheritIPAddr, "", fmt.Sprintf("Device name which IP addr is inherited by devices running LB BPF program (--%s)", option.Devices))
+	option.BindEnv(option.LBDevInheritIPAddr)
+
 	flags.String(option.DatapathMode, defaults.DatapathMode, "Datapath mode name")
 	option.BindEnv(option.DatapathMode)
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -347,7 +347,7 @@ func handleNativeDevices(strict bool) {
 // replacement after all devices are known.
 func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) {
 	if option.Config.EnableNodePort {
-		if err := node.InitNodePortAddrs(option.Config.Devices); err != nil {
+		if err := node.InitNodePortAddrs(option.Config.Devices, option.Config.LBDevInheritIPAddr); err != nil {
 			msg := "Failed to initialize NodePort addrs."
 			if isKubeProxyReplacementStrict {
 				log.WithError(err).Fatal(msg)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -124,6 +124,10 @@ const (
 	// direct routing mode (only required by BPF NodePort)
 	DirectRoutingDevice = "direct-routing-device"
 
+	// LBDevInheritIPAddr is device name which IP addr is inherited by devices
+	// running BPF loadbalancer program
+	LBDevInheritIPAddr = "bpf-lb-dev-ip-addr-inherit"
+
 	// DisableConntrack disables connection tracking
 	DisableConntrack = "disable-conntrack"
 
@@ -1350,6 +1354,7 @@ type DaemonConfig struct {
 	NAT46Prefix         *net.IPNet // NAT46 IPv6 Prefix
 	Devices             []string   // bpf_host device
 	DirectRoutingDevice string     // Direct routing device (used only by NodePort BPF)
+	LBDevInheritIPAddr  string     // Device which IP addr used by bpf_host devices
 	DevicePreFilter     string     // Prefilter device
 	ModePreFilter       string     // Prefilter mode
 	XDPDevice           string     // XDP device
@@ -2457,6 +2462,7 @@ func (c *DaemonConfig) Populate() {
 	c.Debug = viper.GetBool(DebugArg)
 	c.DebugVerbose = viper.GetStringSlice(DebugVerbose)
 	c.DirectRoutingDevice = viper.GetString(DirectRoutingDevice)
+	c.LBDevInheritIPAddr = viper.GetString(LBDevInheritIPAddr)
 	c.DisableConntrack = viper.GetBool(DisableConntrack)
 	c.EnableIPv4 = viper.GetBool(EnableIPv4Name)
 	c.EnableIPv6 = viper.GetBool(EnableIPv6Name)


### PR DESCRIPTION
This commit introduces a new daemon flag` --bpf-lb-dev-ip-addr-inherit`
which allows to specify a device name which IP addr is used for
`--devices` in bpf_host.c (`IP{4,6}_NODEPORT`).

This is useful for cases in which NIC ifaces w/o IP addrs are connected
to a bridge which has an IP addr set, and `IP{4,6}_NODEPORT` addr should
be of the bridge.

Fix #14226 