### PR TITLE
hubble: switch to google.golang.org/protobuf

### DIFF
--- a/pkg/hubble/api/v1/types.go
+++ b/pkg/hubble/api/v1/types.go
@@ -17,13 +17,13 @@ package v1
 import (
 	pb "github.com/cilium/cilium/api/v1/flow"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Event represents a single event observed and stored by Hubble
 type Event struct {
 	// Timestamp when event was observed in Hubble
-	Timestamp *timestamp.Timestamp
+	Timestamp *timestamppb.Timestamp
 	// Event contains the actual event
 	Event interface{}
 }

--- a/pkg/hubble/container/ring.go
+++ b/pkg/hubble/container/ring.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/math"
 	"github.com/cilium/cilium/pkg/lock"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
@@ -379,7 +379,7 @@ func (r *Ring) readFrom(ctx context.Context, read uint64, ch chan<- *v1.Event) {
 			now := time.Now().UTC()
 			select {
 			case ch <- &v1.Event{
-				Timestamp: &timestamp.Timestamp{
+				Timestamp: &timestamppb.Timestamp{
 					Seconds: int64(now.Unix()),
 					Nanos:   int32(now.Nanosecond()),
 				},

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -25,15 +25,15 @@ import (
 
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestRingReader_Previous(t *testing.T) {
 	ring := NewRing(Capacity15)
 	for i := 0; i < 15; i++ {
-		ring.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
+		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 	tests := []struct {
 		start   uint64
@@ -45,36 +45,36 @@ func TestRingReader_Previous(t *testing.T) {
 			start: 13,
 			count: 1,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 13}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 13}},
 			},
 		}, {
 			start: 13,
 			count: 2,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 13}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 12}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 13}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 12}},
 			},
 		}, {
 			start: 5,
 			count: 5,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 5}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 4}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 3}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 2}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 1}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 1}},
 			},
 		}, {
 			start: 0,
 			count: 1,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 0}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
 			},
 		}, {
 			start: 0,
 			count: 1,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 0}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
 			},
 		}, {
 			start:   14,
@@ -111,7 +111,7 @@ func TestRingReader_Previous(t *testing.T) {
 func TestRingReader_Next(t *testing.T) {
 	ring := NewRing(Capacity15)
 	for i := 0; i < 15; i++ {
-		ring.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
+		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 
 	tests := []struct {
@@ -124,30 +124,30 @@ func TestRingReader_Next(t *testing.T) {
 			start: 0,
 			count: 1,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 0}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
 			},
 		}, {
 			start: 0,
 			count: 2,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 0}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 1}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 1}},
 			},
 		}, {
 			start: 5,
 			count: 5,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 5}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 6}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 7}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 8}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 9}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 7}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 8}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 9}},
 			},
 		}, {
 			start: 13,
 			count: 1,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 13}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 13}},
 			},
 		}, {
 			start:   ^uint64(0),
@@ -189,7 +189,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	ring := NewRing(Capacity15)
 	for i := 0; i < 15; i++ {
-		ring.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
+		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 
 	tests := []struct {
@@ -202,30 +202,30 @@ func TestRingReader_NextFollow(t *testing.T) {
 			start: 0,
 			count: 1,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 0}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
 			},
 		}, {
 			start: 0,
 			count: 2,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 0}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 1}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 1}},
 			},
 		}, {
 			start: 5,
 			count: 5,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 5}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 6}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 7}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 8}},
-				{Timestamp: &timestamp.Timestamp{Seconds: 9}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 7}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 8}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 9}},
 			},
 		}, {
 			start: 13,
 			count: 1,
 			want: []*v1.Event{
-				{Timestamp: &timestamp.Timestamp{Seconds: 13}},
+				{Timestamp: &timestamppb.Timestamp{Seconds: 13}},
 			},
 		}, {
 			start:       14,

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -29,12 +29,12 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func BenchmarkRingWrite(b *testing.B) {
@@ -196,14 +196,14 @@ func TestRing_Read(t *testing.T) {
 				mask:     0x7,
 				cycleExp: 0x3, // 7+1=8=2^3
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
-					0x4: {Timestamp: &timestamp.Timestamp{Seconds: 4}},
-					0x5: {Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					0x6: {Timestamp: &timestamp.Timestamp{Seconds: 6}},
-					0x7: {Timestamp: &timestamp.Timestamp{Seconds: 7}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+					0x4: {Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+					0x5: {Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					0x6: {Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+					0x7: {Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 				},
 				// next to be written: 0x9 (idx: 1), last written: 0x8 (idx: 0)
 				write: 0x9,
@@ -211,7 +211,7 @@ func TestRing_Read(t *testing.T) {
 			args: args{
 				read: 0x7,
 			},
-			want:    &v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 7}},
+			want:    &v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 			wantErr: nil,
 		},
 		{
@@ -220,14 +220,14 @@ func TestRing_Read(t *testing.T) {
 				mask:     0x7,
 				cycleExp: 0x3, // 7+1=8=2^3
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
-					0x4: {Timestamp: &timestamp.Timestamp{Seconds: 4}},
-					0x5: {Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					0x6: {Timestamp: &timestamp.Timestamp{Seconds: 6}},
-					0x7: {Timestamp: &timestamp.Timestamp{Seconds: 7}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+					0x4: {Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+					0x5: {Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					0x6: {Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+					0x7: {Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 				},
 				// next to be written: 0x9 (idx: 2), last written: 0x8 (idx: 0)
 				write: 0x9,
@@ -244,14 +244,14 @@ func TestRing_Read(t *testing.T) {
 				mask:     0x7,
 				cycleExp: 0x3, // 7+1=8=2^3
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
-					0x4: {Timestamp: &timestamp.Timestamp{Seconds: 4}},
-					0x5: {Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					0x6: {Timestamp: &timestamp.Timestamp{Seconds: 6}},
-					0x7: {Timestamp: &timestamp.Timestamp{Seconds: 7}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+					0x4: {Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+					0x5: {Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					0x6: {Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+					0x7: {Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 				},
 				// next to be written: 0x10 (idx: 0), last written: 0x0f (idx: 7)
 				write: 0x10,
@@ -269,14 +269,14 @@ func TestRing_Read(t *testing.T) {
 				mask:     0x7,
 				cycleExp: 0x3, // 7+1=8=2^3
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
-					0x4: {Timestamp: &timestamp.Timestamp{Seconds: 4}},
-					0x5: {Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					0x6: {Timestamp: &timestamp.Timestamp{Seconds: 6}},
-					0x7: {Timestamp: &timestamp.Timestamp{Seconds: 7}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+					0x4: {Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+					0x5: {Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					0x6: {Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+					0x7: {Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 				},
 				// next to be written: 0x10 (idx: 0), last written: 0x0f (idx: 7)
 				write: 0x10,
@@ -285,7 +285,7 @@ func TestRing_Read(t *testing.T) {
 				// The next possible entry that we can read is 0x10-0x7-0x1 = 0x8 (idx: 0)
 				read: 0x8,
 			},
-			want:    &v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 0}},
+			want:    &v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
 			wantErr: nil,
 		},
 		{
@@ -294,14 +294,14 @@ func TestRing_Read(t *testing.T) {
 				mask:     0x7,
 				cycleExp: 0x3, // 7+1=8=2^3
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
-					0x4: {Timestamp: &timestamp.Timestamp{Seconds: 4}},
-					0x5: {Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					0x6: {Timestamp: &timestamp.Timestamp{Seconds: 6}},
-					0x7: {Timestamp: &timestamp.Timestamp{Seconds: 7}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+					0x4: {Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+					0x5: {Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					0x6: {Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+					0x7: {Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 				},
 				// next to be written: 0x0 (idx: 0), last written: 0xffffffffffffffff (idx: 7)
 				write: 0x0,
@@ -320,14 +320,14 @@ func TestRing_Read(t *testing.T) {
 				mask:     0x7,
 				cycleExp: 0x3, // 7+1=8=2^3
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
-					0x4: {Timestamp: &timestamp.Timestamp{Seconds: 4}},
-					0x5: {Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					0x6: {Timestamp: &timestamp.Timestamp{Seconds: 6}},
-					0x7: {Timestamp: &timestamp.Timestamp{Seconds: 7}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+					0x4: {Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+					0x5: {Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					0x6: {Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+					0x7: {Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 				},
 				// next to be written: 0x1 (idx: 1), last written: 0x0 (idx: 0)
 				write: 0x1,
@@ -336,7 +336,7 @@ func TestRing_Read(t *testing.T) {
 				// next to be read: ^uint64(0) (idx: 7), last read: 0xfffffffffffffffe (idx: 6)
 				read: ^uint64(0),
 			},
-			want:    &v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 7}},
+			want:    &v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 			wantErr: nil,
 		},
 		{
@@ -345,14 +345,14 @@ func TestRing_Read(t *testing.T) {
 				mask:     0x7,
 				cycleExp: 0x3, // 7+1=8=2^3
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
-					0x4: {Timestamp: &timestamp.Timestamp{Seconds: 4}},
-					0x5: {Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					0x6: {Timestamp: &timestamp.Timestamp{Seconds: 6}},
-					0x7: {Timestamp: &timestamp.Timestamp{Seconds: 7}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
+					0x4: {Timestamp: &timestamppb.Timestamp{Seconds: 4}},
+					0x5: {Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					0x6: {Timestamp: &timestamppb.Timestamp{Seconds: 6}},
+					0x7: {Timestamp: &timestamppb.Timestamp{Seconds: 7}},
 				},
 				// next to be written: 0x8 (idx: 1), last written: 0xffffffffffffffff (idx: 7)
 				write: 0x8,
@@ -406,52 +406,52 @@ func TestRing_Write(t *testing.T) {
 		{
 			name: "normal write",
 			args: args{
-				event: &v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 5}},
+				event: &v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 5}},
 			},
 			fields: fields{
 				len:   0x3,
 				write: 0,
 				data: []*v1.Event{
-					0x0: {Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					0x1: {Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					0x2: {Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					0x3: {Timestamp: &timestamp.Timestamp{Seconds: 3}},
+					0x0: {Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					0x1: {Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					0x2: {Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					0x3: {Timestamp: &timestamppb.Timestamp{Seconds: 3}},
 				},
 			},
 			want: fields{
 				len:   0x3,
 				write: 1,
 				data: []*v1.Event{
-					{Timestamp: &timestamp.Timestamp{Seconds: 5}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 3}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 5}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 3}},
 				},
 			},
 		},
 		{
 			name: "overflow write",
 			args: args{
-				event: &v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 5}},
+				event: &v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 5}},
 			},
 			fields: fields{
 				len:   0x3,
 				write: ^uint64(0),
 				data: []*v1.Event{
-					{Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 3}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 3}},
 				},
 			},
 			want: fields{
 				len:   0x3,
 				write: 0,
 				data: []*v1.Event{
-					{Timestamp: &timestamp.Timestamp{Seconds: 0}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 1}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 2}},
-					{Timestamp: &timestamp.Timestamp{Seconds: 5}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 0}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 1}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 2}},
+					{Timestamp: &timestamppb.Timestamp{Seconds: 5}},
 				},
 			},
 		},
@@ -577,13 +577,13 @@ func TestRingFunctionalityInParallel(t *testing.T) {
 		t.Errorf("lastWrite should be %x. Got %x", ^uint64(0)-1, lastWrite)
 	}
 
-	r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 0}})
+	r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 0}})
 	lastWrite = r.LastWriteParallel()
 	if lastWrite != ^uint64(0) {
 		t.Errorf("lastWrite should be %x. Got %x", ^uint64(0), lastWrite)
 	}
 
-	r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 1}})
+	r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 1}})
 	lastWrite = r.LastWriteParallel()
 	if lastWrite != 0x0 {
 		t.Errorf("lastWrite should be 0x0. Got %x", lastWrite)
@@ -594,7 +594,7 @@ func TestRingFunctionalityInParallel(t *testing.T) {
 		t.Errorf("Should be able to read position %x, got %v", lastWrite, err)
 	}
 	if entry.Timestamp.Seconds != int64(0) {
-		t.Errorf("Read Event should be %+v, got %+v instead", &timestamp.Timestamp{Seconds: 0}, entry.Timestamp)
+		t.Errorf("Read Event should be %+v, got %+v instead", &timestamppb.Timestamp{Seconds: 0}, entry.Timestamp)
 	}
 	lastWrite--
 	_, err = r.read(lastWrite)
@@ -616,13 +616,13 @@ func TestRingFunctionalitySerialized(t *testing.T) {
 		t.Errorf("lastWrite should be %x. Got %x", ^uint64(0)-1, lastWrite)
 	}
 
-	r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 0}})
+	r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 0}})
 	lastWrite = r.LastWrite()
 	if lastWrite != 0x0 {
 		t.Errorf("lastWrite should be %x. Got %x", 0x0, lastWrite)
 	}
 
-	r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: 1}})
+	r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 1}})
 	lastWrite = r.LastWrite()
 	if lastWrite != 0x1 {
 		t.Errorf("lastWrite should be 0x1. Got %x", lastWrite)
@@ -638,7 +638,7 @@ func TestRingFunctionalitySerialized(t *testing.T) {
 		t.Errorf("Should be able to read position %x, got %v", lastWrite, err)
 	}
 	if entry.Timestamp.Seconds != int64(0) {
-		t.Errorf("Read Event should be %+v, got %+v instead", &timestamp.Timestamp{Seconds: 0}, entry.Timestamp)
+		t.Errorf("Read Event should be %+v, got %+v instead", &timestamppb.Timestamp{Seconds: 0}, entry.Timestamp)
 	}
 }
 
@@ -666,7 +666,7 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 
 	// Add 5 events
 	for i := uint64(0); i < 5; i++ {
-		r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
+		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 		lastWrite = r.LastWrite()
 		if lastWrite != i {
 			t.Errorf("lastWrite should be %x. Got %x", i, lastWrite)
@@ -684,7 +684,7 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 	i := int64(0)
 	for entry := range ch {
 		require.NotNil(t, entry)
-		want := &timestamp.Timestamp{Seconds: i}
+		want := &timestamppb.Timestamp{Seconds: i}
 		if entry.Timestamp.Seconds != want.Seconds {
 			t.Errorf("Read Event should be %+v, got %+v instead", want, entry.Timestamp)
 		}
@@ -728,7 +728,7 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 
 	// Add 20 events
 	for i := uint64(0); i < 20; i++ {
-		r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
+		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 		lastWrite = r.LastWrite()
 		if lastWrite != i {
 			t.Errorf("lastWrite should be %x. Got %x", i, lastWrite)
@@ -768,8 +768,8 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 				t.Errorf("LostEvent mismatch (-want +got):\n%s", diff)
 			}
 		default:
-			want := &timestamp.Timestamp{Seconds: i}
-			if diff := cmp.Diff(want, event.Timestamp, cmpopts.IgnoreUnexported(timestamp.Timestamp{})); diff != "" {
+			want := &timestamppb.Timestamp{Seconds: i}
+			if diff := cmp.Diff(want, event.Timestamp, cmpopts.IgnoreUnexported(timestamppb.Timestamp{})); diff != "" {
 				t.Errorf("Event timestamp mismatch (-want +got):\n%s", diff)
 			}
 		}
@@ -787,9 +787,9 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 
 	// Add 20 more events that we read back immediately
 	for i := uint64(0); i < 20; i++ {
-		r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(20 + i)}})
+		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(20 + i)}})
 
-		want := &timestamp.Timestamp{Seconds: int64(20 + (i - 1))}
+		want := &timestamppb.Timestamp{Seconds: int64(20 + (i - 1))}
 		entry, ok := <-ch
 		if !ok {
 			t.Errorf("Channel was have been closed, expected %+v", entry)
@@ -826,7 +826,7 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 
 	// Add 20 events
 	for i := uint64(0); i < 20; i++ {
-		r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})
+		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 		lastWrite = r.LastWrite()
 		if lastWrite != i {
 			t.Errorf("lastWrite should be %x. Got %x", i, lastWrite)
@@ -866,8 +866,8 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 				t.Errorf("%d LostEvent mismatch (-want +got):\n%s", i, diff)
 			}
 		default:
-			want := &timestamp.Timestamp{Seconds: int64(i)}
-			if diff := cmp.Diff(want, entry.Timestamp, cmpopts.IgnoreUnexported(timestamp.Timestamp{})); diff != "" {
+			want := &timestamppb.Timestamp{Seconds: int64(i)}
+			if diff := cmp.Diff(want, entry.Timestamp, cmpopts.IgnoreUnexported(timestamppb.Timestamp{})); diff != "" {
 				t.Errorf("Event timestamp mismatch (-want +got):\n%s", diff)
 			}
 		}
@@ -885,9 +885,9 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 
 	// Add 20 more events that we read back immediately
 	for i := uint64(0); i < 20; i++ {
-		r.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(20 + i)}})
+		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(20 + i)}})
 
-		want := &timestamp.Timestamp{Seconds: int64(20 + (i - 1))}
+		want := &timestamppb.Timestamp{Seconds: int64(20 + (i - 1))}
 		entry, ok := <-ch
 		if !ok {
 			t.Errorf("Channel was have been closed, expected %+v", entry)

--- a/pkg/hubble/filters/reply_test.go
+++ b/pkg/hubble/filters/reply_test.go
@@ -23,7 +23,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func Test_filterByReplyField(t *testing.T) {
@@ -49,7 +49,7 @@ func Test_filterByReplyField(t *testing.T) {
 			name: "empty-param",
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{}}},
-				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrappers.BoolValue{Value: true}}},
+				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrapperspb.BoolValue{Value: true}}},
 			},
 			want: true,
 		},
@@ -57,7 +57,7 @@ func Test_filterByReplyField(t *testing.T) {
 			name: "empty-param-2",
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{}}},
-				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrappers.BoolValue{Value: false}}},
+				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrapperspb.BoolValue{Value: false}}},
 			},
 			want: true,
 		},
@@ -65,7 +65,7 @@ func Test_filterByReplyField(t *testing.T) {
 			name: "no-reply",
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{false}}},
-				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrappers.BoolValue{Value: false}}},
+				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrapperspb.BoolValue{Value: false}}},
 			},
 			want: true,
 		},
@@ -92,7 +92,7 @@ func Test_filterByReplyField(t *testing.T) {
 						Type:    monitorAPI.MessageTypeTrace,
 						SubType: monitorAPI.TraceToLxc,
 					},
-					IsReply: &wrappers.BoolValue{Value: false},
+					IsReply: &wrapperspb.BoolValue{Value: false},
 				}},
 			},
 			want: true,
@@ -101,7 +101,7 @@ func Test_filterByReplyField(t *testing.T) {
 			name: "reply",
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{true}}},
-				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrappers.BoolValue{Value: true}}},
+				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrapperspb.BoolValue{Value: true}}},
 			},
 			want: true,
 		},
@@ -117,7 +117,7 @@ func Test_filterByReplyField(t *testing.T) {
 			name: "no-match",
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{true}}},
-				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrappers.BoolValue{Value: false}}},
+				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrapperspb.BoolValue{Value: false}}},
 			},
 			want: false,
 		},
@@ -125,7 +125,7 @@ func Test_filterByReplyField(t *testing.T) {
 			name: "no-match-2",
 			args: args{
 				f:  []*flowpb.FlowFilter{{Reply: []bool{false}}},
-				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrappers.BoolValue{Value: true}}},
+				ev: &v1.Event{Event: &flowpb.Flow{IsReply: &wrapperspb.BoolValue{Value: true}}},
 			},
 			want: false,
 		},

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -35,10 +35,10 @@ import (
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -136,8 +136,8 @@ func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
 	queueSize := 0
 
 	since := time.Unix(5, 0)
-	sinceProto, err := ptypes.TimestampProto(since)
-	assert.NoError(t, err)
+	sinceProto := timestamppb.New(since)
+	assert.NoError(t, sinceProto.CheckValid())
 	req := &observerpb.GetFlowsRequest{
 		Since:  sinceProto,
 		Follow: true,
@@ -177,8 +177,8 @@ func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
 			assert.Equal(t, response.GetTime(), response.GetFlow().GetTime())
 			assert.Equal(t, response.GetNodeName(), response.GetFlow().GetNodeName())
 
-			ts, err := ptypes.Timestamp(response.GetTime())
-			assert.NoError(t, err)
+			assert.NoError(t, response.GetTime().CheckValid())
+			ts := response.GetTime().AsTime()
 			assert.True(t, !ts.Before(since), "flow had invalid timestamp. ts=%s, since=%s", ts, since)
 
 			// start producing flows once we have seen the most recent one.

--- a/pkg/hubble/parser/agent/parser.go
+++ b/pkg/hubble/parser/agent/parser.go
@@ -23,8 +23,8 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func notifyTimeNotificationToProto(typ flowpb.AgentEventType, n monitorAPI.TimeNotification) *flowpb.AgentEvent {
@@ -83,9 +83,9 @@ func notifyEndpointUpdateNotificationToProto(typ flowpb.AgentEventType, n monito
 	}
 }
 func notifyIPCacheNotificationToProto(typ flowpb.AgentEventType, n monitorAPI.IPCacheNotification) *flowpb.AgentEvent {
-	var oldIdentity *wrappers.UInt32Value
+	var oldIdentity *wrapperspb.UInt32Value
 	if n.OldIdentity != nil {
-		oldIdentity = &wrappers.UInt32Value{
+		oldIdentity = &wrapperspb.UInt32Value{
 			Value: *n.OldIdentity,
 		}
 	}

--- a/pkg/hubble/parser/agent/parser.go
+++ b/pkg/hubble/parser/agent/parser.go
@@ -23,12 +23,12 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func notifyTimeNotificationToProto(typ flowpb.AgentEventType, n monitorAPI.TimeNotification) *flowpb.AgentEvent {
-	var ts *timestamp.Timestamp
+	var ts *timestamppb.Timestamp
 	if goTime, err := time.Parse(time.RFC3339Nano, n.Time); err == nil {
 		ts, _ = ptypes.TimestampProto(goTime)
 	}

--- a/pkg/hubble/parser/agent/parser.go
+++ b/pkg/hubble/parser/agent/parser.go
@@ -22,7 +22,6 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
-	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -30,7 +29,7 @@ import (
 func notifyTimeNotificationToProto(typ flowpb.AgentEventType, n monitorAPI.TimeNotification) *flowpb.AgentEvent {
 	var ts *timestamppb.Timestamp
 	if goTime, err := time.Parse(time.RFC3339Nano, n.Time); err == nil {
-		ts, _ = ptypes.TimestampProto(goTime)
+		ts = timestamppb.New(goTime)
 	}
 	return &flowpb.AgentEvent{
 		Type: typ,

--- a/pkg/hubble/parser/agent/parser_test.go
+++ b/pkg/hubble/parser/agent/parser_test.go
@@ -30,8 +30,8 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 type mockEndpoint struct {
@@ -248,7 +248,7 @@ func TestDecodeAgentEvent(t *testing.T) {
 					IpcacheUpdate: &flowpb.IPCacheNotification{
 						Cidr:     "192.168.10.11/32",
 						Identity: 1023,
-						OldIdentity: &wrappers.UInt32Value{
+						OldIdentity: &wrapperspb.UInt32Value{
 							Value: oldID,
 						},
 						HostIp:     "10.1.5.4",

--- a/pkg/hubble/parser/agent/parser_test.go
+++ b/pkg/hubble/parser/agent/parser_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -57,8 +57,8 @@ func TestDecodeAgentEvent(t *testing.T) {
 	unknownNotificationJSON, _ := json.Marshal(unknownNotification)
 
 	agentStartTS := time.Now()
-	protoAgentStartTimestamp, err := ptypes.TimestampProto(agentStartTS)
-	assert.NoError(t, err)
+	agentStartTSProto := timestamppb.New(agentStartTS)
+	assert.NoError(t, agentStartTSProto.CheckValid())
 
 	mockEP := &mockEndpoint{
 		ID:        65535,
@@ -127,7 +127,7 @@ func TestDecodeAgentEvent(t *testing.T) {
 				Type: flowpb.AgentEventType_AGENT_STARTED,
 				Notification: &flowpb.AgentEvent_AgentStart{
 					AgentStart: &flowpb.TimeNotification{
-						Time: protoAgentStartTimestamp,
+						Time: agentStartTSProto,
 					},
 				},
 			},

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -27,8 +27,8 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -86,7 +86,7 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 	}
 
 	// TODO: Pool decoded flows instead of allocating new objects each time.
-	ts, _ := ptypes.TimestampProto(monitorEvent.Timestamp)
+	ts := timestamppb.New(monitorEvent.Timestamp)
 	ev := &v1.Event{
 		Timestamp: ts,
 	}

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -28,8 +28,8 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // Parser for all flows
@@ -134,7 +134,7 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 		ev.Event = &pb.LostEvent{
 			Source:        lostEventSourceToProto(payload.Source),
 			NumEventsLost: payload.NumLostEvents,
-			Cpu: &wrappers.Int32Value{
+			Cpu: &wrapperspb.Int32Value{
 				Value: int32(payload.CPU),
 			},
 		}

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -31,9 +31,9 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var log *logrus.Logger
@@ -124,7 +124,7 @@ func Test_EventType_RecordLost(t *testing.T) {
 		Timestamp: protoTimestamp,
 		Event: &flowpb.LostEvent{
 			NumEventsLost: 1001,
-			Cpu:           &wrappers.Int32Value{Value: 3},
+			Cpu:           &wrapperspb.Int32Value{Value: 3},
 			Source:        flowpb.LostEventSource_PERF_EVENT_RING_BUFFER,
 		},
 	}, ev)

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -118,8 +118,8 @@ func Test_EventType_RecordLost(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	protoTimestamp, err := ptypes.TimestampProto(ts)
-	assert.NoError(t, err)
+	protoTimestamp := timestamppb.New(ts)
+	assert.NoError(t, protoTimestamp.CheckValid())
 	assert.Equal(t, &v1.Event{
 		Timestamp: protoTimestamp,
 		Event: &flowpb.LostEvent{

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -31,11 +31,11 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/gopacket/layers"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // Parser is a parser for L7 payloads
@@ -401,8 +401,8 @@ func decodeLayer7(r *accesslog.LogRecord) *pb.Layer7 {
 	}
 }
 
-func decodeIsReply(t accesslog.FlowType) *wrappers.BoolValue {
-	return &wrappers.BoolValue{
+func decodeIsReply(t accesslog.FlowType) *wrapperspb.BoolValue {
+	return &wrapperspb.BoolValue{
 		Value: t == accesslog.TypeResponse,
 	}
 }

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/google/gopacket/layers"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/sirupsen/logrus"
@@ -194,12 +193,9 @@ func decodeTime(timestamp string) (goTime time.Time, pbTime *timestamppb.Timesta
 		return
 	}
 
-	pbTime, err = ptypes.TimestampProto(goTime)
-	if err != nil {
-		return
-	}
-
-	return goTime, pbTime, err
+	pbTime = timestamppb.New(goTime)
+	err = pbTime.CheckValid()
+	return
 }
 
 func decodeVerdict(verdict accesslog.FlowVerdict) pb.Verdict {

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -31,11 +31,11 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/gopacket/layers"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Parser is a parser for L7 payloads
@@ -188,7 +188,7 @@ func (p *Parser) computeResponseTime(r *accesslog.LogRecord, timestamp time.Time
 	return 0
 }
 
-func decodeTime(timestamp string) (goTime time.Time, pbTime *timestamp.Timestamp, err error) {
+func decodeTime(timestamp string) (goTime time.Time, pbTime *timestamppb.Timestamp, err error) {
 	goTime, err = time.Parse(time.RFC3339Nano, timestamp)
 	if err != nil {
 		return

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -203,7 +202,7 @@ func TestDecodeL7DNSRecord(t *testing.T) {
 	err = parser.Decode(lr, f)
 	require.NoError(t, err)
 
-	ts, _ := ptypes.Timestamp(f.GetTime())
+	ts := f.GetTime().AsTime()
 	assert.Equal(t, fakeTimestamp, ts.Format(time.RFC3339Nano))
 
 	assert.Equal(t, fakeSourceEndpoint.IPv6, f.GetIP().GetDestination())

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -33,10 +33,10 @@ import (
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // Parser is a parser for L3/L4 payloads
@@ -472,20 +472,20 @@ func decodeICMPv6(icmp *layers.ICMPv6) *pb.Layer4 {
 	}
 }
 
-func decodeIsReply(tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) *wrappers.BoolValue {
+func decodeIsReply(tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) *wrapperspb.BoolValue {
 	switch {
 	case tn != nil && monitorAPI.TraceObservationPointHasConnState(tn.ObsPoint):
 		// Unfortunately, not all trace points have the connection
 		// tracking state available. For certain trace point
 		// events, we do not know if it actually was a reply or not.
-		return &wrappers.BoolValue{
+		return &wrapperspb.BoolValue{
 			Value: tn.Reason & ^monitor.TraceReasonEncryptMask == monitor.TraceReasonCtReply,
 		}
 	case pvn != nil && pvn.Verdict >= 0:
 		// Forwarded PolicyVerdictEvents are emitted for the first packet of
 		// connection, therefore we statically assume that they are not reply
 		// packets
-		return &wrappers.BoolValue{Value: false}
+		return &wrapperspb.BoolValue{Value: false}
 	default:
 		// For other events, such as drops, we simply do not know if they were
 		// replies or not.

--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -26,10 +26,10 @@ import (
 	"github.com/cilium/cilium/pkg/inctimer"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 
-	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func isAvailable(conn poolTypes.ClientConn) bool {
@@ -137,7 +137,7 @@ func nodeStatusError(err error, nodeNames ...string) *observerpb.GetFlowsRespons
 
 	return &observerpb.GetFlowsResponse{
 		NodeName: nodeTypes.GetName(),
-		Time:     ptypes.TimestampNow(),
+		Time:     timestamppb.New(time.Now()),
 		ResponseTypes: &observerpb.GetFlowsResponse_NodeStatus{
 			NodeStatus: &relaypb.NodeStatusEvent{
 				StateChange: relaypb.NodeState_NODE_ERROR,
@@ -151,7 +151,7 @@ func nodeStatusError(err error, nodeNames ...string) *observerpb.GetFlowsRespons
 func nodeStatusEvent(state relaypb.NodeState, nodeNames ...string) *observerpb.GetFlowsResponse {
 	return &observerpb.GetFlowsResponse{
 		NodeName: nodeTypes.GetName(),
-		Time:     ptypes.TimestampNow(),
+		Time:     timestamppb.New(time.Now()),
 		ResponseTypes: &observerpb.GetFlowsResponse_NodeStatus{
 			NodeStatus: &relaypb.NodeStatusEvent{
 				StateChange: state,

--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -23,10 +23,10 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/build"
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // numUnavailableNodesReportMax represents the maximum number of unavailable
@@ -284,10 +284,10 @@ func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusR
 	}()
 	resp := &observerpb.ServerStatusResponse{
 		Version: build.RelayVersion.String(),
-		NumConnectedNodes: &wrappers.UInt32Value{
+		NumConnectedNodes: &wrapperspb.UInt32Value{
 			Value: numConnectedNodes,
 		},
-		NumUnavailableNodes: &wrappers.UInt32Value{
+		NumUnavailableNodes: &wrapperspb.UInt32Value{
 			Value: numUnavailableNodes,
 		},
 		UnavailableNodes: unavailableNodes,

--- a/pkg/hubble/relay/observer/server_test.go
+++ b/pkg/hubble/relay/observer/server_test.go
@@ -32,7 +32,6 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
@@ -41,6 +40,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestGetFlows(t *testing.T) {
@@ -870,8 +870,8 @@ func TestServerStatus(t *testing.T) {
 					MaxFlows:            0,
 					SeenFlows:           0,
 					UptimeNs:            0,
-					NumConnectedNodes:   &wrappers.UInt32Value{Value: 0},
-					NumUnavailableNodes: &wrappers.UInt32Value{Value: 1},
+					NumConnectedNodes:   &wrapperspb.UInt32Value{Value: 0},
+					NumUnavailableNodes: &wrapperspb.UInt32Value{Value: 1},
 					UnavailableNodes:    []string{"noip"},
 				},
 				log: []string{
@@ -946,8 +946,8 @@ func TestServerStatus(t *testing.T) {
 					MaxFlows:            3333,
 					SeenFlows:           3333,
 					UptimeNs:            111111111,
-					NumConnectedNodes:   &wrappers.UInt32Value{Value: 2},
-					NumUnavailableNodes: &wrappers.UInt32Value{Value: 0},
+					NumConnectedNodes:   &wrapperspb.UInt32Value{Value: 2},
+					NumUnavailableNodes: &wrapperspb.UInt32Value{Value: 0},
 				},
 			},
 		}, {
@@ -1012,8 +1012,8 @@ func TestServerStatus(t *testing.T) {
 					MaxFlows:            1111,
 					SeenFlows:           1111,
 					UptimeNs:            111111111,
-					NumConnectedNodes:   &wrappers.UInt32Value{Value: 1},
-					NumUnavailableNodes: &wrappers.UInt32Value{Value: 1},
+					NumConnectedNodes:   &wrapperspb.UInt32Value{Value: 1},
+					NumUnavailableNodes: &wrapperspb.UInt32Value{Value: 1},
 					UnavailableNodes:    []string{"two"},
 				},
 				log: []string{
@@ -1072,8 +1072,8 @@ func TestServerStatus(t *testing.T) {
 					MaxFlows:            0,
 					SeenFlows:           0,
 					UptimeNs:            0,
-					NumConnectedNodes:   &wrappers.UInt32Value{Value: 0},
-					NumUnavailableNodes: &wrappers.UInt32Value{Value: 2},
+					NumConnectedNodes:   &wrapperspb.UInt32Value{Value: 0},
+					NumUnavailableNodes: &wrapperspb.UInt32Value{Value: 2},
 					UnavailableNodes:    []string{"one", "two"},
 				},
 				log: []string{

--- a/pkg/hubble/relay/queue/priority_queue_test.go
+++ b/pkg/hubble/relay/queue/priority_queue_test.go
@@ -22,19 +22,19 @@ import (
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
-	resp0 = &observerpb.GetFlowsResponse{Time: &timestamp.Timestamp{Seconds: 1}}
-	resp1 = &observerpb.GetFlowsResponse{Time: &timestamp.Timestamp{Seconds: 1, Nanos: 1}}
-	resp2 = &observerpb.GetFlowsResponse{Time: &timestamp.Timestamp{Seconds: 2}}
-	resp3 = &observerpb.GetFlowsResponse{Time: &timestamp.Timestamp{Seconds: 3}}
-	resp4 = &observerpb.GetFlowsResponse{Time: &timestamp.Timestamp{Seconds: 4}}
-	resp5 = &observerpb.GetFlowsResponse{Time: &timestamp.Timestamp{Seconds: 5}}
+	resp0 = &observerpb.GetFlowsResponse{Time: &timestamppb.Timestamp{Seconds: 1}}
+	resp1 = &observerpb.GetFlowsResponse{Time: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}}
+	resp2 = &observerpb.GetFlowsResponse{Time: &timestamppb.Timestamp{Seconds: 2}}
+	resp3 = &observerpb.GetFlowsResponse{Time: &timestamppb.Timestamp{Seconds: 3}}
+	resp4 = &observerpb.GetFlowsResponse{Time: &timestamppb.Timestamp{Seconds: 4}}
+	resp5 = &observerpb.GetFlowsResponse{Time: &timestamppb.Timestamp{Seconds: 5}}
 )
 
 func TestPriorityQueue(t *testing.T) {
@@ -112,48 +112,48 @@ func TestPriorityQueue_PopOlderThan(t *testing.T) {
 		{
 			"some older, some newer",
 			[]*observerpb.GetFlowsResponse{
-				{Time: &timestamp.Timestamp{Seconds: 5}},
-				{Time: &timestamp.Timestamp{Seconds: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 4}},
-				{Time: &timestamp.Timestamp{Seconds: 2}},
-				{Time: &timestamp.Timestamp{Seconds: 1, Nanos: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 3}},
+				{Time: &timestamppb.Timestamp{Seconds: 5}},
+				{Time: &timestamppb.Timestamp{Seconds: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 4}},
+				{Time: &timestamppb.Timestamp{Seconds: 2}},
+				{Time: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 3}},
 			},
 			time.Unix(3, 1).UTC(),
 			[]*observerpb.GetFlowsResponse{
-				{Time: &timestamp.Timestamp{Seconds: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 1, Nanos: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 2}},
-				{Time: &timestamp.Timestamp{Seconds: 3}},
+				{Time: &timestamppb.Timestamp{Seconds: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 2}},
+				{Time: &timestamppb.Timestamp{Seconds: 3}},
 			},
 		}, {
 			"all olders",
 			[]*observerpb.GetFlowsResponse{
-				{Time: &timestamp.Timestamp{Seconds: 2}},
-				{Time: &timestamp.Timestamp{Seconds: 5}},
-				{Time: &timestamp.Timestamp{Seconds: 1, Nanos: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 3}},
-				{Time: &timestamp.Timestamp{Seconds: 4}},
-				{Time: &timestamp.Timestamp{Seconds: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 2}},
+				{Time: &timestamppb.Timestamp{Seconds: 5}},
+				{Time: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 3}},
+				{Time: &timestamppb.Timestamp{Seconds: 4}},
+				{Time: &timestamppb.Timestamp{Seconds: 1}},
 			},
 			time.Unix(6, 0).UTC(),
 			[]*observerpb.GetFlowsResponse{
-				{Time: &timestamp.Timestamp{Seconds: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 1, Nanos: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 2}},
-				{Time: &timestamp.Timestamp{Seconds: 3}},
-				{Time: &timestamp.Timestamp{Seconds: 4}},
-				{Time: &timestamp.Timestamp{Seconds: 5}},
+				{Time: &timestamppb.Timestamp{Seconds: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 2}},
+				{Time: &timestamppb.Timestamp{Seconds: 3}},
+				{Time: &timestamppb.Timestamp{Seconds: 4}},
+				{Time: &timestamppb.Timestamp{Seconds: 5}},
 			},
 		}, {
 			"all more recent",
 			[]*observerpb.GetFlowsResponse{
-				{Time: &timestamp.Timestamp{Seconds: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 5}},
-				{Time: &timestamp.Timestamp{Seconds: 2}},
-				{Time: &timestamp.Timestamp{Seconds: 4}},
-				{Time: &timestamp.Timestamp{Seconds: 1, Nanos: 1}},
-				{Time: &timestamp.Timestamp{Seconds: 3}},
+				{Time: &timestamppb.Timestamp{Seconds: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 5}},
+				{Time: &timestamppb.Timestamp{Seconds: 2}},
+				{Time: &timestamppb.Timestamp{Seconds: 4}},
+				{Time: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}},
+				{Time: &timestamppb.Timestamp{Seconds: 3}},
 			},
 			time.Unix(0, 0).UTC(),
 			[]*observerpb.GetFlowsResponse{},
@@ -178,7 +178,7 @@ func TestPriorityQueue_PopOlderThan(t *testing.T) {
 				got,
 				cmpopts.IgnoreUnexported(
 					observerpb.GetFlowsResponse{},
-					timestamp.Timestamp{},
+					timestamppb.Timestamp{},
 				),
 			); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 
 	"github.com/asaskevich/govalidator"
-	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var _ = Describe("K8sHubbleTest", func() {
@@ -110,7 +110,7 @@ var _ = Describe("K8sHubbleTest", func() {
 					}
 
 					f := &pb.Flow{}
-					if err := jsonpb.UnmarshalString(line, f); err != nil {
+					if err := protojson.Unmarshal([]byte(line), f); err != nil {
 						return fmt.Errorf("failed to decode in %q: %w", lines, err)
 					}
 					flows = append(flows, f)


### PR DESCRIPTION
Use the `google.golang.org/protobuf/*` packages instead of their deprecated counterparts in `github.com/golang/protobuf`. Note that `api/v1/hubble` still uses the deprecated packages due to the fact that is uses an older version of `protoc-gen-go`. An attempt to update it is in progress in #13405. Still, we can already use the types from the new packages and assign them to the API fields because the deprecated package type aliases them to the new package's type, e.g. https://github.com/cilium/cilium/blob/9a4c693580ba7e931faf8c9f27832470a05660f1/vendor/github.com/golang/protobuf/ptypes/timestamp/timestamp.pb.go#L15

See individual commit messages for more details.

As previously suggested in https://github.com/cilium/cilium/pull/14168#discussion_r530375980. Following cilium/hubble#452 which did the same for the Hubble CLI.