### PR TITLE
Use toRawJson + quote for storing eniTags into Cilium configmap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -329,7 +329,7 @@ data:
   aws-release-excess-ips: "true"
 {{- end }}
   ec2-api-endpoint: {{ .Values.eni.ec2APIEndpoint | quote }}
-  eni-tags: {{ .Values.eni.eniTags }}
+  eni-tags: {{ .Values.eni.eniTags | toRawJson | quote }}
   subnet-ids-filter: {{ .Values.eni.subnetIDsFilter | quote }}
   subnet-tags-filter: {{ .Values.eni.subnetTagsFilter | quote }}
 {{- end }}


### PR DESCRIPTION
Currently if we want to set eni tags via Helm (`--set eni.eniTags.foo=bar --set eni.eniTags.baz=bob` or a values file) they get stored in the configmap as:
```
$ kubectl get cm -o yaml -n kube-system cilium-config  | grep eni
  eni-tags: map[baz:bob foo:bar]
```
which will make Viper to deserialize into an empty map.

With this change the value will be saved in the configmap as: `eni-tags: '{"baz":"bob","foo":"bar"}'` and we'll rely on Viper to behave correctly deserializing this. Same strategy is used for [`kvstore-opt`](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/templates/cilium-configmap.yaml#L50).

Fixes https://github.com/cilium/cilium/commit/56df8443fdd2a6365718d294d39dd06218cf93f8.