### PR TITLE
policy: Don't nil an empty selectors map.

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -425,7 +425,7 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 // cache at the time when the expectations are created.
 func (m MapState) clearCachedSelectors() {
 	for k, v := range m {
-		v.selectors = nil
+		v.selectors = make(map[CachedSelector]struct{})
 		m[k] = v
 	}
 }

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -490,8 +490,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	// maps on the policy got cleared
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -664,8 +664,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	c.Assert(policy.policyMapChanges.changes, IsNil)
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),


### PR DESCRIPTION
[ upstream commit 03bfb2bece5108549b3d613e119059758035d448 ]

Turns out unit testing did not need this any more and this actually caused a runtime panic.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
