### PR TITLE
Add TagSpecifications to ec2:CreateNetworkInterface only when len > 0

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -357,9 +357,12 @@ func (c *Client) CreateNetworkInterface(ctx context.Context, toAllocate int32, s
 		SecondaryPrivateIpAddressCount: toAllocate,
 		SubnetId:                       aws.String(subnetID),
 		Groups:                         groups,
-		TagSpecifications: []ec2_types.TagSpecification{
+	}
+
+	if len(c.eniTagSpecification.Tags) > 0 {
+		input.TagSpecifications = []ec2_types.TagSpecification{
 			c.eniTagSpecification,
-		},
+		}
 	}
 
 	c.limiter.Limit(ctx, "CreateNetworkInterface")


### PR DESCRIPTION
If no tags are being passed we currently still set the TagSpecification
which results in a 4xx from the ec2 API:
```
Unable to create interface on instance: unable to create ENI operation error EC2: CreateNetworkInterface, https response error StatusCode: 400, RequestID: 328945ae-c171-4987-b829-be5e8cd3e792, api error InvalidParameter: Tag specification must have at least one tag
```

Fixes 02bf3ba40040d735814c599e578a02356f4c861c.

Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

