### PR TITLE
[v1.9] release: Fix script to check presence of docker images

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -119,7 +119,7 @@ check-docker-images:
          MANAGED_ETCD_VERSION=$(MANAGED_ETCD_VERSION) \
          ETCD_VERSION=$(ETCD_VERSION) \
          NODEINIT_VERSION=$(NODEINIT_VERSION) \
-         CERTGEN_VERSION=`echo $(CERTGEN_VERSION) | egrep -o '^.*@' | sed 's/@//'` \
+         CERTGEN_VERSION=$(CERTGEN_VERSION) \
          ../../contrib/release/check-docker-images.sh "v$(VERSION)"
 
 .PHONY: all check-docker-images clean docs experimental-install lint quick-install update-versions


### PR DESCRIPTION
When this script was backported, this egrep expression was added which
causes the following error:

    $ make -C install/kubernetes/ check-docker-images
    docker.io/cilium/certgen: does not exist!
    quay.io/cilium/certgen: does not exist!
    make: *** [Makefile:116: check-docker-images] Error 1

Drop the grep expression, we can just pass the raw variable in.

Fixes: bb9200050332 ("release: add script to check presence of docker images")
