### PR TITLE
pkg/node: only require external IPv4 address if ipv4 mode is enabled

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -326,7 +326,7 @@ func AutoComplete() error {
 // ValidatePostInit validates the entire addressing setup and completes it as
 // required
 func ValidatePostInit() error {
-	if option.Config.EnableIPv4 || option.Config.Tunnel != option.TunnelDisabled {
+	if option.Config.EnableIPv4 && option.Config.Tunnel != option.TunnelDisabled {
 		if ipv4ExternalAddress == nil {
 			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
 		}


### PR DESCRIPTION
The external IPv4 node address is not required in IPv6 since we don't have
tunneling for IPv6 mode.

Fixes: 0c22956df3f1 ("node: Only require external IPv4 node address when IPv4 or encapsulation is enabled")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Allow execution of Cilium in IPv6 only mode regardless of the tunneling mode set
```
