### PR TITLE
Fix clustermesh-apiserver dependencies on pkg/option

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -63,11 +63,16 @@ import (
 )
 
 type configuration struct {
-	clusterName string
+	clusterName      string
+	serviceProxyName string
 }
 
 func (c configuration) LocalClusterName() string {
 	return c.clusterName
+}
+
+func (c configuration) K8sServiceProxyName() string {
+	return c.serviceProxyName
 }
 
 var (
@@ -214,6 +219,9 @@ func runApiserver() error {
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
 		option.KVStoreOpt, "Key-value store options")
 	option.BindEnv(option.KVStoreOpt)
+
+	flags.StringVar(&cfg.serviceProxyName, option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
+	option.BindEnv(option.K8sServiceProxyName)
 
 	viper.BindPFlags(flags)
 	option.Config.Populate()

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -62,6 +62,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+type configuration struct {
+	clusterName string
+}
+
+func (c configuration) LocalClusterName() string {
+	return c.clusterName
+}
+
 var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "clustermesh-apiserver")
 
@@ -86,8 +94,8 @@ var (
 
 	mockFile        string
 	clusterID       int
-	clusterName     string
 	ciliumK8sClient clientset.Interface
+	cfg             configuration
 
 	shutdownSignal = make(chan struct{})
 
@@ -188,7 +196,7 @@ func runApiserver() error {
 	flags.IntVar(&clusterID, option.ClusterIDName, 0, "Cluster ID")
 	option.BindEnv(option.ClusterIDName)
 
-	flags.StringVar(&clusterName, option.ClusterName, "default", "Cluster name")
+	flags.StringVar(&cfg.clusterName, option.ClusterName, "default", "Cluster name")
 	option.BindEnv(option.ClusterName)
 
 	flags.StringVar(&mockFile, "mock-file", "", "Read from mock file")
@@ -218,8 +226,6 @@ func runApiserver() error {
 }
 
 func main() {
-	log.Infof("Starting Cilium ClusterMesh apiserver...")
-
 	installSigHandler()
 
 	if err := runApiserver(); err != nil {
@@ -352,7 +358,7 @@ func (n nodeStub) GetKeyName() string { return string(n) }
 func updateNode(obj interface{}) {
 	if ciliumNode, ok := obj.(*ciliumv2.CiliumNode); ok {
 		n := nodeTypes.ParseCiliumNode(ciliumNode)
-		n.Cluster = clusterName
+		n.Cluster = cfg.clusterName
 		n.ClusterID = clusterID
 		if err := ciliumNodeStore.UpdateLocalKeySync(context.Background(), &n); err != nil {
 			log.WithError(err).Warning("Unable to insert node into etcd")
@@ -497,6 +503,11 @@ func synchronizeCiliumEndpoints() {
 }
 
 func runServer(cmd *cobra.Command) {
+	log.WithFields(logrus.Fields{
+		"cluster-name": cfg.clusterName,
+		"cluster-id":   clusterID,
+	}).Info("Starting clustermesh-apiserver...")
+
 	if mockFile == "" {
 		k8s.Configure("", "", 0.0, 0)
 		if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
@@ -540,7 +551,7 @@ func runServer(cmd *cobra.Command) {
 		synchronizeIdentities()
 		synchronizeNodes()
 		synchronizeCiliumEndpoints()
-		operatorWatchers.StartSynchronizingServices(false)
+		operatorWatchers.StartSynchronizingServices(false, cfg)
 	}
 
 	go func() {

--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -128,9 +128,9 @@ func nodeOverrideFromCEW(n *nodeTypes.RegisterNode, cew *ciliumv2.CiliumExternal
 	}
 
 	// Override cluster
-	nk.Cluster = clusterName
+	nk.Cluster = cfg.clusterName
 	nk.ClusterID = clusterID
-	nk.Labels[k8sConst.PolicyLabelCluster] = clusterName
+	nk.Labels[k8sConst.PolicyLabelCluster] = cfg.clusterName
 
 	// Override CIDRs if defined
 	if cew.Spec.IPv4AllocCIDR != "" {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -606,7 +606,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		d.nodeDiscovery.JoinCluster(nodeTypes.GetName())
 
 		// Start services watcher
-		serviceStore.JoinClusterServices(&d.k8sWatcher.K8sSvcCache)
+		serviceStore.JoinClusterServices(&d.k8sWatcher.K8sSvcCache, option.Config)
 	}
 
 	// Start IPAM

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -361,6 +361,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		d.svc,
 		d.datapath,
 		d.redirectPolicyManager,
+		option.Config,
 	)
 
 	d.redirectPolicyManager.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)

--- a/operator/main.go
+++ b/operator/main.go
@@ -389,7 +389,7 @@ func onOperatorStartLeading(ctx context.Context) {
 
 	if kvstoreEnabled() {
 		if operatorOption.Config.SyncK8sServices {
-			operatorWatchers.StartSynchronizingServices(true)
+			operatorWatchers.StartSynchronizingServices(true, option.Config)
 		}
 
 		var goopts *kvstore.ExtraOptions

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -94,6 +94,8 @@ func k8sServiceHandler(clusterName string) {
 type ServiceSyncConfiguration interface {
 	// LocalClusterName must return the local cluster name
 	LocalClusterName() string
+
+	utils.ServiceConfiguration
 }
 
 // StartSynchronizingServices starts a controller for synchronizing services from k8s to kvstore
@@ -104,7 +106,7 @@ func StartSynchronizingServices(shared bool, cfg ServiceSyncConfiguration) {
 	log.Info("Starting to synchronize k8s services to kvstore...")
 	sharedOnly = shared
 
-	serviceOptsModifier, err := utils.GetServiceListOptionsModifier()
+	serviceOptsModifier, err := utils.GetServiceListOptionsModifier(cfg)
 	if err != nil {
 		log.WithError(err).Fatal("Error creating service option modifier")
 	}

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -50,6 +50,12 @@ type K8sWatcherSuite struct{}
 
 var _ = Suite(&K8sWatcherSuite{})
 
+type fakeWatcherConfiguration struct{}
+
+func (f *fakeWatcherConfiguration) K8sServiceProxyName() string {
+	return ""
+}
+
 type fakeEndpointManager struct {
 	OnGetEndpoints                func() []*endpoint.Endpoint
 	OnLookupPodName               func(string) *endpoint.Endpoint
@@ -226,6 +232,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		nil,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -529,6 +536,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -669,6 +677,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1115,6 +1124,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1408,6 +1418,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1694,6 +1705,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2545,6 +2557,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2057,12 +2057,12 @@ type DaemonConfig struct {
 	// LBMapEntries is the maximum number of entries allowed in BPF lbmap.
 	LBMapEntries int
 
-	// K8sServiceProxyName is the value of service.kubernetes.io/service-proxy-name label,
+	// k8sServiceProxyName is the value of service.kubernetes.io/service-proxy-name label,
 	// that identifies the service objects Cilium should handle.
 	// If the provided value is an empty string, Cilium will manage service objects when
 	// the label is not present. For more details -
 	// https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0031-20181017-kube-proxy-services-optional.md
-	K8sServiceProxyName string
+	k8sServiceProxyName string
 
 	// APIRateLimitName enables configuration of the API rate limits
 	APIRateLimit map[string]string
@@ -2237,6 +2237,13 @@ func (c *DaemonConfig) EndpointStatusIsEnabled(option string) bool {
 // LocalClusterName returns the name of the cluster Cilium is deployed in
 func (c *DaemonConfig) LocalClusterName() string {
 	return c.ClusterName
+}
+
+// K8sServiceProxyName returns the required value for the
+// service.kubernetes.io/service-proxy-name label in order for services to be
+// handled.
+func (c *DaemonConfig) K8sServiceProxyName() string {
+	return c.k8sServiceProxyName
 }
 
 // CiliumNamespaceName returns the name of the namespace in which Cilium is
@@ -2602,7 +2609,7 @@ func (c *DaemonConfig) Populate() {
 	c.PolicyAuditMode = viper.GetBool(PolicyAuditModeArg)
 	c.EnableIPv4FragmentsTracking = viper.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = viper.GetInt(FragmentsMapEntriesName)
-	c.K8sServiceProxyName = viper.GetString(K8sServiceProxyName)
+	c.k8sServiceProxyName = viper.GetString(K8sServiceProxyName)
 	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
 	c.LoadBalancerDSRDispatch = viper.GetString(LoadBalancerDSRDispatch)
 	c.LoadBalancerRSSv4CIDR = viper.GetString(LoadBalancerRSSv4CIDR)


### PR DESCRIPTION
The clustermesh-apiserver code indirectly used `pkg/option` without initializing it properly. Instead of fixing the initialization, refactor the dependency code to no longer use `pkg/option` but offer interfaces to pass in the required configuration.

``` release-note
Fix clustermesh-apiserver to respect non-standard cluster names and support `--k8s-service-proxy-name` option.
```