### PR TITLE
hubble: Extend IP filter to support CIDR ranges

### DIFF
--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -1928,7 +1928,9 @@ type FlowFilter struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// source_ip filters by a list of source ips
+	// source_ip filters by a list of source ips. Each of the source ips can be
+	// specified as an exact match (e.g. "1.1.1.1") or as a CIDR range (e.g.
+	// "1.1.1.0/24").
 	SourceIp []string `protobuf:"bytes,1,rep,name=source_ip,json=sourceIp,proto3" json:"source_ip,omitempty"`
 	// source_pod filters by a list of source pod name prefixes, optionally
 	// within a given namespace (e.g. "xwing", "kube-system/coredns-").
@@ -1943,7 +1945,9 @@ type FlowFilter struct {
 	// source_service filters on a list of source service names. This field
 	// supports the same syntax as the source_pod field.
 	SourceService []string `protobuf:"bytes,16,rep,name=source_service,json=sourceService,proto3" json:"source_service,omitempty"`
-	// destination_ip filters by a list of destination ips
+	// destination_ip filters by a list of destination ips. Each of the
+	// destination ips can be specified as an exact match (e.g. "1.1.1.1") or
+	// as a CIDR range (e.g. "1.1.1.0/24").
 	DestinationIp []string `protobuf:"bytes,3,rep,name=destination_ip,json=destinationIp,proto3" json:"destination_ip,omitempty"`
 	// destination_pod filters by a list of destination pod names
 	DestinationPod []string `protobuf:"bytes,4,rep,name=destination_pod,json=destinationPod,proto3" json:"destination_pod,omitempty"`

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -320,7 +320,9 @@ message CiliumEventType {
 // FlowFilter represent an individual flow filter. All fields are optional. If
 // multiple fields are set, then all fields must match for the filter to match.
 message FlowFilter {
-    // source_ip filters by a list of source ips
+    // source_ip filters by a list of source ips. Each of the source ips can be
+    // specified as an exact match (e.g. "1.1.1.1") or as a CIDR range (e.g.
+    // "1.1.1.0/24").
     repeated string source_ip = 1;
     // source_pod filters by a list of source pod name prefixes, optionally
     // within a given namespace (e.g. "xwing", "kube-system/coredns-").
@@ -336,7 +338,9 @@ message FlowFilter {
     // supports the same syntax as the source_pod field.
     repeated string source_service = 16;
 
-    // destination_ip filters by a list of destination ips
+    // destination_ip filters by a list of destination ips. Each of the
+    // destination ips can be specified as an exact match (e.g. "1.1.1.1") or
+    // as a CIDR range (e.g. "1.1.1.0/24").
     repeated string destination_ip = 3;
     // destination_pod filters by a list of destination pod names
     repeated string destination_pod = 4;

--- a/pkg/hubble/filters/ip_test.go
+++ b/pkg/hubble/filters/ip_test.go
@@ -157,6 +157,62 @@ func TestIPFilter(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "source cidr",
+			args: args{
+				f: []*flowpb.FlowFilter{{SourceIp: []string{"1.1.1.0/24", "f00d::/16"}}},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Source: "1.1.1.1", Destination: "2.2.2.2"}}},
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Source: "2.2.2.2", Destination: "1.1.1.1"}}},
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Source: "f00d::a10:0:0:9195", Destination: "ff02::1:ff00:b3e5"}}},
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Source: "ff02::1:ff00:b3e5", Destination: "f00d::a10:0:0:9195"}}},
+				},
+			},
+			want: []bool{
+				true,
+				false,
+				true,
+				false,
+			},
+		},
+		{
+			name: "destination cidr",
+			args: args{
+				f: []*flowpb.FlowFilter{{DestinationIp: []string{"1.1.1.0/24", "f00d::/16"}}},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Destination: "1.1.1.1", Source: "2.2.2.2"}}},
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Destination: "2.2.2.2", Source: "1.1.1.1"}}},
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Destination: "f00d::a10:0:0:9195", Source: "ff02::1:ff00:b3e5"}}},
+					{Event: &flowpb.Flow{IP: &flowpb.IP{Destination: "ff02::1:ff00:b3e5", Source: "f00d::a10:0:0:9195"}}},
+				},
+			},
+			want: []bool{
+				true,
+				false,
+				true,
+				false,
+			},
+		},
+		{
+			name: "invalid source cidr filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{SourceIp: []string{"1.1.1.1/1234"}},
+					{SourceIp: []string{"2001::/1234"}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid destination cidr filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{DestinationIp: []string{"1.1.1.1/1234"}},
+					{DestinationIp: []string{"2001::/1234"}},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Extend the existing {source,destination}_ip filters to support CIDR
ranges in addition to exact matches.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>