### PR TITLE
bpf: Use optimized memset in send_trace_notify

### DIFF
--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -154,7 +154,7 @@ send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
 			      ctx_len);
-	struct trace_notify msg;
+	struct trace_notify msg __align_stack_8;
 
 	update_trace_metrics(ctx, obs_point, reason);
 
@@ -170,6 +170,7 @@ send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 		.reason		= reason,
 		.ifindex	= ifindex,
 	};
+	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
 
 	ctx_event_output(ctx, &EVENTS_MAP,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,


### PR DESCRIPTION
Going through the BPF bytecode, I noticed that `send_trace_notify` was doing 1-byte writes to the stack, to initialize its `msg` variable:

    2958:    r1 = 0
    2959:    *(u8 *)(r10 - 62) = r1
    2960:    *(u8 *)(r10 - 63) = r1
    2961:    *(u8 *)(r10 - 64) = r1
    2962:    *(u8 *)(r10 - 65) = r1
    2963:    *(u8 *)(r10 - 66) = r1
    2964:    *(u8 *)(r10 - 67) = r1
    2965:    *(u8 *)(r10 - 68) = r1
    2966:    *(u8 *)(r10 - 69) = r1
    2967:    *(u8 *)(r10 - 54) = r1
    2968:    *(u8 *)(r10 - 55) = r1
    2969:    *(u8 *)(r10 - 56) = r1
    2970:    *(u8 *)(r10 - 57) = r1
    2971:    *(u8 *)(r10 - 58) = r1
    2972:    *(u8 *)(r10 - 59) = r1
    2973:    *(u8 *)(r10 - 60) = r1
    2974:    *(u8 *)(r10 - 61) = r1
    2975:    *(u8 *)(r10 - 50) = r1
    2976:    *(u8 *)(r10 - 51) = r1
    2977:    *(u8 *)(r10 - 52) = r1
    2978:    *(u8 *)(r10 - 53) = r1
    2979:    *(u16 *)(r10 - 72) = r1
    2980:    *(u32 *)(r10 - 76) = r1
    2981:    *(u8 *)(r10 - 49) = r1

This is specifically to initialize the original IP address fields, given `send_trace_notify` doesn't take that as a parameter. We can instead force the use of our optimized `memset` to perform 8-bytes writes:

    2958:    r1 = 0
    2959:    *(u64 *)(r10 - 64) = r1
    2960:    *(u32 *)(r10 - 68) = r1
    2961:    *(u8 *)(r10 - 69) = r1
    2962:    *(u16 *)(r10 - 72) = r1
    2963:    *(u32 *)(r10 - 76) = r1
    2964:    *(u64 *)(r10 - 56) = r1

The impact on program size and complexity is low (tested with an extended `verifier-test.sh` for 4.19), but this function is unlikely to change often, so probably worth it. Only two sections are affected, in `bpf_lxc` and `bpf_host`. Before:

    Prog section '2/10' (tail_call IPV6_FROM_LXC) loaded (46)!
     - Instructions: 3299 (0 over limit)
    processed 167498 insns (limit 1000000) max_states_per_insn 27 total_states 10721 peak_states 1427 mark_read 60
    Prog section '2/7' (tail_call IPV4_FROM_LXC) loaded (47)!
     - Instructions: 3562 (0 over limit)
    processed 557902 insns (limit 1000000) max_states_per_insn 24 total_states 35115 peak_states 2235 mark_read 92

After

    Prog section '2/10' (tail_call IPV6_FROM_LXC) loaded (46)!
     - Instructions: 3265 (0 over limit)
    processed 167114 insns (limit 1000000) max_states_per_insn 27 total_states 10718 peak_states 1426 mark_read 60
    Prog section '2/7' (tail_call IPV4_FROM_LXC) loaded (47)!
     - Instructions: 3528 (0 over limit)
    processed 542609 insns (limit 1000000) max_states_per_insn 25 total_states 34263 peak_states 2246 mark_read 92

I checked all our largest sections in object files and didn't find other occurrences of this issue.