### PR TITLE
ci: only run CodeQL analysis on cilium/cilium

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   analyze:
+    if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
As suggested by @kaworu, this prevents the CodeQL analysis from running on forks of `cilium/cilium` where CodeQL might not be enabled.