### PR TITLE
ipcache: Use controller.Manager on IPIdentityCache for bpf-garbage-collection

### DIFF
--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -351,7 +351,7 @@ func (l *BPFListener) OnIPIdentityCacheGC() {
 	// fully to give us the history of all events. As such, periodically check
 	// for inconsistencies in the data-path with that in the agent to ensure
 	// consistent state.
-	controller.NewManager().UpdateController("ipcache-bpf-garbage-collection",
+	ipcache.IPIdentityCache.UpdateController("ipcache-bpf-garbage-collection",
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				wg, err := l.garbageCollect(ctx)


### PR DESCRIPTION
In addition to the local kvstore, for each remote cluster, an `ipcache-bpf-garbage-collection` controller is instantiated. With enough remote clusters, the daemon constantly reports endpoints in either `waiting-to-regenerate` or `regenerating` state because there are now N controllers running every 5 minutes. By using a `controller.Manager` on `ipcache.IPIdentityCache` it dedupes instantiations so that only 1 `ipcache-bpf-garbage-collection` is running at a time.

Fixes: #14120

```release-note
Fix bug where Cilium would constantly regenerate endpoints in environments with etcd and Linux 4.15 or below.
```