### PR TITLE
pkg/logging: do not repeat klog messages on all levels

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -108,6 +108,9 @@ func init() {
 	klog.SetOutputBySeverity("WARNING", log.WriterLevel(logrus.WarnLevel))
 	klog.SetOutputBySeverity("ERROR", log.WriterLevel(logrus.ErrorLevel))
 	klog.SetOutputBySeverity("FATAL", log.WriterLevel(logrus.FatalLevel))
+
+	// Do not repeat log messages on all severities in klog
+	klogFlags.Set("one_output", "true")
 }
 
 // LogOptions maps configuration key-value pairs related to logging.


### PR DESCRIPTION
Klog repeats the logging messages on all log levels by default. Setting
with 'one_output' it only print the log messages in a single log level.

Signed-off-by: André Martins <andre@cilium.io>