### PR TITLE
v1.8: travis: Fix ineffassign version to avoid breaking change

### DIFF
--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -48,4 +48,7 @@ export PATH="/usr/local/clang/bin:$PATH"
 # disable go modules to avoid downloading all dependencies when doing go get
 GO111MODULE=off go get golang.org/x/tools/cmd/cover
 GO111MODULE=off go get github.com/mattn/goveralls
-GO111MODULE=off go get github.com/gordonklaus/ineffassign
+mkdir -p $GOPATH/src/github.com/gordonklaus && cd $GOPATH/src/github.com/gordonklaus
+git clone https://github.com/gordonklaus/ineffassign.git
+cd ineffassign && git checkout -q 3fd9b69f2fb179405773f03d33c68a00f3a1ca4a
+go install ./...

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,7 +65,11 @@ set -o nounset
 set -o pipefail
 
 # Can be removed once PR #11528 with the golangci-lint replacement is merged.
-go get -u github.com/gordonklaus/ineffassign
+export GOPATH=$(go env GOPATH)
+mkdir -p $GOPATH/src/github.com/gordonklaus && cd $GOPATH/src/github.com/gordonklaus
+git clone https://github.com/gordonklaus/ineffassign.git
+cd ineffassign && git checkout -q 3fd9b69f2fb179405773f03d33c68a00f3a1ca4a
+go install ./...
 
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 #{$makeclean}


### PR DESCRIPTION
Our Travis CI tests started failing on v1.8 with the following error:

    ineffassign .
    contrib/scripts/check-logging-subsys-field.sh
    -: no Go files in /home/travis/gopath/src/github.com/cilium/cilium
    ineffassign: error during loading
    Makefile:414: recipe for target 'ineffassign' failed
    make: *** [ineffassign] Error 1
    make: *** Waiting for unfinished jobs....
    The command "./.travis/build.sh" exited with 2.

This error is happening because of [a breaking change](https://github.com/gordonklaus/ineffassign/commit/8eed68eb605f2ddf507412accb8dd7a595b5c114) in how ineffassign interprets its arguments. The same issue doesn't occur on v1.9 and master because we fixed the version we use for ineffassign there [2, 3]. This pull request fixes the error by using the same ineffassign version in v1.8 as in v1.9 and master.
 
1 - https://github.com/cilium/cilium/commit/e75d4a6e5fdc17d446f7e75170f2594f2157b093#diff-887833957d326b6067932340d2e139159f400b4ffff9d6e738af63e851911c9bR53
2 - https://github.com/golangci/golangci-lint/blob/v1.27.0/go.mod#L20