### PR TITLE
Use new metric names for cilium-operator dashboard

### DIFF
--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-operator-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-operator-dashboard.json
@@ -273,7 +273,7 @@
       },
       "id": 6,
       "panels": [],
-      "title": "ENI",
+      "title": "IPAM",
       "type": "row"
     },
     {
@@ -325,7 +325,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(cilium_operator_eni_ips) by (type)",
+          "expr": "avg(cilium_operator_ipam_ips) by (type)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{type}}",
@@ -422,7 +422,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(cilium_operator_eni_aws_api_duration_seconds_sum[1m])/rate(cilium_operator_eni_aws_api_duration_seconds_count[1m])",
+          "expr": "rate(cilium_operator_ec2_api_duration_seconds_sum[1m])/rate(cilium_operator_ec2_api_duration_seconds_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}} {{response_code}}",
@@ -519,7 +519,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "cilium_operator_eni_nodes",
+          "expr": "cilium_operator_ipam_nodes",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{category}}",
@@ -616,10 +616,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "cilium_operator_eni_available",
+          "expr": "cilium_operator_ipam_available",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "ENIs",
+          "legendFormat": "interfaces",
           "refId": "A"
         }
       ],
@@ -627,7 +627,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "# ENIs with addresses available",
+      "title": "# interfaces with addresses available",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -713,7 +713,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(cilium_operator_eni_resync_total[1m])",
+          "expr": "rate(cilium_operator_ipam_resync_total[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "operations",
@@ -810,7 +810,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(cilium_operator_ec2_rate_limit_duration_seconds_sum[1m])/rate(cilium_operator_ec2_rate_limit_duration_seconds_count[1m])",
+          "expr": "rate(cilium_operator_ec2_api_rate_limit_duration_seconds_sum[1m])/rate(cilium_operator_ec2_api_rate_limit_duration_seconds_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -907,7 +907,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_operator_eni_interface_creation_ops[1m])) by (subnetId, status)",
+          "expr": "avg(rate(cilium_operator_ipam_interface_creation_ops[1m])) by (subnetId, status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{status}} ({{subnetId}})",
@@ -918,7 +918,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "ENI Creation",
+      "title": "Interface Creation",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -4475,7 +4475,7 @@ data:
               "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\"}[1m])) by (pod, event_type, source) * 60",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{event_type}} {{source}}",
+              "legendFormat": "{{eventType}} {{source}}",
               "refId": "B"
             }
           ],
@@ -8784,7 +8784,7 @@ data:
           },
           "id": 6,
           "panels": [],
-          "title": "ENI",
+          "title": "IPAM",
           "type": "row"
         },
         {
@@ -8836,7 +8836,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(cilium_operator_eni_ips) by (type)",
+              "expr": "avg(cilium_operator_ipam_ips) by (type)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}}",
@@ -8933,7 +8933,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(cilium_operator_eni_aws_api_duration_seconds_sum[1m])/rate(cilium_operator_eni_aws_api_duration_seconds_count[1m])",
+              "expr": "rate(cilium_operator_ec2_api_duration_seconds_sum[1m])/rate(cilium_operator_ec2_api_duration_seconds_count[1m])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}} {{response_code}}",
@@ -9030,7 +9030,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "cilium_operator_eni_nodes",
+              "expr": "cilium_operator_ipam_nodes",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{category}}",
@@ -9127,10 +9127,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "cilium_operator_eni_available",
+              "expr": "cilium_operator_ipam_available",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "ENIs",
+              "legendFormat": "interfaces",
               "refId": "A"
             }
           ],
@@ -9138,7 +9138,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "# ENIs with addresses available",
+          "title": "# interfaces with addresses available",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -9224,7 +9224,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(cilium_operator_eni_resync_total[1m])",
+              "expr": "rate(cilium_operator_ipam_resync_total[1m])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "operations",
@@ -9321,7 +9321,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(cilium_operator_ec2_rate_limit_duration_seconds_sum[1m])/rate(cilium_operator_ec2_rate_limit_duration_seconds_count[1m])",
+              "expr": "rate(cilium_operator_ec2_api_rate_limit_duration_seconds_sum[1m])/rate(cilium_operator_ec2_api_rate_limit_duration_seconds_count[1m])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -9418,7 +9418,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_operator_eni_interface_creation_ops[1m])) by (subnetId, status)",
+              "expr": "avg(rate(cilium_operator_ipam_interface_creation_ops[1m])) by (subnetId, status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{status}} ({{subnetId}})",
@@ -9429,7 +9429,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "ENI Creation",
+          "title": "Interface Creation",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
When we swapped metric names from `eni` -> `ipam` the dashboard fell behind. https://github.com/cilium/cilium/pull/12502 is the PR did the metrics rename.

Signed-off-by: Vlad Ungureanu <vladu@palantir.com>