### PR TITLE
[v1.8] helm: Fix preflight check resource quota conflict

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
+++ b/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.global.resourceQuotas.enabled (and (ne .Release.Namespace "kube-system") .Values.global.gke.enabled) }}
+{{- if .Values.agent.enabled }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -13,6 +14,8 @@ spec:
       scopeName: PriorityClass
       values:
       - system-node-critical
+{{- end }}
+{{- if .Values.operator.enabled }}
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -28,4 +31,5 @@ spec:
       scopeName: PriorityClass
       values:
       - system-cluster-critical
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Custom backport due to different Helm templates on v1.8.

- #14295 -- helm: Fix preflight check resource quota conflict (@gandro)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14295; do contrib/backporting/set-labels.py $pr done 1.8; done
```