### PR TITLE
test: Fix microk8s deployment hurdles

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -152,11 +152,13 @@ var (
 	}
 
 	microk8sHelmOverrides = map[string]string{
-		"ipv6.enabled":   "false",
-		"cni.confPath":   "/var/snap/microk8s/current/args/cni-network",
-		"cni.binPath":    "/var/snap/microk8s/current/opt/cni/bin",
-		"cni.customConf": "true",
-		"daemon.runPath": "/var/snap/microk8s/current/var/run/cilium",
+		"cni.confPath":      "/var/snap/microk8s/current/args/cni-network",
+		"cni.binPath":       "/var/snap/microk8s/current/opt/cni/bin",
+		"cni.customConf":    "true",
+		"daemon.runPath":    "/var/snap/microk8s/current/var/run/cilium",
+		"image.pullPolicy":  "IfNotPresent",
+		"ipv6.enabled":      "false",
+		"operator.replicas": "1",
 	}
 	minikubeHelmOverrides = map[string]string{
 		"ipv6.enabled":           "false",


### PR DESCRIPTION
Microk8s typically is deployed as a single local node cluster, so the
default of 2 operator replicas causes the cluster readiness checks to
fail as there is always an extra operator waiting to be scheduled.

Furthermore, when testing with microk8s the image is often side-loaded
via the `make microk8s` target, meaning that there is no public image to
pull. Set the pullPolicy for the image to `IfNotPresent` as `Always`
would otherwise fail to find and pull a newer version of the image
`localhost:32000/cilium/cilium:local`.

Tested manually, no need to run CI (CI doesn't use microk8s CI_INTEGRATION).