### PR TITLE
test: Mark GKE CI pipeline as running Linux 4.19

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -173,6 +173,7 @@ pipeline {
                         returnStdout: true,
                         script: 'echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s*/" | tr -d \'\n\''
                         )}"""
+                KERNEL="419"
             }
             steps {
                 dir("${TESTDIR}"){

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -904,9 +904,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 				blockSize  = 5120
 				blockCount = 1
 			)
-			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
 			ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
-			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
+			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
 			ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 
 			_, dstPodIPK8s1 := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDS, 1)
@@ -1749,7 +1749,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			// Destination address and port for fragmented datagram
 			// are not DNAT-ed with kube-proxy but without bpf_sock.
 			if helpers.RunsWithKubeProxy() {
-				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
+				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
 				ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 				hasDNAT = kubectl.HasHostReachableServices(ciliumPodK8s1, false, true)
 			}

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2169,9 +2169,17 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+							options := map[string]string{
 								"hostFirewall": "true",
-							})
+							}
+							// We can't rely on gke.enabled because it enables
+							// per-endpoint routes which are incompatible with
+							// the host firewall.
+							if helpers.RunsOnGKE() {
+								options["gke.enabled"] = "false"
+								options["tunnel"] = "disabled"
+							}
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
 							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
 							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
@@ -2292,11 +2300,19 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+							options := map[string]string{
 								"tunnel":               "disabled",
 								"autoDirectNodeRoutes": "true",
 								"hostFirewall":         "true",
-							})
+							}
+							// We can't rely on gke.enabled because it enables
+							// per-endpoint routes which are incompatible with
+							// the host firewall.
+							if helpers.RunsOnGKE() {
+								options["gke.enabled"] = "false"
+								options["tunnel"] = "disabled"
+							}
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
 							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
 							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2607,7 +2607,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
-		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Supports IPv4 fragments", func() {
+		SkipItIf(func() bool {
+			return helpers.DoesNotRunOnNetNextOr419Kernel() || helpers.RunsOnGKE()
+		}, "Supports IPv4 fragments", func() {
 			DeployCiliumAndDNS(kubectl, ciliumFilename)
 			testIPv4FragmentSupport()
 		})


### PR DESCRIPTION
Marking the GKE pipeline as running 4.19 should enable additional tests (e.g., fragment tracking test that requires 4.19+). It shouldn't cause issues when GKE switches to 5.4 because tests that support 4.19 generally support newer kernels as well.