### PR TITLE
pkg/kvstore: fix panic when closing etcd connections on error

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1654,14 +1654,20 @@ func (e *etcdClient) Close() {
 	}
 	e.RLock()
 	defer e.RUnlock()
-	if err := e.lockSession.Close(); err != nil {
-		e.getLogger().WithError(err).Warning("Failed to revoke lock session while closing etcd client")
+	if e.lockSession != nil {
+		if err := e.lockSession.Close(); err != nil {
+			e.getLogger().WithError(err).Warning("Failed to revoke lock session while closing etcd client")
+		}
 	}
-	if err := e.session.Close(); err != nil {
-		e.getLogger().WithError(err).Warning("Failed to revoke main session while closing etcd client")
+	if e.session != nil {
+		if err := e.session.Close(); err != nil {
+			e.getLogger().WithError(err).Warning("Failed to revoke main session while closing etcd client")
+		}
 	}
-	if err := e.client.Close(); err != nil {
-		e.getLogger().WithError(err).Warning("Failed to close etcd client")
+	if e.client != nil {
+		if err := e.client.Close(); err != nil {
+			e.getLogger().WithError(err).Warning("Failed to close etcd client")
+		}
 	}
 }
 


### PR DESCRIPTION
```
goroutine 319 [running]:
go.etcd.io/etcd/clientv3/concurrency.(*Session).Orphan(...)
        /go/src/github.com/cilium/cilium/vendor/go.etcd.io/etcd/clientv3/concurrency/session.go:90
go.etcd.io/etcd/clientv3/concurrency.(*Session).Close(0xc000dcca50, 0xc00145d790, 0x2)
        /go/src/github.com/cilium/cilium/vendor/go.etcd.io/etcd/clientv3/concurrency/session.go:96 +0x2a
github.com/cilium/cilium/pkg/kvstore.(*etcdClient).Close(0xc0014f2c30)
        /go/src/github.com/cilium/cilium/pkg/kvstore/etcd.go:1652 +0xc8
github.com/cilium/cilium/pkg/clustermesh.(*remoteCluster).restartRemoteConnection.func1(0x2e862e0, 0xc0009fc300, 0x460d7a0, 0x415c26)
        /go/src/github.com/cilium/cilium/pkg/clustermesh/remote_cluster.go:178 +0x408
github.com/cilium/cilium/pkg/controller.(*Controller).runController(0xc0008d2100)
        /go/src/github.com/cilium/cilium/pkg/controller/controller.go:205 +0xa2a
created by github.com/cilium/cilium/pkg/controller.(*Manager).updateController
        /go/src/github.com/cilium/cilium/pkg/controller/manager.go:120 +0xb09
```

Fixes: c1b05dfba81a ("pkg/kvstore: introduced a dedicated session for locks")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix potential panic when closing etcd connection on error
```
