### PR TITLE
docs: Add link from EKS mode to ec2 privileges

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -350,6 +350,8 @@ When a node or instance terminates, the Kubernetes apiserver will send a node
 deletion event. This event will be picked up by the operator and the operator
 will delete the corresponding ``ciliumnodes.cilium.io`` custom resource.
 
+.. _ec2privileges:
+
 *******************
 Required Privileges
 *******************

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -101,6 +101,8 @@ Deploy Cilium release via Helm:
    similar to the behavior of the
    `Amazon VPC CNI plugin <https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html>`_.
 
+   This mode depends on a set of :ref:`ec2privileges` from the EC2 API.
+
    Cilium can alternatively run in EKS using an overlay mode that gives pods non-VPC-routable IPs.
    This allows running more pods per Kubernetes worker node than the ENI limit, but means
    that pod connectivity to resources outside the cluster (e.g., VMs in the VPC or AWS managed


### PR DESCRIPTION
Add a link so it's easier for users to find out which privileges are
required to run the ENI mode.
