### PR TITLE
helm: Do not deploy Hubble mTLS secrets unless Relay is enabled

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -23,7 +23,6 @@ DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_PULLPOLICY_REGEX := '\([pP]ullPolicy:\) .*'
 QUICK_OPTIONS := \
-    --set hubble.tls.auto.enabled=false \
     --set operator.replicas=1
 QUICK_HUBBLE_OPTIONS := \
     --set agent=false \

--- a/install/kubernetes/cilium/templates/hubble-ca-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ca-configmap.yaml
@@ -1,12 +1,14 @@
 {{- if and (not .Values.preflight.enabled) .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled }}
-{{- if or (and (.Values.hubble.tls.auto.enabled) (eq .Values.hubble.tls.auto.method "helm")) .Values.hubble.tls.ca.cert }}
+{{- $hubbleCAProvided := .Values.hubble.tls.ca.cert }}
+{{- $hubbleCAGenerate := and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "helm") .Values.hubble.relay.enabled -}}
+{{- if or $hubbleCAProvided $hubbleCAGenerate }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hubble-ca-cert
   namespace: {{ .Release.Namespace }}
 data:
-{{- if and (.Values.hubble.tls.auto.enabled) (eq .Values.hubble.tls.auto.method "helm") }}
+{{- if $hubbleCAGenerate }}
 {{ include "hubble.ca.gen-cert-only" . | indent 2 }}
 {{- else }}
   ca.crt: |-

--- a/install/kubernetes/cilium/templates/hubble-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble-server-secret.yaml
@@ -1,5 +1,7 @@
 {{- if and .Values.agent (not .Values.preflight.enabled) .Values.hubble.enabled .Values.hubble.tls.enabled }}
-{{- if or (and (.Values.hubble.tls.auto.enabled) (eq .Values.hubble.tls.auto.method "helm")) .Values.hubble.tls.server.cert .Values.hubble.tls.server.key }}
+{{- $hubbleCertsProvided := and .Values.hubble.tls.server.cert .Values.hubble.tls.server.key }}
+{{- $hubbleCertsGenerate := and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "helm") .Values.hubble.relay.enabled -}}
+{{- if or $hubbleCertsProvided $hubbleCertsGenerate }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: kubernetes.io/tls
 data:
-{{- if and (.Values.hubble.tls.auto.enabled) (eq .Values.hubble.tls.auto.method "helm") }}
+{{- if $hubbleCertsGenerate }}
 {{ include "hubble.server.gen-certs" . | indent 2 }}
 {{- else }}
   tls.crt: {{ .Values.hubble.tls.server.cert }}


### PR DESCRIPTION
The Hubble API exposed by Cilium Agent and used by Hubble Relay is
protected by mTLS by default. Since #14221, the Cilium DaemonSet is
configured to open that API endpoint by default, this makes the
deployment of Relay on top of an already existing Cilium installation
easier.

However, because the Hubble API is only ever accessed by Relay, there is
no point in deploying the mTLS secrets before Relay is deployed. Thus,
this commit only deploys the Helm-generated mTLS secrets when Relay is
enabled.

This also means that listening on the Hubble API port is will be delayed
until the certs are in created in Kubernetes. Once the certs are
created, the port will be opened without a pod restart, as we are
watching for the certificate creation on the volume mount via the
`certloader` package.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
