### PR TITLE
AKS: Clean up azure-vnet state on Cilium agent start

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -66,7 +66,6 @@ Deploy Cilium release via Helm:
      --set cni.chainingMode=generic-veth \\
      --set cni.customConf=true \\
      --set nodeinit.enabled=true \\
-     --set nodeinit.expectAzureVnet=true \\
      --set cni.configMap=cni-configuration \\
      --set tunnel=disabled \\
      --set enableIPv4Masquerade=false

--- a/Documentation/gettingstarted/k8s-install-azure.rst
+++ b/Documentation/gettingstarted/k8s-install-azure.rst
@@ -77,6 +77,11 @@ Deploy Cilium
 
 Deploy Cilium release via Helm:
 
+.. warning::
+  Deploying Cilium with ``azure.enabled=true`` will disconnect all running Pods
+  in the cluster that were scheduled using the default ``azure-vnet`` CNI plugin.
+  We aim to remove this limitation before moving Azure IPAM out of Beta.
+
 .. parsed-literal::
 
    helm install cilium |CHART_RELEASE| \\

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -760,6 +760,11 @@ NodePort XDP requires Cilium to run in direct routing mode (``tunnel=disabled``)
 It is recommended to use Azure IPAM for the pod IP address allocation, which
 will automatically configure your virtual network to route pod traffic correctly:
 
+.. warning::
+  Deploying Cilium with ``azure.enabled=true`` will disconnect all running Pods
+  in the cluster that were scheduled using the default ``azure-vnet`` CNI plugin.
+  We aim to remove this limitation before moving Azure IPAM out of Beta.
+
 .. parsed-literal::
 
    helm install cilium |CHART_RELEASE| \\

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -105,7 +105,9 @@ spec:
           - name: CHECKPOINT_PATH
             value: /tmp/node-init.cilium.io
           # STARTUP_SCRIPT is the script run on node bootstrap. Node
-          # bootstrapping can be customized in this script.
+          # bootstrapping can be customized in this script. This script is invoked
+          # using nsenter, so it runs in the host's network and mount namespace using
+          # the host's userland tools!
           - name: STARTUP_SCRIPT
             value: |
               #!/bin/bash
@@ -221,6 +223,40 @@ spec:
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
               fi
 {{- end }}
+
+              # AKS: If azure-vnet is installed on the node, and (still) configured in bridge mode,
+              # configure it as 'transparent' to be consistent with Cilium's CNI chaining config.
+              # If the azure-vnet CNI config is not removed, kubelet will execute CNI CHECK commands
+              # against it every 5 seconds and write 'bridge' to its state file, causing inconsistent
+              # behaviour when Pods are removed.
+              if [ -f /etc/cni/net.d/10-azure.conflist ]; then
+
+                echo "azure-vnet configured in bridge mode. Changing to 'transparent'..."
+                sed -i 's/"mode":\s*"bridge"/"mode":"transparent"/g' /etc/cni/net.d/10-azure.conflist
+
+{{- if .Values.azure.enabled }}
+                # In Azure IPAM mode, also remove the azure-vnet state file, otherwise ebtables rules get
+                # restored by the azure-vnet CNI plugin on every CNI CHECK, which can cause connectivity
+                # issues in Cilium-managed Pods. Since azure-vnet is no longer called on scheduling events,
+                # this file can be removed.
+                rm -f /var/run/azure-vnet.json
+
+                # This breaks connectivity for existing workload Pods when Cilium is scheduled, but we need
+                # to flush these to prevent Cilium-managed Pod IPs conflicting with Pod IPs previously allocated
+                # by azure-vnet. These ebtables DNAT rules contain fixed MACs that are no longer bound on the node,
+                # causing packets for these Pods to be redirected back out to the gateway, where they are dropped.
+                echo 'Flushing ebtables pre/postrouting rules in nat table.. (disconnecting non-Cilium Pods!)'
+                ebtables -t nat -F PREROUTING || true
+                ebtables -t nat -F POSTROUTING || true
+
+                # ip-masq-agent periodically injects PERM neigh entries towards the gateway
+                # for all other k8s nodes in the cluster. These are safe to flush, as ARP can
+                # resolve these nodes as usual. PERM entries will be automatically restored later.
+                echo 'Deleting all permanent neighbour entries on azure0...'
+                ip neigh show dev azure0 nud permanent | cut -d' ' -f1 | xargs -r -n1 ip neigh del dev azure0 to
+{{- end }}
+
+              fi
 
 {{- if .Values.nodeinit.revertReconfigureKubelet }}
               rm -f /tmp/node-deinit.cilium.io

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -162,18 +162,6 @@ spec:
               ip -4 a
               ip -6 a
 
-{{- if or .Values.nodeinit.expectAzureVnet .Values.azure.enabled }}
-              # Azure specific: Transparent bridge mode is required in order
-              # for proxy-redirection to work
-              until [ -f /var/run/azure-vnet.json ]; do
-                echo waiting for azure-vnet to be created
-                sleep 1s
-              done
-              if [ -f /var/run/azure-vnet.json ]; then
-                sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
-              fi
-{{- end }}
-
 {{- if .Values.nodeinit.removeCbrBridge }}
               if ip link show cbr0; then
                 echo "Detected cbr0 bridge. Deleting interface..."


### PR DESCRIPTION
Fixes https://github.com/cilium/cilium/issues/12113
Fixes https://github.com/cilium/cilium/issues/14233

Rationale is documented in the commit messages. We need something to move AKS support forward, as there are multiple breaking issues in 1.9.

@seanmwinn Should a Helm value be added to disable the rm/ebtables/ip neigh path?
@aanm Should we document the fact that deploying with Azure IPAM disconnects all workload Pods in the cluster? (getting rid of this behaviour would be a requirement for declaring Azure IPAM as GA, so this might not be necessary)

```release-note
No longer wait for and modify `/var/run/azure-vnet.json`. This confuses azure-vnet during Pod removal, causing it to incorrectly clean up machine state.
In Azure IPAM mode, remove /var/run/azure-vnet.json on Cilium agent startup, flush ebtables and remove permanent neigh entries.
```
