### PR TITLE
bpf: Correctly use revalidate_data_pull() in do_decrypt()

### DIFF
--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -40,7 +40,7 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 #endif
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4)) {
 			ctx->mark = 0;
 			return CTX_ACT_OK;
 		}


### PR DESCRIPTION
The IPv6 path in do_decrypt() was already correctly using
revalidate_data_pull(). The IPv4 path was node. If not enough headers
were pull'ed, the call would fail which resulted in ESP packets not
being detected correctly and thus not decrypted due to lacking the
packet mark.

This seems to be a regression introduced with the refactoring commit
9ed106a017c5. Only 1.9 is affected.

Fixes: 9ed106a017c5 ("cilium: create lib for encryption")

Suggested-by: John Fastabend <john.fastabend@gmail.com>
