### PR TITLE
v1.8 backports 2020-12-08

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -226,6 +226,26 @@ be only accessible if the source endpoint also has the label ``env=prod``.
 
         .. literalinclude:: ../../examples/policies/l3/requires/requires.json
 
+This ``fromRequires`` rule doesn't allow anything on its own and needs to be
+combined with other rules to allow traffic. For example, when combined with the
+example policy below, the endpoint with label ``env=prod`` will become
+accessible from endpoints that have both labels ``env=prod`` and
+``role=frontend``.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l3/requires/endpoints.json
+
 .. _Services based:
 
 Services based

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -21,11 +21,11 @@ Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
 git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
+sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1
 sphinxcontrib-websupport==1.1.0
-sphinx-rtd-theme==0.2.4
 sphinx-tabs==1.1.13
 sphinx-version-warning==1.1.2
 typing==3.6.6

--- a/examples/policies/l3/requires/endpoints.json
+++ b/examples/policies/l3/requires/endpoints.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "l3-rule"}],
+    "endpointSelector": {"matchLabels": {"env":"prod"}},
+    "ingress": [{
+        "fromEndpoints": [
+            {"matchLabels":{"role":"frontend"}}
+        ]
+    }]
+}]

--- a/examples/policies/l3/requires/endpoints.yaml
+++ b/examples/policies/l3/requires/endpoints.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l3-rule"
+specs:
+  - description: "For endpoints with env=prod, allow if source also has label role=frontend"
+    endpointSelector:
+      matchLabels:
+        env: prod
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          role: frontend

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -169,11 +169,6 @@ func (v *Value) CountFloat() float64 {
 	return float64(v.Count)
 }
 
-// bytesFloat converts the bytes count to float
-func (v *Value) bytesFloat() float64 {
-	return float64(v.Bytes)
-}
-
 // NewValue returns a new empty instance of the structure representing the BPF
 // map value
 func (k *Key) NewValue() bpf.MapValue { return &Value{} }
@@ -199,20 +194,28 @@ func updateMetric(getCounter func() (prometheus.Counter, error), newValue float6
 // updatePrometheusMetrics checks the metricsmap key value pair
 // and determines which prometheus metrics along with respective labels
 // need to be updated.
-func updatePrometheusMetrics(key *Key, val *Value) {
+func updatePrometheusMetrics(key *Key, values *Values) {
+	// Metrics is a per-CPU map so we first need to aggregate the
+	// different entries that make up a value.
+	var packets, bytes uint64
+	for _, value := range *values {
+		packets += value.Count
+		bytes += value.Bytes
+	}
+
 	updateMetric(func() (prometheus.Counter, error) {
 		if key.IsDrop() {
 			return metrics.DropCount.GetMetricWithLabelValues(key.DropForwardReason(), key.Direction())
 		}
 		return metrics.ForwardCount.GetMetricWithLabelValues(key.Direction())
-	}, val.CountFloat())
+	}, float64(packets))
 
 	updateMetric(func() (prometheus.Counter, error) {
 		if key.IsDrop() {
 			return metrics.DropBytes.GetMetricWithLabelValues(key.DropForwardReason(), key.Direction())
 		}
 		return metrics.ForwardBytes.GetMetricWithLabelValues(key.Direction())
-	}, val.bytesFloat())
+	}, float64(bytes))
 }
 
 // SyncMetricsMap is called periodically to sync off the metrics map by
@@ -220,10 +223,8 @@ func updatePrometheusMetrics(key *Key, val *Value) {
 // forwards (by direction) with the prometheus server.
 func SyncMetricsMap(ctx context.Context) error {
 	callback := func(key bpf.MapKey, values bpf.MapValue) {
-		for _, value := range *values.(*Values) {
-			// Increment Prometheus metrics here.
-			updatePrometheusMetrics(key.(*Key), &value)
-		}
+		// Increment Prometheus metrics here.
+		updatePrometheusMetrics(key.(*Key), values.(*Values))
 	}
 
 	if err := Metrics.DumpWithCallback(callback); err != nil {

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -32,9 +32,8 @@ import (
 
 var (
 	// Metrics is the bpf metrics map
-	Metrics      *bpf.Map
-	log          = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-metrics")
-	possibleCpus int
+	Metrics *bpf.Map
+	log     = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-metrics")
 )
 
 const (
@@ -220,49 +219,22 @@ func updatePrometheusMetrics(key *Key, val *Value) {
 // aggregating it into drops (by drop reason and direction) and
 // forwards (by direction) with the prometheus server.
 func SyncMetricsMap(ctx context.Context) error {
-	entry := make([]Value, possibleCpus)
-	file := bpf.MapPath(MapName)
-
-	var err error
-	metricsMap := bpf.GetMap(file)
-	if metricsMap == nil {
-		// Open the map and leave it open, since SyncMetricsMap is called
-		// periodically and it makes sense to use an already opened map rather
-		// than opening the map again and again.
-		// This also prevents the constant registration and unregistration of the
-		// Map.
-		metricsMap, err = bpf.OpenMap(file)
-
-		if err != nil {
-			return fmt.Errorf("Unable to open metrics map: %s", err)
-		}
-	}
-
-	var key, nextKey Key
-	for {
-		err := bpf.GetNextKey(metricsMap.GetFd(), unsafe.Pointer(&key), unsafe.Pointer(&nextKey))
-		if err != nil {
-			break
-		}
-		err = bpf.LookupElement(metricsMap.GetFd(), unsafe.Pointer(&nextKey), unsafe.Pointer(&entry[0]))
-		if err != nil {
-			return fmt.Errorf("unable to lookup metrics map: %s", err)
-		}
-
-		// cannot use `range entry` since, if the first value for a particular
-		// CPU is zero, it never iterates over the next non-zero value.
-		for i := 0; i < possibleCpus; i++ {
+	callback := func(key bpf.MapKey, values bpf.MapValue) {
+		for _, value := range *values.(*Values) {
 			// Increment Prometheus metrics here.
-			updatePrometheusMetrics(&nextKey, &entry[i])
+			updatePrometheusMetrics(key.(*Key), &value)
 		}
-		key = nextKey
-
 	}
+
+	if err := Metrics.DumpWithCallback(callback); err != nil {
+		return fmt.Errorf("error dumping contents of metrics map: %s", err)
+	}
+
 	return nil
 }
 
 func init() {
-	possibleCpus = common.GetNumPossibleCPUs(log)
+	possibleCpus := common.GetNumPossibleCPUs(log)
 
 	vs := make(Values, possibleCpus)
 


### PR DESCRIPTION
* ~#14044 -- test: Bump migrate-svc-test image (@brb)~
 * #14220 -- metricsmap: fix Prometheus exporter (@jibi)
 * #14262 -- docs: Clarify from/toRequires documentation with a new example (@pchaigno)
 * #14264 -- docs: Fix dependency conflict (@joestringer)
 * ~#14153 -- helm/cilium-configmap: added checks to deduplicate keys (@PranaviRoy)~

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14220 14262 14264; do contrib/backporting/set-labels.py $pr done 1.8; done
```

Note: I had to manually resolve conflicts for `#14153 -- helm/cilium-configmap: added checks to deduplicate keys (@PranaviRoy)`