### PR TITLE
bpf: datapath: Fix fetching configured base devices

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -277,11 +277,12 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	devices := make([]netlink.Link, 0, len(option.Config.Devices))
 	if len(option.Config.Devices) != 0 {
 		for _, device := range option.Config.Devices {
-			_, err := netlink.LinkByName(device)
+			link, err := netlink.LinkByName(device)
 			if err != nil {
 				log.WithError(err).WithField("device", device).Warn("Link does not exist")
 				return err
 			}
+			devices = append(devices, link)
 		}
 		args[initArgDevices] = strings.Join(option.Config.Devices, ";")
 	} else if option.Config.IsFlannelMasterDeviceSet() {


### PR DESCRIPTION
Before this change, the base loader logic was not creating the slice of
base devices properly.

Fixes: 9e48678686e2 ("bpf: datapath: Rewite base devices setup in Go")
Reported-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>
