### PR TITLE
cilium: Send pod->node traffic through tunnel in IPSec+vxlan case

### DIFF
--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -47,6 +47,7 @@ var _ = check.Suite(&managerTestSuite{})
 type configMock struct {
 	RemoteNodeIdentity bool
 	NodeEncryption     bool
+	Encryption         bool
 }
 
 func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
@@ -55,6 +56,10 @@ func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
 
 func (c *configMock) NodeEncryptionEnabled() bool {
 	return c.NodeEncryption
+}
+
+func (c *configMock) EncryptionEnabled() bool {
+	return c.Encryption
 }
 
 type nodeEvent struct {
@@ -559,7 +564,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true})
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true, Encryption: true})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2191,6 +2191,11 @@ func (c *DaemonConfig) NodeEncryptionEnabled() bool {
 	return c.EncryptNode
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (c *DaemonConfig) EncryptionEnabled() bool {
+	return c.EnableIPSec
+}
+
 // IPv4Enabled returns true if IPv4 is enabled
 func (c *DaemonConfig) IPv4Enabled() bool {
 	return c.EnableIPv4

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -33,6 +33,11 @@ func (f *Config) RemoteNodeIdentitiesEnabled() bool {
 	return true
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (f *Config) EncryptionEnabled() bool {
+	return true
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true


### PR DESCRIPTION
### Packet path analysis

If a pod in host networking and/or the node itself sends traffic to a pod with encryption+vxlan enabled and encryptNode disabled we may see dropped packets. The flow is the following.

#### Forward path: pod -> node

First, a packet is sent from the host networking with srcIP=nodeIP,dstIP=podIP. Next a source IP is chosen for the packet so
that the route src will not be used. Then the route table 'routes' the packet to cilium_host using the route rule matching podIPs subnet,

    podIPSubnet via $IP dev cilium_host src $SrcIP mtu 1410

Then we drop into BPF space with srcIP=nodeIP,dstIP=podIP as above. Here we do an ipcache lookup for the destination. The ipcache lookup will have a hit for the podIP and will have both a key and tunnelIP. For example something like this,

    10.128.5.129/32     1169 3 10.0.0.4

Using above key identifier, in the example '3', the bpf_host program will mark the packet for encryption. This will pass encryption parameters through the ctx where the ingress program attached to cilium_net will in turn use those parameters to set skb->mark before passing up to the stack for encryption. At this point we have a skb ingress'ing the stack with an skb->mark=0xe00,srcIP=nodeIP,dstIP=podIP.

Here is where the trouble starts. This will miss encryption policy rules because unless encryptNode is enabled we do not have a rule to match srcIP=nodeIP. So the unencrypted packet is sent back to cilium_host using a route in the encryption routing table. Then finally bpf_host will send the skb to the overlay, cilium_vxlan.

The packet is then received by the podIP node and sent to cilium_vxlan because its a vxlan packet. The vxlan header is popped off and the inner (unencrypted) packet is sent to the pod, remember srcIP=nodeIP still.

#### Response path: node -> pod

Assuming the above was a SYN packet the pod will respond with a SYN/ACK with srcIP=podIP,dstIP=nodeIP. This will be handled by the bpf_lxc program.

First, we will do an ipcache lookup and get an ipcache entry, but this entry will not have a tunnelIP (although it will have a key). Because no tunnelIP is available a tunnel map lookup will be done. This will fail because the dstIP is a nodeIP and not in a tunnel subnet. (The tunnel map key is done by masking the dstIP with the subnet.)

Because the program did not find a valid tunnel the packet is sent to the stack. The stack will run through iptables, but because the packet flow is asymmetric (SYN over cilium_vxlan, SYN/ACK over nic) the MASQUERADE rules will be skipped. The end result is we try to send a packet with the srcIP=podIP.

Here a couple different outcomes are possible. If the network infra is strict the packet may be dropped at the sending node, refusing to send a packet with an unknown srcIP. If the receiving node has rp_filter=1 on the receiving interface, the packet will be dropped with a martian IP message in dmesg. Or if rp_filter=0 and the network knows how to route the srcIP somehow, it might work. For example some of my test systems managed to work without any issues.

### Fix with symmetric routing

In order to fix this we can ensure reply packets are symmetric to the request. To do this we inject tunnel info into nodeIP ipcache entry. Once this is done the pod replying will do the following,

Send a packet with srcIP=podIP,dstIP=nodeIP, this is picked up by the bpf_lxc program. The ipcache lookup finds a complete entry now with the tunnel info. Now instead of sending that packet to the stack it will be encapsulated in the vxlan header and sent/received on the original requesting node.

### Notes

A quick observation: some of the passes through the xfrm stack are useless here. We know the miss is going to happen and can signal this to the bpf layer by clearing the encryption key in the ipcache. We will do this as a follow up patch.

Open question, why does the non-encryption sender manage to send a packet with srcIP=cilium_host_IP instead of the node?

```release-note
Fix ipsec+vxlan bug where egressing packets would bypass masquerading on their way to remote nodes 
```