### PR TITLE
policy: Don't nil an empty selectors map.

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -164,10 +164,6 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 	} else if len(entry.selectors) > 0 {
 		// create a new selectors map
 		updatedEntry.selectors = make(map[CachedSelector]struct{}, len(entry.selectors))
-	} else {
-		// Keep the map as nil when empty. This makes a difference for unit testing only.
-		// MergeSelectors below becomes a no-op as 'entry' is empty.
-		updatedEntry.selectors = nil
 	}
 
 	// TODO: Do we need to merge labels as well?
@@ -178,8 +174,7 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 	// Record an incremental Add if desired and entry is new or changed
 	if adds != nil && (!exists || oldEntry.ProxyPort != entry.ProxyPort) {
-		updatedEntry.selectors = nil
-		adds[key] = updatedEntry // copy w/o selectors
+		adds[key] = updatedEntry
 		// Key add overrides any previous delete of the same key
 		if deletes != nil {
 			delete(deletes, key)
@@ -200,11 +195,13 @@ func (keys MapState) deleteKeyWithChanges(key Key, cs CachedSelector, adds, dele
 				if len(entry.selectors) > 0 {
 					return
 				}
+			} else {
+				// 'cs' was not found, do not change anything
+				return
 			}
 		}
 		if deletes != nil {
-			entry.selectors = nil
-			deletes[key] = entry // copy w/o selectors
+			deletes[key] = entry
 			// Remove a potential previously added key
 			if adds != nil {
 				delete(adds, key)
@@ -227,8 +224,7 @@ func (keys MapState) redirectPreferredInsertWithChanges(key Key, entry MapStateE
 		// We store the new entry here, the proxy port of it will be fixed up before
 		// insertion to the bpf map.
 		if adds != nil && entry.IsRedirectEntry() {
-			entry.selectors = nil
-			adds[key] = entry // copy w/o selectors
+			adds[key] = entry
 		}
 		return
 	}

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -642,8 +642,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	c.Assert(policy.policyMapChanges.changes, IsNil)
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),


### PR DESCRIPTION
[ upstream commit 03bfb2bece5108549b3d613e119059758035d448 ]

Turns out unit testing did not need this any more and this actually caused a runtime panic.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
