### PR TITLE
backport 1.9: vendor: Bump github.com/cilium/arping to fix correlation bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 	github.com/blang/semver v3.5.0+incompatible
-	github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d
+	github.com/cilium/arping v1.0.1-0.20210125181454-ec36642003a5
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
 	github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/christarazi/structured-merge-diff/v4 v4.0.2-0.20200917183246-1cc60193
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d h1:xG3H52q51GO+tE9noqKGEJO6nCUQIvXCI62bsJZ5EWM=
-github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
+github.com/cilium/arping v1.0.1-0.20210125181454-ec36642003a5 h1:wD2AlWiJXuPLEk9sKxTMLSSYEpNOB7JEsAwNxmESs1E=
+github.com/cilium/arping v1.0.1-0.20210125181454-ec36642003a5/go.mod h1:hnjbWhP2F454GKo6vEscP3emePUtB+5ODiGAICLgMzQ=
 github.com/cilium/client-go v0.0.0-20201223004022-d3a5d921c1db h1:/pTBEfNgUqDAtjXsjNBHM5ni1dKVTzji/GrbUbYnLlk=
 github.com/cilium/client-go v0.0.0-20201223004022-d3a5d921c1db/go.mod h1:gEiS+efRlXYUEQ9Oz4lmNXlxAl5JZ8y2zbTDGhvXXnk=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=

--- a/vendor/github.com/cilium/arping/arp_datagram.go
+++ b/vendor/github.com/cilium/arping/arp_datagram.go
@@ -73,7 +73,8 @@ func (datagram arpDatagram) SenderMac() net.HardwareAddr {
 }
 
 func (datagram arpDatagram) IsResponseOf(request arpDatagram) bool {
-	return datagram.oper == responseOper && bytes.Compare(request.spa, datagram.tpa) == 0
+	return datagram.oper == responseOper && bytes.Equal(request.spa, datagram.tpa) &&
+		bytes.Equal(request.tpa, datagram.spa)
 }
 
 func parseArpDatagram(buffer []byte) arpDatagram {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cilium/arping v1.0.1-0.20210118131754-d0a46841b03d
+# github.com/cilium/arping v1.0.1-0.20210125181454-ec36642003a5
 ## explicit
 github.com/cilium/arping
 # github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e


### PR DESCRIPTION
The bumped version includes \[1\] which fixes a critical bug in previously
wrong ARP response correlation.  This lead to mixed neigh entries as
reported in \[2\].

\[1\]: https://github.com/cilium/arping/pull/7
\[2\]: https://github.com/cilium/cilium/issues/14693