### PR TITLE
Fix reverse DNAT for externalTrafficPolicy=Local service with kube-proxy

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -147,9 +147,9 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 				 __u32 seclabel, __u32 monitor)
 {
 	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
-
 	if (ret != 0)
 		return ret;
+
 	return redirect(ENCAP_IFINDEX, 0);
 }
 
@@ -193,7 +193,18 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 			return encap_and_redirect_ipsec(ctx, tunnel_endpoint,
 							encrypt_key, seclabel);
 #endif
+#if !defined(ENABLE_NODEPORT) && (defined(ENABLE_IPSEC) || defined(ENABLE_HOST_FIREWALL))
+		/* For IPSec and the host firewall, traffic from a pod to a remote node
+		 * is sent through the tunnel. In the case of node --> VIP@remote pod,
+		 * packets may be DNATed when they enter the remote node. If kube-proxy
+		 * is used, the response needs to go through the stack on the way to
+		 * the tunnel, to apply the correct reverse DNAT.
+		 * See #14674 for details.
+		 */
+		return __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+#else
 		return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+#endif /* !ENABLE_NODEPORT && (ENABLE_IPSEC || ENABLE_HOST_FIREWALL) */
 	}
 
 	tunnel = map_lookup_elem(&TUNNEL_MAP, key);

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1003,20 +1003,17 @@ func (m *IptablesManager) installMasqueradeRules(prog, ifName, localDeliveryInte
 
 	if option.Config.Tunnel != option.TunnelDisabled {
 		// Masquerade all traffic from the host into the ifName
-		// interface if the source is not the internal IP
+		// interface if the source is not in the node's pod CIDR.
 		//
 		// The following conditions must be met:
 		// * Must be targeted for the ifName interface
 		// * Must be targeted to an IP that is not local
-		// * Tunnel mode:
-		//   * May not already be originating from the masquerade IP
-		// * Non-tunnel mode:
-		//   * May not orignate from any IP inside of the cluster range
+		// * May not already be originating from the node's pod CIDR.
 		if err := runProg(prog, append(
 			m.waitArgs,
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
-			"!", "-s", hostMasqueradeIP,
+			"!", "-s", allocRange,
 			"!", "-d", allocRange,
 			"-o", "cilium_host",
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",


### PR DESCRIPTION
See commits for details.

I'll rebase on https://github.com/cilium/cilium/pull/14675 once merged (the two PRs share the same first commit).

EDIT: The release note describes the fix for the host firewall. The regression for IPSec didn't make it into a release, so no need for a release note.
```release-note
Fix connectivity to externalTrafficPolicy=Local services when using the host firewall with kube-proxy
```