### PR TITLE
v1.7 backports 2021-01-25

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -11,8 +11,8 @@ ACTS_YAML=".github/cilium-actions.yml"
 
 usage() {
     logecho "usage: $0 <VERSION> <GH-PROJECT>"
-    logecho "VERSION    Target release version"
-    logecho "GH-PROJECT Project ID for next release"
+    logecho "VERSION    Target release version (format: X.Y.Z)"
+    logecho "GH-PROJECT Project Number for next (X.Y.Z+1) development release"
     logecho
     logecho "--help     Print this help message"
 }


### PR DESCRIPTION
* #14684 -- contrib/release: clarify project number for release process (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14684; do contrib/backporting/set-labels.py $pr done 1.7; done
```