### PR TITLE
dependabot: fix labels for go module PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     schedule:
       interval: weekly
     labels:
-    - enhancement
+    - kind/enhancement
+    - release-note/misc
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Same as commit 143500ddcced ("dependabot: Fix labels") did for the GH
action PRs.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>