### PR TITLE
[v1.7] release: Fix script to check presence of docker images

### DIFF
--- a/contrib/release/check-docker-images.sh
+++ b/contrib/release/check-docker-images.sh
@@ -4,36 +4,35 @@ cilium_tag="${1}"
 org="cilium"
 
 external_dependencies_docker=(
-  "envoyproxy/envoy:${HUBBLE_PROXY_VERSION}" \
 )
 
 external_dependencies_quay=(
-  "coreos/etcd:${ETCD_VERSION}" \
+)
+
+external_dependencies_gcr=(
+  "google-containers/startup-script:${NODEINIT_VERSION}"
 )
 
 internal_dependencies=(
-  "certgen:${CERTGEN_VERSION}" \
   "cilium-etcd-operator:${MANAGED_ETCD_VERSION}" \
-  "startup-script:${NODEINIT_VERSION}"
-  "hubble-ui:${HUBBLE_UI_VERSION}" \
-  "hubble-ui-backend:${HUBBLE_UI_VERSION}" \
 )
 
 cilium_images=(\
   "cilium" \
-  "clustermesh-apiserver" \
   "docker-plugin" \
-  "hubble-relay" \
   "operator" \
-  "operator-azure" \
-  "operator-aws" \
-  "operator-generic" \
 )
 
 docker_tag_exists(){
   local repo="${1}"
   local tag="${2}"
   curl --silent -f -lSL "https://index.docker.io/v1/repositories/${repo}/tags/${tag}" &> /dev/null
+}
+
+gcr_tag_exists(){
+  local repo="${1}"
+  local tag="${2}"
+  curl --silent -f -lSL "https://gcr.io/api/v1/repository/${repo}/tag/${tag}/images" &> /dev/null
 }
 
 quay_tag_exists(){
@@ -47,6 +46,15 @@ for image in "${external_dependencies_docker[@]}" ; do
   image_name=${image%":$image_tag"}
   if ! docker_tag_exists "${image_name}" "${image_tag}" ; then
     echo "docker.io/${image} does not exist!"
+    not_found=true
+  fi
+done
+
+for image in "${external_dependencies_gcr[@]}" ; do
+  image_tag=${image#*:}
+  image_name=${image%":$image_tag"}
+  if ! gcr_tag_exists "${image_name}" "${image_tag}" ; then
+    echo "gcr.io/${image} does not exist!"
     not_found=true
   fi
 done

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -2,6 +2,7 @@ include ../../Makefile.defs
 include $(ROOT_DIR)/Makefile.quiet
 
 MANAGED_ETCD_VERSION := "v2.0.7"
+NODEINIT_VERSION := "v1"
 
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
 MANAGED_ETCD_PATH := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/charts/managed-etcd/values.yaml"
@@ -42,13 +43,10 @@ update-versions:
 clean:
 	$(RM) $(QUICK_INSTALL)
 
-	$(QUIET)\
-         HUBBLE_PROXY_VERSION=$(HUBBLE_PROXY_VERSION) \
-         HUBBLE_UI_VERSION=$(HUBBLE_UI_VERSION) \
-         MANAGED_ETCD_VERSION=$(MANAGED_ETCD_VERSION) \
-         ETCD_VERSION=$(ETCD_VERSION) \
-         NODEINIT_VERSION=$(NODEINIT_VERSION) \
-         CERTGEN_VERSION=`echo $(CERTGEN_VERSION) | egrep -o '^.*@' | sed 's/@//'` \
-         ../../contrib/release/check-docker-images.sh "v$(VERSION)"
+check-docker-images:
+	$(QUIET) \
+		MANAGED_ETCD_VERSION=$(MANAGED_ETCD_VERSION) \
+		NODEINIT_VERSION=$(NODEINIT_VERSION) \
+		$(ROOT_DIR)/contrib/release/check-docker-images.sh "v$(VERSION)"
 
 .phony: all check-docker-images clean update-versions


### PR DESCRIPTION
When this script was backported, differences in the v1.7 branch were not
taken into account, so it was just broken. Fix up the make target and
update the images to fetch, matching the ones v1.7 uses. Notably, there
is no platform-specific operator images, no hubble and no
clustermesh-apiserver (or related dependencies like etcd).

Fixes: 5273db146877 ("release: add script to check presence of docker images")
