### PR TITLE
test: Fix kube-proxy service tests when running with socket-level LB

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -587,6 +587,8 @@ func DoesNotExistNodeWithoutCilium() bool {
 	return !ExistNodeWithoutCilium()
 }
 
+// HasHostReachableServices returns true if the given Cilium pod has TCP and/or
+// UDP host reachable services are enabled.
 func (kub *Kubectl) HasHostReachableServices(pod string, checkTCP, checkUDP bool) bool {
 	status := kub.CiliumExecContext(context.TODO(), pod,
 		"cilium status -o jsonpath='{.kube-proxy-replacement.features.hostReachableServices}'")
@@ -603,6 +605,16 @@ func (kub *Kubectl) HasHostReachableServices(pod string, checkTCP, checkUDP bool
 		return false
 	}
 	return true
+}
+
+// HasBPFNodePort returns true if the given Cilium pod has BPF NodePort enabled.
+func (kub *Kubectl) HasBPFNodePort(pod string) bool {
+	status := kub.CiliumExecContext(context.TODO(), pod,
+		"cilium status -o jsonpath='{.kube-proxy-replacement.features.nodePort.enabled}'")
+	status.ExpectSuccess("Failed to get status: %s", status.OutputPrettyPrint())
+	lines := status.ByLines()
+	Expect(len(lines)).ShouldNot(Equal(0), "Failed to get nodePort status")
+	return strings.Contains(lines[0], "true")
 }
 
 // GetNodeWithoutCilium returns a name of a node which does not run cilium.


### PR DESCRIPTION
I would normally send this as part of the PR that requires it, but I have two WIP PRs that will be blocked by this: https://github.com/cilium/cilium/pull/14543 and the fix for https://github.com/cilium/cilium/pull/14628.
```
When running Cilium with the following configuration, requests from k8s2 to
NodePort services with backends only in k8s2 will be dropped if the
request is sent to k8s1.

    kube-proxy-replacement: partial
    enable-node-port: false
    enable-host-reachable-services: true

This is a known behavior of kube-proxy 1.15+. The request won't be
translated by the socket-level LB since, when BPF NodePort is disabled,
the BPF service map is only populated with ClusterIP entries.

The above configuration can be obtained by running on newer kernels with
IPSec enabled [1], which disables BPF NodePort but not socket-level LB.
This same configuration is also tested in the work-in-progress hybrid CI
pipeline [2], where the kube-proxy replacement runs alongside kube-proxy.

1 - https://github.com/cilium/cilium/pull/14628
2 - https://github.com/cilium/cilium/pull/14543
Signed-off-by: Paul Chaignon <paul@cilium.io>
```