### PR TITLE
hubble: Fix numeric identity lookup for FQDN identities 

### DIFF
--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -328,10 +328,9 @@ func (d *Daemon) LookupSecIDByIP(ip net.IP) (id ipcache.Identity, ok bool) {
 		bits = net.IPv6len * 8
 	}
 	for _, prefixLen := range prefixes {
-		if prefixLen == bits {
-			// IP lookup was already done above; skip it here
-			continue
-		}
+		// note: we perform a lookup even when `prefixLen == bits`, as some
+		// entries derived by a single address cidr-range will not have been
+		// found by the above lookup
 		mask := net.CIDRMask(prefixLen, bits)
 		cidr := net.IPNet{
 			IP:   ip.Mask(mask),


### PR DESCRIPTION
This fixes an issue where Hubble is unable to assign the correct numeric identity, 
as evident the debug log messages reported in #14427:

```
Dec 16 10:43:53 k8s1 cilium-agent[6429]: level=debug msg="stale identity observed" identity=16777218 ipAddr=172.217.168.36 oldIdentity=2 subsys=hubble
```

The root cause for the failure turned out to be that keys in the Cilium
user-space IPCache are either of the form `ip` or `ip/cidr`. When performing
a lookup in the IPCache to map a given IP to its numeric identity, Hubble
would skip lookups for full netmasks such as e.g. `1.1.1.1/32`, with the
assumption that a lookup on `1.1.1.1` would already have succeeded.

This assumption however turned out to be incorrect. Entries derived from
CIDR rules (and, consequently also FQDN rules) can contain a full
netmask, for which the IP lookup without the full CIDR will not succeed.

This commit therefore fixes this issue by also performing the full netmask lookup.

The user space numeric identity is only used for trace points such as
`from-endpoint`, which are not emitted with the default monitor aggregation.
To be able to introduce a regression test for this fix in CI, this PR therefore
also disables the monitor aggregation in the Hubble test suite. The Relay
CI helper is refactored to allow inspection of the returned flow(s).
