### PR TITLE
health: print error on HTTP probe failure

### DIFF
--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -288,7 +288,7 @@ func (p *prober) runHTTPProbe() {
 				if status.HTTP.Status != "" {
 					scopedLog.WithFields(logrus.Fields{
 						logfields.Port: port,
-					}).Debugf("Failed to probe: %s", status.HTTP.Status)
+					}).Errorf("Failed to probe: %s", status.HTTP.Status)
 				}
 			}
 


### PR DESCRIPTION
This helps a lot in determining where the cilium-health initialization
process is stuck, as all the probe failures are unprinted currently, and
the probe process may take several hours (each node takes 2*0.5 minute
to timeout if it is not reachable, and the probe process is sequential).

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>