### PR TITLE
test: Test policy enforcement through tunnels

### DIFF
--- a/test/k8sT/manifests/l3-policy-demo.yaml
+++ b/test/k8sT/manifests/l3-policy-demo.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l3-policy-demo"
+spec:
+  description: "L3 policy for allowing all traffic in demo DS"
+  endpointSelector:
+    matchLabels:
+      zgroup: testDS
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        zgroup: testDSClient


### PR DESCRIPTION
This pull request extends our tests to validate the source identity is properly transmitted in tunneling mode and we are able to enforce policies on the destination node. In particular, it will ensure such regressions as fixed by https://github.com/cilium/cilium/pull/14381 won't happen anymore.

See commits for details.