### PR TITLE
test: Only wait for one operator instance to be ready

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -616,6 +616,20 @@ func (kub *Kubectl) PrepareCluster() {
 	}
 }
 
+// NumNodes returns the number of Kubernetes nodes
+func (kub *Kubectl) NumNodes() int {
+	cmd := KubectlCmd + " get nodes -o json | jq '.items | length'"
+	res := kub.ExecShort(cmd)
+	if !res.WasSuccessful() {
+		ginkgoext.Failf("unable to retrieve all nodes with '%s': %s", cmd, res.OutputPrettyPrint())
+	}
+	i, err := strconv.Atoi(strings.TrimSpace(res.Stdout()))
+	if err != nil {
+		ginkgoext.Failf("unable to parse number of nodes from '%s': %s", res.Stdout(), err)
+	}
+	return i
+}
+
 // labelNodes labels all Kubernetes nodes for use by the CI tests
 func (kub *Kubectl) labelNodes() error {
 	cmd := KubectlCmd + " get nodes -o json | jq -r '[ .items[] | select(.metadata.labels[\"node-role.kubernetes.io/controlplane\"] == null).metadata.name ]'"

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -58,7 +58,12 @@ func ExpectCiliumNotRunning(vm *helpers.Kubectl) {
 // the error returned by that function is nil.
 func ExpectCiliumOperatorReady(vm *helpers.Kubectl) {
 	By("Waiting for cilium-operator to be ready")
-	err := vm.WaitforPods(helpers.CiliumNamespace, "-l name=cilium-operator", longTimeout)
+	var err error
+	if vm.NumNodes() < 2 {
+		err = vm.WaitforNPods(helpers.CiliumNamespace, "-l name=cilium-operator", 1, longTimeout)
+	} else {
+		err = vm.WaitforPods(helpers.CiliumNamespace, "-l name=cilium-operator", longTimeout)
+	}
 	ExpectWithOffset(1, err).Should(BeNil(), "Cilium operator was not able to get into ready state")
 }
 


### PR DESCRIPTION
Waiting for only one Cilium operator instance to be ready allows
testing in single node environments, such as Minikube.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
