### PR TITLE
hubble relay: various logging improvements

### DIFF
--- a/pkg/crypto/certloader/fswatcher/fswatcher.go
+++ b/pkg/crypto/certloader/fswatcher/fswatcher.go
@@ -343,11 +343,13 @@ func (w *Watcher) loop() {
 				}
 			}
 		case err := <-w.watcher.Errors:
-			log.WithError(err).Debug("Received fsnotify error")
+			log.WithError(err).Debug("Received fsnotify error while watching")
 			w.Errors <- err
 		case <-w.stop:
 			err := w.watcher.Close()
-			log.WithError(err).Debug("Received fsnotify error on close")
+			if err != nil {
+				log.WithError(err).Warn("Received fsnotify error on close")
+			}
 			close(w.Events)
 			close(w.Errors)
 			return

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -137,7 +137,7 @@ connect:
 					continue connect
 				}
 			}
-			m.opts.log.WithField("change notification", cn).Debug("Received peer change notification")
+			m.opts.log.WithField("change notification", cn).Info("Received peer change notification")
 			p := peerTypes.FromChangeNotification(cn)
 			switch cn.GetType() {
 			case peerpb.ChangeNotificationType_PEER_ADDED:
@@ -323,7 +323,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 
 	m.opts.log.WithFields(logrus.Fields{
 		"address": p.Address,
-	}).Debugf("Connecting peer %s...", p.Name)
+	}).Infof("Connecting peer %s...", p.Name)
 	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), p.TLSServerName)
 	if err != nil {
 		duration := m.opts.backoff.Duration(p.connAttempts)
@@ -337,7 +337,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 		p.nextConnAttempt = time.Time{}
 		p.connAttempts = 0
 		p.conn = conn
-		m.opts.log.Debugf("Peer %s connected", p.Name)
+		m.opts.log.Infof("Peer %s connected", p.Name)
 	}
 }
 
@@ -350,12 +350,12 @@ func (m *PeerManager) disconnect(p *peer) {
 	if p.conn == nil {
 		return
 	}
-	m.opts.log.Debugf("Disconnecting peer %s...", p.Name)
+	m.opts.log.Infof("Disconnecting peer %s...", p.Name)
 	if err := p.conn.Close(); err != nil {
 		m.opts.log.WithFields(logrus.Fields{
 			"error": err,
 		}).Warningf("Failed to properly close gRPC client connection to peer %s", p.Name)
 	}
 	p.conn = nil
-	m.opts.log.Debugf("Peer %s disconnected", p.Name)
+	m.opts.log.Infof("Peer %s disconnected", p.Name)
 }

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -322,7 +322,8 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 	}
 
 	m.opts.log.WithFields(logrus.Fields{
-		"address": p.Address,
+		"address":    p.Address,
+		"hubble-tls": p.TLSEnabled,
 	}).Infof("Connecting peer %s...", p.Name)
 	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), p.TLSServerName)
 	if err != nil {

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -600,7 +600,7 @@ func TestPeerManager(t *testing.T) {
 					},
 				},
 				log: []string{
-					`level=warning msg="Failed to create gRPC client connection to peer unreachable; next attempt after 10s" address="192.0.1.1:4244" error="Don't feel like workin' today"`,
+					`level=warning msg="Failed to create gRPC client" address="192.0.1.1:4244" error="Don't feel like workin' today" hubble-tls=false next-try-in=10s peer=unreachable`,
 				},
 			},
 		}, {


### PR DESCRIPTION
Raise the logging level of debug messages to info and improve mTLS misconfiguration error message.

### Plaintext Hubble, mTLS Relay
Before this patch:

    level=debug msg="os.Hostname() returned" nodeName=hubble-relay-5d86f9dc74-z76sx subsys=node
    level=info msg="Starting server..." options="{hubbleTarget:unix:///var/run/cilium/hubble.sock dialTimeout:5000000000 retryTimeout:30000000000 listenAddress::4245 log:0xc0002dd7a0 serverTLSConfig:<nil> insecureServer:true clientTLSConfig:0xc0002f81a0 insecureClient:false observerOptions:[0x1287be0 0x1287cc0]}" subsys=hubble-relay
    level=debug msg="Received peer change notification" change notification="name:\"kind-worker2\" address:\"172.18.0.4\" type:PEER_ADDED" subsys=hubble-relay
    level=debug msg="Received peer change notification" change notification="name:\"kind-control-plane\" address:\"172.18.0.3\" type:PEER_ADDED" subsys=hubble-relay
    level=debug msg="Received peer change notification" change notification="name:\"kind-worker\" address:\"172.18.0.2\" type:PEER_ADDED" subsys=hubble-relay
    level=debug msg="Connecting peer kind-worker..." address="172.18.0.2:4244" subsys=hubble-relay
    level=debug msg="Connecting peer kind-worker2..." address="172.18.0.4:4244" subsys=hubble-relay
    level=debug msg="Connecting peer kind-control-plane..." address="172.18.0.3:4244" subsys=hubble-relay
    level=warning msg="Failed to create gRPC client connection to peer kind-worker; next attempt after 10s" address="172.18.0.2:4244" error="context deadline exceeded" subsys=hubble-relay
    level=warning msg="Failed to create gRPC client connection to peer kind-worker2; next attempt after 10s" address="172.18.0.4:4244" error="context deadline exceeded" subsys=hubble-relay
    level=warning msg="Failed to create gRPC client connection to peer kind-control-plane; next attempt after 10s" address="172.18.0.3:4244" error="context deadline exceeded" subsys=hubble-relay

After this patch:

    level=debug msg="os.Hostname() returned" nodeName=hubble-relay-5d86f9dc74-kfw6h subsys=node
    level=info msg="Starting server..." options="{hubbleTarget:unix:///var/run/cilium/hubble.sock dialTimeout:5000000000 retryTimeout:30000000000 listenAddress::4245 log:0xc000246540 serverTLSConfig:<nil> insecureServer:true clientTLSConfig:0xc000514b80 insecureClient:false observerOptions:[0x1287be0 0x1287cc0]}" subsys=hubble-relay
    level=info msg="Received peer change notification" change notification="name:\"kind-worker\" address:\"172.18.0.2\" type:PEER_ADDED" subsys=hubble-relay
    level=info msg="Received peer change notification" change notification="name:\"kind-control-plane\" address:\"172.18.0.4\" type:PEER_ADDED" subsys=hubble-relay
    level=info msg="Received peer change notification" change notification="name:\"kind-worker2\" address:\"172.18.0.3\" type:PEER_ADDED" subsys=hubble-relay
    level=info msg="Connecting peer kind-worker2..." address="172.18.0.3:4244" subsys=hubble-relay hubble-tls=false
    level=warning msg="Failed to create gRPC client connection to peer kind-worker2; next attempt after 10s" address="172.18.0.3:4244" error="missing TLS ServerName for 172.18.0.3:4244" subsys=hubble-relay
    level=info msg="Connecting peer kind-worker..." address="172.18.0.2:4244" subsys=hubble-relay hubble-tls=false
    level=warning msg="Failed to create gRPC client connection to peer kind-worker; next attempt after 10s" address="172.18.0.2:4244" error="missing TLS ServerName for 172.18.0.2:4244" subsys=hubble-relay
    level=info msg="Connecting peer kind-control-plane..." address="172.18.0.4:4244" subsys=hubble-relay hubble-tls=false
    level=warning msg="Failed to create gRPC client connection to peer kind-control-plane; next attempt after 10s" address="172.18.0.4:4244" error="missing TLS ServerName for 172.18.0.4:4244" subsys=hubble-relay

### mTLS Hubble, Plaintext Relay
Before this patch:

    level=debug msg="os.Hostname() returned" nodeName=hubble-relay-5d86f9dc74-pgfrq subsys=node
    level=info msg="Starting server..." options="{hubbleTarget:unix:///var/run/cilium/hubble.sock dialTimeout:5000000000 retryTimeout:30000000000 listenAddress::4245 log:0xc0002b9810 serverTLSConfig:<nil> insecureServer:true clientTLSConfig:<nil> insecureClient:true observerOptions:[0x1287be0 0x1287cc0]}" subsys=hubble-relay
    level=debug msg="Received peer change notification" change notification="name:\"kind-worker\" address:\"172.18.0.2\" type:PEER_ADDED tls:{server_name:\"kind-worker.default.hubble-grpc.cilium.io\"}" subsys=hubble-relay
    level=debug msg="Received peer change notification" change notification="name:\"kind-control-plane\" address:\"172.18.0.3\" type:PEER_ADDED tls:{server_name:\"kind-control-plane.default.hubble-grpc.cilium.io\"}" subsys=hubble-relay
    level=debug msg="Received peer change notification" change notification="name:\"kind-worker2\" address:\"172.18.0.4\" type:PEER_ADDED tls:{server_name:\"kind-worker2.default.hubble-grpc.cilium.io\"}" subsys=hubble-relay
    level=debug msg="Connecting peer kind-worker..." address="172.18.0.2:4244" subsys=hubble-relay
    level=debug msg="Connecting peer kind-worker2..." address="172.18.0.4:4244" subsys=hubble-relay
    level=debug msg="Connecting peer kind-control-plane..." address="172.18.0.3:4244" subsys=hubble-relay
    level=warning msg="Failed to create gRPC client connection to peer kind-control-plane; next attempt after 10s" address="172.18.0.3:4244" error="write tcp 10.30.1.211:35480->172.18.0.3:4244: use of closed network connection" subsys=hubble-relay
    level=warning msg="Failed to create gRPC client connection to peer kind-worker; next attempt after 10s" address="172.18.0.2:4244" error="context deadline exceeded" subsys=hubble-relay
    level=warning msg="Failed to create gRPC client connection to peer kind-worker2; next attempt after 10s" address="172.18.0.4:4244" error="context deadline exceeded" subsys=hubble-relay

After this patch:

    level=debug msg="os.Hostname() returned" nodeName=hubble-relay-5d86f9dc74-r79sc subsys=node
    level=info msg="Starting server..." options="{hubbleTarget:unix:///var/run/cilium/hubble.sock dialTimeout:5000000000 retryTimeout:30000000000 listenAddress::4245 log:0xc00021d0a0 serverTLSConfig:<nil> insecureServer:true clientTLSConfig:<nil> insecureClient:true observerOptions:[0x1287be0 0x1287cc0]}" subsys=hubble-relay
    level=info msg="Received peer change notification" change notification="name:\"kind-worker2\" address:\"172.18.0.3\" type:PEER_ADDED tls:{server_name:\"kind-worker2.default.hubble-grpc.cilium.io\"}" subsys=hubble-relay
    level=info msg="Received peer change notification" change notification="name:\"kind-control-plane\" address:\"172.18.0.4\" type:PEER_ADDED tls:{server_name:\"kind-control-plane.default.hubble-grpc.cilium.io\"}" subsys=hubble-relay
    level=info msg="Received peer change notification" change notification="name:\"kind-worker\" address:\"172.18.0.2\" type:PEER_ADDED tls:{server_name:\"kind-worker.default.hubble-grpc.cilium.io\"}" subsys=hubble-relay
    level=info msg="Connecting peer kind-worker..." address="172.18.0.2:4244" subsys=hubble-relay hubble-tls=true
    level=info msg="Connecting peer kind-worker2..." address="172.18.0.3:4244" subsys=hubble-relay hubble-tls=true
    level=warning msg="Failed to create gRPC client connection to peer kind-worker2; next attempt after 10s" address="172.18.0.3:4244" error="unexpected TLS ServerName kind-worker2.default.hubble-grpc.cilium.io for 172.18.0.3:4244" subsys=hubble-relay
    level=warning msg="Failed to create gRPC client connection to peer kind-worker; next attempt after 10s" address="172.18.0.2:4244" error="unexpected TLS ServerName kind-worker.default.hubble-grpc.cilium.io for 172.18.0.2:4244" subsys=hubble-relay
    level=info msg="Connecting peer kind-control-plane..." address="172.18.0.4:4244" subsys=hubble-relay hubble-tls=true
    level=warning msg="Failed to create gRPC client connection to peer kind-control-plane; next attempt after 10s" address="172.18.0.4:4244" error="unexpected TLS ServerName kind-control-plane.default.hubble-grpc.cilium.io for 172.18.0.4:4244" subsys=hubble-relay

Fix #13087