### PR TITLE
Add hubble relay docker images + fix k8s version for eks in contrib testing script

### DIFF
--- a/contrib/testing/integrations.sh
+++ b/contrib/testing/integrations.sh
@@ -29,9 +29,6 @@ gct()
             >&2 echo "Switching to $CILIUM_DIR..."
             cd "$CILIUM_DIR"
         fi
-        local k8s_version=$(kubectl version -o json)
-        local k8s_major=$(echo "$k8s_version" | jq '.serverVersion.major')
-        local k8s_minor=$(echo "$k8s_version" | jq '.serverVersion.minor')
 
         CNI_INTEGRATION="$1"; shift
         CILIUM_IMAGE="$(echo "$1" | sed 's/^\(.*\):[^:]*$/\1/')"
@@ -45,9 +42,11 @@ gct()
         CNI_INTEGRATION="$CNI_INTEGRATION" \
         CILIUM_IMAGE="$CILIUM_IMAGE" \
         CILIUM_TAG="$CILIUM_TAG" \
-        CILIUM_OPERATOR_IMAGE="${CILIUM_OPERATOR_IMAGE:-"docker.io/cilium/operator"}" \
+        CILIUM_OPERATOR_IMAGE="${CILIUM_OPERATOR_IMAGE:-"quay.io/cilium/operator"}" \
         CILIUM_OPERATOR_TAG="${CILIUM_OPERATOR_TAG:-"latest"}" \
-        K8S_VERSION="$k8s_major.$ks_minor" \
+        HUBBLE_RELAY_IMAGE="${HUBBLE_RELAY_IMAGE:-"quay.io/cilium/hubble-relay"}" \
+        HUBBLE_RELAY_IMAGE_TAG="${HUBBLE_RELAY_IMAGE_TAG:-"latest"}" \
+        K8S_VERSION="$(kubectl version -o json |  jq -r '(.serverVersion.major + "." + (.serverVersion.minor | scan("[0-9]+")))' | sed 's/"//g')" \
         ginkgo -v "$FOCUS" -- \
             -cilium.provision=false \
             -cilium.kubeconfig=$HOME/.kube/config \


### PR DESCRIPTION
While working on which tests are passing on EKS I've found these 2 things that we missed initially:
- hubble tests are failing because if we do not override the image + tag it will default to [`k8s1:5000` registry](https://github.com/cilium/cilium/blob/50974a2c7c09916664f9bc0e43ed8cb0a06cb049/test/helpers/kubectl.go#L101) 
- k8s version reported on eks is `1.18+` which breaks https://github.com/cilium/cilium/blob/749689fde587227c19fa067ed7479e128beb1234/test/k8sT/Services.go#L1344

Also I've swapped the registry that the script uses for the operator image to be `quay.io`.