### PR TITLE
Check whether to setup proxy rules when init bpf

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -38,6 +38,7 @@ NODE_PORT_BIND=${20}
 MCPU=${21}
 NR_CPUS=${22}
 ENDPOINT_ROUTES=${23}
+PROXY_RULE=${24}
 
 ID_HOST=1
 ID_WORLD=2
@@ -428,12 +429,14 @@ case "${MODE}" in
         ;;
 esac
 
+if [ "$PROXY_RULE" = "true" ]; then
 # Decrease priority of the rule to identify local addresses
 move_local_rules
 
 # Install new rules before local rule to ensure that packets from the proxy are
 # using a separate routing table
 setup_proxy_rules
+fi
 
 sed -i '/ENCAP_GENEVE/d' $RUNDIR/globals/node_config.h
 sed -i '/ENCAP_VXLAN/d' $RUNDIR/globals/node_config.h

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -66,6 +66,7 @@ const (
 	initBPFCPU
 	initArgNrCPUs
 	initArgEndpointRoutes
+	initArgProxyRule
 	initArgMax
 )
 
@@ -343,6 +344,12 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 	args[initArgHostDev1] = hostDev1.Attrs().Name
 	args[initArgHostDev2] = hostDev2.Attrs().Name
+
+	if option.Config.InstallIptRules {
+		args[initArgProxyRule] = "true"
+	} else {
+		args[initArgProxyRule] = "false"
+	}
 
 	// "Legacy" datapath inizialization with the init.sh script
 	// TODO(mrostecki): Rewrite the whole init.sh in Go, step by step.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
proxy rules should not be setup when iptables marked with 0x200 and 0xa00 not installed
Fixes: #issue-number
