### PR TITLE
[HELM] added flag for proxy.prometheus.enabled in helm chart

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -111,7 +111,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libriaries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
 | enableIPv4Masquerade | bool | `true` | hashSeed is the cluster-wide base64 encoded seed for the hashing hashSeed: -- Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
-| enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by  mirroring it into the KVstore for reduced overhead in large clusters. |
+| enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters. |
 | enableXTSocketFallback | bool | `true` |  |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |
@@ -315,7 +315,7 @@ contributors across the globe, there is almost always someone available to help.
 | priorityClassName | string | `""` |  |
 | prometheus | object | `{"enabled":false,"port":9090,"serviceMonitor":{"enabled":false}}` | Configure prometheus metrics on the configured port at /metrics |
 | prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
-| proxy | object | `{"prometheus":{"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
+| proxy | object | `{"prometheus":{"enabled":true,"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
 | proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
 | remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -243,10 +243,12 @@ spec:
           hostPort: {{ .Values.prometheus.port }}
           name: prometheus
           protocol: TCP
+{{- if .Values.proxy.prometheus.enabled }}          
         - containerPort: {{ .Values.proxy.prometheus.port }}
           hostPort: {{ .Values.proxy.prometheus.port }}
           name: envoy-metrics
           protocol: TCP
+{{- end }}
 {{- end }}
 {{- if .Values.hubble.metrics.enabled }}
         - containerPort: {{ .Values.hubble.metrics.port }}

--- a/install/kubernetes/cilium/templates/cilium-agent-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-service.yaml
@@ -20,7 +20,7 @@ spec:
     targetPort: envoy-metrics
   selector:
     k8s-app: cilium
-{{- else if .Values.prometheus.enabled }}
+{{- else if and (.Values.prometheus.enabled) (.Values.proxy.prometheus.enabled) }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -143,7 +143,9 @@ data:
   prometheus-serve-addr: ":{{ .Values.prometheus.port }}"
   # Port to expose Envoy metrics (e.g. "9095"). Envoy metrics listener will be disabled if this
   # field is not set.
+  {{- if .Values.proxy.prometheus.enabled }}
   proxy-prometheus-port: "{{ .Values.proxy.prometheus.port }}"
+  {{- end }}
 {{- end }}
 
 {{- if .Values.operator.prometheus.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -355,7 +355,7 @@ daemon:
 
 enableCnpStatusUpdates: false
 
-# -- Configures the use of the KVStore to optimize Kubernetes event handling by 
+# -- Configures the use of the KVStore to optimize Kubernetes event handling by
 # mirroring it into the KVstore for reduced overhead in large clusters.
 enableK8sEventHandover: false
 
@@ -918,6 +918,7 @@ prometheus:
 # -- Configure Istio proxy options.
 proxy:
   prometheus:
+    enabled: true
     port: "9095"
   # -- Regular expression matching compatible Istio sidecar istio-proxy
   # container image names


### PR DESCRIPTION
<!-- Description of change -->
By default the service is crated and has annotation of scrape metrics, I don't use envoy, Istio and I have auto discovery for all annotation about prometheus. The endpoint is created in promehtues and spam alerts about it. I want have ability to disable the service. I have set value `true` because it was enabled by default, any users are not effected who wants to disable they should change the flag to `false`

```release-note
Added flag `proxy.prometheus.enabled` to helm chart for disabling service 
```
