### PR TITLE
arp: Add retries to arping

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -1024,9 +1023,6 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		Name:        "node1",
 		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, ip1}},
 	}
-	// wait 1 second to give the OS time to setup the routes for the veth pairs
-	// just created.
-	time.Sleep(time.Second)
 	err = linuxNodeHandler.NodeAdd(nodev1)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
It has been observed that sometimes arping fails with "i/o timeout".
Further investigation \[1\] has shown that this happen due to the kernel
not sending packets. Therefore, to mitigate the issue, try multiple times
to send the request if the timeout error is encountered.

\[1\]: https://github.com/cilium/cilium/issues/14125#issuecomment-748499731

---

Currently, I'm not labeling it for backporting to v1.{8,9}, as I've opened a discussion whether we could backport the arp library too which would significantly reduce complexity of arping-related backports.