### PR TITLE
install/kubernetes: remove privileged from Cilium DaemonSet

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -225,6 +225,7 @@ cilium-agent [flags]
       --pprof-port int                                       Port that the pprof listens on (default 6060)
       --preallocate-bpf-maps                                 Enable BPF map pre-allocation (default true)
       --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
+      --procfs string                                        Root's proc filesystem path (default "/proc")
       --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
       --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1440,7 +1440,7 @@
    * - securityContext
      - Security context to be added to agent pods
      - object
-     - ``{}``
+     - ``{"privileged":false}``
    * - serviceAccounts
      - Define serviceAccount names for components.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1164,7 +1164,7 @@
    * - nodeinit.securityContext
      - Security context to be added to nodeinit pods.
      - object
-     - ``{"privileged":true}``
+     - ``{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}``
    * - nodeinit.tolerations
      - Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
      - list

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -729,6 +729,7 @@ prepulls
 prerequirement
 priori
 priorityClassName
+procfs
 productpage
 profiler
 prog

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -2,31 +2,33 @@
 # SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 # Copyright Authors of Cilium
 
-LIB=$1
-RUNDIR=$2
-IP4_HOST=$3
-IP6_HOST=$4
-MODE=$5
-TUNNEL_MODE=$6
+LIB=${1}
+RUNDIR=${2}
+PROCSYSNETDIR=${3}
+SYSCLASSNETDIR=${4}
+IP4_HOST=${5}
+IP6_HOST=${6}
+MODE=${7}
+TUNNEL_MODE=${8}
 # Only set if TUNNEL_MODE = "vxlan", "geneve"
-TUNNEL_PORT=$7
+TUNNEL_PORT=${9}
 # Only set if MODE = "direct", "ipvlan"
-NATIVE_DEVS=$8
-HOST_DEV1=$9
-HOST_DEV2=${10}
-MTU=${11}
-HOSTLB=${12}
-HOSTLB_UDP=${13}
-HOSTLB_PEER=${14}
-CGROUP_ROOT=${15}
-BPFFS_ROOT=${16}
-NODE_PORT=${17}
-NODE_PORT_BIND=${18}
-MCPU=${19}
-NR_CPUS=${20}
-ENDPOINT_ROUTES=${21}
-PROXY_RULE=${22}
-FILTER_PRIO=${23}
+NATIVE_DEVS=${10}
+HOST_DEV1=${11}
+HOST_DEV2=${12}
+MTU=${13}
+HOSTLB=${14}
+HOSTLB_UDP=${15}
+HOSTLB_PEER=${16}
+CGROUP_ROOT=${17}
+BPFFS_ROOT=${18}
+NODE_PORT=${19}
+NODE_PORT_BIND=${20}
+MCPU=${21}
+NR_CPUS=${22}
+ENDPOINT_ROUTES=${23}
+PROXY_RULE=${24}
+FILTER_PRIO=${25}
 
 ID_HOST=1
 ID_WORLD=2
@@ -53,14 +55,14 @@ function setup_dev()
 	ip link set $NAME up
 
 	if [ "$IP6_HOST" != "<nil>" ]; then
-		echo 1 > /proc/sys/net/ipv6/conf/${NAME}/forwarding
+		echo 1 > "${PROCSYSNETDIR}/ipv6/conf/${NAME}/forwarding"
 	fi
 
 	if [ "$IP4_HOST" != "<nil>" ]; then
-		echo 1 > /proc/sys/net/ipv4/conf/${NAME}/forwarding
-		echo 0 > /proc/sys/net/ipv4/conf/${NAME}/rp_filter
-		echo 1 > /proc/sys/net/ipv4/conf/${NAME}/accept_local
-		echo 0 > /proc/sys/net/ipv4/conf/${NAME}/send_redirects
+		echo 1 > "${PROCSYSNETDIR}/ipv4/conf/${NAME}/forwarding"
+		echo 0 > "${PROCSYSNETDIR}/ipv4/conf/${NAME}/rp_filter"
+		echo 1 > "${PROCSYSNETDIR}/ipv4/conf/${NAME}/accept_local"
+		echo 0 > "${PROCSYSNETDIR}/ipv4/conf/${NAME}/send_redirects"
 	fi
 }
 
@@ -332,7 +334,7 @@ case "${MODE}" in
 		echo "#endif /* CILIUM_NET_MAC */" >> $RUNDIR/globals/node_config.h
 
 		sed -i '/^#.*HOST_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
-		HOST_IDX=$(cat /sys/class/net/${HOST_DEV2}/ifindex)
+		HOST_IDX=$(cat "${SYSCLASSNETDIR}/${HOST_DEV2}/ifindex")
 		echo "#define HOST_IFINDEX $HOST_IDX" >> $RUNDIR/globals/node_config.h
 
 		sed -i '/^#.*HOST_IFINDEX_MAC.*$/d' $RUNDIR/globals/node_config.h
@@ -341,10 +343,10 @@ case "${MODE}" in
 		echo "#define HOST_IFINDEX_MAC { .addr = ${HOST_MAC}}" >> $RUNDIR/globals/node_config.h
 
 		sed -i '/^#.*CILIUM_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
-		CILIUM_IDX=$(cat /sys/class/net/${HOST_DEV1}/ifindex)
+		CILIUM_IDX=$(cat "${SYSCLASSNETDIR}/${HOST_DEV1}/ifindex")
 		echo "#define CILIUM_IFINDEX $CILIUM_IDX" >> $RUNDIR/globals/node_config.h
 
-		CILIUM_EPHEMERAL_MIN=$(cat /proc/sys/net/ipv4/ip_local_port_range | awk '{print $1}')
+		CILIUM_EPHEMERAL_MIN=$(cat "${PROCSYSNETDIR}/ipv4/ip_local_port_range" | awk '{print $1}')
 		echo "#define EPHEMERAL_MIN $CILIUM_EPHEMERAL_MIN" >> $RUNDIR/globals/node_config.h
 esac
 
@@ -380,7 +382,7 @@ if [ "$MODE" = "ipip" ]; then
 		}
 		setup_dev $ENCAP_DEV || encap_fail
 
-		ENCAP_IDX=$(cat /sys/class/net/${ENCAP_DEV}/ifindex)
+		ENCAP_IDX=$(cat "${SYSCLASSNETDIR}/${ENCAP_DEV}/ifindex")
 		sed -i '/^#.*ENCAP4_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
 		echo "#define ENCAP4_IFINDEX $ENCAP_IDX" >> $RUNDIR/globals/node_config.h
 	else
@@ -401,7 +403,7 @@ if [ "$MODE" = "ipip" ]; then
 		}
 		setup_dev $ENCAP_DEV || encap_fail
 
-		ENCAP_IDX=$(cat /sys/class/net/${ENCAP_DEV}/ifindex)
+		ENCAP_IDX=$(cat "${SYSCLASSNETDIR}/${ENCAP_DEV}/ifindex")
 		sed -i '/^#.*ENCAP6_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
 		echo "#define ENCAP6_IFINDEX $ENCAP_IDX" >> $RUNDIR/globals/node_config.h
 	else
@@ -434,7 +436,7 @@ if [ "${TUNNEL_MODE}" != "<nil>" ]; then
 
 	setup_dev $ENCAP_DEV || encap_fail
 
-	ENCAP_IDX=$(cat /sys/class/net/${ENCAP_DEV}/ifindex)
+	ENCAP_IDX=$(cat "${SYSCLASSNETDIR}/${ENCAP_DEV}/ifindex")
 	sed -i '/^#.*ENCAP_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
 	echo "#define ENCAP_IFINDEX $ENCAP_IDX" >> $RUNDIR/globals/node_config.h
 
@@ -460,7 +462,7 @@ if [ "$MODE" = "direct" ] || [ "$MODE" = "ipvlan" ] || [ "$NODE_PORT" = "true" ]
 		echo "No device specified for $MODE mode, ignoring..."
 	else
 		if [ "$IP6_HOST" != "<nil>" ]; then
-			echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+			echo 1 > "${PROCSYSNETDIR}/ipv6/conf/all/forwarding"
 		fi
 		echo "$NATIVE_DEVS" > $RUNDIR/device.state
 	fi
@@ -500,12 +502,12 @@ done
 
 if [ "$HOSTLB" = "true" ]; then
 	if [ "$IP6_HOST" != "<nil>" ]; then
-		echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+		echo 1 > "${PROCSYSNETDIR}/ipv6/conf/all/forwarding"
 	fi
 
 	CALLS_MAP="cilium_calls_lb"
 	COPTS=""
-	if [ "$IP6_HOST" != "<nil>" ] || [ "$IP4_HOST" != "<nil>" ] && [ -f /proc/sys/net/ipv6/conf/all/forwarding ]; then
+	if [ "$IP6_HOST" != "<nil>" ] || [ "$IP4_HOST" != "<nil>" ] && [ -f "${PROCSYSNETDIR}/ipv6/conf/all/forwarding" ]; then
 		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr connect6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
 		if [ "$HOSTLB_PEER" = "true" ]; then
 			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr getpeername6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -74,6 +74,7 @@ import (
 	"github.com/cilium/cilium/pkg/pidfile"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
 	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
 	wireguardTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -765,6 +766,9 @@ func initializeFlags() {
 	flags.Int(option.MTUName, 0, "Overwrite auto-detected MTU of underlying network")
 	option.BindEnv(option.MTUName)
 
+	flags.String(option.ProcFs, "/proc", "Root's proc filesystem path")
+	option.BindEnv(option.ProcFs)
+
 	flags.Int(option.RouteMetric, 0, "Overwrite the metric used by cilium when adding routes to its 'cilium_host' device")
 	option.BindEnv(option.RouteMetric)
 
@@ -1178,6 +1182,8 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	option.LogRegisteredOptions(log)
+
+	sysctl.SetProcfs(option.Config.ProcFs)
 
 	// Configure k8s as soon as possible so that k8s.IsEnabled() has the right
 	// behavior.
@@ -1681,6 +1687,7 @@ func (d *Daemon) initKVStore() {
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
 		HostDevice: defaults.HostDevice,
+		ProcFs:     option.Config.ProcFs,
 	}
 
 	log.Info("Initializing daemon")

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -341,7 +341,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
 | nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| nodeinit.securityContext | object | `{"privileged":true}` | Security context to be added to nodeinit pods. |
+| nodeinit.securityContext | object | `{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}` | Security context to be added to nodeinit pods. |
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -410,7 +410,7 @@ contributors across the globe, there is almost always someone available to help.
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
-| securityContext | object | `{}` | Security context to be added to agent pods |
+| securityContext | object | `{"privileged":false}` | Security context to be added to agent pods |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -43,6 +43,14 @@ spec:
         # ensure pods roll when configmap updates
         cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
         {{- end }}
+        {{- if not .Values.securityContext.privileged }}
+        # Set app AppArmor's profile to "unconfined". The value of this annotation
+        # can be modified as long users know which profiles they have available
+        # in AppArmor.
+        container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
+        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
+        container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -233,13 +241,59 @@ spec:
         {{- end }}
         {{- end }}
         securityContext:
+          {{- if .Values.securityContext.privileged }}
           privileged: true
+          {{- else }}
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            add:
+              # Used to terminate envoy child process
+              - KILL
+              # Used since cilium modifies routing tables, etc...
+              - NET_ADMIN
+              # Used in iptables. Consider removing once we are iptables-free
+              - SYS_MODULE
+              # We need it for now but might not need it for >= 5.11 specially
+              # for the 'SYS_RESOURCE'.
+              # In >= 5.8 there's already BPF and PERMON capabilities
+              - SYS_ADMIN
+              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+              - SYS_RESOURCE
+              # Both PERFMON and BPF requires kernel 5.8, container runtime
+              # cri-o >= v1.22.0 or containerd >= v1.5.0.
+              # If available, SYS_ADMIN can be removed.
+              #- PERFMON
+              #- BPF
+          {{- end}}
         volumeMounts:
+        {{- if not .Values.securityContext.privileged }}
+        # Unprivileged containers need to mount /proc/sys/net from the host
+        # to have write access
+        - mountPath: /host/proc/sys/net
+          name: host-proc-sys-net
+        # Unprivileged containers need to mount /proc/sys/kernel from the host
+        # to have write access
+        - mountPath: /host/proc/sys/kernel
+          name: host-proc-sys-kernel
+        {{- end}}
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
         {{- if not (eq .Values.containerRuntime.integration "crio") }}
         - name: bpf-maps
           mountPath: /sys/fs/bpf
+          {{- if .Values.securityContext.privileged }}
           mountPropagation: Bidirectional
+          {{- else }}
+          # Unprivileged containers can't set mount propagation to bidirectional
+          # in this case we will mount the bpf fs from an init container that
+          # is privileged and set the mount propagation from host to container
+          # in Cilium.
+          mountPropagation: HostToContainer
+          {{- end}}
         {{- end }}
         {{- if not (contains "/run/cilium/cgroupv2" .Values.cgroup.hostRoot) }}
         # Check for duplicate mounts before mounting
@@ -369,7 +423,45 @@ spec:
         - name: cni-path
           mountPath: /hostbin
         securityContext:
+          {{- if .Values.securityContext.privileged }}
           privileged: true
+          {{- else }}
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            add:
+              # Only used for 'mount' cgroup
+              - SYS_ADMIN
+              # Used for nsenter
+              - SYS_PTRACE
+          {{- end}}
+      {{- end }}
+      {{- if not .Values.securityContext.privileged }}
+      # Mount the bpf fs if it is not mounted. We will perform this task
+      # from a privileged container because the mount propagation bidirectional
+      # only works from privileged containers.
+      - name: mount-bpf-fs
+        image: {{ include "cilium.image" .Values.image | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
+        command:
+        - /bin/bash
+        - -c
+        - --
+        securityContext:
+          privileged: true
+      {{- /* CRI-O already mounts the BPF filesystem */ -}}
+      {{- if not (eq .Values.containerRuntime.integration "crio") }}
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
+        {{- end }}
       {{- end }}
       {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
       - name: wait-for-node-init
@@ -417,7 +509,37 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         securityContext:
+          {{- if .Values.securityContext.privileged }}
           privileged: true
+          {{- else }}
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            # Most of the capabilities here are the same ones used in the
+            # cilium-agent's container because this container can be used to
+            # uninstall all Cilium resources, and therefore it is likely that
+            # will need the same capabilities.
+            add:
+              # Used since cilium modifies routing tables, etc...
+              - NET_ADMIN
+              # Used in iptables. Consider removing once we are iptables-free
+              - SYS_MODULE
+              # We need it for now but might not need it for >= 5.11 specially
+              # for the 'SYS_RESOURCE'.
+              # In >= 5.8 there's already BPF and PERMON capabilities
+              - SYS_ADMIN
+              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+              - SYS_RESOURCE
+              # Both PERFMON and BPF requires kernel 5.8, container runtime
+              # cri-o >= v1.22.0 or containerd >= v1.5.0.
+              # If available, SYS_ADMIN can be removed.
+              #- PERFMON
+              #- BPF
+          {{- end}}
         volumeMounts:
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
         {{- if not (eq .Values.containerRuntime.integration "crio") }}
@@ -581,6 +703,16 @@ spec:
       - name: bgp-config-path
         configMap:
           name: bgp-config
+      {{- end }}
+      {{- if not .Values.securityContext.privileged }}
+      - name: host-proc-sys-net
+        hostPath:
+          path: /proc/sys/net
+          type: Directory
+      - name: host-proc-sys-kernel
+        hostPath:
+          path: /proc/sys/kernel
+          type: Directory
       {{- end }}
       {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
       - name: hubble-tls

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -826,6 +826,10 @@ data:
   enable-bgp-control-plane: "false"
 {{- end }}
 
+{{- if not .Values.securityContext.privileged }}
+  procfs: "/host/proc"
+{{- end }}
+
 {{- if hasKey .Values.bpf "root" }}
   bpf-root: {{ .Values.bpf.root | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -21,6 +21,12 @@ spec:
         {{- with .Values.nodeinit.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if not .Values.securityContext.privileged }}
+        # Set app AppArmor's profile to "unconfined". The value of this annotation
+        # can be modified as long users know which profiles they have available
+        # in AppArmor.
+        container.apparmor.security.beta.kubernetes.io/node-init: "unconfined"
+        {{- end }}
       labels:
         app: cilium-node-init
         {{- with .Values.nodeinit.podLabels }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -170,8 +170,9 @@ resources: {}
   #   memory: 512Mi
 
 # -- Security context to be added to agent pods
-securityContext: {}
+securityContext:
   # runAsUser: 0
+  privileged: false
 
 # -- Cilium agent update strategy
 updateStrategy:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1644,7 +1644,21 @@ nodeinit:
 
   # -- Security context to be added to nodeinit pods.
   securityContext:
-    privileged: true
+    privileged: false
+    seLinuxOptions:
+      level: 's0'
+      # Running with spc_t since we have removed the privileged mode.
+      # Users can change it to a different type as long as they have the
+      # type available on the system.
+      type: 'spc_t'
+    capabilities:
+      add:
+        # Used in iptables. Consider removing once we are iptables-free
+        - SYS_MODULE
+        # Used for nsenter
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_PTRACE
 
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet

--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -25,4 +25,6 @@ type Datapath interface {
 
 	// WireguardAgent returns the Wireguard agent for the local node
 	WireguardAgent() WireguardAgent
+
+	Procfs() string
 }

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -90,6 +90,10 @@ func (f *fakeDatapath) WireguardAgent() datapath.WireguardAgent {
 	return nil
 }
 
+func (f *fakeDatapath) Procfs() string {
+	return "/proc"
+}
+
 // Loader is an interface to abstract out loading of datapath programs.
 type fakeLoader struct {
 }

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -15,6 +15,8 @@ import (
 type DatapathConfiguration struct {
 	// HostDevice is the name of the device to be used to access the host.
 	HostDevice string
+
+	ProcFs string
 }
 
 type linuxDatapath struct {
@@ -59,4 +61,8 @@ func (l *linuxDatapath) Loader() datapath.Loader {
 
 func (l *linuxDatapath) WireguardAgent() datapath.WireguardAgent {
 	return l.wgAgent
+}
+
+func (l *linuxDatapath) Procfs() string {
+	return l.config.ProcFs
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -41,6 +41,8 @@ import (
 const (
 	initArgLib int = iota
 	initArgRundir
+	initArgProcSysNetDir
+	initArgSysDir
 	initArgIPv4NodeIP
 	initArgIPv6NodeIP
 	initArgMode
@@ -263,6 +265,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		log.WithError(err).Warn("Unable to write netdev header")
 		return err
 	}
+	args[initArgProcSysNetDir] = filepath.Join(o.Datapath().Procfs(), "sys", "net")
+	args[initArgSysDir] = filepath.Join("/sys", "class", "net")
 
 	if option.Config.EnableXDPPrefilter {
 		scopedLog := log.WithField(logfields.Devices, option.Config.Devices)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -427,6 +427,8 @@ const (
 	// PrefilterMode { "+ModePreFilterNative+" | "+ModePreFilterGeneric+" } (default: "+option.ModePreFilterNative+")
 	PrefilterMode = "prefilter-mode"
 
+	ProcFs = "procfs"
+
 	// PrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 	PrometheusServeAddr = "prometheus-serve-addr"
 
@@ -1489,6 +1491,8 @@ type DaemonConfig struct {
 
 	// EnableSockOps specifies whether to enable sockops (socket lookup).
 	SockopsEnable bool
+
+	ProcFs string
 
 	// PrependIptablesChains is the name of the option to enable prepending
 	// iptables chains instead of appending
@@ -2797,6 +2801,7 @@ func (c *DaemonConfig) Populate() {
 	c.PProfPort = viper.GetInt(PProfPort)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
+	c.ProcFs = viper.GetString(ProcFs)
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
 	c.ProxyGID = viper.GetInt(ProxyGID)

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -21,7 +22,7 @@ import (
 const (
 	subsystem = "sysctl"
 
-	prefixDir = "/proc/sys"
+	procFsDefault = "/proc"
 )
 
 var (
@@ -29,6 +30,11 @@ var (
 
 	// parameterElemRx matches an element of a sysctl parameter.
 	parameterElemRx = regexp.MustCompile(`\A[-0-9_a-z]+\z`)
+
+	procFsMU lock.Mutex
+	// procFsRead is mark as true if procFs changes value.
+	procFsRead bool
+	procFs     = procFsDefault
 )
 
 // An ErrInvalidSysctlParameter is returned when a parameter is invalid.
@@ -54,7 +60,28 @@ func parameterPath(name string) (string, error) {
 			return "", ErrInvalidSysctlParameter(name)
 		}
 	}
-	return filepath.Join(append([]string{prefixDir}, elems...)...), nil
+	return filepath.Join(append([]string{GetProcfs(), "sys"}, elems...)...), nil
+}
+
+// SetProcfs sets path for the root's /proc. Calling it after GetProcfs causes
+// panic.
+func SetProcfs(path string) {
+	procFsMU.Lock()
+	defer procFsMU.Unlock()
+	if procFsRead {
+		// do not change the procfs after we have gotten its value from GetProcfs
+		panic("SetProcfs called after GetProcfs")
+	}
+	procFs = path
+}
+
+// GetProcfs returns the path set in procFs. Executing SetProcFs after GetProcfs
+// might panic depending. See SetProcfs for more info.
+func GetProcfs() string {
+	procFsMU.Lock()
+	defer procFsMU.Unlock()
+	procFsRead = true
+	return procFs
 }
 
 func writeSysctl(name string, value string) error {


### PR DESCRIPTION
We are already setting all the capabilities that Cilium requires so we
don't need to set privileged as true.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Remove privileged mode in Cilium's DaemonSet
```

**Note for reviewers**: all tests have passed on PR https://github.com/cilium/cilium/pull/19449 which includes these changes.