### PR TITLE
cilium-cni: Fix error handling for bad netns

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -352,6 +352,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	netNs, err = ns.GetNS(args.Netns)
 	if err != nil {
 		err = fmt.Errorf("failed to open netns %q: %s", args.Netns, err)
+		return
 	}
 	defer netNs.Close()
 


### PR DESCRIPTION
If kubelet gives cilium-cni bad input (no netns), the error here would
not be returned properly to the caller, which could result in a segfault:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14e0c8b]
    goroutine 1 [running, locked to thread]:
    main.cmdAdd(0xc00015a000, 0xc0004d60e8, 0x5)
            /go/src/github.com/cilium/cilium/plugins/cilium-cni/cilium-cni.go:354 +0x5cb
    github.com/containernetworking/cni/pkg/skel.(*dispatcher).checkVersionAndCall(0xc0005e5d40, 0xc00015a000, 0x1a42f20, 0xc0004de000, 0x18d07c0, 0x0, 0x44a1ef)
            /go/src/github.com/cilium/cilium/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:185 +0x258
    github.com/containernetworking/cni/pkg/skel.(*dispatcher).pluginMain(0xc0005e5d40, 0x18d07c0, 0x0, 0x18d07c8, 0x1a42f20, 0xc0004de000, 0xc000174000, 0x5d, 0xc000174000)
            /go/src/github.com/cilium/cilium/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:221 +0x546
    github.com/containernetworking/cni/pkg/skel.PluginMainWithError(...)
            /go/src/github.com/cilium/cilium/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:286
    github.com/containernetworking/cni/pkg/skel.PluginMain(0x18d07c0, 0x0, 0x18d07c8, 0x1a42f20, 0xc0004de000, 0xc000174000, 0x5d)
            /go/src/github.com/cilium/cilium/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:301 +0x128
    main.main()
            /go/src/github.com/cilium/cilium/plugins/cilium-cni/cilium-cni.go:85 +0x33c

The above logs would typically be pushed to kubelet logs.

Related: #11430