### PR TITLE
docker: bump cilium-iproute2 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN make RACE=$RACE NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNE
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3
+FROM quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-12-10@sha256:57012cdb87e43f3f6e50027a6a18381601a579ae081d6493460854cfa77f42b8 as builder
+FROM quay.io/cilium/cilium-builder:2021-01-12@sha256:bc3465140fb5fc1db7170b40a2cd75144d532199d43ad42597af8c9466129525 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -3,7 +3,7 @@
 #
 FROM docker.io/cilium/cilium-llvm:cae23fe2f43497ae268bd8ec186930bc5f32afac as cilium-llvm
 
-FROM quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3
+FROM quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57
 LABEL maintainer="maintainer@cilium.io"
 ARG ARCH=amd64
 WORKDIR /go/src/github.com/cilium/cilium

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -3,7 +3,7 @@
 # development environmennt
 FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
-FROM quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3
+FROM quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57
 LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -57,7 +57,7 @@ RUN apt-get update && \
     strip -s ./loopback
 COPY --from=docker.io/cilium/cilium-llvm:cae23fe2f43497ae268bd8ec186930bc5f32afac /usr/local/bin/clang /usr/local/bin/llc /bin/
 COPY --from=docker.io/cilium/cilium-bpftool:906ffee7cd996bf6bde2c074cdd5954703a0fd5f /usr/local/bin/bpftool /bin/
-COPY --from=docker.io/cilium/cilium-iproute2:3f4e19bb56e261313291f314b604d44fe15ea47f /usr/local/bin/tc /usr/local/bin/ip /usr/local/bin/ss /bin/
+COPY --from=docker.io/cilium/cilium-iproute2:f873abca8c7128f48206c6aecbbcdc6315d3d79d /usr/local/bin/tc /usr/local/bin/ip /usr/local/bin/ss /bin/
 COPY --from=gops /go/bin/gops /bin/
 
 #

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.1-experimental
 
-# Copyright 2020 Authors of Cilium
+# Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:5af8f784456b17fc0a2bbe3777855ca198124272
-ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:95fea74fae5d8ef4adc5a07d4b79d7772d89a724
+ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:6b71cfc0306524da4ec2b9737f6dab747fed2b7b
 
 FROM ${CILIUM_BUILDER_IMAGE} as builder
 

--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.1-experimental
 
-# Copyright 2020 Authors of Cilium
+# Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:57f235db9a07e81c5b60c536498ecbf2501dd267@sha256:080245ac0d7d061e05613e6bf887dc3c8bb07392cd2ce265b8a4aaaad17f2125
@@ -10,7 +10,7 @@ ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bc
 
 ARG CILIUM_LLVM_IMAGE=docker.io/cilium/cilium-llvm:cae23fe2f43497ae268bd8ec186930bc5f32afac
 ARG CILIUM_BPFTOOL_IMAGE=docker.io/cilium/cilium-bpftool:fbb2e86339609f6755f53fcefd2257e4beea4423
-ARG CILIUM_IPROUTE2_IMAGE=docker.io/cilium/cilium-iproute2:3f4e19bb56e261313291f314b604d44fe15ea47f
+ARG CILIUM_IPROUTE2_IMAGE=docker.io/cilium/cilium-iproute2:f873abca8c7128f48206c6aecbbcdc6315d3d79d
 
 FROM ${CILIUM_LLVM_IMAGE} as llvm-dist
 FROM ${CILIUM_BPFTOOL_IMAGE} as bpftool-dist

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57"; fi'
             )}"""
     }
 

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57"; fi'
             )}"""
     }
 

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57"; fi'
             )}"""
         RUN_QUARANTINED="""${sh(
                 returnStdout: true,

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57"; fi'
             )}"""
     }
 

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-10@sha256:ee6f0f81fa73125234466c13fd16bed30cc3209daa2f57098f63e0285779e5f3"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-12@sha256:58655346265fda806deacd2b82735e9866b39d9d241f2f4b1d45e63cacc45b57"; fi'
             )}"""
     }
 

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:2020-12-10@sha256:57012cdb87e43f3f6e50027a6a18381601a579ae081d6493460854cfa77f42b8
+    image: quay.io/cilium/cilium-builder:2021-01-12@sha256:bc3465140fb5fc1db7170b40a2cd75144d532199d43ad42597af8c9466129525
     workingDir: /cilium
     command: ["sleep"]
     args:


### PR DESCRIPTION
Bump iproute2 image, and then cilium-runtime and cilium-builder that depend on it:

- Update iproute2 image to [f873abca8c71](quay.io/cilium/cilium-iproute2:f873abca8c7128f48206c6aecbbcdc6315d3d79d), using [latest build from image-tools](https://github.com/cilium/image-tools/runs/1688953137)
- Update cilium-runtime-dev with scripts/update-cilium-runtime-image.sh
- Build cilium-runtime [from Quay](https://quay.io/repository/cilium/cilium-runtime/build/0b08a52d-413c-4e52-953d-e49b3326652b) on top of the above changes, and update
- Build cilium-builder [from Quay](https://quay.io/repository/cilium/cilium-builder/build/05954363-4ae3-4570-8cf8-ddff9b0dec03) on top of the above changes, and update

```release-note
Expose the XFRM output mask in the bugtool archive.
```