### PR TITLE
daemon, option: remove always-true option.Config.RunMonitorAgent

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -690,18 +690,15 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	}
 
 	// We can only start monitor agent once cilium_event has been set up.
-	if option.Config.RunMonitorAgent {
-		monitorAgent, err := monitoragent.NewAgent(d.ctx, defaults.MonitorBufferPages)
+	d.monitorAgent, err = monitoragent.NewAgent(d.ctx, defaults.MonitorBufferPages)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if option.Config.EnableMonitor {
+		err = monitoragent.ServeMonitorAPI(d.monitorAgent)
 		if err != nil {
 			return nil, nil, err
-		}
-		d.monitorAgent = monitorAgent
-
-		if option.Config.EnableMonitor {
-			err = monitoragent.ServeMonitorAPI(monitorAgent)
-			if err != nil {
-				return nil, nil, err
-			}
 		}
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1361,8 +1361,6 @@ func runDaemon() {
 		}
 	}
 
-	option.Config.RunMonitorAgent = true
-
 	if err := enableIPForwarding(); err != nil {
 		log.WithError(err).Fatal("Error when enabling sysctl parameters")
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1787,9 +1787,6 @@ type DaemonConfig struct {
 	// Specifies wheather to annotate the kubernetes nodes or not
 	AnnotateK8sNode bool
 
-	// RunMonitorAgent indicates whether to run the monitor agent
-	RunMonitorAgent bool
-
 	// ReadCNIConfiguration reads the CNI configuration file and extracts
 	// Cilium relevant information. This can be used to pass per node
 	// configuration to Cilium.


### PR DESCRIPTION
`pkg/option.Config.RunMonitorAgent` is unconditionally set to true in func
`daemon/cmd.runDaemon` and there is no way to set it using an agent
option. Its value is later only checked in `daemon/cmd.NewDaemon`.

Drop `pkg/option.Config.RunMonitorAgent` and unconditionally create the
monitor agent. Its start is still gated by `option.Config.EnableMonitor`
which is set by the `--enable-monitor` agent option.