### PR TITLE
nodeinit: use azure0 presence as a condition for flushing ebtables & neigh

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -230,11 +230,16 @@ spec:
               # against it every 5 seconds and write 'bridge' to its state file, causing inconsistent
               # behaviour when Pods are removed.
               if [ -f /etc/cni/net.d/10-azure.conflist ]; then
-
-                echo "azure-vnet configured in bridge mode. Changing to 'transparent'..."
+                echo "Ensuring azure-vnet is configured in 'transparent' mode..."
                 sed -i 's/"mode":\s*"bridge"/"mode":"transparent"/g' /etc/cni/net.d/10-azure.conflist
+              fi
 
 {{- if .Values.azure.enabled }}
+              # The azure0 interface being present means the node was booted with azure-vnet configured
+              # in bridge mode. This means there might be ebtables rules and neight entries interfering
+              # with pod connectivity if we deploy with Azure IPAM.
+              if ip l show dev azure0 >/dev/null 2>&1; then
+
                 # In Azure IPAM mode, also remove the azure-vnet state file, otherwise ebtables rules get
                 # restored by the azure-vnet CNI plugin on every CNI CHECK, which can cause connectivity
                 # issues in Cilium-managed Pods. Since azure-vnet is no longer called on scheduling events,
@@ -253,10 +258,9 @@ spec:
                 # for all other k8s nodes in the cluster. These are safe to flush, as ARP can
                 # resolve these nodes as usual. PERM entries will be automatically restored later.
                 echo 'Deleting all permanent neighbour entries on azure0...'
-                ip neigh show dev azure0 nud permanent | cut -d' ' -f1 | xargs -r -n1 ip neigh del dev azure0 to
-{{- end }}
-
+                ip neigh show dev azure0 nud permanent | cut -d' ' -f1 | xargs -r -n1 ip neigh del dev azure0 to || true
               fi
+{{- end }}
 
 {{- if .Values.nodeinit.revertReconfigureKubelet }}
               rm -f /tmp/node-deinit.cilium.io


### PR DESCRIPTION
With https://github.com/cilium/cilium/pull/14192, the assumption that `10-azure-vnet.conflist` is still present when nodeinit runs is invalidated.

Split AKS node-init in two stages; one to ensure azure-vnet is configured in bridge mode and another that only runs when configured with Azure IPAM that flushes ebtables & neigh when azure0 is present.

```release-note
Split AKS node-init into two stages. Use azure0 presence as a condition for flushing ebtables & neigh.
```
