### PR TITLE
backport 1.9: vendor: Bump github.com/cilium/arping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 	github.com/blang/semver v3.5.0+incompatible
-	github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1
+	github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
 	github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc60193
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1 h1:PcOKzY6o4mkmGzrmr6pFCx5X802LjD/o4zUD+rsGpm8=
-github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
+github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d h1:xG3H52q51GO+tE9noqKGEJO6nCUQIvXCI62bsJZ5EWM=
+github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
 github.com/cilium/client-go v0.0.0-20201223004022-d3a5d921c1db h1:/pTBEfNgUqDAtjXsjNBHM5ni1dKVTzji/GrbUbYnLlk=
 github.com/cilium/client-go v0.0.0-20201223004022-d3a5d921c1db/go.mod h1:gEiS+efRlXYUEQ9Oz4lmNXlxAl5JZ8y2zbTDGhvXXnk=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cilium/arping v1.0.1-0.20201211141342-f9e11e567ce1
+# github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d
 ## explicit
 github.com/cilium/arping
 # github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e


### PR DESCRIPTION
The bumped version includes https://github.com/cilium/arping/pull/6.