### PR TITLE
v1.8 backports 2021-01-28

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -49,7 +49,11 @@ assignees: ''
       & push to repository
 - [ ] Run sanity check of Helm install using connectivity-check script.
       Suggested approach: Follow the full [GKE getting started guide].
-- [ ] Check draft release from [releases] page and publish the release
+- [ ] Check draft release from [releases] page
+  - [ ] Update the text at the top with 2-3 highlights of the release
+  - [ ] Run `contrib/release/pull-docker-manifests.sh` to fetch the image SHAs
+        and copy the text into the end of the release
+  - [ ] Publish the release
 - [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
 
 ## Post-release

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -107,6 +107,10 @@ Reference steps for the template
    Following the steps above, the release draft will already be prepared.
    Preview the description and then publish the release.
 
+   #. Use ``contrib/release/pull-docker-manifests.sh`` to fetch the official
+      docker manifests for the release and add these into the Github release
+      announcement.
+
 #. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    and push the changes into that repository (not the main cilium repository):
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -420,8 +420,10 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 		struct remote_endpoint_info *info;
 		union v6addr *dst;
 
-		if (!revalidate_data(ctx, &data, &data_end, &ip6))
-			return DROP_INVALID;
+		if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
+			ret = DROP_INVALID;
+			goto drop_err;
+		}
 
 		dst = (union v6addr *)&ip6->daddr;
 		info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
@@ -429,16 +431,20 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						  SECLABEL, TRACE_PAYLOAD_LEN);
 			if (ret)
-				return ret;
+				goto drop_err;
 
 			BPF_V6(target.addr, ROUTER_IP);
 			fib_params.l.ifindex = ENCAP_IFINDEX;
 
 			/* fib lookup not necessary when going over tunnel. */
-			if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0)
-				return DROP_WRITE_ERROR;
-			if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0)
-				return DROP_WRITE_ERROR;
+			if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto drop_err;
+			}
+			if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto drop_err;
+			}
 		}
 	}
 #endif

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+IMAGES=(cilium docker-plugin hubble-relay operator operator-generic operator-aws operator-azure)
+REGISTRIES=(docker.io quay.io)
+
+usage() {
+    logecho "usage: $0 <VERSION>"
+    logecho "VERSION    Target version"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local ersion="$(echo $1 | sed 's/^v//')"
+    local version="v$ersion"
+
+    >&2 echo n "Fetching docker images for $version"
+    for image in ${IMAGES[@]}; do
+        for registry in ${REGISTRIES[@]}; do
+            >&2 $CONTAINER_ENGINE pull $registry/cilium/$image:$version
+        done
+    done
+
+    >&2 echo "Generating manifest text for $version release notes"
+    >&2
+    echo "Docker Manifests"
+    echo "----------------"
+    for image in ${IMAGES[@]}; do
+        echo; echo "## $image"; echo
+        for registry in ${REGISTRIES[@]}; do
+            digest="$(docker inspect $registry/cilium/$image:$version | jq -r '.[0].RepoDigests[0]')"
+            if ! echo $digest | grep -q $registry; then
+                digest="$registry/$digest"
+            fi
+            echo "\`$digest\`"
+        done
+    done
+}
+
+main "$@"
+


### PR DESCRIPTION
* #14730 -- bpf: Send packet drop notify for ipv6 lb nat mode failures. (@hzhou8)
 * #14707 -- contrib: Add script to fetch docker manifests (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14730 14707; do contrib/backporting/set-labels.py $pr done 1.8; done
```