### PR TITLE
v1.9 backports 2021-01-18

### DIFF
--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -39,7 +39,8 @@ pipeline {
         SERVER_BOX = "cilium/ubuntu"
         FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
         CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
-        GINKGO_TIMEOUT="98m"
+        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
+        GINKGO_TIMEOUT="118m"
         RACE="""${sh(
                 returnStdout: true,
                 script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n ""; else echo -n "1"; fi'


### PR DESCRIPTION
* #14524 -- jenkinsfile: Allow enabling host firewall in k8s-all CI (@pchaigno)
 * #14624 -- docs: AKS - remove azure0 from CNI chaining config (@ti-mo)
 * #14623 -- pkg/kvstore: fix panic when closing etcd connections on error (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14524 14624 14623; do contrib/backporting/set-labels.py $pr done 1.9; done
```