### PR TITLE
pkg/datapath: fix arp ping handling

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -978,7 +979,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	ip1 := net.ParseIP("9.9.9.250")
 	ipnet.IP = ip0
 	addr := &netlink.Addr{IPNet: ipnet}
-	netlink.AddrAdd(veth0, addr)
+	err = netlink.AddrAdd(veth0, addr)
 	c.Assert(err, check.IsNil)
 	err = netlink.LinkSetUp(veth0)
 	c.Assert(err, check.IsNil)
@@ -1022,6 +1023,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		Name:        "node1",
 		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, ip1}},
 	}
+	// wait 1 second to give the OS time to setup the routes for the veth pairs
+	// just created.
+	time.Sleep(time.Second)
 	err = linuxNodeHandler.NodeAdd(nodev1)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
Due some underlying concurrency issues, the ARP requests were dropped by
the kernel ("arp_error_report") as the neighbor lookup fails. This
caused the unit test to fail while waiting for an ARP reply, for which a
ARP request was never sent. To avoid this issue, a time.Sleep of 1
second is added in the unit test.

Fixes: c5ed9aeb217e ("node: Add unit test for node arpinging")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/14125