### PR TITLE
pkg/node: Skip setting MTU on local node routes

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -200,34 +200,34 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 
 	if s.enableIPv4 {
 		// add & remove IPv4 node route
-		err = linuxNodeHandler.updateNodeRoute(ip4CIDR, true)
+		err = linuxNodeHandler.updateNodeRoute(ip4CIDR, true, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4CIDR)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 
-		err = linuxNodeHandler.deleteNodeRoute(ip4CIDR)
+		err = linuxNodeHandler.deleteNodeRoute(ip4CIDR, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4CIDR)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
 		// add & remove IPv6 node route
-		err = linuxNodeHandler.updateNodeRoute(ip6CIDR, true)
+		err = linuxNodeHandler.updateNodeRoute(ip6CIDR, true, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6CIDR)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 
-		err = linuxNodeHandler.deleteNodeRoute(ip6CIDR)
+		err = linuxNodeHandler.deleteNodeRoute(ip6CIDR, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6CIDR)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -248,13 +248,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -266,12 +266,12 @@ func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR())
+	foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
 	c.Assert(err, check.IsNil)
 	c.Assert(foundRoute, check.IsNil)
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -285,13 +285,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -314,13 +314,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -334,13 +334,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -354,13 +354,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -410,7 +410,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -420,7 +420,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -449,7 +449,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -459,7 +459,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -496,12 +496,12 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc1 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -513,12 +513,12 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc1 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -542,14 +542,14 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv4 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -579,7 +579,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -591,7 +591,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -616,14 +616,14 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv4 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -871,7 +871,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 }
 
 func insertFakeRoute(c *check.C, n *linuxNodeHandler, prefix *cidr.CIDR) {
-	nodeRoute, err := n.createNodeRoute(prefix)
+	nodeRoute, err := n.createNodeRouteSpec(prefix, false)
 	c.Assert(err, check.IsNil)
 
 	nodeRoute.Device = dummyExternalDeviceName
@@ -881,7 +881,7 @@ func insertFakeRoute(c *check.C, n *linuxNodeHandler, prefix *cidr.CIDR) {
 }
 
 func lookupFakeRoute(c *check.C, n *linuxNodeHandler, prefix *cidr.CIDR) bool {
-	routeSpec, err := n.createNodeRoute(prefix)
+	routeSpec, err := n.createNodeRouteSpec(prefix, false)
 	c.Assert(err, check.IsNil)
 
 	routeSpec.Device = dummyExternalDeviceName


### PR DESCRIPTION
Previously, we were setting mtu on local node routes, which takes effect in
routing in recent kernels. This could lead to drops for jumbo packets when the
"Don't fragment" bit is set. Regardless of the kernel routing, we shouldn't
restrict mtu on the host local routes.

This fix avoids setting an mtu on local node routes (i.e., when
enable-local-node flag is enabled).

Testing notes are in the commit description. Integration tests will be added as a follow-up. 

**Release note**
```release-note
Fix a route MTU issue where pods cannot receive large packets from outside the cluster 
when the sender sets the "don't fragment" (DF) bit. 
```