### PR TITLE
istio: Update to 1.8.2

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -38,20 +38,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.7.6 <https://github.com/cilium/istio/releases/tag/1.7.6>`_:
+Download the `cilium enhanced istioctl version 1.8.2 <https://github.com/cilium/istio/releases/tag/1.8.2>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.7.6/cilium-istioctl-1.7.6-linux-amd64.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-linux-amd64.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.7.6/cilium-istioctl-1.7.6-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-osx.tar.gz | tar xz
 
 .. note::
 


### PR DESCRIPTION
Update Istio integration to Istio release 1.8.2.

Istioctl no longer lists the service name for an inbound port.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
```release-note
Istio integration is updated to Istio release 1.8.2.
```
