### PR TITLE
helm: set dnsPolicy based on etcd.k8sService

### DIFF
--- a/Documentation/concepts/kubernetes/requirements.rst
+++ b/Documentation/concepts/kubernetes/requirements.rst
@@ -51,8 +51,13 @@ The :ref:`k8s_install_etcd_operator` relies on the etcd-operator to manage an
 etcd cluster. In order for the etcd cluster to be available, the Cilium pod is
 being run with ``dnsPolicy: ClusterFirstWithHostNet`` in order for Cilium to be
 able to look up Kubernetes service names via DNS. This creates a dependency on
-kube-dns. If you would like to avoid running kube-dns, choose a different
-installation method and remove the ``dnsPolicy`` field from the ``DaemonSet``.
+kube-dns. It is possible to avoid this dependency by deploying Cilium with
+``etcd.k8sService=true``. This option will allow Cilium to perform the name
+translation automatically by checking the service IP of the service name for
+the etcd cluster. This service name is usually in the form of ``cilium-etcd-client.<namespace>.svc``
+and it is automatically created by Cilium etcd Operator.
+
+For more information about ``dnsPolicy`` see: https://pkg.go.dev/k8s.io/api@v0.20.2/core/v1#DNSPolicy
 
 Enable automatic node CIDR allocation (Recommended)
 ===================================================

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -40,7 +40,8 @@ Deploy Cilium release via Helm:
    helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
       --set etcd.enabled=true \\
-      --set etcd.managed=true
+      --set etcd.managed=true \\
+      --set etcd.k8sService=true
 
 
 Validate the Installation

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -341,7 +341,7 @@ spec:
           {{- toYaml .Values.monitor.resources | trim | nindent 10 }}
 {{- end }}
 {{- end }}
-{{- if .Values.etcd.managed }}
+{{- if (and .Values.etcd.managed (not .Values.etcd.k8sService)) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -192,7 +192,7 @@ spec:
           {{- toYaml .Values.operator.resources | trim | nindent 10 }}
 {{- end }}
       hostNetwork: true
-{{- if .Values.etcd.managed }}
+{{- if (and .Values.etcd.managed (not .Values.etcd.k8sService)) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
As Cilium can perform the domain translation for etcd, if the service is
running in k8s, we do not need to run dnsPolicy with
`ClusterFirstWithHostNet` as it will depend on CoreDNS to be up and
running.

Also clarify the documentation around this option in the requirements
guide.

Signed-off-by: André Martins <andre@cilium.io>