### PR TITLE
v1.9 backports 2021-01-14

### DIFF
--- a/Documentation/concepts/kubernetes/policy.rst
+++ b/Documentation/concepts/kubernetes/policy.rst
@@ -115,20 +115,26 @@ CiliumClusterwideNetworkPolicy
 `CiliumClusterwideNetworkPolicy` is similar to `CiliumNetworkPolicy`, except
 (1) policies defined by `CiliumClusterwideNetworkPolicy` are non-namespaced and
 cluster-scoped, and (2) it enables the use of :ref:`NodeSelector`. Internally
-the policy is composed of `CiliumNetworkPolicy` itself and thus the effects of
-this policy specification are also same.
+the policy is identical to `CiliumNetworkPolicy` and thus the effects of this
+policy specification are also same.
 
 The raw specification of the resource in go looks like this:
 
 .. code-block:: go
 
         type CiliumClusterwideNetworkPolicy struct {
-                *CiliumNetworkPolicy
+                // Spec is the desired Cilium specific rule specification.
+                Spec *api.Rule
 
-                // Status is the status of the Cilium policy rule
-                // +optional
-                // The reason this field exists in this structure is due a bug in the k8s code-generator
-                // that doesn't create a `UpdateStatus` method because the field does not exist in
-                // the structure.
-                Status CiliumNetworkPolicyStatus `json:"status"`
+                // Specs is a list of desired Cilium specific rule specification.
+                Specs api.Rules
+
+                // Status is the status of the Cilium policy rule.
+                //
+                // The reason this field exists in this structure is due a bug in the k8s
+                // code-generator that doesn't create a `UpdateStatus` method because the
+                // field does not exist in the structure.
+                //
+                // +kubebuilder:validation:Optional
+                Status CiliumNetworkPolicyStatus
         }

--- a/Documentation/concepts/kubernetes/policy.rst
+++ b/Documentation/concepts/kubernetes/policy.rst
@@ -69,9 +69,10 @@ The raw specification of the resource in Go looks like this:
 .. code-block:: go
 
         type CiliumNetworkPolicy struct {
+                // +deepequal-gen=false
                 metav1.TypeMeta `json:",inline"`
-                // +optional
-                Metadata metav1.ObjectMeta `json:"metadata"`
+                // +deepequal-gen=false
+                metav1.ObjectMeta `json:"metadata"`
 
                 // Spec is the desired Cilium specific rule specification.
                 Spec *api.Rule `json:"spec,omitempty"`
@@ -80,7 +81,9 @@ The raw specification of the resource in Go looks like this:
                 Specs api.Rules `json:"specs,omitempty"`
 
                 // Status is the status of the Cilium policy rule
-                // +optional
+                //
+                // +deepequal-gen=false
+                // +kubebuilder:validation:Optional
                 Status CiliumNetworkPolicyStatus `json:"status"`
         }
 

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -66,7 +66,6 @@ Deploy Cilium release via Helm:
      --set cni.chainingMode=generic-veth \\
      --set cni.customConf=true \\
      --set nodeinit.enabled=true \\
-     --set nodeinit.expectAzureVnet=true \\
      --set cni.configMap=cni-configuration \\
      --set tunnel=disabled \\
      --set masquerade=false

--- a/Documentation/gettingstarted/k8s-install-azure.rst
+++ b/Documentation/gettingstarted/k8s-install-azure.rst
@@ -77,6 +77,11 @@ Deploy Cilium
 
 Deploy Cilium release via Helm:
 
+.. warning::
+  Deploying Cilium with ``azure.enabled=true`` will disconnect all running Pods
+  in the cluster that were scheduled using the default ``azure-vnet`` CNI plugin.
+  We aim to remove this limitation before moving Azure IPAM out of Beta.
+
 .. parsed-literal::
 
    helm install cilium |CHART_RELEASE| \\

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -760,6 +760,11 @@ NodePort XDP requires Cilium to run in direct routing mode (``tunnel=disabled``)
 It is recommended to use Azure IPAM for the pod IP address allocation, which
 will automatically configure your virtual network to route pod traffic correctly:
 
+.. warning::
+  Deploying Cilium with ``azure.enabled=true`` will disconnect all running Pods
+  in the cluster that were scheduled using the default ``azure-vnet`` CNI plugin.
+  We aim to remove this limitation before moving Azure IPAM out of Beta.
+
 .. parsed-literal::
 
    helm install cilium |CHART_RELEASE| \\

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -62,11 +62,16 @@ import (
 )
 
 type configuration struct {
-	clusterName string
+	clusterName      string
+	serviceProxyName string
 }
 
 func (c configuration) LocalClusterName() string {
 	return c.clusterName
+}
+
+func (c configuration) K8sServiceProxyName() string {
+	return c.serviceProxyName
 }
 
 var (
@@ -213,6 +218,9 @@ func runApiserver() error {
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
 		option.KVStoreOpt, "Key-value store options")
 	option.BindEnv(option.KVStoreOpt)
+
+	flags.StringVar(&cfg.serviceProxyName, option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
+	option.BindEnv(option.K8sServiceProxyName)
 
 	viper.BindPFlags(flags)
 	option.Config.Populate()

--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -129,9 +129,9 @@ func nodeOverrideFromCEW(n *nodeTypes.RegisterNode, cew *ciliumv2.CiliumExternal
 	}
 
 	// Override cluster
-	nk.Cluster = clusterName
+	nk.Cluster = cfg.clusterName
 	nk.ClusterID = clusterID
-	nk.Labels[k8sConst.PolicyLabelCluster] = clusterName
+	nk.Labels[k8sConst.PolicyLabelCluster] = cfg.clusterName
 
 	// Override CIDRs if defined
 	if cew.Spec.IPv4AllocCIDR != "" {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -363,6 +363,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		d.svc,
 		d.datapath,
 		d.redirectPolicyManager,
+		option.Config,
 	)
 
 	d.redirectPolicyManager.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -608,7 +608,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		d.nodeDiscovery.JoinCluster(nodeTypes.GetName())
 
 		// Start services watcher
-		serviceStore.JoinClusterServices(&d.k8sWatcher.K8sSvcCache)
+		serviceStore.JoinClusterServices(&d.k8sWatcher.K8sSvcCache, option.Config)
 	}
 
 	// Start IPAM

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -549,6 +549,11 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		log.Fatalf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.Masquerade, option.EnableBPFMasquerade)
+	} else if !option.Config.Masquerade && option.Config.EnableBPFMasquerade {
+		// There is not yet support for option.Config.EnableIPv6Masquerade
+		log.Infof("Auto-disabling %q feature since IPv4 masquerading was generally disabled",
+			option.EnableBPFMasquerade)
+		option.Config.EnableBPFMasquerade = false
 	}
 	if option.Config.EnableIPMasqAgent {
 		if !option.Config.EnableIPv4 {

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -105,7 +105,9 @@ spec:
           - name: CHECKPOINT_PATH
             value: /tmp/node-init.cilium.io
           # STARTUP_SCRIPT is the script run on node bootstrap. Node
-          # bootstrapping can be customized in this script.
+          # bootstrapping can be customized in this script. This script is invoked
+          # using nsenter, so it runs in the host's network and mount namespace using
+          # the host's userland tools!
           - name: STARTUP_SCRIPT
             value: |
               #!/bin/bash
@@ -221,6 +223,40 @@ spec:
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
               fi
 {{- end }}
+
+              # AKS: If azure-vnet is installed on the node, and (still) configured in bridge mode,
+              # configure it as 'transparent' to be consistent with Cilium's CNI chaining config.
+              # If the azure-vnet CNI config is not removed, kubelet will execute CNI CHECK commands
+              # against it every 5 seconds and write 'bridge' to its state file, causing inconsistent
+              # behaviour when Pods are removed.
+              if [ -f /etc/cni/net.d/10-azure.conflist ]; then
+
+                echo "azure-vnet configured in bridge mode. Changing to 'transparent'..."
+                sed -i 's/"mode":\s*"bridge"/"mode":"transparent"/g' /etc/cni/net.d/10-azure.conflist
+
+{{- if .Values.azure.enabled }}
+                # In Azure IPAM mode, also remove the azure-vnet state file, otherwise ebtables rules get
+                # restored by the azure-vnet CNI plugin on every CNI CHECK, which can cause connectivity
+                # issues in Cilium-managed Pods. Since azure-vnet is no longer called on scheduling events,
+                # this file can be removed.
+                rm -f /var/run/azure-vnet.json
+
+                # This breaks connectivity for existing workload Pods when Cilium is scheduled, but we need
+                # to flush these to prevent Cilium-managed Pod IPs conflicting with Pod IPs previously allocated
+                # by azure-vnet. These ebtables DNAT rules contain fixed MACs that are no longer bound on the node,
+                # causing packets for these Pods to be redirected back out to the gateway, where they are dropped.
+                echo 'Flushing ebtables pre/postrouting rules in nat table.. (disconnecting non-Cilium Pods!)'
+                ebtables -t nat -F PREROUTING || true
+                ebtables -t nat -F POSTROUTING || true
+
+                # ip-masq-agent periodically injects PERM neigh entries towards the gateway
+                # for all other k8s nodes in the cluster. These are safe to flush, as ARP can
+                # resolve these nodes as usual. PERM entries will be automatically restored later.
+                echo 'Deleting all permanent neighbour entries on azure0...'
+                ip neigh show dev azure0 nud permanent | cut -d' ' -f1 | xargs -r -n1 ip neigh del dev azure0 to
+{{- end }}
+
+              fi
 
 {{- if .Values.nodeinit.revertReconfigureKubelet }}
               rm -f /tmp/node-deinit.cilium.io

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -230,11 +230,16 @@ spec:
               # against it every 5 seconds and write 'bridge' to its state file, causing inconsistent
               # behaviour when Pods are removed.
               if [ -f /etc/cni/net.d/10-azure.conflist ]; then
-
-                echo "azure-vnet configured in bridge mode. Changing to 'transparent'..."
+                echo "Ensuring azure-vnet is configured in 'transparent' mode..."
                 sed -i 's/"mode":\s*"bridge"/"mode":"transparent"/g' /etc/cni/net.d/10-azure.conflist
+              fi
 
 {{- if .Values.azure.enabled }}
+              # The azure0 interface being present means the node was booted with azure-vnet configured
+              # in bridge mode. This means there might be ebtables rules and neight entries interfering
+              # with pod connectivity if we deploy with Azure IPAM.
+              if ip l show dev azure0 >/dev/null 2>&1; then
+
                 # In Azure IPAM mode, also remove the azure-vnet state file, otherwise ebtables rules get
                 # restored by the azure-vnet CNI plugin on every CNI CHECK, which can cause connectivity
                 # issues in Cilium-managed Pods. Since azure-vnet is no longer called on scheduling events,
@@ -253,10 +258,9 @@ spec:
                 # for all other k8s nodes in the cluster. These are safe to flush, as ARP can
                 # resolve these nodes as usual. PERM entries will be automatically restored later.
                 echo 'Deleting all permanent neighbour entries on azure0...'
-                ip neigh show dev azure0 nud permanent | cut -d' ' -f1 | xargs -r -n1 ip neigh del dev azure0 to
-{{- end }}
-
+                ip neigh show dev azure0 nud permanent | cut -d' ' -f1 | xargs -r -n1 ip neigh del dev azure0 to || true
               fi
+{{- end }}
 
 {{- if .Values.nodeinit.revertReconfigureKubelet }}
               rm -f /tmp/node-deinit.cilium.io

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -162,18 +162,6 @@ spec:
               ip -4 a
               ip -6 a
 
-{{- if or .Values.nodeinit.expectAzureVnet .Values.azure.enabled }}
-              # Azure specific: Transparent bridge mode is required in order
-              # for proxy-redirection to work
-              until [ -f /var/run/azure-vnet.json ]; do
-                echo waiting for azure-vnet to be created
-                sleep 1s
-              done
-              if [ -f /var/run/azure-vnet.json ]; then
-                sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
-              fi
-{{- end }}
-
 {{- if .Values.nodeinit.removeCbrBridge }}
               if ip link show cbr0; then
                 echo "Detected cbr0 bridge. Deleting interface..."

--- a/operator/main.go
+++ b/operator/main.go
@@ -345,7 +345,7 @@ func onOperatorStartLeading(ctx context.Context) {
 
 	if kvstoreEnabled() {
 		if operatorOption.Config.SyncK8sServices {
-			operatorWatchers.StartSynchronizingServices(true)
+			operatorWatchers.StartSynchronizingServices(true, option.Config)
 		}
 
 		var goopts *kvstore.ExtraOptions

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -94,6 +94,8 @@ func k8sServiceHandler(clusterName string) {
 type ServiceSyncConfiguration interface {
 	// LocalClusterName must return the local cluster name
 	LocalClusterName() string
+
+	utils.ServiceConfiguration
 }
 
 // StartSynchronizingServices starts a controller for synchronizing services from k8s to kvstore
@@ -104,7 +106,7 @@ func StartSynchronizingServices(shared bool, cfg ServiceSyncConfiguration) {
 	log.Info("Starting to synchronize k8s services to kvstore...")
 	sharedOnly = shared
 
-	serviceOptsModifier, err := utils.GetServiceListOptionsModifier()
+	serviceOptsModifier, err := utils.GetServiceListOptionsModifier(cfg)
 	if err != nil {
 		log.WithError(err).Fatal("Error creating service option modifier")
 	}

--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -66,6 +66,23 @@ func isEtcdConfigFile(path string) bool {
 	return strings.Contains(string(b), "endpoints:")
 }
 
+func (cdw *configDirectoryWatcher) handleAddedFile(name, absolutePath string) {
+	// A typical directory will look like this:
+	// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test5 -> ..data/test5
+	// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
+	//
+	// Ignore all backing files and only read the symlinks
+	if strings.HasPrefix(name, "..") {
+		return
+	}
+
+	if !isEtcdConfigFile(absolutePath) {
+		return
+	}
+
+	cdw.lifecycle.add(name, absolutePath)
+}
+
 func (cdw *configDirectoryWatcher) watch() error {
 	log.WithField(fieldConfig, cdw.path).Debug("Starting config directory watcher")
 
@@ -75,22 +92,12 @@ func (cdw *configDirectoryWatcher) watch() error {
 	}
 
 	for _, f := range files {
-		// A typical directory will look like this:
-		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test5 -> ..data/test5
-		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
-		//
-		// Ignore all backing files and only read the symlinks
-		if strings.HasPrefix(f.Name(), "..") || f.IsDir() {
+		if f.IsDir() {
 			continue
 		}
 
 		absolutePath := path.Join(cdw.path, f.Name())
-		if !isEtcdConfigFile(absolutePath) {
-			continue
-		}
-
-		log.WithField(fieldClusterName, f.Name()).WithField("mode", f.Mode()).Debugf("Found configuration in initial scan")
-		cdw.lifecycle.add(f.Name(), absolutePath)
+		cdw.handleAddedFile(f.Name(), absolutePath)
 	}
 
 	go func() {
@@ -103,7 +110,7 @@ func (cdw *configDirectoryWatcher) watch() error {
 				case event.Op&fsnotify.Create == fsnotify.Create,
 					event.Op&fsnotify.Write == fsnotify.Write,
 					event.Op&fsnotify.Chmod == fsnotify.Chmod:
-					cdw.lifecycle.add(name, event.Name)
+					cdw.handleAddedFile(name, event.Name)
 				case event.Op&fsnotify.Remove == fsnotify.Remove,
 					event.Op&fsnotify.Rename == fsnotify.Rename:
 					cdw.lifecycle.remove(name)

--- a/pkg/crypto/certloader/fswatcher/fswatcher.go
+++ b/pkg/crypto/certloader/fswatcher/fswatcher.go
@@ -343,11 +343,13 @@ func (w *Watcher) loop() {
 				}
 			}
 		case err := <-w.watcher.Errors:
-			log.WithError(err).Debug("Received fsnotify error")
+			log.WithError(err).Debug("Received fsnotify error while watching")
 			w.Errors <- err
 		case <-w.stop:
 			err := w.watcher.Close()
-			log.WithError(err).Debug("Received fsnotify error on close")
+			if err != nil {
+				log.WithError(err).Warn("Received fsnotify error on close")
+			}
 			close(w.Events)
 			close(w.Errors)
 			return

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -385,7 +385,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			cDefinesMap["SNAT_MAPPING_IPV6_SIZE"] = fmt.Sprintf("%d", option.Config.NATMapEntriesGlobal)
 		}
 
-		if option.Config.EnableBPFMasquerade && option.Config.EnableIPv4 {
+		if option.Config.Masquerade && option.Config.EnableBPFMasquerade && option.Config.EnableIPv4 {
 			cDefinesMap["ENABLE_MASQUERADE"] = "1"
 			cidr := datapath.RemoteSNATDstAddrExclusionCIDR()
 			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR"] =

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -979,7 +980,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	ip1 := net.ParseIP("9.9.9.250")
 	ipnet.IP = ip0
 	addr := &netlink.Addr{IPNet: ipnet}
-	netlink.AddrAdd(veth0, addr)
+	err = netlink.AddrAdd(veth0, addr)
 	c.Assert(err, check.IsNil)
 	err = netlink.LinkSetUp(veth0)
 	c.Assert(err, check.IsNil)
@@ -1023,6 +1024,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		Name:        "node1",
 		IPAddresses: []nodeTypes.Address{{nodeaddressing.NodeInternalIP, ip1}},
 	}
+	// wait 1 second to give the OS time to setup the routes for the veth pairs
+	// just created.
+	time.Sleep(time.Second)
 	err = linuxNodeHandler.NodeAdd(nodev1)
 	c.Assert(err, check.IsNil)
 

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -134,7 +134,7 @@ connect:
 					continue connect
 				}
 			}
-			m.opts.log.WithField("change notification", cn).Debug("Received peer change notification")
+			m.opts.log.WithField("change notification", cn).Info("Received peer change notification")
 			p := peerTypes.FromChangeNotification(cn)
 			switch cn.GetType() {
 			case peerpb.ChangeNotificationType_PEER_ADDED:
@@ -318,7 +318,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 
 	m.opts.log.WithFields(logrus.Fields{
 		"address": p.Address,
-	}).Debugf("Connecting peer %s...", p.Name)
+	}).Infof("Connecting peer %s...", p.Name)
 	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), p.TLSServerName)
 	if err != nil {
 		duration := m.opts.backoff.Duration(p.connAttempts)
@@ -332,7 +332,7 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 		p.nextConnAttempt = time.Time{}
 		p.connAttempts = 0
 		p.conn = conn
-		m.opts.log.Debugf("Peer %s connected", p.Name)
+		m.opts.log.Infof("Peer %s connected", p.Name)
 	}
 }
 
@@ -345,12 +345,12 @@ func (m *PeerManager) disconnect(p *peer) {
 	if p.conn == nil {
 		return
 	}
-	m.opts.log.Debugf("Disconnecting peer %s...", p.Name)
+	m.opts.log.Infof("Disconnecting peer %s...", p.Name)
 	if err := p.conn.Close(); err != nil {
 		m.opts.log.WithFields(logrus.Fields{
 			"error": err,
 		}).Warningf("Failed to properly close gRPC client connection to peer %s", p.Name)
 	}
 	p.conn = nil
-	m.opts.log.Debugf("Peer %s disconnected", p.Name)
+	m.opts.log.Infof("Peer %s disconnected", p.Name)
 }

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -317,7 +317,8 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 	}
 
 	m.opts.log.WithFields(logrus.Fields{
-		"address": p.Address,
+		"address":    p.Address,
+		"hubble-tls": p.TLSEnabled,
 	}).Infof("Connecting peer %s...", p.Name)
 	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), p.TLSServerName)
 	if err != nil {

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -310,30 +310,34 @@ func (m *PeerManager) connect(p *peer, ignoreBackoff bool) {
 			if err := p.conn.Close(); err != nil {
 				m.opts.log.WithFields(logrus.Fields{
 					"error": err,
-				}).Warningf("Failed to properly close gRPC client connection to peer %s", p.Name)
+					"peer":  p.Name,
+				}).Warning("Failed to properly close gRPC client connection")
 			}
 			p.conn = nil
 		}
 	}
 
-	m.opts.log.WithFields(logrus.Fields{
+	scopedLog := m.opts.log.WithFields(logrus.Fields{
 		"address":    p.Address,
 		"hubble-tls": p.TLSEnabled,
-	}).Infof("Connecting peer %s...", p.Name)
+		"peer":       p.Name,
+	})
+
+	scopedLog.Info("Connecting")
 	conn, err := m.opts.clientConnBuilder.ClientConn(p.Address.String(), p.TLSServerName)
 	if err != nil {
 		duration := m.opts.backoff.Duration(p.connAttempts)
 		p.nextConnAttempt = now.Add(duration)
 		p.connAttempts++
-		m.opts.log.WithFields(logrus.Fields{
-			"address": p.Address,
-			"error":   err,
-		}).Warningf("Failed to create gRPC client connection to peer %s; next attempt after %s", p.Name, duration)
+		scopedLog.WithFields(logrus.Fields{
+			"error":       err,
+			"next-try-in": duration,
+		}).Warning("Failed to create gRPC client")
 	} else {
 		p.nextConnAttempt = time.Time{}
 		p.connAttempts = 0
 		p.conn = conn
-		m.opts.log.Infof("Peer %s connected", p.Name)
+		scopedLog.Info("Connected")
 	}
 }
 
@@ -346,12 +350,17 @@ func (m *PeerManager) disconnect(p *peer) {
 	if p.conn == nil {
 		return
 	}
-	m.opts.log.Infof("Disconnecting peer %s...", p.Name)
+
+	scopedLog := m.opts.log.WithFields(logrus.Fields{
+		"address":    p.Address,
+		"hubble-tls": p.TLSEnabled,
+		"peer":       p.Name,
+	})
+
+	scopedLog.Info("Disconnecting")
 	if err := p.conn.Close(); err != nil {
-		m.opts.log.WithFields(logrus.Fields{
-			"error": err,
-		}).Warningf("Failed to properly close gRPC client connection to peer %s", p.Name)
+		scopedLog.WithField("error", err).Warning("Failed to properly close gRPC client connection")
 	}
 	p.conn = nil
-	m.opts.log.Infof("Peer %s disconnected", p.Name)
+	scopedLog.Info("Disconnected")
 }

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -600,7 +600,7 @@ func TestPeerManager(t *testing.T) {
 					},
 				},
 				log: []string{
-					`level=warning msg="Failed to create gRPC client connection to peer unreachable; next attempt after 10s" address="192.0.1.1:4244" error="Don't feel like workin' today"`,
+					`level=warning msg="Failed to create gRPC client" address="192.0.1.1:4244" error="Don't feel like workin' today" hubble-tls=false next-try-in=10s peer=unreachable`,
 				},
 			},
 		}, {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -216,6 +216,11 @@ func removeCIDR(allowCIDR, removeCIDR *net.IPNet) ([]*net.IPNet, error) {
 	allowSize, _ := allowCIDR.Mask.Size()
 	removeSize, _ := removeCIDR.Mask.Size()
 
+	// Removing a CIDR from itself should result into an empty set
+	if allowSize == removeSize && allowCIDR.IP.Equal(removeCIDR.IP) {
+		return nil, nil
+	}
+
 	if allowSize >= removeSize {
 		return nil, fmt.Errorf("allow CIDR prefix must be a superset of " +
 			"remove CIDR prefix")

--- a/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
@@ -17,6 +17,7 @@ package v2
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	k8sCiliumUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -35,20 +36,16 @@ import (
 // modified version of CiliumNetworkPolicy which is cluster scoped rather than
 // namespace scoped.
 type CiliumClusterwideNetworkPolicy struct {
-	// Note: The following two fields are required (regardless of embedding
-	// CiliumNetworkPolicy below which bring these in), because controller-gen
-	// ignores structs when generating CRDs that do not have these fields. The
-	// controller-gen code responsible:
-	// https://github.com/kubernetes-sigs/controller-tools/blob/4a903ddb7005459a7baf4777c67244a74c91083d/pkg/crd/gen.go#L221
-
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
 	metav1.ObjectMeta `json:"metadata"`
 
-	// Embedded fields require json inline tag, source:
-	// https://github.com/kubernetes-sigs/controller-tools/issues/244
-	*CiliumNetworkPolicy `json:",inline"`
+	// Spec is the desired Cilium specific rule specification.
+	Spec *api.Rule `json:"spec,omitempty"`
+
+	// Specs is a list of desired Cilium specific rule specification.
+	Specs api.Rules `json:"specs,omitempty"`
 
 	// Status is the status of the Cilium policy rule.
 	//
@@ -63,7 +60,44 @@ type CiliumClusterwideNetworkPolicy struct {
 // DeepEqual compares 2 CCNPs while ignoring the LastAppliedConfigAnnotation
 // and ignoring the Status field of the CCNP.
 func (in *CiliumClusterwideNetworkPolicy) DeepEqual(other *CiliumClusterwideNetworkPolicy) bool {
-	return sharedCNPDeepEqual(in.CiliumNetworkPolicy, other.CiliumNetworkPolicy) && in.deepEqual(other)
+	return objectMetaDeepEqual(in.ObjectMeta, other.ObjectMeta) && in.deepEqual(other)
+}
+
+// GetPolicyStatus returns the CiliumClusterwideNetworkPolicyNodeStatus corresponding to
+// nodeName in the provided CiliumClusterwideNetworkPolicy. If Nodes within the rule's
+// Status is nil, returns an empty CiliumClusterwideNetworkPolicyNodeStatus.
+func (r *CiliumClusterwideNetworkPolicy) GetPolicyStatus(nodeName string) CiliumNetworkPolicyNodeStatus {
+	if r.Status.Nodes == nil {
+		return CiliumNetworkPolicyNodeStatus{}
+	}
+	return r.Status.Nodes[nodeName]
+}
+
+// SetPolicyStatus sets the given policy status for the given nodes' map.
+func (r *CiliumClusterwideNetworkPolicy) SetPolicyStatus(nodeName string, cnpns CiliumNetworkPolicyNodeStatus) {
+	if r.Status.Nodes == nil {
+		r.Status.Nodes = map[string]CiliumNetworkPolicyNodeStatus{}
+	}
+	r.Status.Nodes[nodeName] = cnpns
+}
+
+// SetDerivedPolicyStatus set the derivative policy status for the given
+// derivative policy name.
+func (r *CiliumClusterwideNetworkPolicy) SetDerivedPolicyStatus(derivativePolicyName string, status CiliumNetworkPolicyNodeStatus) {
+	if r.Status.DerivativePolicies == nil {
+		r.Status.DerivativePolicies = map[string]CiliumNetworkPolicyNodeStatus{}
+	}
+	r.Status.DerivativePolicies[derivativePolicyName] = status
+}
+
+// AnnotationsEquals returns true if ObjectMeta.Annotations of each
+// CiliumClusterwideNetworkPolicy are equivalent (i.e., they contain equivalent key-value
+// pairs).
+func (r *CiliumClusterwideNetworkPolicy) AnnotationsEquals(o *CiliumClusterwideNetworkPolicy) bool {
+	if o == nil {
+		return r == nil
+	}
+	return reflect.DeepEqual(r.ObjectMeta.Annotations, o.ObjectMeta.Annotations)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -62,20 +62,13 @@ type CiliumNetworkPolicy struct {
 
 // DeepEqual compares 2 CNPs.
 func (in *CiliumNetworkPolicy) DeepEqual(other *CiliumNetworkPolicy) bool {
-	return sharedCNPDeepEqual(in, other) && in.deepEqual(other)
+	return objectMetaDeepEqual(in.ObjectMeta, other.ObjectMeta) && in.deepEqual(other)
 }
 
-// sharedCNPDeepEqual performs an equality check for CNP that ignores the
-// LastAppliedConfigAnnotation and ignores the Status field of the CNP. This
-// function's usage is shared among CNP and CCNP as CCNP embeds a CNP.
-func sharedCNPDeepEqual(in, other *CiliumNetworkPolicy) bool {
-	switch {
-	case (in == nil) != (other == nil):
-		return false
-	case (in == nil) && (other == nil):
-		return true
-	}
-
+// objectMetaDeepEqual performs an equality check for metav1.ObjectMeta that
+// ignores the LastAppliedConfigAnnotation. This function's usage is shared
+// among CNP and CCNP as they have the same structure.
+func objectMetaDeepEqual(in, other metav1.ObjectMeta) bool {
 	if !(in.Name == other.Name && in.Namespace == other.Namespace) {
 		return false
 	}
@@ -213,10 +206,11 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	// convert them back to CCNPs to allow proper parsing.
 	if namespace == "" {
 		ccnp := CiliumClusterwideNetworkPolicy{
-			TypeMeta:            r.TypeMeta,
-			ObjectMeta:          r.ObjectMeta,
-			CiliumNetworkPolicy: r,
-			Status:              r.Status,
+			TypeMeta:   r.TypeMeta,
+			ObjectMeta: r.ObjectMeta,
+			Spec:       r.Spec,
+			Specs:      r.Specs,
+			Status:     r.Status,
 		}
 		return ccnp.Parse()
 	}

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -364,7 +364,6 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 			Name: "rule1",
 			UID:  uuidRule,
 		},
-		CiliumNetworkPolicy: empty,
 	}
 	_, err = emptyCCNP.Parse()
 	c.Assert(err, checker.DeepEquals, ErrEmptyCCNP)
@@ -514,7 +513,7 @@ func (s *CiliumV2Suite) TestParseWithNodeSelector(c *C) {
 			Name:      "rule",
 			UID:       uuidRule,
 		},
-		CiliumNetworkPolicy: &cnpl,
+		Spec: cnpl.Spec,
 	}
 	_, err = ccnpl.Parse()
 	c.Assert(err, IsNil)

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -233,6 +233,82 @@ func (s *CNPValidationSuite) Test_UnknownFieldDetection(c *C) {
 		err         error
 	}{
 		{
+			name: "ccnp GH-14526",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"cilium.io/v2","kind":"CiliumClusterwideNetworkPolicy","metadata":{"annotations":{},"name":"ccnp-default-deny-egress"},"spec":{"egress":[{}],"endpointSelector":{}}}
+  creationTimestamp: "2021-01-07T00:26:34Z"
+  generation: 1
+  managedFields:
+  - apiVersion: cilium.io/v2
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+      f:spec:
+        .: {}
+        f:egress: {}
+        f:endpointSelector: {}
+    manager: kubectl-client-side-apply
+    operation: Update
+    time: "2021-01-07T00:26:34Z"
+  name: ccnp-default-deny-egress
+  resourceVersion: "7849"
+  selfLink: /apis/cilium.io/v2/ciliumclusterwidenetworkpolicies/ccnp-default-deny-egress
+  uid: f776ca84-86dc-4589-ab91-64fccdec468a
+spec:
+  egress:
+  - {}
+  endpointSelector: {}
+`),
+			clusterwide: true,
+			err:         nil,
+		},
+		{
+			name: "cnp GH-14526",
+			policy: []byte(`
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"cilium.io/v2","kind":"CiliumNetworkPolicy","metadata":{"annotations":{},"name":"ccnp-default-deny-egress"},"spec":{"egress":[{}],"endpointSelector":{}}}
+  creationTimestamp: "2021-01-07T00:26:34Z"
+  generation: 1
+  managedFields:
+  - apiVersion: cilium.io/v2
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+      f:spec:
+        .: {}
+        f:egress: {}
+        f:endpointSelector: {}
+    manager: kubectl-client-side-apply
+    operation: Update
+    time: "2021-01-07T00:26:34Z"
+  name: ccnp-default-deny-egress
+  resourceVersion: "7849"
+  selfLink: /apis/cilium.io/v2/ciliumnetworkpolicies/ccnp-default-deny-egress
+  uid: f776ca84-86dc-4589-ab91-64fccdec468a
+spec:
+  egress:
+  - {}
+  endpointSelector: {}
+`),
+			clusterwide: false,
+			err:         nil,
+		},
+		{
 			name: "neither a cnp or ccnp",
 			policy: []byte(`
 kind: ServiceAccount

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -29,10 +29,21 @@ func (in *CiliumClusterwideNetworkPolicy) DeepCopyInto(out *CiliumClusterwideNet
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.CiliumNetworkPolicy != nil {
-		in, out := &in.CiliumNetworkPolicy, &out.CiliumNetworkPolicy
-		*out = new(CiliumNetworkPolicy)
+	if in.Spec != nil {
+		in, out := &in.Spec, &out.Spec
+		*out = new(api.Rule)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Specs != nil {
+		in, out := &in.Specs, &out.Specs
+		*out = make(api.Rules, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(api.Rule)
+				(*in).DeepCopyInto(*out)
+			}
+		}
 	}
 	in.Status.DeepCopyInto(&out.Status)
 	return

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -82,10 +82,17 @@ func (in *CiliumClusterwideNetworkPolicy) deepEqual(other *CiliumClusterwideNetw
 		return false
 	}
 
-	if (in.CiliumNetworkPolicy == nil) != (other.CiliumNetworkPolicy == nil) {
+	if (in.Spec == nil) != (other.Spec == nil) {
 		return false
-	} else if in.CiliumNetworkPolicy != nil {
-		if !in.CiliumNetworkPolicy.DeepEqual(other.CiliumNetworkPolicy) {
+	} else if in.Spec != nil {
+		if !in.Spec.DeepEqual(other.Spec) {
+			return false
+		}
+	}
+
+	if ((in.Specs != nil) && (other.Specs != nil)) || ((in.Specs == nil) != (other.Specs == nil)) {
+		in, other := &in.Specs, &other.Specs
+		if other == nil || !in.DeepEqual(other) {
 			return false
 		}
 	}

--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -608,10 +608,11 @@ func updateStatusesByCapabilities(client clientset.Interface, capabilities k8sve
 				// Need to explicitly copy all the fields even though CNP is
 				// embedded inside CCNP. See comment inside CCNP type
 				// definition. This is required for K8s versions < 1.13.
-				TypeMeta:            cnp.TypeMeta,
-				ObjectMeta:          cnp.ObjectMeta,
-				CiliumNetworkPolicy: cnp.CiliumNetworkPolicy,
-				Status:              cnp.CiliumNetworkPolicy.Status,
+				TypeMeta:   cnp.TypeMeta,
+				ObjectMeta: cnp.ObjectMeta,
+				Spec:       cnp.CiliumNetworkPolicy.Spec,
+				Specs:      cnp.CiliumNetworkPolicy.Specs,
+				Status:     cnp.CiliumNetworkPolicy.Status,
 			}
 			_, err = client.CiliumV2().CiliumClusterwideNetworkPolicies().UpdateStatus(context.TODO(), ccnp, metav1.UpdateOptions{})
 		} else {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -400,7 +400,13 @@ func ConvertToCCNPWithStatus(obj interface{}) interface{} {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumClusterwideNetworkPolicy:
 		t := &types.SlimCNP{
-			CiliumNetworkPolicy: concreteObj.CiliumNetworkPolicy,
+			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+				TypeMeta:   concreteObj.TypeMeta,
+				ObjectMeta: concreteObj.ObjectMeta,
+				Spec:       concreteObj.Spec,
+				Specs:      concreteObj.Specs,
+				Status:     concreteObj.Status,
+			},
 		}
 		// Need to explicitly copy all the fields even though CNP is embedded
 		// inside CCNP. See comment inside CCNP type definition. This is
@@ -419,7 +425,13 @@ func ConvertToCCNPWithStatus(obj interface{}) interface{} {
 			return obj
 		}
 		t := &types.SlimCNP{
-			CiliumNetworkPolicy: cnp.CiliumNetworkPolicy,
+			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+				TypeMeta:   cnp.TypeMeta,
+				ObjectMeta: cnp.ObjectMeta,
+				Spec:       cnp.Spec,
+				Specs:      cnp.Specs,
+				Status:     cnp.Status,
+			},
 		}
 		// Need to explicitly copy all the fields even though CNP is embedded
 		// inside CCNP. See comment inside CCNP type definition. This is
@@ -479,39 +491,35 @@ func ConvertToCNPWithStatus(obj interface{}) interface{} {
 func ConvertToCCNP(obj interface{}) interface{} {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumClusterwideNetworkPolicy:
-		cnp := &types.SlimCNP{
+		ccnp := &types.SlimCNP{
 			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
 				TypeMeta:   concreteObj.TypeMeta,
 				ObjectMeta: concreteObj.ObjectMeta,
+				Spec:       concreteObj.Spec,
+				Specs:      concreteObj.Specs,
 			},
 		}
-		if concreteObj.CiliumNetworkPolicy != nil {
-			cnp.Spec = concreteObj.Spec
-			cnp.Specs = concreteObj.Specs
-		}
 		*concreteObj = cilium_v2.CiliumClusterwideNetworkPolicy{}
-		return cnp
+		return ccnp
 
 	case cache.DeletedFinalStateUnknown:
-		cnp, ok := concreteObj.Obj.(*cilium_v2.CiliumClusterwideNetworkPolicy)
+		ccnp, ok := concreteObj.Obj.(*cilium_v2.CiliumClusterwideNetworkPolicy)
 		if !ok {
 			return obj
 		}
 		slimCNP := &types.SlimCNP{
 			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
-				TypeMeta:   cnp.TypeMeta,
-				ObjectMeta: cnp.ObjectMeta,
+				TypeMeta:   ccnp.TypeMeta,
+				ObjectMeta: ccnp.ObjectMeta,
+				Spec:       ccnp.Spec,
+				Specs:      ccnp.Specs,
 			},
-		}
-		if cnp.CiliumNetworkPolicy != nil {
-			slimCNP.Spec = cnp.Spec
-			slimCNP.Specs = cnp.Specs
 		}
 		dfsu := cache.DeletedFinalStateUnknown{
 			Key: concreteObj.Key,
 			Obj: slimCNP,
 		}
-		*cnp = cilium_v2.CiliumClusterwideNetworkPolicy{}
+		*ccnp = cilium_v2.CiliumClusterwideNetworkPolicy{}
 		return dfsu
 
 	default:

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -1041,9 +1041,7 @@ func (s *K8sSuite) Test_ConvertToCCNPWithStatus(c *C) {
 		{
 			name: "normal conversion",
 			args: args{
-				obj: &v2.CiliumClusterwideNetworkPolicy{
-					CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
-				},
+				obj: &v2.CiliumClusterwideNetworkPolicy{},
 			},
 			want: &types.SlimCNP{
 				CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
@@ -1054,9 +1052,7 @@ func (s *K8sSuite) Test_ConvertToCCNPWithStatus(c *C) {
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{
 					Key: "foo",
-					Obj: &v2.CiliumClusterwideNetworkPolicy{
-						CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
-					},
+					Obj: &v2.CiliumClusterwideNetworkPolicy{},
 				},
 			},
 			want: cache.DeletedFinalStateUnknown{
@@ -1165,9 +1161,7 @@ func (s *K8sSuite) Test_ConvertToCCNP(c *C) {
 		{
 			name: "normal conversion",
 			args: args{
-				obj: &v2.CiliumClusterwideNetworkPolicy{
-					CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
-				},
+				obj: &v2.CiliumClusterwideNetworkPolicy{},
 			},
 			want: &types.SlimCNP{
 				CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
@@ -1187,9 +1181,7 @@ func (s *K8sSuite) Test_ConvertToCCNP(c *C) {
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{
 					Key: "foo",
-					Obj: &v2.CiliumClusterwideNetworkPolicy{
-						CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
-					},
+					Obj: &v2.CiliumClusterwideNetworkPolicy{},
 				},
 			},
 			want: cache.DeletedFinalStateUnknown{

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -186,6 +186,8 @@ type K8sWatcher struct {
 	datapath       datapath.Datapath
 
 	networkpolicyStore cache.Store
+
+	cfg WatcherConfiguration
 }
 
 func NewK8sWatcher(
@@ -196,6 +198,7 @@ func NewK8sWatcher(
 	svcManager svcManager,
 	datapath datapath.Datapath,
 	redirectPolicyManager redirectPolicyManager,
+	cfg WatcherConfiguration,
 ) *K8sWatcher {
 	return &K8sWatcher{
 		K8sSvcCache:           k8s.NewServiceCache(datapath.LocalNodeAddressing()),
@@ -208,6 +211,7 @@ func NewK8sWatcher(
 		podStoreSet:           make(chan struct{}),
 		datapath:              datapath,
 		redirectPolicyManager: redirectPolicyManager,
+		cfg:                   cfg,
 	}
 }
 
@@ -333,6 +337,11 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
 	return cachesSynced
 }
 
+// WatcherConfiguration is the required configuration for EnableK8sWatcher
+type WatcherConfiguration interface {
+	utils.ServiceConfiguration
+}
+
 // EnableK8sWatcher watches for policy, services and endpoint changes on the Kubernetes
 // api server defined in the receiver's daemon k8sClient.
 func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context) error {
@@ -349,7 +358,7 @@ func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context) error {
 	swgKNP := lock.NewStoppableWaitGroup()
 	k.networkPoliciesInit(k8s.WatcherClient(), swgKNP)
 
-	serviceOptModifier, err := utils.GetServiceListOptionsModifier()
+	serviceOptModifier, err := utils.GetServiceListOptionsModifier(k.cfg)
 	if err != nil {
 		return fmt.Errorf("error creating service list option modifier: %w", err)
 	}

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -50,6 +50,12 @@ type K8sWatcherSuite struct{}
 
 var _ = Suite(&K8sWatcherSuite{})
 
+type fakeWatcherConfiguration struct{}
+
+func (f *fakeWatcherConfiguration) K8sServiceProxyName() string {
+	return ""
+}
+
 type fakeEndpointManager struct {
 	OnGetEndpoints                func() []*endpoint.Endpoint
 	OnLookupPodName               func(string) *endpoint.Endpoint
@@ -226,6 +232,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		nil,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -529,6 +536,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -669,6 +677,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1115,6 +1124,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1408,6 +1418,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1694,6 +1705,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2545,6 +2557,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		svcManager,
 		fakeDatapath.NewDatapath(),
 		nil,
+		&fakeWatcherConfiguration{},
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -572,14 +572,17 @@ func (m *Manager) StartNeighborRefresh(nh datapath.NodeHandler) {
 				m.mutex.RLock()
 				defer m.mutex.RUnlock()
 				for _, entry := range m.nodes {
-					if entry.node.IsLocal() {
+					entry.mutex.Lock()
+					entryNode := entry.node
+					entry.mutex.Unlock()
+					if entryNode.IsLocal() {
 						continue
 					}
-					go func(c context.Context, e *nodeEntry) {
+					go func(c context.Context, e nodeTypes.Node) {
 						n := randGen.Int63n(int64(interval / 2))
 						time.Sleep(interval/2 + time.Duration(n))
-						nh.NodeNeighborRefresh(c, e.node)
-					}(ctx, entry)
+						nh.NodeNeighborRefresh(c, e)
+					}(ctx, entryNode)
 				}
 				return nil
 			},

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2023,12 +2023,12 @@ type DaemonConfig struct {
 	// LBMapEntries is the maximum number of entries allowed in BPF lbmap.
 	LBMapEntries int
 
-	// K8sServiceProxyName is the value of service.kubernetes.io/service-proxy-name label,
+	// k8sServiceProxyName is the value of service.kubernetes.io/service-proxy-name label,
 	// that identifies the service objects Cilium should handle.
 	// If the provided value is an empty string, Cilium will manage service objects when
 	// the label is not present. For more details -
 	// https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0031-20181017-kube-proxy-services-optional.md
-	K8sServiceProxyName string
+	k8sServiceProxyName string
 
 	// APIRateLimitName enables configuration of the API rate limits
 	APIRateLimit map[string]string
@@ -2203,6 +2203,13 @@ func (c *DaemonConfig) EndpointStatusIsEnabled(option string) bool {
 // LocalClusterName returns the name of the cluster Cilium is deployed in
 func (c *DaemonConfig) LocalClusterName() string {
 	return c.ClusterName
+}
+
+// K8sServiceProxyName returns the required value for the
+// service.kubernetes.io/service-proxy-name label in order for services to be
+// handled.
+func (c *DaemonConfig) K8sServiceProxyName() string {
+	return c.k8sServiceProxyName
 }
 
 // CiliumNamespaceName returns the name of the namespace in which Cilium is
@@ -2570,7 +2577,7 @@ func (c *DaemonConfig) Populate() {
 	c.PolicyAuditMode = viper.GetBool(PolicyAuditModeArg)
 	c.EnableIPv4FragmentsTracking = viper.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = viper.GetInt(FragmentsMapEntriesName)
-	c.K8sServiceProxyName = viper.GetString(K8sServiceProxyName)
+	c.k8sServiceProxyName = viper.GetString(K8sServiceProxyName)
 	c.CRDWaitTimeout = viper.GetDuration(CRDWaitTimeout)
 	c.populateLoadBalancerSettings()
 	c.populateDevices()

--- a/pkg/policy/groups/helpers.go
+++ b/pkg/policy/groups/helpers.go
@@ -102,10 +102,11 @@ func createDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 // createDerivativeCCNP will return a new CCNP based on the given rule.
 func createDerivativeCCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumClusterwideNetworkPolicy, error) {
 	ccnp := &cilium_v2.CiliumClusterwideNetworkPolicy{
-		TypeMeta:            cnp.TypeMeta,
-		ObjectMeta:          cnp.ObjectMeta,
-		CiliumNetworkPolicy: cnp,
-		Status:              cnp.Status,
+		TypeMeta:   cnp.TypeMeta,
+		ObjectMeta: cnp.ObjectMeta,
+		Spec:       cnp.Spec,
+		Specs:      cnp.Specs,
+		Status:     cnp.Status,
 	}
 
 	// CCNP informer may provide a CCNP object without APIVersion or Kind.
@@ -126,7 +127,6 @@ func createDerivativeCCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolic
 				cnpKindKey: cnpKindName,
 			},
 		},
-		CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{},
 	}
 
 	var (

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -27,6 +27,14 @@ while [ $locked -ne 0 ]; do
 		continue
 	fi
 
+
+	echo "checking whether cluster ${cluster_uri} has node pools"
+	node_pools=($(gcloud container node-pools list --project "${project}" --region "${region}" --cluster "${cluster_uri}" --format="value(name)"))
+	if [ "${#node_pools[@]}" -ne 1 ] ; then
+	  echo "expected 1 node pool, found ${#node_pools[@]}"
+	  continue
+	fi
+
 	echo "getting kubeconfig for ${cluster_uri} (will store in ${KUBECONFIG})"
 	gcloud container clusters get-credentials --project "${project}" --region "${region}" "${cluster_uri}"
 


### PR DESCRIPTION
 * #14501 -- pkg/datapath: fix arp ping handling (@aanm)
 * #14452 -- AKS: Clean up azure-vnet state on Cilium agent start (@ti-mo)
 * #14565 -- clustermesh: Ignore symlink files on fsnotify events (@tgraf)
 * #14577 -- Fix clustermesh-apiserver dependencies on pkg/option (@tgraf)
 * #14596 -- bpf: fix misconfigured nat to 0.0.0.0 on !masquerade config (@borkmann)
 * #14516 -- Pr/jrajahalme/remove cidr fix (@jrajahalme)
 * #14576 -- ci: check if gke cluster has a nodepool before reserving it (@nebril)
 * #14591 -- pkg/node: fix concurrent access of entry node (@aanm)
 * #14557 -- k8s: Decouple CNP embedding inside CCNP (@christarazi)
 * #14521 -- hubble relay: various logging improvements (@kaworu)
 * #14616 -- nodeinit: use azure0 presence as a condition for flushing ebtables & neigh (@ti-mo)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14501 14452 14565 14577 14596 14516 14576 14591 14557 14521  14616; do contrib/backporting/set-labels.py $pr done 1.9; done
```