### PR TITLE
Bugtool: add taskset 

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -91,6 +91,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"sysctl -a",
 		"bpftool map show",
 		"bpftool prog show",
+		"taskset -pc 1",
 		// iptables
 		"iptables-save -c",
 		"iptables -S",


### PR DESCRIPTION
To assist with additional debugging around processor affinity, we are
adding the Taskset command to the bugtool.

Fixes: #14566

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

