### PR TITLE
helm: fix TLS cert server name for cluster names containing dots with certgen

### DIFF
--- a/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
@@ -14,8 +14,9 @@ spec:
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
           command:
             - "/usr/bin/cilium-certgen"
-          {{/* Because this is executed as a job, we pass the values as command line args instead of via config map,
-                this allows users to inspect the values used in past runs by inspecting the completed pod */ -}}
+          # Because this is executed as a job, we pass the values as command
+          # line args instead of via config map. This allows users to inspect
+          # the values used in past runs by inspecting the completed pod.
           args:
             - "--cilium-namespace={{ .Release.Namespace }}"
             - "--hubble-ca-reuse-secret=true"
@@ -36,6 +37,7 @@ spec:
             - "--hubble-server-cert-generate=false"
             {{- else }}
             - "--hubble-server-cert-generate=true"
+            - "--hubble-server-cert-common-name={{ list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." }}"
             - "--hubble-server-cert-validity-duration={{ $certValiditySecondsStr }}"
             - "--hubble-server-cert-secret-name=hubble-server-certs"
             {{- end }}

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -1227,6 +1227,9 @@ spec:
           imagePullPolicy: Always
           command:
             - "/usr/bin/cilium-certgen"
+          # Because this is executed as a job, we pass the values as command
+          # line args instead of via config map. This allows users to inspect
+          # the values used in past runs by inspecting the completed pod.
           args:
             - "--cilium-namespace=kube-system"
             - "--hubble-ca-reuse-secret=true"
@@ -1236,6 +1239,7 @@ spec:
             - "--hubble-ca-config-map-create=true"
             - "--hubble-ca-config-map-name=hubble-ca-cert"
             - "--hubble-server-cert-generate=true"
+            - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
             - "--hubble-server-cert-validity-duration=94608000s"
             - "--hubble-server-cert-secret-name=hubble-server-certs"
             - "--hubble-relay-client-cert-generate=true"
@@ -1272,6 +1276,9 @@ spec:
               imagePullPolicy: Always
               command:
                 - "/usr/bin/cilium-certgen"
+              # Because this is executed as a job, we pass the values as command
+              # line args instead of via config map. This allows users to inspect
+              # the values used in past runs by inspecting the completed pod.
               args:
                 - "--cilium-namespace=kube-system"
                 - "--hubble-ca-reuse-secret=true"
@@ -1281,6 +1288,7 @@ spec:
                 - "--hubble-ca-config-map-create=true"
                 - "--hubble-ca-config-map-name=hubble-ca-cert"
                 - "--hubble-server-cert-generate=true"
+                - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
                 - "--hubble-server-cert-validity-duration=94608000s"
                 - "--hubble-server-cert-secret-name=hubble-server-certs"
                 - "--hubble-relay-client-cert-generate=true"

--- a/install/kubernetes/quick-hubble-install.yaml
+++ b/install/kubernetes/quick-hubble-install.yaml
@@ -468,6 +468,9 @@ spec:
           imagePullPolicy: Always
           command:
             - "/usr/bin/cilium-certgen"
+          # Because this is executed as a job, we pass the values as command
+          # line args instead of via config map. This allows users to inspect
+          # the values used in past runs by inspecting the completed pod.
           args:
             - "--cilium-namespace=kube-system"
             - "--hubble-ca-reuse-secret=true"
@@ -477,6 +480,7 @@ spec:
             - "--hubble-ca-config-map-create=true"
             - "--hubble-ca-config-map-name=hubble-ca-cert"
             - "--hubble-server-cert-generate=true"
+            - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
             - "--hubble-server-cert-validity-duration=94608000s"
             - "--hubble-server-cert-secret-name=hubble-server-certs"
             - "--hubble-relay-client-cert-generate=true"
@@ -513,6 +517,9 @@ spec:
               imagePullPolicy: Always
               command:
                 - "/usr/bin/cilium-certgen"
+              # Because this is executed as a job, we pass the values as command
+              # line args instead of via config map. This allows users to inspect
+              # the values used in past runs by inspecting the completed pod.
               args:
                 - "--cilium-namespace=kube-system"
                 - "--hubble-ca-reuse-secret=true"
@@ -522,6 +529,7 @@ spec:
                 - "--hubble-ca-config-map-create=true"
                 - "--hubble-ca-config-map-name=hubble-ca-cert"
                 - "--hubble-server-cert-generate=true"
+                - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
                 - "--hubble-server-cert-validity-duration=94608000s"
                 - "--hubble-server-cert-secret-name=hubble-server-certs"
                 - "--hubble-relay-client-cert-generate=true"


### PR DESCRIPTION
Before this patch, when using Helm installing with `--set hubble.tls.auto.method=cronJob` and a cluster name containing dots (`.`), Relay would fail the mTLS handshake with Hubble.

The root cause is that we don't provide the cluster name info to certgen through Helm, and certgen then assumes that the cluster name is "default".

This PR ensure that the common name for the Hubble certificate is given to certgen through Helm in a way that is consistent with the peer service and also `hubble.tls.auto.method=helm`.

See also https://github.com/cilium/cilium/pull/14413

Fix https://github.com/cilium/cilium/issues/14392