### PR TITLE
test: add iptables masquerading without random-fully test

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -280,6 +280,17 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
 				Should(BeTrue(), "Connectivity test to http://google.com failed")
 		})
+
+		It("Check iptables masquerading without random-fully", func() {
+			deploymentManager.DeployCilium(map[string]string{
+				"bpf.masquerade": "false",
+			}, DeployCiliumOptionsAndDNS)
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+
+			By("Test iptables masquerading")
+			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
+				Should(BeTrue(), "Connectivity test to http://google.com failed")
+		})
 	})
 
 	// DirectRouting without AutoDirectNodeRoutes not supported outside of GKE.


### PR DESCRIPTION
As suggested in the ticket, let's add a test for iptables masqueranding
_without_ the random-fully option. This should tell us if the
"K8sDatapathConfig Encapsulation Check iptables masquerading with
random-fully" test is failing due to the random-fully option or not.

Related-to: #13773