### PR TITLE
iptables: Don't SNAT connections from podCIDR

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1013,7 +1013,7 @@ func (m *IptablesManager) installMasqueradeRules(prog, ifName, localDeliveryInte
 			m.waitArgs,
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
-			"!", "-s", hostMasqueradeIP,
+			"!", "-s", allocRange,
 			"!", "-d", allocRange,
 			"-o", "cilium_host",
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1013,9 +1013,10 @@ func (m *IptablesManager) installMasqueradeRules(prog, ifName, localDeliveryInte
 			m.waitArgs,
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
-			"!", "-s", allocRange,
+			"!", "-s", hostMasqueradeIP,
 			"!", "-d", allocRange,
 			"-o", "cilium_host",
+			"-m", "conntrack", "--ctstate", "NEW",
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",
 			"-j", "SNAT", "--to-source", hostMasqueradeIP), false); err != nil {
 			return err

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1016,7 +1016,7 @@ func (m *IptablesManager) installMasqueradeRules(prog, ifName, localDeliveryInte
 			"!", "-s", hostMasqueradeIP,
 			"!", "-d", allocRange,
 			"-o", "cilium_host",
-			"-m", "conntrack", "--ctstate", "NEW",
+			"!", "-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask),
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",
 			"-j", "SNAT", "--to-source", hostMasqueradeIP), false); err != nil {
 			return err

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -980,7 +980,7 @@ func (m *IptablesManager) installMasqueradeRules(prog, ifName, localDeliveryInte
 		m.waitArgs,
 		"-t", "nat",
 		"-A", ciliumPostNatChain,
-		"!", "-o", localDeliveryInterface,
+		"!", "-o", ifName,
 		"-m", "comment", "--comment", "exclude non-"+ifName+" traffic from masquerade",
 		"-j", "RETURN"), false); err != nil {
 		return err
@@ -1016,7 +1016,6 @@ func (m *IptablesManager) installMasqueradeRules(prog, ifName, localDeliveryInte
 			"!", "-s", hostMasqueradeIP,
 			"!", "-d", allocRange,
 			"-o", "cilium_host",
-			"!", "-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask),
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",
 			"-j", "SNAT", "--to-source", hostMasqueradeIP), false); err != nil {
 			return err


### PR DESCRIPTION
For IPSec and the host firewall, in order to apply kube-proxy's reverse DNAT, we want to send traffic through the tunnel via the stack instead of doing a redirect call. Such traffic therefore goes from the lxc device to `cilium_host` where it is redirected to the tunneling device.

We however SNAT that traffic on its way to `cilium_host`. We don't need to apply SNAT there for the pod CIDR as any traffic from the pod CIDR will either leave directly through the native device (masquerading happening there) or go through `cilium_host` and be redirected to the tunnel.