### PR TITLE
Remove deprecated v1.10 options

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -353,6 +353,12 @@ The following metrics have been removed:
 * Label ``subnetId`` and ``availabilityZone`` in ``cilium_operator_ipam_available_ips_per_subnet`` are removed. Please
   use label ``subnet_id`` and ``availability_zone`` instead.
 
+Removed Options
+~~~~~~~~~~~~~~~
+
+* ``k8s-watcher-queue-size``: this option does not have any effect since 1.8 and
+  is now removed.
+
 .. _1.9_upgrade_notes:
 
 1.9.1 Upgrade Notes

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -362,6 +362,8 @@ Removed Options
   1.9 and is now removed.
 * ``device``: this option was deprecated in 1.9 in favor of ``devices`` and is
   now removed.
+* ``crd-wait-timeout``: this option does not have any effect since 1.9 and is
+  now removed.
 
 .. _1.9_upgrade_notes:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -360,6 +360,8 @@ Removed Options
   is now removed.
 * ``blacklist-conflicting-routes``: this option does not have any effect since
   1.9 and is now removed.
+* ``device``: this option was deprecated in 1.9 in favor of ``devices`` and is
+  now removed.
 
 .. _1.9_upgrade_notes:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -358,6 +358,8 @@ Removed Options
 
 * ``k8s-watcher-queue-size``: this option does not have any effect since 1.8 and
   is now removed.
+* ``blacklist-conflicting-routes``: this option does not have any effect since
+  1.9 and is now removed.
 
 .. _1.9_upgrade_notes:
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -254,11 +254,6 @@ func init() {
 	flags.StringSlice(option.DebugVerbose, []string{}, "List of enabled verbose debug groups")
 	option.BindEnv(option.DebugVerbose)
 
-	flags.StringP(option.Device, "d", "",
-		fmt.Sprintf("Device facing cluster/external network for attaching bpf_host. Deprecated in favor of --%s", option.Devices))
-	flags.MarkDeprecated(option.Device, "This option will be removed in v1.10")
-	option.BindEnv(option.Device)
-
 	flags.StringSlice(option.Devices, []string{}, "List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)")
 	option.BindEnv(option.Devices)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -504,10 +504,6 @@ func init() {
 	flags.MarkHidden(option.K8sSyncTimeoutName)
 	option.BindEnv(option.K8sSyncTimeoutName)
 
-	flags.Uint(option.K8sWatcherQueueSize, 1024, "Queue size used to serialize each k8s event type")
-	option.BindEnv(option.K8sWatcherQueueSize)
-	flags.MarkDeprecated(option.K8sWatcherQueueSize, "Unused flag, will be removed in 1.10")
-
 	flags.String(option.LabelPrefixFile, "", "Valid label prefixes file path")
 	option.BindEnv(option.LabelPrefixFile)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -212,10 +212,6 @@ func init() {
 	flags.Bool(option.AnnotateK8sNode, defaults.AnnotateK8sNode, "Annotate Kubernetes node")
 	option.BindEnv(option.AnnotateK8sNode)
 
-	flags.Bool(option.BlacklistConflictingRoutes, false, "Don't blacklist IP allocations conflicting with local non-cilium routes")
-	flags.MarkDeprecated(option.BlacklistConflictingRoutes, "This flag is no longer available and will be removed in the v1.10")
-	option.BindEnv(option.BlacklistConflictingRoutes)
-
 	flags.Bool(option.AutoCreateCiliumNodeResource, defaults.AutoCreateCiliumNodeResource, "Automatically create CiliumNode resource for own node on startup")
 	option.BindEnv(option.AutoCreateCiliumNodeResource)
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -267,10 +267,6 @@ func init() {
 	flags.Duration(option.K8sHeartbeatTimeout, 30*time.Second, "Configures the timeout for api-server heartbeat, set to 0 to disable")
 	option.BindEnv(option.K8sHeartbeatTimeout)
 
-	flags.Duration(operatorOption.CRDWaitTimeout, 5*time.Minute, "Operator will exit if CRDs are not available within this duration upon startup")
-	option.BindEnv(operatorOption.CRDWaitTimeout)
-	flags.MarkDeprecated(operatorOption.CRDWaitTimeout, "This option is no longer used and has been deprecated to be removed in v1.10")
-
 	flags.Duration(operatorOption.LeaderElectionLeaseDuration, 15*time.Second,
 		"Duration that non-leader operator candidates will wait before forcing to acquire leadership")
 	option.BindEnv(operatorOption.LeaderElectionLeaseDuration)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -159,9 +159,6 @@ const (
 	// primary IPConfiguration
 	AzureUsePrimaryAddress = "azure-use-primary-address"
 
-	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
-	CRDWaitTimeout = "crd-wait-timeout"
-
 	// LeaderElectionLeaseDuration is the duration that non-leader candidates will wait to
 	// force acquire leadership
 	LeaderElectionLeaseDuration = "leader-election-lease-duration"
@@ -302,9 +299,6 @@ type OperatorConfig struct {
 	// primary IPConfiguration
 	AzureUsePrimaryAddress bool
 
-	// CRDWaitTimeout it the time after which Cilium CRDs have to be available.
-	CRDWaitTimeout time.Duration
-
 	// LeaderElectionLeaseDuration is the duration that non-leader candidates will wait to
 	// force acquire leadership in Cilium Operator HA deployment.
 	LeaderElectionLeaseDuration time.Duration
@@ -339,7 +333,6 @@ func (c *OperatorConfig) Populate() {
 	c.ClusterPoolIPv4CIDR = viper.GetStringSlice(ClusterPoolIPv4CIDR)
 	c.ClusterPoolIPv6CIDR = viper.GetStringSlice(ClusterPoolIPv6CIDR)
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
-	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
 	c.LeaderElectionLeaseDuration = viper.GetDuration(LeaderElectionLeaseDuration)
 	c.LeaderElectionRenewDeadline = viper.GetDuration(LeaderElectionRenewDeadline)
 	c.LeaderElectionRetryPeriod = viper.GetDuration(LeaderElectionRetryPeriod)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -208,9 +208,6 @@ const (
 	// K8sSyncTimeout is the timeout to synchronize all resources with k8s.
 	K8sSyncTimeoutName = "k8s-sync-timeout"
 
-	// K8sWatcherQueueSize is the queue size used to serialize each k8s event type
-	K8sWatcherQueueSize = "k8s-watcher-queue-size"
-
 	// KeepConfig when restoring state, keeps containers' configuration in place
 	KeepConfig = "keep-config"
 
@@ -940,7 +937,6 @@ var HelpFlagSections = []FlagsSection{
 			K8sRequireIPv6PodCIDRName,
 			K8sSyncTimeoutName,
 			K8sWatcherEndpointSelector,
-			K8sWatcherQueueSize,
 			K8sEventHandover,
 			AnnotateK8sNode,
 			K8sForceJSONPatch,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -687,10 +687,6 @@ const (
 	// names shared by all endpoints
 	EndpointInterfaceNamePrefix = "endpoint-interface-name-prefix"
 
-	// BlacklistConflictingRoutes removes all IPs from the IPAM block if a
-	// local route not owned by Cilium conflicts with it
-	BlacklistConflictingRoutes = "blacklist-conflicting-routes"
-
 	// ForceLocalPolicyEvalAtSource forces a policy decision at the source
 	// endpoint for all local communication
 	ForceLocalPolicyEvalAtSource = "force-local-policy-eval-at-source"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -114,9 +114,6 @@ const (
 	// DebugVerbose is the argument enables verbose log message for particular subsystems
 	DebugVerbose = "debug-verbose"
 
-	// Device facing cluster/external network for attaching bpf_host
-	Device = "device"
-
 	// Devices facing cluster/external network for attaching bpf_host
 	Devices = "devices"
 
@@ -1112,7 +1109,6 @@ var HelpFlagSections = []FlagsSection{
 	{
 		Name: "Networking flags",
 		Flags: []string{
-			Device,
 			DatapathMode,
 			ConntrackGCInterval,
 			DisableConntrack,
@@ -2797,17 +2793,6 @@ func (c *DaemonConfig) Populate() {
 
 func (c *DaemonConfig) populateDevices() {
 	c.Devices = viper.GetStringSlice(Devices)
-	device := viper.GetString(Device)
-
-	if len(c.Devices) != 0 && device != "" {
-		log.Fatalf("--%s and --%s (deprecated) are mutually exclusive",
-			Devices, Device)
-	}
-
-	// For backward compatibility until the flag is completely deprecated
-	if device != "" {
-		c.Devices = []string{device}
-	}
 
 	// Make sure that devices are unique
 	if len(c.Devices) <= 1 {


### PR DESCRIPTION
Remove deprecated v1.10 options:
* `k8s-watcher-queue-size`
* `blacklist-conflicting-routes`
* `device`
* `crd-wait-timeout` (operator)

I've requested the review of André, Deepesh, Martynas and Chris as you have marked these options as deprecated as so should have the most context on them.