### PR TITLE
A pod-link CNI chain that can be used with Terway (Alibaba Cloud CNI Plugin)

### DIFF
--- a/pkg/datapath/connector/ipvlan.go
+++ b/pkg/datapath/connector/ipvlan.go
@@ -19,10 +19,10 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-func getEntryProgInstructions(fd int) asm.Instructions {
+func getEntryProgInstructions(fd int, index int32) asm.Instructions {
 	return asm.Instructions{
 		asm.LoadMapPtr(asm.R2, fd),
-		asm.Mov.Imm(asm.R3, 0),
+		asm.Mov.Imm(asm.R3, index),
 		asm.FnTailCall.Call(),
 		asm.Mov.Imm(asm.R0, 0),
 		asm.Return(),
@@ -80,7 +80,7 @@ func setupIpvlanInRemoteNs(netNs ns.NetNS, srcIfName, dstIfName string) (*ebpf.M
 
 		prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 			Type:         ebpf.SchedCLS,
-			Instructions: getEntryProgInstructions(m.FD()),
+			Instructions: getEntryProgInstructions(m.FD(), 0),
 			License:      "ASL2",
 		})
 		if err != nil {

--- a/pkg/datapath/connector/ipvlan_test.go
+++ b/pkg/datapath/connector/ipvlan_test.go
@@ -16,7 +16,7 @@ import (
 func TestEntryProgInstructions(t *testing.T) {
 	mapFD := 0xaabbccdd
 	tmp := (*[4]byte)(unsafe.Pointer(&mapFD))
-	immProg := []byte{
+	immProg0 := []byte{
 		0x18, 0x12, 0x00, 0x00, tmp[0], tmp[1], tmp[2], tmp[3],
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0xb7, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -25,14 +25,34 @@ func TestEntryProgInstructions(t *testing.T) {
 		0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	}
 
-	prog := getEntryProgInstructions(mapFD)
-	var buf bytes.Buffer
-	if err := prog.Marshal(&buf, binary.LittleEndian); err != nil {
+	prog0 := getEntryProgInstructions(mapFD, 0)
+	var buf0 bytes.Buffer
+	if err := prog0.Marshal(&buf0, binary.LittleEndian); err != nil {
 		t.Fatal(err)
 	}
 
-	if insnsProg := buf.Bytes(); !bytes.Equal(insnsProg, immProg) {
+	if insnsProg := buf0.Bytes(); !bytes.Equal(insnsProg, immProg0) {
 		t.Errorf("Marshalled entry program does not match immediate encoding:\ngot:\n%s\nwant:\n%s",
-			hex.Dump(insnsProg), hex.Dump(immProg))
+			hex.Dump(insnsProg), hex.Dump(immProg0))
+	}
+
+	immProg1 := []byte{
+		0x18, 0x12, 0x00, 0x00, tmp[0], tmp[1], tmp[2], tmp[3],
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xb7, 0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+		0x85, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
+		0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	prog1 := getEntryProgInstructions(mapFD, 1)
+	var buf1 bytes.Buffer
+	if err := prog1.Marshal(&buf1, binary.LittleEndian); err != nil {
+		t.Fatal(err)
+	}
+
+	if insnsProg := buf1.Bytes(); !bytes.Equal(insnsProg, immProg1) {
+		t.Errorf("Marshalled entry program does not match immediate encoding:\ngot:\n%s\nwant:\n%s",
+			hex.Dump(insnsProg), hex.Dump(immProg1))
 	}
 }

--- a/pkg/datapath/connector/pod-link.go
+++ b/pkg/datapath/connector/pod-link.go
@@ -1,0 +1,140 @@
+package connector
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/datapath/link"
+)
+
+// SetupNicInRemoteNs creates a tail call map, renames the netdevice inside
+// the target netns and attaches a BPF program to it.
+// egress is on 0. ingress is on 1.
+// NB: Do not close the returned map before it has been pinned. Otherwise,
+// the map will be destroyed.
+func SetupNicInRemoteNs(netNs ns.NetNS, srcIfName, dstIfName string, egress bool, ingress bool) (*ebpf.Map, error) {
+	rl := unix.Rlimit{
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
+	}
+
+	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &rl)
+	if err != nil {
+		return nil, fmt.Errorf("unable to increase rlimit: %s", err)
+	}
+
+	entries := uint32(0)
+	if egress {
+		entries++
+	}
+	if ingress {
+		entries++
+	}
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.ProgramArray,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: entries,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create root BPF map for %q: %s", dstIfName, err)
+	}
+
+	err = netNs.Do(func(_ ns.NetNS) error {
+		var err error
+
+		if srcIfName != dstIfName {
+			err = link.Rename(srcIfName, dstIfName)
+			if err != nil {
+				return fmt.Errorf("failed to rename ipvlan from %q to %q: %s", srcIfName, dstIfName, err)
+			}
+		}
+
+		ipvlan, err := netlink.LinkByName(dstIfName)
+		if err != nil {
+			return fmt.Errorf("failed to lookup ipvlan device %q: %s", dstIfName, err)
+		}
+
+		qdiscAttrs := netlink.QdiscAttrs{
+			LinkIndex: ipvlan.Attrs().Index,
+			Handle:    netlink.MakeHandle(0xffff, 0),
+			Parent:    netlink.HANDLE_CLSACT,
+		}
+		qdisc := &netlink.GenericQdisc{
+			QdiscAttrs: qdiscAttrs,
+			QdiscType:  "clsact",
+		}
+		if err = netlink.QdiscAdd(qdisc); err != nil {
+			return fmt.Errorf("failed to create clsact qdisc on %q: %s", dstIfName, err)
+		}
+
+		if egress {
+			prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+				Type:         ebpf.SchedCLS,
+				Instructions: getEntryProgInstructions(m.FD(), 0),
+				License:      "ASL2",
+			})
+			if err != nil {
+				return fmt.Errorf("failed to load root BPF prog for %q: %s", dstIfName, err)
+			}
+
+			filterAttrs := netlink.FilterAttrs{
+				LinkIndex: ipvlan.Attrs().Index,
+				Parent:    netlink.HANDLE_MIN_EGRESS,
+				Handle:    netlink.MakeHandle(0, 1),
+				Protocol:  3,
+				Priority:  1,
+			}
+			filter := &netlink.BpfFilter{
+				FilterAttrs:  filterAttrs,
+				Fd:           prog.FD(),
+				Name:         "polEntry",
+				DirectAction: true,
+			}
+			if err = netlink.FilterAdd(filter); err != nil {
+				prog.Close()
+				return fmt.Errorf("failed to create cls_bpf filter on %q: %s", dstIfName, err)
+			}
+		}
+
+		if ingress {
+			prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+				Type:         ebpf.SchedCLS,
+				Instructions: getEntryProgInstructions(m.FD(), 1),
+				License:      "ASL2",
+			})
+			if err != nil {
+				return fmt.Errorf("failed to load root BPF prog for %q: %s", dstIfName, err)
+			}
+
+			filterAttrs := netlink.FilterAttrs{
+				LinkIndex: ipvlan.Attrs().Index,
+				Parent:    netlink.HANDLE_MIN_INGRESS,
+				Handle:    netlink.MakeHandle(0, 1),
+				Protocol:  3,
+				Priority:  1,
+			}
+			filter := &netlink.BpfFilter{
+				FilterAttrs:  filterAttrs,
+				Fd:           prog.FD(),
+				Name:         "ingressPolEntry",
+				DirectAction: true,
+			}
+			if err = netlink.FilterAdd(filter); err != nil {
+				prog.Close()
+				return fmt.Errorf("failed to create ingress cls_bpf filter on %q: %s", dstIfName, err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		m.Close()
+		return nil, err
+	}
+	return m, nil
+}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -904,10 +904,11 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 
 	fmt.Fprintf(fw, "#define HOST_EP_ID %d\n", uint32(node.GetEndpointID()))
 
+	if e.RequireARPPassthrough() {
+		fmt.Fprint(fw, "#define ENABLE_ARP_PASSTHROUGH 1\n")
+	}
 	if !e.HasIpvlanDataPath() {
-		if e.RequireARPPassthrough() {
-			fmt.Fprint(fw, "#define ENABLE_ARP_PASSTHROUGH 1\n")
-		} else {
+		if !e.RequireARPPassthrough() {
 			fmt.Fprint(fw, "#define ENABLE_ARP_RESPONDER 1\n")
 		}
 

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -29,6 +29,9 @@ const (
 	tunnelMode = baseDeviceMode("tunnel")
 
 	libbpfFixupMsg = "struct bpf_elf_map fixup performed due to size mismatch!"
+
+	ingressKey = "0"
+	egressKey  = "1"
 )
 
 func replaceQdisc(ifName string) error {
@@ -126,7 +129,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 }
 
 // graftDatapath replaces obj in tail call map
-func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error {
+func graftDatapath(ctx context.Context, mapPath, objPath, progSec, key string) error {
 	if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), objPath); err != nil {
 		return fmt.Errorf("Failed to start bpffs map migration: %w", err)
 	}
@@ -140,8 +143,7 @@ func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error 
 	}()
 
 	// FIXME: replace exec with native call
-	// FIXME: only key 0 right now, could be made more flexible
-	args := []string{"exec", "bpf", "graft", mapPath, "key", "0",
+	args := []string{"exec", "bpf", "graft", mapPath, "key", key,
 		"obj", objPath, "sec", progSec,
 	}
 	cmd := exec.CommandContext(ctx, "tc", args...).WithFilters(libbpfFixupMsg)

--- a/plugins/cilium-cni/chaining/pod-link/pod-link.go
+++ b/plugins/cilium-cni/chaining/pod-link/pod-link.go
@@ -1,0 +1,189 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podlink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/datapath/connector"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
+	cniVersion "github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+const name = "pod-link"
+
+type GenericLink struct{}
+
+// ImplementsAdd returns true if method 'add' is available
+func (g *GenericLink) ImplementsAdd() bool {
+	return true
+}
+
+// Add setups the link port's tc-bpf
+func (g *GenericLink) Add(ctx context.Context, pluginCtx chainingapi.PluginContext) (res *cniTypesVer.Result, err error) {
+	err = cniVersion.ParsePrevResult(&pluginCtx.NetConf.NetConf)
+	if err != nil {
+		err = fmt.Errorf("unable to understand network config: %w", err)
+		return
+	}
+
+	var prevRes *cniTypesVer.Result
+	prevRes, err = cniTypesVer.NewResultFromResult(pluginCtx.NetConf.PrevResult)
+	if err != nil {
+		err = fmt.Errorf("unable to get previous network result: %w", err)
+		return
+	}
+	defer func() {
+		if err != nil {
+			pluginCtx.Logger.WithError(err).
+				WithFields(logrus.Fields{"cni-pre-result": pluginCtx.NetConf.PrevResult}).
+				Errorf("Unable to create endpoint")
+		}
+	}()
+
+	netNs, err := ns.GetNS(pluginCtx.Args.Netns)
+	if err != nil {
+		err = fmt.Errorf("failed to open netns %q: %w", pluginCtx.Args.Netns, err)
+		return
+	}
+	defer netNs.Close()
+
+	var (
+		ifName                                     = ""
+		disabled                                   = false
+		containerIPv4, containerIPv6, containerMac string
+		containerIfIndex                           int
+	)
+
+	if err = netNs.Do(func(_ ns.NetNS) error {
+		links, err := netlink.LinkList()
+		if err != nil {
+			return fmt.Errorf("failed to list link %s", pluginCtx.Args.Netns)
+		}
+		for _, link := range links {
+			pluginCtx.Logger.Debugf("Found interface in container %+v", link.Attrs())
+
+			if link.Attrs().Name == "lo" {
+				continue
+			}
+
+			ifName = link.Attrs().Name
+			containerMac = link.Attrs().HardwareAddr.String()
+
+			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			if err == nil && len(addrs) > 0 {
+				containerIPv4 = addrs[0].IPNet.IP.String()
+			} else if err != nil {
+				pluginCtx.Logger.WithError(err).WithFields(logrus.Fields{
+					logfields.Interface: link.Attrs().Name}).Warn("No valid IPv4 address found")
+			}
+
+			addrsv6, err := netlink.AddrList(link, netlink.FAMILY_V6)
+			if err == nil && len(addrsv6) > 0 {
+				containerIPv6 = addrsv6[0].IPNet.IP.String()
+			} else if err != nil {
+				pluginCtx.Logger.WithError(err).WithFields(logrus.Fields{
+					logfields.Interface: link.Attrs().Name}).Warn("No valid IPv6 address found")
+			}
+
+			return nil
+		}
+
+		return fmt.Errorf("no link found inside container")
+	}); err != nil {
+		return
+	}
+
+	if containerIPv4 == "" && containerIPv6 == "" {
+		err = errors.New("unable to determine IP address of the container")
+		return
+	}
+
+	// set bpf
+	m, err := connector.SetupNicInRemoteNs(netNs, ifName, ifName, true, true)
+	if err != nil {
+		pluginCtx.Logger.WithError(err).Warn("Unable to set ebpf")
+		return
+	}
+	defer m.Close()
+	mapID, err := m.ID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get map ID: %w", err)
+	}
+
+	// create endpoint
+	ep := &models.EndpointChangeRequest{
+		Addressing: &models.AddressPair{
+			IPV4: containerIPv4,
+			IPV6: containerIPv6,
+		},
+		ContainerID:       pluginCtx.Args.ContainerID,
+		State:             models.EndpointStateWaitingForIdentity,
+		HostMac:           containerMac,
+		InterfaceIndex:    int64(containerIfIndex),
+		Mac:               containerMac,
+		InterfaceName:     ifName,
+		K8sPodName:        string(pluginCtx.CniArgs.K8S_POD_NAME),
+		K8sNamespace:      string(pluginCtx.CniArgs.K8S_POD_NAMESPACE),
+		SyncBuildEndpoint: true,
+		DatapathMapID:     int64(mapID),
+		DatapathConfiguration: &models.EndpointDatapathConfiguration{
+			RequireArpPassthrough: true,
+			RequireEgressProg:     true,
+			ExternalIpam:          true,
+			RequireRouting:        &disabled,
+		},
+	}
+
+	err = pluginCtx.Client.EndpointCreate(ep)
+	if err != nil {
+		pluginCtx.Logger.WithError(err).WithField(logfields.ContainerID, ep.ContainerID).Warn("Unable to create endpoint")
+		err = fmt.Errorf("unable to create endpoint: %s", err)
+		return
+	}
+
+	pluginCtx.Logger.WithField(logfields.ContainerID, ep.ContainerID).Debug("Endpoint successfully created")
+
+	res = prevRes
+	return
+}
+
+// ImplementsDelete return true if method 'delete' is available
+func (g *GenericLink) ImplementsDelete() bool {
+	return true
+}
+
+// Delete deletes cilium endpoint
+func (g *GenericLink) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+	id := endpointid.NewID(endpointid.ContainerIdPrefix, pluginCtx.Args.ContainerID)
+	if err := pluginCtx.Client.EndpointDelete(id); err != nil {
+		pluginCtx.Logger.WithError(err).Warning("Errors encountered while deleting endpoint")
+	}
+	return nil
+}
+
+func init() {
+	chainingapi.Register(name, &GenericLink{})
+}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -48,6 +48,7 @@ import (
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/azure"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/flannel"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
+	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/pod-link"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
 )


### PR DESCRIPTION
This merge request introduces a pod-link cni chain. In pod-link chain mode, cilium,  as the second CNI, attaches bpf to pod netns's interface. Pod-link chain can be used with CNIs that are based on sriov, eni, macvlan or ipvlan ect...  These CNIs usually have better performance, but they are hard to support kubernetes service network, network policy and other advanced network functions. Pod-link chain provides a way to implement advanced network functions for these plugins.

For Terway(CNI for Alibaba Cloud), we will use the pod-link chain with ENI and IPVlan L2 container network, and build a high performance kubernetes network solution.