### PR TITLE
maglev: Parallelize calculation of permutations

### DIFF
--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -60,7 +60,7 @@ func (s *MaglevTestSuite) TestBackendRemoval(c *C) {
 
 func (s *MaglevTestSuite) BenchmarkGetMaglevTable(c *C) {
 	backendCount := 1000
-	m := uint64(DefaultTableSize)
+	m := uint64(131071)
 
 	backends := make([]string, 0, backendCount)
 	for i := 0; i < backendCount; i++ {


### PR DESCRIPTION
Create a number of goroutines to calculate Maglev backend permutatons.

We choose the number to be equal to the number of CPUs available, as the
calculation doesn't block and is completely CPU-bound. So, adding more
goroutines would introduce an overhead instead of an improvement.

The optimization gives ~5x improvement in time:

	BEFORE OPTIMIZATION
	> go test -v -check.v -check.b -check.btime 5s -check.bmem
	[..]
	MaglevTestSuite.BenchmarkGetMaglevTable 5 1352437020 ns/op 1049633299 B/op 9 allocs/op

	AFTER OPTIMIZATION
	> go test -v -check.v -check.b -check.btime 5s -check.bmem
	[..]
	MaglevTestSuite.BenchmarkGetMaglevTable 50 271517785 ns/op 1049633901 B/op 12 allocs/op

Signed-off-by: Chris Tarazi <chris@isovalent.com>
Signed-off-by: Martynas Pumputis <m@lambda.lt>

Related: https://github.com/cilium/cilium/issues/14397.