### PR TITLE
datapath: Remove IPV{4,6}_NODEPORT

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -36,10 +36,8 @@ BPFFS_ROOT=${18}
 NODE_PORT=${19}
 NODE_PORT_BIND=${20}
 MCPU=${21}
-NODE_PORT_IPV4_ADDRS=${22}
-NODE_PORT_IPV6_ADDRS=${23}
-NR_CPUS=${24}
-ENDPOINT_ROUTES=${25}
+NR_CPUS=${22}
+ENDPOINT_ROUTES=${23}
 
 ID_HOST=1
 ID_WORLD=2
@@ -478,22 +476,6 @@ if [ "$MODE" = "direct" ] || [ "$MODE" = "ipvlan" ] || [ "$NODE_PORT" = "true" ]
 		if [ "$IP6_HOST" != "<nil>" ]; then
 			echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
 		fi
-
-		if [ "$NODE_PORT_IPV4_ADDRS" != "<nil>" ]; then
-			declare -A v4_addrs
-			for a in ${NODE_PORT_IPV4_ADDRS//;/ }; do
-				IFS== read iface addr <<< "$a"
-				v4_addrs[$iface]=$addr
-			done
-		fi
-		if [ "$NODE_PORT_IPV6_ADDRS" != "<nil>" ]; then
-			declare -A v6_addrs
-			for a in ${NODE_PORT_IPV6_ADDRS//;/ }; do
-				IFS== read iface addr <<< "$a"
-				v6_addrs[$iface]=$addr
-			done
-		fi
-
 		echo "$NATIVE_DEVS" > $RUNDIR/device.state
 	fi
 else
@@ -618,13 +600,6 @@ if [ "$XDP_DEV" != "<nil>" ]; then
 	if [ "$NODE_PORT" = "true" ]; then
 		NATIVE_DEV_IDX=$(cat /sys/class/net/${XDP_DEV}/ifindex)
 		COPTS="${COPTS} -DNATIVE_DEV_IFINDEX=${NATIVE_DEV_IDX}"
-		# Currently it assumes that XDP_DEV is listed among NATIVE_DEVS
-		if [ "$IP4_HOST" != "<nil>" ]; then
-			COPTS="${COPTS} -DIPV4_NODEPORT=${v4_addrs[$XDP_DEV]}"
-		fi
-		if [ "$IP6_HOST" != "<nil>" ]; then
-			COPTS="${COPTS} -DIPV6_NODEPORT_VAL={.addr={${v6_addrs[$XDP_DEV]}}}"
-		fi
 	fi
 	xdp_load $XDP_DEV $XDP_MODE "$COPTS" bpf_xdp.c bpf_xdp.o from-netdev $CIDR_MAP
 fi

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -536,14 +536,6 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 			// values for the native devices.
 			fmt.Fprint(fw, "/* Fake values, replaced by 0 for host device and by actual values for native devices. */\n")
 			fmt.Fprint(fw, defineUint32("NATIVE_DEV_IFINDEX", 1))
-			if option.Config.EnableIPv6 {
-				placeholderIPv6 := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
-				fmt.Fprint(fw, defineIPv6("IPV6_NODEPORT", placeholderIPv6))
-			}
-			if option.Config.EnableIPv4 {
-				placeholderIPv4 := []byte{1, 1, 1, 1}
-				fmt.Fprint(fw, defineIPv4("IPV4_NODEPORT", placeholderIPv4))
-			}
 			fmt.Fprint(fw, "\n")
 		}
 		if option.Config.Masquerade && option.Config.EnableBPFMasquerade {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -20,11 +20,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/common"
@@ -66,8 +64,6 @@ const (
 	initArgNodePort
 	initArgNodePortBind
 	initBPFCPU
-	initArgNodePortIPv4Addrs
-	initArgNodePortIPv6Addrs
 	initArgNrCPUs
 	initArgEndpointRoutes
 	initArgMax
@@ -305,32 +301,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.EnableNodePort {
 		args[initArgNodePort] = "true"
-		if option.Config.EnableIPv4 {
-			addrs := node.GetNodePortIPv4AddrsWithDevices()
-			tmp := make([]string, 0, len(addrs))
-			for iface, ipv4 := range addrs {
-				tmp = append(tmp,
-					fmt.Sprintf("%s=%#x", iface,
-						byteorder.HostSliceToNetwork(ipv4, reflect.Uint32).(uint32)))
-			}
-			args[initArgNodePortIPv4Addrs] = strings.Join(tmp, ";")
-		} else {
-			args[initArgNodePortIPv4Addrs] = "<nil>"
-		}
-		if option.Config.EnableIPv6 {
-			addrs := node.GetNodePortIPv6AddrsWithDevices()
-			tmp := make([]string, 0, len(addrs))
-			for iface, ipv6 := range addrs {
-				tmp = append(tmp, fmt.Sprintf("%s=%s", iface, common.GoArray2CNoSpaces(ipv6)))
-			}
-			args[initArgNodePortIPv6Addrs] = strings.Join(tmp, ";")
-		} else {
-			args[initArgNodePortIPv6Addrs] = "<nil>"
-		}
 	} else {
 		args[initArgNodePort] = "false"
-		args[initArgNodePortIPv4Addrs] = "<nil>"
-		args[initArgNodePortIPv6Addrs] = "<nil>"
 	}
 
 	if option.Config.NodePortBindProtection {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -139,7 +139,8 @@ func nullifyStringSubstitutions(strings map[string]string) map[string]string {
 // Since the two object files should only differ by the values of their
 // NODE_MAC symbols, we can avoid a full compilation.
 func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName string,
-	nodePortIPv4Addrs, nodePortIPv6Addrs, bpfMasqIPv4Addrs map[string]net.IP) error {
+	bpfMasqIPv4Addrs map[string]net.IP) error {
+
 	hostObj, err := elf.Open(objPath)
 	if err != nil {
 		return err
@@ -168,19 +169,8 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 		opts["SECCTX_FROM_IPCACHE"] = uint32(SecctxFromIpcacheDisabled)
 	}
 
-	if option.Config.EnableNodePort && nodePortIPv4Addrs != nil && nodePortIPv6Addrs != nil {
+	if option.Config.EnableNodePort {
 		opts["NATIVE_DEV_IFINDEX"] = ifIndex
-		if option.Config.EnableIPv4 {
-			ipv4 := nodePortIPv4Addrs[ifName]
-			opts["IPV4_NODEPORT"] = byteorder.HostSliceToNetwork(ipv4, reflect.Uint32).(uint32)
-		}
-		if option.Config.EnableIPv6 {
-			nodePortIPv6 := nodePortIPv6Addrs[ifName]
-			opts["IPV6_NODEPORT_1"] = sliceToBe32(nodePortIPv6[0:4])
-			opts["IPV6_NODEPORT_2"] = sliceToBe32(nodePortIPv6[4:8])
-			opts["IPV6_NODEPORT_3"] = sliceToBe32(nodePortIPv6[8:12])
-			opts["IPV6_NODEPORT_4"] = sliceToBe32(nodePortIPv6[12:16])
-		}
 	}
 	if option.Config.Masquerade && option.Config.EnableBPFMasquerade && bpfMasqIPv4Addrs != nil {
 		if option.Config.EnableIPv4 {
@@ -230,15 +220,13 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			symbols = append(symbols, symbolToHostEp)
 			directions = append(directions, dirIngress)
 			secondDevObjPath := path.Join(ep.StateDir(), hostEndpointPrefix+"_"+defaults.SecondHostDevice+".o")
-			if err := patchHostNetdevDatapath(ep, objPath, secondDevObjPath, defaults.SecondHostDevice, nil, nil, nil); err != nil {
+			if err := patchHostNetdevDatapath(ep, objPath, secondDevObjPath, defaults.SecondHostDevice, nil); err != nil {
 				return err
 			}
 			objPaths = append(objPaths, secondDevObjPath)
 		}
 	}
 
-	nodePortIPv4Addrs := node.GetNodePortIPv4AddrsWithDevices()
-	nodePortIPv6Addrs := node.GetNodePortIPv6AddrsWithDevices()
 	bpfMasqIPv4Addrs := node.GetMasqIPv4AddrsWithDevices()
 
 	for _, device := range option.Config.Devices {
@@ -248,8 +236,7 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		}
 
 		netdevObjPath := path.Join(ep.StateDir(), hostEndpointNetdevPrefix+device+".o")
-		if err := patchHostNetdevDatapath(ep, objPath, netdevObjPath, device,
-			nodePortIPv4Addrs, nodePortIPv6Addrs, bpfMasqIPv4Addrs); err != nil {
+		if err := patchHostNetdevDatapath(ep, objPath, netdevObjPath, device, bpfMasqIPv4Addrs); err != nil {
 			return err
 		}
 		objPaths = append(objPaths, netdevObjPath)

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -225,21 +225,9 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 	result["NODE_MAC_1"] = sliceToBe32(mac[0:4])
 	result["NODE_MAC_2"] = uint32(sliceToBe16(mac[4:6]))
 
-	// These values are defined in nodeport.h regardless even for bpf_lxc (so
-	// regardless of whether it's the host endpoint).
-	if option.Config.EnableNodePort && option.Config.EnableIPv6 {
-		result["IPV6_NODEPORT_1"] = 0
-		result["IPV6_NODEPORT_2"] = 0
-		result["IPV6_NODEPORT_3"] = 0
-		result["IPV6_NODEPORT_4"] = 0
-	}
-
 	if ep.IsHost() {
 		if option.Config.EnableNodePort {
 			result["NATIVE_DEV_IFINDEX"] = 0
-			if option.Config.EnableIPv4 {
-				result["IPV4_NODEPORT"] = 0
-			}
 		}
 		if option.Config.Masquerade && option.Config.EnableBPFMasquerade {
 			if option.Config.EnableIPv4 {


### PR DESCRIPTION
After introducing `IPV{4,6}_MASQUERADE`, the former is no longer in use.

For the case when a LB request has to be forwarded to a destination
node, we use `IPV{4,6}_DIRECT_ROUTING`. For SNAT from endpoint to outside
we use `IPV{4,6}_MASQUERADE`.

Fix #14273 