### PR TITLE
install/kubernetes: set the right option for expectAzureVnet

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -162,7 +162,7 @@ spec:
               ip -4 a
               ip -6 a
 
-{{- if or .Values.expectAzureVnet .Values.azure.enabled }}
+{{- if or .Values.nodeinit.expectAzureVnet .Values.azure.enabled }}
               # Azure specific: Transparent bridge mode is required in order
               # for proxy-redirection to work
               until [ -f /var/run/azure-vnet.json ]; do


### PR DESCRIPTION
Fixes: 011546bcb1ca ("helm/azure: Fatal error for CNI Azure installation")
Signed-off-by: André Martins <andre@cilium.io>

```release-notes
Fix behavior of the helm option `--set nodeinit.expectAzureVnet=true`
```