### PR TITLE
test: CI pipeline with kube-proxy running alongside our replacement

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
                         // We need to define all ${KERNEL}-dependent env vars in stage instead of top environment block
                         // because jenkins doesn't initialize these values sequentially within one block
 
-                        // We set KUBEPROXY="0" if we are running net-next or 4.19; otherwise, KUBEPROXY=""
+                        // We set KUBEPROXY="0" if we are running net-next; otherwise, KUBEPROXY=""
                         // If we are running in net-next, we need to set NETNEXT=1, K8S_NODES=3, and NO_CILIUM_ON_NODE="k8s3";
                         // otherwise we set NETNEXT=0, K8S_NODES=2, and NO_CILIUM_ON_NODE="".
                         NETNEXT="""${sh(
@@ -143,7 +143,7 @@ pipeline {
                             )}"""
                         KUBEPROXY="""${sh(
                             returnStdout: true,
-                            script: 'if [ "${KERNEL}" = "net-next" ] || [ "${KERNEL}" = "419" ]; then echo -n "0"; else echo -n ""; fi'
+                            script: 'if [ "${KERNEL}" = "net-next" ]; then echo -n "0"; else echo -n ""; fi'
                             )}"""
                     }
                     steps {
@@ -202,7 +202,7 @@ pipeline {
                 // We need to define all ${KERNEL}-dependent env vars in stage instead of top environment block
                 // because jenkins doesn't initialize these values sequentially within one block
 
-                // We set KUBEPROXY="0" if we are running net-next or 4.19; otherwise, KUBEPROXY=""
+                // We set KUBEPROXY="0" if we are running net-next; otherwise, KUBEPROXY=""
                 // If we are running in net-next, we need to set NETNEXT=1, K8S_NODES=3, and NO_CILIUM_ON_NODE="k8s3";
                 // otherwise we set NETNEXT=0, K8S_NODES=2, and NO_CILIUM_ON_NODE="".
                 NETNEXT="""${sh(
@@ -219,7 +219,7 @@ pipeline {
                     )}"""
                 KUBEPROXY="""${sh(
                     returnStdout: true,
-                    script: 'if [ "${KERNEL}" = "net-next" ] || [ "${KERNEL}" = "419" ]; then echo -n "0"; else echo -n ""; fi'
+                    script: 'if [ "${KERNEL}" = "net-next" ]; then echo -n "0"; else echo -n ""; fi'
                     )}"""
                 CILIUM_IMAGE = "quay.io/cilium/cilium-ci"
                 CILIUM_TAG = "${DOCKER_TAG}"

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -200,7 +200,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(status.IntOutput()).Should(Equal(numEntries), "Did not find expected number of entries in BPF tunnel map")
 		}
 
-		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Check connectivity with transparent encryption and VXLAN encapsulation", func() {
+		SkipItIf(helpers.RunsWithoutKubeProxy, "Check connectivity with transparent encryption and VXLAN encapsulation", func() {
 			// FIXME(brb) Currently, the test is broken with CI 4.19 setup. Run it on 4.19
 			//			  once we have kube-proxy disabled there.
 			if !helpers.RunsOnNetNextKernel() {
@@ -210,7 +210,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
 			deploymentManager.DeployCilium(map[string]string{
-				"encryption.enabled": "true",
+				"kubeProxyReplacement": "disabled",
+				"encryption.enabled":   "true",
 			}, DeployCiliumOptionsAndDNS)
 			validateBPFTunnelMap()
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")
@@ -550,7 +551,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("Transparent encryption DirectRouting", func() {
-		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Check connectivity with transparent encryption and direct routing", func() {
+		SkipItIf(helpers.RunsWithoutKubeProxy, "Check connectivity with transparent encryption and direct routing", func() {
 			SkipIfIntegration(helpers.CIIntegrationFlannel)
 			SkipIfIntegration(helpers.CIIntegrationGKE)
 
@@ -565,6 +566,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"encryption.interface": privateIface,
 				"devices":              "",
 				"hostFirewall":         "false",
+				"kubeProxyReplacement": "disabled",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})


### PR DESCRIPTION
This pull request changes our 4.19 CI job to keep kube-proxy installed, which then allows us to run the IPSec tests on that kernel.

Fixes: #14155