### PR TITLE
Sort v1.9.1 backports complexity

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1203,6 +1203,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 					   verdict, policy_match_type, audited);
 	}
 
+	relax_verifier();
 	if (ret == CT_NEW) {
 #ifdef ENABLE_DSR
 	{

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -80,6 +80,8 @@ static __always_inline __u32 __ct_update_timeout(struct ct_entry *entry,
 #ifdef NEEDS_TIMEOUT
 	WRITE_ONCE(entry->lifetime, now + lifetime);
 #endif
+
+	relax_verifier();
 	if (dir == CT_INGRESS) {
 		accumulated_flags = READ_ONCE(entry->rx_flags_seen);
 		last_report = READ_ONCE(entry->last_rx_report);
@@ -209,8 +211,6 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 	struct ct_entry *entry;
 	int reopen;
 
-	relax_verifier();
-
 	entry = map_lookup_elem(map, tuple);
 	if (entry) {
 		cilium_dbg(ctx, DBG_CT_MATCH, entry->lifetime, entry->rev_nat_index);
@@ -234,6 +234,7 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 #endif
 #ifdef CONNTRACK_ACCOUNTING
 		/* FIXME: This is slow, per-cpu counters? */
+		relax_verifier();
 		if (dir == CT_INGRESS) {
 			__sync_fetch_and_add(&entry->rx_packets, 1);
 			__sync_fetch_and_add(&entry->rx_bytes, ctx_full_len(ctx));
@@ -670,8 +671,6 @@ static __always_inline int ct_lookup4(const void *map,
 		goto out;
 	}
 
-	relax_verifier();
-
 	/* Lookup entry in forward direction */
 	if (dir != CT_SERVICE) {
 		ipv4_ct_tuple_reverse(tuple);
@@ -818,6 +817,8 @@ static __always_inline int ct_create4(const void *map_main,
 	struct ct_entry entry = { };
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
 	union tcp_flags seen_flags = { .value = 0 };
+
+	relax_verifier();
 
 	/* Note if this is a proxy connection so that replies can be redirected
 	 * back to the proxy.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -521,7 +521,6 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	struct lb6_service *svc;
 	struct lb6_key key = {};
 	struct ct_state ct_state_new = {};
-	struct ct_state ct_state = {};
 	union macaddr smac, *mac;
 	bool backend_local;
 	__u32 monitor = 0;
@@ -573,10 +572,6 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 		return DROP_MISSED_TAIL_CALL;
 	}
 
-	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-			 &ct_state, &monitor);
-	if (ret < 0)
-		return ret;
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
@@ -584,50 +579,53 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	if (!backend_local && lb6_svc_is_hostport(svc))
 		return DROP_INVALID;
 
-	switch (ret) {
-	case CT_NEW:
+	if (backend_local || !nodeport_uses_dsr6(&tuple)) {
+		struct ct_state ct_state = {};
+
+		ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
+				 CT_EGRESS, &ct_state, &monitor);
+		switch (ret) {
+		case CT_NEW:
 redo_all:
-		ct_state_new.src_sec_id = SECLABEL;
-		ct_state_new.node_port = 1;
-		ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
-		ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false);
-		if (IS_ERR(ret))
-			return ret;
-		if (backend_local) {
-			ct_flip_tuple_dir6(&tuple);
-redo_local:
-			ct_state_new.rev_nat_index = 0;
+			ct_state_new.src_sec_id = SECLABEL;
+			ct_state_new.node_port = 1;
+			ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
 			ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
-					 CT_INGRESS, &ct_state_new, false);
+					 CT_EGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))
 				return ret;
-		}
-		break;
-
-	case CT_REOPENED:
-	case CT_ESTABLISHED:
-	case CT_REPLY:
-		if (unlikely(ct_state.rev_nat_index != svc->rev_nat_index))
-			goto redo_all;
-
-		if (backend_local) {
-			ct_flip_tuple_dir6(&tuple);
-			if (!__ct_entry_keep_alive(get_ct_map6(&tuple),
-						   &tuple)) {
-				ct_state_new.src_sec_id = SECLABEL;
-				ct_state_new.node_port = 1;
-				ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
-				goto redo_local;
+			if (backend_local) {
+				ct_flip_tuple_dir6(&tuple);
+redo_local:
+				ct_state_new.rev_nat_index = 0;
+				ret = ct_create6(get_ct_map6(&tuple), NULL,
+						 &tuple, ctx, CT_INGRESS,
+						 &ct_state_new, false);
+				if (IS_ERR(ret))
+					return ret;
 			}
+			break;
+		case CT_REOPENED:
+		case CT_ESTABLISHED:
+		case CT_REPLY:
+			if (unlikely(ct_state.rev_nat_index !=
+				     svc->rev_nat_index))
+				goto redo_all;
+			if (backend_local) {
+				ct_flip_tuple_dir6(&tuple);
+				if (!__ct_entry_keep_alive(get_ct_map6(&tuple),
+							   &tuple)) {
+					ct_state_new.src_sec_id = SECLABEL;
+					ct_state_new.node_port = 1;
+					ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
+					goto redo_local;
+				}
+			}
+			break;
+		default:
+			return DROP_UNKNOWN_CT;
 		}
-		break;
 
-	default:
-		return DROP_UNKNOWN_CT;
-	}
-
-	if (backend_local || (!backend_local && !nodeport_uses_dsr6(&tuple))) {
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 		if (eth_load_saddr(ctx, smac.addr, 0) < 0)
@@ -1239,7 +1237,6 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	struct lb4_service *svc;
 	struct lb4_key key = {};
 	struct ct_state ct_state_new = {};
-	struct ct_state ct_state = {};
 	union macaddr smac, *mac;
 	bool backend_local;
 	__u32 monitor = 0;
@@ -1290,10 +1287,6 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		return DROP_MISSED_TAIL_CALL;
 	}
 
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-			 &ct_state, &monitor);
-	if (ret < 0)
-		return ret;
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
@@ -1301,56 +1294,62 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	if (!backend_local && lb4_svc_is_hostport(svc))
 		return DROP_INVALID;
 
-	switch (ret) {
-	case CT_NEW:
+	/* Reply from DSR packet is never seen on this node again hence no
+	 * need to track in here.
+	 */
+	if (backend_local || !nodeport_uses_dsr4(&tuple)) {
+		struct ct_state ct_state = {};
+
+		ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
+				 CT_EGRESS, &ct_state, &monitor);
+		switch (ret) {
+		case CT_NEW:
 redo_all:
-		ct_state_new.src_sec_id = SECLABEL;
-		ct_state_new.node_port = 1;
-		ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
-		ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false);
-		if (IS_ERR(ret))
-			return ret;
-		if (backend_local) {
-			ct_flip_tuple_dir4(&tuple);
-redo_local:
-			/* Reset rev_nat_index, otherwise ipv4_policy() in
-			 * bpf_lxc will do invalid xlation.
-			 */
-			ct_state_new.rev_nat_index = 0;
+			ct_state_new.src_sec_id = SECLABEL;
+			ct_state_new.node_port = 1;
+			ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
 			ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
-					 CT_INGRESS, &ct_state_new, false);
+					 CT_EGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))
 				return ret;
-		}
-		break;
-
-	case CT_REOPENED:
-	case CT_ESTABLISHED:
-	case CT_REPLY:
-		/* Recreate CT entries, as the existing one is stale and belongs
-		 * to a flow which target a different svc.
-		 */
-		if (unlikely(ct_state.rev_nat_index != svc->rev_nat_index))
-			goto redo_all;
-
-		if (backend_local) {
-			ct_flip_tuple_dir4(&tuple);
-			if (!__ct_entry_keep_alive(get_ct_map4(&tuple),
-						   &tuple)) {
-				ct_state_new.src_sec_id = SECLABEL;
-				ct_state_new.node_port = 1;
-				ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
-				goto redo_local;
+			if (backend_local) {
+				ct_flip_tuple_dir4(&tuple);
+redo_local:
+				/* Reset rev_nat_index, otherwise ipv4_policy()
+				 * in bpf_lxc will do invalid xlation.
+				 */
+				ct_state_new.rev_nat_index = 0;
+				ret = ct_create4(get_ct_map4(&tuple), NULL,
+						 &tuple, ctx, CT_INGRESS,
+						 &ct_state_new, false);
+				if (IS_ERR(ret))
+					return ret;
 			}
+			break;
+		case CT_REOPENED:
+		case CT_ESTABLISHED:
+		case CT_REPLY:
+			/* Recreate CT entries, as the existing one is stale and
+			 * belongs to a flow which target a different svc.
+			 */
+			if (unlikely(ct_state.rev_nat_index !=
+				     svc->rev_nat_index))
+				goto redo_all;
+			if (backend_local) {
+				ct_flip_tuple_dir4(&tuple);
+				if (!__ct_entry_keep_alive(get_ct_map4(&tuple),
+							   &tuple)) {
+					ct_state_new.src_sec_id = SECLABEL;
+					ct_state_new.node_port = 1;
+					ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
+					goto redo_local;
+				}
+			}
+			break;
+		default:
+			return DROP_UNKNOWN_CT;
 		}
-		break;
 
-	default:
-		return DROP_UNKNOWN_CT;
-	}
-
-	if (backend_local || (!backend_local && !nodeport_uses_dsr4(&tuple))) {
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 		if (eth_load_saddr(ctx, smac.addr, 0) < 0)


### PR DESCRIPTION
* #14193 -- bpf: optimize dsr and add ipip support for lb-only (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14193; do contrib/backporting/set-labels.py $pr done 1.9; done
```