### PR TITLE
daemon, node: refresh neighbor by sending arping periodically

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1517,6 +1517,11 @@ func runDaemon() {
 		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
 
+	// Start periodical arping to refresh neighbor table
+	if d.datapath.Node().NodeNeighDiscoveryEnabled() {
+		d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
+	}
+
 	log.WithField("bootstrapTime", time.Since(bootstrapTimestamp)).
 		Info("Daemon initialization completed")
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -478,6 +478,16 @@ func (c *clusterNodesClient) NodeConfigurationChanged(config datapath.LocalNodeC
 	return nil
 }
 
+func (c *clusterNodesClient) NodeNeighDiscoveryEnabled() bool {
+	// no-op
+	return false
+}
+
+func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	// no-op
+	return
+}
+
 func (h *getNodes) cleanupClients() {
 	past := time.Now().Add(-clientGCTimeout)
 	for k, v := range h.clients {

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -15,6 +15,8 @@
 package fake
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/datapath"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
@@ -44,4 +46,12 @@ func (n *fakeNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error 
 
 func (n *fakeNodeHandler) NodeConfigurationChanged(config datapath.LocalNodeConfiguration) error {
 	return nil
+}
+
+func (n *fakeNodeHandler) NodeNeighDiscoveryEnabled() bool {
+	return false
+}
+
+func (n *fakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	return
 }

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -17,6 +17,7 @@
 package linux
 
 import (
+	"context"
 	"net"
 	"runtime"
 	"testing"
@@ -1036,6 +1037,36 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}
 	}
 	c.Assert(found, check.Equals, true)
+
+	// Swap MAC addresses of veth0 and veth1 to ensure the MAC address of veth1 changed.
+	// Trigger neighbor refresh on veth0 and check whether the arp entry was updated.
+	var veth0HwAddr, veth1HwAddr, updatedHwAddrFromArpEntry net.HardwareAddr
+	veth0HwAddr = veth0.Attrs().HardwareAddr
+	netns0.Do(func(ns.NetNS) error {
+		veth1, err := netlink.LinkByName("veth1")
+		c.Assert(err, check.IsNil)
+		veth1HwAddr = veth1.Attrs().HardwareAddr
+		err = netlink.LinkSetHardwareAddr(veth1, veth0HwAddr)
+		c.Assert(err, check.IsNil)
+		return nil
+	})
+
+	err = netlink.LinkSetHardwareAddr(veth0, veth1HwAddr)
+	c.Assert(err, check.IsNil)
+
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found = false
+	for _, n := range neighs {
+		if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+			found = true
+			updatedHwAddrFromArpEntry = n.HardwareAddr
+			break
+		}
+	}
+	c.Assert(found, check.Equals, true)
+	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth0HwAddr.String())
 
 	// Remove nodev1, and check whether the arp entry was removed
 	err = linuxNodeHandler.NodeDelete(nodev1)

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -15,6 +15,7 @@
 package datapath
 
 import (
+	"context"
 	"net"
 
 	"github.com/cilium/cilium/pkg/cidr"
@@ -133,4 +134,10 @@ type NodeHandler interface {
 	// NodeConfigurationChanged is called when the local node configuration
 	// has changed
 	NodeConfigurationChanged(config LocalNodeConfiguration) error
+
+	// NodeNeighDiscoveryEnabled returns whether node neighbor discovery is enabled
+	NodeNeighDiscoveryEnabled() bool
+
+	// NodeNeighborRefresh is called to refresh node neighbor table
+	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node)
 }

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -15,6 +15,7 @@
 package peer
 
 import (
+	"context"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/datapath"
@@ -114,6 +115,20 @@ func (h handler) NodeValidateImplementation(_ types.Node) error {
 func (h handler) NodeConfigurationChanged(_ datapath.LocalNodeConfiguration) error {
 	// no-op
 	return nil
+}
+
+// NodeNeighDiscoveryEnabled implements
+// datapath.NodeHandler.NodeNeighDiscoveryEnabled. It is a no-op.
+func (h handler) NodeNeighDiscoveryEnabled() bool {
+	// no-op
+	return false
+}
+
+// NodeNeighborRefresh implements
+// datapath.NodeHandler.NodeNeighborRefresh. It is a no-op.
+func (h handler) NodeNeighborRefresh(_ context.Context, _ types.Node) {
+	// no-op
+	return
 }
 
 // Close frees handler resources.

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -17,6 +17,7 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -131,6 +132,14 @@ func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) erro
 
 func (n *signalNodeHandler) NodeConfigurationChanged(config datapath.LocalNodeConfiguration) error {
 	return nil
+}
+
+func (n *signalNodeHandler) NodeNeighDiscoveryEnabled() bool {
+	return false
+}
+
+func (n *signalNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	return
 }
 
 func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {

--- a/pkg/rand/safe_rand.go
+++ b/pkg/rand/safe_rand.go
@@ -48,6 +48,13 @@ func (sr *safeRand) Int63() int64 {
 	return v
 }
 
+func (sr *safeRand) Int63n(n int64) int64 {
+	sr.mu.Lock()
+	v := sr.r.Int63n(n)
+	sr.mu.Unlock()
+	return v
+}
+
 func (sr *safeRand) Uint32() uint32 {
 	sr.mu.Lock()
 	v := sr.r.Uint32()


### PR DESCRIPTION
Currently, changes of the MAC address won't be detected after
a permanent arp entry is inserted by cilium. The connectivity
to a neighbor node or gateway will be lost if its MAC address changes.

This patch introduces a controller to refresh neighbor table by
sending arping periodically. The neighbor refresh interval is
similar to linux kernel neighbor module: an arp entry is kept in
reachable state for a random duration between (0.5 ~ 1.5) * `base_reachable_time_ms`.
A new config option `base-neighbor-refresh-interval` is introduced.
If it's not set, cilium-agent tries to derive the value from
kernel parameter `net.ipv4.neigh.default.base_reachable_time_ms`
or the default value 30s will be used.

Fixes: #14322
Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

