### PR TITLE
docs: Clarify from/toRequires documentation with a new example

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -226,6 +226,26 @@ be only accessible if the source endpoint also has the label ``env=prod``.
 
         .. literalinclude:: ../../examples/policies/l3/requires/requires.json
 
+This ``fromRequires`` rule doesn't allow anything on its own and needs to be
+combined with other rules to allow traffic. For example, when combined with the
+example policy below, the endpoint with label ``env=prod`` will become
+accessible from endpoints that have both labels ``env=prod`` and
+``role=frontend``.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.json
+
 .. _Services based:
 
 Services based

--- a/examples/policies/l3/requires/endpoints.json
+++ b/examples/policies/l3/requires/endpoints.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "l3-rule"}],
+    "endpointSelector": {"matchLabels": {"env":"prod"}},
+    "ingress": [{
+        "fromEndpoints": [
+            {"matchLabels":{"role":"frontend"}}
+        ]
+    }]
+}]

--- a/examples/policies/l3/requires/endpoints.yaml
+++ b/examples/policies/l3/requires/endpoints.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l3-rule"
+specs:
+  - description: "For endpoints with env=prod, allow if source also has label role=frontend"
+    endpointSelector:
+      matchLabels:
+        env: prod
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          role: frontend


### PR DESCRIPTION
The difference between using `toRequires`+`toEndpoints` vs. `toEndpoints`+`toEndpoints` (i.e., first is logical AND of the rules, whereas the second is OR) is not particularly obvious when first reading the `toRequires` documentation.

This pull request attempts to clarify this difference by completing the `fromRequires` example with a `fromEndpoints` policy.

![image](https://user-images.githubusercontent.com/1764210/101087702-dfcae900-35b2-11eb-9983-914a7d2108c2.png)
