### PR TITLE
add_vagrant_box.sh: remove downloaded files after installing a VM image

### DIFF
--- a/test/packet/scripts/add_vagrant_box.sh
+++ b/test/packet/scripts/add_vagrant_box.sh
@@ -175,4 +175,7 @@ for box in $boxes; do
             vagrant box add cilium/$box --box-version $version
         fi
     fi
+
+    rm -f -- "$outdir/metadata.json"
+    rm -f -- "$outdir/package.box"
 done


### PR DESCRIPTION
Installing new VM images consists in downloading a metadata.json file, a package.box file containing the image, and then in unpacking the latter. After that, both metadata.json and package.box can be removed.

To speed up downloads of package.box files (several GB), add_vagrant_box.sh relies on aria2c. When downloading multiple VM images, we had an issue in the past where aria2c would rename the downloaded file (e.g. package.box.1 if package.box is already present), causing vagrant to install the wrong image.

To avoid that, we passed the `--auto-file-renaming=false` option to aria2c. However, in some cases (but not all, it seems - exact conditions have not been determined) the tool refuses to overwrite an existing file. One solution could be to add `--allow-overwrite=true`.

But instead, this PR follows another approach. Considering that, for downloading multiple images, we overwrite the previous package.box with the new one, we end up removing all download files except for the last box installed. In order to be consistent for all images and to fix any renaming/overwriting issue, simply delete the download files after unpacking a VM image.
