### PR TITLE
v1.9 backports 2021-01-18

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -21,7 +21,6 @@ desired CNI chaining configuration:
             {
               "type": "azure-vnet",
               "mode": "transparent",
-              "bridge": "azure0",
               "ipam": {
                  "type": "azure-vnet-ipam"
                }

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
         SERVER_BOX = "cilium/ubuntu"
         FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
         CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
+        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
         GINKGO_TIMEOUT="98m"
         RACE="""${sh(
                 returnStdout: true,

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1646,14 +1646,20 @@ func (e *etcdClient) Close() {
 	}
 	e.RLock()
 	defer e.RUnlock()
-	if err := e.lockSession.Close(); err != nil {
-		e.getLogger().WithError(err).Warning("Failed to revoke lock session while closing etcd client")
+	if e.lockSession != nil {
+		if err := e.lockSession.Close(); err != nil {
+			e.getLogger().WithError(err).Warning("Failed to revoke lock session while closing etcd client")
+		}
 	}
-	if err := e.session.Close(); err != nil {
-		e.getLogger().WithError(err).Warning("Failed to revoke main session while closing etcd client")
+	if e.session != nil {
+		if err := e.session.Close(); err != nil {
+			e.getLogger().WithError(err).Warning("Failed to revoke main session while closing etcd client")
+		}
 	}
-	if err := e.client.Close(); err != nil {
-		e.getLogger().WithError(err).Warning("Failed to close etcd client")
+	if e.client != nil {
+		if err := e.client.Close(); err != nil {
+			e.getLogger().WithError(err).Warning("Failed to close etcd client")
+		}
 	}
 }
 


### PR DESCRIPTION
* #14524 -- jenkinsfile: Allow enabling host firewall in k8s-all CI (@pchaigno)
 * #14624 -- docs: AKS - remove azure0 from CNI chaining config (@ti-mo)
 * #14623 -- pkg/kvstore: fix panic when closing etcd connections on error (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14524 14624 14623; do contrib/backporting/set-labels.py $pr done 1.9; done
```