### PR TITLE
.github: change step order

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -25,8 +25,11 @@ assignees: ''
 - [ ] Ensure that outstanding [backport PRs] are merged
 - [ ] Consider building new [cilium-runtime images] and bumping the base image
       versions on this branch
+- [ ] Execute `release --current-version X.Y.Z --next-dev-version X.Y.W` to automatically
+  move any unresolved issues/PRs from old release project into the new
+  project. (`W` should be calculation of `Z+1`)
 - [ ] Push a PR including the changes necessary for the new release:
-  - [ ] Pull latest branch
+  - [ ] Pull latest changes from the branch being released
   - [ ] Run `contrib/release/start-release.sh`
   - [ ] (If applicable) Update the `cilium_version` and `cilium_tag` in
         `examples/getting-started/Vagrantfile`
@@ -34,9 +37,6 @@ assignees: ''
         instructions.
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
-- [ ] Execute `release --current-version X.Y.Z --next-dev-version X.Y.W` to automatically
-      move any unresolved issues/PRs from old release project into the new
-      project. (`W` should be calculation of `Z+1`)
 - [ ] Merge PR
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
   - Pull latest branch locally and run `contrib/release/tag-release.sh`


### PR DESCRIPTION
We can run the `release` tool before starting the release process.

Signed-off-by: André Martins <andre@cilium.io>

@joestringer feel free to merge this "step" as part of the `start-release.sh` script. We could ask the developer to pass version to be released (x.y.z), and next version of development (x.y.z+1) to avoid doing the calculation with bash