### PR TITLE
contrib/k8s: Add 'nsexec' script to run commands in the network namespace of a POD

### DIFF
--- a/contrib/k8s/nsexec
+++ b/contrib/k8s/nsexec
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Execute command in the network namespace of the named k8s POD
+# E.g.:
+#
+# $ nsexec hello ip addr
+# $ nsexec hello -- ip addr
+#
+# Both would show the IP interfaces in the network namespace of a
+# local k8s docker container named "k8s_POD_hello*", given that there
+# is only one docker container that starts with that name.  "ip" is
+# run from your current environment, it does not need to exist within
+# the k8s POD.
+#
+# This has the limitation that this only works if k8s containers are
+# run via Docker.
+#
+
+set -e
+
+CONTAINER_ID=$(docker ps -q --filter "name=k8s_POD_$1")
+if [ "$(echo ${CONTAINER_ID} | wc -w)" -ne "1" ] ; then
+    echo "Argument must be a unique prefix of the name of a single running k8s POD. Current docker containers matching \"$1\" are:"
+    docker ps --filter "name=k8s_POD_$1"
+    exit 1
+fi
+
+PID=$(docker inspect -f '{{.State.Pid}}' ${CONTAINER_ID})
+[ -z "${PID}" ] && exit 1
+
+[ ! -d "/var/run/netns" ] && sudo mkdir -p /var/run/netns
+
+function cleanup {
+    sudo rm /var/run/netns/${CONTAINER_ID}
+}
+
+# Create and remove netns link only if needed
+if [ ! -L /var/run/netns/${CONTAINER_ID} ] ; then
+    sudo ln -sfT /proc/${PID}/ns/net /var/run/netns/${CONTAINER_ID}
+    trap cleanup EXIT
+fi
+
+shift
+[ "$1" = "--" ] && shift
+sudo ip netns exec ${CONTAINER_ID} $@


### PR DESCRIPTION
Add script 'nsexec' for running commands in the network namespace of a
k8s POD. This is useful for inspecting and debugging the networking
configuration within a pod, or originating traffic from a POD without
needing to install 'curl' in there, for example.

Currently this relies on Docker being the container runtime.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>