### PR TITLE
preflight: Ignore managed fields in policy validator

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields_test.go
@@ -68,6 +68,23 @@ func (s *CNPValidationSuite) Test_getFields(c *C) {
 			err:      nil,
 		},
 		{
+			name: "contains fields to be ignored",
+			structure: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"data": "fake-data",
+					"managedFields": map[string]interface{}{
+						"field-1": "value-1",
+					},
+					"name": "fake-name",
+				},
+				"spec": map[string]interface{}{
+					"more": "",
+				},
+			},
+			expected: []string{"metadata.data", "spec.more"},
+			err:      nil,
+		},
+		{
 			name: `contains "matchLabels"`,
 			structure: map[string]interface{}{
 				"spec": map[string]interface{}{


### PR DESCRIPTION
Fixes: 5aa807c348 ("preflight: Add unknown fields check for validation")
Fixes: https://github.com/cilium/cilium/issues/14526

Reported-by: Robert Stam

```
Fix bug where internal K8s fields are warned about in the preflight policy validator. These fields should be ignored
```