### PR TITLE
cilium-cni: address shellcheck warnings for cni-(un)install.sh

### DIFF
--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -23,7 +23,7 @@ function uninstall_cilium_from_pod() {
 
 function get_list_of_veth_from_bridge() {
     CNI_MASTER_DEVICE="${1}"
-    echo "$(ip -o link show master "${CNI_MASTER_DEVICE}" type veth | awk '{print $2}' | sed 's/@.*//g')"
+    ip -o link show master "${CNI_MASTER_DEVICE}" type veth | awk '{print $2}' | sed 's/@.*//g'
 }
 
 HOST_PREFIX=${HOST_PREFIX:-/host}
@@ -31,16 +31,16 @@ BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 
 echo "Removing ${CNI_DIR}/bin/cilium-cni..."
-rm -f ${CNI_DIR}/bin/${BIN_NAME}
-rm -f ${CNI_DIR}/bin/${BIN_NAME}.old
+rm -f "${CNI_DIR}/bin/${BIN_NAME}"
+rm -f "${CNI_DIR}/bin/${BIN_NAME}.old"
 
 if [[ "${CILIUM_FLANNEL_UNINSTALL_ON_EXIT}" == "true" ]]; then
     echo "Removing BPF programs from all containers and from ${CILIUM_FLANNEL_MASTER_DEVICE}"
     echo "Uninstalling cilium from ${CILIUM_FLANNEL_MASTER_DEVICE}"
     uninstall_cilium_from_flannel_master "${CILIUM_FLANNEL_MASTER_DEVICE}"
 
-    for iDev in $(get_list_of_veth_from_bridge "${CILIUM_FLANNEL_MASTER_DEVICE}"); do
-        echo "Uninstalling cilium from ${iDev}"
-        uninstall_cilium_from_pod ${iDev}
+    for dev in $(get_list_of_veth_from_bridge "${CILIUM_FLANNEL_MASTER_DEVICE}"); do
+        echo "Uninstalling cilium from ${dev}"
+        uninstall_cilium_from_pod "${dev}"
     done
 fi


### PR DESCRIPTION
Mostly adding quotes. cni-install.sh's interpreter was changed to /bin/bash because 'sh' doesn't support the '&>' operator.

This was pulled out of https://github.com/cilium/cilium/pull/14095 to make that PR easier to review.

```release-note
Address shellcheck warnings in cni-(un)install.sh.
```
