### PR TITLE
pkg/logging: Init klog with flag set name

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -89,17 +89,20 @@ var (
 func init() {
 	log := DefaultLogger.WithField(logfields.LogSubsys, "klog")
 
+	//Create a new flag set and set error handler
+	klogFlags := flag.NewFlagSet("cilium", flag.ExitOnError)
+
 	// Make sure that klog logging variables are initialized so that we can
 	// update them from this file.
-	klog.InitFlags(nil)
+	klog.InitFlags(klogFlags)
 
 	// Make sure klog does not log to stderr as we want it to control the output
 	// of klog so we want klog to log the errors to each writer of each level.
-	flag.Set("logtostderr", "false")
+	klogFlags.Set("logtostderr", "false")
 
 	// We don't need all headers because logrus will already print them if
 	// necessary.
-	flag.Set("skip_headers", "true")
+	klogFlags.Set("skip_headers", "true")
 
 	klog.SetOutputBySeverity("INFO", log.WriterLevel(logrus.InfoLevel))
 	klog.SetOutputBySeverity("WARNING", log.WriterLevel(logrus.WarnLevel))


### PR DESCRIPTION
Previously, klog init flag with nil by using default flag commandline, if other operator
init flag by nil will result in flag log_dir redefined errors.

This commit resolved the log_dir flag redefined problem by instantiating flag.NewFlagSet

Fixes: #14317
Signed-off-by: fafucoder <lx1960754013@gmail.com>