### PR TITLE
hubble/filter: filters based on ip version

### DIFF
--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -2089,6 +2089,8 @@ type FlowFilter struct {
 	// node_name is a list of patterns to filter on the node name, e.g. (e.g.
 	// "k8s*", "test-cluster/*.domain.com", "cluster-name/").
 	NodeName []string `protobuf:"bytes,24,rep,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	// filter based on IP version (ipv4 or ipv6)
+	IpVersion []IPVersion `protobuf:"varint,25,rep,packed,name=ip_version,json=ipVersion,proto3,enum=flow.IPVersion" json:"ip_version,omitempty"`
 }
 
 func (x *FlowFilter) Reset() {
@@ -2287,6 +2289,13 @@ func (x *FlowFilter) GetTcpFlags() []*TCPFlags {
 func (x *FlowFilter) GetNodeName() []string {
 	if x != nil {
 		return x.NodeName
+	}
+	return nil
+}
+
+func (x *FlowFilter) GetIpVersion() []IPVersion {
+	if x != nil {
+		return x.IpVersion
 	}
 	return nil
 }
@@ -3756,7 +3765,7 @@ var file_flow_flow_proto_rawDesc = []byte{
 	0x69, 0x75, 0x6d, 0x45, 0x76, 0x65, 0x6e, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x12, 0x0a, 0x04,
 	0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
 	0x12, 0x19, 0x0a, 0x08, 0x73, 0x75, 0x62, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01,
-	0x28, 0x05, 0x52, 0x07, 0x73, 0x75, 0x62, 0x54, 0x79, 0x70, 0x65, 0x22, 0x94, 0x07, 0x0a, 0x0a,
+	0x28, 0x05, 0x52, 0x07, 0x73, 0x75, 0x62, 0x54, 0x79, 0x70, 0x65, 0x22, 0xc4, 0x07, 0x0a, 0x0a,
 	0x46, 0x6c, 0x6f, 0x77, 0x46, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x12, 0x1b, 0x0a, 0x09, 0x73, 0x6f,
 	0x75, 0x72, 0x63, 0x65, 0x5f, 0x69, 0x70, 0x18, 0x01, 0x20, 0x03, 0x28, 0x09, 0x52, 0x08, 0x73,
 	0x6f, 0x75, 0x72, 0x63, 0x65, 0x49, 0x70, 0x12, 0x1d, 0x0a, 0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63,
@@ -3814,7 +3823,10 @@ var file_flow_flow_proto_rawDesc = []byte{
 	0x6f, 0x77, 0x2e, 0x54, 0x43, 0x50, 0x46, 0x6c, 0x61, 0x67, 0x73, 0x52, 0x08, 0x74, 0x63, 0x70,
 	0x46, 0x6c, 0x61, 0x67, 0x73, 0x12, 0x1b, 0x0a, 0x09, 0x6e, 0x6f, 0x64, 0x65, 0x5f, 0x6e, 0x61,
 	0x6d, 0x65, 0x18, 0x18, 0x20, 0x03, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x6f, 0x64, 0x65, 0x4e, 0x61,
-	0x6d, 0x65, 0x22, 0xce, 0x01, 0x0a, 0x03, 0x44, 0x4e, 0x53, 0x12, 0x14, 0x0a, 0x05, 0x71, 0x75,
+	0x6d, 0x65, 0x12, 0x2e, 0x0a, 0x0a, 0x69, 0x70, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e,
+	0x18, 0x19, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x0f, 0x2e, 0x66, 0x6c, 0x6f, 0x77, 0x2e, 0x49, 0x50,
+	0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x09, 0x69, 0x70, 0x56, 0x65, 0x72, 0x73, 0x69,
+	0x6f, 0x6e, 0x22, 0xce, 0x01, 0x0a, 0x03, 0x44, 0x4e, 0x53, 0x12, 0x14, 0x0a, 0x05, 0x71, 0x75,
 	0x65, 0x72, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79,
 	0x12, 0x10, 0x0a, 0x03, 0x69, 0x70, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52, 0x03, 0x69,
 	0x70, 0x73, 0x12, 0x10, 0x0a, 0x03, 0x74, 0x74, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0d, 0x52,
@@ -4269,27 +4281,28 @@ var file_flow_flow_proto_depIdxs = []int32{
 	4,  // 28: flow.FlowFilter.verdict:type_name -> flow.Verdict
 	22, // 29: flow.FlowFilter.event_type:type_name -> flow.EventTypeFilter
 	18, // 30: flow.FlowFilter.tcp_flags:type_name -> flow.TCPFlags
-	26, // 31: flow.HTTP.headers:type_name -> flow.HTTPHeader
-	9,  // 32: flow.LostEvent.source:type_name -> flow.LostEventSource
-	44, // 33: flow.LostEvent.cpu:type_name -> google.protobuf.Int32Value
-	10, // 34: flow.AgentEvent.type:type_name -> flow.AgentEventType
-	32, // 35: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
-	33, // 36: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
-	34, // 37: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
-	35, // 38: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
-	36, // 39: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
-	37, // 40: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
-	39, // 41: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
-	40, // 42: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
-	42, // 43: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
-	45, // 44: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
-	38, // 45: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
-	38, // 46: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
-	47, // [47:47] is the sub-list for method output_type
-	47, // [47:47] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	3,  // 31: flow.FlowFilter.ip_version:type_name -> flow.IPVersion
+	26, // 32: flow.HTTP.headers:type_name -> flow.HTTPHeader
+	9,  // 33: flow.LostEvent.source:type_name -> flow.LostEventSource
+	44, // 34: flow.LostEvent.cpu:type_name -> google.protobuf.Int32Value
+	10, // 35: flow.AgentEvent.type:type_name -> flow.AgentEventType
+	32, // 36: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
+	33, // 37: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
+	34, // 38: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
+	35, // 39: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
+	36, // 40: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
+	37, // 41: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
+	39, // 42: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
+	40, // 43: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
+	42, // 44: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
+	45, // 45: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
+	38, // 46: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
+	38, // 47: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
+	48, // [48:48] is the sub-list for method output_type
+	48, // [48:48] is the sub-list for method input_type
+	48, // [48:48] is the sub-list for extension type_name
+	48, // [48:48] is the sub-list for extension extendee
+	0,  // [0:48] is the sub-list for field type_name
 }
 
 func init() { file_flow_flow_proto_init() }

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -411,6 +411,9 @@ message FlowFilter {
     // node_name is a list of patterns to filter on the node name, e.g. (e.g.
     // "k8s*", "test-cluster/*.domain.com", "cluster-name/").
     repeated string node_name = 24;
+
+    // filter based on IP version (ipv4 or ipv6)
+    repeated IPVersion ip_version = 25;
 }
 
 // EventType are constants are based on the ones from <linux/perf_event.h>.

--- a/pkg/hubble/filters/filters.go
+++ b/pkg/hubble/filters/filters.go
@@ -149,4 +149,5 @@ var DefaultFilters = []OnBuildFilter{
 	&HTTPFilter{},
 	&TCPFilter{},
 	&NodeNameFilter{},
+	&IPVersionFilter{},
 }

--- a/pkg/hubble/filters/ip.go
+++ b/pkg/hubble/filters/ip.go
@@ -103,3 +103,37 @@ func (f *IPFilter) OnBuildFilter(ctx context.Context, ff *flowpb.FlowFilter) ([]
 
 	return fs, nil
 }
+
+func filterByIPVersion(ipver []flowpb.IPVersion) (FilterFunc, error) {
+	return func(ev *v1.Event) bool {
+		flow := ev.GetFlow()
+		if flow == nil {
+			return false
+		}
+		ver := flow.GetIP().GetIpVersion()
+		for _, v := range ipver {
+			if v == ver {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+// IPVersionFilter implements IP version based filtering
+type IPVersionFilter struct{}
+
+// OnBuildFilter builds an IP version filter
+func (f *IPVersionFilter) OnBuildFilter(ctx context.Context, ff *flowpb.FlowFilter) ([]FilterFunc, error) {
+	var fs []FilterFunc
+
+	if ff.GetIpVersion() != nil {
+		pf, err := filterByIPVersion(ff.GetIpVersion())
+		if err != nil {
+			return nil, err
+		}
+		fs = append(fs, pf)
+	}
+
+	return fs, nil
+}

--- a/pkg/hubble/filters/ip_test.go
+++ b/pkg/hubble/filters/ip_test.go
@@ -229,3 +229,138 @@ func TestIPFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestIPVersionFilter(t *testing.T) {
+	allvers := []*v1.Event{
+		{Event: &flowpb.Flow{IP: &flowpb.IP{IpVersion: flowpb.IPVersion_IPv4}}},
+		{Event: &flowpb.Flow{IP: &flowpb.IP{IpVersion: flowpb.IPVersion_IPv6}}},
+		{Event: &flowpb.Flow{IP: &flowpb.IP{IpVersion: flowpb.IPVersion_IP_NOT_USED}}},
+	}
+	type args struct {
+		f  []*flowpb.FlowFilter
+		ev []*v1.Event
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    []bool
+	}{
+		{
+			name: "ipv4 test",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv4}},
+				},
+				ev: allvers,
+			},
+			want: []bool{
+				true,
+				false,
+				false,
+			},
+		},
+		{
+			name: "ipv6 test",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv6}},
+				},
+				ev: allvers,
+			},
+			want: []bool{
+				false,
+				true,
+				false,
+			},
+		},
+		{
+			name: "unknown network protocol test",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IP_NOT_USED}},
+				},
+				ev: allvers,
+			},
+			want: []bool{
+				false,
+				false,
+				true,
+			},
+		},
+		{
+			name: "both ipv4 and ipv6 allow test",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv4}},
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv6}},
+				},
+				ev: allvers,
+			},
+			want: []bool{
+				true,
+				true,
+				false,
+			},
+		},
+		{
+			name: "all ipv4,ipv6,unknown allow test",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv4}},
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv6}},
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IP_NOT_USED}},
+				},
+				ev: allvers,
+			},
+			want: []bool{
+				true,
+				true,
+				true,
+			},
+		},
+		{
+			name: "test with non-flow event",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv4}},
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IPv6}},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.AgentEvent{}},
+				},
+			},
+			want: []bool{
+				false,
+			},
+		},
+		{
+			name: "test with non-flow event and IP_NOT_USED",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{IpVersion: []flowpb.IPVersion{flowpb.IPVersion_IP_NOT_USED}},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.AgentEvent{}},
+				},
+			},
+			want: []bool{
+				false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&IPVersionFilter{}})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildFilterList(context.Background(), ) error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i, ev := range tt.args.ev {
+				if filterResult := fl.MatchOne(ev); filterResult != tt.want[i] {
+					t.Errorf("\"%s\" filterResult %d = %v, want %v", tt.name, i, filterResult, tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the server-side capability to filter events based on
IP version (ipv4/ipv6).

Fixes: cilium/hubble#459

```release-note
Adds capability to filter events based on IP version.
```
