### PR TITLE
Create top level eni block for Helm values and add more options to it

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -45,7 +45,7 @@ Deploy Cilium release via Helm:
 
    helm install cilium |CHART_RELEASE| \\
      --namespace kube-system \\
-     --set eni=true \\
+     --set eni.enabled=true \\
      --set ipam.mode=eni \\
      --set egressMasqueradeInterfaces=eth0 \\
      --set tunnel=disabled \\

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -88,7 +88,7 @@ Deploy Cilium release via Helm:
 
    helm install cilium |CHART_RELEASE| \\
      --namespace kube-system \\
-     --set eni=true \\
+     --set eni.enabled=true \\
      --set ipam.mode=eni \\
      --set egressMasqueradeInterfaces=eth0 \\
      --set tunnel=disabled \\
@@ -96,7 +96,7 @@ Deploy Cilium release via Helm:
 
 .. note::
 
-   This helm command sets ``eni=true`` and ``tunnel=disabled``,
+   This helm command sets ``eni.enabled=true`` and ``tunnel=disabled``,
    meaning that Cilium will allocate a fully-routable AWS ENI IP address for each pod,
    similar to the behavior of the
    `Amazon VPC CNI plugin <https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html>`_.
@@ -105,7 +105,7 @@ Deploy Cilium release via Helm:
    This allows running more pods per Kubernetes worker node than the ENI limit, but means
    that pod connectivity to resources outside the cluster (e.g., VMs in the VPC or AWS managed
    services) is masqueraded (i.e., SNAT) by Cilium to use the VPC IP address of the Kubernetes worker node.
-   Excluding the lines for ``eni=true`` and ``tunnel=disabled`` from the
+   Excluding the lines for ``eni.enabled=true`` and ``tunnel=disabled`` from the
    helm command will configure Cilium to use overlay routing mode (which is the helm default).
 
 .. include:: aws-create-nodegroup.rst

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -375,6 +375,7 @@ Removed Options
   now removed.
 * ``crd-wait-timeout``: this option does not have any effect since 1.9 and is
   now removed.
+* ``eni``: this option has been replaced by ``eni.enabled`` option.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -119,7 +119,13 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. |
 | endpointHealthChecking.enabled | bool | `true` |  |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
+| eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |
+| eni.ec2APIEndpoint | string | `""` | EC2 API endpoint to usee |
 | eni.enabled | bool | `false` | Enable Elastic Network Interface (ENI) integration. |
+| eni.eniTags | object | `{}` | Tags to apply to the newly created ENIs |
+| eni.subnetIDsFilter | string | `""` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs |
+| eni.subnetTagsFilter | string | `""` | Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs |
+| eni.updateEC2AdapterLimitViaAPI | bool | `false` | Update ENI Adapter limits from the EC2 API |
 | etcd.clusterDomain | string | `"cluster.local"` | Cluster domain for cilium-etcd-operator. |
 | etcd.clusterSize | int | `3` | Size of the managed etcd cluster. |
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -119,7 +119,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. |
 | endpointHealthChecking.enabled | bool | `true` |  |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
-| eni | bool | `false` | Enable Elastic Network Interface (ENI) integration. |
+| eni.enabled | bool | `false` | Enable Elastic Network Interface (ENI) integration. |
 | etcd.clusterDomain | string | `"cluster.local"` | Cluster domain for cilium-etcd-operator. |
 | etcd.clusterSize | int | `3` | Size of the managed etcd cluster. |
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -317,7 +317,7 @@ data:
   tunnel: {{ .Values.tunnel }}
 {{- end }}
 
-{{- if .Values.eni }}
+{{- if .Values.eni.enabled }}
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -320,6 +320,18 @@ data:
 {{- if .Values.eni.enabled }}
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
+{{- if .Values.eni.updateEC2AdapterLimitViaAPI }}
+  update-ec2-adapter-limit-via-api: "true"
+  # The below value is deprecated and will be removed in a future release, see https://github.com/cilium/cilium/issues/12396
+  update-ec2-apdater-limit-via-api: "true"
+{{- end }}
+{{- if .Values.eni.awsReleaseExcessIPs }}
+  aws-release-excess-ips: "true"
+{{- end }}
+  ec2-api-endpoint: {{ .Values.eni.ec2APIEndpoint | quote }}
+  eni-tags: {{ .Values.eni.eniTags }}
+  subnet-ids-filter: {{ .Values.eni.subnetIDsFilter | quote }}
+  subnet-tags-filter: {{ .Values.eni.subnetTagsFilter | quote }}
 {{- end }}
 
 {{- if .Values.azure.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
         command:
-{{- if .Values.eni }}
+{{- if .Values.eni.enabled }}
         - cilium-operator-aws
 {{- else if .Values.azure.enabled }}
         - cilium-operator-azure
@@ -79,7 +79,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-{{- if .Values.eni }}
+{{- if .Values.eni.enabled }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -131,7 +131,7 @@ spec:
         - name: {{ $key }}
           value: {{ $value }}
 {{- end }}
-{{- if .Values.eni }}
+{{- if .Values.eni.enabled }}
         image: {{ .Values.operator.image.repository }}-aws:{{ .Values.operator.image.tag }}
 {{- else if .Values.azure.enabled }}
         image: {{ .Values.operator.image.repository }}-azure:{{ .Values.operator.image.tag }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -380,6 +380,18 @@ endpointRoutes:
 eni:
   # -- Enable Elastic Network Interface (ENI) integration.
   enabled: false
+  # -- Update ENI Adapter limits from the EC2 API
+  updateEC2AdapterLimitViaAPI: false
+  # -- Release IPs not used from the ENI
+  awsReleaseExcessIPs: false
+  # -- EC2 API endpoint to usee
+  ec2APIEndpoint: ""
+  # -- Tags to apply to the newly created ENIs
+  eniTags: {}
+  # -- Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs
+  subnetIDsFilter: ""
+  # -- Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs
+  subnetTagsFilter: ""
 
 externalIPs:
   # -- Enable ExternalIPs service support.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -377,8 +377,9 @@ endpointRoutes:
   # the cilium_host interface.
   enabled: false
 
-# -- Enable Elastic Network Interface (ENI) integration.
-eni: false
+eni:
+  # -- Enable Elastic Network Interface (ENI) integration.
+  enabled: false
 
 externalIPs:
   # -- Enable ExternalIPs service support.

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -141,7 +141,7 @@ var (
 
 	eksHelmOverrides = map[string]string{
 		"egressMasqueradeInterfaces": "eth0",
-		"eni":                        "true",
+		"eni.enabled":                "true",
 		"ipam.mode":                  "eni",
 		"ipv6.enabled":               "false",
 		"k8s.requireIPv4PodCIDR":     "false",
@@ -2554,7 +2554,7 @@ func (kub *Kubectl) convertOptionsToLegacyOptions(options map[string]string) map
 			if newKey == "image.repository" {
 				result["agent.image"] = v + ":" + options["image.tag"]
 			} else if newKey == "operator.image.repository" {
-				if options["eni"] == "true" {
+				if options["eni.enabled"] == "true" {
 					result["operator.image"] = v + "-aws:" + options["image.tag"]
 				} else if options["azure.enabled"] == "true" {
 					result["operator.image"] = v + "-azure:" + options["image.tag"]


### PR DESCRIPTION
Best to review commit by commit.

1st one adds the `eni` top level helm block and put the `enabled` option under it.
2nd commit adds the `cilium-operator-aws` specific configs flags to helm and defaults them to what the operator currently has (details in the commit message).