### PR TITLE
helm: add install/kubernetes/hubble-cli.yaml

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -61,6 +61,8 @@ jobs:
             template: install/kubernetes/quick-hubble-install.yaml
           - name: experimental-install
             template: install/kubernetes/experimental-install.yaml
+          - name: hubble-cli
+            template: install/kubernetes/hubble-cli.yaml
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -22,6 +22,7 @@ MIN_K8S_OPTIONS := \
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
 QUICK_HUBBLE_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-hubble-install.yaml"
 EXPERIMENTAL_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/experimental-install.yaml"
+HUBBLE_CLI := "$(ROOT_DIR)/$(RELATIVE_DIR)/hubble-cli.yaml"
 CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium"
 CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml"
 CHART_FILE := "$(CILIUM_CHARTS)/Chart.yaml"
@@ -52,6 +53,10 @@ EXPERIMENTAL_OPTIONS := \
     --set hubble.ui.enabled=true \
     --set localRedirectPolicy=true \
     --set operator.replicas=1
+HUBBLE_CLI_OPTIONS := \
+    --set agent=false \
+    --set operator.enabled=false \
+    --set hubble.cli.enabled=true
 
 DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 	--workdir /src/install/kubernetes \
@@ -66,7 +71,7 @@ HELM_DOCS := $(DOCKER_RUN) $(HELM_DOCS_IMAGE)
 LOGO_BASE_URL := https://cdn.jsdelivr.net/gh/cilium
 LOGO_PATH := Documentation/images/logo-solo.svg
 
-all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL) $(QUICK_HUBBLE_INSTALL) docs
+all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL) $(QUICK_HUBBLE_INSTALL) $(HUBBLE_CLI) docs
 
 $(QUICK_INSTALL) quick-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system $(QUICK_OPTIONS) > $(QUICK_INSTALL)
@@ -76,6 +81,9 @@ $(QUICK_HUBBLE_INSTALL) quick-hubble-install: $(shell find cilium/ -type f) upda
 
 $(EXPERIMENTAL_INSTALL) experimental-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
+
+$(HUBBLE_CLI) hubble-cli: $(shell find cilium/ -type f) update-versions
+	$(QUIET)helm template cilium cilium --namespace=kube-system $(HUBBLE_CLI_OPTIONS) > $(HUBBLE_CLI)
 
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"
@@ -131,7 +139,7 @@ lint:
 	$(QUIET)helm lint --with-subcharts --values ./cilium/values.yaml ./cilium
 
 clean:
-	$(RM) $(QUICK_INSTALL) $(QUICK_HUBBLE_INSTALL) $(EXPERIMENTAL_INSTALL)
+	$(RM) $(QUICK_INSTALL) $(QUICK_HUBBLE_INSTALL) $(EXPERIMENTAL_INSTALL) $(HUBBLE_CLI)
 
 docs:
 	$(QUIET)$(HELM_DOCS)
@@ -146,4 +154,4 @@ check-docker-images:
          CERTGEN_VERSION=$(CERTGEN_VERSION) \
          ../../contrib/release/check-docker-images.sh "v$(VERSION)"
 
-.PHONY: all check-docker-images clean docs experimental-install lint quick-install update-versions
+.PHONY: all check-docker-images clean docs quick-install quick-hubble-install experimental-install hubble-cli update-versions lint

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -175,6 +175,8 @@ contributors across the globe, there is almost always someone available to help.
 | hostServices | object | `{"enabled":false,"protocols":"tcp,udp"}` | Configure ClusterIP service handling in the host namespace (the node). |
 | hostServices.enabled | bool | `false` | Enable host reachable services. |
 | hostServices.protocols | string | `"tcp,udp"` | Supported list of protocols to apply ClusterIP translation to. |
+| hubble.cli.enabled | bool | `false` | Enable the hubble-cli Pod |
+| hubble.cli.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble","tag":"latest"}` | Hubble-cli container image. |
 | hubble.enabled | bool | `true` | Enable Hubble (true by default). |
 | hubble.listenAddress | string | `":4244"` | An additional address for Hubble to listen to. Set this field ":4244" if you are enabling Hubble Relay, as it assumes that Hubble is listening on port 4244. |
 | hubble.metrics | object | `{"enabled":null,"port":9091,"serviceMonitor":{"enabled":false}}` | Buffer size of the channel Hubble uses to receive monitor events. If this value is not set, the queue size is set to the default monitor queue size. eventQueueSize: "" -- Number of recent flows for Hubble to cache. Defaults to 4095. Possible values are:   1, 3, 7, 15, 31, 63, 127, 255, 511, 1023,   2047, 4095, 8191, 16383, 32767, 65535 eventBufferCapacity: "4095" -- Hubble metrics configuration. See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |

--- a/install/kubernetes/cilium/templates/hubble-cli.yaml
+++ b/install/kubernetes/cilium/templates/hubble-cli.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.hubble.cli.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hubble-cli
+  labels:
+    k8s-app: hubble-cli
+  namespace: {{ .Release.Namespace }}
+spec:
+  containers:
+  - name: hubble-cli
+    image: "{{ .Values.hubble.cli.image.repository }}:{{ .Values.hubble.cli.image.tag }}"
+    imagePullPolicy: {{ .Values.hubble.cli.image.pullPolicy }}
+    command:
+      - tail -f /dev/null
+    volumeMounts:
+      - mountPath: {{ dir .Values.hubble.socketPath }}
+        name: hubble-sock-dir
+        readOnly: true
+{{- if .Values.hubble.tls.enabled }}
+      - mountPath: /var/lib/hubble-relay/tls
+        name: tls
+        readOnly: true
+{{- end }}
+  restartPolicy: Always
+  volumes:
+  - hostPath:
+      path: {{ dir .Values.hubble.socketPath }}
+      type: Directory
+    name: hubble-sock-dir
+{{- if .Values.hubble.tls.enabled }}
+  - name: tls
+    projected:
+      sources:
+      - secret:
+          name: hubble-relay-client-certs
+          items:
+            - key: tls.crt
+              path: client.crt
+            - key: tls.key
+              path: client.key
+      - configMap:
+          name: hubble-ca-cert
+          items:
+            - key: ca.crt
+              path: hubble-server-ca.crt
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -95,18 +95,19 @@ spec:
       {{- toYaml . | trim | nindent 8 }}
 {{- end }}
       volumes:
-      - configMap:
+      - name: config
+        configMap:
           name: hubble-relay-config
           items:
           - key: config.yaml
             path: config.yaml
-        name: config
-      - hostPath:
+      - name: hubble-sock-dir
+        hostPath:
           path: {{ dir .Values.hubble.socketPath }}
           type: Directory
-        name: hubble-sock-dir
 {{- if .Values.hubble.tls.enabled }}
-      - projected:
+      - name: tls
+        projected:
           sources:
           - secret:
               name: hubble-relay-client-certs
@@ -126,6 +127,5 @@ spec:
                 - key: tls.key
                   path: server.key
 {{- end }}
-        name: tls
 {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -794,6 +794,14 @@ hubble:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+  cli:
+    # -- Enable the hubble-cli Pod
+    enabled: false
+    # -- Hubble-cli container image.
+    image:
+      repository: quay.io/cilium/hubble
+      tag: latest
+      pullPolicy: Always
 
 
 # TODO: Add documentation


### PR DESCRIPTION
introduce `hubble-cli.yaml` to help debugging Relay mTLS related issues.

Because we're stuck with `google.golang.org/grpc@v1.29.1` (see https://github.com/cilium/cilium/pull/13405#issuecomment-704766707), Relay will log _"context deadline exceeded"_ for various kind of issues, including all mTLS handshake failures:

```
level=info msg=Connecting address="172.18.0.2:4244" hubble-tls=true peer=alex-worker2 subsys=hubble-relay
level=warning msg="Failed to create gRPC client" address="172.18.0.2:4244" error="context deadline exceeded" hubble-tls=true next-try-in=20s peer=alex-worker2 subsys=hubble-relay
```

Using `hubble-cli.yaml` introduced by this patch, one can quickly attempt to connect to a Hubble observer server in the same way Relay does using the Hubble CLI. The benefit of the `latest` CLI is access to a recent grpc version supporting `grpc.WithReturnConnectionError` that will effectively display the underlying connection error (see https://github.com/cilium/hubble/pull/3720):
```
% kubectl exec -it -n kube-system hubble-cli -- hubble status --server tls://172.18.0.2:4244 --debug --tls-server-name alex-worker2.default.hubble-grpc.cilium.io --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt --tls-client-cert-file /var/lib/hubble-relay/tls/client.crt --tls-client-key-file /var/lib/hubble-relay/tls/client.key
failed to connect to 'tls://172.18.0.2:4244': context deadline exceeded: connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for *.oups.hubble-grpc.cilium.io, not alex-worker2.default.hubble-grpc.cilium.io"
command terminated with exit code 1
```

In this case, we can clearly see that the issue is a mismatch between the client's SNI and the certificate's DNS name.