### PR TITLE
docs: AKS - remove azure0 from CNI chaining config

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -21,7 +21,6 @@ desired CNI chaining configuration:
             {
               "type": "azure-vnet",
               "mode": "transparent",
-              "bridge": "azure0",
               "ipam": {
                  "type": "azure-vnet-ipam"
                }


### PR DESCRIPTION
The new AKS node pools are configured in transparent mode by default and no longer have an azure0 interface. The 'bridge' parameter was ignored in transparent mode anyway.

```release-note
Remove 'bridge' parameter in Azure CNI chaining configuration.
```
