### PR TITLE
Vagrant: Add support for .devvmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ GIT_VERSION
 # During image builds following files get created
 .buildx
 .buildx_builder
+
+# Local developer config to be executed in the dev VM and CI VMs started locally
+.devvmrc

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -93,6 +93,36 @@ existing cluster. For example, to add a net-next VM to a one-node cluster:
 
     $ NWORKERS=1 NETNEXT=1 ./contrib/vagrant/start.sh k8s2+
 
+Cilium Vagrantfiles look for a file ``.devvmrc`` in the root of your
+Cilium repository. This file is ignored for Git, so it does not exist
+by default. If this file exists and is executable, it will be executed
+in the beginning of the VM bootstrap. This allows you to automatically
+customize the new VM, e.g., with your personal Git configuration. You
+may also want to add any local entries you need in ``/etc/hosts``,
+etc.
+
+For example, you could have something like this in your ``.devvmrc``:
+
+::
+
+    #!/usr/bin/env bash
+
+    git config --global user.name "Firstname Lastname"
+    git config --global user.email developer@company.com
+
+    sudo tee -a /etc/hosts <<EOF
+    192.168.99.99 nas
+    EOF
+
+Remember to make the script executable (``chmod +x .devvmrc``). When
+successfully running, the VM bootstrap shows a message like this right
+after the shared folders have been set up:
+
+::
+
+    runtime: ----------------------------------------------------------------
+    runtime: Executing .devvmrc
+
 The box is currently available for the following providers:
 
 * virtualbox

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [ -x /home/vagrant/go/src/github.com/cilium/cilium/.devvmrc ] ; then
+   echo "----------------------------------------------------------------"
+   echo "Executing .devvmrc"
+   /home/vagrant/go/src/github.com/cilium/cilium/.devvmrc || true
+fi
+
 echo "----------------------------------------------------------------"
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -56,6 +56,21 @@ class VagrantPlugins::ProviderVirtualBox::Action::Network
   end
 end
 
+$bootstrap = <<SCRIPT
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -x /home/vagrant/go/src/github.com/cilium/cilium/.devvmrc ] ; then
+   echo "----------------------------------------------------------------"
+   echo "Executing .devvmrc"
+   /home/vagrant/go/src/github.com/cilium/cilium/.devvmrc || true
+fi
+echo "----------------------------------------------------------------"
+sudo sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile
+echo 'export GOPATH=$(go env GOPATH)' >> /home/vagrant/.bashrc
+SCRIPT
+
 Vagrant.configure("2") do |config|
     cilium_dir = '../'
     cilium_path = '/home/vagrant/go/src/github.com/cilium/cilium'
@@ -107,16 +122,7 @@ Vagrant.configure("2") do |config|
         end
 
         # Provision section
-        server.vm.provision :shell,
-            :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
-        # Disable unattended-upgrades to prevent it from holding the dpkg frontend lock
-        # To be removed once this has been added through packer-ci-build
-        server.vm.provision :shell,
-            :inline => "sudo systemctl disable unattended-upgrades.service"
-        server.vm.provision :shell,
-            :inline => "sudo systemctl stop unattended-upgrades.service"
-        server.vm.provision :shell,
-            :inline => "echo 'export GOPATH=$(go env GOPATH)' >> /home/vagrant/.bashrc"
+        server.vm.provision "bootstrap", type: "shell", inline: $bootstrap
         server.vm.provision "file", source: "provision/", destination: "/tmp/"
         server.vm.provision "shell" do |sh|
             sh.path = "./provision/runtime_install.sh"
@@ -186,16 +192,9 @@ Vagrant.configure("2") do |config|
                 server.vm.synced_folder cilium_dir, cilium_path
             end
             # Provision section
+            server.vm.provision "bootstrap", type: "shell", inline: $bootstrap
             server.vm.provision :shell,
                 :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=1"
-            server.vm.provision :shell,
-                :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
-            # Disable unattended-upgrades to prevent it from holding the dpkg frontend lock
-            # To be removed once this has been added through packer-ci-build
-            server.vm.provision :shell,
-                :inline => "sudo systemctl disable unattended-upgrades.service"
-            server.vm.provision :shell,
-                :inline => "sudo systemctl stop unattended-upgrades.service"
             server.vm.provision "file", source: "provision/", destination: "/tmp/"
             server.vm.provision "shell" do |sh|
                 sh.path = "./provision/k8s_install.sh"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -83,7 +83,7 @@ fi
 sudo ln -sf $KUBEDNS_DEPLOYMENT $DNS_DEPLOYMENT
 $PROVISIONSRC/dns.sh
 
-cat <<EOF > /etc/hosts
+cat <<EOF >> /etc/hosts
 127.0.0.1       localhost
 ::1     localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes


### PR DESCRIPTION
Execute the file .devvmrc within the Developer VM and CI VMs, if it
exists in the cilium repo. This allows for setting git config, docker
registry caching, or any other personal settings for the Dev's environment
automatically.

Setting up /etc/hosts in k8s_install.sh is changed to append instead
of replace, so that .devvmrc can add host entries without losing them
right after when k8s_install runs.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
