### PR TITLE
[v1.9] docker: bump cilium-iproute2 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-12-07-v1.9@sha256:e916b1ed5a1b7cc2098a7f60ca3e6d296121d7436f9501672b2d1fa812289cab as builder
+FROM quay.io/cilium/cilium-builder:2021-01-14-v1.9@sha256:b427908d08879ebe1ead7f6a64e3766ffffeeda2c9fabdce2c2aa5757a987df9 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN make RACE=$RACE NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNE
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00
+FROM quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,7 +1,7 @@
 #
 # Cilium build-time base image (image created from this file is used to build Cilium)
 #
-FROM quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00
+FROM quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c
 LABEL maintainer="maintainer@cilium.io"
 ARG ARCH=amd64
 WORKDIR /go/src/github.com/cilium/cilium

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -3,7 +3,7 @@
 # development environmennt
 FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
-FROM quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00
+FROM quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c
 LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -57,7 +57,7 @@ RUN apt-get update && \
     strip -s ./loopback
 COPY --from=docker.io/cilium/cilium-llvm:8f18c7d16d85fd7f9c86fba5176a25a85f8f5a1a /usr/local/bin/clang /usr/local/bin/llc /bin/
 COPY --from=docker.io/cilium/cilium-bpftool:906ffee7cd996bf6bde2c074cdd5954703a0fd5f /usr/local/bin/bpftool /bin/
-COPY --from=docker.io/cilium/cilium-iproute2:4de8fae57d731146a4b8a353dc97cdf0f598096c /usr/local/bin/tc /usr/local/bin/ip /usr/local/bin/ss /bin/
+COPY --from=docker.io/cilium/cilium-iproute2:f873abca8c7128f48206c6aecbbcdc6315d3d79d /usr/local/bin/tc /usr/local/bin/ip /usr/local/bin/ss /bin/
 COPY --from=gops /go/bin/gops /bin/
 
 #

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.1-experimental
 
-# Copyright 2020 Authors of Cilium
+# Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:5af8f784456b17fc0a2bbe3777855ca198124272
-ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:0096e195e99708f11d35a57a31ff270ef8177e70
+ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:c3d6e952c7c9cf75fa6f555a63073b045c856ef4
 
 FROM ${CILIUM_BUILDER_IMAGE} as builder
 

--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.1-experimental
 
-# Copyright 2020 Authors of Cilium
+# Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:57f235db9a07e81c5b60c536498ecbf2501dd267@sha256:080245ac0d7d061e05613e6bf887dc3c8bb07392cd2ce265b8a4aaaad17f2125
@@ -10,7 +10,7 @@ ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bc
 
 ARG CILIUM_LLVM_IMAGE=docker.io/cilium/cilium-llvm:3355296c86c669ca92077e37bd5901d41c8142b9
 ARG CILIUM_BPFTOOL_IMAGE=docker.io/cilium/cilium-bpftool:fbb2e86339609f6755f53fcefd2257e4beea4423
-ARG CILIUM_IPROUTE2_IMAGE=docker.io/cilium/cilium-iproute2:44d4c6ebc57b78af0f1080ef52da2bae2605a439
+ARG CILIUM_IPROUTE2_IMAGE=docker.io/cilium/cilium-iproute2:f873abca8c7128f48206c6aecbbcdc6315d3d79d
 
 FROM ${CILIUM_LLVM_IMAGE} as llvm-dist
 FROM ${CILIUM_BPFTOOL_IMAGE} as bpftool-dist

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c"; fi'
             )}"""
     }
 

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c"; fi'
             )}"""
     }
 

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c"; fi'
             )}"""
     }
 

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c"; fi'
             )}"""
     }
 

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
             )}"""
         BASE_IMAGE="""${sh(
                 returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2020-12-07-v1.9@sha256:199452dac6c4a3bf0fc76c0a12b42949daf8ffc85015d508b5d16ca91b37fe00"; fi'
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-14-v1.9@sha256:3ae294a0b17d3f222ee81cb5c673cad779d4b8f13d1a3ae35006567e0303fb3c"; fi'
             )}"""
     }
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2020-12-07-v1.9@sha256:e916b1ed5a1b7cc2098a7f60ca3e6d296121d7436f9501672b2d1fa812289cab"
+    image: "quay.io/cilium/cilium-builder:2021-01-14-v1.9@sha256:b427908d08879ebe1ead7f6a64e3766ffffeeda2c9fabdce2c2aa5757a987df9"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:2020-12-07-v1.9@sha256:e916b1ed5a1b7cc2098a7f60ca3e6d296121d7436f9501672b2d1fa812289cab
+    image: quay.io/cilium/cilium-builder:2021-01-14-v1.9@sha256:b427908d08879ebe1ead7f6a64e3766ffffeeda2c9fabdce2c2aa5757a987df9
     command: ["sleep"]
     args:
       - "1000h"


### PR DESCRIPTION
Backport #14593 to 1.9.

The same iproute2 image tag as in the original PR is used, but cilium-runtime and then cilium-builder have been rebuilt specifically for the 1.9 branch. See notes in individual commit logs for adjustments.

Once this PR is merged, you can update the PR label via:
```upstream-prs
for pr in 14593; do contrib/backporting/set-labels.py $pr done 1.9; done
```