### PR TITLE
jenkinsfile: Increase timeout for k8s-all tests

### DIFF
--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
         SERVER_BOX = "cilium/ubuntu"
         FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
         CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
-        GINKGO_TIMEOUT="98m"
+        GINKGO_TIMEOUT="118m"
         RACE="""${sh(
                 returnStdout: true,
                 script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n ""; else echo -n "1"; fi'


### PR DESCRIPTION
The ginkgo timeout for k8s-all has been reached often recently [[1](https://jenkins.cilium.io/view/PR/job/Cilium-PR-Ginkgo-Tests-K8s/3864/testReport/junit/Suite-k8s-1/14/K8sHubbleTest_Hubble_Observe_Test_L3_L4_Flow/), [2](https://jenkins.cilium.io/view/PR/job/Cilium-PR-Ginkgo-Tests-K8s/3862/testReport/junit/Suite-k8s-1/14/K8sDatapathConfig_Encapsulation_Check_iptables_masquerading_with_random_fully/), [3](https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/3868/testReport/junit/Suite-k8s-1/14/K8sChaosTest_Restart_with_long_lived_connections_L3_L4_policies_still_work_while_Cilium_is_restarted/)] for jobs running on master. This pull request increases the timeout value.

Unfortunately, the CI dashboard doesn't allow us to separate k8s-all jobs based on master from other k8s-all jobs (mostly backports). It is therefore difficult to figure if there's a specific change that increased the runtime.