### PR TITLE
remove xtables.lock and privileged=true from node-local-dns example

### DIFF
--- a/examples/kubernetes-local-redirect/node-local-dns.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns.yaml
@@ -129,8 +129,6 @@ spec:
             cpu: 25m
             memory: 5Mi
         args: [ "-localip", "169.254.20.10,__PILLAR__DNS__SERVER__", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream", "-skipteardown=true", "-setupinterface=false", "-setupiptables=false" ]
-        securityContext:
-          privileged: true
         ports:
         - containerPort: 53
           name: dns
@@ -148,18 +146,11 @@ spec:
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:
-        - mountPath: /run/xtables.lock
-          name: xtables-lock
-          readOnly: false
         - name: config-volume
           mountPath: /etc/coredns
         - name: kube-dns-config
           mountPath: /etc/kube-dns
       volumes:
-      - name: xtables-lock
-        hostPath:
-          path: /run/xtables.lock
-          type: FileOrCreate
       - name: kube-dns-config
         configMap:
           name: kube-dns


### PR DESCRIPTION
As discussed in [slack](https://cilium.slack.com/archives/C1MATJ5U5/p1607346433098100), the node-local-dns cache container does not need the iptables xtables.lock mount and can thus be run unprivileged. This PR fixes the example deployment by removing the mount of the lock and the `privileged: true` directive.

\cc @Weil0ng 