### PR TITLE
Export and use agent event sub-types for Hubble

### DIFF
--- a/pkg/hubble/metrics/flow/handler.go
+++ b/pkg/hubble/metrics/flow/handler.go
@@ -56,6 +56,7 @@ func (h *flowHandler) ProcessFlow(flow v1.Flow) {
 	switch flow.GetEventType().Type {
 	case monitorAPI.MessageTypeAgent:
 		typeName = "Agent"
+		subType = monitorAPI.AgentNotifications[monitorAPI.AgentNotification(flow.GetEventType().SubType)]
 	case monitorAPI.MessageTypeAccessLog:
 		typeName = "L7"
 		if l7 := flow.GetL7(); l7 != nil {

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -232,7 +232,8 @@ const (
 	AgentNotifyServiceDeleted
 )
 
-var notifyTable = map[AgentNotification]string{
+// AgentNotifications is a map of all supported agent notification types.
+var AgentNotifications = map[AgentNotification]string{
 	AgentNotifyUnspec:                    "unspecified",
 	AgentNotifyGeneric:                   "Message",
 	AgentNotifyStart:                     "Cilium agent started",
@@ -249,7 +250,7 @@ var notifyTable = map[AgentNotification]string{
 }
 
 func resolveAgentType(t AgentNotification) string {
-	if n, ok := notifyTable[t]; ok {
+	if n, ok := AgentNotifications[t]; ok {
 		return n
 	}
 


### PR DESCRIPTION
Export the agent event types in `pkg/monitor` so it can be used outside the package and use it in `pkg/hubble/metrics/flow`. This will also be used in a follow-up PR in the cilium/hubble repo to allow filtering by agent event sub-type in the Hubble CLI.