### PR TITLE
docs: Add section in external etcd about identity-allocation-mode

### DIFF
--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -43,6 +43,12 @@ Deploy Cilium release via Helm:
       --set etcd.managed=true \\
       --set etcd.k8sService=true
 
+If you do not want Cilium to store state in Kubernetes custom resources (CRDs),
+consider setting ``identityAllocationMode``:
+
+.. parsed-literal::
+
+    --set identityAllocationMode=kvstore
 
 Validate the Installation
 =========================

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -61,6 +61,13 @@ Deploy Cilium release via Helm:
       --set "etcd.endpoints[1]=http://etcd-endpoint2:2379" \\
       --set "etcd.endpoints[2]=http://etcd-endpoint3:2379"
 
+If you do not want Cilium to store state in Kubernetes custom resources (CRDs),
+consider setting ``identityAllocationMode``:
+
+.. parsed-literal::
+
+    --set identityAllocationMode=kvstore
+
 
 Optional: Configure the SSL certificates
 ----------------------------------------


### PR DESCRIPTION
Users have reported that they weren't aware of this option when using
external etcd. It is not required, but better to raise awareness.