### PR TITLE
Improve pod deletion resiliency

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
@@ -133,7 +132,7 @@ type Daemon struct {
 
 	netConf *cnitypes.NetConf
 
-	endpointManager *endpointmanager.EndpointManager
+	endpointManager *endpointManager
 
 	identityAllocator *cache.CachingIdentityAllocator
 
@@ -331,7 +330,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	ipcache.IdentityAllocator = d.identityAllocator
 	proxy.Allocator = d.identityAllocator
 
-	d.endpointManager = endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{
+	d.endpointManager = NewEndpointManager(&d, &endpointsynchronizer.EndpointSynchronizer{
 		Allocator: d.identityAllocator,
 	})
 	d.endpointManager.InitMetrics()

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1315,7 +1315,7 @@ func runDaemon() {
 			d.dnsNameManager.CompleteBootstrap()
 
 			ms := maps.NewMapSweeper(&EndpointMapManager{
-				EndpointManager: d.endpointManager,
+				endpointManager: d.endpointManager,
 			})
 			ms.CollectStaleMapGarbage()
 			ms.RemoveDisabledMaps()

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -740,6 +740,10 @@ func init() {
 	flags.Int(option.EndpointQueueSize, defaults.EndpointQueueSize, "size of EventQueue per-endpoint")
 	option.BindEnv(option.EndpointQueueSize)
 
+	flags.Duration(option.EndpointGCInterval, 5*time.Minute, "Periodically monitor local endpoint health via link status on this interval and garbage collect them if they become unhealthy, set to 0 to disable")
+	flags.MarkHidden(option.EndpointGCInterval)
+	option.BindEnv(option.EndpointGCInterval)
+
 	flags.Bool(option.SelectiveRegeneration, true, "only regenerate endpoints which need to be regenerated upon policy changes")
 	flags.MarkHidden(option.SelectiveRegeneration)
 	option.BindEnv(option.SelectiveRegeneration)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -144,7 +144,10 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.OnQueueEndpointBuild = nil
 	ds.OnGetCompilationLock = nil
 	ds.OnSendNotification = nil
-	ds.d.endpointManager = endpointmanager.NewEndpointManager(&dummyEpSyncher{})
+	ds.d.endpointManager = &endpointManager{
+		d:               ds.d,
+		EndpointManager: endpointmanager.NewEndpointManager(&dummyEpSyncher{}),
+	}
 
 	// Reset the most common endpoint states before each test.
 	for _, s := range []string{

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -28,7 +28,6 @@ import (
 	datapathIpcache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -133,7 +132,7 @@ func (d *Daemon) SetPrefilter(preFilter *prefilter.PreFilter) {
 // EndpointMapManager is a wrapper around an endpointmanager as well as the
 // filesystem for removing maps related to endpoints from the filesystem.
 type EndpointMapManager struct {
-	*endpointmanager.EndpointManager
+	*endpointManager
 }
 
 // RemoveDatapathMapping unlinks the endpointID from the global policy map, preventing

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -135,7 +135,7 @@ func (d *Daemon) cleanupHealthEndpoint() {
 		log.Debug("Didn't find existing cilium-health endpoint to delete")
 	} else {
 		log.Debug("Removing existing cilium-health endpoint")
-		errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
+		errs := d.endpointManager.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
 			NoIPRelease: true,
 		})
 		for _, err := range errs {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -83,7 +83,7 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 					logfields.K8sPodName:   ep.K8sPodName,
 				})
 				scopedLog.Warningf("kubernetes pod not found, deleting endpoint from endpoint manager")
-				errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
+				errs := d.endpointManager.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
 					// If the IP is managed by an external IPAM, it does not need to be released
 					NoIPRelease: ep.DatapathConfiguration.ExternalIpam,
 				})
@@ -316,7 +316,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// release it easily as it will require to block on kvstore
 			// connectivity which we can't do at this point. Let the lease
 			// expire to release the identity.
-			d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
+			d.endpointManager.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
 				NoIdentityRelease: true,
 				NoIPRelease:       true,
 			})

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -471,6 +471,18 @@ func (e *Endpoint) GetID16() uint16 {
 	return e.ID
 }
 
+// HostInterface returns the name of the link-layer interface used for
+// communicating with the endpoint from the host (if available).
+//
+// In some datapath modes, it may return an empty string as there is no unique
+// host netns network interface for this endpoint.
+func (e *Endpoint) HostInterface() string {
+	if e.HasIpvlanDataPath() {
+		return ""
+	}
+	return e.ifName
+}
+
 // getK8sPodLabels returns all labels that exist in the endpoint and were
 // derived from k8s pod.
 func (e *Endpoint) getK8sPodLabels() pkgLabels.Labels {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -56,6 +57,16 @@ type EndpointManager struct {
 	// EndpointSynchronizer updates external resources (e.g., Kubernetes) with
 	// up-to-date information about endpoints managed by the endpoint manager.
 	EndpointResourceSynchronizer
+
+	// checker supports endpoint garbage collection by verifying the health
+	// of an endpoint.
+	checker EndpointChecker
+
+	// A mark-and-sweep garbage collector may operate on the endpoint list.
+	// This is configured via WithPeriodicEndpointGC() and will mark
+	// endpoints for removal on one run of the controller, then in the
+	// subsequent controller run will remove the endpoints.
+	markedEndpoints []uint16
 }
 
 // EndpointResourceSynchronizer is an interface which synchronizes CiliumEndpoint
@@ -73,6 +84,94 @@ func NewEndpointManager(epSynchronizer EndpointResourceSynchronizer) *EndpointMa
 	}
 
 	return &mgr
+}
+
+// EndpointChecker can verify whether an endpoint is currently healthy.
+type EndpointChecker interface {
+	Check(*endpoint.Endpoint) error
+	DeleteEndpoint(*endpoint.Endpoint) int
+}
+
+// WithPeriodicEndpointGC runs a controller to periodically garbage collect
+// endpoints that match the specified checker.
+func (mgr *EndpointManager) WithPeriodicEndpointGC(ctx context.Context, checker EndpointChecker, interval time.Duration) *EndpointManager {
+	mgr.checker = checker
+	controller.NewManager().UpdateController("endpoint-gc",
+		controller.ControllerParams{
+			DoFunc:      mgr.markAndSweep,
+			RunInterval: interval,
+			Context:     ctx,
+		})
+	return mgr
+}
+
+// markAndSweep performs a two-phase garbage collection of endpoints using the
+// configured EndpointChecker.
+//
+// 1) Mark all endpoints that require GC. Do not GC these endpoints this round.
+// 2) Sweep all endpoints marked as requiring GC during the previous iteration.
+//
+// This way, if there is a temporary condition that will be resolved by other
+// components in the system, then we will not flag warnings about the system
+// getting out-of-sync.
+func (mgr *EndpointManager) markAndSweep(ctx context.Context) error {
+	marked := mgr.markEndpoints()
+
+	mgr.mutex.Lock()
+	toSweep := mgr.markedEndpoints
+	mgr.markedEndpoints = marked
+	mgr.mutex.Unlock()
+
+	// Avoid returning an error which would cause the calling controller to
+	// re-run the garbage collection more frequently than the RunInterval.
+	mgr.sweepEndpoints(toSweep)
+	return nil
+}
+
+// markEndpoints runs all endpoints in the manager against the configured
+// EndpointChecker and returns a slice of endpoint ids that require garbage
+// collection.
+func (mgr *EndpointManager) markEndpoints() []uint16 {
+	mgr.mutex.RLock()
+	defer mgr.mutex.RUnlock()
+
+	// TODO: Consider exposing visibility via Endpoint.SetState().
+	needsGC := make([]uint16, 0, len(mgr.endpoints))
+	for eid, ep := range mgr.endpoints {
+		if err := mgr.checker.Check(ep); err != nil {
+			needsGC = append(needsGC, eid)
+		}
+	}
+	return needsGC
+}
+
+// sweepEndpoints iterates through the specified list of endpoints marked for
+// deletion and attempts to garbage-collect them if they still exist.
+func (mgr *EndpointManager) sweepEndpoints(markedEndpoints []uint16) {
+	toSweep := make([]*endpoint.Endpoint, 0, len(markedEndpoints))
+
+	// 'markedEndpoints' were marked during the previous mark round, so
+	// they may no longer be valid endpoints. Narrow the list to only the
+	// endpoints that remain. Then, release the lock so DeleteEndpoint()
+	// below can independently grab it.
+	mgr.mutex.RLock()
+	for _, id := range markedEndpoints {
+		if ep, ok := mgr.endpoints[id]; ok {
+			toSweep = append(toSweep, ep)
+		}
+	}
+	mgr.mutex.RUnlock()
+
+	for _, ep := range toSweep {
+		log.WithFields(logrus.Fields{
+			logfields.EndpointID:  ep.StringID(),
+			logfields.ContainerID: ep.GetShortContainerID(),
+			logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+			logfields.URL:         "https://github.com/kubernetes/kubernetes/issues/86944",
+		}).Warning("Stray endpoint found. You may be affected by upstream Kubernetes issue #86944.")
+		// Callee handles the errors which we ignore.
+		_ = mgr.checker.DeleteEndpoint(ep)
+	}
 }
 
 // waitForProxyCompletions blocks until all proxy changes have been completed.

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -413,4 +413,9 @@ const (
 
 	// SysParamValue is the value of the kernel parameter (sysctl)
 	SysParamValue = "sysParamValue"
+
+	// HelpMessage is the help message corresponding to a log message. This
+	// is to make sure we keep separate contexts for logs and help
+	// messages.
+	HelpMessage = "helpMessage"
 )

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -405,6 +405,9 @@ const (
 	// Key is the identity of the encryption key
 	Key = "key"
 
+	// URL represents a Uniform Resource Locator.
+	URL = "url"
+
 	// SysParamName is the name of the kernel parameter (sysctl)
 	SysParamName = "sysParamName"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -587,6 +587,10 @@ const (
 	// EndpointQueueSize is the size of the EventQueue per-endpoint.
 	EndpointQueueSize = "endpoint-queue-size"
 
+	// EndpointGCInterval interval to attempt garbage collection of
+	// endpoints that are no longer alive and healthy.
+	EndpointGCInterval = "endpoint-gc-interval"
+
 	// SelectiveRegeneration specifies whether only the endpoints which policy
 	// changes select should be regenerated upon policy changes.
 	SelectiveRegeneration = "enable-selective-regeneration"
@@ -1312,6 +1316,10 @@ type DaemonConfig struct {
 	// in the case where a cluster might be under high load for endpoint-related
 	// events, specifically those which cause many regenerations.
 	EndpointQueueSize int
+
+	// EndpointGCInterval is interval to attempt garbage collection of
+	// endpoints that are no longer alive and healthy.
+	EndpointGCInterval time.Duration
 
 	// SelectiveRegeneration, when true, enables the functionality to only
 	// regenerate endpoints which are selected by the policy rules that have
@@ -2197,6 +2205,7 @@ func (c *DaemonConfig) Populate() {
 	c.CMDRefDir = viper.GetString(CMDRef)
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)
+	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)


### PR DESCRIPTION
Review commit by commit.

The main fix is this one:

```
In a user environment, we encountered a scenario where pods would
"disappear" and Cilium seemingly received no notification of deletion
(eg, CNI DELETE command). If this occurs regularly over time, then
this leads to Cilium managing a series of phantom endpoints which no
longer have corresponding k8s objects.

Some symptoms include:

* Exhaustion of IP address management pool, causing inability to deploy
  new endpoints on the node;
* Metrics such as cilium_endpoint_count increase to the maximum
  number of endpoints on the node (typically limited by IP pool);
* Label resolution controllers reporting errors in "cilium status"
  output, such as: pod.core "my-pod-name" not found; and
* Endpoints that Cilium is aware of have no corresponding veth interfaces.

Fix this by periodically iterating the list of exposed endpoints and
checking that the endpoints are still alive and healthy, by checking
that the link is still present on the node. If an endpoint's link is not
present for two consecutive iterations of the garbage collection (and
the endpoint is not otherwise cleaned up by CNI DELETE or similar
operations), then disconnect it from the endpointmanager and release its
resources.
```

I manually tested this new branch by deploying an image based on this
code, deploying an application, finding its corresponding link via the
`cilium endpoint list -o json` API, and deleting it. After two GC intervals,
the controller kicked in to clean up the endpoint.

I also separately checked that if you create a network namespace, then
create a veth and put one half of the veth inside the network namespace,
then delete the network namespace, it causes the veth link to also be
deleted by the kernel. This means that if the container runtime
prematurely deletes the network namespace without informing us via CNI
DELETE, we have a mechanism to detect that the endpoint has gone
away and clean it up.

The new option "endpoint-gc-interval" allows configuration of the
endpoint garbage collection behaviour. If set to less than around 90s,
then it is possible for it to think that an endpoint has gone away and
Cilium missed a CNI delete while a CNI delete is still enqueued to be
sent to Cilium. In this case, Cilium may mistakenly log a warning
regarding the "stray" endpoint despite the upper CNI layer behaving
correctly.

In some datapath modes, most notably when enabling IPVLAN, there is
no host-side network interface to use for this detection so this PR is
ineffective. You may disable the functionality by configuring
`endpoint-gc-interval="0"`.

Related: https://github.com/kubernetes/kubernetes/issues/86944

```release-note
Fix bug where Cilium endpoints are not cleaned up, eventually leading to IP exhaustion despite a small number of endpoints on the node.
```