### PR TITLE
refactor: Remove `time.After` from any Loops

### DIFF
--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.15.5
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -513,6 +513,8 @@ endif
 	$(QUIET) contrib/scripts/check-assert-deep-equals.sh
 	@$(ECHO_CHECK) contrib/scripts/lock-check.sh
 	$(QUIET) contrib/scripts/lock-check.sh
+	@$(ECHO_CHECK) contrib/scripts/custom-vet-check.sh
+	$(QUIET) contrib/scripts/custom-vet-check.sh
 	@$(ECHO_CHECK) contrib/scripts/rand-check.sh
 	$(QUIET) contrib/scripts/rand-check.sh
 

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -533,6 +534,8 @@ func runServer(cmd *cobra.Command) {
 	}
 
 	go func() {
+		timer, timerDone := inctimer.New()
+		defer timerDone()
 		for {
 			ctx, cancel := context.WithTimeout(context.Background(), defaults.LockLeaseTTL)
 			err := kvstore.Client().Update(ctx, kvstore.HeartbeatPath, []byte(time.Now().Format(time.RFC3339)), true)
@@ -540,7 +543,7 @@ func runServer(cmd *cobra.Command) {
 				log.WithError(err).Warning("Unable to update heartbeat key")
 			}
 			cancel()
-			<-time.After(kvstore.HeartbeatWriteInterval)
+			<-timer.After(kvstore.HeartbeatWriteInterval)
 		}
 	}()
 

--- a/contrib/scripts/custom-vet-check.sh
+++ b/contrib/scripts/custom-vet-check.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright 2020 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used to cause failure when pkg/lock is not used
+GO111MODULE=off go get github.com/cilium/customvet
+go vet --vettool=$(which customvet) -timeafter.ignore inctimer ./...

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
@@ -195,6 +196,8 @@ func (c *Controller) runController() {
 	c.mutex.RUnlock()
 	runFunc := true
 	interval := 10 * time.Minute
+	runTimer, timerDone := inctimer.New()
+	defer timerDone()
 
 	for {
 		var err error
@@ -258,7 +261,6 @@ func (c *Controller) runController() {
 
 			c.mutex.Unlock()
 		}
-
 		select {
 		case <-c.stop:
 			goto shutdown
@@ -280,7 +282,7 @@ func (c *Controller) runController() {
 			c.mutex.RUnlock()
 			runFunc = true
 
-		case <-time.After(interval):
+		case <-runTimer.After(interval):
 		}
 
 	}

--- a/pkg/crypto/certloader/watcher.go
+++ b/pkg/crypto/certloader/watcher.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/crypto/certloader/fswatcher"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -159,11 +160,11 @@ func (w *Watcher) Watch() <-chan struct{} {
 
 				if keypairUpdated {
 					if keypairReload == nil {
-						keypairReload = time.After(watcherEventCoalesceWindow)
+						keypairReload = inctimer.After(watcherEventCoalesceWindow)
 					}
 				} else if caUpdated {
 					if caReload == nil {
-						caReload = time.After(watcherEventCoalesceWindow)
+						caReload = inctimer.After(watcherEventCoalesceWindow)
 					}
 				} else {
 					// fswatcher should never send events for unknown files

--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -23,6 +23,7 @@ import (
 	relaypb "github.com/cilium/cilium/api/v1/relay"
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/hubble/relay/queue"
+	"github.com/cilium/cilium/pkg/inctimer"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 
 	"github.com/golang/protobuf/ptypes"
@@ -83,7 +84,8 @@ func sortFlows(
 
 	go func() {
 		defer close(sortedFlows)
-
+		bufferTimer, bufferTimerDone := inctimer.New()
+		defer bufferTimerDone()
 	flowsLoop:
 		for {
 			select {
@@ -100,7 +102,7 @@ func sortFlows(
 					}
 				}
 				pq.Push(flow)
-			case t := <-time.After(bufferDrainTimeout):
+			case t := <-bufferTimer.After(bufferDrainTimeout):
 				// Make sure to drain old flows from the queue when no new
 				// flows are received. The bufferDrainTimeout duration is used
 				// as a sorting window.
@@ -212,7 +214,7 @@ func aggregateErrors(
 				}
 
 				pendingResponse = response
-				flushPending = time.After(errorAggregationWindow)
+				flushPending = inctimer.After(errorAggregationWindow)
 			case <-flushPending:
 				select {
 				case aggregated <- pendingResponse:

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -23,6 +23,7 @@ import (
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	peerTypes "github.com/cilium/cilium/pkg/hubble/peer/types"
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 
 	"github.com/sirupsen/logrus"
@@ -80,6 +81,8 @@ func (m *PeerManager) Start() {
 
 func (m *PeerManager) watchNotifications() {
 	ctx, cancel := context.WithCancel(context.Background())
+	retryTimer, retryTimerDone := inctimer.New()
+	defer retryTimerDone()
 connect:
 	for {
 		cl, err := m.opts.peerClientBuilder.Client(m.opts.peerServiceAddress)
@@ -92,7 +95,7 @@ connect:
 			case <-m.stop:
 				cancel()
 				return
-			case <-time.After(m.opts.retryTimeout):
+			case <-retryTimer.After(m.opts.retryTimeout):
 				continue
 			}
 		}
@@ -107,7 +110,7 @@ connect:
 			case <-m.stop:
 				cancel()
 				return
-			case <-time.After(m.opts.retryTimeout):
+			case <-retryTimer.After(m.opts.retryTimeout):
 				continue
 			}
 		}
@@ -130,7 +133,7 @@ connect:
 				case <-m.stop:
 					cancel()
 					return
-				case <-time.After(m.opts.retryTimeout):
+				case <-retryTimer.After(m.opts.retryTimeout):
 					continue connect
 				}
 			}
@@ -149,6 +152,8 @@ connect:
 }
 
 func (m *PeerManager) manageConnections() {
+	connTimer, connTimerDone := inctimer.New()
+	defer connTimerDone()
 	for {
 		select {
 		case <-m.stop:
@@ -163,7 +168,7 @@ func (m *PeerManager) manageConnections() {
 				// a connection request has been made, make sure to attempt a connection
 				m.connect(p, true)
 			}()
-		case <-time.After(m.opts.connCheckInterval):
+		case <-connTimer.After(m.opts.connCheckInterval):
 			m.mu.RLock()
 			now := time.Now()
 			for _, p := range m.peers {

--- a/pkg/inctimer/inctimer.go
+++ b/pkg/inctimer/inctimer.go
@@ -1,0 +1,72 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inctimer
+
+import "time"
+
+// IncTimer should be the preferred mechanism over
+// calling `time.After` when wanting an `After`-like
+// function in a loop. This prevents memory build up
+// as the `time.After` method creates a new timer
+// instance every time it is called, and it is not
+// garbage collected until after it fires. Conversely,
+// IncTimer only uses one timer and correctly stops
+// the timer, clears its channel, and resets it
+// everytime that `After` is called.
+type IncTimer interface {
+	After(time.Duration) <-chan time.Time
+}
+
+type incTimer struct {
+	t *time.Timer
+}
+
+// New creates a new IncTimer and a done function.
+// IncTimer only uses one timer and correctly stops
+// the timer, clears the channel, and resets it every
+// time the `After` function is called.
+// WARNING: Concurrent use is not expected. The use
+// of this timer should be for only one goroutine.
+func New() (IncTimer, func() bool) {
+	t := time.NewTimer(time.Nanosecond)
+	return &incTimer{
+		t: t,
+	}, t.Stop
+}
+
+// After returns a channel that will fire after
+// the specified duration.
+func (it *incTimer) After(d time.Duration) <-chan time.Time {
+	// We cannot call reset on an expired timer,
+	// so we need to stop it and drain it first.
+	// See https://golang.org/pkg/time/#Timer.Reset for more details.
+	if !it.t.Stop() {
+		// It could be that the channel was read already
+		select {
+		case <-it.t.C:
+		default:
+		}
+	}
+	it.t.Reset(d)
+	return it.t.C
+}
+
+// After wraps the time.After function to get
+// around the customvet warning for cases
+// where it is inconvenient to use the instantiated
+// version.
+func After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}

--- a/pkg/inctimer/inctimer_test.go
+++ b/pkg/inctimer/inctimer_test.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package inctimer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimerHardReset(t *testing.T) {
+	tr, done := New()
+	defer done()
+	for i := 0; i < 100; i++ {
+		select {
+		case <-tr.After(time.Millisecond):
+		case <-time.After(time.Millisecond * 2):
+			t.Fatal("`IncTimer`, after being reset, did not fire")
+		}
+	}
+}

--- a/pkg/k8s/cnpstatus.go
+++ b/pkg/k8s/cnpstatus.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/pkg/inctimer"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
@@ -229,11 +230,14 @@ func (c *CNPStatusEventHandler) runStatusHandler(cnpKey string, cnp *types.SlimC
 			nodeStatusMap[cnpns.Node] = cnpns.CiliumNetworkPolicyNodeStatus
 		}
 	}
+	updateTimer, updateDone := inctimer.New()
+	defer updateDone()
+
 	for {
 		// Allow for a bunch of different node status updates to come before
 		// we break out to avoid jitter in updates across the cluster
 		// to affect batching on our end.
-		limit := time.After(c.updateInterval)
+		limit := updateTimer.After(c.updateInterval)
 
 		// Collect any other events that have come in, but bail out after the
 		// above limit is hit so that we can send the updates we have received.

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/contexthelpers"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rand"
@@ -1105,6 +1106,9 @@ func (e *etcdClient) statusChecker() {
 
 	consecutiveQuorumErrors := 0
 
+	statusTimer, statusTimerDone := inctimer.New()
+	defer statusTimerDone()
+
 	for {
 		newStatus := []string{}
 		ok := 0
@@ -1168,7 +1172,7 @@ func (e *etcdClient) statusChecker() {
 		case <-e.stopStatusChecker:
 			close(e.statusCheckErrors)
 			return
-		case <-time.After(e.extraOptions.StatusCheckInterval(allConnected)):
+		case <-statusTimer.After(e.extraOptions.StatusCheckInterval(allConnected)):
 		}
 	}
 }

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	uuidfactor "github.com/cilium/cilium/pkg/uuid"
 
@@ -90,6 +91,8 @@ func (pl *pathLocks) runGC() {
 }
 
 func (pl *pathLocks) lock(ctx context.Context, path string) (id uuid.UUID, err error) {
+	lockTimer, lockTimerDone := inctimer.New()
+	defer lockTimerDone()
 	for {
 		pl.mutex.Lock()
 		if _, ok := pl.lockPaths[path]; !ok {
@@ -104,7 +107,7 @@ func (pl *pathLocks) lock(ctx context.Context, path string) (id uuid.UUID, err e
 		pl.mutex.Unlock()
 
 		select {
-		case <-time.After(time.Duration(10) * time.Millisecond):
+		case <-lockTimer.After(time.Duration(10) * time.Millisecond):
 		case <-ctx.Done():
 			err = fmt.Errorf("lock was cancelled: %s", ctx.Err())
 			return

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -50,6 +51,8 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 		ipv4Orig := ipv4
 		ipv6Orig := ipv6
 		triggeredBySignal := false
+		ctTimer, ctTimerDone := inctimer.New()
+		defer ctTimerDone()
 		for {
 			var (
 				maxDeleteRatio float64
@@ -133,7 +136,7 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 						ipv6 = true
 					}
 				}
-			case <-time.After(ctmap.GetInterval(mapType, maxDeleteRatio)):
+			case <-ctTimer.After(ctmap.GetInterval(mapType, maxDeleteRatio)):
 				ipv4 = ipv4Orig
 				ipv6 = ipv6Orig
 			}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -275,6 +276,8 @@ func (m *Manager) backgroundSyncInterval() time.Duration {
 }
 
 func (m *Manager) backgroundSync() {
+	syncTimer, syncTimerDone := inctimer.New()
+	defer syncTimerDone()
 	for {
 		syncInterval := m.backgroundSyncInterval()
 		log.WithField("syncInterval", syncInterval.String()).Debug("Performing regular background work")
@@ -305,7 +308,7 @@ func (m *Manager) backgroundSync() {
 		select {
 		case <-m.closeChan:
 			return
-		case <-time.After(syncInterval):
+		case <-syncTimer.After(syncInterval):
 		}
 	}
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -329,6 +330,8 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 
 	go func() {
 		nodeValidationsReceived := 0
+		timer, timerDone := inctimer.New()
+		defer timerDone()
 		for {
 			select {
 			case <-signalNodeHandler.NodeValidateImplementationEvent:
@@ -337,7 +340,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 					allNodeValidateCallsReceived.Done()
 					return
 				}
-			case <-time.After(time.Second * 5):
+			case <-timer.After(time.Second * 5):
 				c.Errorf("Timeout while waiting for NodeValidateImplementation() to be called")
 			}
 		}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -141,6 +142,8 @@ func (c *Collector) GetStaleProbes() map[string]time.Time {
 // spawnProbe starts a goroutine which invokes the probe at the particular interval.
 func (c *Collector) spawnProbe(p *Probe) {
 	go func() {
+		timer, stopTimer := inctimer.New()
+		defer stopTimer()
 		for {
 			c.runProbe(p)
 
@@ -148,12 +151,11 @@ func (c *Collector) spawnProbe(p *Probe) {
 			if p.Interval != nil {
 				interval = p.Interval(p.consecutiveFailures)
 			}
-
 			select {
 			case <-c.stop:
 				// collector is closed, stop looping
 				return
-			case <-time.After(interval):
+			case <-timer.After(interval):
 				// keep looping
 			}
 		}

--- a/pkg/trigger/trigger.go
+++ b/pkg/trigger/trigger.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -180,6 +181,8 @@ func (t *Trigger) Shutdown() {
 }
 
 func (t *Trigger) waiter() {
+	sleepTimer, sleepTimerDone := inctimer.New()
+	defer sleepTimerDone()
 	for {
 		// keep critical section as small as possible
 		t.mutex.Lock()
@@ -213,7 +216,7 @@ func (t *Trigger) waiter() {
 
 		select {
 		case <-t.wakeupChan:
-		case <-time.After(t.params.sleepInterval):
+		case <-sleepTimer.After(t.params.sleepInterval):
 
 		case <-t.closeChan:
 			return

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -23,11 +23,12 @@ import (
 
 	_ "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/proxylib/proxylib"
 	"github.com/cilium/cilium/proxylib/test"
 	_ "github.com/cilium/cilium/proxylib/testparsers"
 
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -125,6 +126,8 @@ func checkAccessLogs(t *testing.T, logServer *test.AccessLogServer, expPasses, e
 	passes, drops := 0, 0
 	nWaits := 0
 	done := false
+	timer, timerDone := inctimer.New()
+	defer timerDone()
 	// Loop until done or when the timeout has ticked 100 times without any logs being received
 	for !done && nWaits < 100 {
 		select {
@@ -136,7 +139,7 @@ func checkAccessLogs(t *testing.T, logServer *test.AccessLogServer, expPasses, e
 			}
 			// Start the timeout again (for upto 5 seconds)
 			nWaits = 0
-		case <-time.After(50 * time.Millisecond):
+		case <-timer.After(50 * time.Millisecond):
 			// Count the number of times we have waited since the last log was received
 			nWaits++
 			// Finish when expected number of passes and drops have been collected

--- a/proxylib/test/accesslog_server.go
+++ b/proxylib/test/accesslog_server.go
@@ -23,7 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cilium/proxy/go/cilium/api"
+	"github.com/cilium/cilium/pkg/inctimer"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
@@ -62,7 +63,7 @@ func (s *AccessLogServer) Clear() (passed, drops int) {
 			} else {
 				passes++
 			}
-		case <-time.After(10 * time.Millisecond):
+		case <-inctimer.After(10 * time.Millisecond):
 			empty = true
 		}
 	}


### PR DESCRIPTION
`time.After` is not garbage collected until after
its channel fires once. In situations where it is called
repeatedely this *can* lead to significant memory build up.
Instead of creating a new timer object for every iteration,
a single timer, with a hard-reset mechanism, is used in
situations where `time.After` is being called repeatedely.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

Fixes: #14219
