### PR TITLE
policy: Track selectors that contribute to MapStateEntries

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -403,7 +403,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 				labels.NewLabel(policy.LabelKeyPolicyDerivedFrom, policy.LabelVisibilityAnnotation, labels.LabelSourceReserved),
 			},
 		}
-		entry := policy.NewMapStateEntry(derivedFrom, true)
+		entry := policy.NewMapStateEntry(nil, derivedFrom, true)
 		entry.ProxyPort = redirectPort
 
 		e.desiredPolicy.PolicyMapState[newKey] = entry
@@ -1080,11 +1080,6 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool, had
 	// Operation was successful, remove from realized state.
 	delete(e.realizedPolicy.PolicyMapState, keyToDelete)
 
-	// Incremental updates need to update the desired state as well.
-	if incremental && e.desiredPolicy != e.realizedPolicy {
-		delete(e.desiredPolicy.PolicyMapState, keyToDelete)
-	}
-
 	e.policyDebug(logrus.Fields{
 		logfields.BPFMapKey:   keyToDelete,
 		logfields.BPFMapValue: entry,
@@ -1114,11 +1109,6 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry,
 
 	// Operation was successful, add to realized state.
 	e.realizedPolicy.PolicyMapState[keyToAdd] = entry
-
-	// Incremental updates need to update the desired state as well.
-	if incremental && e.desiredPolicy != e.realizedPolicy {
-		e.desiredPolicy.PolicyMapState[keyToAdd] = entry
-	}
 
 	e.policyDebug(logrus.Fields{
 		logfields.BPFMapKey:   keyToAdd,
@@ -1169,6 +1159,9 @@ func (e *Endpoint) applyPolicyMapChanges() (proxyChanges bool, err error) {
 	//  collected on the newly computed desired policy, which is
 	//  not fully realized yet. This is why we get the map changes
 	//  from the desired policy here.
+	//  ConsumeMapChanges() applies the incremental updates to the
+	//  desired policy and only returns changes that need to be
+	//  applied to the Endpoint's bpf policy map.
 	adds, deletes := e.desiredPolicy.ConsumeMapChanges()
 
 	// Add policy map entries before deleting to avoid transient drops
@@ -1281,10 +1274,6 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 
 	if e.realizedPolicy.PolicyMapState == nil {
 		e.realizedPolicy.PolicyMapState = make(policy.MapState)
-	}
-
-	if e.desiredPolicy.PolicyMapState == nil {
-		e.desiredPolicy.PolicyMapState = make(policy.MapState)
 	}
 
 	if e.policyMap == nil {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -92,12 +92,18 @@ type MapStateEntry struct {
 
 	// DerivedFromRules tracks the policy rules this entry derives from
 	DerivedFromRules labels.LabelArrayList
+
+	// Selectors collects the selectors in the policy that require this key to be present.
+	// TODO: keep track which selector needed the entry to be a redirect, or just allow.
+	selectors map[CachedSelector]struct{}
 }
 
 // NewMapStateEntry creates a map state entry. If redirect is true, the
 // caller is expected to replace the ProxyPort field before it is added to
 // the actual BPF map.
-func NewMapStateEntry(derivedFrom labels.LabelArrayList, redirect bool) MapStateEntry {
+// 'cs' is used to keep track of which policy selectors need this entry. If it is 'nil' this entry
+// will become sticky and cannot be completely removed via incremental updates.
+func NewMapStateEntry(cs CachedSelector, derivedFrom labels.LabelArrayList, redirect bool) MapStateEntry {
 	var proxyPort uint16
 	if redirect {
 		// Any non-zero value will do, as the callers replace this with the
@@ -109,6 +115,14 @@ func NewMapStateEntry(derivedFrom labels.LabelArrayList, redirect bool) MapState
 	return MapStateEntry{
 		ProxyPort:        proxyPort,
 		DerivedFromRules: derivedFrom,
+		selectors:        map[CachedSelector]struct{}{cs: {}},
+	}
+}
+
+// MergeSelectors adds selectors from entry 'b' to 'e'. 'b' is not modified.
+func (e *MapStateEntry) MergeSelectors(b *MapStateEntry) {
+	for cs, v := range b.selectors {
+		e.selectors[cs] = v
 	}
 }
 
@@ -133,16 +147,93 @@ func (e MapStateEntry) String() string {
 
 // RedirectPreferredInsert inserts a new entry giving priority to L7-redirects by
 // not overwriting a L7-redirect entry with a non-redirect entry
+// This form may be used when a full policy is computed and we are not yet interested
+// in accumulating incremental changes.
 func (keys MapState) RedirectPreferredInsert(key Key, entry MapStateEntry) {
-	if !entry.IsRedirectEntry() {
-		if _, ok := keys[key]; ok {
-			// Key already exist, keep the existing entry so that
-			// a redirect entry is never overwritten by a non-redirect
-			// entry
-			return
+	keys.redirectPreferredInsertWithChanges(key, entry, nil, nil)
+}
+
+// addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes'
+func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, deletes MapState) {
+	// Keep all selectors that need this entry so that it is deleted only if all the selectors delete their contribution
+	updatedEntry := entry
+	oldEntry, exists := keys[key]
+	if exists {
+		// keep the existing selectors map of the old entry
+		updatedEntry.selectors = oldEntry.selectors
+	} else if len(entry.selectors) > 0 {
+		// create a new selectors map
+		updatedEntry.selectors = make(map[CachedSelector]struct{}, len(entry.selectors))
+	} else {
+		// Keep the map as nil when empty. This makes a difference for unit testing only.
+		// MergeSelectors below becomes a no-op as 'entry' is empty.
+		updatedEntry.selectors = nil
+	}
+
+	// TODO: Do we need to merge labels as well?
+	// Merge new selectors to the updated entry without modifying 'entry' as it is being reused by the caller
+	updatedEntry.MergeSelectors(&entry)
+	// Update (or insert) the entry
+	keys[key] = updatedEntry
+
+	// Record an incremental Add if desired and entry is new or changed
+	if adds != nil && (!exists || oldEntry.ProxyPort != entry.ProxyPort) {
+		updatedEntry.selectors = nil
+		adds[key] = updatedEntry // copy w/o selectors
+		// Key add overrides any previous delete of the same key
+		if deletes != nil {
+			delete(deletes, key)
 		}
 	}
-	keys[key] = entry
+}
+
+// deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
+// The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
+func (keys MapState) deleteKeyWithChanges(key Key, cs CachedSelector, adds, deletes MapState) {
+	if entry, exists := keys[key]; exists {
+		if cs != nil {
+			// remove the contribution of the given selector only
+			if _, exists = entry.selectors[cs]; exists {
+				// Remove the contribution of this selector from the entry
+				delete(entry.selectors, cs)
+				// key is not deleted if other selectors still need it
+				if len(entry.selectors) > 0 {
+					return
+				}
+			}
+		}
+		if deletes != nil {
+			entry.selectors = nil
+			deletes[key] = entry // copy w/o selectors
+			// Remove a potential previously added key
+			if adds != nil {
+				delete(adds, key)
+			}
+		}
+		delete(keys, key)
+	}
+}
+
+// redirectPreferredInsertWithChanges inserts a new entry giving priority to L7-redirects by
+// not overwriting a L7-redirect entry with a non-redirect entry.
+func (keys MapState) redirectPreferredInsertWithChanges(key Key, entry MapStateEntry, adds, deletes MapState) {
+	// Do not overwrite the entry, but only merge selectors if the old entry is a redirect.
+	// This prevents an existing redirect being overridden by a non-redirect.
+	if oldEntry, exists := keys[key]; exists && oldEntry.IsRedirectEntry() {
+		oldEntry.MergeSelectors(&entry)
+		keys[key] = oldEntry
+		// For compatibility with old redirect management code we'll have to pass on
+		// redirect entry if the oldEntry is also a redirect, even if they are equal.
+		// We store the new entry here, the proxy port of it will be fixed up before
+		// insertion to the bpf map.
+		if adds != nil && entry.IsRedirectEntry() {
+			entry.selectors = nil
+			adds[key] = entry // copy w/o selectors
+		}
+		return
+	}
+	// Otherwise write the entry to the map
+	keys.addKeyWithChanges(key, entry, adds, deletes)
 }
 
 // DetermineAllowLocalhostIngress determines whether communication should be allowed
@@ -156,9 +247,9 @@ func (keys MapState) DetermineAllowLocalhostIngress(l4Policy *L4Policy) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowLocalHostIngress, labels.LabelSourceReserved),
 			},
 		}
-		keys[localHostKey] = NewMapStateEntry(derivedFrom, false)
+		keys[localHostKey] = NewMapStateEntry(nil, derivedFrom, false)
 		if !option.Config.EnableRemoteNodeIdentity {
-			keys[localRemoteNodeKey] = NewMapStateEntry(derivedFrom, false)
+			keys[localRemoteNodeKey] = NewMapStateEntry(nil, derivedFrom, false)
 		}
 	}
 }
@@ -179,7 +270,7 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowLocalHostIngress, labels.LabelSourceReserved),
 			},
 		}
-		keys[keyToAdd] = NewMapStateEntry(derivedFrom, false)
+		keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false)
 	}
 	if egress {
 		keyToAdd := Key{
@@ -193,7 +284,7 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyEgress, labels.LabelSourceReserved),
 			},
 		}
-		keys[keyToAdd] = NewMapStateEntry(derivedFrom, false)
+		keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false)
 	}
 }
 
@@ -202,20 +293,21 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 // and deletes. 'mutex' must be held for any access.
 type MapChanges struct {
 	mutex   lock.Mutex
-	adds    MapState
-	deletes MapState
+	changes []MapChange
+}
+
+type MapChange struct {
+	add   bool // false deletes
+	key   Key
+	value MapStateEntry
 }
 
 // AccumulateMapChanges accumulates the given changes to the
-// MapChanges, updating both maps for each add and delete, as
-// applicable.
+// MapChanges.
 //
 // The caller is responsible for making sure the same identity is not
-// present in both 'adds' and 'deletes'.  Accross multiple calls we
-// maintain the adds and deletes within the MapChanges are disjoint in
-// cases where an identity is first added and then deleted, or first
-// deleted and then added.
-func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdentity,
+// present in both 'adds' and 'deletes'.
+func (mc *MapChanges) AccumulateMapChanges(cs CachedSelector, adds, deletes []identity.NumericIdentity,
 	port uint16, proto uint8, direction trafficdirection.TrafficDirection,
 	redirect bool, derivedFrom labels.LabelArrayList) {
 	key := Key{
@@ -227,10 +319,11 @@ func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdent
 		TrafficDirection: direction.Uint8(),
 	}
 
-	value := NewMapStateEntry(derivedFrom, redirect)
+	value := NewMapStateEntry(cs, derivedFrom, redirect)
 
 	if option.Config.Debug {
 		log.WithFields(logrus.Fields{
+			logfields.EndpointSelector: cs,
 			logfields.AddedPolicyID:    adds,
 			logfields.DeletedPolicyID:  deletes,
 			logfields.Port:             port,
@@ -241,45 +334,37 @@ func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdent
 	}
 
 	mc.mutex.Lock()
-	if len(adds) > 0 {
-		if mc.adds == nil {
-			mc.adds = make(MapState)
-		}
-		for _, id := range adds {
-			key.Identity = id.Uint32()
-			// insert but do not allow non-redirect entries to overwrite a redirect entry
-			mc.adds.RedirectPreferredInsert(key, value)
-
-			// Remove a potential previously deleted key
-			if mc.deletes != nil {
-				delete(mc.deletes, key)
-			}
-		}
+	for _, id := range adds {
+		key.Identity = id.Uint32()
+		mc.changes = append(mc.changes, MapChange{true, key, value})
 	}
-	if len(deletes) > 0 {
-		if mc.deletes == nil {
-			mc.deletes = make(MapState)
-		}
-		for _, id := range deletes {
-			key.Identity = id.Uint32()
-			mc.deletes[key] = value
-			// Remove a potential previously added key
-			if mc.adds != nil {
-				delete(mc.adds, key)
-			}
-		}
+	for _, id := range deletes {
+		key.Identity = id.Uint32()
+		mc.changes = append(mc.changes, MapChange{false, key, value})
 	}
 	mc.mutex.Unlock()
 }
 
-// consumeMapChanges transfers the changes from MapChanges to the caller.
-// May return nil maps.
-func (mc *MapChanges) consumeMapChanges() (adds, deletes MapState) {
+// consumeMapChanges transfers the incremental changes from MapChanges to the caller,
+// while applying the changes to PolicyMapState.
+func (mc *MapChanges) consumeMapChanges(policyMapState MapState) (adds, deletes MapState) {
 	mc.mutex.Lock()
-	adds = mc.adds
-	mc.adds = nil
-	deletes = mc.deletes
-	mc.deletes = nil
+	adds = make(MapState, len(mc.changes))
+	deletes = make(MapState, len(mc.changes))
+
+	for i := range mc.changes {
+		if mc.changes[i].add {
+			// Insert but do not allow non-redirect entries to overwrite a redirect entry.
+			// Collect the incremental changes to the overall state in 'adds' and 'deletes'.
+			policyMapState.redirectPreferredInsertWithChanges(mc.changes[i].key, mc.changes[i].value, adds, deletes)
+		} else {
+			// Delete the contribution of this cs to the key and collect incremental changes
+			for cs := range mc.changes[i].value.selectors { // get the sole selector
+				policyMapState.deleteKeyWithChanges(mc.changes[i].key, cs, adds, deletes)
+			}
+		}
+	}
+	mc.changes = nil
 	mc.mutex.Unlock()
 	return adds, deletes
 }

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -17,10 +17,32 @@
 package policy
 
 import (
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 
 	"gopkg.in/check.v1"
 )
+
+// WithSelectors returns a copy of 'e', but selectors replaced with 'selectors'. 'e' is not modified.
+// No selectors is represented with a 'nil' map.
+func (e MapStateEntry) WithSelectors(selectors ...CachedSelector) MapStateEntry {
+	mse := e
+	if len(selectors) > 0 {
+		mse.selectors = make(map[CachedSelector]struct{}, len(selectors))
+		for _, cs := range selectors {
+			mse.selectors[cs] = struct{}{}
+		}
+	} else {
+		mse.selectors = nil
+	}
+	return mse
+}
+
+// WithoutSelectors returns a copy of 'e', but selectors replaced with 'nil'. 'e' is not modified.
+// Note: This is used only in unit tests and helps test readability.
+func (e MapStateEntry) WithoutSelectors() MapStateEntry {
+	return e.WithSelectors()
+}
 
 func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
 	k := Key{TrafficDirection: trafficdirection.Ingress.Uint8()}
@@ -30,4 +52,248 @@ func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
 	k = Key{TrafficDirection: trafficdirection.Egress.Uint8()}
 	c.Assert(k.IsIngress(), check.Equals, false)
 	c.Assert(k.IsEgress(), check.Equals, true)
+}
+
+func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
+	csFoo := newTestCachedSelector("Foo", false)
+	csBar := newTestCachedSelector("Bar", false)
+
+	TestKey := func(id int, port uint16, proto uint8, direction trafficdirection.TrafficDirection) Key {
+		return Key{
+			Identity:         uint32(id),
+			DestPort:         port,
+			Nexthdr:          proto,
+			TrafficDirection: direction.Uint8(),
+		}
+	}
+	TestIngressKey := func(id int, port uint16, proto uint8) Key {
+		return TestKey(id, port, proto, trafficdirection.Ingress)
+	}
+	TestEgressKey := func(id int, port uint16, proto uint8) Key {
+		return TestKey(id, port, proto, trafficdirection.Egress)
+	}
+	DNSUDPEgressKey := func(id int) Key {
+		return TestEgressKey(id, 53, 17)
+	}
+	DNSTCPEgressKey := func(id int) Key {
+		return TestEgressKey(id, 53, 6)
+	}
+	HostIngressKey := func() Key {
+		return TestIngressKey(1, 0, 0)
+	}
+	AnyIngressKey := func() Key {
+		return TestIngressKey(0, 0, 0)
+	}
+	//AnyEgressKey := func() Key {
+	//	return TestEgressKey(0, 0, 0)
+	//}
+	HttpIngressKey := func(id int) Key {
+		return TestIngressKey(id, 80, 6)
+	}
+	HttpEgressKey := func(id int) Key {
+		return TestEgressKey(id, 80, 6)
+	}
+
+	TestEntry := func(proxyPort uint16, selectors ...CachedSelector) MapStateEntry {
+		entry := MapStateEntry{
+			ProxyPort: proxyPort,
+		}
+		if len(selectors) > 0 {
+			entry.selectors = make(map[CachedSelector]struct{}, len(selectors))
+			for _, cs := range selectors {
+				entry.selectors[cs] = struct{}{}
+			}
+		}
+		return entry
+	}
+
+	type args struct {
+		cs       *testCachedSelector
+		adds     []int
+		deletes  []int
+		port     uint16
+		proto    uint8
+		ingress  bool
+		redirect bool
+	}
+	tests := []struct {
+		continued bool // Start from the end state of the previous test
+		name      string
+		args      []args // changes applied, in order
+		state     MapState
+		adds      MapState
+		deletes   MapState
+	}{{
+		name: "test-1 - Adding identity to an empty state",
+		args: []args{
+			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): TestEntry(0, csFoo),
+		},
+		adds: MapState{
+			HttpIngressKey(42): TestEntry(0),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2 - Removing the sole key",
+		args: []args{
+			{cs: csFoo, adds: nil, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{},
+		adds:  MapState{},
+		deletes: MapState{
+			HttpIngressKey(42): TestEntry(0),
+		},
+	}, {
+		name: "test-3 - Adding 2 identities, and deleting a nonexisting key on an empty state",
+		args: []args{
+			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): TestEntry(0, csFoo),
+			HttpIngressKey(43): TestEntry(0, csFoo),
+		},
+		adds: MapState{
+			HttpIngressKey(42): TestEntry(0),
+			HttpIngressKey(43): TestEntry(0),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-4 - Adding Bar also selecting 42",
+		args: []args{
+			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): TestEntry(0, csFoo, csBar),
+			HttpIngressKey(43): TestEntry(0, csFoo),
+			HttpIngressKey(44): TestEntry(0, csBar),
+		},
+		adds: MapState{
+			HttpIngressKey(44): TestEntry(0),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-5 - Deleting 42 from Foo, remains on Bar and no deletes",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): TestEntry(0, csBar),
+			HttpIngressKey(43): TestEntry(0, csFoo),
+			HttpIngressKey(44): TestEntry(0, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-6 - Deleting 42 from Bar, deleted",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{
+			HttpIngressKey(43): TestEntry(0, csFoo),
+			HttpIngressKey(44): TestEntry(0, csBar),
+		},
+		adds: MapState{},
+		deletes: MapState{
+			HttpIngressKey(42): TestEntry(0),
+		},
+	}, {
+		continued: true,
+		name:      "test-6b - Adding an entry that already exists, no adds",
+		args: []args{
+			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{
+			HttpIngressKey(43): TestEntry(0, csFoo),
+			HttpIngressKey(44): TestEntry(0, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-7a - egress HTTP proxy (setup)",
+		args: []args{
+			{cs: nil, adds: []int{0}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false},
+			{cs: nil, adds: []int{1}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false},
+		},
+		state: MapState{
+			AnyIngressKey():     TestEntry(0, nil),
+			HostIngressKey():    TestEntry(0, nil),
+			DNSUDPEgressKey(42): TestEntry(0, csBar),
+			DNSTCPEgressKey(42): TestEntry(0, csBar),
+		},
+		adds: MapState{
+			AnyIngressKey():     TestEntry(0),
+			HostIngressKey():    TestEntry(0),
+			DNSUDPEgressKey(42): TestEntry(0),
+			DNSTCPEgressKey(42): TestEntry(0),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-7b - egress HTTP proxy (incremental update)",
+		args: []args{
+			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true},
+		},
+		state: MapState{
+			AnyIngressKey():     TestEntry(0, nil),
+			HostIngressKey():    TestEntry(0, nil),
+			DNSUDPEgressKey(42): TestEntry(0, csBar),
+			DNSTCPEgressKey(42): TestEntry(0, csBar),
+			HttpEgressKey(43):   TestEntry(1, csFoo),
+		},
+		adds: MapState{
+			HttpEgressKey(43): TestEntry(1),
+		},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-n - title",
+		args:      []args{
+			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false},
+		},
+		state: MapState{
+			//HttpIngressKey(42): TestEntry(0, csFoo),
+		},
+		adds: MapState{
+			//HttpIngressKey(42): TestEntry(0),
+		},
+		deletes: MapState{
+			//HttpIngressKey(43): TestEntry(0),
+		},
+	},
+	}
+
+	policyMapState := MapState{}
+
+	for _, tt := range tests {
+		policyMaps := MapChanges{}
+		if !tt.continued {
+			policyMapState = MapState{}
+		}
+		for _, x := range tt.args {
+			dir := trafficdirection.Egress
+			if x.ingress {
+				dir = trafficdirection.Ingress
+			}
+			adds := x.cs.addSelections(x.adds...)
+			deletes := x.cs.deleteSelections(x.deletes...)
+			var cs CachedSelector
+			if x.cs != nil {
+				cs = x.cs
+			}
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, nil)
+		}
+		adds, deletes := policyMaps.consumeMapChanges(policyMapState)
+		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
+		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
+		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))
+	}
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -64,6 +64,7 @@ type EndpointPolicy struct {
 	// It maps each Key to the proxy port if proxy redirection is needed.
 	// Proxy port 0 indicates no proxy redirection.
 	// All fields within the Key and the proxy port must be in host byte-order.
+	// Must only be accessed with PolicyOwner (aka Endpoint) lock taken.
 	PolicyMapState MapState
 
 	// policyMapChanges collects pending changes to the PolicyMapState
@@ -190,10 +191,11 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(l4PolicyMap L4Policy
 // ConsumeMapChanges transfers the changes from MapChanges to the caller,
 // locking the selector cache to make sure concurrent identity updates
 // have completed.
+// PolicyOwner (aka Endpoint) is also locked during this call.
 func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes MapState) {
 	p.selectorPolicy.SelectorCache.mutex.Lock()
 	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
-	return p.policyMapChanges.consumeMapChanges()
+	return p.policyMapChanges.consumeMapChanges(p.PolicyMapState)
 }
 
 // NewEndpointPolicy returns an empty EndpointPolicy stub.

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -465,8 +465,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
-	rule1MapStateEntry := NewMapStateEntry(labels.LabelArrayList{ruleLabel}, false)
-	allowEgressMapStateEntry := NewMapStateEntry(labels.LabelArrayList{ruleLabelAllowAnyEgress}, false)
+	rule1MapStateEntry := NewMapStateEntry(wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, false)
+	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, false)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{
@@ -501,13 +501,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 		},
 	}
 
-	// Add new identity to test accumulation of PolicyMapChanges
+	// Add new identity to test accumulation of MapChanges
 	added1 := cache.IdentityCache{
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
-	c.Assert(policy.policyMapChanges.adds, HasLen, 0)
-	c.Assert(policy.policyMapChanges.deletes, HasLen, 0)
+	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
 	policy.selectorPolicy.Detach()
@@ -570,22 +569,22 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	c.Assert(err, IsNil)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
 
-	// Add new identity to test accumulation of PolicyMapChanges
+	// Add new identity to test accumulation of MapChanges
 	added1 := cache.IdentityCache{
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1", "num=1"),
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 		identity.NumericIdentity(194): labels.ParseSelectLabelArray("id=resolve_test_1", "num=3"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
-	c.Assert(policy.policyMapChanges.adds, HasLen, 3)
-	c.Assert(policy.policyMapChanges.deletes, HasLen, 0)
+	// Cleanup the identities from the testSelectorCache
+	defer testSelectorCache.UpdateIdentities(nil, added1)
+	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	testSelectorCache.UpdateIdentities(nil, deleted1)
-	c.Assert(policy.policyMapChanges.adds, HasLen, 2)
-	c.Assert(policy.policyMapChanges.deletes, HasLen, 1)
+	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])
 	c.Assert(cachedSelectorWorld, Not(IsNil))
@@ -593,8 +592,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	cachedSelectorTest := testSelectorCache.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	c.Assert(cachedSelectorTest, Not(IsNil))
 
-	rule1MapStateEntry := NewMapStateEntry(labels.LabelArrayList{ruleLabel, ruleLabel}, false)
-	allowEgressMapStateEntry := NewMapStateEntry(labels.LabelArrayList{ruleLabelAllowAnyEgress}, false)
+	rule1MapStateEntry := NewMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel, ruleLabel}, false)
+	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, false)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{
@@ -625,16 +624,9 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		PolicyOwner: DummyOwner{},
 		PolicyMapState: MapState{
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                          allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		},
-		policyMapChanges: MapChanges{
-			adds: MapState{
-				{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-				{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-			},
-			deletes: MapState{
-				{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-			},
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithSelectors(cachedSelectorWorld),
+			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
+			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 		},
 	}
 
@@ -645,18 +637,17 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	cachedSelectorTest = testSelectorCache.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	c.Assert(cachedSelectorTest, IsNil)
 
-	c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
-
 	adds, deletes := policy.ConsumeMapChanges()
 	// maps on the policy got cleared
-	c.Assert(policy.policyMapChanges.adds, IsNil)
-	c.Assert(policy.policyMapChanges.deletes, IsNil)
+	c.Assert(policy.policyMapChanges.changes, IsNil)
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
 	})
 	c.Assert(deletes, checker.Equals, MapState{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
 	})
+
+	c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
 }

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -123,6 +123,83 @@ func (csu *cachedSelectionUser) IdentitySelectionUpdated(selector CachedSelector
 	csu.selections[selector] = selections
 }
 
+// Mock CachedSelector for unit testing.
+
+type testCachedSelector struct {
+	name       string
+	wildcard   bool
+	selections []identity.NumericIdentity
+}
+
+func newTestCachedSelector(name string, wildcard bool, selections ...int) *testCachedSelector {
+	cs := &testCachedSelector{
+		name:       name,
+		wildcard:   wildcard,
+		selections: make([]identity.NumericIdentity, 0, len(selections)),
+	}
+	cs.addSelections(selections...)
+	return cs
+}
+
+// returns selections as []identity.NumericIdentity
+func (cs *testCachedSelector) addSelections(selections ...int) (adds []identity.NumericIdentity) {
+	for _, id := range selections {
+		nid := identity.NumericIdentity(id)
+		adds = append(adds, nid)
+		if cs == nil {
+			continue
+		}
+		if !cs.Selects(nid) {
+			cs.selections = append(cs.selections, nid)
+		}
+	}
+	return adds
+}
+
+// returns selections as []identity.NumericIdentity
+func (cs *testCachedSelector) deleteSelections(selections ...int) (deletes []identity.NumericIdentity) {
+	for _, id := range selections {
+		nid := identity.NumericIdentity(id)
+		deletes = append(deletes, nid)
+		if cs == nil {
+			continue
+		}
+		for i := 0; i < len(cs.selections); i++ {
+			if nid == cs.selections[i] {
+				cs.selections = append(cs.selections[:i], cs.selections[i+1:]...)
+				i--
+			}
+		}
+	}
+	return deletes
+}
+
+// CachedSelector interface
+
+func (cs *testCachedSelector) GetSelections() []identity.NumericIdentity {
+	return cs.selections
+}
+func (cs *testCachedSelector) Selects(nid identity.NumericIdentity) bool {
+	for _, id := range cs.selections {
+		if id == nid {
+			return true
+		}
+	}
+	return false
+}
+
+func (cs *testCachedSelector) IsWildcard() bool {
+	return cs.wildcard
+}
+
+func (cs *testCachedSelector) IsNone() bool {
+	return false
+}
+
+func (cs *testCachedSelector) String() string {
+	return cs.name
+}
+
 func (ds *SelectorCacheTestSuite) SetUpTest(c *C) {
 }
 


### PR DESCRIPTION
[ upstream commit 04840b96530031a84bc359c476a59d320617d2db ]

Track which selectors in policy require a specific bpf policy map key to
be present, and keep policy entries in the map as long as any selector
requires it's presence. Without this it is possible for a timed-out
DNS cache entry to clear a policy cache key that is still required by
another selector (FQDN or CIDR).

To implement this, each MapStateEntry is now equipped with a set of
(cached) selectors through which the policy map key/value was
added. 'nil' has the special significance that it is used as the
CachedSelector in cases where the policy map entry is added due to
some administrative or configuration reason. Currently incremental
updates will never remove such entries.

Incremental policy updates now simply collect the requested map
changes. When the endpoint then pulls the changes they are first
applied the desired policy map (MapState), while tallying which
selectors still need the map entries to be present. The actual bpf map
diffs are recorded based on the total count of selectors on each map
entry.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
