### PR TITLE
Unit tests refactor

### DIFF
--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -15,17 +15,19 @@
 package fake
 
 import (
-	"context"
 	"io"
 
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 )
 
 type fakeDatapath struct {
 	node           datapath.NodeHandler
 	nodeAddressing datapath.NodeAddressing
 	loader         datapath.Loader
+
+	// Implement methods that need to mock out real behaviour in the following interfaces.
+	datapath.ConfigWriter
+	datapath.IptablesManager
 }
 
 // NewDatapath returns a new fake datapath
@@ -48,52 +50,9 @@ func (f *fakeDatapath) LocalNodeAddressing() datapath.NodeAddressing {
 	return f.nodeAddressing
 }
 
-// WriteNodeConfig pretends to write the datapath configuration to the writer.
-func (f *fakeDatapath) WriteNodeConfig(io.Writer, *datapath.LocalNodeConfiguration) error {
-	return nil
-}
-
-// WriteNetdevConfig pretends to write the netdev configuration to a writer.
-func (f *fakeDatapath) WriteNetdevConfig(io.Writer, datapath.DeviceConfiguration) error {
-	return nil
-}
-
-// WriteTemplateConfig pretends to write the endpoint configuration to a writer.
-func (f *fakeDatapath) WriteTemplateConfig(io.Writer, datapath.EndpointConfiguration) error {
-	return nil
-}
-
 // WriteEndpointConfig pretends to write the endpoint configuration to a writer.
 func (f *fakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfiguration) error {
 	return nil
-}
-
-func (f *fakeDatapath) InstallProxyRules(uint16, bool, string) error {
-	return nil
-}
-
-func (f *fakeDatapath) RemoveProxyRules(uint16, bool, string) error {
-	return nil
-}
-
-func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
-	return false
-}
-
-func (f *fakeDatapath) RemoveRules(quiet bool) {}
-
-func (f *fakeDatapath) InstallRules(ifName string) error {
-	return nil
-}
-func (f *fakeDatapath) TransientRulesStart(ifName string) error {
-	return nil
-}
-func (f *fakeDatapath) TransientRulesEnd(quiet bool) {
-	return
-}
-
-func (m *fakeDatapath) GetProxyPort(name string) uint16 {
-	return 0
 }
 
 func (f *fakeDatapath) Loader() datapath.Loader {
@@ -102,32 +61,6 @@ func (f *fakeDatapath) Loader() datapath.Loader {
 
 // Loader is an interface to abstract out loading of datapath programs.
 type fakeLoader struct {
-}
-
-func (f *fakeLoader) CompileAndLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
-	panic("implement me")
-}
-
-func (f *fakeLoader) CompileOrLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
-	panic("implement me")
-}
-
-func (f *fakeLoader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
-	panic("implement me")
-}
-
-func (f *fakeLoader) EndpointHash(cfg datapath.EndpointConfiguration) (string, error) {
-	panic("implement me")
-}
-
-func (f *fakeLoader) Unload(ep datapath.Endpoint) {
-}
-
-func (f *fakeLoader) CallsMapPath(id uint16) string {
-	return ""
-}
-
-// Reinitialize does nothing.
-func (f *fakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
-	return nil
+	// Implement methods that need to mock out real behaviour.
+	datapath.Loader
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -19,23 +19,21 @@ package endpoint
 import (
 	"context"
 
+	"gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/lock"
-	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/u8proto"
-	"gopkg.in/check.v1"
 )
 
 type RedirectSuite struct{}
@@ -89,46 +87,16 @@ func (d *DummyIdentityAllocatorOwner) GetNodeSuffix() string {
 	return ""
 }
 
-// DummyOwner implements pkg/endpoint/regeneration/Owner. Used for unit testing.
+// DummyOwner mocks out pkg/endpoint/regeneration/Owner. Used for unit testing.
 type DummyOwner struct {
 	repo *policy.Repository
+	// Implement methods that need to mock out real behaviour in the following interface.
+	regeneration.Owner
 }
 
 // GetPolicyRepository returns the policy repository of the owner.
 func (d *DummyOwner) GetPolicyRepository() *policy.Repository {
 	return d.repo
-}
-
-// QueueEndpointBuild does nothing.
-func (d *DummyOwner) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
-	return nil, nil
-}
-
-// GetCompilationLock does nothing.
-func (d *DummyOwner) GetCompilationLock() *lock.RWMutex {
-	return nil
-}
-
-// GetCIDRPrefixLengths does nothing.
-func (d *DummyOwner) GetCIDRPrefixLengths() (s6, s4 []int) {
-	return nil, nil
-}
-
-// SendNotification does nothing.
-func (d *DummyOwner) SendNotification(msg monitorAPI.AgentNotifyMessage) error {
-	return nil
-}
-
-// Datapath returns a nil datapath.
-func (d *DummyOwner) Datapath() datapath.Datapath {
-	return nil
-}
-
-func (s *DummyOwner) GetDNSRules(epID uint16) restore.DNSRules {
-	return nil
-}
-
-func (s *DummyOwner) RemoveRestoredDNSRules(epID uint16) {
 }
 
 // GetNodeSuffix does nothing.


### PR DESCRIPTION
Refactor interface implementation in fakes

Embed interface into a mock struct so that all the methods
are inherited, and only the methods that are relevant to
unit test cases can be implemented to override actual code behavior.

This gets rid of redundant/no-op method implementations in fakes/mocks like -

type (m mockFoo) testFoo {
panic("Implement me")
}

type (m mockBar) testBar {

}

There are other places in the code which can use a similar kind of refactor, and can be addressed in a follow-up PR. Some examples - 
https://github.com/cilium/cilium/blob/master/daemon/cmd/daemon_test.go#L152
https://github.com/cilium/cilium/blob/master/pkg/node/manager/manager_test.go

Signed-off-by: Aditi Ghag <aditi@cilium.io>