### PR TITLE
ci/dependabot: fix labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     schedule:
       interval: weekly
     labels:
-    - enhancement
+    - kind/enhancement
+    - release-note/misc
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
A `release-note/` label is required and `enhancement` does not exist (but there's `kind/enhancement` instead).
