### PR TITLE
Observer to ignore unhandled debug event types

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -139,7 +139,11 @@ nextEvent:
 		ev, err := s.payloadParser.Decode(monitorEvent)
 		if err != nil {
 			if !errors.Is(err, parserErrors.ErrUnknownEventType) {
-				s.log.WithError(err).WithField("event", monitorEvent).Debug("failed to decode payload")
+				// Debug event types MessageTypeDebug and MessageTypeCapture are treated as invalid type.
+				// To avoid spamming debug log, silence them until the parser for them is implemented.
+				if !parserErrors.IsErrInvalidType(err) {
+					s.log.WithError(err).WithField("event", monitorEvent).Debug("failed to decode payload")
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
When running cilium-agent in debug mode, the cilium-agent will throw
tons of logs which looks like this:
```
level=debug msg="failed to decode payload" error="can't decode following payload type: 2"
```
Type 2 means MessageTypeDebug. Similarly Type 3 MessageTypeCapture also
has similar issue. They are only for debug, so ignore the them from local observer.

