### PR TITLE
Bump alpine base image to 3.13.0

### DIFF
--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -24,7 +24,7 @@ RUN make GOARCH=$TARGETARCH NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cil
 WORKDIR /go/src/github.com/cilium/cilium
 RUN make GOARCH=$TARGETARCH licenses-all
 
-FROM docker.io/library/alpine:3.12.0 as certs
+FROM docker.io/library/alpine:3.13.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -24,7 +24,7 @@ RUN make GOARCH=$TARGETARCH NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cil
 WORKDIR /go/src/github.com/cilium/cilium
 RUN make GOARCH=$TARGETARCH licenses-all
 
-FROM docker.io/library/alpine:3.12.0 as certs
+FROM docker.io/library/alpine:3.13.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -24,7 +24,7 @@ RUN make GOARCH=$TARGETARCH NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG RACE=$RACE cil
 WORKDIR /go/src/github.com/cilium/cilium
 RUN make GOARCH=$TARGETARCH licenses-all
 
-FROM docker.io/library/alpine:3.12.0 as certs
+FROM docker.io/library/alpine:3.13.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -24,7 +24,7 @@ RUN make GOARCH=$TARGETARCH RACE=$RACE NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG cil
 WORKDIR /go/src/github.com/cilium/cilium
 RUN make GOARCH=$TARGETARCH licenses-all
 
-FROM docker.io/library/alpine:3.12.0 as certs
+FROM docker.io/library/alpine:3.13.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/clustermesh-apiserver.Dockerfile
+++ b/clustermesh-apiserver.Dockerfile
@@ -23,7 +23,7 @@ RUN make GOARCH=$TARGETARCH licenses-all
 
 # CGO_ENABLED=0 GOOS=linux go build
 
-FROM docker.io/library/alpine:3.12.0 as certs
+FROM docker.io/library/alpine:3.13.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/contrib/coccinelle/Dockerfile
+++ b/contrib/coccinelle/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/alpine:3.12
+FROM docker.io/library/alpine:3.13.0
 
 LABEL maintainer="maintainer@cilium.io"
 

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -19,7 +19,7 @@ RUN make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} LOCKDEBUG=${LOCKDE
 WORKDIR /go/src/github.com/cilium/cilium
 RUN make licenses-all
 
-FROM docker.io/library/alpine:3.12.0 as certs
+FROM docker.io/library/alpine:3.13.0 as certs
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates

--- a/images/hubble-proto/Dockerfile
+++ b/images/hubble-proto/Dockerfile
@@ -1,8 +1,8 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG GOLANG_IMAGE=docker.io/library/golang:1.15.7-alpine3.12
-ARG ALPINE_IMAGE=docker.io/library/alpine:3.12
+ARG GOLANG_IMAGE=docker.io/library/golang:1.15.7-alpine3.13
+ARG ALPINE_IMAGE=docker.io/library/alpine:3.13.0
 
 FROM ${GOLANG_IMAGE} as builder
 

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -48,7 +48,7 @@ const (
 	MemcacheBinClient = "docker.io/cilium/python-bmemcached:v0.0.2"
 
 	// AlpineImage is used during the memcached tests as the text client.
-	AlpineImage = "docker.io/library/alpine:3.9"
+	AlpineImage = "docker.io/library/alpine:3.13.0"
 
 	// CassandraImage is the image used for testing of the cassandra proxy
 	// functionality in Cilium.


### PR DESCRIPTION
Consistently use the explicit stable 3.13.0 version tag rather than the
rolling 3.13.

This also allows to pre-pull a single stable version for the Vagrant box.

Suggested-by: Alexandre Perrin <alex@kaworu.ch>