### PR TITLE
[v1.8] release: Fix script to check presence of docker images

### DIFF
--- a/contrib/release/check-docker-images.sh
+++ b/contrib/release/check-docker-images.sh
@@ -4,24 +4,19 @@ cilium_tag="${1}"
 org="cilium"
 
 external_dependencies_docker=(
-  "envoyproxy/envoy:${HUBBLE_PROXY_VERSION}" \
 )
 
 external_dependencies_quay=(
-  "coreos/etcd:${ETCD_VERSION}" \
 )
 
 internal_dependencies=(
-  "certgen:${CERTGEN_VERSION}" \
   "cilium-etcd-operator:${MANAGED_ETCD_VERSION}" \
   "startup-script:${NODEINIT_VERSION}"
   "hubble-ui:${HUBBLE_UI_VERSION}" \
-  "hubble-ui-backend:${HUBBLE_UI_VERSION}" \
 )
 
 cilium_images=(\
   "cilium" \
-  "clustermesh-apiserver" \
   "docker-plugin" \
   "hubble-relay" \
   "operator" \

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -4,6 +4,8 @@
 include ../../Makefile.defs
 
 MANAGED_ETCD_VERSION := "v2.0.7"
+NODEINIT_VERSION := "62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"
+HUBBLE_UI_VERSION := "v0.6.1"
 
 QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
 EXPERIMENTAL_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/experimental-install.yaml"
@@ -60,12 +62,9 @@ docs:
 
 check-docker-images:
 	$(QUIET)\
-         HUBBLE_PROXY_VERSION=$(HUBBLE_PROXY_VERSION) \
-         HUBBLE_UI_VERSION=$(HUBBLE_UI_VERSION) \
-         MANAGED_ETCD_VERSION=$(MANAGED_ETCD_VERSION) \
-         ETCD_VERSION=$(ETCD_VERSION) \
-         NODEINIT_VERSION=$(NODEINIT_VERSION) \
-         CERTGEN_VERSION=`echo $(CERTGEN_VERSION) | egrep -o '^.*@' | sed 's/@//'` \
-         ../../contrib/release/check-docker-images.sh "v$(VERSION)"
+		HUBBLE_UI_VERSION=$(HUBBLE_UI_VERSION) \
+		MANAGED_ETCD_VERSION=$(MANAGED_ETCD_VERSION) \
+		NODEINIT_VERSION=$(NODEINIT_VERSION) \
+		$(ROOT_DIR)/contrib/release/check-docker-images.sh "v$(VERSION)"
 
 .PHONY: all check-docker-images clean docs experimental-install lint quick-install update-versions


### PR DESCRIPTION
When this script was backported, differences in the v1.8 branch were not
taken into account, so it was just broken. Fix up the make target and
update the images to fetch, matching the ones v1.8 uses. Notably, there
is no hubble UI and no clustermesh-apiserver (or related dependencies like
etcd).

Fixes: 0c37855c94ba ("release: add script to check presence of docker images")
