### PR TITLE
contrib: Add integration testing shell helpers

### DIFF
--- a/contrib/testing/integrations.sh
+++ b/contrib/testing/integrations.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright 2021 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+# Ginkgo Cilium Test
+#
+# $1 - integration
+# $2 - cilium image
+# $3 - focus string
+# $4 - additional ginkgo arguments
+gct()
+{
+    if [ $# -lt 2 ]; then
+        >&2 echo "usage: gct <INTEGRATION> <IMAGE> [FOCUS] [GINKGO-ARGS]"
+        return 1
+    fi
+    for dep in jq kubectl ginkgo; do
+        if ! which $dep >/dev/null; then
+            >&2 echo "This script requires '$dep'"
+            return 1
+        fi
+    done
+    (
+        set -e
+        set -o pipefail
+
+        if [ ! -e $PWD/test_suite_test.go ]; then
+            CILIUM_DIR="${CILIUM_DIR:-"$GOPATH/src/github.com/cilium/cilium/test"}"
+            >&2 echo "Switching to $CILIUM_DIR..."
+            cd "$CILIUM_DIR"
+        fi
+        local k8s_version=$(kubectl version -o json)
+        local k8s_major=$(echo "$k8s_version" | jq '.serverVersion.major')
+        local k8s_minor=$(echo "$k8s_version" | jq '.serverVersion.minor')
+
+        CNI_INTEGRATION="$1"; shift
+        CILIUM_IMAGE="$(echo "$1" | sed 's/^\(.*\):[^:]*$/\1/')"
+        CILIUM_TAG="$(echo "$1" | sed 's/^.*:\([^:]*\)$/\1/')"
+        shift
+        FOCUS=""
+        if [ $# -ge 1 ]; then
+            FOCUS="--focus=$1"
+        fi
+        shift
+        CNI_INTEGRATION="$CNI_INTEGRATION" \
+        CILIUM_IMAGE="$CILIUM_IMAGE" \
+        CILIUM_TAG="$CILIUM_TAG" \
+        CILIUM_OPERATOR_IMAGE="${CILIUM_OPERATOR_IMAGE:-"docker.io/cilium/operator"}" \
+        CILIUM_OPERATOR_TAG="${CILIUM_OPERATOR_TAG:-"latest"}" \
+        K8S_VERSION="$k8s_major.$ks_minor" \
+        ginkgo -v "$FOCUS" -- \
+            -cilium.provision=false \
+            -cilium.kubeconfig=$HOME/.kube/config \
+            -cilium.passCLIEnvironment=true \
+            -cilium.testScope=k8s \
+            -cilium.holdEnvironment=true \
+            -cilium.skipLogs=true \
+            "$@"
+    )
+}
+
+# Ginkgo for eKS
+gks()
+{
+    if [ $# -lt 2 ]; then
+        >&2 echo "usage: gks <IMAGE> [FOCUS] [ARGS]"
+        return 1
+    fi
+    IMAGE="$1"; shift
+    FOCUS="$1"; shift
+    gct "eks" "$IMAGE" "$FOCUS" "$@"
+}
+
+
+# GinKgo for Gke
+gkg()
+{
+    if [ $# -lt 2 ]; then
+        >&2 echo "usage: gkg <IMAGE> [FOCUS] [ARGS]"
+        return 1
+    fi
+    IMAGE="$1"; shift
+    FOCUS="$1"; shift
+    gct "gke" "$IMAGE" "$FOCUS" "$@"
+}
+
+# GinKgo for Kind
+gkk()
+{
+    if [ $# -lt 2 ]; then
+        >&2 echo "usage: gkk <IMAGE> [FOCUS] [ARGS]"
+        return 1
+    fi
+    IMAGE="$1"; shift
+    FOCUS="$1"; shift
+    kind load docker-image "$IMAGE" || return 1
+    gct "kind" "$IMAGE" "$FOCUS" "$@"
+}
+
+# GinKgo for Microk8s
+gkm()
+{
+    if [ $# -lt 1 ]; then
+        >&2 echo "usage: gkm [FOCUS] [ARGS]"
+        return 1
+    fi
+    IMAGE="${CILIUM_IMAGE:-"localhost:32000/cilium/cilium:local"}"
+    FOCUS="$1"; shift
+    gct "microk8s" "$IMAGE" "$FOCUS" "$@"
+}


### PR DESCRIPTION
Add some little helpers for making it easy to run CI against different
targets, specifically focused on the set of options required to run a
test and if it fails, hold the environment for further testing.

Options included:
* -v: Verbose output so you can figure out what the test is doing
* -cilium.provision=false: Don't re-run provision steps.
* -cilium.kubeconfig: Access the cluster with the same credentials you use
* -cilium.passCLIEnvironment: Pass through env variables to the test env.
* -cilium.testScope=k8s: Only run the kubernetes-based tests.
* -cilium.holdEnvironment: On failure, hold the environment in the
  failing state for further debugging. Do not clean it up immediately.
* -cilium.skipLogs=true: When complete, do not gather logs from the
  environment. No need to gather logs if you have a live environment.

For Ginkgo Cilium Test against any integration:

    $ gct <INTEGRATION> <IMAGE> [FOCUS] [GINKGO-ARGS]

For EKS:

    $  gks <IMAGE> [FOCUS] [ARGS]

For GKE:

    $  gkg <IMAGE> [FOCUS] [ARGS]

For Kind:

    $ gkk <IMAGE> [FOCUS] [ARGS]

Microk8s is also supported, however as of the submission of this commit,
single-node testing like with a local microk8s environment is not well
supported. Additional tweaks to the environment may be necessary such as
setting the number of cilium-operator replicas and changing the
ImagePullPolicy for Cilium to IfNotPresent to ensure that it uses the
locally-available image. Tests that require multiple nodes will also
fail due to scheduling constraints.

For Microk8s (defaults to image target created by 'make microk8s'):

    $ gkm [FOCUS] [ARGS]
