### PR TITLE
Tag ENIs at creation time

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -365,12 +365,9 @@ perform ENI creation and IP allocation:
  * ``AttachNetworkInterface``
  * ``ModifyNetworkInterface``
  * ``AssignPrivateIpAddresses``
-
-Additionally if the ENI tagging feature is enabled it will require the following EC2 API operation as well:
-
  * ``CreateTags``
 
- If release excess IP enabled:
+If release excess IP enabled:
 
  * ``UnassignPrivateIpAddresses``
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -336,6 +336,9 @@ Annotations:
 ------------------
 
 * Cilium has bumped the minimal Kubernetes version supported to v1.13.0.
+* When using the ENI-based IPAM in conjunction with the ``--eni-tags``, failures
+  to create tags are treated as errors which will result in ENIs not being
+  created. Ensure that the ``ec2:CreateTags`` IAM permissions are granted.
 
 Removed Metrics/Labels
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -41,7 +41,6 @@ type EC2API interface {
 	ModifyNetworkInterface(ctx context.Context, eniID, attachmentID string, deleteOnTermination bool) error
 	AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) error
 	UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error
-	TagENI(ctx context.Context, eniID string, eniTags map[string]string) error
 }
 
 // InstancesManager maintains the list of instances. It must be kept up to date
@@ -53,15 +52,13 @@ type InstancesManager struct {
 	vpcs           ipamTypes.VirtualNetworkMap
 	securityGroups types.SecurityGroupMap
 	api            EC2API
-	eniTags        map[string]string
 }
 
 // NewInstancesManager returns a new instances manager
-func NewInstancesManager(api EC2API, eniTags map[string]string) *InstancesManager {
+func NewInstancesManager(api EC2API) *InstancesManager {
 	return &InstancesManager{
 		instances: ipamTypes.NewInstanceMap(),
 		api:       api,
-		eniTags:   eniTags,
 	}
 }
 

--- a/pkg/aws/eni/instances_test.go
+++ b/pkg/aws/eni/instances_test.go
@@ -203,7 +203,7 @@ func (e *ENISuite) TestGetSubnet(c *check.C) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups)
 	c.Assert(api, check.Not(check.IsNil))
 
-	mngr := NewInstancesManager(api, nil)
+	mngr := NewInstancesManager(api)
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	c.Assert(mngr.GetSubnet("subnet-1"), check.IsNil)
@@ -241,7 +241,7 @@ func (e *ENISuite) TestFindSubnetByTags(c *check.C) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups)
 	c.Assert(api, check.Not(check.IsNil))
 
-	mngr := NewInstancesManager(api, nil)
+	mngr := NewInstancesManager(api)
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	iteration1(api, mngr)
@@ -277,7 +277,7 @@ func (e *ENISuite) TestGetSecurityGroupByTags(c *check.C) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups)
 	c.Assert(api, check.Not(check.IsNil))
 
-	mngr := NewInstancesManager(api, nil)
+	mngr := NewInstancesManager(api)
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	sgGroups := mngr.FindSecurityGroupByTags("vpc-1", map[string]string{

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -445,14 +445,6 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 		}
 	}
 
-	if len(n.manager.eniTags) != 0 {
-		if err := n.manager.api.TagENI(ctx, eniID, n.manager.eniTags); err != nil {
-			// treating above as a warn rather than error since it's not mandatory for ENI tagging to succeed
-			// given at this point given that it won't affect IPAM functionality
-			scopedLog.WithError(err).Warning("Unable to tag ENI")
-		}
-	}
-
 	// Add the information of the created ENI to the instances manager
 	n.manager.UpdateENI(n.node.InstanceID(), eni)
 	return toAllocate, "", nil

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -74,7 +74,7 @@ func (e *ENISuite) TearDownTest(c *check.C) {
 
 func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false)
 	c.Assert(err, check.IsNil)
@@ -110,7 +110,7 @@ func (e *ENISuite) TestGetNodeNames(c *check.C) {
 
 func (e *ENISuite) TestNodeManagerGet(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false)
 	c.Assert(err, check.IsNil)
@@ -245,7 +245,7 @@ func reachedAddressesNeeded(mngr *ipam.NodeManager, nodeName string, needed int)
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -285,7 +285,7 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -340,7 +340,7 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -390,7 +390,7 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -447,7 +447,7 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -525,7 +525,7 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -584,7 +584,7 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 	}
 
 	ec2api := ec2mock.NewAPI(subnets, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instancesManager := NewInstancesManager(ec2api, nil)
+	instancesManager := NewInstancesManager(ec2api)
 	mngr, err := ipam.NewNodeManager(instancesManager, k8sapi, metricsapi, 10, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
@@ -646,7 +646,7 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	metricsMock := metricsmock.NewMockMetrics()
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -686,7 +686,7 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 1, "s-1", "desc", []string{"sg1", "sg2"})
 	c.Assert(err, check.IsNil)
@@ -736,7 +736,7 @@ func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLi
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet1, testSubnet2, testSubnet3}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	ec2api.SetDelay(ec2mock.AllOperations, delay)
 	ec2api.SetLimiter(rateLimit, burst)
-	instances := NewInstancesManager(ec2api, nil)
+	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false)
 	c.Assert(err, check.IsNil)

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -55,7 +55,7 @@ func (a *AllocatorAWS) Init(ctx context.Context) error {
 	} else {
 		aMetrics = &apiMetrics.NoOpMetrics{}
 	}
-	a.client = ec2shim.NewClient(ec2.NewFromConfig(cfg), aMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, subnetsFilters)
+	a.client = ec2shim.NewClient(ec2.NewFromConfig(cfg), aMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, subnetsFilters, operatorOption.Config.ENITags)
 
 	if err := limits.UpdateFromUserDefinedMappings(operatorOption.Config.AWSInstanceLimitMapping); err != nil {
 		return fmt.Errorf("failed to parse aws-instance-limit-mapping: %w", err)
@@ -81,7 +81,7 @@ func (a *AllocatorAWS) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 	} else {
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
-	instances := eni.NewInstancesManager(a.client, operatorOption.Config.ENITags)
+	instances := eni.NewInstancesManager(a.client)
 	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics,
 		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AWSReleaseExcessIPs)
 	if err != nil {


### PR DESCRIPTION
AWS EC2 APIs now support tagging resources at creation time which means
we can remove one extra API call. This is helpful in an environment
where there are a lot of clients to the EC2 API and the server is
rate-limiting.

The downside with this is that now if the client does not have
ec2:CreateTags IAM permissions the full ENI creation will fail with a
403 error code.

Signed-off-by: Vlad Ungureanu <vladu@palantir.com>