### PR TITLE
treat empty NetworkPolicyPort as "all ports on TCP" during parsing

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -278,16 +278,12 @@ func ipBlockToCIDRRule(block *slim_networkingv1.IPBlock) api.CIDRRule {
 func parsePorts(ports []slim_networkingv1.NetworkPolicyPort) []api.PortRule {
 	portRules := []api.PortRule{}
 	for _, port := range ports {
-		if port.Protocol == nil && port.Port == nil {
-			continue
-		}
-
 		protocol := api.ProtoTCP
 		if port.Protocol != nil {
 			protocol, _ = api.ParseL4Proto(string(*port.Protocol))
 		}
 
-		portStr := ""
+		portStr := "0"
 		if port.Port != nil {
 			portStr = port.Port.String()
 		}

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -676,6 +676,40 @@ func (s *K8sSuite) TestParseNetworkPolicyNamedPort(c *C) {
 	c.Assert(len(rules), Equals, 1)
 }
 
+func (s *K8sSuite) TestParseNetworkPolicyEmptyPort(c *C) {
+	netPolicy := &slim_networkingv1.NetworkPolicy{
+		Spec: slim_networkingv1.NetworkPolicySpec{
+			Ingress: []slim_networkingv1.NetworkPolicyIngressRule{
+				{
+					Ports: []slim_networkingv1.NetworkPolicyPort{
+						{},
+					},
+				},
+			},
+		},
+	}
+
+	rules, err := ParseNetworkPolicy(netPolicy)
+	c.Assert(err, IsNil)
+	c.Assert(len(rules), Equals, 1)
+	c.Assert(len(rules[0].Ingress), Equals, 1)
+	c.Assert(len(rules[0].Ingress[0].ToPorts), Equals, 1)
+	ports := rules[0].Ingress[0].ToPorts[0].Ports
+	c.Assert(len(ports), Equals, 1)
+	c.Assert(ports[0].Port, Equals, "0")
+	c.Assert(ports[0].Protocol, Equals, api.ProtoTCP)
+}
+
+func (s *K8sSuite) TestParsePorts(c *C) {
+	rules := parsePorts([]slim_networkingv1.NetworkPolicyPort{
+		{},
+	})
+	c.Assert(len(rules), Equals, 1)
+	c.Assert(len(rules[0].Ports), Equals, 1)
+	c.Assert(rules[0].Ports[0].Port, Equals, "0")
+	c.Assert(rules[0].Ports[0].Protocol, Equals, api.ProtoTCP)
+}
+
 func (s *K8sSuite) TestParseNetworkPolicyUnknownProto(c *C) {
 	unknownProtocol := slim_corev1.Protocol("unknown")
 	netPolicy := &slim_networkingv1.NetworkPolicy{

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -237,6 +237,33 @@ func (s *PolicyAPITestSuite) TestL7RulesWithNonTCPProtocols(c *C) {
 
 }
 
+// This test ensures that L7 rules reject unspecified ports.
+func (s *PolicyAPITestSuite) TestL7RuleRejectsEmptyPort(c *C) {
+	invalidL7PortRule := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				IngressCommonRule: IngressCommonRule{
+					FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "0", Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err := invalidL7PortRule.Sanitize()
+	c.Assert(err, Not(IsNil))
+}
+
 // This test ensures that PortRules using the HTTP protocol have valid regular
 // expressions for the method and path fields.
 func (s *PolicyAPITestSuite) TestHTTPRuleRegexes(c *C) {


### PR DESCRIPTION
<!-- Description of change -->

Fixes: #14678

```release-note
Treat empty NetworkPolicyPort as "all ports on TCP" during network policy parsing
```

## Test plan

```
cd cilium

pushd pkg/k8s && go test
popd

pushd pkg/policy && go test
popd

pushd pkg/policy/api && go test
popd
```
