### PR TITLE
docs: Fix dependency conflict

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -21,11 +21,11 @@ Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
 git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
+sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1
 sphinxcontrib-websupport==1.1.0
-sphinx-rtd-theme==0.2.4
 sphinx-tabs==1.1.13
 sphinx-version-warning==1.1.2
 typing==3.6.6


### PR DESCRIPTION
Pip 20.3 introduced a new dependency resolver[[0]] which silently
reinterprets our current requirements file in a different way to
resolve the dependencies, which results the build being broken.

On non-aarch64 systems, there are two requirements that satisfy
the sphinx-rtd-theme package:
* One provided by our own theme repository[[1]] which has nice consistent
  theming for the website, and
* One provided by the upstream sphinx-rtd-theme package.

Prior to pip 20.3, the default resolver was able to resolve this
conflict to favour our custom theme, which is the one we intend to use
in most cases. Unfortunately, with the new resolver, this conflict is
resolved the other way. As far as I can tell, there is no "strict" mode
to prescribe that pip should resolve conflicts first and fail out if the
requirements are ambiguous. Instead, pip silently resolves this conflict
and we do not find out that there was ambiguity until later in the
process.

In addition, on readthedocs.org, new versions of pip are automatically
pulled upon each new docs build, which meant that from one day to the
next, a previously successful build began to consistently fail with
weird errors that imply a problem with the dependency but don't explain
why the problem was introduced without changes to code in our build
system:

```
  Theme error:
  no theme named 'sphinx_rtd_theme_cilium' found (missing theme.conf?)
  make[1]: *** [Makefile:48: html] Error 2
  make: *** [Makefile:552: test-docs] Error 2
```

Fix the issue by disambiguating the theme dependency.

[0]: http://pyfound.blogspot.com/2020/11/pip-20-3-new-resolver.html
[1]: https://github.com/cilium/sphinx_rtd_theme

Fixes: #14252