### PR TITLE
bpf: Fix traces before NodePort redirect() calls

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -113,7 +113,7 @@ encap_remap_v6_host_address(struct __ctx_buff *ctx __maybe_unused,
 
 static __always_inline int
 __encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
-		    __u32 seclabel, __u32 monitor)
+		    __u32 seclabel)
 {
 	struct bpf_tunnel_key key = {};
 	__u32 node_id;
@@ -137,8 +137,6 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 	if (unlikely(ret < 0))
 		return DROP_WRITE_ERROR;
 
-	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, 0, 0, ENCAP_IFINDEX,
-			  0, monitor);
 	return 0;
 }
 
@@ -146,10 +144,12 @@ static __always_inline int
 __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 				 __u32 seclabel, __u32 monitor)
 {
-	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
-
+	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel);
 	if (ret != 0)
 		return ret;
+
+	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, 0, 0, ENCAP_IFINDEX,
+			  0, monitor);
 	return redirect(ENCAP_IFINDEX, 0);
 }
 


### PR DESCRIPTION
In the NodePort code, the `redirect` helper is used a couple times to send the packet either to the tunneling device or to a native device. Packet traces are however only emitted when redirecting to the tunneling device.

This pull request fixes it to also emit `TRACE_TO_NETWORK` traces. Incidentally, the `TRACE_TO_OVERLAY` traces are moved closer to the actual `redirect()` call. Having those just before the `redirect()` call avoids cases where we fail between the trace emittion and the actual redirection.

```release-note
Emit additional packet traces when sending packets to the network.
```