### PR TITLE
node: Remove check whether nextHop is in same L2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 	github.com/blang/semver/v4 v4.0.0
-	github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5
+	github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.3.0
 	github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc60193
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5 h1:4f4AuCR25RFRemzNgw1FK0ZBSr9KgJVn5MiVA9K7HpI=
-github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
+github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1 h1:PcOKzY6o4mkmGzrmr6pFCx5X802LjD/o4zUD+rsGpm8=
+github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e/go.mod h1:c4R5wxGyXhbM6zyKeRKNIc9aab5EZi4z4oOSZvUMvZA=
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3 h1:wenYMyWJ08dgEUUj0Ija8qdK/V9vL3ThAD5sjOYlFlg=

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -555,6 +555,7 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 		return
 	}
 
+	srcIP := make(net.IP, 4)
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
 	copy(nextHopIPv4, newNodeIP)
@@ -576,6 +577,7 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 			// a gateway. Send arping to the gw IP addr instead of newNode IP addr.
 			// NOTE: we currently don't handle multipath, so only one gw can be used.
 			copy(nextHopIPv4, route.Gw)
+			copy(srcIP, route.Src)
 			break
 		}
 	}
@@ -599,7 +601,7 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 		}
 		link := linkAttr.Attrs().Index
 
-		hwAddr, _, err := arping.PingOverIface(nextHopIPv4, *iface)
+		hwAddr, _, err := arping.PingOverIface(nextHopIPv4, *iface, srcIP)
 		if err != nil {
 			scopedLog.WithError(err).Error("arping failed")
 			return

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -592,12 +592,6 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 			return
 		}
 
-		_, err = arping.FindIPInNetworkFromIface(nextHopIPv4, *iface)
-		if err != nil {
-			scopedLog.WithError(err).Error("IP is not L2 reachable")
-			return
-		}
-
 		linkAttr, err := netlink.LinkByName(ifaceName)
 		if err != nil {
 			scopedLog.WithError(err).Error("Failed to retrieve iface by name (netlink)")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cilium/arping v1.0.1-0.20201126164629-5142c9527af5
+# github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1
 ## explicit
 github.com/cilium/arping
 # github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e


### PR DESCRIPTION
It was reported that on a GKE cluster the neigh handling logged the
following error:

    level=error msg="IP is not L2 reachable" error="iface: 'eth0' can't
    reach ip: '10.164.0.1'" interface=eth0 ipAddr=10.164.0.1
    subsys=linux-datapath

The "ip route" and "ip addr" had the following relevant entries:

    default via 10.164.0.1 dev eth0 proto dhcp metric 1024
    10.164.0.1 dev eth0 proto dhcp scope link metric 1024

    eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc mq state UP
    group default qlen 1000 link/ether 42:01:0a:a4:00:4f brd ff:ff:ff:ff:ff:ff
    inet 10.164.0.79/32 scope global dynamic eth0

As we can see, eth0 had IP addr assigned from /32 subnet which made the
check for nexthop in the same L2 to fail regardless of the "10.164.0.1
dev eth0" route.

This commit removes the check, as nexthop is guaranteed to be L2-reachable
by the Linux kernel routing system.

Reported-by: Joe Stringer <joe@cilium.io>
Reported-by: Paul Chaignon <paul@cilium.io>
Fix #14340 