### PR TITLE
v1.7 backports 2021-01-20

### DIFF
--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -66,6 +66,23 @@ func isEtcdConfigFile(path string) bool {
 	return strings.Contains(string(b), "endpoints:")
 }
 
+func (cdw *configDirectoryWatcher) handleAddedFile(name, absolutePath string) {
+	// A typical directory will look like this:
+	// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test5 -> ..data/test5
+	// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
+	//
+	// Ignore all backing files and only read the symlinks
+	if strings.HasPrefix(name, "..") {
+		return
+	}
+
+	if !isEtcdConfigFile(absolutePath) {
+		return
+	}
+
+	cdw.lifecycle.add(name, absolutePath)
+}
+
 func (cdw *configDirectoryWatcher) watch() error {
 	log.WithField(fieldConfig, cdw.path).Debug("Starting config directory watcher")
 
@@ -75,22 +92,12 @@ func (cdw *configDirectoryWatcher) watch() error {
 	}
 
 	for _, f := range files {
-		// A typical directory will look like this:
-		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test5 -> ..data/test5
-		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
-		//
-		// Ignore all backing files and only read the symlinks
-		if strings.HasPrefix(f.Name(), "..") {
+		if f.IsDir() {
 			continue
 		}
 
 		absolutePath := path.Join(cdw.path, f.Name())
-		if !isEtcdConfigFile(absolutePath) {
-			continue
-		}
-
-		log.WithField(fieldClusterName, f.Name()).WithField("mode", f.Mode()).Debugf("Found configuration in initial scan")
-		cdw.lifecycle.add(f.Name(), absolutePath)
+		cdw.handleAddedFile(f.Name(), absolutePath)
 	}
 
 	go func() {
@@ -103,7 +110,7 @@ func (cdw *configDirectoryWatcher) watch() error {
 				case event.Op&fsnotify.Create == fsnotify.Create,
 					event.Op&fsnotify.Write == fsnotify.Write,
 					event.Op&fsnotify.Chmod == fsnotify.Chmod:
-					cdw.lifecycle.add(name, event.Name)
+					cdw.handleAddedFile(name, event.Name)
 				case event.Op&fsnotify.Remove == fsnotify.Remove,
 					event.Op&fsnotify.Rename == fsnotify.Rename:
 					cdw.lifecycle.remove(name)

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -217,6 +217,11 @@ func removeCIDR(allowCIDR, removeCIDR *net.IPNet) ([]*net.IPNet, error) {
 	allowSize, _ := allowCIDR.Mask.Size()
 	removeSize, _ := removeCIDR.Mask.Size()
 
+	// Removing a CIDR from itself should result into an empty set
+	if allowSize == removeSize && allowCIDR.IP.Equal(removeCIDR.IP) {
+		return nil, nil
+	}
+
 	if allowSize >= removeSize {
 		return nil, fmt.Errorf("allow CIDR prefix must be a superset of " +
 			"remove CIDR prefix")

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -350,6 +350,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	netNs, err = ns.GetNS(args.Netns)
 	if err != nil {
 		err = fmt.Errorf("failed to open netns %q: %s", args.Netns, err)
+		return
 	}
 	defer netNs.Close()
 


### PR DESCRIPTION
 * #14565 -- clustermesh: Ignore symlink files on fsnotify events (@tgraf)
 * #14516 -- Fix CIDR coalescing issue in ExceptCIDR rule expressions (@jrajahalme)
 * #14645 -- cilium-cni: Fix error handling for bad netns (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14565 14516 14645; do contrib/backporting/set-labels.py $pr done 1.7; done
```