### PR TITLE
stale-bot: stale PRs with assignees

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -53,6 +53,7 @@ pulls:
     This pull request has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
     for your contributions.
+  exemptAssignees: false
 
 # issues:
 #   exemptLabels:


### PR DESCRIPTION
With the introduction of assignees to review PRs, as a consequence the
stale bot will never stale such PRs. To change this behavior we can
modify the configuration for the stale bot to also stale PRs that have
assignees.

Signed-off-by: André Martins <andre@cilium.io>