### PR TITLE
docs: add troubleshooting steps for unbalanced traffic

### DIFF
--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -713,6 +713,47 @@ When running in :ref:`arch_direct_routing` mode:
 
 4. Verify that the firewall on each node permits to route the endpoint IPs.
 
+Traffic to Service Endpoints is unbalanced
+------------------------------------------
+
+Symptom
+~~~~~~~
+
+Service endpoint communication is successful, but unbalanced traffic is
+observed in the following situations:
+
+  * A ``NodePort``, ``LoadBalancer`` or ``externalIP`` service is accessed from
+    outside a cluster when ``NodePort`` BPF is enabled
+  * A ``ClusterIP`` service is accessed within a cluster when the
+    :ref:`Host-reachable services<host-services>`
+
+This problem typically manifests as an imbalance of connections or requests to
+a subset of endpoints for a Service.
+
+Troubleshooting steps:
+~~~~~~~~~~~~~~~~~~~~~~
+
+Consider whether running without ``kube-proxy`` is an option for your cluster.
+More details can be found in :ref:`kubeproxy-free`, along with the
+requirements, and steps for enabling.
+
+If running without ``kube-proxy`` is not an option for the cluster, or traffic
+is generated outside the cluster, the following parameters can provide more
+fine-grained control over traffic imbalances to Service endpoints:
+
+  * ``bpf-ct-timeout-service-tcp`` and ``bpf-ct-timeout-service-any`` controls
+    the amount of time endpoints are tracked via conntrack becoming eligible
+    for garbage collection.
+  * ``conntrack-gc-interval`` controls the garbage collection period for
+    conntrack.
+
+One common approach to tuning these parameters is to lower the conntrack
+timeouts while increasing the garbage connection interval.
+
+It is important to note that tuning the above can have an adverse impact on
+performance. Specifically, tuning the ``bpf-ct-timeout-service-*`` parameters
+can result in long-lived connections being reset if the timeouts are too short.
+More frequent GCs require extra CPU usage.
 
 Useful Scripts
 ==============


### PR DESCRIPTION
Add a section to the troubleshooting symptom library that details how to
diagnose and investigate potential traffic imbalance issues.

This is a follow up to some discussion in #14250.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>