### PR TITLE
test: RuntimePolicies: Fix flake when validating logs

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -62,10 +62,20 @@ var _ = Describe("RuntimePolicies", func() {
 		vm            *helpers.SSHMeta
 		monitorStop   = func() error { return nil }
 		initContainer string
+		testStartTime time.Time
 	)
 
 	BeforeAll(func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+
+		// We need to stop and start Cilium separately (vs. doing a restart) to
+		// allow us to validate only the logs of the startup. The stop may
+		// contain "bad" log messages but they are expected (abrupt stop during
+		// endpoint regeneration).
+		vm.ExecWithSudo("systemctl stop cilium").ExpectSuccess("Failed trying to stop cilium via systemctl")
+		ExpectCiliumNotRunning(vm)
+		testStartTime = time.Now()
+
 		// Make sure that Cilium is started with appropriate CLI options
 		// (specifically to exclude the local addresses that are populated for
 		// CIDR policy tests).
@@ -78,6 +88,8 @@ var _ = Describe("RuntimePolicies", func() {
 
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 	})
 
 	BeforeEach(func() {
@@ -90,10 +102,11 @@ var _ = Describe("RuntimePolicies", func() {
 
 	JustBeforeEach(func() {
 		_, monitorStop = vm.MonitorStart()
+		testStartTime = time.Now()
 	})
 
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 


### PR DESCRIPTION
For the first test executed as part of RuntimePolicies, the validation of logs may include logs from the `BeforeAll` block's execution. Given we restart Cilium in that block, it may lead to `JoinEP` messages in logs if Cilium was stopped while endpoints were being regenerated.

An example of such a flake is visible at [Cilium-PR-Runtime-4.9#3207](https://jenkins.cilium.io/job/Cilium-PR-Runtime-4.9/3207/testReport/junit/(root)/Suite-runtime/RuntimePolicies_L3_L4_Checks/). That test failed because `JoinEP` messages were found in logs. Using timestamps from `test-output.log`, we can check that the validation of logs included the `BeforeAll` block:

    18:58:10 STEP: Running BeforeAll block for EntireTestsuite RuntimePolicies
    [...]
    19:03:27 STEP: Running JustAfterEach block for EntireTestsuite RuntimePolicies
    time="2021-01-05T19:03:27Z" level=debug msg="running command: sudo journalctl -au cilium --since '316.7919274 seconds ago'"

This pull request changes our validation of logs in RuntimePolicies to ensure we only validate logs that correspond to the current test, excluding `BeforeAll`/`BeforeEach` blocks.

Related: e558100 ("test: RuntimeKVStoreTest: Fix flake when validating logs")