### PR TITLE
Vagrantfile: Add support for SHARE_PARENT=2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -270,7 +270,10 @@ Vagrant.configure(2) do |config|
     end
     cilium_dir = '.'
     cilium_path = '/home/vagrant/go/src/github.com/cilium/cilium'
-    if ENV["SHARE_PARENT"] then
+    if ENV["SHARE_PARENT"] == "2" then
+      cilium_dir = '../..'
+      cilium_path = '/home/vagrant/go/src/github.com'
+    elsif ENV["SHARE_PARENT"] then
       cilium_dir = '..'
       cilium_path = '/home/vagrant/go/src/github.com/cilium'
     end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -74,7 +74,10 @@ SCRIPT
 Vagrant.configure("2") do |config|
     cilium_dir = '../'
     cilium_path = '/home/vagrant/go/src/github.com/cilium/cilium'
-    if ENV["SHARE_PARENT"] then
+    if ENV["SHARE_PARENT"] == "2" then
+        cilium_dir = '../../..'
+        cilium_path = '/home/vagrant/go/src/github.com'
+    elsif ENV["SHARE_PARENT"] then
         cilium_dir = '../..'
         cilium_path = '/home/vagrant/go/src/github.com/cilium'
     end


### PR DESCRIPTION
Add support for value "2" for "SHARE_PARENT" environment variable,
which causes the parent of the parent of the current directory to be
shared with the Dev VM. This is useful to share all the github.com
repositories in the developer's directory tree with the dev VM without
using "USER_MOUNTS".

This also fixes the NFS mount error on macOS when one exported NFS
directory is within another. This would happen if the cilium repo is
in the same tree that would be shared with USER_MOUNTS.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
