### PR TITLE
clustermesh: Ignore symlink files on fsnotify events

### DIFF
--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -66,6 +66,23 @@ func isEtcdConfigFile(path string) bool {
 	return strings.Contains(string(b), "endpoints:")
 }
 
+func (cdw *configDirectoryWatcher) handleAddedFile(name, absolutePath string) {
+	// A typical directory will look like this:
+	// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test5 -> ..data/test5
+	// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
+	//
+	// Ignore all backing files and only read the symlinks
+	if strings.HasPrefix(name, "..") {
+		return
+	}
+
+	if !isEtcdConfigFile(absolutePath) {
+		return
+	}
+
+	cdw.lifecycle.add(name, absolutePath)
+}
+
 func (cdw *configDirectoryWatcher) watch() error {
 	log.WithField(fieldConfig, cdw.path).Debug("Starting config directory watcher")
 
@@ -75,22 +92,12 @@ func (cdw *configDirectoryWatcher) watch() error {
 	}
 
 	for _, f := range files {
-		// A typical directory will look like this:
-		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test5 -> ..data/test5
-		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
-		//
-		// Ignore all backing files and only read the symlinks
-		if strings.HasPrefix(f.Name(), "..") || f.IsDir() {
+		if f.IsDir() {
 			continue
 		}
 
 		absolutePath := path.Join(cdw.path, f.Name())
-		if !isEtcdConfigFile(absolutePath) {
-			continue
-		}
-
-		log.WithField(fieldClusterName, f.Name()).WithField("mode", f.Mode()).Debugf("Found configuration in initial scan")
-		cdw.lifecycle.add(f.Name(), absolutePath)
+		cdw.handleAddedFile(f.Name(), absolutePath)
 	}
 
 	go func() {
@@ -103,7 +110,7 @@ func (cdw *configDirectoryWatcher) watch() error {
 				case event.Op&fsnotify.Create == fsnotify.Create,
 					event.Op&fsnotify.Write == fsnotify.Write,
 					event.Op&fsnotify.Chmod == fsnotify.Chmod:
-					cdw.lifecycle.add(name, event.Name)
+					cdw.handleAddedFile(name, event.Name)
 				case event.Op&fsnotify.Remove == fsnotify.Remove,
 					event.Op&fsnotify.Rename == fsnotify.Rename:
 					cdw.lifecycle.remove(name)


### PR DESCRIPTION
Kubernetes secrets are mapped into the pod using symlinks. The initial
scan was already correctly ignoring symlinks but the fsnotify events
have not been. This has resulted in invalid cluster configurations being
added:

```
ClusterMesh:            0/3 clusters ready, 0 global-services
   cluster2: not-ready, 0 nodes, 0 identities, 0 services, 0 failures (last: never)
   └  Waiting for initial connection to be established
   ..2021_01_08_21_11_57.892158678: not-ready, 0 nodes, 0 identities, 0 services, 0 failures (last: never)
   └  Waiting for initial connection to be established
   ..data: not-ready, 0 nodes, 0 identities, 0 services, 0 failures (last: never)
   └  Waiting for initial connection to be established
```

Fixes: 076b0188b98 ("Inter cluster connectivity (ClusterMesh)")