### PR TITLE
.github, bpf: Update reference to cilium-checkpatch image

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://cilium/cilium-checkpatch:71bf805000d58c07c45eb6e436640a4dc0ca6c84
+        uses: docker://cilium/cilium-checkpatch:e6a6843cef50a43c38819badb55a21061967ce64
   coccicheck:
     name: coccicheck
     runs-on: ubuntu-latest

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -55,7 +55,7 @@ checkpatch:
 		--workdir /workspace \
 		--volume $(CURDIR)/..:/workspace \
 		--user "$(shell id -u):$(shell id -g)" \
-		cilium/cilium-checkpatch:5b099019bf0db775b33b3f32cd5ecea55dd15f21
+		cilium/cilium-checkpatch:e6a6843cef50a43c38819badb55a21061967ce64
 
 coccicheck:
 	$(QUIET) $(foreach TARGET,$(shell find $(ROOT_DIR)/contrib/coccinelle/ -name '*.cocci'), \


### PR DESCRIPTION
Update the `cilium-checkpatch` image used in our GitHub action to avoid the `Co-authored-by` false positive.

Related: https://github.com/cilium/image-tools/pull/97