### PR TITLE
Remove docker-compose leftovers

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -22,10 +22,7 @@ verified. These tests must always pass.
 
 The configuration for this job is contained within ``ginkgo.Jenkinsfile``.
 
-It first runs unit tests using docker-compose using a YAML located at
-``test/docker-compose.yaml``.
-
-The next steps happens in parallel:
+The job runs the following steps in parallel:
 
     - Runs the single-node e2e tests using the Docker runtime.
     - Runs the multi-node Kubernetes e2e tests against the latest default

--- a/test/packet/scripts/install.sh
+++ b/test/packet/scripts/install.sh
@@ -70,7 +70,4 @@ go get -u github.com/onsi/ginkgo/ginkgo
 go get -u github.com/onsi/gomega/...
 sudo ln -sf /go/bin/* /usr/local/bin/
 
-sudo curl -L https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
-
 echo 'cd /root/go/src/github.com/cilium/cilium' >> /root/.bashrc

--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -95,12 +95,6 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 			versionRegexp: regexp.MustCompile(`Docker version (\d+\.\d+\.\d+)`),
 		},
 		&binaryCheck{
-			name:          "docker-compose",
-			ifNotFound:    checkInfo,
-			versionArgs:   []string{"--version"},
-			versionRegexp: regexp.MustCompile(`docker-compose version (\d+\.\d+\.\d+)`),
-		},
-		&binaryCheck{
 			name:          "helm",
 			ifNotFound:    checkWarning,
 			versionArgs:   []string{"version"},


### PR DESCRIPTION
`docker-compose` is no longer used in CI with #14400 merged. Adjust docs, test installation scripts and dev-doctor accordingly. See individual commits for details.