### PR TITLE
Log host routing fallback & document kernel requirement

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -189,6 +189,7 @@ Cilium Feature                           Minimum Kernel Version
 :ref:`local-redirect-policy`             >= 4.19.57, >= 5.1.16,  >= 5.2
 Full support for :ref:`session-affinity` >= 5.7
 BPF-based proxy redirection              >= 5.7
+BPF-based host routing                   >= 5.10
 ======================================== ===============================
 
 .. _req_kvstore:


### PR DESCRIPTION
First commit adds `level=info` logs for host routing fallbacks and the second documents the kernel required for BPF host routing.