### PR TITLE
docs: Add cgroups kernel config requirements

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -134,6 +134,8 @@ linked, either choice is valid.
         CONFIG_NET_SCH_INGRESS=y
         CONFIG_CRYPTO_SHA1=y
         CONFIG_CRYPTO_USER_API_HASH=y
+        CONFIG_CGROUPS=y
+        CONFIG_CGROUP_BPF=y
 
 .. note::
 


### PR DESCRIPTION
Add the cgroups kernel requirements for the advanced eBPF functionality.
