### PR TITLE
[v1.8] docker: bump cilium-iproute2 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGI
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-12-07-v1.8@sha256:32174d873efd2b51e8004ed327dced0b23cb85aadc1447494e1a266c59a00fc7
+FROM quay.io/cilium/cilium-runtime:2021-01-14-v1.8@sha256:ed2db0d551001a4d98b19fc511b1acc31c7b926412c806b05503bf27310427e9
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-12-07-v1.8@sha256:97e32922ef3028d74c2797b3a5fda501be28eafc6499044a01de9cd8d1248940 as builder
+FROM quay.io/cilium/cilium-builder:2021-01-14-v1.8@sha256:74a619ce8bc2f16f4c67b77139f37b71efcad7571582c1430cb3f27a984486dd as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,7 +1,7 @@
 #
 # Cilium build-time base image (image created from this file is used to build Cilium)
 
-FROM quay.io/cilium/cilium-runtime:2020-12-07-v1.8@sha256:32174d873efd2b51e8004ed327dced0b23cb85aadc1447494e1a266c59a00fc7
+FROM quay.io/cilium/cilium-runtime:2021-01-14-v1.8@sha256:ed2db0d551001a4d98b19fc511b1acc31c7b926412c806b05503bf27310427e9
 LABEL maintainer="maintainer@cilium.io"
 ARG ARCH=amd64
 WORKDIR /go/src/github.com/cilium/cilium

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -3,7 +3,7 @@
 # development environmennt
 FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
-FROM quay.io/cilium/cilium-runtime:2020-12-07-v1.8@sha256:32174d873efd2b51e8004ed327dced0b23cb85aadc1447494e1a266c59a00fc7
+FROM quay.io/cilium/cilium-runtime:2021-01-14-v1.8@sha256:ed2db0d551001a4d98b19fc511b1acc31c7b926412c806b05503bf27310427e9
 LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -54,7 +54,7 @@ RUN apt-get update && \
     strip -s ./loopback
 COPY --from=docker.io/cilium/cilium-llvm:178583d8925906270379830fb44641c38f7cc062 /bin/clang /bin/llc /bin/
 COPY --from=docker.io/cilium/cilium-bpftool:f0bbd0cb389ce92b33ff29f0489c17c8e33f9da7 /bin/bpftool /bin/
-COPY --from=docker.io/cilium/cilium-iproute2:044e7a6a43d5a42a8ce696535b3dbf773f82dbec /bin/tc /bin/ip /bin/ss /bin/
+COPY --from=docker.io/cilium/cilium-iproute2:f873abca8c7128f48206c6aecbbcdc6315d3d79d /usr/local/bin/tc /usr/local/bin/ip /usr/local/bin/ss /bin/
 COPY --from=gops /go/bin/gops /bin/
 
 #

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2020-12-07-v1.8@sha256:97e32922ef3028d74c2797b3a5fda501be28eafc6499044a01de9cd8d1248940"
+    image: "quay.io/cilium/cilium-builder:2021-01-14-v1.8@sha256:74a619ce8bc2f16f4c67b77139f37b71efcad7571582c1430cb3f27a984486dd"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:2020-12-07-v1.8@sha256:97e32922ef3028d74c2797b3a5fda501be28eafc6499044a01de9cd8d1248940
+    image: quay.io/cilium/cilium-builder:2021-01-14-v1.8@sha256:74a619ce8bc2f16f4c67b77139f37b71efcad7571582c1430cb3f27a984486dd
     command: ["sleep"]
     args:
       - "1000h"


### PR DESCRIPTION
Backport #14593 to 1.8.

The same iproute2 image tag as in the original PR is used, but cilium-runtime and then cilium-builder have been rebuilt specifically for the 1.8 branch. See notes in individual commit logs for adjustments.

Once this PR is merged, you can update the PR label via:
```upstream-prs
$ contrib/backporting/set-labels.py 14593 done 1.8
```