### PR TITLE
v1.9 backports 2020-12-14

### DIFF
--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -398,6 +398,9 @@ You can verify by checking the DNS cache's metrics ``coredns_dns_request_count_t
 ``<node-local-dns pod IP>:9253/metrics``, the metric should increment as new DNS requests being issued from
 application pods are now redirected to the ``node-local-dns`` pod.
 
+In the absence of a node-local DNS cache, DNS queries from application pods
+will get directed to cluster DNS pods backed by the ``kube-dns`` service.
+
 kiam redirect on EKS
 --------------------
 `kiam <https://github.com/uswitch/kiam>`_ agent runs on each node in an EKS
@@ -474,6 +477,5 @@ Miscellaneous
 =============
 When a Local Redirect Policy is applied, cilium BPF datapath translates frontend
 (ip/port/protocol tuple) from the policy to a node-local backend pod selected
-by the policy. However, such translation is skipped for traffic that originates
-from the backend and is destined to the frontend.
-
+by the policy. However, such translation is skipped using ``sk_lookup`` BPF
+helpers for traffic that originates from the backend and is destined to the frontend .

--- a/Documentation/gettingstarted/microk8s.rst
+++ b/Documentation/gettingstarted/microk8s.rst
@@ -25,7 +25,7 @@ Install microk8s
 
    ::
 
-      microk8s.enable cilium
+      microk8s enable cilium
 
 #. Cilium is now configured! The ``cilium`` CLI is provided as ``microk8s.cilium``.
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -627,6 +627,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		return nil, nil, err
 	}
 
+	// Must occur after d.allocateIPs(), see GH-14245 and its fix.
 	d.nodeDiscovery.StartDiscovery(nodeTypes.GetName())
 
 	// Annotation of the k8s node must happen after discovery of the

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -56,6 +56,7 @@ import (
 
 // LocalConfig returns the local configuration of the daemon's nodediscovery.
 func (d *Daemon) LocalConfig() *datapath.LocalNodeConfiguration {
+	<-d.nodeDiscovery.Registered
 	return &d.nodeDiscovery.LocalConfig
 }
 

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -351,7 +351,7 @@ func (l *BPFListener) OnIPIdentityCacheGC() {
 	// fully to give us the history of all events. As such, periodically check
 	// for inconsistencies in the data-path with that in the agent to ensure
 	// consistent state.
-	controller.NewManager().UpdateController("ipcache-bpf-garbage-collection",
+	ipcache.IPIdentityCache.UpdateController("ipcache-bpf-garbage-collection",
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				wg, err := l.garbageCollect(ctx)

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -165,7 +165,8 @@ func nodeAddress(n types.Node) string {
 //
 // When nodeName is not provided, an empty string is returned. All Dot (.) in
 // nodeName are replaced by Hyphen (-). When clusterName is not provided, it
-// defaults to the default cluster name.
+// defaults to the default cluster name. All Dot (.) in clusterName are
+// replaced by Hypen (-).
 func tlsServerName(nodeName, clusterName string) string {
 	if nodeName == "" {
 		return ""
@@ -176,9 +177,11 @@ func tlsServerName(nodeName, clusterName string) string {
 	if clusterName == "" {
 		clusterName = ciliumDefaults.ClusterName
 	}
+	// The cluster name may also contain dots.
+	cn := strings.ReplaceAll(clusterName, ".", "-")
 	return strings.Join([]string{
 		nn,
-		clusterName,
+		cn,
 		defaults.GRPCServiceName,
 		defaults.DomainName,
 	}, ".")

--- a/pkg/hubble/peer/handler_test.go
+++ b/pkg/hubble/peer/handler_test.go
@@ -135,6 +135,20 @@ func TestNodeAdd(t *testing.T) {
 					ServerName: "my-very-long-node-name.cluster.hubble-grpc.cilium.io",
 				},
 			},
+		}, {
+			name: "node name with dots in the cluster name section",
+			arg: types.Node{
+				Name:    "my.very.long.node.name",
+				Cluster: "cluster.name.with.dots",
+			},
+			want: &peerpb.ChangeNotification{
+				Name:    "cluster.name.with.dots/my.very.long.node.name",
+				Address: "",
+				Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+				Tls: &peerpb.TLS{
+					ServerName: "my-very-long-node-name.cluster-name-with-dots.hubble-grpc.cilium.io",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -483,9 +483,11 @@ func ConvertToCCNP(obj interface{}) interface{} {
 			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 				TypeMeta:   concreteObj.TypeMeta,
 				ObjectMeta: concreteObj.ObjectMeta,
-				Spec:       concreteObj.Spec,
-				Specs:      concreteObj.Specs,
 			},
+		}
+		if concreteObj.CiliumNetworkPolicy != nil {
+			cnp.Spec = concreteObj.Spec
+			cnp.Specs = concreteObj.Specs
 		}
 		*concreteObj = cilium_v2.CiliumClusterwideNetworkPolicy{}
 		return cnp
@@ -495,16 +497,19 @@ func ConvertToCCNP(obj interface{}) interface{} {
 		if !ok {
 			return obj
 		}
+		slimCNP := &types.SlimCNP{
+			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+				TypeMeta:   cnp.TypeMeta,
+				ObjectMeta: cnp.ObjectMeta,
+			},
+		}
+		if cnp.CiliumNetworkPolicy != nil {
+			slimCNP.Spec = cnp.Spec
+			slimCNP.Specs = cnp.Specs
+		}
 		dfsu := cache.DeletedFinalStateUnknown{
 			Key: concreteObj.Key,
-			Obj: &types.SlimCNP{
-				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
-					TypeMeta:   cnp.TypeMeta,
-					ObjectMeta: cnp.ObjectMeta,
-					Spec:       cnp.Spec,
-					Specs:      cnp.Specs,
-				},
-			},
+			Obj: slimCNP,
 		}
 		*cnp = cilium_v2.CiliumClusterwideNetworkPolicy{}
 		return dfsu

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -1174,6 +1174,15 @@ func (s *K8sSuite) Test_ConvertToCCNP(c *C) {
 			},
 		},
 		{
+			name: "A CCNP where it doesn't contain neither a spec nor specs",
+			args: args{
+				obj: &v2.CiliumClusterwideNetworkPolicy{},
+			},
+			want: &types.SlimCNP{
+				CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
+			},
+		},
+		{
 			name: "delete final state unknown conversion",
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -81,7 +81,12 @@ func (k *K8sWatcher) createPodController(getter cache.Getter, fieldSelector fiel
 					// handling.
 					if ep := k.endpointManager.LookupPodName(podNSName); ep != nil {
 						epCreatedAt := ep.GetCreatedAt()
-						metrics.EventLagK8s.Set(time.Since(epCreatedAt).Seconds())
+						timeSinceEpCreated := time.Since(epCreatedAt)
+						if timeSinceEpCreated <= 0 {
+							metrics.EventLagK8s.Set(0)
+						} else {
+							metrics.EventLagK8s.Set(timeSinceEpCreated.Round(time.Second).Seconds())
+						}
 					}
 					err := k.addK8sPodV1(pod)
 					k.K8sEventProcessed(metricPod, metricCreate, err == nil)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -426,17 +426,17 @@ func (kub *Kubectl) AddRegistryCredentials(cred string, registry string) error {
 // WaitForCiliumReadiness waits for the Cilium DaemonSet to become ready.
 // Readiness is achieved when all Cilium pods which are desired to run on a
 // node are in ready state.
-func (kub *Kubectl) WaitForCiliumReadiness() error {
+func (kub *Kubectl) WaitForCiliumReadiness(offset int, errMsg string) {
 	ginkgoext.By("Waiting for Cilium to become ready")
-	return RepeatUntilTrue(func() bool {
+	gomega.EventuallyWithOffset(1+offset, func() error {
 		numPods, err := kub.DaemonSetIsReady(CiliumNamespace, "cilium")
 		if err != nil {
 			ginkgoext.By("Cilium DaemonSet not ready yet: %s", err)
 		} else {
 			ginkgoext.By("Number of ready Cilium pods: %d", numPods)
 		}
-		return err == nil
-	}, &TimeoutConfig{Timeout: 4 * time.Minute})
+		return err
+	}, 4*time.Minute).Should(gomega.BeNil(), errMsg)
 }
 
 // DeleteResourceInAnyNamespace deletes all objects with the provided name of

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4389,6 +4389,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"serviceaccount":     "cilium cilium-operator hubble-relay",
 			"service":            "cilium-agent hubble-metrics hubble-relay",
 			"secret":             "hubble-relay-client-certs hubble-server-certs",
+			"resourcequota":      "cilium-resource-quota cilium-operator-resource-quota",
 		}
 
 		crdsToDelete = synced.AllCRDResourceNames

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -111,18 +111,16 @@ var _ = Describe("K8sDatapathConfig", func() {
 			By("Checking that ICMP notifications in egress direction were observed")
 			expEgress := fmt.Sprintf("ICMPv4.*DstIP=%s", targetIP)
 			expEgressRegex := regexp.MustCompile(expEgress)
-			err := helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				return searchMonitorLog(expEgressRegex)
-			})
-			Expect(err).To(BeNil(), "Egress ICMPv4 flow (%q) not found in monitor log\n%s", expEgress, monitorOutput)
+			}, helpers.HelperTimeout).Should(BeTrue(), "Egress ICMPv4 flow (%q) not found in monitor log\n%s", expEgress, monitorOutput)
 
 			By("Checking that ICMP notifications in ingress direction were observed")
 			expIngress := fmt.Sprintf("ICMPv4.*SrcIP=%s", targetIP)
 			expIngressRegex := regexp.MustCompile(expIngress)
-			err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				return searchMonitorLog(expIngressRegex)
-			})
-			Expect(err).To(BeNil(), "Ingress ICMPv4 flow (%q) not found in monitor log\n%s", expIngress, monitorOutput)
+			}, helpers.HelperTimeout).Should(BeTrue(), "Ingress ICMPv4 flow (%q) not found in monitor log\n%s", expIngress, monitorOutput)
 
 			By("Checking the set of TCP notifications received matches expectations")
 			// | TCP Flags | Direction | Report? | Why?
@@ -137,11 +135,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// | ACK       |    ->     |    Y    | monitorAggregation=medium
 			egressPktCount := 3
 			ingressPktCount := 2
-			err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				monitorOutput = monitorRes.CombineOutput().Bytes()
 				return checkMonitorOutput(monitorOutput, egressPktCount, ingressPktCount)
-			})
-			Expect(err).To(BeNil(), "Monitor log did not contain %d ingress and %d egress TCP notifications\n%s",
+			}, helpers.HelperTimeout).Should(BeTrue(), "Monitor log did not contain %d ingress and %d egress TCP notifications\n%s",
 				ingressPktCount, egressPktCount, monitorOutput)
 
 			helpers.WriteToReportFile(monitorOutput, monitorLog)
@@ -172,11 +169,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// | ACK       |    ->     |    Y    | monitorAggregation=medium
 			egressPktCount := 4
 			ingressPktCount := 3
-			err := helpers.RepeatUntilTrueDefaultTimeout(func() bool {
+			Eventually(func() bool {
 				monitorOutput = monitorRes.CombineOutput().Bytes()
 				return checkMonitorOutput(monitorOutput, egressPktCount, ingressPktCount)
-			})
-			Expect(err).To(BeNil(), "monitor aggregation did not result in correct number of TCP notifications\n%s", monitorOutput)
+			}, helpers.HelperTimeout).Should(BeTrue(), "monitor aggregation did not result in correct number of TCP notifications\n%s", monitorOutput)
 			helpers.WriteToReportFile(monitorOutput, monitorLog)
 		})
 	})

--- a/test/k8sT/Identity.go
+++ b/test/k8sT/Identity.go
@@ -66,10 +66,9 @@ var _ = Describe("K8sIdentity", func() {
 			kubectl.ApplyDefault(dummyIdentity).ExpectSuccess("Cannot import dummy identity")
 
 			By("Waiting for CiliumIdentity to be garbage collected")
-			err := helpers.RepeatUntilTrue(func() bool {
+			Eventually(func() bool {
 				return !kubectl.ExecShort(helpers.KubectlCmd + " get ciliumidentity 99999").WasSuccessful()
-			}, &helpers.TimeoutConfig{Timeout: 2 * time.Minute})
-			Expect(err).Should(BeNil(), "CiliumIdentity did not get garbage collected before timeout")
+			}, 2*time.Minute).Should(BeTrue(), "CiliumIdentity did not get garbage collected before timeout")
 		})
 	})
 })

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1445,13 +1445,10 @@ var _ = Describe("K8sPolicyTest", func() {
 				defer monitorCancel()
 
 				By("Asserting that the expected policy verdict logs are in the monitor output")
-				var verdicts int
-				err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-					verdicts = len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-					return verdicts >= count
-				})
-				Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-					verdicts, count, policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
+				Eventually(func() int {
+					return len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+				}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+					policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
 			})
 
 			It("connectivity is restored after importing ingress policy", func() {
@@ -1479,13 +1476,10 @@ var _ = Describe("K8sPolicyTest", func() {
 				defer monitorCancel()
 
 				By("Asserting that the expected policy verdict logs are in the monitor output")
-				var verdicts int
-				err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-					verdicts = len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-					return verdicts >= count
-				})
-				Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-					verdicts, count, policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
+				Eventually(func() int {
+					return len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+				}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+					policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
 			})
 
 			Context("With host policy", func() {
@@ -1530,13 +1524,10 @@ var _ = Describe("K8sPolicyTest", func() {
 					defer monitorCancel()
 
 					By("Asserting that the expected policy verdict logs are in the monitor output")
-					var verdicts int
-					err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-						verdicts = len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-						return verdicts >= count
-					})
-					Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-						verdicts, count, policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
+					Eventually(func() int {
+						return len(policyVerdictDenyRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+					}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+						policyVerdictDenyRegex, monitor.CombineOutput().Bytes())
 				})
 
 				It("Connectivity is restored after importing ingress policy", func() {
@@ -1564,13 +1555,10 @@ var _ = Describe("K8sPolicyTest", func() {
 					defer monitorCancel()
 
 					By("Asserting that the expected policy verdict logs are in the monitor output")
-					var verdicts int
-					err = helpers.RepeatUntilTrueDefaultTimeout(func() bool {
-						verdicts = len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
-						return verdicts >= count
-					})
-					Expect(err).To(BeNil(), "Monitor output is missing verdicts (%d < %d): %s\n%s",
-						verdicts, count, policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
+					Eventually(func() int {
+						return len(policyVerdictAllowRegex.FindAll(monitor.CombineOutput().Bytes(), -1))
+					}).Should(BeNumerically(">=", count), "Monitor output is missing verdicts: %s\n%s",
+						policyVerdictAllowRegex, monitor.CombineOutput().Bytes())
 
 					By("Removing the fromCIDR+toPorts ingress host policy")
 					// This is to ensure this policy is always removed before the default-deny one.

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -199,8 +199,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			)
 		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), fmt.Sprintf("Cilium clean state %q was not able to be deployed", chartVersion))
 
-		err = kubectl.WaitForCiliumReadiness()
-		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q did not become ready in time", chartVersion)
+		kubectl.WaitForCiliumReadiness(1, fmt.Sprintf("Cilium %q did not become ready in time", chartVersion))
 		err = kubectl.WaitForCiliumInitContainerToFinish()
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be clean up environment", chartVersion)
 		cmd := kubectl.ExecMiddle("helm delete cilium --namespace=" + helpers.CiliumNamespace)
@@ -456,8 +455,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		cmd := kubectl.ExecMiddle("helm delete cilium-preflight --namespace=" + helpers.CiliumNamespace)
 		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Unable to delete preflight")
 
-		err = kubectl.WaitForCiliumReadiness()
-		ExpectWithOffset(1, err).Should(BeNil(), "Cilium is not ready after timeout")
+		kubectl.WaitForCiliumReadiness(1, "Cilium is not ready after timeout")
 		// Need to run using the kvstore-based allocator because upgrading from
 		// kvstore-based allocator to CRD-based allocator is not currently
 		// supported at this time.

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -41,10 +41,9 @@ func ExpectKubeDNSReady(vm *helpers.Kubectl) {
 // ExpectCiliumReady is a wrapper around helpers/WaitForPods. It asserts that
 // the error returned by that function is nil.
 func ExpectCiliumReady(vm *helpers.Kubectl) {
-	err := vm.WaitForCiliumReadiness()
-	Expect(err).To(BeNil(), "Timeout while waiting for Cilium to become ready")
+	vm.WaitForCiliumReadiness(0, "Timeout while waiting for Cilium to become ready")
 
-	err = vm.CiliumPreFlightCheck()
+	err := vm.CiliumPreFlightCheck()
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium pre-flight checks failed")
 }
 
@@ -119,8 +118,7 @@ func redeployCilium(vm *helpers.Kubectl, ciliumFilename string, options map[stri
 	err := vm.CiliumInstall(ciliumFilename, options)
 	Expect(err).To(BeNil(), "Cilium cannot be installed")
 
-	err = vm.WaitForCiliumReadiness()
-	Expect(err).To(BeNil(), "Timeout while waiting for Cilium to become ready")
+	vm.WaitForCiliumReadiness(0, "Timeout while waiting for Cilium to become ready")
 }
 
 // RedeployCilium reinstantiates the Cilium DS and ensures it is running.

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -84,7 +84,7 @@ var _ = Describe("K8sHubbleTest", func() {
 		res.ExpectSuccess("removing proxy visibility annotation failed")
 	}
 
-	hubbleObserveUntilMatch := func(hubblePod, args, filter, expected string, timeout *helpers.TimeoutConfig) {
+	hubbleObserveUntilMatch := func(hubblePod, args, filter, expected string, timeout time.Duration) {
 		hubbleObserve := func() bool {
 			res := kubectl.HubbleObserve(hubblePod, args)
 			res.ExpectSuccess("hubble observe invocation failed: %q", res.OutputPrettyPrint())
@@ -101,8 +101,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			return false
 		}
 
-		err := helpers.RepeatUntilTrue(hubbleObserve, timeout)
-		Expect(err).Should(BeNil(),
+		Eventually(hubbleObserve, timeout).Should(BeTrue(),
 			"hubble observe: filter %q never matched expected string %q", filter, expected)
 	}
 
@@ -226,11 +225,7 @@ var _ = Describe("K8sHubbleTest", func() {
 				"--server %s --last 1 --type trace --from-pod %s/%s --to-namespace %s --to-label %s --to-port %d",
 				hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels, app1Port),
 				`{$.Type}`, "L3_L4",
-				&helpers.TimeoutConfig{
-					Ticker:  5 * time.Second,
-					Timeout: helpers.MidCommandTimeout,
-				},
-			)
+				helpers.MidCommandTimeout)
 		})
 
 		It("Test L7 Flow", func() {
@@ -273,11 +268,7 @@ var _ = Describe("K8sHubbleTest", func() {
 				"--server %s --last 1 --type l7 --from-pod %s/%s --to-namespace %s --to-label %s --protocol http",
 				hubbleRelayAddress, namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels),
 				`{$.Type}`, "L7",
-				&helpers.TimeoutConfig{
-					Ticker:  5 * time.Second,
-					Timeout: helpers.MidCommandTimeout,
-				},
-			)
+				helpers.MidCommandTimeout)
 		})
 	})
 })


### PR DESCRIPTION
* #14297 -- docs: Document expected behavior for node-local DNS (@aditighag)
 * #14313 -- pkg/k8s: fix k8s_event_lag_seconds for negative time (@aanm)
 * #14300 -- ipcache: Use controller.Manager on IPIdentityCache for bpf-garbage-collection (@dctrwatson)
 * #14286 -- test: Fix flake on policy verdict count check (@pchaigno)
 * #14299 -- Fix rare crash on startup when kubernetes initialization occurs before IP address configuration (@joestringer)
 * #14325 -- microk8s: fix  add-on-command for enabling cilium  (@brandshaide)
 * #14294 -- ci/helpers: Clean-up resource quotas (@gandro)
 * #14375 -- pkg/k8s: fix nil pointer for invalid CCNP (@aanm)
 * #14378 -- hubble/peer: fix TLS server name for cluster names containing dots (@Rolinh)

Skipped due to conflicts, PTAL:
 * #14329 -- cilium, gops: remap to fixed port to avoid collision with nodeport range (@borkmann)
 * #14345 -- maglev: Delete map if previous M's do not match (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14297 14313 14300 14286 14325 14299 14294 14375 14378; do contrib/backporting/set-labels.py $pr done 1.9; done
```