### PR TITLE
bpf: fix misconfigured nat to 0.0.0.0 on !masquerade config

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -547,6 +547,11 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		log.Fatalf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.Masquerade, option.EnableBPFMasquerade)
+	} else if !option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
+		// There is not yet support for option.Config.EnableIPv6Masquerade
+		log.Infof("Auto-disabling %q feature since IPv4 masquerading was generally disabled",
+			option.EnableBPFMasquerade)
+		option.Config.EnableBPFMasquerade = false
 	}
 	if option.Config.EnableIPMasqAgent {
 		if !option.Config.EnableIPv4 {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -422,7 +422,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			cDefinesMap["SNAT_MAPPING_IPV6_SIZE"] = fmt.Sprintf("%d", option.Config.NATMapEntriesGlobal)
 		}
 
-		if option.Config.EnableBPFMasquerade && option.Config.EnableIPv4 {
+		if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
 			cDefinesMap["ENABLE_MASQUERADE"] = "1"
 			cidr := datapath.RemoteSNATDstAddrExclusionCIDRv4()
 			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR"] =


### PR DESCRIPTION
(See commit msg for detailled analysis.)