### PR TITLE
Adds no track annotation to example node-local-dns yaml

### DIFF
--- a/examples/kubernetes-local-redirect/node-local-dns.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns.yaml
@@ -107,6 +107,7 @@ spec:
       labels:
         k8s-app: node-local-dns
       annotations:
+        io.cilium.no-track-port: "53"
         prometheus.io/port: "9253"
         prometheus.io/scrape: "true"
     spec:


### PR DESCRIPTION
Support for no-track-port was added in PR #13805 

Signed-off-by: Weilong Cui <cuiwl@google.com>