### PR TITLE
pkg/k8s: fix k8s_event_lag_seconds for negative time

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -79,7 +79,12 @@ func (k *K8sWatcher) createPodController(getter cache.Getter, fieldSelector fiel
 					// handling.
 					if ep := k.endpointManager.LookupPodName(podNSName); ep != nil {
 						epCreatedAt := ep.GetCreatedAt()
-						metrics.EventLagK8s.Set(time.Since(epCreatedAt).Seconds())
+						timeSinceEpCreated := time.Since(epCreatedAt)
+						if timeSinceEpCreated <= 0 {
+							metrics.EventLagK8s.Set(0)
+						} else {
+							metrics.EventLagK8s.Set(timeSinceEpCreated.Round(time.Second).Seconds())
+						}
 					}
 					err := k.addK8sPodV1(pod)
 					k.K8sEventProcessed(metricPod, metricCreate, err == nil)


### PR DESCRIPTION
In some occasions the metric `k8s_event_lag_seconds` could be presented
as an overflown value such as `9223372036854775807`. This commit fixes
this by checking if the calculated value is less than zero by only
setting this metric for positive times.

Fixes: 4e2913004340 ("pkg/endpoint: calculate Kube API-Server lag from pod events")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/14309

```release-note
Fix possible overflow in values presented in the `k8s_event_lag_seconds` metric.
```
