### PR TITLE
helm: fix TLS cert server name for cluster names containing dots

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -58,7 +58,7 @@ ca.crt: |-
 {{- define "hubble.server.gen-certs" }}
 {{- $ca := .ca | default (genCA "hubble-ca.cilium.io" (.Values.hubble.tls.auto.certValidityDuration | int)) -}}
 {{- $_ := set . "ca" $ca -}}
-{{- $cn := list "*" .Values.cluster.name "hubble-grpc.cilium.io" | join "." }}
+{{- $cn := list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." }}
 {{- $cert := genSignedCert $cn nil (list $cn) (.Values.hubble.tls.auto.certValidityDuration | int) $ca -}}
 tls.crt: {{ $cert.Cert | b64enc }}
 tls.key: {{ $cert.Key | b64enc }}


### PR DESCRIPTION
Before this patch, when the cluster name contains dots (`.`), the generated certificate will not match the name provided by the peer service.

This patch replace all dots (`.`) in the cluster name with hypens (`-`) to match the server names provided by the Hubble peer service.

Partially fix #14392, as this PR only address the Helm case.

See also #14378