### PR TITLE
daemon: Turn on policy debug logging if Cilium is started with --debug

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -971,6 +971,10 @@ func initEnv(cmd *cobra.Command) {
 			log.Warningf("Unknown verbose debug group: %s", grp)
 		}
 	}
+	// Enable policy debugging if debug is enabled.
+	if option.Config.Debug {
+		option.Config.Opts.SetBool(option.DebugPolicy, true)
+	}
 
 	common.RequireRootPrivilege("cilium-agent")
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -717,6 +717,9 @@ func (e *Endpoint) SetDefaultOpts(opts *option.IntOptions) {
 			e.Options.SetValidated(k, opts.GetValue(k))
 		}
 	}
+	if option.Config.Debug {
+		e.Options.SetValidated(option.DebugPolicy, option.OptionEnabled)
+	}
 	e.UpdateLogger(nil)
 }
 


### PR DESCRIPTION
The purpose of the separate --debug-verbose=policy setting is to be
able to turn on policy map debug logging without turning debug on in
general. In the reverse case, when debug is enabled, we generally also
want to get the policy map debugs, though.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
