### PR TITLE
ci: Use correct `agent` value in preflight check

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/pkg/versioncheck"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
@@ -433,11 +434,16 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 
 		opts = map[string]string{
 			"preflight.enabled":   "true ",
-			"agent.enabled":       "false ",
 			"config.enabled":      "false ",
 			"operator.enabled":    "false ",
 			"preflight.image.tag": newImageVersion,
 			"nodeinit.enabled":    "false",
+		}
+		hasNewHelmValues := versioncheck.MustCompile(">=1.8.90")
+		if hasNewHelmValues(versioncheck.MustVersion(newHelmChartVersion)) {
+			opts["agent"] = "false "
+		} else {
+			opts["agent.enabled"] = "false "
 		}
 		if helpers.RunsWithoutKubeProxy() || helpers.RunsOn419Kernel() {
 			switch oldHelmChartVersion {


### PR DESCRIPTION
The `K8sUpdates` deploys the Helm preflight check on top of an existing
older Cilium installation. To deploy the preflight check, the agent
must be disabled. The flag to disable the agent has been renamed in the
Cilium 1.9 charts. Therefore the upgrade test needs to set the proper
value.

This fixes an issue with the upgrade test on GKE where it fails as
follows:

```
coalesce.go:165: warning: skipped value for agent: Not a table.
Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: kind: ResourceQuota, namespace: cilium, name: cilium-resource-quota
```

I have been able to pass the `K8sUpdates` test with this commit manually on GKE against the master branch.