### PR TITLE
pkg/loadbalancer: Optimize L3n4Addr.Hash for performance

### DIFF
--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -361,3 +361,30 @@ func TestServiceFlags_String(t *testing.T) {
 		})
 	}
 }
+
+func benchmarkHash(b *testing.B, addr *L3n4Addr) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr.Hash()
+	}
+}
+
+func BenchmarkL3n4Addr_Hash_IPv4(b *testing.B) {
+	addr := NewL3n4Addr(TCP, net.IPv4(1, 2, 3, 4), 8080, ScopeInternal)
+	benchmarkHash(b, addr)
+}
+
+func BenchmarkL3n4Addr_Hash_IPv6_Short(b *testing.B) {
+	addr := NewL3n4Addr(TCP, net.ParseIP("fd00::1:36c6"), 8080, ScopeInternal)
+	benchmarkHash(b, addr)
+}
+
+func BenchmarkL3n4Addr_Hash_IPv6_Long(b *testing.B) {
+	addr := NewL3n4Addr(TCP, net.ParseIP("2001:0db8:85a3::8a2e:0370:7334"), 8080, ScopeInternal)
+	benchmarkHash(b, addr)
+}
+
+func BenchmarkL3n4Addr_Hash_IPv6_Max(b *testing.B) {
+	addr := NewL3n4Addr(TCP, net.ParseIP("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"), 30303, 100)
+	benchmarkHash(b, addr)
+}


### PR DESCRIPTION
This commit optimizes the L3n4Addr.Hash function. It is used as a key in
Golang maps and therefore needs to be unique, but it does not need to actually
be a secure hash.

The previous implementation was slow issues because it relied on defer
statements, reflection (due to the use of `%+v`), and SHA256. This
function is used during service lookup in Hubble's hot path, therefore
this optimization should reduce the overhead of Hubble:

![image](https://user-images.githubusercontent.com/50564/104613557-a42e3f00-5687-11eb-95b3-317d2e6b101f.png)


Before this commit:

    BenchmarkL3n4Addr_Hash_IPv4-8         	  608378	      1856 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Short-8   	  620024	      2080 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Long-8    	  535290	      2168 ns/op

After this commit:

    BenchmarkL3n4Addr_Hash_IPv4-8         	15079537	        81.1 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Short-8   	 8348496	       149 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Long-8    	 4463416	       259 ns/op