### PR TITLE
test: Fix flake on policy verdict count check

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -426,17 +426,17 @@ func (kub *Kubectl) AddRegistryCredentials(cred string, registry string) error {
 // WaitForCiliumReadiness waits for the Cilium DaemonSet to become ready.
 // Readiness is achieved when all Cilium pods which are desired to run on a
 // node are in ready state.
-func (kub *Kubectl) WaitForCiliumReadiness() error {
+func (kub *Kubectl) WaitForCiliumReadiness(offset int, errMsg string) {
 	ginkgoext.By("Waiting for Cilium to become ready")
-	return RepeatUntilTrue(func() bool {
+	gomega.EventuallyWithOffset(1+offset, func() error {
 		numPods, err := kub.DaemonSetIsReady(CiliumNamespace, "cilium")
 		if err != nil {
 			ginkgoext.By("Cilium DaemonSet not ready yet: %s", err)
 		} else {
 			ginkgoext.By("Number of ready Cilium pods: %d", numPods)
 		}
-		return err == nil
-	}, &TimeoutConfig{Timeout: 4 * time.Minute})
+		return err
+	}, 4*time.Minute).Should(gomega.BeNil(), errMsg)
 }
 
 // DeleteResourceInAnyNamespace deletes all objects with the provided name of

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -111,18 +111,16 @@ var _ = Describe("K8sDatapathConfig", func() {
 			By("Checking that ICMP notifications in egress direction were observed")
 			expEgress := fmt.Sprintf("ICMPv4.*DstIP=%s", targetIP)
 			expEgressRegex := regexp.MustCompile(expEgress)
-			err := helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				return searchMonitorLog(expEgressRegex)
-			})
-			Expect(err).To(BeNil(), "Egress ICMPv4 flow (%q) not found in monitor log\n%s", expEgress, monitorOutput)
+			}, helpers.HelperTimeout).Should(BeTrue(), "Egress ICMPv4 flow (%q) not found in monitor log\n%s", expEgress, monitorOutput)
 
 			By("Checking that ICMP notifications in ingress direction were observed")
 			expIngress := fmt.Sprintf("ICMPv4.*SrcIP=%s", targetIP)
 			expIngressRegex := regexp.MustCompile(expIngress)
-			err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				return searchMonitorLog(expIngressRegex)
-			})
-			Expect(err).To(BeNil(), "Ingress ICMPv4 flow (%q) not found in monitor log\n%s", expIngress, monitorOutput)
+			}, helpers.HelperTimeout).Should(BeTrue(), "Ingress ICMPv4 flow (%q) not found in monitor log\n%s", expIngress, monitorOutput)
 
 			By("Checking the set of TCP notifications received matches expectations")
 			// | TCP Flags | Direction | Report? | Why?
@@ -137,11 +135,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// | ACK       |    ->     |    Y    | monitorAggregation=medium
 			egressPktCount := 3
 			ingressPktCount := 2
-			err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				monitorOutput = monitorRes.CombineOutput().Bytes()
 				return checkMonitorOutput(monitorOutput, egressPktCount, ingressPktCount)
-			})
-			Expect(err).To(BeNil(), "Monitor log did not contain %d ingress and %d egress TCP notifications\n%s",
+			}, helpers.HelperTimeout).Should(BeTrue(), "Monitor log did not contain %d ingress and %d egress TCP notifications\n%s",
 				ingressPktCount, egressPktCount, monitorOutput)
 
 			helpers.WriteToReportFile(monitorOutput, monitorLog)
@@ -172,11 +169,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// | ACK       |    ->     |    Y    | monitorAggregation=medium
 			egressPktCount := 4
 			ingressPktCount := 3
-			err := helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				monitorOutput = monitorRes.CombineOutput().Bytes()
 				return checkMonitorOutput(monitorOutput, egressPktCount, ingressPktCount)
-			})
-			Expect(err).To(BeNil(), "monitor aggregation did not result in correct number of TCP notifications\n%s", monitorOutput)
+			}, helpers.HelperTimeout).Should(BeTrue(), "monitor aggregation did not result in correct number of TCP notifications\n%s", monitorOutput)
 			helpers.WriteToReportFile(monitorOutput, monitorLog)
 		})
 	})

--- a/test/k8sT/Identity.go
+++ b/test/k8sT/Identity.go
@@ -66,10 +66,9 @@ var _ = Describe("K8sIdentity", func() {
 			kubectl.ApplyDefault(dummyIdentity).ExpectSuccess("Cannot import dummy identity")
 
 			By("Waiting for CiliumIdentity to be garbage collected")
-			err := helpers.RepeatUntilTrue(func() bool {
+			Eventually(func() bool {
 				return !kubectl.ExecShort(helpers.KubectlCmd + " get ciliumidentity 99999").WasSuccessful()
-			}, &helpers.TimeoutConfig{Timeout: 2 * time.Minute})
-			Expect(err).Should(BeNil(), "CiliumIdentity did not get garbage collected before timeout")
+			}, 2*time.Minute).Should(BeTrue(), "CiliumIdentity did not get garbage collected before timeout")
 		})
 	})
 })

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1445,13 +1445,10 @@ var _ = Describe("K8sPolicyTest", func() {
 				defer monitorCancel()
 
 				By("Asserting that the expected policy verdict logs are in the monitor output")
-				var verdicts int
-				err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-					verdicts = len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-					return verdicts >= count
-				})
-				Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-					verdicts, count, policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
+				Eventually(func() int {
+					return len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+				}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+					policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
 			})
 
 			It("connectivity is restored after importing ingress policy", func() {
@@ -1479,13 +1476,10 @@ var _ = Describe("K8sPolicyTest", func() {
 				defer monitorCancel()
 
 				By("Asserting that the expected policy verdict logs are in the monitor output")
-				var verdicts int
-				err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-					verdicts = len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-					return verdicts >= count
-				})
-				Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-					verdicts, count, policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
+				Eventually(func() int {
+					return len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+				}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+					policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
 			})
 
 			Context("With host policy", func() {
@@ -1530,13 +1524,10 @@ var _ = Describe("K8sPolicyTest", func() {
 					defer monitorCancel()
 
 					By("Asserting that the expected policy verdict logs are in the monitor output")
-					var verdicts int
-					err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-						verdicts = len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-						return verdicts >= count
-					})
-					Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-						verdicts, count, policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
+					Eventually(func() int {
+						return len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+					}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+						policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
 				})
 
 				It("Connectivity is restored after importing ingress policy", func() {
@@ -1564,13 +1555,10 @@ var _ = Describe("K8sPolicyTest", func() {
 					defer monitorCancel()
 
 					By("Asserting that the expected policy verdict logs are in the monitor output")
-					var verdicts int
-					err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-						verdicts = len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-						return verdicts >= count
-					})
-					Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-						verdicts, count, policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
+					Eventually(func() int {
+						return len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+					}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+						policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
 
 					By("Removing the fromCIDR+toPorts ingress host policy")
 					// This is to ensure this policy is always removed before the default-deny one.

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -199,8 +199,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			)
 		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), fmt.Sprintf("Cilium clean state %q was not able to be deployed", chartVersion))
 
-		err = kubectl.WaitForCiliumReadiness()
-		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q did not become ready in time", chartVersion)
+		kubectl.WaitForCiliumReadiness(1, fmt.Sprintf("Cilium %q did not become ready in time", chartVersion))
 		err = kubectl.WaitForCiliumInitContainerToFinish()
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be clean up environment", chartVersion)
 		cmd := kubectl.ExecMiddle("helm delete cilium --namespace=" + helpers.CiliumNamespace)
@@ -456,8 +455,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		cmd := kubectl.ExecMiddle("helm delete cilium-preflight --namespace=" + helpers.CiliumNamespace)
 		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Unable to delete preflight")
 
-		err = kubectl.WaitForCiliumReadiness()
-		ExpectWithOffset(1, err).Should(BeNil(), "Cilium is not ready after timeout")
+		kubectl.WaitForCiliumReadiness(1, "Cilium is not ready after timeout")
 		// Need to run using the kvstore-based allocator because upgrading from
 		// kvstore-based allocator to CRD-based allocator is not currently
 		// supported at this time.

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -41,10 +41,9 @@ func ExpectKubeDNSReady(vm *helpers.Kubectl) {
 // ExpectCiliumReady is a wrapper around helpers/WaitForPods. It asserts that
 // the error returned by that function is nil.
 func ExpectCiliumReady(vm *helpers.Kubectl) {
-	err := vm.WaitForCiliumReadiness()
-	Expect(err).To(BeNil(), "Timeout while waiting for Cilium to become ready")
+	vm.WaitForCiliumReadiness(0, "Timeout while waiting for Cilium to become ready")
 
-	err = vm.CiliumPreFlightCheck()
+	err := vm.CiliumPreFlightCheck()
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium pre-flight checks failed")
 }
 
@@ -119,8 +118,7 @@ func redeployCilium(vm *helpers.Kubectl, ciliumFilename string, options map[stri
 	err := vm.CiliumInstall(ciliumFilename, options)
 	Expect(err).To(BeNil(), "Cilium cannot be installed")
 
-	err = vm.WaitForCiliumReadiness()
-	Expect(err).To(BeNil(), "Timeout while waiting for Cilium to become ready")
+	vm.WaitForCiliumReadiness(0, "Timeout while waiting for Cilium to become ready")
 }
 
 // RedeployCilium reinstantiates the Cilium DS and ensures it is running.

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -84,7 +84,7 @@ var _ = Describe("K8sHubbleTest", func() {
 		res.ExpectSuccess("removing proxy visibility annotation failed")
 	}
 
-	hubbleObserveUntilMatch := func(hubblePod, args, filter, expected string, timeout *helpers.TimeoutConfig) {
+	hubbleObserveUntilMatch := func(hubblePod, args, filter, expected string, timeout time.Duration) {
 		hubbleObserve := func() bool {
 			res := kubectl.HubbleObserve(hubblePod, args)
 			res.ExpectSuccess("hubble observe invocation failed: %q", res.OutputPrettyPrint())
@@ -101,8 +101,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			return false
 		}
 
-		err := helpers.RepeatUntilTrue(hubbleObserve, timeout)
-		Expect(err).Should(BeNil(),
+		Eventually(hubbleObserve, timeout).Should(BeTrue(),
 			"hubble observe: filter %q never matched expected string %q", filter, expected)
 	}
 
@@ -226,11 +225,7 @@ var _ = Describe("K8sHubbleTest", func() {
 				"--server %s --last 1 --type trace --from-pod %s/%s --to-namespace %s --to-label %s --to-port %d",
 				hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels, app1Port),
 				`{$.Type}`, "L3_L4",
-				&helpers.TimeoutConfig{
-					Ticker:  5 * time.Second,
-					Timeout: helpers.MidCommandTimeout,
-				},
-			)
+				helpers.MidCommandTimeout)
 		})
 
 		It("Test L7 Flow", func() {
@@ -273,11 +268,7 @@ var _ = Describe("K8sHubbleTest", func() {
 				"--server %s --last 1 --type l7 --from-pod %s/%s --to-namespace %s --to-label %s --protocol http",
 				hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels),
 				`{$.Type}`, "L7",
-				&helpers.TimeoutConfig{
-					Ticker:  5 * time.Second,
-					Timeout: helpers.MidCommandTimeout,
-				},
-			)
+				helpers.MidCommandTimeout)
 		})
 	})
 })


### PR DESCRIPTION
Our fromCIDR+toPorts tests have been flaking for a while. In particular, the check on the number of policy verdicts found in the output of `cilium monitor` sometimes fails. Those fails happen because we read `cilium monitor`'s output too soon, before it has a chance to drain the ring buffer (see https://github.com/cilium/cilium/issues/12596#issuecomment-738983309 for a detailed analysis of the logs).

This commit fixes it by repeatedly checking the output against our regular expression until it succeeds or times out, similarly to what is already done in `K8sDatapathConfig MonitorAggregation`.

Fixes: #12596
Fixes: https://github.com/cilium/cilium/pull/12482
Fixes: https://github.com/cilium/cilium/pull/12621