### PR TITLE
v1.8-backport-2021-01-11

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -174,6 +174,7 @@ Cilium Feature                           Minimum Kernel Version
 ======================================== ===============================
 :ref:`concepts_fragmentation`            >= 4.10
 :ref:`cidr_limitations`                  >= 4.11
+:ref:`encryption` in tunneling mode      >= 4.19
 :ref:`host-services`                     >= 4.19.57, >= 5.1.16,  >= 5.2
 :ref:`kubeproxy-free`                    >= 4.19.57, >= 5.1.16,  >= 5.2
 Full support for :ref:`session-affinity` >= 5.7

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/maps"
@@ -1143,6 +1144,12 @@ func initEnv(cmd *cobra.Command) {
 
 	if option.Config.EnableL7Proxy && !option.Config.InstallIptRules {
 		log.Fatal("L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
+	}
+
+	if option.Config.EnableIPSec && option.Config.Tunnel != option.TunnelDisabled {
+		if err := ipsec.ProbeXfrmStateOutputMask(); err != nil {
+			log.WithError(err).Fatal("IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later).")
+		}
 	}
 
 	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && option.Config.EncryptInterface == "" {

--- a/pkg/datapath/linux/ipsec/probe_linux.go
+++ b/pkg/datapath/linux/ipsec/probe_linux.go
@@ -1,0 +1,87 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build linux
+
+package ipsec
+
+import (
+	"encoding/hex"
+	"errors"
+	"net"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	dummyIP  = "169.254.169.254"
+	aeadKey  = "4242424242424242424242424242424242424242"
+	aeadAlgo = "rfc4106(gcm(aes))"
+	stateId  = 42
+)
+
+func initDummyXfrmState() *netlink.XfrmState {
+	state := ipSecNewState()
+
+	k, _ := hex.DecodeString(aeadKey)
+	state.Aead = &netlink.XfrmStateAlgo{
+		Name:   aeadAlgo,
+		Key:    k,
+		ICVLen: 128,
+	}
+	state.Spi = int(stateId)
+	state.Reqid = stateId
+
+	state.Src = net.ParseIP(dummyIP)
+	state.Dst = net.ParseIP(dummyIP)
+	return state
+}
+
+func createDummyXfrmState(state *netlink.XfrmState) error {
+	state.Mark = &netlink.XfrmMark{
+		Value: linux_defaults.RouteMarkDecrypt,
+		Mask:  linux_defaults.IPsecMarkMaskIn,
+	}
+	state.OutputMark = &netlink.XfrmMark{
+		Value: linux_defaults.RouteMarkDecrypt,
+		Mask:  linux_defaults.RouteMarkMask,
+	}
+	return netlink.XfrmStateAdd(state)
+}
+
+// ProbeXfrmStateOutputMask probes the kernel to determine if it supports
+// setting the xfrm state output mask (Linux 4.19+). It returns an error if
+// the output mask is not supported or if an error occurred, nil otherwise.
+func ProbeXfrmStateOutputMask() error {
+	state := initDummyXfrmState()
+	err := createDummyXfrmState(state)
+	if err != nil {
+		return err
+	}
+	defer netlink.XfrmStateDel(state)
+
+	var probedState *netlink.XfrmState
+	if probedState, err = netlink.XfrmStateGet(state); err != nil {
+		return err
+	}
+	if probedState == nil || probedState.OutputMark == nil {
+		return errors.New("IPSec output mark attribute missing from xfrm probe")
+	}
+	if probedState.OutputMark.Mask != linux_defaults.RouteMarkMask {
+		return errors.New("incorrect value for probed IPSec output mask attribute")
+	}
+	return nil
+}


### PR DESCRIPTION
v1.8 backports 2021-01-11

 * #14525 -- ipsec: Fatal on unsupported, <4.19 kernels in tunneling mode (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14525; do contrib/backporting/set-labels.py $pr done 1.8; done
```