### PR TITLE
daemon, lbmap: Avoid premature initialization of BPF maps

### DIFF
--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,6 +107,13 @@ var bpfLBListCmd = &cobra.Command{
 	Short:   "List load-balancing configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf lb list")
+
+		// Ensure that the BPF map objects have been initialized before trying
+		// to list them. Note, this is _not_ creating a new map, but rather
+		// initializing the Go object representing the map. We don't need to
+		// pass the correct sizes here because once the maps are opened, their
+		// size will be read.
+		lbmap.Init(lbmap.InitParams{IPv4: true, IPv6: true})
 
 		var firstTitle string
 		serviceList := make(map[string][]string)

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -30,6 +30,14 @@ const (
 )
 
 var (
+	// AffinityMatchMap is the BPF map to implement session affinity.
+	AffinityMatchMap *bpf.Map
+	Affinity4Map     *bpf.Map
+	Affinity6Map     *bpf.Map
+)
+
+// initAffinity creates the BPF maps for implementing session affinity.
+func initAffinity(params InitParams) {
 	AffinityMatchMap = bpf.NewMap(
 		AffinityMatchMapName,
 		bpf.MapTypeHash,
@@ -41,31 +49,37 @@ var (
 		0, 0,
 		bpf.ConvertKeyValue,
 	).WithCache()
-	Affinity4Map = bpf.NewMap(
-		Affinity4MapName,
-		bpf.MapTypeLRUHash,
-		&Affinity4Key{},
-		int(unsafe.Sizeof(Affinity4Key{})),
-		&AffinityValue{},
-		int(unsafe.Sizeof(AffinityValue{})),
-		MaxEntries,
-		0,
-		0,
-		bpf.ConvertKeyValue,
-	)
-	Affinity6Map = bpf.NewMap(
-		Affinity6MapName,
-		bpf.MapTypeLRUHash,
-		&Affinity6Key{},
-		int(unsafe.Sizeof(Affinity6Key{})),
-		&AffinityValue{},
-		int(unsafe.Sizeof(AffinityValue{})),
-		MaxEntries,
-		0,
-		0,
-		bpf.ConvertKeyValue,
-	)
-)
+
+	if params.IPv4 {
+		Affinity4Map = bpf.NewMap(
+			Affinity4MapName,
+			bpf.MapTypeLRUHash,
+			&Affinity4Key{},
+			int(unsafe.Sizeof(Affinity4Key{})),
+			&AffinityValue{},
+			int(unsafe.Sizeof(AffinityValue{})),
+			MaxEntries,
+			0,
+			0,
+			bpf.ConvertKeyValue,
+		)
+	}
+
+	if params.IPv6 {
+		Affinity6Map = bpf.NewMap(
+			Affinity6MapName,
+			bpf.MapTypeLRUHash,
+			&Affinity6Key{},
+			int(unsafe.Sizeof(Affinity6Key{})),
+			&AffinityValue{},
+			int(unsafe.Sizeof(AffinityValue{})),
+			MaxEntries,
+			0,
+			0,
+			bpf.ConvertKeyValue,
+		)
+	}
+}
 
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapKey

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,46 +35,100 @@ const (
 
 	// SockRevNat4MapSize is the maximum number of entries in the BPF map.
 	SockRevNat4MapSize = 256 * 1024
+
+	// Service4MapV2Name is the name of the IPv4 LB Services v2 BPF map.
+	Service4MapV2Name = "cilium_lb4_services_v2"
+	// Backend4MapName is the name of the IPv4 LB backends BPF map.
+	Backend4MapName = "cilium_lb4_backends"
+	// RevNat4MapName is the name of the IPv4 LB reverse NAT BPF map.
+	RevNat4MapName = "cilium_lb4_reverse_nat"
 )
 
 var (
-	// MaxSockRevNat4MapEntries is the maximum number of entries in the BPF map.
-	// It is set by InitMapInfo(), but unit tests use the initial value below.
+	// MaxSockRevNat4MapEntries is the maximum number of entries in the BPF
+	// map. It is set by Init(), but unit tests use the initial value below.
 	MaxSockRevNat4MapEntries = SockRevNat4MapSize
+
+	// The following BPF maps are initialized in initSVC().
+
+	// Service4MapV2 is the IPv4 LB Services v2 BPF map.
+	Service4MapV2 *bpf.Map
+	// Backend4Map is the IPv4 LB backends BPF map.
+	Backend4Map *bpf.Map
+	// RevNat4Map is the IPv4 LB reverse NAT BPF map.
+	RevNat4Map *bpf.Map
 )
 
-var (
-	Service4MapV2 = bpf.NewMap("cilium_lb4_services_v2",
-		bpf.MapTypeHash,
-		&Service4Key{},
-		int(unsafe.Sizeof(Service4Key{})),
-		&Service4Value{},
-		int(unsafe.Sizeof(Service4Value{})),
-		MaxEntries,
-		0, 0,
-		bpf.ConvertKeyValue,
-	).WithCache()
-	Backend4Map = bpf.NewMap("cilium_lb4_backends",
-		bpf.MapTypeHash,
-		&Backend4Key{},
-		int(unsafe.Sizeof(Backend4Key{})),
-		&Backend4Value{},
-		int(unsafe.Sizeof(Backend4Value{})),
-		MaxEntries,
-		0, 0,
-		bpf.ConvertKeyValue,
-	).WithCache()
-	RevNat4Map = bpf.NewMap("cilium_lb4_reverse_nat",
-		bpf.MapTypeHash,
-		&RevNat4Key{},
-		int(unsafe.Sizeof(RevNat4Key{})),
-		&RevNat4Value{},
-		int(unsafe.Sizeof(RevNat4Value{})),
-		MaxEntries,
-		0, 0,
-		bpf.ConvertKeyValue,
-	).WithCache()
-)
+// initSVC constructs the IPv4 & IPv6 LB BPF maps used for Services. The maps
+// have their maximum entries configured. Note this does not create or open the
+// maps; it simply constructs the objects.
+func initSVC(params InitParams) {
+	if params.IPv4 {
+		Service4MapV2 = bpf.NewMap(Service4MapV2Name,
+			bpf.MapTypeHash,
+			&Service4Key{},
+			int(unsafe.Sizeof(Service4Key{})),
+			&Service4Value{},
+			int(unsafe.Sizeof(Service4Value{})),
+			MaxEntries,
+			0, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+		Backend4Map = bpf.NewMap(Backend4MapName,
+			bpf.MapTypeHash,
+			&Backend4Key{},
+			int(unsafe.Sizeof(Backend4Key{})),
+			&Backend4Value{},
+			int(unsafe.Sizeof(Backend4Value{})),
+			MaxEntries,
+			0, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+		RevNat4Map = bpf.NewMap(RevNat4MapName,
+			bpf.MapTypeHash,
+			&RevNat4Key{},
+			int(unsafe.Sizeof(RevNat4Key{})),
+			&RevNat4Value{},
+			int(unsafe.Sizeof(RevNat4Value{})),
+			MaxEntries,
+			0, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+	}
+
+	if params.IPv6 {
+		Service6MapV2 = bpf.NewMap(Service6MapV2Name,
+			bpf.MapTypeHash,
+			&Service6Key{},
+			int(unsafe.Sizeof(Service6Key{})),
+			&Service6Value{},
+			int(unsafe.Sizeof(Service6Value{})),
+			MaxEntries,
+			0, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+		Backend6Map = bpf.NewMap(Backend6MapName,
+			bpf.MapTypeHash,
+			&Backend6Key{},
+			int(unsafe.Sizeof(Backend6Key{})),
+			&Backend6Value{},
+			int(unsafe.Sizeof(Backend6Value{})),
+			MaxEntries,
+			0, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+		RevNat6Map = bpf.NewMap(RevNat6MapName,
+			bpf.MapTypeHash,
+			&RevNat6Key{},
+			int(unsafe.Sizeof(RevNat6Key{})),
+			&RevNat6Value{},
+			int(unsafe.Sizeof(RevNat6Value{})),
+			MaxEntries,
+			0, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+	}
+}
 
 // The compile-time check for whether the structs implement the interfaces
 var _ RevNatKey = (*RevNat4Key)(nil)

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,46 +35,28 @@ const (
 
 	// SockRevNat6MapSize is the maximum number of entries in the BPF map.
 	SockRevNat6MapSize = 256 * 1024
+
+	// Service6MapV2Name is the name of the IPv6 LB Services v2 BPF map.
+	Service6MapV2Name = "cilium_lb6_services_v2"
+	// Backend6MapName is the name of the IPv6 LB backends BPF map.
+	Backend6MapName = "cilium_lb6_backends"
+	// RevNat6MapName is the name of the IPv6 LB reverse NAT BPF map.
+	RevNat6MapName = "cilium_lb6_reverse_nat"
 )
 
 var (
-	// MaxSockRevNat6MapEntries is the maximum number of entries in the BPF map.
-	// It is set by InitMapInfo(), but unit tests use the initial value below.
+	// MaxSockRevNat6MapEntries is the maximum number of entries in the BPF
+	// map. It is set by Init(), but unit tests use the initial value below.
 	MaxSockRevNat6MapEntries = SockRevNat6MapSize
-)
 
-var (
-	Service6MapV2 = bpf.NewMap("cilium_lb6_services_v2",
-		bpf.MapTypeHash,
-		&Service6Key{},
-		int(unsafe.Sizeof(Service6Key{})),
-		&Service6Value{},
-		int(unsafe.Sizeof(Service6Value{})),
-		MaxEntries,
-		0, 0,
-		bpf.ConvertKeyValue,
-	).WithCache()
-	Backend6Map = bpf.NewMap("cilium_lb6_backends",
-		bpf.MapTypeHash,
-		&Backend6Key{},
-		int(unsafe.Sizeof(Backend6Key{})),
-		&Backend6Value{},
-		int(unsafe.Sizeof(Backend6Value{})),
-		MaxEntries,
-		0, 0,
-		bpf.ConvertKeyValue,
-	).WithCache()
-	// RevNat6Map represents the BPF map for reverse NAT in IPv6 load balancer
-	RevNat6Map = bpf.NewMap("cilium_lb6_reverse_nat",
-		bpf.MapTypeHash,
-		&RevNat6Key{},
-		int(unsafe.Sizeof(RevNat6Key{})),
-		&RevNat6Value{},
-		int(unsafe.Sizeof(RevNat6Value{})),
-		MaxEntries,
-		0, 0,
-		bpf.ConvertKeyValue,
-	).WithCache()
+	// The following BPF maps are initialized in initSVC().
+
+	// Service6MapV2 is the IPv6 LB Services v2 BPF map.
+	Service6MapV2 *bpf.Map
+	// Backend6Map is the IPv6 LB backends BPF map.
+	Backend6Map *bpf.Map
+	// RevNat6Map is the IPv6 LB reverse NAT BPF map.
+	RevNat6Map *bpf.Map
 )
 
 // The compile-time check for whether the structs implement the interfaces

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -610,10 +610,26 @@ func (svcs svcMap) addFEnBE(fe *loadbalancer.L3n4AddrID, be *loadbalancer.Backen
 	return &lbsvc
 }
 
-// InitMapInfo updates the map info defaults for sock rev nat {4,6} and lb maps.
-func InitMapInfo(maxSockRevNatEntries, lbMapMaxEntries int) {
-	MaxSockRevNat4MapEntries = maxSockRevNatEntries
-	MaxSockRevNat6MapEntries = maxSockRevNatEntries
+// Init updates the map info defaults for sock rev nat {4,6} and LB maps and
+// then initializes all LB-related maps.
+func Init(params InitParams) {
+	if params.MaxSockRevNatMapEntries != 0 {
+		MaxSockRevNat4MapEntries = params.MaxSockRevNatMapEntries
+		MaxSockRevNat6MapEntries = params.MaxSockRevNatMapEntries
+	}
 
-	MaxEntries = lbMapMaxEntries
+	if params.MaxEntries != 0 {
+		MaxEntries = params.MaxEntries
+	}
+
+	initSVC(params)
+	initAffinity(params)
+	initSourceRange(params)
+}
+
+// InitParams represents the parameters to be passed to Init().
+type InitParams struct {
+	IPv4, IPv6 bool
+
+	MaxSockRevNatMapEntries, MaxEntries int
 }

--- a/pkg/maps/lbmap/source_range.go
+++ b/pkg/maps/lbmap/source_range.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,25 +138,42 @@ type SourceRangeValue struct {
 func (v *SourceRangeValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 func (v *SourceRangeValue) String() string              { return "" }
 
-var SourceRange4Map = bpf.NewMap(
-	SourceRange4MapName,
-	bpf.MapTypeLPMTrie,
-	&SourceRangeKey4{}, int(unsafe.Sizeof(SourceRangeKey4{})),
-	&SourceRangeValue{}, int(unsafe.Sizeof(SourceRangeValue{})),
-	MaxEntries,
-	bpf.BPF_F_NO_PREALLOC, 0,
-	bpf.ConvertKeyValue,
-).WithCache()
+var (
+	// SourceRange4Map is the BPF map for storing IPv4 service source ranges to
+	// check if option.Config.EnableSVCSourceRangeCheck is enabled.
+	SourceRange4Map *bpf.Map
+	// SourceRange6Map is the BPF map for storing IPv6 service source ranges to
+	// check if option.Config.EnableSVCSourceRangeCheck is enabled.
+	SourceRange6Map *bpf.Map
+)
 
-var SourceRange6Map = bpf.NewMap(
-	SourceRange6MapName,
-	bpf.MapTypeLPMTrie,
-	&SourceRangeKey6{}, int(unsafe.Sizeof(SourceRangeKey6{})),
-	&SourceRangeValue{}, int(unsafe.Sizeof(SourceRangeValue{})),
-	MaxEntries,
-	bpf.BPF_F_NO_PREALLOC, 0,
-	bpf.ConvertKeyValue,
-).WithCache()
+// initSourceRange creates the BPF maps for storing both IPv4 and IPv6
+// service source ranges.
+func initSourceRange(params InitParams) {
+	if params.IPv4 {
+		SourceRange4Map = bpf.NewMap(
+			SourceRange4MapName,
+			bpf.MapTypeLPMTrie,
+			&SourceRangeKey4{}, int(unsafe.Sizeof(SourceRangeKey4{})),
+			&SourceRangeValue{}, int(unsafe.Sizeof(SourceRangeValue{})),
+			MaxEntries,
+			bpf.BPF_F_NO_PREALLOC, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+	}
+
+	if params.IPv6 {
+		SourceRange6Map = bpf.NewMap(
+			SourceRange6MapName,
+			bpf.MapTypeLPMTrie,
+			&SourceRangeKey6{}, int(unsafe.Sizeof(SourceRangeKey6{})),
+			&SourceRangeValue{}, int(unsafe.Sizeof(SourceRangeValue{})),
+			MaxEntries,
+			bpf.BPF_F_NO_PREALLOC, 0,
+			bpf.ConvertKeyValue,
+		).WithCache()
+	}
+}
 
 func srcRangeKey(cidr *cidr.CIDR, revNATID uint16, ipv6 bool) bpf.MapKey {
 	ones, _ := cidr.Mask.Size()


### PR DESCRIPTION
There is a flag called `--bpf-lb-map-max` that controls the maximum
number of entries in BPF LB maps. When this is set, it updates
`lbmap.MaxEntries` which is a package-level variable. All LB maps use
this variable to configure their maximum size.

However, due to `bpf.NewMap()` being called at the package-level (to
initialize "cilium_lb4_services_v2", "cilium_lb4_backends", etc.)
because it's in a `var()` block, `lbmap.MaxEntries` has not been updated
yet with the value passed from the aforementioned flag.

Ultimately, this means that the flag was never respected, meaning the
user was never able to change the maximum size of their BPF LB maps.

The reason `lbmap.MaxEntries` wasn't updated is because Golang will
initialize variables defined in the `var()` block as soon as the package
is imported, aka before `main()` [1]. In this case, whenever the `lbmap`
package was first imported, then the call to `bpf.NewMap()` was made
with the yet-to-be updated `lbmap.MaxEntries`. Only after this has
happened (`main()` begins execution), then Cilium will eventually get to
reading the flag value and updating `lbmap.MaxEntries`.

This commit avoids the initialization at the `var()` block and instead
defines explicit initialization functions to be called when appropriate,
in this case, after reading the flag and updating `lbmap.MaxEntries`,
inside `lbmap.Init()`.

This was found by running scale tests against the service code, e.g.
creating 1000+ backends per service. The following error was observed
and has been fixed with this commit:

```
[PUT /service/{id}][500] putServiceIdFailure  Unable to update service entry 1.1.0.131:36895 => 2871 (37415) [FLAGS: 0x0]: Unable to update element for map with file descriptor 14: argument list too long
```

[1]: See below for excerpt. Source:
https://golang.org/ref/spec#Program_initialization_and_execution

    Within a package, package-level variable initialization proceeds
    stepwise, with each step selecting the variable earliest in
    declaration order which has no dependencies on uninitialized
    variables.

    [...]

    A package with no imports is initialized by assigning initial values
    to all its package-level variables followed by calling all init
    functions in the order they appear in the source, possibly in
    multiple files, as presented to the compiler. If a package has
    imports, the imported packages are initialized before initializing
    the package itself. If multiple packages import a package, the
    imported package will be initialized only once. The importing of
    packages, by construction, guarantees that there can be no cyclic
    initialization dependencies.

    Package initialization—variable initialization and the invocation of
    init functions—happens in a single goroutine, sequentially, one
    package at a time. An init function may launch other goroutines,
    which can run concurrently with the initialization code. However,
    initialization always sequences the init functions: it will not
    invoke the next one until the previous one has returned.


```release-note
Fix bug where Cilium did not respect `--bpf-lb-map-max` and wouldn't update the maximum size of BPF LB maps
```