### PR TITLE
DualStack kubernetes based IPv6 testing for Cilium

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -123,6 +123,8 @@ var (
 		// We need CNP node status to know when a policy is being enforced
 		"enableCnpStatusUpdates": "true",
 		"nativeRoutingCIDR":      "10.0.0.0/8",
+
+		"ipam.operator.clusterPoolIPv6PodCIDR": "fd02::/112",
 	}
 
 	flannelHelmOverrides = map[string]string{

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -635,3 +635,17 @@ func SkipK8sVersions(k8sVersions string) bool {
 	constraint := versioncheck.MustCompile(k8sVersions)
 	return constraint(k8sVersion)
 }
+
+// DualStackSupported returns whether the current environment has DualStack IPv6
+// enabled or not for the cluster.
+func DualStackSupported() bool {
+	k8sVersion := GetCurrentK8SEnv()
+	switch k8sVersion {
+	// Older kubernetes versions do not support DualStack mode.
+	case "1.12", "1.13", "1.14", "1.15", "1.16", "1.17":
+		return false
+	}
+
+	// We only have DualStack enabled in Vagrant test env.
+	return GetCurrentIntegration() == ""
+}

--- a/test/k8sT/manifests/1.18/demo_ds_dualstack.yaml
+++ b/test/k8sT/manifests/1.18/demo_ds_dualstack.yaml
@@ -1,0 +1,141 @@
+# The default family of the cluster is IPv4 so we have V4 version of these
+# services as defaults in the manfiests/ directory.
+# For IPv6 we can have different configuration for different Kuberentes
+# versions. Therefore v6 services manfiests are placed in version specific
+# directories inside manifests/.
+apiVersion: v1
+kind: Service
+metadata:
+  name: testds-service-ipv6
+spec:
+  ipFamily: IPv6
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    targetPort: 69
+    protocol: UDP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-affinity-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  sessionAffinity: ClientIP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-k8s2-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-k8s2-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-external-ips-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 20080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 20069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  externalIPs:
+  - fd03::999
+  selector:
+    zgroup: testDS

--- a/test/k8sT/manifests/1.18/demo_dualstack.yaml
+++ b/test/k8sT/manifests/1.18/demo_dualstack.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app1-service-ipv6
+spec:
+  ipFamily: IPv6
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
+  selector:
+    id: app1

--- a/test/k8sT/manifests/1.18/echo-svc_dualstack.yaml
+++ b/test/k8sT/manifests/1.18/echo-svc_dualstack.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
+  selector:
+    name: echo

--- a/test/k8sT/manifests/1.19/demo_ds_dualstack.yaml
+++ b/test/k8sT/manifests/1.19/demo_ds_dualstack.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: testds-service-ipv6
+spec:
+  ipFamily: IPv6
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    targetPort: 69
+    protocol: UDP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-affinity-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  sessionAffinity: ClientIP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-k8s2-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-k8s2-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-external-ips-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - port: 20080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 20069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  externalIPs:
+  - fd03::999
+  selector:
+    zgroup: testDS

--- a/test/k8sT/manifests/1.19/demo_dualstack.yaml
+++ b/test/k8sT/manifests/1.19/demo_dualstack.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app1-service-ipv6
+spec:
+  ipFamily: IPv6
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
+  selector:
+    id: app1

--- a/test/k8sT/manifests/1.19/echo-svc_dualstack.yaml
+++ b/test/k8sT/manifests/1.19/echo-svc_dualstack.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-ipv6
+spec:
+  ipFamily: IPv6
+  type: NodePort
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
+  selector:
+    name: echo

--- a/test/k8sT/manifests/demo_ds_dualstack.yaml
+++ b/test/k8sT/manifests/demo_ds_dualstack.yaml
@@ -1,0 +1,143 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: testds-service-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    targetPort: 69
+    protocol: UDP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-affinity-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  sessionAffinity: ClientIP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-k8s2-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-k8s2-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-external-ips-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  type: NodePort
+  ports:
+  - port: 20080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 20069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  externalIPs:
+  - fd03::999
+  selector:
+    zgroup: testDS

--- a/test/k8sT/manifests/demo_dualstack.yaml
+++ b/test/k8sT/manifests/demo_dualstack.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app1-service-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
+  selector:
+    id: app1

--- a/test/k8sT/manifests/echo-svc_dualstack.yaml
+++ b/test/k8sT/manifests/echo-svc_dualstack.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-ipv6
+spec:
+  ipFamilies:
+  - IPv6
+  type: NodePort
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
+  selector:
+    name: echo

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -96,6 +96,11 @@ ff02::2 ip6-allrouters
 192.168.36.16 k8s6
 EOF
 
+# Configure default IPv6 route without this connectivity from host to
+# services is not possible as there is no default route. enp0s8 is the primary
+# interface for test environment.
+sudo ip -6 route add default dev enp0s8
+
 cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF


### PR DESCRIPTION
Update K8sServiceTests to include IPv6 tests for Kubernetes running in Dual Stack mode.