### PR TITLE
test/helpers: Allow ssh.InsecureIgnoreHostKey in test code

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,7 +76,8 @@ func (cfg *SSHConfig) GetSSHClient() *SSHClient {
 		Auth: []ssh.AuthMethod{
 			cfg.GetSSHAgent(),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		// ssh.InsecureIgnoreHostKey is OK in test code.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // lgtm[go/insecure-hostkeycallback]
 		Timeout:         15 * time.Second,
 	}
 
@@ -338,7 +339,8 @@ func GetSSHClient(host string, port int, user string) *SSHClient {
 		Auth: []ssh.AuthMethod{
 			SSHAgent(),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		// ssh.InsecureIgnoreHostKey is OK in test code.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // lgtm[go/insecure-hostkeycallback]
 		Timeout:         15 * time.Second,
 	}
 


### PR DESCRIPTION
This suppresses a warning from CodeQL.

Refs #14514.

Signed-off-by: Tom Payne <tom@isovalent.com>
