### PR TITLE
istio: Update to 1.7.6

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -14,10 +14,11 @@ managed with Istio.  It is a detailed walk-through of getting a
 single-node Cilium + Istio environment running on your machine.
 
 Cilium's Istio integration allows Cilium to enforce HTTP L7 network
-policies within the Istio sidecar proxies. Note that Istio can also be
-deployed without Cilium integration by running a standard version of
-``istioctl``.  In that case Cilium will enforce HTTP L7 policies outside
-of the Istio sidecar proxy.
+policies for mTLS protected traffic within the Istio sidecar
+proxies. Note that Istio can also be deployed without Cilium
+integration by running a standard version of ``istioctl``.  In that
+case Cilium will enforce HTTP L7 policies outside of the Istio sidecar
+proxy, but that will only work if mTLS is not used.
 
 .. include:: gsg_requirements.rst
 
@@ -37,20 +38,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.6.14 <https://github.com/cilium/istio/releases/tag/1.6.14>`_:
+Download the `cilium enhanced istioctl version 1.7.6 <https://github.com/cilium/istio/releases/tag/1.7.6>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.6.14/cilium-istioctl-1.6.14-linux-amd64.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.7.6/cilium-istioctl-1.7.6-linux-amd64.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.6.14/cilium-istioctl-1.6.14-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.7.6/cilium-istioctl-1.7.6-osx.tar.gz | tar xz
 
 .. note::
 
@@ -62,7 +63,7 @@ Deploy the default Istio configuration profile onto Kubernetes:
 
 ::
 
-    ./cilium-istioctl manifest apply -y
+    ./cilium-istioctl install -y
 
 Add a namespace label to instruct Istio to automatically inject Envoy sidecar proxies when you deploy your application later:
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -36,19 +36,19 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.6.14"
+		istioVersion = "1.7.6"
 
 		// Modifiers for pre-release testing, normally empty
-		prerelease     = "" // "-beta.10"
+		prerelease     = "" // "-beta.1"
 		istioctlParams = ""
 
 		// Keeping these here in comments serve multiple purposes:
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.6.14" +
-		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.6.14" +
-		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.6.14" +
+		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.7.6" +
+		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.7.6" +
+		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.7.6" +
 		// " --set values.global.proxy.logLevel=trace"
 		// " --set values.global.logging.level=debug"
 		// " --set values.global.mtls.auto=false"
@@ -115,7 +115,7 @@ var _ = Describe("K8sIstioTest", func() {
 		res.ExpectSuccess("unable to label namespace %q", helpers.DefaultNamespace)
 
 		By("Deploying Istio")
-		res = kubectl.Exec("./cilium-istioctl manifest apply -y" + istioctlParams)
+		res = kubectl.Exec("./cilium-istioctl install -y" + istioctlParams)
 		res.ExpectSuccess("unable to deploy Istio")
 	})
 


### PR DESCRIPTION
Update Istio integration to Istio release 1.7.6.

Istioctl CLI syntax has changed slightly, instead of `cilium-istioctl
manifest apply -y` we now use `cilium-istioctl install -y`.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Istio integration has been updated to Istio release 1.7.6.
```
