### PR TITLE
Helm: Respect serviceAccounts.*.create value

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -287,6 +287,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
+| operator.serviceAccountName | string | `"cilium-operator"` | For using with an existing serviceAccount. |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |

--- a/install/kubernetes/cilium/templates/cilium-operator-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-clusterrolebinding.yaml
@@ -9,6 +9,6 @@ roleRef:
   name: cilium-operator
 subjects:
 - kind: ServiceAccount
-  name: cilium-operator
+  name: {{ .Values.operator.serviceAccountName | quote }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -205,8 +205,13 @@ spec:
 {{- if and (or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (ge .Capabilities.KubeVersion.Minor "17") (gt .Capabilities.KubeVersion.Major "1")) .Values.enableCriticalPriorityClass }}
       priorityClassName: system-cluster-critical
 {{- end }}
+{{- if .Values.serviceAccounts.operator.create }}
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+{{- else }}
+      serviceAccount: {{ .Values.operator.serviceAccountName | quote }}
+      serviceAccountName: {{ .Values.operator.serviceAccountName | quote }}
+{{- end }}
 {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-operator-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.enabled }}
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1100,6 +1100,9 @@ operator:
   # -- Number of replicas to run for the cilium-operator deployment
   replicas: 2
 
+  # -- For using with an existing serviceAccount.
+  serviceAccountName: cilium-operator
+ 
   # -- cilium-operator priorityClassName
   priorityClassName: ""
 

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -587,7 +587,7 @@ roleRef:
   name: cilium-operator
 subjects:
 - kind: ServiceAccount
-  name: cilium-operator
+  name: "cilium-operator"
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-generate-certs-clusterrolebinding.yaml

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -363,7 +363,7 @@ roleRef:
   name: cilium-operator
 subjects:
 - kind: ServiceAccount
-  name: cilium-operator
+  name: "cilium-operator"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-agent-daemonset.yaml


### PR DESCRIPTION
When using Helm, we are currently deploying the cilium-operator serviceAccount by only
following the global `operator.enabled` value.
The `serviceAccounts.operator.create` has no impact on the creation of the
serviceAccount.

Fixes: #14681

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

