### PR TITLE
Add startupProbe for Cilium-agent

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -85,6 +85,24 @@ spec:
 {{- end }}
         command:
         - cilium-agent
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.Version }}
+        startupProbe:
+          httpGet:
+{{- if .Values.ipv4.enabled }}
+            host: '127.0.0.1'
+{{- else }}
+            host: '::1'
+{{- end }}
+            path: /healthz
+            port: {{ .Values.healthPort }}
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 24
+          periodSeconds: 2
+          successThreshold: 1
+{{- end }}
         livenessProbe:
 {{- if or .Values.keepDeprecatedProbes (eq $defaultKeepDeprecatedProbes "true") }}
           exec:
@@ -107,10 +125,14 @@ spec:
               value: "true"
 {{- end }}
           failureThreshold: 10
+{{- if semverCompare "<1.20-0" .Capabilities.KubeVersion.Version }}
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
+          # Starting from Kubernetes 1.20, we are using startupProbe instead
+          # of this field.
           initialDelaySeconds: 120
+{{- end }}
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 5
@@ -136,7 +158,9 @@ spec:
               value: "true"
 {{- end }}
           failureThreshold: 3
+{{- if semverCompare "<1.20-0" .Capabilities.KubeVersion.Version }}
           initialDelaySeconds: 5
+{{- end }}
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 5

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -756,6 +756,8 @@ spec:
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
+          # Starting from Kubernetes 1.20, we are using startupProbe instead
+          # of this field.
           initialDelaySeconds: 120
           periodSeconds: 30
           successThreshold: 1

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -434,6 +434,8 @@ spec:
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
+          # Starting from Kubernetes 1.20, we are using startupProbe instead
+          # of this field.
           initialDelaySeconds: 120
           periodSeconds: 30
           successThreshold: 1


### PR DESCRIPTION
As of K8s 1.20, a new feature called startupProbe has been added.
This allows getting better startup times especially for slow starting
containers.

Fixes: #14342 

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

```release-note
Add startupProbe for Cilium-agent for faster readiness in Kubernetes >= 1.20
```
