### PR TITLE
v1.9 backports 2020-12-08

### DIFF
--- a/Documentation/gettingstarted/k8s-install-connectivity-test.rst
+++ b/Documentation/gettingstarted/k8s-install-connectivity-test.rst
@@ -37,7 +37,7 @@ indicates success or failure of the test:
    pod-to-b-multi-node-headless-7d44b85d69-mtscc            1/1     Running   0          66s
    pod-to-b-multi-node-nodeport-7ffc76db7c-rrw82            1/1     Running   0          65s
    pod-to-external-1111-d56f47579-d79dz                     1/1     Running   0          66s
-   pod-to-external-fqdn-allow-google-cnp-78986f4bcf-btjn7   0/1     Running   0          66s
+   pod-to-external-fqdn-allow-google-cnp-78986f4bcf-btjn7   1/1     Running   0          66s
 
 .. note::
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -214,8 +214,6 @@ version which was installed in this cluster. Valid options are:
       --set ipam.mode=kubernetes \\
       --set kubeProxyReplacement=strict
 
-
-
    Instead of using ``--set``, you can also save the values relative to your
    deployment in a YAML file and use it to regenerate the YAML for the latest
    Cilium version. Running any of the previous commands will overwrite
@@ -226,7 +224,12 @@ version which was installed in this cluster. Valid options are:
    .. code-block:: yaml
 
       agent: true
-      upgradeCompatibility: 1.7
+      upgradeCompatibility: "1.8"
+      ipam:
+        mode: "kubernetes"
+      k8sServiceHost: "API_SERVER_IP"
+      k8sServicePort: "API_SERVER_PORT"
+      kubeProxyReplacement: "strict"
 
    You can then upgrade using this values file by running:
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -226,6 +226,26 @@ be only accessible if the source endpoint also has the label ``env=prod``.
 
         .. literalinclude:: ../../examples/policies/l3/requires/requires.json
 
+This ``fromRequires`` rule doesn't allow anything on its own and needs to be
+combined with other rules to allow traffic. For example, when combined with the
+example policy below, the endpoint with label ``env=prod`` will become
+accessible from endpoints that have both labels ``env=prod`` and
+``role=frontend``.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.json
+
 .. _Services based:
 
 Services based

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -21,11 +21,11 @@ Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
 git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
+sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1
 sphinxcontrib-websupport==1.1.0
-sphinx-rtd-theme==0.2.4
 sphinx-tabs==1.1.13
 sphinx-version-warning==1.1.2
 typing==3.6.6

--- a/examples/policies/l3/requires/endpoints.json
+++ b/examples/policies/l3/requires/endpoints.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "l3-rule"}],
+    "endpointSelector": {"matchLabels": {"env":"prod"}},
+    "ingress": [{
+        "fromEndpoints": [
+            {"matchLabels":{"role":"frontend"}}
+        ]
+    }]
+}]

--- a/examples/policies/l3/requires/endpoints.yaml
+++ b/examples/policies/l3/requires/endpoints.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l3-rule"
+specs:
+  - description: "For endpoints with env=prod, allow if source also has label role=frontend"
+    endpointSelector:
+      matchLabels:
+        env: prod
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          role: frontend

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -295,13 +295,6 @@ data:
   # container image names
   sidecar-istio-proxy-image: "{{ .Values.proxy.sidecarImageRegex }}"
 
-  # Encapsulation mode for communication between nodes
-  # Possible values:
-  #   - disabled
-  #   - vxlan (default)
-  #   - geneve
-  tunnel: {{ .Values.tunnel }}
-
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: {{ .Values.cluster.name }}
 
@@ -311,12 +304,17 @@ data:
   cluster-id: "{{ .Values.cluster.id }}"
 {{- end }}
 
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
 {{- if .Values.gke.enabled }}
-
-  ipam: "kubernetes"
   tunnel: "disabled"
   enable-endpoint-routes: "true"
   enable-local-node-route: "false"
+{{- else }}
+  tunnel: {{ .Values.tunnel }}
 {{- end }}
 
 {{- if .Values.eni }}
@@ -608,9 +606,8 @@ data:
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: {{ .Values.disableIptablesFeederRules | join " " | quote }}
 {{- end }}
-{{- if ne $ipam "hostscope" }}
   ipam: {{ $ipam | quote }}
-{{- end }}
+
 {{- if eq $ipam "cluster-pool" }}
 {{- if .Values.ipv4.enabled }}
   cluster-pool-ipv4-cidr: {{ .Values.ipam.operator.clusterPoolIPv4PodCIDR | quote }}

--- a/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
+++ b/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.resourceQuotas.enabled (and (ne .Release.Namespace "kube-system") .Values.gke.enabled) }}
+{{- if .Values.agent }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -13,6 +14,8 @@ spec:
       scopeName: PriorityClass
       values:
       - system-node-critical
+{{- end }}
+{{- if .Values.operator.enabled }}
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -28,4 +31,5 @@ spec:
       scopeName: PriorityClass
       values:
       - system-cluster-critical
+{{- end }}
 {{- end }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -119,18 +119,18 @@ data:
   # container image names
   sidecar-istio-proxy-image: "cilium/istio_proxy"
 
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  cluster-id: ""
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
   tunnel: vxlan
-
-  # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: default
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
-  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
-  cluster-id: ""
   # Enables L7 proxy for L7 policy enforcement and visibility
   enable-l7-proxy: "true"
 

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -98,18 +98,18 @@ data:
   # container image names
   sidecar-istio-proxy-image: "cilium/istio_proxy"
 
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  cluster-id: ""
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
   tunnel: vxlan
-
-  # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: default
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
-  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
-  cluster-id: ""
   # Enables L7 proxy for L7 policy enforcement and visibility
   enable-l7-proxy: "true"
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -858,3 +858,24 @@ func (e *Endpoint) UpdateBandwidthPolicy(annoCB AnnotationsResolverCB) {
 	}
 	<-ch
 }
+
+// GetRealizedPolicyRuleLabelsForKey returns the list of policy rule labels
+// which match a given flow key (in host byte-order). The returned
+// LabelArrayList is shallow-copied and therefore must not be mutated.
+// This function explicitly exported to be accessed by code outside of the
+// Cilium source code tree and for testing.
+func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
+	derivedFrom labels.LabelArrayList,
+	revision uint64,
+	ok bool,
+) {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	entry, ok := e.realizedPolicy.PolicyMapState[key]
+	if !ok {
+		return nil, 0, false
+	}
+
+	return entry.DerivedFromRules, e.policyRevision, true
+}

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -32,8 +32,11 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/monitor"
 	"github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/source"
 
 	"github.com/google/gopacket"
@@ -443,12 +446,42 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	localIP := net.ParseIP("1.2.3.4")
 	localEP := uint16(1234)
 	remoteIP := net.ParseIP("5.6.7.8")
+	remoteID := uint32(5678)
+
+	directionFromProto := func(direction flowpb.TrafficDirection) trafficdirection.TrafficDirection {
+		switch direction {
+		case flowpb.TrafficDirection_INGRESS:
+			return trafficdirection.Ingress
+		case flowpb.TrafficDirection_EGRESS:
+			return trafficdirection.Egress
+		}
+		return trafficdirection.Invalid
+	}
+
+	type policyGetter interface {
+		GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
+			derivedFrom labels.LabelArrayList,
+			revision uint64,
+			ok bool,
+		)
+	}
+	policyLabel := labels.LabelArrayList{labels.ParseLabelArray("foo=bar")}
+	policyKey := policy.Key{
+		Identity:         remoteID,
+		DestPort:         0,
+		Nexthdr:          0,
+		TrafficDirection: trafficdirection.Egress.Uint8(),
+	}
 
 	endpointGetter := &testutils.FakeEndpointGetter{
 		OnGetEndpointInfo: func(ip net.IP) (endpoint v1.EndpointInfo, ok bool) {
 			if ip.Equal(localIP) {
 				return &testutils.FakeEndpointInfo{
 					ID: uint64(localEP),
+					PolicyMap: map[policy.Key]labels.LabelArrayList{
+						policyKey: policyLabel,
+					},
+					PolicyRevision: 1,
 				}, true
 			}
 			return nil, false
@@ -561,13 +594,24 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 	// PolicyVerdictNotify Egress
 	pvn := monitor.PolicyVerdictNotify{
-		Type:   byte(api.MessageTypePolicyVerdict),
-		Source: localEP,
-		Flags:  api.PolicyEgress,
+		Type:        byte(api.MessageTypePolicyVerdict),
+		Source:      localEP,
+		Flags:       api.PolicyEgress,
+		RemoteLabel: remoteID,
 	}
 	f = parseFlow(pvn, localIP, remoteIP)
 	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
 	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+
+	ep, ok := endpointGetter.GetEndpointInfo(localIP)
+	assert.Equal(t, true, ok)
+	lbls, rev, ok := ep.(policyGetter).GetRealizedPolicyRuleLabelsForKey(policy.Key{
+		Identity:         f.GetDestination().GetIdentity(),
+		TrafficDirection: directionFromProto(f.GetTrafficDirection()).Uint8(),
+	})
+	assert.Equal(t, true, ok)
+	assert.Equal(t, lbls, policyLabel)
+	assert.Equal(t, uint64(1), rev)
 
 	// PolicyVerdictNotify Ingress
 	pvn = monitor.PolicyVerdictNotify{

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -29,6 +29,8 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -504,6 +506,9 @@ type FakeEndpointInfo struct {
 	PodName      string
 	PodNamespace string
 	Labels       []string
+
+	PolicyMap      map[policy.Key]labels.LabelArrayList
+	PolicyRevision uint64
 }
 
 // GetID returns the ID of the endpoint.
@@ -529,4 +534,13 @@ func (e *FakeEndpointInfo) GetK8sNamespace() string {
 // GetLabels returns the labels of the endpoint.
 func (e *FakeEndpointInfo) GetLabels() []string {
 	return e.Labels
+}
+
+func (e *FakeEndpointInfo) GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
+	derivedFrom labels.LabelArrayList,
+	revision uint64,
+	ok bool,
+) {
+	derivedFrom, ok = e.PolicyMap[key]
+	return derivedFrom, e.PolicyRevision, ok
 }


### PR DESCRIPTION
 * #14278 -- docs: Fix connectivity check output (@errordeveloper)
 * #14262 -- docs: Clarify from/toRequires documentation with a new example (@pchaigno)
 * #14264 -- docs: Fix dependency conflict (@joestringer)
 * #14237 -- docs: Fix values.yaml upgrade guide to match helm args (@joestringer)
 * #14153 -- helm/cilium-configmap: added checks to deduplicate keys (@PranaviRoy)
 * #14295 -- helm: Fix preflight check resource quota conflict (@gandro)
 * #14257 -- pkg/endpoint: Readd GetRealizedPolicyRuleLabelsForKey (@gandro)

Edit:

Dropped due to verifier complexity issues:

* #14193 -- bpf: optimize dsr and add ipip support for lb-only (@borkmann)


Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14278 14262 14264 14237 14153 14295 14257; do contrib/backporting/set-labels.py $pr done 1.9; done
```