### PR TITLE
Add tunnel mode config and egress gateway config params

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -19,26 +19,27 @@ RUNDIR=$2
 IP4_HOST=$3
 IP6_HOST=$4
 MODE=$5
+TUNNEL_MODE=$6
 # Only set if MODE = "direct", "ipvlan", "flannel"
-NATIVE_DEVS=$6
-HOST_DEV1=$7
-HOST_DEV2=$8
-XDP_DEV=$9
-XDP_MODE=${10}
-MTU=${11}
-IPSEC=${12}
-ENCRYPT_DEV=${13}
-HOSTLB=${14}
-HOSTLB_UDP=${15}
-HOSTLB_PEER=${16}
-CGROUP_ROOT=${17}
-BPFFS_ROOT=${18}
-NODE_PORT=${19}
-NODE_PORT_BIND=${20}
-MCPU=${21}
-NR_CPUS=${22}
-ENDPOINT_ROUTES=${23}
-PROXY_RULE=${24}
+NATIVE_DEVS=$7
+HOST_DEV1=$8
+HOST_DEV2=$9
+XDP_DEV=${10}
+XDP_MODE=${11}
+MTU=${12}
+IPSEC=${13}
+ENCRYPT_DEV=${14}
+HOSTLB=${15}
+HOSTLB_UDP=${16}
+HOSTLB_PEER=${17}
+CGROUP_ROOT=${18}
+BPFFS_ROOT=${19}
+NODE_PORT=${20}
+NODE_PORT_BIND=${21}
+MCPU=${22}
+NR_CPUS=${23}
+ENDPOINT_ROUTES=${24}
+PROXY_RULE=${25}
 
 ID_HOST=1
 ID_WORLD=2
@@ -481,10 +482,10 @@ else
 	ip link del cilium_sit   2> /dev/null || true
 fi
 
-if [ "$MODE" = "vxlan" -o "$MODE" = "geneve" ]; then
-	ENCAP_DEV="cilium_${MODE}"
+if [ "$MODE" = "tunnel" ]; then
+	ENCAP_DEV="cilium_${TUNNEL_MODE}"
 	ip link show $ENCAP_DEV || {
-		ip link add name $ENCAP_DEV address $(rnd_mac_addr) type $MODE external || encap_fail
+		ip link add name $ENCAP_DEV address $(rnd_mac_addr) type $TUNNEL_MODE external || encap_fail
 	}
 	ip link set $ENCAP_DEV mtu $MTU || encap_fail
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -642,6 +642,10 @@ func init() {
 	flags.Bool(option.EnableIPMasqAgent, false, "Enable BPF ip-masq-agent")
 	option.BindEnv(option.EnableIPMasqAgent)
 
+	flags.Bool(option.EnableEgressGateway, false, "Enable egress gateway")
+	option.BindEnv(option.EnableEgressGateway)
+	flags.MarkHidden(option.EnableEgressGateway)
+
 	flags.String(option.IPMasqAgentConfigPath, "/etc/config/ip-masq-agent", "ip-masq-agent configuration file path")
 	option.BindEnv(option.IPMasqAgentConfigPath)
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -48,6 +48,7 @@ const (
 	initArgIPv4NodeIP
 	initArgIPv6NodeIP
 	initArgMode
+	initArgTunnelMode
 	initArgDevices
 	initArgHostDev1
 	initArgHostDev2
@@ -289,11 +290,13 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	var mode baseDeviceMode
+	args[initArgTunnelMode] = "<nil>"
 	switch {
 	case option.Config.IsFlannelMasterDeviceSet():
 		mode = flannelMode
 	case option.Config.Tunnel != option.TunnelDisabled:
-		mode = baseDeviceMode(option.Config.Tunnel)
+		mode = tunnelMode
+		args[initArgTunnelMode] = option.Config.Tunnel
 	case option.Config.DatapathMode == datapathOption.DatapathModeIpvlan:
 		mode = ipvlanMode
 	case option.Config.EnableHealthDatapath:

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -306,6 +306,12 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 	args[initArgMode] = string(mode)
 
+	if option.Config.Tunnel == option.TunnelDisabled && option.Config.EnableEgressGateway {
+		// Enable tunnel mode to vxlan if egress gateway is configured
+		// Tunnel is required for egress traffic under this config
+		args[initArgTunnelMode] = option.TunnelVXLAN
+	}
+
 	if option.Config.EnableNodePort {
 		args[initArgNodePort] = "true"
 	} else {

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -35,6 +35,7 @@ const (
 	flannelMode = baseDeviceMode("flannel")
 	ipvlanMode  = baseDeviceMode("ipvlan")
 	directMode  = baseDeviceMode("direct")
+	tunnelMode  = baseDeviceMode("tunnel")
 
 	libbpfFixupMsg = "struct bpf_elf_map fixup performed due to size mismatch!"
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -340,6 +340,9 @@ const (
 	// EnableIPMasqAgent enables BPF ip-masq-agent
 	EnableIPMasqAgent = "enable-ip-masq-agent"
 
+	// EnableEgressGateway enables egress-gateway
+	EnableEgressGateway = "enable-egress-gateway"
+
 	// IPMasqAgentConfigPath is the configuration file path
 	IPMasqAgentConfigPath = "ip-masq-agent-config-path"
 
@@ -1642,6 +1645,7 @@ type DaemonConfig struct {
 	EnableBPFMasquerade    bool
 	EnableBPFClockProbe    bool
 	EnableIPMasqAgent      bool
+	EnableEgressGateway    bool
 	IPMasqAgentConfigPath  string
 	InstallIptRules        bool
 	MonitorAggregation     string
@@ -2586,6 +2590,7 @@ func (c *DaemonConfig) Populate() {
 	c.LoopbackIPv4 = viper.GetString(LoopbackIPv4)
 	c.EnableBPFClockProbe = viper.GetBool(EnableBPFClockProbe)
 	c.EnableIPMasqAgent = viper.GetBool(EnableIPMasqAgent)
+	c.EnableEgressGateway = viper.GetBool(EnableEgressGateway)
 	c.IPMasqAgentConfigPath = viper.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
 	c.IPTablesLockTimeout = viper.GetDuration(IPTablesLockTimeout)


### PR DESCRIPTION
This PR adds a tunnel mode arg to the init script of cilium devices so
that 'mode' and 'tunnel mode' is represented in separate params. It 
also adds the config options for enabling egress gateway and makes
sure that tunnel is enabled when egress gateway is specified.

This change is part the egress NAT feature, Ref: #13575.


Signed-off-by: Bolun Zhao <blzhao@google.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Thanks for contributing!

<!-- Description of change -->

