### PR TITLE
pkg/clustermesh: fix memory leak while reconnecting to remote cluster

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package clustermesh
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
@@ -143,12 +144,13 @@ func (cm *ClusterMesh) Close() {
 
 func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 	return &remoteCluster{
-		name:        name,
-		configPath:  path,
-		mesh:        cm,
-		changed:     make(chan bool, configNotificationsChannelSize),
-		controllers: controller.NewManager(),
-		swg:         lock.NewStoppableWaitGroup(),
+		name:           name,
+		configPath:     path,
+		mesh:           cm,
+		changed:        make(chan bool, configNotificationsChannelSize),
+		controllers:    controller.NewManager(),
+		swg:            lock.NewStoppableWaitGroup(),
+		releaseTimeout: 5 * time.Second,
 	}
 }
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -101,7 +101,7 @@ func (o *testObserver) OnDelete(k store.NamedKey) {
 
 func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	kvstore.SetupDummy("etcd")
-	defer kvstore.Client().Close()
+	defer kvstore.Client().Close(context.TODO())
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -151,7 +151,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 			remoteServices.Close(context.TODO())
 		}
 		if backend != nil {
-			backend.Close()
+			backend.Close(context.TODO())
 		}
 	}()
 }
@@ -175,7 +175,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				err, isErr := <-errChan
 				if isErr {
 					if backend != nil {
-						backend.Close()
+						backend.Close(context.TODO())
 					}
 					rc.getLogger().WithError(err).Warning("Unable to establish etcd connection to remote cluster")
 					return err
@@ -191,7 +191,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					Observer:                rc.mesh.conf.NodeObserver(),
 				})
 				if err != nil {
-					backend.Close()
+					backend.Close(context.TODO())
 					return err
 				}
 
@@ -210,7 +210,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				})
 				if err != nil {
 					remoteNodes.Close(context.TODO())
-					backend.Close()
+					backend.Close(context.TODO())
 					return err
 				}
 				rc.swg.Stop()
@@ -219,7 +219,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				if err != nil {
 					remoteServices.Close(context.TODO())
 					remoteNodes.Close(context.TODO())
-					backend.Close()
+					backend.Close(context.TODO())
 					return err
 				}
 

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -112,7 +112,7 @@ func (s *ClusterMeshServicesTestSuite) TearDownTest(c *C) {
 
 	os.RemoveAll(s.testDir)
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 func (s *ClusterMeshServicesTestSuite) expectEvent(c *C, action k8s.CacheAction, id k8s.ServiceID, fn func(event k8s.ServiceEvent) bool) {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -136,7 +136,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 
 func (s *EndpointSuite) TearDownTest(c *C) {
 	s.mgr.Close()
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 func (s *EndpointSuite) TestEndpointStatus(c *C) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -142,7 +142,7 @@ func (d *DummyOwner) UpdateIdentities(added, deleted cache.IdentityCache) {}
 func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	// Setup dependencies for endpoint.
 	kvstore.SetupDummy("etcd")
-	defer kvstore.Client().Close()
+	defer kvstore.Client().Close(context.TODO())
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -101,7 +101,7 @@ func (e *IdentityAllocatorEtcdSuite) SetUpTest(c *C) {
 }
 
 func (e *IdentityAllocatorEtcdSuite) TearDownTest(c *C) {
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type IdentityAllocatorConsulSuite struct {
@@ -115,7 +115,7 @@ func (e *IdentityAllocatorConsulSuite) SetUpTest(c *C) {
 }
 
 func (e *IdentityAllocatorConsulSuite) TearDownTest(c *C) {
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type dummyOwner struct {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -58,7 +58,7 @@ func (e *AllocatorEtcdSuite) SetUpTest(c *C) {
 
 func (e *AllocatorEtcdSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type AllocatorConsulSuite struct {
@@ -74,7 +74,7 @@ func (e *AllocatorConsulSuite) SetUpTest(c *C) {
 
 func (e *AllocatorConsulSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 //FIXME: this should be named better, it implements pkg/allocator.Backend

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -204,7 +204,7 @@ type BackendOperations interface {
 	Watch(ctx context.Context, w *Watcher)
 
 	// Close closes the kvstore client
-	Close()
+	Close(ctx context.Context)
 
 	// GetCapabilities returns the capabilities of the backend
 	GetCapabilities() Capabilities

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -733,7 +733,7 @@ func (c *consulClient) listPrefix(ctx context.Context, prefix string) (KeyValueP
 }
 
 // Close closes the consul session
-func (c *consulClient) Close() {
+func (c *consulClient) Close(ctx context.Context) {
 	close(c.statusCheckErrors)
 	if c.controllers != nil {
 		c.controllers.RemoveAll()

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -39,7 +39,7 @@ func (e *ConsulSuite) SetUpTest(c *C) {
 }
 
 func (e *ConsulSuite) TearDownTest(c *C) {
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 var handler http.HandlerFunc

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1646,9 +1646,9 @@ func (e *etcdClient) ListPrefix(ctx context.Context, prefix string) (v KeyValueP
 }
 
 // Close closes the etcd session
-func (e *etcdClient) Close() {
+func (e *etcdClient) Close(ctx context.Context) {
 	close(e.stopStatusChecker)
-	sessionErr := e.waitForInitialSession(context.Background())
+	sessionErr := e.waitForInitialSession(ctx)
 	if e.controllers != nil {
 		e.controllers.RemoveAll()
 	}

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -44,7 +44,7 @@ func (e *EtcdSuite) SetUpTest(c *C) {
 }
 
 func (e *EtcdSuite) TearDownTest(c *C) {
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 type MaintenanceMocker struct {
@@ -363,7 +363,7 @@ func (e *EtcdLockedSuite) SetUpSuite(c *C) {
 func (e *EtcdLockedSuite) TearDownSuite(c *C) {
 	err := e.etcdClient.Close()
 	c.Assert(err, IsNil)
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
@@ -1970,7 +1970,7 @@ func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
 			err = kvlocker.Unlock(context.TODO())
 			c.Assert(err, IsNil)
 		}
-		Client().Close()
+		Client().Close(context.TODO())
 
 		// Clean created KV Pairs if populateKVPairs is disabled and cleanKVPairs is enabled.
 		if !op.populateKVPairs && op.cleanKVPairs {
@@ -2005,7 +2005,7 @@ func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
 			err = kvlocker.Unlock(context.TODO())
 			c.Assert(err, IsNil)
 		}
-		Client().Close()
+		Client().Close(context.TODO())
 
 		if op.needCondKey {
 			_, err = e.etcdClient.Delete(context.Background(), condKey)

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -54,7 +54,7 @@ func (e *StoreEtcdSuite) SetUpTest(c *C) {
 
 func (e *StoreEtcdSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type StoreConsulSuite struct {
@@ -69,7 +69,7 @@ func (e *StoreConsulSuite) SetUpTest(c *C) {
 
 func (e *StoreConsulSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 	time.Sleep(sharedKeyDeleteDelay + 5*time.Second)
 }
 


### PR DESCRIPTION
By running the Release operation in a separate go routine it prevented the garbage collector to cleanup the used memory causing memory leaks. To avoid such leaks, as well as avoid deleting remote entries since it was performed in a parallel go routine, we need to make sure "Release" operations are executed before attempting to re-connect to the remote KVStore cluster. Although this is not perform in parallel, Closing and Cleanup operations of the previous connection will be done within N minutes (default 1) to make sure the controller will not hang forever while attempting to reconnect.

Fixes https://github.com/cilium/cilium/issues/13446

```release-note
Fix potential memory leak in clustermesh on re-connection attempts
```