### PR TITLE
Remove two unused OpenAPI properties

### DIFF
--- a/Documentation/cheatsheet.rst
+++ b/Documentation/cheatsheet.rst
@@ -106,7 +106,6 @@ Check the status of the agent
 
     $ cilium status
     KVStore:                Ok         Consul: 172.17.0.3:8300
-    ContainerRuntime:       Ok
     Kubernetes:             Disabled
     Cilium:                 Ok         OK
     NodeMonitor:            Listening for events on 2 CPUs with 64x4096 of shared memory
@@ -121,7 +120,6 @@ Get a detailed status of the agent:
 
     $ cilium status --all-controllers --all-health --all-redirects
     KVStore:                Ok         Consul: 172.17.0.3:8300
-    ContainerRuntime:       Ok
     Kubernetes:             Disabled
     Cilium:                 Ok         OK
     NodeMonitor:            Listening for events on 2 CPUs with 64x4096 of shared memory

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -435,7 +435,6 @@ saved, in case of a failing test an exhaustive data will be added.
 	level=info msg="Vagrant: running command \"vagrant ssh-config runtime\""
 	cmd: "sudo cilium status" exitCode: 0
 	 KVStore:            Ok         Consul: 172.17.0.3:8300
-	ContainerRuntime:   Ok
 	Kubernetes:         Disabled
 	Kubernetes APIs:    [""]
 	Cilium:             Ok   OK

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -57,7 +57,6 @@ context of that pod:
 
    $ kubectl -n kube-system exec -ti cilium-2hq5z -- cilium status
    KVStore:                Ok   etcd: 1/1 connected: http://demo-etcd-lab--a.etcd.tgraf.test1.lab.corp.isovalent.link:2379 - 3.2.5 (Leader)
-   ContainerRuntime:       Ok   docker daemon: OK
    Kubernetes:             Ok   OK
    Kubernetes APIs:        ["cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service", "core/v1::Endpoint", "core/v1::Node", "CustomResourceDefinition"]
    Cilium:                 Ok   OK
@@ -82,7 +81,6 @@ of all nodes in the cluster:
 
    $ ./k8s-cilium-exec.sh cilium status
    KVStore:                Ok   Etcd: http://127.0.0.1:2379 - (Leader) 3.1.10
-   ContainerRuntime:       Ok
    Kubernetes:             Ok   OK
    Kubernetes APIs:        ["extensions/v1beta1::Ingress", "core/v1::Node", "CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service", "core/v1::Endpoint"]
    Cilium:                 Ok   OK
@@ -127,7 +125,6 @@ e.g.:
 
    $ cilium status
    KVStore:                Ok   etcd: 1/1 connected: https://192.168.33.11:2379 - 3.2.7 (Leader)
-   ContainerRuntime:       Ok
    Kubernetes:             Ok   OK
    Kubernetes APIs:        ["core/v1::Endpoint", "extensions/v1beta1::Ingress", "core/v1::Node", "CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service"]
    Cilium:                 Ok   OK

--- a/api/v1/models/name_manager.go
+++ b/api/v1/models/name_manager.go
@@ -21,9 +21,6 @@ import (
 // swagger:model NameManager
 type NameManager struct {
 
-	// Names to poll for DNS Poller
-	DNSPollNames []string `json:"DNSPollNames"`
-
 	// Mapping of FQDNSelectors to corresponding regular expressions
 	FQDNPolicySelectors []*SelectorEntry `json:"FQDNPolicySelectors"`
 }

--- a/api/v1/models/status_response.go
+++ b/api/v1/models/status_response.go
@@ -46,9 +46,6 @@ type StatusResponse struct {
 	// Status of ClusterMesh
 	ClusterMesh *ClusterMeshStatus `json:"cluster-mesh,omitempty"`
 
-	// Status of local container runtime
-	ContainerRuntime *Status `json:"container-runtime,omitempty"`
-
 	// Status of all endpoint controllers
 	Controllers ControllerStatuses `json:"controllers,omitempty"`
 
@@ -108,10 +105,6 @@ func (m *StatusResponse) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateClusterMesh(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateContainerRuntime(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -265,24 +258,6 @@ func (m *StatusResponse) validateClusterMesh(formats strfmt.Registry) error {
 		if err := m.ClusterMesh.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cluster-mesh")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *StatusResponse) validateContainerRuntime(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ContainerRuntime) { // not required
-		return nil
-	}
-
-	if m.ContainerRuntime != nil {
-		if err := m.ContainerRuntime.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("container-runtime")
 			}
 			return err
 		}

--- a/api/v1/models/zz_generated.deepcopy.go
+++ b/api/v1/models/zz_generated.deepcopy.go
@@ -857,11 +857,6 @@ func (in *StatusResponse) DeepCopyInto(out *StatusResponse) {
 		*out = new(ClusterMeshStatus)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ContainerRuntime != nil {
-		in, out := &in.ContainerRuntime, &out.ContainerRuntime
-		*out = new(Status)
-		**out = **in
-	}
 	if in.Controllers != nil {
 		in, out := &in.Controllers, &out.Controllers
 		*out = make(ControllerStatuses, len(*in))

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1594,9 +1594,6 @@ definitions:
       kvstore:
         description: Status of key/value datastore
         "$ref": "#/definitions/Status"
-      container-runtime:
-        description: Status of local container runtime
-        "$ref": "#/definitions/Status"
       hubble:
         description: Status of Hubble server
         "$ref": "#/definitions/HubbleStatus"

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2722,11 +2722,6 @@ definitions:
     description: Internal state about DNS names in relation to policy subsystem
     type: object
     properties:
-      DNSPollNames:
-        description: Names to poll for DNS Poller
-        type: array
-        items:
-          type: string
       FQDNPolicySelectors:
         description: Mapping of FQDNSelectors to corresponding regular expressions
         type: array

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3510,10 +3510,6 @@ func init() {
           "description": "Status of ClusterMesh",
           "$ref": "#/definitions/ClusterMeshStatus"
         },
-        "container-runtime": {
-          "description": "Status of local container runtime",
-          "$ref": "#/definitions/Status"
-        },
         "controllers": {
           "description": "Status of all endpoint controllers",
           "$ref": "#/definitions/ControllerStatuses"
@@ -7723,10 +7719,6 @@ func init() {
         "cluster-mesh": {
           "description": "Status of ClusterMesh",
           "$ref": "#/definitions/ClusterMeshStatus"
-        },
-        "container-runtime": {
-          "description": "Status of local container runtime",
-          "$ref": "#/definitions/Status"
         },
         "controllers": {
           "description": "Status of all endpoint controllers",

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3019,13 +3019,6 @@ func init() {
       "description": "Internal state about DNS names in relation to policy subsystem",
       "type": "object",
       "properties": {
-        "DNSPollNames": {
-          "description": "Names to poll for DNS Poller",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "FQDNPolicySelectors": {
           "description": "Mapping of FQDNSelectors to corresponding regular expressions",
           "type": "array",
@@ -7190,13 +7183,6 @@ func init() {
       "description": "Internal state about DNS names in relation to policy subsystem",
       "type": "object",
       "properties": {
-        "DNSPollNames": {
-          "description": "Names to poll for DNS Poller",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "FQDNPolicySelectors": {
           "description": "Mapping of FQDNSelectors to corresponding regular expressions",
           "type": "array",

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -627,15 +627,6 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 			State: d.statusResponse.Kvstore.State,
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
-	case d.statusResponse.ContainerRuntime != nil && d.statusResponse.ContainerRuntime.State != models.StatusStateOk:
-		msg := "Container runtime is not ready"
-		if d.statusResponse.ContainerRuntime.State == models.StatusStateDisabled {
-			msg = "Container runtime is disabled"
-		}
-		sr.Cilium = &models.Status{
-			State: d.statusResponse.ContainerRuntime.State,
-			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
-		}
 	case k8s.IsEnabled() && d.statusResponse.Kubernetes != nil && d.statusResponse.Kubernetes.State != models.StatusStateOk:
 		msg := "Kubernetes service is not ready"
 		sr.Cilium = &models.Status{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -190,8 +190,6 @@ func FormatStatusResponseBrief(w io.Writer, sr *models.StatusResponse) {
 	switch {
 	case statusUnhealthy(sr.Kvstore):
 		msg = fmt.Sprintf("kvstore: %s", sr.Kvstore.Msg)
-	case statusUnhealthy(sr.ContainerRuntime):
-		msg = fmt.Sprintf("container runtime: %s", sr.ContainerRuntime.Msg)
 	case sr.Kubernetes != nil && stateUnhealthy(sr.Kubernetes.State):
 		msg = fmt.Sprintf("kubernetes: %s", sr.Kubernetes.Msg)
 	case statusUnhealthy(sr.Cilium):
@@ -280,10 +278,6 @@ var (
 func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetails) {
 	if sr.Kvstore != nil {
 		fmt.Fprintf(w, "KVStore:\t%s\t%s\n", sr.Kvstore.State, sr.Kvstore.Msg)
-	}
-	if sr.ContainerRuntime != nil {
-		fmt.Fprintf(w, "ContainerRuntime:\t%s\t%s\n",
-			sr.ContainerRuntime.State, sr.ContainerRuntime.Msg)
 	}
 
 	kubeProxyDevices := ""

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3300,8 +3300,7 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 			}
 		}
 		statusFilter := `Status: {.cilium.state}  Health: {.cluster.ciliumHealth.state}` +
-			` Nodes "{.cluster.nodes[*].name}" ContinerRuntime: {.container-runtime.state}` +
-			` Kubernetes: {.kubernetes.state} KVstore: {.kvstore.state}`
+			` Nodes "{.cluster.nodes[*].name}" Kubernetes: {.kubernetes.state} KVstore: {.kvstore.state}`
 		data, _ := status.Filter(statusFilter)
 		fmt.Fprintf(CheckLogs, "%sCilium agent '%s': %s Controllers: Total %d Failed %d\n",
 			prefix, pod, data, total, failed)


### PR DESCRIPTION
The container runtime status property is no longer set by the daemon since commit 532ad9d44a6f. Support for DNS poller was removed in PR #13229 and the respective property is no longer set since commit 5590bf464ab4.

Remove these properties before eventually declaring the API stable.

```release-note
Remove the unused container runtime status and DNS poller names properties from Cilium API.
```
