### PR TITLE
[v1.9] docs: Add `quick-hubble-install.yaml` method

### DIFF
--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -2,18 +2,33 @@ Enable Hubble for Cluster-Wide Visibility
 =========================================
 
 Hubble is the component for observability in Cilium. To obtain cluster-wide
-visibility into your network traffic, deploy Hubble Relay and the UI with the
-following Helm upgrade command on your existing installation
-(Cilium agent pods will be restarted in the process).
+visibility into your network traffic, deploy Hubble Relay and the UI as follows
+on your existing installation:
 
-.. parsed-literal::
+.. tabs::
 
-   helm upgrade cilium |CHART_RELEASE| \\
-      --namespace $CILIUM_NAMESPACE \\
-      --reuse-values \\
-      --set hubble.listenAddress=":4244" \\
-      --set hubble.relay.enabled=true \\
-      --set hubble.ui.enabled=true
+    .. group-tab:: Installation via Helm
+
+        If you installed Cilium via ``helm install``, you may enable Hubble
+        Relay and UI with the following command:
+
+        .. parsed-literal::
+
+           helm upgrade cilium |CHART_RELEASE| \\
+              --namespace $CILIUM_NAMESPACE \\
+              --reuse-values \\
+              --set hubble.relay.enabled=true \\
+              --set hubble.ui.enabled=true
+
+    .. group-tab:: Installation via ``quick-hubble-install.yaml``
+
+        If you installed Cilium via the provided ``quick-install.yaml``,
+        you may deploy Hubble Relay and UI on top of your existing installation
+        with the following command:
+
+        .. parsed-literal::
+
+            kubectl apply -f |SCM_WEB|/install/kubernetes/quick-hubble-install.yaml
 
 Once the Hubble UI pod is started, use port forwarding for the ``hubble-ui``
 service. This allows opening the UI locally on a browser:

--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -17,18 +17,48 @@ on your existing installation:
            helm upgrade cilium |CHART_RELEASE| \\
               --namespace $CILIUM_NAMESPACE \\
               --reuse-values \\
+              --set hubble.listenAddress=":4244" \\
               --set hubble.relay.enabled=true \\
               --set hubble.ui.enabled=true
 
+        On Cilium 1.9.1 and older, the Cilium agent pods will be restarted in
+        the process.
+
     .. group-tab:: Installation via ``quick-hubble-install.yaml``
 
-        If you installed Cilium via the provided ``quick-install.yaml``,
-        you may deploy Hubble Relay and UI on top of your existing installation
-        with the following command:
+        If you installed Cilium **1.9.2 or newer** via the provided
+        ``quick-install.yaml``, you may deploy Hubble Relay and UI on top of
+        your existing installation with the following command:
 
         .. parsed-literal::
 
             kubectl apply -f |SCM_WEB|/install/kubernetes/quick-hubble-install.yaml
+
+        Installation via ``quick-hubble-install.yaml`` only works if the
+        installed Cilium version is 1.9.2 or newer.  Users of Cilium 1.9.0
+        or 1.9.1 are encouraged to upgrade to a newer version by applying the
+        most recent Cilium ``quick-install.yaml`` first.
+
+        Alternatively, it is possible to manually generate a YAML manifest
+        for the Cilium DaemonSet and Hubble Relay/UI as follows. The generated
+        YAML can be applied on top of an existing installation:
+
+        .. code:: bash
+
+           # Set this to your installed Cilium version
+           export CILIUM_VERSION=1.9.1
+           # Please set any custom Helm values you may need for Cilium,
+           # such as for example `--set operator.replicas=1` on single-cluster nodes.
+           helm template cilium cilium/cilium --version $CILIUM_VERSION \\
+              --namespace $CILIUM_NAMESPACE \\
+              --set hubble.tls.auto.method="cronJob" \\
+              --set hubble.listenAddress=":4244" \\
+              --set hubble.relay.enabled=true \\
+              --set hubble.ui.enabled=true > cilium-with-hubble.yaml
+           # This will modify your existing Cilium DaemonSet and ConfigMap
+           kubectl apply -f cilium-with-hubble.yaml
+
+        The Cilium agent pods will be restarted in the process.
 
 Once the Hubble UI pod is started, use port forwarding for the ``hubble-ui``
 service. This allows opening the UI locally on a browser:

--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -84,7 +84,8 @@ Relay and Hubble's graphical UI.
 
        .. parsed-literal::
 
-            kubectl apply -f |SCM_WEB|/install/kubernetes/experimental-install.yaml
+            kubectl apply -f |SCM_WEB|/install/kubernetes/quick-install.yaml
+            kubectl apply -f |SCM_WEB|/install/kubernetes/quick-hubble-install.yaml
 
     .. group-tab:: Multi-node cluster with ``kind``
 

--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -60,6 +60,8 @@ On each node, run the following to mount the eBPF Filesystem:
 .. include:: quick-install.rst
 .. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
+.. include:: hubble-enable.rst
 
 Now that you have a Kubernetes cluster with Cilium up and running, you can take
 a couple of next steps to explore various capabilities:

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -34,3 +34,5 @@ Install Cilium
     kubectl create -f \ |SCM_WEB|\/install/kubernetes/quick-install.yaml
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
+.. include:: hubble-enable.rst

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -74,6 +74,8 @@ should be healthy and ready:
     coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
     etcd-operator-5cf67779fd-hd9j7          1/1     Running   0          2m42s
 
+.. include:: namespace-kube-system.rst
+.. include:: hubble-enable.rst
 
 Troubleshooting
 ===============

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -102,3 +102,6 @@ Verify that Cilium pods were started on each of your worker nodes
     kubectl -n kube-system get deployments cilium-operator
     NAME              READY   UP-TO-DATE   AVAILABLE   AGE
     cilium-operator   2/2     2            2           2m6s
+
+.. include:: namespace-kube-system.rst
+.. include:: hubble-enable.rst

--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -59,4 +59,5 @@ Deploy Cilium release via Helm:
    helm install cilium |CHART_RELEASE| --namespace kube-system
 
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst

--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -21,6 +21,8 @@ Install kubectl & minikube
 .. include:: minikube-install.rst
 .. include:: quick-install.rst
 .. include:: k8s-install-validate.rst
+.. include:: namespace-kube-system.rst
+.. include:: hubble-enable.rst
 
 Next steps
 ==========


### PR DESCRIPTION
This PR documents a simplified version to install Hubble Relay. The new variant will be available with the next release of Cilium 1.9. Users of Cilium 1.9.0/1.9.1 will need to fall back on Helm. The commits are a modified backport of the documentation changes in #14221.

Therefore, **this PR should not be merged until 1.9.2 has been released**, to avoid referencing an unreleased version in the 1.9 docs (as discussed in https://github.com/cilium/cilium/pull/14221#issuecomment-740172217)