### PR TITLE
ci/helpers: Clean-up resource quotas

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4399,6 +4399,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"serviceaccount":     "cilium cilium-operator hubble-relay",
 			"service":            "cilium-agent hubble-metrics hubble-relay",
 			"secret":             "hubble-relay-client-certs hubble-server-certs",
+			"resourcequota":      "cilium-resource-quota cilium-operator-resource-quota",
 		}
 
 		crdsToDelete = synced.AllCRDResourceNames


### PR DESCRIPTION
Support for ResourceQuotas (specifically for GKE) was added in #13878. We want to remove them when we clean up the cilium components.