### PR TITLE
microk8s: fix  add-on-command for enabling cilium 

### DIFF
--- a/Documentation/gettingstarted/microk8s.rst
+++ b/Documentation/gettingstarted/microk8s.rst
@@ -25,7 +25,7 @@ Install microk8s
 
    ::
 
-      microk8s.enable cilium
+      microk8s enable cilium
 
 #. Cilium is now configured! The ``cilium`` CLI is provided as ``microk8s.cilium``.
 


### PR DESCRIPTION
As per Documentation of [microk8s](https://microk8s.io/docs/addons),  enabling add-ons are being invoked with `microk8s enable <addon>` - note the missing dot
Also tested this locally

`microk8s enable cilium`

Signed-off-by: Philipp Gniewosz <philipp.gniewosz@posteo.de>
