### PR TITLE
v1.8 backports: daemon, node: refresh neighbor by sending arping periodically

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1414,6 +1414,11 @@ func runDaemon() {
 		d.SendNotification(monitorAPI.AgentNotifyStart, repr)
 	}
 
+	// Start periodical arping to refresh neighbor table
+	if d.datapath.Node().NodeNeighDiscoveryEnabled() {
+		d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
+	}
+
 	log.WithField("bootstrapTime", time.Since(bootstrapTimestamp)).
 		Info("Daemon initialization completed")
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -308,6 +308,16 @@ func (c *clusterNodesClient) NodeConfigurationChanged(config datapath.LocalNodeC
 	return nil
 }
 
+func (c *clusterNodesClient) NodeNeighDiscoveryEnabled() bool {
+	// no-op
+	return false
+}
+
+func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	// no-op
+	return
+}
+
 func (h *getNodes) cleanupClients() {
 	past := time.Now().Add(-clientGCTimeout)
 	for k, v := range h.clients {

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -15,6 +15,8 @@
 package fake
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/datapath"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
@@ -44,4 +46,12 @@ func (n *fakeNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error 
 
 func (n *fakeNodeHandler) NodeConfigurationChanged(config datapath.LocalNodeConfiguration) error {
 	return nil
+}
+
+func (n *fakeNodeHandler) NodeNeighDiscoveryEnabled() bool {
+	return false
+}
+
+func (n *fakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	return
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -15,6 +15,7 @@
 package linux
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -548,13 +549,41 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 }
 
+func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP, ifaceName string) (srcIPv4, nextHopIPv4 net.IP, err error) {
+	// Figure out whether nodeIPv4 is directly reachable (i.e. in the same L2)
+	routes, err := netlink.RouteGet(nodeIPv4)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to retrieve route for remote node IP: %w", err)
+	}
+
+	if len(routes) == 0 {
+		return nil, nil, fmt.Errorf("Remote node IP is not routable. Connectivity to pods on that node may be unavailable.")
+	}
+
+	// Use the first available route by default
+	srcIPv4 = make(net.IP, net.IPv4len)
+	nextHopIPv4 = nodeIPv4
+	copy(srcIPv4, routes[0].Src.To4())
+
+	for _, route := range routes {
+		if route.Gw != nil {
+			// nodeIPv4 is in a different L2 subnet, so it must be reachable through
+			// a gateway. Send arping to the gw IP addr instead of nodeIPv4.
+			// NOTE: we currently don't handle multipath, so only one gw can be used.
+			copy(srcIPv4, route.Src.To4())
+			copy(nextHopIPv4, route.Gw.To4())
+			break
+		}
+	}
+	return srcIPv4, nextHopIPv4, nil
+}
+
 // Must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName string) {
 	if newNode.IsLocal() {
 		return
 	}
 
-	srcIP := make(net.IP, net.IPv4len)
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
 	copy(nextHopIPv4, newNodeIP)
@@ -564,21 +593,10 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 		logfields.IPAddr:    nextHopIPv4,
 	})
 
-	// Figure out whether newNode is directly reachable (i.e. in the same L2)
-	routes, err := netlink.RouteGet(nextHopIPv4)
+	srcIPv4, nextHopIPv4, err := n.getSrcAndNextHopIPv4(nextHopIPv4, ifaceName)
 	if err != nil {
-		scopedLog.WithError(err).Error("Failed to retrieve route for remote node IP")
+		scopedLog.WithError(err).Error("Failed to determine source and next hop ip for arping")
 		return
-	}
-	for _, route := range routes {
-		if route.Gw != nil {
-			// newNode is in a different L2 subnet, so it must be reachable through
-			// a gateway. Send arping to the gw IP addr instead of newNode IP addr.
-			// NOTE: we currently don't handle multipath, so only one gw can be used.
-			copy(nextHopIPv4, route.Gw.To4())
-			copy(srcIP, route.Src.To4())
-			break
-		}
 	}
 
 	nextHopStr := nextHopIPv4.String()
@@ -600,7 +618,7 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 		}
 		link := linkAttr.Attrs().Index
 
-		hwAddr, _, err := arping.PingOverIface(nextHopIPv4, *iface, srcIP)
+		hwAddr, _, err := arping.PingOverIface(nextHopIPv4, *iface, srcIPv4)
 		if err != nil {
 			scopedLog.WithError(err).Error("arping failed")
 			return
@@ -625,6 +643,95 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *nodeTypes.Node, ifaceName str
 	}
 }
 
+func (n *linuxNodeHandler) refreshNeighbor(ctx context.Context, nodeToRefresh *nodeTypes.Node, ifaceName string, ch chan struct{}) {
+	defer close(ch)
+	if nodeToRefresh.IsLocal() {
+		return
+	}
+
+	nodeIP := nodeToRefresh.GetNodeIP(false).To4()
+	nextHopIPv4 := make(net.IP, len(nodeIP))
+	copy(nextHopIPv4, nodeIP)
+
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.Interface: ifaceName,
+		logfields.IPAddr:    nextHopIPv4,
+	})
+
+	srcIPv4, nextHopIPv4, err := n.getSrcAndNextHopIPv4(nextHopIPv4, ifaceName)
+	if err != nil {
+		scopedLog.WithError(err).Error("Failed to determine source and next hop ip for arping")
+		return
+	}
+
+	nextHopStr := nextHopIPv4.String()
+	n.mutex.Lock()
+	n.neighNextHopByNode[nodeToRefresh.Identity()] = nextHopStr
+	oldNeigh, oldNeighFound := n.neighByNextHop[nextHopStr]
+	_, refCountExists := n.neighNextHopRefCount[nextHopStr]
+
+	// If somehow the next hop of the neighbor we are refreshing hasn't been referenced, add it.
+	if !refCountExists {
+		n.neighNextHopRefCount.Add(nextHopStr)
+	}
+	n.mutex.Unlock()
+
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		scopedLog.WithError(err).Error("Failed to retrieve iface by name")
+		return
+	}
+
+	linkAttr, err := netlink.LinkByName(ifaceName)
+	if err != nil {
+		scopedLog.WithError(err).Error("Failed to retrieve iface by name (netlink)")
+		return
+	}
+	link := linkAttr.Attrs().Index
+
+	hwAddr, _, err := arping.PingOverIface(nextHopIPv4, *iface, srcIPv4)
+	if err != nil {
+		scopedLog.WithError(err).Error("arping failed")
+		return
+	}
+
+	// MAC address hasn't changed.
+	if oldNeighFound && hwAddr.String() == oldNeigh.HardwareAddr.String() {
+		return
+	}
+
+	scopedLog = scopedLog.WithField(logfields.HardwareAddr, hwAddr)
+
+	neigh := netlink.Neigh{
+		LinkIndex:    link,
+		IP:           nextHopIPv4,
+		HardwareAddr: hwAddr,
+		State:        netlink.NUD_PERMANENT,
+	}
+
+	// Don't proceed if the refresh controller canceled the context
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	if err := netlink.NeighSet(&neigh); err != nil {
+		scopedLog.WithError(err).Error("Failed to replace neighbor entry")
+		return
+	}
+	scopedLog.Debug("Neighbor MAC address has changed, replaced neighbor entry")
+
+	n.mutex.Lock()
+	n.neighByNextHop[nextHopStr] = &neigh
+	if option.Config.NodePortHairpin {
+		neighborsmap.NeighRetire(nextHopIPv4)
+	}
+	n.mutex.Unlock()
+	return
+}
+
+// Must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 	nextHopStr, found := n.neighNextHopByNode[oldNode.Identity()]
 	if !found {
@@ -1181,6 +1288,32 @@ func (n *linuxNodeHandler) NodeValidateImplementation(nodeToValidate nodeTypes.N
 	defer n.mutex.Unlock()
 
 	return n.nodeUpdate(nil, &nodeToValidate, false)
+}
+
+// NodeNeighDiscoveryEnabled returns whether node neighbor discovery is enabled
+func (n *linuxNodeHandler) NodeNeighDiscoveryEnabled() bool {
+	return n.enableNeighDiscovery
+}
+
+// NodeNeighborRefresh is called to refresh node neighbor table.
+// This is currently triggered by controller neighbor-table-refresh
+func (n *linuxNodeHandler) NodeNeighborRefresh(ctx context.Context, nodeToRefresh nodeTypes.Node) {
+	var ifaceName string
+	if option.Config.EnableNodePort {
+		ifaceName = option.Config.DirectRoutingDevice
+	} else if option.Config.EnableIPSec {
+		ifaceName = option.Config.EncryptInterface
+	}
+	refreshComplete := make(chan struct{})
+	go n.refreshNeighbor(ctx, &nodeToRefresh, ifaceName, refreshComplete)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-refreshComplete:
+			return
+		}
+	}
 }
 
 // NodeDeviceNameWithDefaultRoute returns the node's device name which

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -17,6 +17,7 @@
 package linux
 
 import (
+	"context"
 	"net"
 	"runtime"
 	"testing"
@@ -1036,6 +1037,36 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}
 	}
 	c.Assert(found, check.Equals, true)
+
+	// Swap MAC addresses of veth0 and veth1 to ensure the MAC address of veth1 changed.
+	// Trigger neighbor refresh on veth0 and check whether the arp entry was updated.
+	var veth0HwAddr, veth1HwAddr, updatedHwAddrFromArpEntry net.HardwareAddr
+	veth0HwAddr = veth0.Attrs().HardwareAddr
+	netns0.Do(func(ns.NetNS) error {
+		veth1, err := netlink.LinkByName("veth1")
+		c.Assert(err, check.IsNil)
+		veth1HwAddr = veth1.Attrs().HardwareAddr
+		err = netlink.LinkSetHardwareAddr(veth1, veth0HwAddr)
+		c.Assert(err, check.IsNil)
+		return nil
+	})
+
+	err = netlink.LinkSetHardwareAddr(veth0, veth1HwAddr)
+	c.Assert(err, check.IsNil)
+
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found = false
+	for _, n := range neighs {
+		if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+			found = true
+			updatedHwAddrFromArpEntry = n.HardwareAddr
+			break
+		}
+	}
+	c.Assert(found, check.Equals, true)
+	c.Assert(updatedHwAddrFromArpEntry.String(), check.Equals, veth0HwAddr.String())
 
 	// Remove nodev1, and check whether the arp entry was removed
 	err = linuxNodeHandler.NodeDelete(nodev1)

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -15,6 +15,7 @@
 package datapath
 
 import (
+	"context"
 	"net"
 
 	"github.com/cilium/cilium/pkg/cidr"
@@ -133,4 +134,10 @@ type NodeHandler interface {
 	// NodeConfigurationChanged is called when the local node configuration
 	// has changed
 	NodeConfigurationChanged(config LocalNodeConfiguration) error
+
+	// NodeNeighDiscoveryEnabled returns whether node neighbor discovery is enabled
+	NodeNeighDiscoveryEnabled() bool
+
+	// NodeNeighborRefresh is called to refresh node neighbor table
+	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node)
 }

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -15,6 +15,8 @@
 package peer
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/node/types"
 
@@ -123,6 +125,20 @@ func (h handler) NodeValidateImplementation(_ types.Node) error {
 func (h handler) NodeConfigurationChanged(_ datapath.LocalNodeConfiguration) error {
 	// no-op
 	return nil
+}
+
+// NodeNeighDiscoveryEnabled implements
+// datapath.NodeHandler.NodeNeighDiscoveryEnabled. It is a no-op.
+func (h handler) NodeNeighDiscoveryEnabled() bool {
+	// no-op
+	return false
+}
+
+// NodeNeighborRefresh implements
+// datapath.NodeHandler.NodeNeighborRefresh. It is a no-op.
+func (h handler) NodeNeighborRefresh(_ context.Context, _ types.Node) {
+	// no-op
+	return
 }
 
 // Close frees handler resources.

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -15,10 +15,13 @@
 package manager
 
 import (
+	"context"
 	"math"
 	"net"
+	"strconv"
 	"time"
 
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -27,13 +30,21 @@ import (
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
 	baseBackgroundSyncInterval = time.Minute
+	// The default value of kernel parameter net.ipv4.neigh.default.base_reachable_time_ms.
+	// If option.NeighborRefreshBaseInterval is not configured and we failed to
+	// read from sysctl, refresh at this interval.
+	neighborRefreshBaseInterval = 30 * time.Second
+
+	randGen = rand.NewSafeRand(time.Now().UnixNano())
 )
 
 type nodeEntry struct {
@@ -523,4 +534,49 @@ func (m *Manager) DeleteAllNodes() {
 	}
 	m.nodes = map[nodeTypes.Identity]*nodeEntry{}
 	m.mutex.Unlock()
+}
+
+// StartNeighborRefresh spawns a controller which refreshes neighbor table
+// by sending arping periodically. Linux keeps an arp entry in reachable
+// state for (0.5 ~ 1.5) * base_reachable_time_ms, default by 15 to 45 seconds:
+// https://elixir.bootlin.com/linux/v5.7.19/source/net/core/neighbour.c#L113
+// We do the refresh in a similar way.
+func (m *Manager) StartNeighborRefresh(nh datapath.NodeHandler) {
+	var interval time.Duration
+	baseReachableStr, err := sysctl.Read("net.ipv4.neigh.default.base_reachable_time_ms")
+	if err != nil {
+		interval = neighborRefreshBaseInterval
+	} else {
+		baseReachableU32, err := strconv.ParseUint(baseReachableStr, 10, 32)
+		if err != nil {
+			interval = neighborRefreshBaseInterval
+		} else {
+			interval = time.Duration(baseReachableU32) * time.Millisecond
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	controller.NewManager().UpdateController("neighbor-table-refresh",
+		controller.ControllerParams{
+			DoFunc: func(controllerCtx context.Context) error {
+				// cancel previous go routines from previous controller run
+				cancel()
+				ctx, cancel = context.WithCancel(controllerCtx)
+				m.mutex.RLock()
+				defer m.mutex.RUnlock()
+				for _, entry := range m.nodes {
+					if entry.node.IsLocal() {
+						continue
+					}
+					go func(c context.Context, e *nodeEntry) {
+						n := randGen.Int63n(int64(interval / 2))
+						time.Sleep(interval/2 + time.Duration(n))
+						nh.NodeNeighborRefresh(c, e.node)
+					}(ctx, entry)
+				}
+				return nil
+			},
+			RunInterval: interval,
+		},
+	)
+	return
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -17,6 +17,7 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -130,6 +131,14 @@ func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) erro
 
 func (n *signalNodeHandler) NodeConfigurationChanged(config datapath.LocalNodeConfiguration) error {
 	return nil
+}
+
+func (n *signalNodeHandler) NodeNeighDiscoveryEnabled() bool {
+	return false
+}
+
+func (n *signalNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	return
 }
 
 func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {

--- a/pkg/rand/safe_rand.go
+++ b/pkg/rand/safe_rand.go
@@ -48,6 +48,13 @@ func (sr *safeRand) Int63() int64 {
 	return v
 }
 
+func (sr *safeRand) Int63n(n int64) int64 {
+	sr.mu.Lock()
+	v := sr.r.Int63n(n)
+	sr.mu.Unlock()
+	return v
+}
+
 func (sr *safeRand) Uint32() uint32 {
 	sr.mu.Lock()
 	v := sr.r.Uint32()


### PR DESCRIPTION
v1.8 backports 2021-01-11

 * #14498 -- daemon, node: refresh neighbor by sending arping periodically (@jaffcheng)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14498; do contrib/backporting/set-labels.py $pr done 1.8; done
```