### PR TITLE
health: Disable routing in BPF when per-endpoint routes are enabled

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -267,9 +267,11 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	if option.Config.EnableEndpointRoutes {
+		disabled := false
 		dpConfig := &models.EndpointDatapathConfiguration{
 			InstallEndpointRoute: true,
 			RequireEgressProg:    true,
+			RequireRouting:       &disabled,
 		}
 		info.DatapathConfiguration = dpConfig
 	}


### PR DESCRIPTION
This commit fixes a datapath configuration discrepancy between the health endpoint and other endpoints. `ENABLE_ROUTING` should be [undefined if per-endpoint routes are enabled](https://github.com/cilium/cilium/blob/e463cfe80102486d1a3423b77f9c54afd0be94a2/daemon/cmd/endpoint.go#L309-L327); for the health endpoint, the macro is defined regardless of the settings.

Quite surprisingly, I'm not aware of any bug caused by this oversight, although it probably requires one more template and full compilation than necessary when per-endpoint routes are enabled.