### PR TITLE
helm: Fix preflight check resource quota conflict

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
+++ b/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.resourceQuotas.enabled (and (ne .Release.Namespace "kube-system") .Values.gke.enabled) }}
+{{- if .Values.agent }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -13,6 +14,8 @@ spec:
       scopeName: PriorityClass
       values:
       - system-node-critical
+{{- end }}
+{{- if .Values.operator.enabled }}
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -28,4 +31,5 @@ spec:
       scopeName: PriorityClass
       values:
       - system-cluster-critical
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This commit fixes the preflight check on GKE which currently conflicts
with the resource quotas that may be present from an already installed
Cilium version:

```
Error: rendered manifests contain a resource that already exists. Unable
to continue with install: existing resource conflict: kind:
ResourceQuota, namespace: cilium, name: cilium-resource-quota
```

Fixes: 14ff743b5bb6 ("gke: add resource quotas for Cilium namespace")

This also needs a custom backport to 1.8 which I will do in a separate PR (thus backport pending for 1.8).