### PR TITLE
Makefile: build Cilium with madvdontneed=1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,6 @@ RUN groupadd -f cilium \
     && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 
 ENV INITSYSTEM="SYSTEMD"
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium"]

--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -53,4 +53,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-aws"]

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -53,4 +53,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-azure"]

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -53,4 +53,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-generic"]

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -53,4 +53,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator"]

--- a/clustermesh-apiserver.Dockerfile
+++ b/clustermesh-apiserver.Dockerfile
@@ -56,4 +56,6 @@ COPY --from=builder /go/src/github.com/cilium/cilium/clustermesh-apiserver/clust
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 ENTRYPOINT ["/usr/bin/clustermesh-apiserver"]

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -348,6 +348,8 @@ sleep 2s
 if [ -n "\${K8S}" ]; then
     echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
 fi
+# FIXME Remove me once we add support for Go 1.16
+echo 'GODEBUG="madvdontneed=1"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPTS="${cilium_options}"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPERATOR_OPTS="${cilium_operator_options}"' >> /etc/sysconfig/cilium
 echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -48,4 +48,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 ENTRYPOINT ["/usr/bin/hubble-relay"]
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["serve"]


### PR DESCRIPTION
Setting this option makes Cilium to be compiled in a mode that will
allow it to reduce its process' RSS even if the system is not under
memory pressure.

By default, i.e. without 'madvdontneed' being set, Cilium will only
release its process' RSS when the system is under pressure. This
may be confusing for users since they will assume Cilium needs the
memory reported in RSS, which is not true.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Make Go runtime to return unused memory to OS more often
```

Benchmark results:
100 node cluster with clusterloader2:
The red lines represent the beginning and end of the test

**BASE** VS **NEW**
<img width="1210" alt="diff" src="https://user-images.githubusercontent.com/5714066/107526635-563e2580-6bb8-11eb-8d83-24314ab64ceb.png">
