### PR TITLE
node-init: Fixing pods restart on nodes running containerd on COS

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -89,8 +89,8 @@ spec:
                       # Works for COS, ubuntu
                       while docker ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     else
-                      # COS-beta (with containerd)
-                      while crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
+                      # COS-beta (with containerd). Some versions of COS have crictl in /home/kubernetes/bin.
+                      while PATH="${PATH}:/home/kubernetes/bin" crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     fi
 
                     systemctl disable sys-fs-bpf.mount || true
@@ -242,8 +242,8 @@ spec:
                   docker kill "${container_id}" || true
                 done
               else
-                # COS-beta (with containerd)
-                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
+                # COS-beta (with containerd). Some versions of COS have crictl in /home/kubernetes/bin.
+                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do PATH="${PATH}:/home/kubernetes/bin" crictl stopp "$(sed 's/\r//;1q' $f)" || true; done
               fi
 {{- end }}
 


### PR DESCRIPTION
The startup script for the node-init was not properly working for nodes running containerd on COS for two reasons:
 1. crictl is not available in the PATH for root
 2. extracting the sandbox id using cat was returning an extra line

This fix is necessary for deployment on GKE using preemptible nodes. Otherwise, pods on nodes getting preempted might be created before Cilium is ready to manage them and they will remain that way unless they are properly stopped.

Fixes: #13167

```release-note
Fixing pods restart on nodes running containerd on COS
```
