### PR TITLE
policy: Don't nil an empty selectors map.

### DIFF
--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -618,8 +618,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	c.Assert(policy.policyMapChanges.changes, IsNil)
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),


### PR DESCRIPTION
[ upstream commit 03bfb2bece5108549b3d613e119059758035d448 ]

Turns out unit testing did not need this any more and this actually caused a runtime panic.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
