### PR TITLE
Helm: Add option to enable k8s events handover.

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -111,6 +111,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libriaries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
 | enableIPv4Masquerade | bool | `true` | hashSeed is the cluster-wide base64 encoded seed for the hashing hashSeed: -- Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
+| enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by  mirroring it into the KVstore for reduced overhead in large clusters. |
 | enableXTSocketFallback | bool | `true` |  |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -646,6 +646,10 @@ data:
   disable-cnp-status-updates: "true"
 {{- end }}
 
+{{- if .Values.enableK8sEventHandover }}
+  enable-k8s-event-handover: "true"
+{{- end }}
+
 {{- if hasKey .Values "crdWaitTimeout" }}
   crd-wait-timeout: {{ .Values.crdWaitTimeout | quote }}
 {{- else if ( ne $crdWaitTimeout "5m" ) }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -352,6 +352,10 @@ daemon:
 
 enableCnpStatusUpdates: false
 
+# -- Configures the use of the KVStore to optimize Kubernetes event handling by 
+# mirroring it into the KVstore for reduced overhead in large clusters.
+enableK8sEventHandover: false
+
 # TODO: Add documentation
 # enableIdentityMark: false
 


### PR DESCRIPTION
Currently, there is no way to configure the operator to handle the CNP
status updates using Helm.

This PR adds the missing field in the Cilium's ConfigMap needed when
using the Helm side to allow CNP status updates: `enable-k8s-event-handover`

Fixes: #14547

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

```release-note
Helm: Allow enable-k8s-event-handover to be configured via Helm to control CNP Node status updates
 ```
