### PR TITLE
maglev: Allocate permutations slice ahead of time

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -186,7 +186,10 @@ func initKubeProxyReplacementOptions() (strict bool) {
 				log.Fatalf("Invalid value for --%s: %d, supported values are: %v",
 					option.MaglevTableSize, option.Config.MaglevTableSize, supportedPrimes)
 			}
-			if err := maglev.InitMaglevSeeds(option.Config.MaglevHashSeed); err != nil {
+			if err := maglev.Init(
+				option.Config.MaglevHashSeed,
+				uint64(option.Config.MaglevTableSize),
+			); err != nil {
 				log.WithError(err).Fatalf("Failed to initialize maglev hash seeds")
 			}
 		}

--- a/pkg/maglev/maglev.go
+++ b/pkg/maglev/maglev.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/murmur3"
+	"github.com/shirou/gopsutil/mem"
 )
 
 const (
@@ -35,9 +36,14 @@ var (
 
 	SeedJhash0 uint32
 	SeedJhash1 uint32
+
+	// permutation is the slice containing the Maglev permutation calculations.
+	permutation []uint64
 )
 
-func InitMaglevSeeds(seed string) error {
+// Init initializes the Maglev subsystem with the seed and the backend table
+// size (m).
+func Init(seed string, m uint64) error {
 	d, err := base64.StdEncoding.DecodeString(seed)
 	if err != nil {
 		return fmt.Errorf("Cannot decode base64 Maglev hash seed %q: %w", seed, err)
@@ -50,6 +56,10 @@ func InitMaglevSeeds(seed string) error {
 
 	SeedJhash0 = uint32(d[4])<<24 | uint32(d[5])<<16 | uint32(d[6])<<8 | uint32(d[7])
 	SeedJhash1 = uint32(d[8])<<24 | uint32(d[9])<<16 | uint32(d[10])<<8 | uint32(d[11])
+
+	// Allocate this ahead of time to avoid expensive allocations inside
+	// getPermutation().
+	permutation = make([]uint64, derivePermutationSliceLen(m))
 
 	return nil
 }
@@ -64,15 +74,20 @@ func getOffsetAndSkip(backend string, m uint64) (uint64, uint64) {
 
 func getPermutation(backends []string, m uint64, numCPU int) []uint64 {
 	var wg sync.WaitGroup
-	bCount := len(backends)
-	perm := make([]uint64, bCount*int(m))
 
 	// The idea is to split the calculation into batches so that they can be
-	// concurrently executed.  We limit the number of concurrent goroutines to
+	// concurrently executed. We limit the number of concurrent goroutines to
 	// the number of available CPU cores. This is because the calculation does
 	// not block and is completely CPU-bound. Therefore, adding more goroutines
 	// would result into an overhead (allocation of stackframes, stress on
 	// scheduling, etc) instead of a performance gain.
+
+	bCount := len(backends)
+	if size := uint64(bCount) * m; size > uint64(len(permutation)) {
+		// Reallocate slice so we don't have to allocate again on the next
+		// call.
+		permutation = make([]uint64, size)
+	}
 
 	batchSize := bCount / numCPU
 	if batchSize == 0 {
@@ -88,18 +103,17 @@ func getPermutation(backends []string, m uint64, numCPU int) []uint64 {
 			}
 			for i := from; i < to; i++ {
 				offset, skip := getOffsetAndSkip(backends[i], m)
-				perm[i*int(m)] = offset % m
+				permutation[i*int(m)] = offset % m
 				for j := uint64(1); j < m; j++ {
-					perm[i*int(m)+int(j)] = (perm[i*int(m)+int(j-1)] + skip) % m
+					permutation[i*int(m)+int(j)] = (permutation[i*int(m)+int(j-1)] + skip) % m
 				}
-
 			}
 			wg.Done()
 		}(g)
 	}
 	wg.Wait()
 
-	return perm
+	return permutation[:bCount*int(m)]
 }
 
 // GetLookupTable returns the Maglev lookup table of the size "m" for the given
@@ -131,4 +145,34 @@ func GetLookupTable(backends []string, m uint64) []int {
 	}
 
 	return entry
+}
+
+// derivePermutationSliceLen derives the permutations slice length depending on
+// the Maglev table size "m". The formula is (M / 100) * M. The heuristic gives
+// the following slice size for the given M.
+//
+//   251:    0.004806594848632812 MB
+//   509:    0.019766311645507812 MB
+//   1021:   0.07953193664550783 MB
+//   2039:   0.3171936798095703 MB
+//   4093:   1.2781256866455077 MB
+//   8191:   5.118750076293945 MB
+//   16381:  20.472500686645507 MB
+//   32749:  81.82502754211426 MB
+//   65521:  327.5300171661377 MB
+//   131071: 1310.700000076294 MB
+//
+// The heuristic does not apply to nodes with less than or equal to 8GB, as to
+// avoid memory pressure on memory-tight systems.
+//
+// Note, this function does not return the MB, but rather returns the number of
+// uint64 elements in the slice that equal to the total MB (length). To get the
+// MB, multiply by sizeof(uint64).
+func derivePermutationSliceLen(m uint64) uint64 {
+	threshold := uint64(8 * 1024 * 1024 * 1024) // 8GB
+	if vm, err := mem.VirtualMemory(); err != nil || vm == nil || vm.Total <= threshold {
+		return 0
+	}
+
+	return (m / uint64(100)) * m
 }

--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -33,7 +33,7 @@ type MaglevTestSuite struct{}
 var _ = Suite(&MaglevTestSuite{})
 
 func (s *MaglevTestSuite) SetUpTest(c *C) {
-	if err := InitMaglevSeeds(DefaultHashSeed); err != nil {
+	if err := Init(DefaultHashSeed, DefaultTableSize); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -91,6 +91,10 @@ func (s *MaglevTestSuite) TestBackendRemoval(c *C) {
 func (s *MaglevTestSuite) BenchmarkGetMaglevTable(c *C) {
 	backendCount := 1000
 	m := uint64(131071)
+
+	if err := Init(DefaultHashSeed, m); err != nil {
+		c.Fatal(err)
+	}
 
 	backends := make([]string, 0, backendCount)
 	for i := 0; i < backendCount; i++ {


### PR DESCRIPTION
Previously, the Maglev permutations slice is allocated inside
`getPermutation()`, which means every time `maglev.GetLookupTable()` is
called, the slice will be recreated. That means it would recreated on
every Service creation or update.

This commit allocates the slice ahead of time when the Maglev subsystem
is initialized (`maglev.Init()`). This gives a rough improvement in time
of around 15%.

The slice is allocated based on a heuristic computation, involving the M
size. Nodes running with less than 8GB of RAM do not apply and Cilium
will not be preallocate the slice ahead of time. For nodes with more
than the aforementioned threshold, the formula for the heuristic is:

    (M / 100) * 100

This is derived from the maximum backends property from Maglev where
|backends| * 100 < M. This gives the following memory pressure profile
based on M (left-hand side):

    251:    0.004806594848632812 MB
    509:    0.019766311645507812 MB
    1021:   0.07953193664550783 MB
    2039:   0.3171936798095703 MB
    4093:   1.2781256866455077 MB
    8191:   5.118750076293945 MB
    16381:  20.472500686645507 MB
    32749:  81.82502754211426 MB
    65521:  327.5300171661377 MB
    131071: 1310.700000076294 MB

If the user has more backends than the preallocated size, we will adjust
the allocation to be |backends| * M. This is because we want to ensure
that the Maglev subsystem isn't thrashing trying to reallocate the slice
on each Service create or update.

Benchmark timings:

Before
```
$ go test -v ./pkg/maglev -check.v -check.b -check.btime 5s -check.bmem
=== RUN   Test
PASS: maglev_test.go:91: MaglevTestSuite.BenchmarkGetMaglevTable              50         341255883 ns/op1049633800 B/op        12 allocs/op
OK: 1 passed
--- PASS: Test (17.42s)
PASS
ok      github.com/cilium/cilium/pkg/maglev     17.475s
```

After
```
$ go test -v ./pkg/maglev -check.v -check.b -check.btime 5s -check.bmem
=== RUN   Test
PASS: maglev_test.go:91: MaglevTestSuite.BenchmarkGetMaglevTable              50         282792516 ns/op 1057899 B/op          11 allocs/op
OK: 1 passed
--- PASS: Test (17.89s)
PASS
ok      github.com/cilium/cilium/pkg/maglev     17.943s
```

Suggested-by: Martynas Pumputis <m@lambda.lt>

FlameGraphs:

![Before](https://user-images.githubusercontent.com/3885308/104666682-51558700-5689-11eb-941d-28bb2c124c0e.png)
![After](https://user-images.githubusercontent.com/3885308/104666723-6a5e3800-5689-11eb-9edb-fa3c5d2c4904.png)

Related: https://github.com/cilium/cilium/issues/14397