### PR TITLE
hubble/peer: fix TLS server name for cluster names containing dots

### DIFF
--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -165,7 +165,8 @@ func nodeAddress(n types.Node) string {
 //
 // When nodeName is not provided, an empty string is returned. All Dot (.) in
 // nodeName are replaced by Hyphen (-). When clusterName is not provided, it
-// defaults to the default cluster name.
+// defaults to the default cluster name. All Dot (.) in clusterName are
+// replaced by Hypen (-).
 func tlsServerName(nodeName, clusterName string) string {
 	if nodeName == "" {
 		return ""
@@ -176,9 +177,11 @@ func tlsServerName(nodeName, clusterName string) string {
 	if clusterName == "" {
 		clusterName = ciliumDefaults.ClusterName
 	}
+	// The cluster name may also contain dots.
+	cn := strings.ReplaceAll(clusterName, ".", "-")
 	return strings.Join([]string{
 		nn,
-		clusterName,
+		cn,
 		defaults.GRPCServiceName,
 		defaults.DomainName,
 	}, ".")

--- a/pkg/hubble/peer/handler_test.go
+++ b/pkg/hubble/peer/handler_test.go
@@ -135,6 +135,20 @@ func TestNodeAdd(t *testing.T) {
 					ServerName: "my-very-long-node-name.cluster.hubble-grpc.cilium.io",
 				},
 			},
+		}, {
+			name: "node name with dots in the cluster name section",
+			arg: types.Node{
+				Name:    "my.very.long.node.name",
+				Cluster: "cluster.name.with.dots",
+			},
+			want: &peerpb.ChangeNotification{
+				Name:    "cluster.name.with.dots/my.very.long.node.name",
+				Address: "",
+				Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+				Tls: &peerpb.TLS{
+					ServerName: "my-very-long-node-name.cluster-name-with-dots.hubble-grpc.cilium.io",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Similarly to a node name, a cluster name may contain dots (.). In such a
case, dots need to be replaced by dashes (-) so that the TLS server name
matches the certificate server's identity.

This patch is similar to the way node names containing dots are treated.

```release-note
Handle cluster names with dots for TLS server names. This prevented Hubble Relay from connecting to peers with TLS enabled in such a scenario. 
```
