### PR TITLE
endpoint: Enhance policy map sync

### DIFF
--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -123,6 +123,18 @@ type PolicyEntry struct {
 	Bytes     uint64 `align:"bytes"`
 }
 
+// ToHost returns a copy of entry with fields converted from network byte-order
+// to host-byte-order if necessary.
+func (pe *PolicyEntry) ToHost() PolicyEntry {
+	if pe == nil {
+		return PolicyEntry{}
+	}
+
+	n := *pe
+	n.ProxyPort = byteorder.NetworkToHost(n.ProxyPort).(uint16)
+	return n
+}
+
 func (pe *PolicyEntry) SetFlags(flags uint8) {
 	pe.Flags = flags
 }
@@ -373,18 +385,6 @@ func (pm *PolicyMap) DumpToSlice() (PolicyEntriesDump, error) {
 	err := pm.DumpWithCallback(cb)
 
 	return entries, err
-}
-
-func (pm *PolicyMap) DumpKeysToSlice() ([]PolicyKey, error) {
-	var policyKeys []PolicyKey
-
-	cb := func(key bpf.MapKey, value bpf.MapValue) {
-		keyDump := *key.DeepCopyMapKey().(*PolicyKey)
-		policyKeys = append(policyKeys, keyDump)
-	}
-	err := pm.DumpWithCallback(cb)
-
-	return policyKeys, err
 }
 
 func newMap(path string) *PolicyMap {

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -105,32 +105,6 @@ func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	c.Assert(len(dump), Equals, 2)
 }
 
-func (pm *PolicyMapTestSuite) TestPolicyMapDumpKeysToSlice(c *C) {
-	c.Assert(testMap, NotNil)
-
-	fooEntry := newKey(1, 1, 1, 1)
-	err := testMap.AllowKey(fooEntry, 0)
-	c.Assert(err, IsNil)
-
-	dump, err := testMap.DumpKeysToSlice()
-	c.Assert(err, IsNil)
-	c.Assert(len(dump), Equals, 1)
-
-	// FIXME: It's weird that AllowKey() does the implicit byteorder
-	//        conversion above. But not really a bug, so work around it.
-	fooEntry = fooEntry.ToNetwork()
-	c.Assert(dump[0], checker.DeepEquals, fooEntry)
-
-	// Special case: allow-all entry
-	barEntry := newKey(0, 0, 0, 0)
-	err = testMap.AllowKey(barEntry, 0)
-	c.Assert(err, IsNil)
-
-	dump, err = testMap.DumpKeysToSlice()
-	c.Assert(err, IsNil)
-	c.Assert(len(dump), Equals, 2)
-}
-
 func (pm *PolicyMapTestSuite) TestDeleteNonexistentKey(c *C) {
 	key := newKey(27, 80, u8proto.ANY, trafficdirection.Ingress)
 	err := testMap.Map.Delete(&key)
@@ -141,34 +115,6 @@ func (pm *PolicyMapTestSuite) TestDeleteNonexistentKey(c *C) {
 }
 
 func (pm *PolicyMapTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
-	c.Assert(testMap, NotNil)
-
-	fooEntry := newKey(1, 1, 1, 1)
-	fooValue := newEntry(0, NewPolicyEntryFlag(&PolicyEntryFlagParam{IsDeny: true}))
-	err := testMap.DenyKey(fooEntry)
-	c.Assert(err, IsNil)
-
-	dump, err := testMap.DumpToSlice()
-	c.Assert(err, IsNil)
-	c.Assert(len(dump), Equals, 1)
-
-	// FIXME: It's weird that AllowKey() does the implicit byteorder
-	//        conversion above. But not really a bug, so work around it.
-	fooEntry = fooEntry.ToNetwork()
-	c.Assert(dump[0].Key, checker.DeepEquals, fooEntry)
-	c.Assert(dump[0].PolicyEntry, checker.DeepEquals, fooValue)
-
-	// Special case: deny-all entry
-	barEntry := newKey(0, 0, 0, 0)
-	err = testMap.DenyKey(barEntry)
-	c.Assert(err, IsNil)
-
-	dump, err = testMap.DumpToSlice()
-	c.Assert(err, IsNil)
-	c.Assert(len(dump), Equals, 2)
-}
-
-func (pm *PolicyMapTestSuite) TestDenyPolicyMapDumpKeysToSlice(c *C) {
 	c.Assert(testMap, NotNil)
 
 	fooEntry := newKey(1, 1, 1, 1)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -476,9 +476,9 @@ type MapChanges struct {
 }
 
 type MapChange struct {
-	add   bool // false deletes
-	key   Key
-	value MapStateEntry
+	Add   bool // false deletes
+	Key   Key
+	Value MapStateEntry
 }
 
 // AccumulateMapChanges accumulates the given changes to the
@@ -515,11 +515,11 @@ func (mc *MapChanges) AccumulateMapChanges(cs CachedSelector, adds, deletes []id
 	mc.mutex.Lock()
 	for _, id := range adds {
 		key.Identity = id.Uint32()
-		mc.changes = append(mc.changes, MapChange{true, key, value})
+		mc.changes = append(mc.changes, MapChange{Add: true, Key: key, Value: value})
 	}
 	for _, id := range deletes {
 		key.Identity = id.Uint32()
-		mc.changes = append(mc.changes, MapChange{false, key, value})
+		mc.changes = append(mc.changes, MapChange{Add: false, Key: key, Value: value})
 	}
 	mc.mutex.Unlock()
 }
@@ -532,15 +532,15 @@ func (mc *MapChanges) consumeMapChanges(policyMapState MapState) (adds, deletes 
 	deletes = make(MapState, len(mc.changes))
 
 	for i := range mc.changes {
-		if mc.changes[i].add {
+		if mc.changes[i].Add {
 			// insert but do not allow non-redirect entries to overwrite a redirect entry,
 			// nor allow non-deny entries to overwrite deny entries.
 			// Collect the incremental changes to the overall state in 'mc.adds' and 'mc.deletes'.
-			policyMapState.denyPreferredInsertWithChanges(mc.changes[i].key, mc.changes[i].value, adds, deletes)
+			policyMapState.denyPreferredInsertWithChanges(mc.changes[i].Key, mc.changes[i].Value, adds, deletes)
 		} else {
 			// Delete the contribution of this cs to the key and collect incremental changes
-			for cs := range mc.changes[i].value.selectors { // get the sole selector
-				policyMapState.deleteKeyWithChanges(mc.changes[i].key, cs, adds, deletes)
+			for cs := range mc.changes[i].Value.selectors { // get the sole selector
+				policyMapState.deleteKeyWithChanges(mc.changes[i].Key, cs, adds, deletes)
 			}
 		}
 	}


### PR DESCRIPTION
When syncing policy map with dump, compare the desired policy map to
the dumped map for both deletes and adds. Record and log any
differences found.

Fixes: #14358
Fixes: #14357
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
