### PR TITLE
service: Restore Maglev table when M changes

### DIFF
--- a/pkg/maps/lbmap/maglev.go
+++ b/pkg/maps/lbmap/maglev.go
@@ -36,10 +36,16 @@ const (
 	MaglevOuter6MapName = "cilium_lb6_maglev"
 )
 
-var MaglevOuter4Map *bpf.Map
-var MaglevOuter6Map *bpf.Map
+var (
+	MaglevOuter4Map     *bpf.Map
+	MaglevOuter6Map     *bpf.Map
+	maglevRecreatedIPv4 bool
+	maglevRecreatedIPv6 bool
+)
 
 func InitMaglevMaps(ipv4 bool, ipv6 bool) error {
+	var err error
+
 	dummyInnerMap := newInnerMaglevMap("cilium_lb_maglev_dummy")
 	if err := dummyInnerMap.CreateUnpinned(); err != nil {
 		return err
@@ -47,7 +53,7 @@ func InitMaglevMaps(ipv4 bool, ipv6 bool) error {
 	defer dummyInnerMap.Close()
 
 	if ipv4 {
-		if _, err := deleteMapIfMNotMatch(MaglevOuter4MapName); err != nil {
+		if maglevRecreatedIPv4, err = deleteMapIfMNotMatch(MaglevOuter4MapName); err != nil {
 			return err
 		}
 		MaglevOuter4Map = newOuterMaglevMap(MaglevOuter4MapName, dummyInnerMap)
@@ -56,7 +62,7 @@ func InitMaglevMaps(ipv4 bool, ipv6 bool) error {
 		}
 	}
 	if ipv6 {
-		if _, err := deleteMapIfMNotMatch(MaglevOuter6MapName); err != nil {
+		if maglevRecreatedIPv6, err = deleteMapIfMNotMatch(MaglevOuter6MapName); err != nil {
 			return err
 		}
 		MaglevOuter6Map = newOuterMaglevMap(MaglevOuter6MapName, dummyInnerMap)


### PR DESCRIPTION
When running in the lb-only mode, there is no connectivity to
kube-apiserver, and UpsertService() can be only invoked by the Cilium
API calls.

When cilium-agent restarts, it might recreate the Maglev BPF map if it
detects that the M param might have changed. The recreation removes the
lookup entries from the map leaving the map empty.

As there is no way to resync (with kube-apiserver) after the restart, we
need to fix this by recalculating the Maglev tables during the
restoration of services from the LB BPF maps.

Reported-by: Han Zhou <hzhou8@ebay.com>