### PR TITLE
test: Add missing gomega Eventually intervals

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -436,7 +436,7 @@ func (kub *Kubectl) WaitForCiliumReadiness(offset int, errMsg string) {
 			ginkgoext.By("Number of ready Cilium pods: %d", numPods)
 		}
 		return err
-	}, 4*time.Minute).Should(gomega.BeNil(), errMsg)
+	}, 4*time.Minute, time.Second).Should(gomega.BeNil(), errMsg)
 }
 
 // DeleteResourceInAnyNamespace deletes all objects with the provided name of

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -113,14 +113,14 @@ var _ = Describe("K8sDatapathConfig", func() {
 			expEgressRegex := regexp.MustCompile(expEgress)
 			Eventually(func() bool {
 				return searchMonitorLog(expEgressRegex)
-			}, helpers.HelperTimeout).Should(BeTrue(), "Egress ICMPv4 flow (%q) not found in monitor log\n%s", expEgress, monitorOutput)
+			}, helpers.HelperTimeout, time.Second).Should(BeTrue(), "Egress ICMPv4 flow (%q) not found in monitor log\n%s", expEgress, monitorOutput)
 
 			By("Checking that ICMP notifications in ingress direction were observed")
 			expIngress := fmt.Sprintf("ICMPv4.*SrcIP=%s", targetIP)
 			expIngressRegex := regexp.MustCompile(expIngress)
 			Eventually(func() bool {
 				return searchMonitorLog(expIngressRegex)
-			}, helpers.HelperTimeout).Should(BeTrue(), "Ingress ICMPv4 flow (%q) not found in monitor log\n%s", expIngress, monitorOutput)
+			}, helpers.HelperTimeout, time.Second).Should(BeTrue(), "Ingress ICMPv4 flow (%q) not found in monitor log\n%s", expIngress, monitorOutput)
 
 			By("Checking the set of TCP notifications received matches expectations")
 			// | TCP Flags | Direction | Report? | Why?
@@ -138,7 +138,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Eventually(func() bool {
 				monitorOutput = monitorRes.CombineOutput().Bytes()
 				return checkMonitorOutput(monitorOutput, egressPktCount, ingressPktCount)
-			}, helpers.HelperTimeout).Should(BeTrue(), "Monitor log did not contain %d ingress and %d egress TCP notifications\n%s",
+			}, helpers.HelperTimeout, time.Second).Should(BeTrue(), "Monitor log did not contain %d ingress and %d egress TCP notifications\n%s",
 				ingressPktCount, egressPktCount, monitorOutput)
 
 			helpers.WriteToReportFile(monitorOutput, monitorLog)
@@ -172,7 +172,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Eventually(func() bool {
 				monitorOutput = monitorRes.CombineOutput().Bytes()
 				return checkMonitorOutput(monitorOutput, egressPktCount, ingressPktCount)
-			}, helpers.HelperTimeout).Should(BeTrue(), "monitor aggregation did not result in correct number of TCP notifications\n%s", monitorOutput)
+			}, helpers.HelperTimeout, time.Second).Should(BeTrue(), "monitor aggregation did not result in correct number of TCP notifications\n%s", monitorOutput)
 			helpers.WriteToReportFile(monitorOutput, monitorLog)
 		})
 	})

--- a/test/k8sT/Identity.go
+++ b/test/k8sT/Identity.go
@@ -69,7 +69,7 @@ var _ = Describe("K8sIdentity", func() {
 			By("Waiting for CiliumIdentity to be garbage collected")
 			Eventually(func() bool {
 				return !kubectl.ExecShort(helpers.KubectlCmd + " get ciliumidentity 99999").WasSuccessful()
-			}, 2*time.Minute).Should(BeTrue(), "CiliumIdentity did not get garbage collected before timeout")
+			}, 2*time.Minute, time.Second).Should(BeTrue(), "CiliumIdentity did not get garbage collected before timeout")
 		})
 	})
 })

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -385,7 +385,7 @@ var _ = Describe("K8sServicesTest", func() {
 			res := kubectl.Exec(fmt.Sprintf("kubectl label services/%s %s=%s", echoServiceName, serviceProxyLabelName, "dummy-lb"))
 			res.ExpectSuccess("cannot label service")
 
-			// Wait for all cilium pods to remove the serivce from its list.
+			// Wait for all cilium pods to remove the service from its list.
 			By("Validating that Cilium is not handling the service")
 			Eventually(func() int {
 				validPods := 0

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -109,7 +109,7 @@ var _ = Describe("K8sHubbleTest", func() {
 				return false
 			}
 
-			Eventually(hubbleObserve, timeout).Should(BeTrue(),
+			Eventually(hubbleObserve, timeout, time.Second).Should(BeTrue(),
 				"hubble observe: filter %q never matched expected string %q", filter, expected)
 		}
 


### PR DESCRIPTION
Gomega time interval between Eventually retries is 10ms. Use 1 second
to clean up the test logs like these:

...
15:31:27  23:31:26 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:27  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:27  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:27  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:27  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:27  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:27  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:27  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:27 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:28 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
15:31:28  23:31:28 STEP: Cilium DaemonSet not ready yet: only 1 of 2 desired pods are ready
...

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
