### PR TITLE
add_vagrant_box.sh: Fix incorrect vagrant box updates

### DIFF
--- a/test/packet/scripts/add_vagrant_box.sh
+++ b/test/packet/scripts/add_vagrant_box.sh
@@ -144,7 +144,7 @@ for box in $boxes; do
         if [[ $ret -eq 0 ]]; then
             url="$vagrant_url$box/$version/package.box"
             if [[ $use_aria2 -eq 1 ]] ; then
-                aria2c -x16 -s16 -c --auto-file-renaming=false -d "$outdir" -o package.box "$url"
+                aria2c -x16 -s16 -c --auto-file-renaming=false --console-log-level=warn -d "$outdir" -o package.box "$url"
             else
                 curl "$url" -o "$outdir/package.box"
             fi

--- a/test/packet/scripts/add_vagrant_box.sh
+++ b/test/packet/scripts/add_vagrant_box.sh
@@ -144,7 +144,7 @@ for box in $boxes; do
         if [[ $ret -eq 0 ]]; then
             url="$vagrant_url$box/$version/package.box"
             if [[ $use_aria2 -eq 1 ]] ; then
-                aria2c -x16 -s16 -c -d "$outdir" -o package.box "$url"
+                aria2c -x16 -s16 -c --auto-file-renaming=false -d "$outdir" -o package.box "$url"
             else
                 curl "$url" -o "$outdir/package.box"
             fi


### PR DESCRIPTION
When running `add_vagrant_box.sh` with aria2c and a `package.box` file already present in the destination directory, the script ends up adding the existing `.box` file instead of the downloaded one. This can also happen if several VM images are downloaded during the same run of `add_vagrant_box.sh`.

    01/05 17:00:15 [NOTICE] Download complete: /home/qmo/tmp/package.3.box
    Download Results:
    gid   |stat|avg speed  |path/URI
    ======+====+===========+=======================================================
    138a73|OK  |   4.5MiB/s|/home/qmo/tmp/package.3.box
    Status Legend:
    (OK):download completed.
    ==> box: Box file was not detected as metadata. Adding it directly...
    ==> box: Adding box 'cilium/ubuntu-4-19' (v0) for provider:
        box: Unpacking necessary files from: file:///home/qmo/tmp/package.box

We can easily fix this by instructing aria2c to overwrite any existing `package.box` file.