### PR TITLE
test: Test of externalTrafficPolicy=Local in IPSec+vxlan mode

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -169,10 +169,7 @@ pipeline {
                     returnStdout: true,
                     script: 'if [ "${KERNEL}" = "net-next" ]; then echo -n "k8s3"; else echo -n ""; fi'
                     )}"""
-                KUBEPROXY="""${sh(
-                    returnStdout: true,
-                    script: 'if [ "${KERNEL}" = "net-next" ] || [ "${KERNEL}" = "419" ]; then echo -n "0"; else echo -n ""; fi'
-                    )}"""
+                KUBEPROXY="1"
             }
             steps {
                 withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
@@ -221,10 +218,7 @@ pipeline {
                     returnStdout: true,
                     script: 'if [ "${KERNEL}" = "net-next" ]; then echo -n "k8s3"; else echo -n ""; fi'
                     )}"""
-                KUBEPROXY="""${sh(
-                    returnStdout: true,
-                    script: 'if [ "${KERNEL}" = "net-next" ] || [ "${KERNEL}" = "419" ]; then echo -n "0"; else echo -n ""; fi'
-                    )}"""
+                KUBEPROXY="1"
                 CILIUM_IMAGE = """${sh(
                         returnStdout: true,
                         script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/cilium'

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -134,7 +134,7 @@ pipeline {
                         K8S_VERSION="1.13"
                         K8S_NODES="3"
                         NO_CILIUM_ON_NODE="k8s3"
-                        KUBEPROXY="0"
+                        KUBEPROXY="1"
                         KUBECONFIG="vagrant-kubeconfig"
                     }
                     steps {
@@ -248,7 +248,7 @@ pipeline {
                         KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                         K8S_VERSION="1.13"
                         K8S_NODES="3"
-                        KUBEPROXY="0"
+                        KUBEPROXY="1"
                         NO_CILIUM_ON_NODE="k8s3"
                         HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
                     }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -47,6 +47,7 @@ var _ = check.Suite(&managerTestSuite{})
 type configMock struct {
 	RemoteNodeIdentity bool
 	NodeEncryption     bool
+	Encryption         bool
 }
 
 func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
@@ -55,6 +56,10 @@ func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
 
 func (c *configMock) NodeEncryptionEnabled() bool {
 	return c.NodeEncryption
+}
+
+func (c *configMock) EncryptionEnabled() bool {
+	return c.Encryption
 }
 
 type nodeEvent struct {
@@ -559,7 +564,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true})
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true, Encryption: true})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2191,6 +2191,11 @@ func (c *DaemonConfig) NodeEncryptionEnabled() bool {
 	return c.EncryptNode
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (c *DaemonConfig) EncryptionEnabled() bool {
+	return c.EnableIPSec
+}
+
 // IPv4Enabled returns true if IPv4 is enabled
 func (c *DaemonConfig) IPv4Enabled() bool {
 	return c.EnableIPv4

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -33,6 +33,11 @@ func (f *Config) RemoteNodeIdentitiesEnabled() bool {
 	return true
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (f *Config) EncryptionEnabled() bool {
+	return true
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1932,7 +1932,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			deploymentManager.SetKubectl(kubectl)
 			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"encryption.enabled": "true",
+				"encryption.enabled":   "true",
+				"kubeProxyReplacement": "partial",
+				"hostServices.enabled": "true",
 				// When kube-proxy is enabled, the host firewall is not
 				// compatible with externalTrafficPolicy=Local because traffic
 				// from pods to remote nodes goes through the tunnel.


### PR DESCRIPTION
This test validates a potential regression on the path `node1 -> pod@node2` via service with `externalTrafficPolicy=Local`.

Related: #14611.