### PR TITLE
datapath/linux: Fix clang version regex check

### DIFF
--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ func getClangVersion(filePath string) (semver.Version, error) {
 	if err != nil {
 		log.WithError(err).Fatal("clang version: NOT OK")
 	}
-	res := regexp.MustCompile(`(clang version )([^ ]*)`).FindStringSubmatch(string(verOut))
+	res := regexp.MustCompile(`(clang version )([^\s]*)`).FindStringSubmatch(string(verOut))
 	if len(res) != 3 {
 		log.Fatalf("clang version: NOT OK: unable to get clang's version "+
 			"from: %q", string(verOut))


### PR DESCRIPTION
This fixes the following error when the machine has clang 11.0.1
installed:

```
level=info msg="Cilium 1.9.90 0bffe8b39 2021-01-26T11:16:34+01:00 go version go1.15.7 linux/amd64" subsys=daemon
level=info msg="Envoy version check disabled" subsys=daemon
level=fatal msg="clang: NOT OK" error="Invalid character(s) found in patch number \"1\\nTarget:\"" subsys=linux-datapath
```

The issue was that the regex pattern was matching only against " " and
not any other kind of whitespace, especially newlines. Changing the
regex to match against all whitespace, including newlines, the pattern
is able to stop the match at the correct spot. The output it was trying
to match against was:

```
clang version 11.0.1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

Signed-off-by: Chris Tarazi <chris@isovalent.com>
