### PR TITLE
datapath: Do not use proxy original source address with tunneling

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -456,8 +456,9 @@ func (m *IptablesManager) Init() {
 // the source IP address.
 func (m *IptablesManager) SupportsOriginalSourceAddr() bool {
 	// Original source address use works if xt_socket match is supported, or if ip early demux
-	// is disabled, or if the datapath is in a tunneling mode.
-	return m.haveSocketMatch || m.ipEarlyDemuxDisabled || option.Config.Tunnel != option.TunnelDisabled
+	// is disabled, but it is not needed when tunneling is used as the tunnel header carries
+	// the source security ID.
+	return (m.haveSocketMatch || m.ipEarlyDemuxDisabled) && option.Config.Tunnel == option.TunnelDisabled
 }
 
 // RemoveRules removes iptables rules installed by Cilium.


### PR DESCRIPTION
Tunnel headers carry the source security ID so the use of original
source address on Envoy upstream connections is not needed when
tunneling. This commit disables the use of original source address
when tunneling is used, which allows Envoy redirection to work also
when using Kind to simulate multiple nodes in a single docker host.

Fixes: #14268
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy use of original source address in upstream connetions is disabled when datapath is tunneling.
```
