### PR TITLE
arp: Set deadline for each retry

### DIFF
--- a/pkg/datapath/linux/arp/ping.go
+++ b/pkg/datapath/linux/arp/ping.go
@@ -47,11 +47,11 @@ func PingOverLink(link netlink.Link, src net.IP, dst net.IP) (hwAddr net.Hardwar
 	}
 	defer p.close()
 
-	if err := p.setDeadline(time.Now().Add(timeout)); err != nil {
-		return nil, err
-	}
-
 	for i := 0; i < retries; i++ {
+		if err := p.setDeadline(time.Now().Add(timeout)); err != nil {
+			return nil, err
+		}
+
 		hwAddr, err = p.resolve(dst)
 		if err == nil {
 			return


### PR DESCRIPTION
Otherwise, the deadline is set only for the first request which renders the retries mechanism useless.

Should fix https://github.com/cilium/cilium/pull/14601.

Reported-by: André Martins <andre@cilium.io>