### PR TITLE
v1.7 backports 2020-12-17

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -17,7 +17,8 @@ six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.8.1
 # forked read the docs themez
-git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7
+git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
+sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-websupport==1.1.0

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -351,7 +351,7 @@ func (l *BPFListener) OnIPIdentityCacheGC() {
 	// fully to give us the history of all events. As such, periodically check
 	// for inconsistencies in the data-path with that in the agent to ensure
 	// consistent state.
-	controller.NewManager().UpdateController("ipcache-bpf-garbage-collection",
+	ipcache.IPIdentityCache.UpdateController("ipcache-bpf-garbage-collection",
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				wg, err := l.garbageCollect(ctx)

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -17,6 +17,7 @@ package ipcache
 import (
 	"net"
 
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -79,6 +80,9 @@ type IPCache struct {
 	v6PrefixLengths map[int]int
 
 	listeners []IPIdentityMappingListener
+
+	// controllers manages the async controllers for this IPCache
+	controllers *controller.Manager
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
@@ -92,6 +96,7 @@ func NewIPCache() *IPCache {
 		ipToK8sMetadata:   map[string]K8sMetadata{},
 		v4PrefixLengths:   map[int]int{},
 		v6PrefixLengths:   map[int]int{},
+		controllers:       controller.NewManager(),
 	}
 }
 
@@ -136,6 +141,11 @@ func (ipc *IPCache) AddListener(listener IPIdentityMappingListener) {
 	defer ipc.mutex.RUnlock()
 	// Initialize new listener with the current mappings
 	ipc.DumpToListenerLocked(listener)
+}
+
+// Update a controller for this IPCache
+func (ipc *IPCache) UpdateController(name string, params controller.ControllerParams) {
+	ipc.controllers.UpdateController(name, params)
 }
 
 // endpointIPToCIDR converts the endpoint IP into an equivalent full CIDR.

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -78,7 +78,12 @@ func (k *K8sWatcher) podsInit(k8sClient kubernetes.Interface, serPods *serialize
 								// handling.
 								if ep := k.endpointManager.LookupPodName(podNSName); ep != nil {
 									epCreatedAt := ep.GetCreatedAt()
-									metrics.EventLagK8s.Set(time.Since(epCreatedAt).Seconds())
+									timeSinceEpCreated := time.Since(epCreatedAt)
+									if timeSinceEpCreated <= 0 {
+										metrics.EventLagK8s.Set(0)
+									} else {
+										metrics.EventLagK8s.Set(timeSinceEpCreated.Round(time.Second).Seconds())
+									}
 								}
 								err := k.addK8sPodV1(pod)
 								k.K8sEventProcessed(metricPod, metricCreate, err == nil)


### PR DESCRIPTION
* #14264 -- docs: Fix dependency conflict (@joestringer)
 * #14313 -- pkg/k8s: fix k8s_event_lag_seconds for negative time (@aanm)
 * #14300 -- ipcache: Use controller.Manager on IPIdentityCache for bpf-garbage-collection (@dctrwatson)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14264 14313 14300; do contrib/backporting/set-labels.py $pr done 1.7; done
```

:warning:  All 3 PRs had conflicts that I had to manually solve, so please double check the backported changes