### PR TITLE
make: Use buildkit for docker targets by default

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -12,6 +12,8 @@ clean:
 	-$(QUIET)rm -rf _build _preview Pipfile Pipfile.lock
 
 builder-image: Dockerfile requirements.txt
+	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
+	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 docker pull
 	$(QUIET)tar c requirements.txt Dockerfile \
 	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ debug: all
 
 include Makefile.defs
 
-# This is a no-op unless DOCKER_BUILDKIT is defined
 # Provides buildkit specific defaults BUILD_DIR and DOCKER_BUILD_DIR
 include Makefile.buildkit
 

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -1,14 +1,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: builder-info
-# nothing by default
-builder-info:
-
 DOCKER_BUILDER := default
-
-ifdef DOCKER_BUILDKIT
-
 BUILD_DIR := _build
 
 # Export with value expected by docker
@@ -27,6 +20,7 @@ ifeq ($(DOCKER_BUILDER),default)
 endif
 endif
 
+.PHONY: builder-info
 builder-info:
 	@echo "Using Docker Buildx builder \"$(DOCKER_BUILDER)\" with build flags \"$(DOCKER_FLAGS)\"."
 
@@ -138,7 +132,5 @@ _build/context/GIT_VERSION: GIT_VERSION _build/context
 
 check-status:
 	@if [ -n "`git status --porcelain`" ] ; then git status && echo "These changes will not be included in build, aborting. Define IGNORE_GIT_STATUS to build anyway." && test $(IGNORE_GIT_STATUS); fi
-
-endif
 
 endif

--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -11,7 +11,7 @@ pushd "${script_dir}/.."
 lock
 trap unlock EXIT
 
-DOCKER_BUILDKIT=1 make docker-images-all DOCKER_IMAGE_TAG="$2" DOCKER_FLAGS="$3"
+make docker-images-all DOCKER_IMAGE_TAG="$2" DOCKER_FLAGS="$3"
 
 docker tag "cilium/cilium:$2" "$1/cilium/cilium:$2"
 docker tag "cilium/cilium:$2" "$1/cilium/cilium-dev:$2"

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -35,7 +35,7 @@ then
 
       if [[ "${CILIUM_IMAGE}" == "" ]]; then
         echo "building cilium container image..."
-        DOCKER_BUILDKIT=1 make LOCKDEBUG=1 docker-cilium-image
+        make LOCKDEBUG=1 docker-cilium-image
         echo "tagging cilium image..."
         docker tag cilium/cilium "${REGISTRY}/${CILIUM_TAG}"
         echo "pushing cilium image to ${REGISTRY}/${CILIUM_TAG}..."
@@ -48,13 +48,13 @@ then
 
       if [[ "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
         echo "building cilium-operator image..."
-        DOCKER_BUILDKIT=1 make LOCKDEBUG=1 docker-operator-image
+        make LOCKDEBUG=1 docker-operator-image
         echo "building cilium-operator-aws image..."
-        DOCKER_BUILDKIT=1 make -B LOCKDEBUG=1 docker-operator-aws-image
+        make -B LOCKDEBUG=1 docker-operator-aws-image
         echo "building cilium-operator-azure image..."
-        DOCKER_BUILDKIT=1 make -B LOCKDEBUG=1 docker-operator-azure-image
+        make -B LOCKDEBUG=1 docker-operator-azure-image
         echo "building cilium-operator-generic image..."
-        DOCKER_BUILDKIT=1 make -B LOCKDEBUG=1 docker-operator-generic-image
+        make -B LOCKDEBUG=1 docker-operator-generic-image
         echo "tagging cilium-operator images..."
         docker tag "${CILIUM_OPERATOR_TAG}" "${REGISTRY}/${CILIUM_OPERATOR_TAG}"
         docker tag "${CILIUM_OPERATOR_AWS_TAG}" "${REGISTRY}/${CILIUM_OPERATOR_AWS_TAG}"
@@ -84,7 +84,7 @@ then
 
       if [[ "${HUBBLE_RELAY_IMAGE}" == "" ]]; then
         echo "building hubble-relay image..."
-        DOCKER_BUILDKIT=1 make LOCKDEBUG=1 docker-hubble-relay-image
+        make LOCKDEBUG=1 docker-hubble-relay-image
         echo "tagging hubble-relay image..."
         docker tag ${HUBBLE_RELAY_TAG} ${REGISTRY}/${HUBBLE_RELAY_TAG}
         echo "pushing hubble-relay image to ${REGISTRY}/${HUBBLE_RELAY_TAG}..."

--- a/test/provision/externalworkload_install.sh
+++ b/test/provision/externalworkload_install.sh
@@ -4,6 +4,6 @@ set -e
 cd /home/vagrant/go/src/github.com/cilium/cilium
 
 # Build docker image
-DOCKER_BUILDKIT=1 make docker-cilium-image
+make docker-cilium-image
 
 CLUSTER_ADDR=192.168.36.11:32379 HOST_IP=192.168.36.10 CILIUM_IMAGE=cilium/cilium:latest contrib/k8s/install-external-workload.sh


### PR DESCRIPTION
Use docker buildkit for all docker make targets. Docker builds
directly from repo still maintain the classic docker syntax.

Docker buildkit builds use generated .dockerignore files that leave
all non-source files and .git directory out of the Docker build
context, and use build cache mounts, making builds much faster.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
