### PR TITLE
Helm: Add custom serviceAccounts

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -347,6 +347,8 @@ Annotations:
   as well as the default CNI plugins shipped by most managed Kubernetes
   distributions. Set the ``cni.exclusive=false`` Helm flag to disable this
   behaviour.
+* Helm option ``serviceAccounts.certgen`` is removed, please use ``serviceAccounts.clustermeshcertgen``
+  for Clustermesh certificate generation and ``serviceAccounts.hubblecertgen`` for Hubble certificate generation.
 
 Removed Metrics/Labels
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -326,7 +326,8 @@ contributors across the globe, there is almost always someone available to help.
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
 | securityContext | object | `{}` | Security context to be added to agent pods |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
-| serviceAccounts.certgen | object | `{"annotations":{},"create":true}` | Certgen is used if hubble.tls.auto.method=cronJob |
+| serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
+| serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
 | sleepAfterInit | bool | `false` |  |
 | sockops | object | `{"enabled":false}` | Configure BPF socket operations configuration |
 | tls.enabled | bool | `true` |  |

--- a/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
@@ -6,8 +6,8 @@ spec:
       labels:
         k8s-app: clustermesh-apiserver-generate-certs
     spec:
-      serviceAccount: clustermesh-apiserver-generate-certs
-      serviceAccountName: clustermesh-apiserver-generate-certs
+      serviceAccount: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       containers:
         - name: certgen
           image: {{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}

--- a/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
@@ -6,8 +6,8 @@ spec:
       labels:
         k8s-app: hubble-generate-certs
     spec:
-      serviceAccount: hubble-generate-certs
-      serviceAccountName: hubble-generate-certs
+      serviceAccount: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
       containers:
         - name: certgen
           image: {{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}

--- a/install/kubernetes/cilium/templates/cilium-agent-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.agent) (not .Values.preflight.enabled) }}
+{{- if and (.Values.agent) (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: cilium
 subjects:
 - kind: ServiceAccount
-  name: cilium
+  name: {{ .Values.serviceAccounts.cilium.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -439,8 +439,8 @@ spec:
 {{- if and (or (and (eq .Release.Namespace "kube-system") (gt $k8sMinor "10")) (ge $k8sMinor "17") (gt $k8sMajor "1")) .Values.enableCriticalPriorityClass }}
       priorityClassName: system-node-critical
 {{- end }}
-      serviceAccount: cilium
-      serviceAccountName: cilium
+      serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}
       terminationGracePeriodSeconds: 1
 {{- with .Values.tolerations }}
       tolerations:

--- a/install/kubernetes/cilium/templates/cilium-agent-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if and (.Values.agent) (not .Values.preflight.enabled) }}
+{{- if and (.Values.agent) (.Values.serviceAccounts.cilium.create) (not .Values.preflight.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium
+  name: {{ .Values.serviceAccounts.cilium.name | quote }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccounts.cilium.annotations }}
   annotations:

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.etcd.managed }}
+{{- if and .Values.etcd.managed .Values.serviceAccounts.etcd.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: cilium-etcd-operator
 subjects:
 - kind: ServiceAccount
-  name: cilium-etcd-operator
+  name: {{ .Values.serviceAccounts.etcd.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
@@ -93,8 +93,8 @@ spec:
       priorityClassName: system-cluster-critical
 {{- end }}
       restartPolicy: Always
-      serviceAccount: cilium-etcd-operator
-      serviceAccountName: cilium-etcd-operator
+      serviceAccount: {{ .Values.serviceAccounts.etcd.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.etcd.name | quote }}
 {{- with .Values.etcd.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-serviceaccount.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.etcd.managed }}
-{{- if .Values.serviceAccounts.etcd.create }}
+{{- if and .Values.etcd.managed .Values.serviceAccounts.etcd.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium-etcd-operator
+  name: {{ .Values.serviceAccounts.etcd.name | quote }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccounts.etcd.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccounts.etcd.annotations | indent 4 }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.enabled }}
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: cilium-operator
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.operator.serviceAccountName | quote }}
+  name: {{ .Values.serviceAccounts.operator.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -225,13 +225,8 @@ spec:
 {{- if and (or (and (eq .Release.Namespace "kube-system") (gt $k8sMinor "10")) (ge $k8sMinor "17") (gt $k8sMajor "1")) .Values.enableCriticalPriorityClass }}
       priorityClassName: system-cluster-critical
 {{- end }}
-{{- if .Values.serviceAccounts.operator.create }}
-      serviceAccount: cilium-operator
-      serviceAccountName: cilium-operator
-{{- else }}
-      serviceAccount: {{ .Values.operator.serviceAccountName | quote }}
-      serviceAccountName: {{ .Values.operator.serviceAccountName | quote }}
-{{- end }}
+      serviceAccount: {{ .Values.serviceAccounts.operator.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.operator.name | quote }}
 {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-operator-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium-operator
+  name: {{ .Values.serviceAccounts.operator.name | quote }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccounts.operator.annotations }}
   annotations:

--- a/install/kubernetes/cilium/templates/cilium-preflight-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.preflight.enabled }}
+{{- if and (.Values.preflight.enabled) (.Values.serviceAccounts.preflight.create) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: cilium-pre-flight
 subjects:
 - kind: ServiceAccount
-  name: cilium-pre-flight
+  name: {{ .Values.serviceAccounts.preflight.name | quote }} 
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
@@ -120,8 +120,8 @@ spec:
       # enabled when etcd.managed=true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
-      serviceAccount: cilium-pre-flight
-      serviceAccountName: cilium-pre-flight
+      serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       terminationGracePeriodSeconds: 1
 {{- with .Values.tolerations }}
       tolerations:

--- a/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
@@ -71,8 +71,8 @@ spec:
 {{- end }}
       hostNetwork: true
       restartPolicy: Always
-      serviceAccount: cilium-pre-flight
-      serviceAccountName: cilium-pre-flight
+      serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       terminationGracePeriodSeconds: 1
 {{- with .Values.preflight.nodeSelector }}
       nodeSelector:

--- a/install/kubernetes/cilium/templates/cilium-preflight-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium-pre-flight
+  name: {{ .Values.serviceAccounts.preflight.name | quote }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccounts.preflight.annotations }}
   annotations:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (.Values.serviceAccounts.clustermeshApiserver.create) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: clustermesh-apiserver
 subjects:
 - kind: ServiceAccount
-  name: clustermesh-apiserver
+  name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -27,7 +27,8 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 8 }}
 {{- end }}
       restartPolicy: Always
-      serviceAccount: clustermesh-apiserver
+      serviceAccount: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
       initContainers:
       - name: etcd-init
         image: {{ .Values.clustermesh.apiserver.etcd.image.repository }}:{{ .Values.clustermesh.apiserver.etcd.image.tag }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-role.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.clustermeshcertgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.clustermeshcertgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -10,6 +10,6 @@ roleRef:
   name: clustermesh-apiserver-generate-certs
 subjects:
 - kind: ServiceAccount
-  name: clustermesh-apiserver-generate-certs
+  name: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }} 
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-generate-certs-serviceaccount.yaml
@@ -1,10 +1,10 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.serviceAccounts.clustermeshcertgen.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: clustermesh-apiserver-generate-certs
+  name: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }} 
   namespace: {{ .Release.Namespace }}
-{{- with .Values.serviceAccounts.certgen.annotations }}
+{{- with .Values.serviceAccounts.clustermeshcertgen.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: clustermesh-apiserver
+  name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{- with .Values.serviceAccounts.clustermeshApiserver.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-generate-certs-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-generate-certs-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/hubble-generate-certs-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-generate-certs-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: hubble-generate-certs
 subjects:
 - kind: ServiceAccount
-  name: hubble-generate-certs
+  name: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-generate-certs-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-generate-certs-serviceaccount.yaml
@@ -1,11 +1,11 @@
-{{- if and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.certgen.create }}
+{{- if and .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-generate-certs
+  name: {{ .Values.serviceAccounts.hubblecertgen.name | quote }} 
   namespace: {{ .Release.Namespace }}
-{{- if .Values.serviceAccounts.certgen.annotations }}
+{{- if .Values.serviceAccounts.hubblecertgen.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.certgen.annotations | indent 4 }}
+{{ toYaml .Values.serviceAccounts.hubblecertgen.annotations | indent 4 }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: hubble-relay
+  name: {{ .Values.serviceAccounts.relay.name | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -80,8 +80,8 @@ spec:
             readOnly: true
 {{- end }}
       restartPolicy: Always
-      serviceAccount: hubble-relay
-      serviceAccountName: hubble-relay
+      serviceAccount: {{ .Values.serviceAccounts.relay.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.relay.name | quote }}
       terminationGracePeriodSeconds: 0
 {{- with .Values.hubble.relay.nodeSelector }}
       nodeSelector:

--- a/install/kubernetes/cilium/templates/hubble-relay-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-relay
+  name: {{ .Values.serviceAccounts.relay.name | quote }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccounts.relay.annotations }}
   annotations:

--- a/install/kubernetes/cilium/templates/hubble-ui-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: hubble-ui
+  name: {{ .Values.serviceAccounts.ui.name | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -28,8 +28,8 @@ spec:
       securityContext:
         runAsUser: 1001
       {{- end }}
-      serviceAccount: hubble-ui
-      serviceAccountName: hubble-ui
+      serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.ui.name | quote }}
 {{- with .Values.hubble.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/hubble-ui-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-ui
+  name: {{ .Values.serviceAccounts.ui.name | quote }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccounts.ui.annotations }}
   annotations:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -34,28 +34,41 @@ cluster:
 serviceAccounts:
   cilium:
     create: true
+    name: cilium
     annotations: {}
   etcd:
     create: true
+    name: cilium-etcd-operator
     annotations: {}
   operator:
     create: true
+    name: cilium-operator
     annotations: {}
   preflight:
     create: true
+    name: cilium-pre-flight 
     annotations: {}
   relay:
     create: true
+    name: hubble-relay
     annotations: {}
   ui:
     create: true
+    name: hubble-ui
     annotations: {}
   clustermeshApiserver:
     create: true
+    name: clustermesh-apiserver
     annotations: {}
-  # -- Certgen is used if hubble.tls.auto.method=cronJob
-  certgen:
+  # -- Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob
+  clustermeshcertgen:
     create: true
+    name: clustermesh-apiserver-generate-certs
+    annotations: {}
+  # -- Hubblecertgen is used if hubble.tls.auto.method=cronJob
+  hubblecertgen:
+    create: true
+    name: hubble-generate-certs
     annotations: {}
 
 # -- Install the cilium agent resources.

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -3,35 +3,35 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium
+  name: "cilium"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-operator-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium-operator
+  name: "cilium-operator"
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-generate-certs-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-generate-certs
+  name: "hubble-generate-certs" 
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-relay-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-relay
+  name: "hubble-relay"
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-ui-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-ui
+  name: "hubble-ui"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-configmap.yaml
@@ -573,7 +573,7 @@ roleRef:
   name: cilium
 subjects:
 - kind: ServiceAccount
-  name: cilium
+  name: "cilium"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-operator-clusterrolebinding.yaml
@@ -601,7 +601,7 @@ roleRef:
   name: hubble-generate-certs
 subjects:
 - kind: ServiceAccount
-  name: hubble-generate-certs
+  name: "hubble-generate-certs"
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-relay-clusterrolebinding.yaml
@@ -616,7 +616,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: kube-system
-  name: hubble-relay
+  name: "hubble-relay"
 ---
 # Source: cilium/templates/hubble-ui-clusterrolebinding.yaml
 kind: ClusterRoleBinding
@@ -630,7 +630,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: kube-system
-  name: hubble-ui
+  name: "hubble-ui"
 ---
 # Source: cilium/templates/cilium-agent-service.yaml
 kind: Service
@@ -905,8 +905,8 @@ spec:
             memory: 100Mi
       restartPolicy: Always
       priorityClassName: system-node-critical
-      serviceAccount: cilium
-      serviceAccountName: cilium
+      serviceAccount: "cilium"
+      serviceAccountName: "cilium"
       terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
@@ -1052,8 +1052,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-cluster-critical
-      serviceAccount: cilium-operator
-      serviceAccountName: cilium-operator
+      serviceAccount: "cilium-operator"
+      serviceAccountName: "cilium-operator"
       tolerations:
       - operator: Exists
       volumes:
@@ -1124,8 +1124,8 @@ spec:
             name: tls
             readOnly: true
       restartPolicy: Always
-      serviceAccount: hubble-relay
-      serviceAccountName: hubble-relay
+      serviceAccount: "hubble-relay"
+      serviceAccountName: "hubble-relay"
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
@@ -1175,8 +1175,8 @@ spec:
     spec:
       securityContext:
         runAsUser: 1001
-      serviceAccount: hubble-ui
-      serviceAccountName: hubble-ui
+      serviceAccount: "hubble-ui"
+      serviceAccountName: "hubble-ui"
       containers:
         - name: frontend
           image: "quay.io/cilium/hubble-ui:latest"
@@ -1238,8 +1238,8 @@ spec:
       labels:
         k8s-app: hubble-generate-certs
     spec:
-      serviceAccount: hubble-generate-certs
-      serviceAccountName: hubble-generate-certs
+      serviceAccount: "hubble-generate-certs"
+      serviceAccountName: "hubble-generate-certs"
       containers:
         - name: certgen
           image: quay.io/cilium/certgen:v0.1.3
@@ -1287,8 +1287,8 @@ spec:
           labels:
             k8s-app: hubble-generate-certs
         spec:
-          serviceAccount: hubble-generate-certs
-          serviceAccountName: hubble-generate-certs
+          serviceAccount: "hubble-generate-certs"
+          serviceAccountName: "hubble-generate-certs"
           containers:
             - name: certgen
               image: quay.io/cilium/certgen:v0.1.3

--- a/install/kubernetes/quick-hubble-install.yaml
+++ b/install/kubernetes/quick-hubble-install.yaml
@@ -3,21 +3,21 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-generate-certs
+  name: "hubble-generate-certs" 
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-relay-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-relay
+  name: "hubble-relay"
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-ui-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hubble-ui
+  name: "hubble-ui"
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-relay-configmap.yaml
@@ -221,7 +221,7 @@ roleRef:
   name: hubble-generate-certs
 subjects:
 - kind: ServiceAccount
-  name: hubble-generate-certs
+  name: "hubble-generate-certs"
   namespace: kube-system
 ---
 # Source: cilium/templates/hubble-relay-clusterrolebinding.yaml
@@ -236,7 +236,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: kube-system
-  name: hubble-relay
+  name: "hubble-relay"
 ---
 # Source: cilium/templates/hubble-ui-clusterrolebinding.yaml
 kind: ClusterRoleBinding
@@ -250,7 +250,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: kube-system
-  name: hubble-ui
+  name: "hubble-ui"
 ---
 # Source: cilium/templates/hubble-relay-service.yaml
 kind: Service
@@ -348,8 +348,8 @@ spec:
             name: tls
             readOnly: true
       restartPolicy: Always
-      serviceAccount: hubble-relay
-      serviceAccountName: hubble-relay
+      serviceAccount: "hubble-relay"
+      serviceAccountName: "hubble-relay"
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
@@ -399,8 +399,8 @@ spec:
     spec:
       securityContext:
         runAsUser: 1001
-      serviceAccount: hubble-ui
-      serviceAccountName: hubble-ui
+      serviceAccount: "hubble-ui"
+      serviceAccountName: "hubble-ui"
       containers:
         - name: frontend
           image: "quay.io/cilium/hubble-ui:latest"
@@ -462,8 +462,8 @@ spec:
       labels:
         k8s-app: hubble-generate-certs
     spec:
-      serviceAccount: hubble-generate-certs
-      serviceAccountName: hubble-generate-certs
+      serviceAccount: "hubble-generate-certs"
+      serviceAccountName: "hubble-generate-certs"
       containers:
         - name: certgen
           image: quay.io/cilium/certgen:v0.1.3
@@ -511,8 +511,8 @@ spec:
           labels:
             k8s-app: hubble-generate-certs
         spec:
-          serviceAccount: hubble-generate-certs
-          serviceAccountName: hubble-generate-certs
+          serviceAccount: "hubble-generate-certs"
+          serviceAccountName: "hubble-generate-certs"
           containers:
             - name: certgen
               image: quay.io/cilium/certgen:v0.1.3

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium
+  name: "cilium"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-operator-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium-operator
+  name: "cilium-operator"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-configmap.yaml
@@ -349,7 +349,7 @@ roleRef:
   name: cilium
 subjects:
 - kind: ServiceAccount
-  name: cilium
+  name: "cilium"
   namespace: kube-system
 ---
 # Source: cilium/templates/cilium-operator-clusterrolebinding.yaml
@@ -578,8 +578,8 @@ spec:
             memory: 100Mi
       restartPolicy: Always
       priorityClassName: system-node-critical
-      serviceAccount: cilium
-      serviceAccountName: cilium
+      serviceAccount: "cilium"
+      serviceAccountName: "cilium"
       terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
@@ -725,8 +725,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-cluster-critical
-      serviceAccount: cilium-operator
-      serviceAccountName: cilium-operator
+      serviceAccount: "cilium-operator"
+      serviceAccountName: "cilium-operator"
       tolerations:
       - operator: Exists
       volumes:


### PR DESCRIPTION
Follow-up for #14681.

When using Helm, the components are deployed with hard-coded serviceAccounts.
This PR will allow the users to deploy Cilium using custom
serviceAccounts.

Fixes: #14729 

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

```release-note
Helm: Using external serviceAccounts is now possible.
```
