### PR TITLE
ensure pods roll when configmap is updated, better support for gitops

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -184,6 +184,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
 | hubble.relay.resources | object | `{}` | Specifies the resources for the hubble-relay pods |
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
+| hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
 | hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
 | hubble.relay.sortBufferLenMax | string | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
 | hubble.relay.tls | object | `{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"key":""}}` | TLS configuration for Hubble Relay |
@@ -213,6 +214,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.14.5"}` | Hubble-ui ingress proxy image. |
 | hubble.ui.proxy.resources | object | `{}` |  |
 | hubble.ui.replicas | int | `1` |  |
+| hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
 | hubble.ui.securityContext.enabled | bool | `true` |  |
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
@@ -282,6 +284,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
 | operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |
@@ -317,6 +320,7 @@ contributors across the globe, there is almost always someone available to help.
 | remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
 | securityContext | object | `{}` | Security context to be added to agent pods |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.certgen | object | `{"annotations":{},"create":true}` | Certgen is used if hubble.tls.auto.method=cronJob |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -39,6 +39,10 @@ spec:
         prometheus.io/port: "{{ .Values.prometheus.port }}"
         prometheus.io/scrape: "true"
 {{- end }}
+{{- if .Values.rollOutCiliumPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -27,6 +27,10 @@ spec:
   template:
     metadata:
       annotations:
+{{- if .Values.operator.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
 {{- if and .Values.operator.prometheus.enabled (not .Values.operator.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: {{ .Values.operator.prometheus.port | quote }}
         prometheus.io/scrape: "true"

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -16,8 +16,9 @@ spec:
 {{- end }}
   template:
     metadata:
+      annotations:
 {{- with .Values.clustermesh.apiserver.podAnnotations }}
-      annotations: {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
 {{- end }}
       labels:
         k8s-app: clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -18,9 +18,13 @@ spec:
 {{- end }}
   template:
     metadata:
-{{- with .Values.hubble.relay.podAnnotations }}
       annotations:
-        {{ toYaml . | trim | indent 8 }}
+{{- if .Values.hubble.relay.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/hubble-relay-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-relay-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
+{{- with .Values.hubble.relay.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
 {{- end }}
       labels:
         k8s-app: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -13,8 +13,12 @@ spec:
       k8s-app: hubble-ui
   template:
     metadata:
-{{- with .Values.hubble.ui.podAnnotations }}
       annotations:
+{{- if .Values.hubble.ui.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/hubble-ui-envoy-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-ui-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
+{{- with .Values.hubble.ui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
 {{- end }}
       labels:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -64,6 +64,9 @@ agent: true
 # -- Agent container name.
 name: cilium
 
+# -- Roll out cilium agent pods automatically when configmap is updated.
+rollOutCiliumPods: false
+
 # -- Agent container image.
 image:
   repository: quay.io/cilium/cilium
@@ -563,6 +566,9 @@ hubble:
     # -- Enable Hubble Relay (requires hubble.enabled=true)
     enabled: false
 
+    # -- Roll out Hubble Relay pods automatically when configmap is updated.
+    rollOutPods: false
+
     # -- Hubble-relay container image.
     image:
       repository: quay.io/cilium/hubble-relay
@@ -639,6 +645,9 @@ hubble:
 
   ui:
     enabled: false
+
+    # -- Roll out Hubble-ui pods automatically when configmap is updated.
+    rollOutPods: false
 
     backend:
       # -- Hubble-ui backend image.
@@ -1074,6 +1083,9 @@ etcd:
 operator:
   # -- Enable the cilium-operator component (required).
   enabled: true
+
+  # -- Roll out cilium-operator pods automatically when configmap is updated.
+  rollOutPods: false
 
   # -- cilium-operator image.
   image:

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -1079,6 +1079,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-relay
     spec:
@@ -1165,6 +1166,7 @@ spec:
       k8s-app: hubble-ui
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-ui
     spec:

--- a/install/kubernetes/quick-hubble-install.yaml
+++ b/install/kubernetes/quick-hubble-install.yaml
@@ -306,6 +306,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-relay
     spec:
@@ -392,6 +393,7 @@ spec:
       k8s-app: hubble-ui
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-ui
     spec:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #14331 

```release-note
Helm Chart: add checksum to configmap to ensure pods roll when configmap is updated
```

Introduces the following new values:

```
rollOutCiliumPods: false

hubble:
  ui:
    rollOutPods: false
  relay:
    rollOutPods: false

operator:
  rollOutPods: false
```