### PR TITLE
 hubble: Support --{last,since,until} on agent and debug events 

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -430,6 +430,7 @@ func (r *eventsReader) Next(ctx context.Context) (*observerpb.GetFlowsResponse, 
 				},
 			}, nil
 		case *flowpb.AgentEvent:
+			r.eventCount++
 			return &observerpb.GetFlowsResponse{
 				Time:     e.Timestamp,
 				NodeName: nodeTypes.GetName(),
@@ -438,6 +439,7 @@ func (r *eventsReader) Next(ctx context.Context) (*observerpb.GetFlowsResponse, 
 				},
 			}, nil
 		case *flowpb.DebugEvent:
+			r.eventCount++
 			return &observerpb.GetFlowsResponse{
 				Time:     e.Timestamp,
 				NodeName: nodeTypes.GetName(),
@@ -484,8 +486,8 @@ func newRingReader(ring *container.Ring, req *observerpb.GetFlowsRequest, whitel
 		}
 		// Note: LostEvent type is ignored here and this is expected as lost
 		// events will never be explicitly requested by the caller
-		_, ok := e.Event.(*flowpb.Flow)
-		if !ok || !filters.Apply(whitelist, blacklist, e) {
+		_, isLostEvent := e.Event.(*flowpb.LostEvent)
+		if isLostEvent || !filters.Apply(whitelist, blacklist, e) {
 			continue
 		}
 		eventCount++

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -131,6 +131,80 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 	assert.Equal(t, req.Number, uint64(i))
 }
 
+func TestLocalObserverServer_GetFlows_AgentEvent(t *testing.T) {
+	numEvents := 100
+	queueSize := 0
+	req := &observerpb.GetFlowsRequest{
+		Number: uint64(10),
+		Whitelist: []*observerpb.FlowFilter{
+			{
+				EventType: []*observerpb.EventTypeFilter{
+					{
+						Type: monitorAPI.MessageTypeAgent,
+					},
+				},
+			},
+		},
+	}
+	i := 0
+	fakeServer := &testutils.FakeGetFlowsServer{
+		OnSend: func(response *observerpb.GetFlowsResponse) error {
+			assert.NotNil(t, int64(1), response.GetAgentEvent().GetAgentStart().GetTime().GetSeconds()%2)
+			assert.Equal(t, int64(1), response.GetTime().GetSeconds()%2)
+			i++
+			return nil
+		},
+		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
+			OnContext: func() context.Context {
+				return context.Background()
+			},
+		},
+	}
+
+	pp := noopParser(t)
+	s, err := NewLocalServer(pp, log,
+		observeroption.WithMaxFlows(container.Capacity127),
+		observeroption.WithMonitorBuffer(queueSize),
+	)
+	require.NoError(t, err)
+	go s.Start()
+
+	m := s.GetEventsChannel()
+	for i := 0; i < numEvents; i++ {
+		// flow events are even, agent events are odd
+		generateFlowEvent := i%2 == 0
+		ts := time.Unix(int64(i), 0)
+		node := fmt.Sprintf("node #%03d", i)
+		if generateFlowEvent {
+			tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+			data := testutils.MustCreateL3L4Payload(tn)
+			m <- &observerTypes.MonitorEvent{
+				Timestamp: ts,
+				NodeName:  node,
+				Payload: &observerTypes.PerfEvent{
+					Data: data,
+					CPU:  0,
+				},
+			}
+		} else {
+			m <- &observerTypes.MonitorEvent{
+				Timestamp: ts,
+				NodeName:  node,
+				Payload: &observerTypes.AgentEvent{
+					Type:    monitorAPI.MessageTypeAgent,
+					Message: monitorAPI.StartMessage(ts),
+				},
+			}
+		}
+
+	}
+	close(s.GetEventsChannel())
+	<-s.GetStopped()
+	err = s.GetFlows(req, fakeServer)
+	assert.NoError(t, err)
+	assert.Equal(t, req.Number, uint64(i))
+}
+
 func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
 	numFlows := 100
 	queueSize := 0


### PR DESCRIPTION
This PR ensures that the `Number`, `Until` and `Since` filters on
the `GetFlowsRequest` are treated the same on agent and debug events as
they are on flow events.

Previously, the observer API would only stop reading from the ring
buffer once it had collected enough flows. All interleaved debug and
agent events were returned without proper accounting (assuming they were
allows by the event type filter). This meant that if a request was only
requesting agent and/or debug events, that it would try to dump all such
events in the ring buffer.

The first commit in this PR is a simple refactor renaming `flowsReader` to `eventsReader`.
It should not contain any functional changes.