### PR TITLE
test: Respect cilium.holdEnvironment on DNS check

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2077,7 +2077,7 @@ func (kub *Kubectl) RedeployKubernetesDnsIfNecessary() {
 		desc := kub.ExecShort(fmt.Sprintf("%s describe pods -n %s -l %s", KubectlCmd, KubeSystemNamespace, kubeDNSLabel))
 		ginkgoext.By(desc.GetDebugMessage())
 
-		ginkgoext.Fail("Kubernetes DNS did not become ready in time")
+		Fail("Kubernetes DNS did not become ready in time")
 	}
 }
 


### PR DESCRIPTION
Very simple change, but it has annoyed me often enough during local testing:
```
The DNS check is one of the first things we check when starting a new
test. As such, the following error is common in CI and local tests.

    Kubernetes DNS did not become ready in time

In local tests however, when -cilium.holdEnvironment=true, the tests
don't pause after such failures. That is because we fail the test with
ginkgo.Fail instead of our wrapper function helpers.Fail. This commit
fixes it.

Signed-off-by: Paul Chaignon <paul@cilium.io>
```