### PR TITLE
ci: only run Nightly workflows on cilium/cilium

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   policy-stress-test:
     name: Start Nightly Policy Stress tests
+    if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-18.04
     steps:
       - name: Trim git sha
@@ -19,6 +20,7 @@ jobs:
           args: --namespace=test-clusters --image=cilium/cilium-test-dev:${{ steps.vars.outputs.sha_short }} "/usr/local/bin/cilium-test-gke.sh" "quay.io/cilium/cilium:latest" "quay.io/cilium/operator-generic:latest" "quay.io/cilium/hubble-relay:latest" "NightlyPolicyStress"
   baseline-test:
     name: Start performance test
+    if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Before this patch, any fork of Cilium on GitHub would attempt to run the Nightly jobs.