### PR TITLE
docker: Pre-pull images correctly

### DIFF
--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -78,7 +78,7 @@ _build/%ockerfile: %ockerfile _build/%ockerfile.dockerignore force
 	@-mkdir -p $(dir $@)
 	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
 ifeq ($(DOCKER_BUILDER),default)
-	@-grep "^FROM " $@ | cut -d ' ' -f2 | grep -v -e "scratch" -e "[\$$_{}]" | xargs -P4 -n1 docker pull
+	@-grep "^FROM " $< | cut -d ' ' -f2 | grep -v -e "scratch" -e "[\$$_{}]" | xargs -P4 -n1 docker pull
 endif
 
 #


### PR DESCRIPTION
Docker buildkit sometimes fails to actually pull images referenced on
FROM lines. We mitigate for this by pre-pulling all images before
docker build. A recent change to allow for multi-arch image builds
caused cilium-builder image to not be pre-pulled due to additional
filtering of Dockerfiles. Fix this by scanning the FROM lines from the
original dockerfiles instead of the generated ones.

Before:
```
cilium/cilium$ make _build/Dockerfile
quay.io/cilium/cilium-envoy@sha256:77d087a1f24ad357e9e3738367913c8a88daa8b172c81d186f0ba8c3c6f4e3a0: Pulling from cilium/cilium-envoy
...
quay.io/cilium/hubble@sha256:cc76aa6394d613eaeeac0f15b72f50d426b3c47d4676557431661e6aa5e1597b: Pulling from cilium/hubble
...
quay.io/cilium/cilium-runtime@sha256:247eff116cc5d0b3a4931eabd67ea2e8679f7c12877729a73929d3f30753065b: Pulling from cilium/cilium-runtime
...
```

After:
```
cilium/cilium$ make _build/Dockerfile
quay.io/cilium/cilium-envoy@sha256:77d087a1f24ad357e9e3738367913c8a88daa8b172c81d186f0ba8c3c6f4e3a0: Pulling from cilium/cilium-envoy
...
quay.io/cilium/hubble@sha256:cc76aa6394d613eaeeac0f15b72f50d426b3c47d4676557431661e6aa5e1597b: Pulling from cilium/hubble
...
quay.io/cilium/cilium-builder@sha256:09f63f516a88f82e714dac758362d34db9544188ac53b3ba88e85867b1a042bb: Pulling from cilium/cilium-builder
...
quay.io/cilium/cilium-runtime@sha256:247eff116cc5d0b3a4931eabd67ea2e8679f7c12877729a73929d3f30753065b: Pulling from cilium/cilium-runtime
...
```

Fixes: #14208
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
