### PR TITLE
pkg/sysctl: Sanitize parameter names

### DIFF
--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
 package sysctl
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/logging"
@@ -35,7 +37,17 @@ const (
 
 var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsystem)
+
+	// parameterElemRx matches an element of a sysctl parameter.
+	parameterElemRx = regexp.MustCompile(`\A[-0-9_a-z]+\z`)
 )
+
+// An ErrInvalidSysctlParameter is returned when a parameter is invalid.
+type ErrInvalidSysctlParameter string
+
+func (e ErrInvalidSysctlParameter) Error() string {
+	return fmt.Sprintf("invalid sysctl parameter: %q", string(e))
+}
 
 // Setting represents a sysctl setting. Its purpose it to be able to iterate
 // over a slice of settings.
@@ -45,21 +57,31 @@ type Setting struct {
 	IgnoreErr bool
 }
 
-func fullPath(name string) string {
-	return filepath.Join(prefixDir, strings.Replace(name, ".", "/", -1))
+// parameterPath returns the path to the sysctl file for parameter name.
+func parameterPath(name string) (string, error) {
+	elems := strings.Split(name, ".")
+	for _, elem := range elems {
+		if !parameterElemRx.MatchString(elem) {
+			return "", ErrInvalidSysctlParameter(name)
+		}
+	}
+	return filepath.Join(append([]string{prefixDir}, elems...)...), nil
 }
 
 func writeSysctl(name string, value string) error {
-	fPath := fullPath(name)
-	f, err := os.OpenFile(fPath, os.O_RDWR, 0644)
+	path, err := parameterPath(name)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0644)
 	if err != nil {
 		return fmt.Errorf("could not open the sysctl file %s: %s",
-			fPath, err)
+			path, err)
 	}
 	defer f.Close()
 	if _, err := io.WriteString(f, value); err != nil {
 		return fmt.Errorf("could not write to the systctl file %s: %s",
-			fPath, err)
+			path, err)
 	}
 	return nil
 }
@@ -81,10 +103,13 @@ func Write(name string, val string) error {
 
 // Read reads the given sysctl parameter.
 func Read(name string) (string, error) {
-	fPath := fullPath(name)
-	val, err := os.ReadFile(fPath)
+	path, err := parameterPath(name)
 	if err != nil {
-		return "", fmt.Errorf("Failed to read %s: %s", fPath, val)
+		return "", err
+	}
+	val, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("Failed to read %s: %s", path, err)
 	}
 
 	return strings.TrimRight(string(val), "\n"), nil
@@ -97,7 +122,7 @@ func ApplySettings(sysSettings []Setting) error {
 			logfields.SysParamValue: s.Val,
 		}).Info("Setting sysctl")
 		if err := Write(s.Name, s.Val); err != nil {
-			if !s.IgnoreErr {
+			if !s.IgnoreErr || errors.Is(err, ErrInvalidSysctlParameter("")) {
 				return fmt.Errorf("Failed to sysctl -w %s=%s: %s", s.Name, s.Val, err)
 			}
 			log.WithError(err).WithFields(logrus.Fields{

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -30,13 +30,13 @@ import (
 )
 
 const (
-	Subsystem = "sysctl"
+	subsystem = "sysctl"
 
 	prefixDir = "/proc/sys"
 )
 
 var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsystem)
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
 
 	// parameterElemRx matches an element of a sysctl parameter.
 	parameterElemRx = regexp.MustCompile(`\A[-0-9_a-z]+\z`)
@@ -115,6 +115,7 @@ func Read(name string) (string, error) {
 	return strings.TrimRight(string(val), "\n"), nil
 }
 
+// ApplySettings applies all settings in sysSettings.
 func ApplySettings(sysSettings []Setting) error {
 	for _, s := range sysSettings {
 		log.WithFields(logrus.Fields{

--- a/pkg/sysctl/sysctl_test.go
+++ b/pkg/sysctl/sysctl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,8 +33,9 @@ var _ = Suite(&SysctlLinuxTestSuite{})
 
 func (s *SysctlLinuxTestSuite) TestFullPath(c *C) {
 	testCases := []struct {
-		name     string
-		expected string
+		name        string
+		expected    string
+		expectedErr bool
 	}{
 		{
 			name:     "net.ipv4.ip_forward",
@@ -52,9 +53,23 @@ func (s *SysctlLinuxTestSuite) TestFullPath(c *C) {
 			name:     "foo.bar",
 			expected: "/proc/sys/foo/bar",
 		},
+		{
+			name:        "double..dot",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid.char$",
+			expectedErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
-		c.Assert(fullPath(tc.name), Equals, tc.expected)
+		path, err := parameterPath(tc.name)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+			c.Assert(path, Equals, tc.expected)
+		}
 	}
 }

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -47,6 +48,8 @@ import (
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-docker-driver")
+
+var endpointIDRx = regexp.MustCompile(`\A[-.0-9a-z]+\z`)
 
 // Driver interface that listens for docker requests.
 type Driver interface {
@@ -373,6 +376,10 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	if create.Interface.Address == "" && create.Interface.AddressIPv6 == "" {
 		sendError(w, "No IPv4 or IPv6 address provided (required)", http.StatusBadRequest)
+		return
+	}
+	if !endpointIDRx.MatchString(create.EndpointID) {
+		sendError(w, "Invalid endpoint ID", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
This PR avoids a [warning issued by CodeQL](https://github.com/cilium/cilium/security/code-scanning/2?query=ref%3Arefs%2Fheads%2Fpr%2Ftwpayne%2Fcodeql-analysis) where it identified "Uncontrolled data used in path expression". Refs #14514.