### PR TITLE
pkg/k8s: fix nil pointer for invalid CCNP

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -483,9 +483,11 @@ func ConvertToCCNP(obj interface{}) interface{} {
 			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 				TypeMeta:   concreteObj.TypeMeta,
 				ObjectMeta: concreteObj.ObjectMeta,
-				Spec:       concreteObj.Spec,
-				Specs:      concreteObj.Specs,
 			},
+		}
+		if concreteObj.CiliumNetworkPolicy != nil {
+			cnp.Spec = concreteObj.Spec
+			cnp.Specs = concreteObj.Specs
 		}
 		*concreteObj = cilium_v2.CiliumClusterwideNetworkPolicy{}
 		return cnp
@@ -495,16 +497,19 @@ func ConvertToCCNP(obj interface{}) interface{} {
 		if !ok {
 			return obj
 		}
+		slimCNP := &types.SlimCNP{
+			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+				TypeMeta:   cnp.TypeMeta,
+				ObjectMeta: cnp.ObjectMeta,
+			},
+		}
+		if cnp.CiliumNetworkPolicy != nil {
+			slimCNP.Spec = cnp.Spec
+			slimCNP.Specs = cnp.Specs
+		}
 		dfsu := cache.DeletedFinalStateUnknown{
 			Key: concreteObj.Key,
-			Obj: &types.SlimCNP{
-				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
-					TypeMeta:   cnp.TypeMeta,
-					ObjectMeta: cnp.ObjectMeta,
-					Spec:       cnp.Spec,
-					Specs:      cnp.Specs,
-				},
-			},
+			Obj: slimCNP,
 		}
 		*cnp = cilium_v2.CiliumClusterwideNetworkPolicy{}
 		return dfsu

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -1174,6 +1174,15 @@ func (s *K8sSuite) Test_ConvertToCCNP(c *C) {
 			},
 		},
 		{
+			name: "A CCNP where it doesn't contain neither a spec nor specs",
+			args: args{
+				obj: &v2.CiliumClusterwideNetworkPolicy{},
+			},
+			want: &types.SlimCNP{
+				CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
+			},
+		},
+		{
 			name: "delete final state unknown conversion",
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{


### PR DESCRIPTION
If a CCNP does not contain a spec nor specs, which means the embedded
CNP is nil, it will cause a nil pointer exception if we try to access
those fields. To prevent this we should be checking for this embedded
CNP struct before access its fields.

Fixes: 9d7082e9a57e ("policy: add k8s controller to daemon for clusterwide policies")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix potential nil pointer exception for an invalid CCNP in the Cilium Operator
```

Fixes https://github.com/cilium/cilium/issues/14373
