### PR TITLE
datapath: remove SNAT maps entries when kube-proxy is enabled

### DIFF
--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -175,6 +175,10 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 		}...)
 	}
 
+	if !option.Config.EnableNodePort {
+		maps = append(maps, []string{"cilium_snat_v4_external", "cilium_snat_v6_external"}...)
+	}
+
 	if !option.Config.EnableIPv4FragmentsTracking {
 		maps = append(maps, "cilium_ipv4_frag_datagrams")
 	}


### PR DESCRIPTION
This path remove SNAT maps entries to support the case when the user toggles off from using BPF to kube-proxy

Fixes: #13835
Signed-off-by: Salvatore Mazzarino <salvatore@accuknox.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Remove SNAT maps entries to support the case when the user toggles off from using BPF to kube-proxy.
```
