### PR TITLE
Add labels to scrape cilium agent and operator metrics

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent-servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-servicemonitor.yaml
@@ -21,6 +21,8 @@ spec:
     interval: 10s
     honorLabels: true
     path: /metrics
+  targetLabels:
+  - k8s-app
 {{- end }}
 {{- if and .Values.hubble.metrics.enabled (.Values.hubble.metrics.serviceMonitor.enabled) }}
 ---

--- a/install/kubernetes/cilium/templates/cilium-operator-servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-servicemonitor.yaml
@@ -21,4 +21,6 @@ spec:
     interval: 10s
     honorLabels: true
     path: /metrics
+  targetLabels:
+  - io.cilium/app
 {{- end }}


### PR DESCRIPTION
The prometheus queries in dashboards provided as part of the [cilium examples](https://github.com/cilium/cilium/tree/cc12cccda33a8f3913ba84f994c42fa447889f32/examples/kubernetes/addons/prometheus/files/grafana-dashboards) use the labels k8s_app(in cilium agent) and io_cilium_app(in cilium operator) as metric labels. But the service monitor manifests provided as part of the helm chart don't add these labels as part of scraping the metrics. As part of this PR I've added these labels to the [targetLabels](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec) of the serviceMonitor manifests. [Ref slack conversation](https://cilium.slack.com/archives/C1MATJ5U5/p1611732455134600)