### PR TITLE
test: Un-Quarantine K8sUpdates on GKE

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -118,7 +118,7 @@ var _ = Describe("K8sUpdates", func() {
 		ExpectAllPodsTerminated(kubectl)
 	})
 
-	SkipItIf(helpers.SkipGKEQuarantined, "Tests upgrade and downgrade from a Cilium stable image to master", func() {
+	It("Tests upgrade and downgrade from a Cilium stable image to master", func() {
 		var assertUpgradeSuccessful func()
 		assertUpgradeSuccessful, cleanupCallback =
 			InstallAndValidateCiliumUpgrades(


### PR DESCRIPTION
This removes the quarantine check for the K8sUpdates test on GKE. The
issues with upgrade tests had on GKE were addressed in #14187, #14294,
 #14295, and #14393.

The last fix was merged 6 days ago. The quarantined GKE pipeline had
since no failures that look related to the issues with DNS that we
previously observed.

Fixes: #13833
Fixes: #13898
