### PR TITLE
Doc: Add note to open tcp:4244 for Hubble Relay

### DIFF
--- a/Documentation/gettingstarted/hubble-enable.rst
+++ b/Documentation/gettingstarted/hubble-enable.rst
@@ -5,6 +5,10 @@ Hubble is the component for observability in Cilium. To obtain cluster-wide
 visibility into your network traffic, deploy Hubble Relay and the UI as follows
 on your existing installation:
 
+.. note::
+   Hubble Relay will fail to connect to peers if a host firewall
+   is blocking ``tcp:4244``. Make sure the port is open in your network.
+
 .. tabs::
 
     .. group-tab:: Installation via Helm


### PR DESCRIPTION
Hubble Relay will fail to connect to peers if a host firewall is blocking
tcp:4244. The documentation should contain a heads-up/note about this so that
users using a host firewall don't forget to open tcp:4244 when enabling
Hubble Relay.

Fixes: #14402

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>


