### PR TITLE
v1.9 backports 2021-01-28

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -56,7 +56,11 @@ assignees: ''
       & push to repository
 - [ ] Run sanity check of Helm install using connectivity-check script.
       Suggested approach: Follow the full [GKE getting started guide].
-- [ ] Check draft release from [releases] page and publish the release
+- [ ] Check draft release from [releases] page
+  - [ ] Update the text at the top with 2-3 highlights of the release
+  - [ ] Run `contrib/release/pull-docker-manifests.sh` to fetch the image SHAs
+        and copy the text into the end of the release
+  - [ ] Publish the release
 - [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
 
 ## Post-release

--- a/Documentation/concepts/kubernetes/requirements.rst
+++ b/Documentation/concepts/kubernetes/requirements.rst
@@ -51,8 +51,13 @@ The :ref:`k8s_install_etcd_operator` relies on the etcd-operator to manage an
 etcd cluster. In order for the etcd cluster to be available, the Cilium pod is
 being run with ``dnsPolicy: ClusterFirstWithHostNet`` in order for Cilium to be
 able to look up Kubernetes service names via DNS. This creates a dependency on
-kube-dns. If you would like to avoid running kube-dns, choose a different
-installation method and remove the ``dnsPolicy`` field from the ``DaemonSet``.
+kube-dns. It is possible to avoid this dependency by deploying Cilium with
+``etcd.k8sService=true``. This option will allow Cilium to perform the name
+translation automatically by checking the service IP of the service name for
+the etcd cluster. This service name is usually in the form of ``cilium-etcd-client.<namespace>.svc``
+and it is automatically created by Cilium etcd Operator.
+
+For more information about ``dnsPolicy`` see: https://pkg.go.dev/k8s.io/api@v0.20.2/core/v1#DNSPolicy
 
 Enable automatic node CIDR allocation (Recommended)
 ===================================================

--- a/Documentation/concepts/networking/ipam/cluster-pool.rst
+++ b/Documentation/concepts/networking/ipam/cluster-pool.rst
@@ -14,7 +14,7 @@ The cluster-scope IPAM mode assigns per-node PodCIDRs to each node and
 allocates IPs using a host-scope allocator on each node. It is thus similar to
 the :ref:`k8s_hostscope` mode. The difference is that instead of Kubernetes
 assigning the per-node PodCIDRs via the Kubernetes ``v1.Node`` resource, the
-Cilium operator will manage the per-node PodCIDRs via the ``v2.CilumNode``
+Cilium operator will manage the per-node PodCIDRs via the ``v2.CiliumNode``
 resource. The advantage of this mode is that it does not depend on Kubernetes
 being configured to hand out per-node PodCIDRs.
 

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -107,6 +107,10 @@ Reference steps for the template
    Following the steps above, the release draft will already be prepared.
    Preview the description and then publish the release.
 
+   #. Use ``contrib/release/pull-docker-manifests.sh`` to fetch the official
+      docker manifests for the release and add these into the Github release
+      announcement.
+
 #. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    and push the changes into that repository (not the main cilium repository):
 

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -40,7 +40,8 @@ Deploy Cilium release via Helm:
    helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
       --set etcd.enabled=true \\
-      --set etcd.managed=true
+      --set etcd.managed=true \\
+      --set etcd.k8sService=true
 
 
 Validate the Installation

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -43,6 +43,12 @@ Deploy Cilium release via Helm:
       --set etcd.managed=true \\
       --set etcd.k8sService=true
 
+If you do not want Cilium to store state in Kubernetes custom resources (CRDs),
+consider setting ``identityAllocationMode``:
+
+.. parsed-literal::
+
+    --set identityAllocationMode=kvstore
 
 Validate the Installation
 =========================

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -61,6 +61,13 @@ Deploy Cilium release via Helm:
       --set "etcd.endpoints[1]=http://etcd-endpoint2:2379" \\
       --set "etcd.endpoints[2]=http://etcd-endpoint3:2379"
 
+If you do not want Cilium to store state in Kubernetes custom resources (CRDs),
+consider setting ``identityAllocationMode``:
+
+.. parsed-literal::
+
+    --set identityAllocationMode=kvstore
+
 
 Optional: Configure the SSL certificates
 ----------------------------------------

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -40,7 +40,7 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 #endif
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4)) {
 			ctx->mark = 0;
 			return CTX_ACT_OK;
 		}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -335,8 +335,10 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	__be32 dport;
 	int ret;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
+	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
+		ret = DROP_INVALID;
+		goto drop_err;
+	}
 
 	dport   = ctx_load_meta(ctx, CB_SVC_PORT);
 	addr.p1 = ctx_load_meta(ctx, CB_SVC_ADDR_V6_1);
@@ -346,19 +348,25 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 
 	ret = set_dsr_ext6(ctx, ip6, &addr, dport);
 	if (ret)
-		return ret;
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
+		goto drop_err;
+	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
+		ret = DROP_INVALID;
+		goto drop_err;
+	}
 
 	if (nodeport_lb_hairpin())
 		dmac = map_lookup_elem(&NODEPORT_NEIGH6, &ip6->daddr);
 	if (dmac) {
 		union macaddr mac = NATIVE_DEV_MAC_BY_IFINDEX(fib_params.l.ifindex);
 
-		if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
-			return DROP_WRITE_ERROR;
-		if (eth_store_saddr_aligned(ctx, mac.addr, 0) < 0)
-			return DROP_WRITE_ERROR;
+		if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
+		if (eth_store_saddr_aligned(ctx, mac.addr, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
 	} else {
 		ipv6_addr_copy((union v6addr *) &fib_params.l.ipv6_src,
 			       (union v6addr *) &ip6->saddr);
@@ -367,18 +375,27 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 
 		ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params),
 				 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
-		if (ret != 0)
-			return DROP_NO_FIB;
+		if (ret != 0) {
+			ret = DROP_NO_FIB;
+			goto drop_err;
+		}
 		if (nodeport_lb_hairpin())
 			map_update_elem(&NODEPORT_NEIGH6, &ip6->daddr,
 					fib_params.l.dmac, 0);
-		if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0)
-			return DROP_WRITE_ERROR;
-		if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0)
-			return DROP_WRITE_ERROR;
+		if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
+		if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
 	}
 
 	return ctx_redirect(ctx, fib_params.l.ifindex, 0);
+
+drop_err:
+	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 }
 # endif /* ENABLE_DSR */
 
@@ -1063,42 +1080,61 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 	address = ctx_load_meta(ctx, CB_SVC_ADDR_V4);
 	dport = ctx_load_meta(ctx, CB_SVC_PORT);
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
+	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+		ret = DROP_INVALID;
+		goto drop_err;
+	}
 
 	ret = set_dsr_opt4(ctx, ip4, address, dport);
-	if (ret != 0)
-		return DROP_INVALID;
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
+	if (ret != 0) {
+		ret = DROP_INVALID;
+		goto drop_err;
+	}
+	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+		ret = DROP_INVALID;
+		goto drop_err;
+	}
 
 	if (nodeport_lb_hairpin())
 		dmac = map_lookup_elem(&NODEPORT_NEIGH4, &ip4->daddr);
 	if (dmac) {
 		union macaddr mac = NATIVE_DEV_MAC_BY_IFINDEX(fib_params.l.ifindex);
 
-		if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
-			return DROP_WRITE_ERROR;
-		if (eth_store_saddr_aligned(ctx, mac.addr, 0) < 0)
-			return DROP_WRITE_ERROR;
+		if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
+		if (eth_store_saddr_aligned(ctx, mac.addr, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
 	} else {
 		fib_params.l.ipv4_src = ip4->saddr;
 		fib_params.l.ipv4_dst = ip4->daddr;
 
 		ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params),
 				 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
-		if (ret != 0)
-			return DROP_NO_FIB;
+		if (ret != 0) {
+			ret = DROP_NO_FIB;
+			goto drop_err;
+		}
 		if (nodeport_lb_hairpin())
 			map_update_elem(&NODEPORT_NEIGH4, &ip4->daddr,
 					fib_params.l.dmac, 0);
-		if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0)
-			return DROP_WRITE_ERROR;
-		if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0)
-			return DROP_WRITE_ERROR;
+		if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
+		if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0) {
+			ret = DROP_WRITE_ERROR;
+			goto drop_err;
+		}
 	}
 
 	return ctx_redirect(ctx, fib_params.l.ifindex, 0);
+
+drop_err:
+	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 }
 # endif /* ENABLE_DSR */
 
@@ -1126,24 +1162,30 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 	if (dir == NAT_DIR_EGRESS) {
 		struct remote_endpoint_info *info;
 
-		if (!revalidate_data(ctx, &data, &data_end, &ip4))
-			return DROP_INVALID;
+		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+			ret = DROP_INVALID;
+			goto drop_err;
+		}
 
 		info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 		if (info != NULL && info->tunnel_endpoint != 0) {
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						  SECLABEL, TRACE_PAYLOAD_LEN);
 			if (ret)
-				return ret;
+				goto drop_err;
 
 			target.addr = IPV4_GATEWAY;
 			fib_params.l.ifindex = ENCAP_IFINDEX;
 
 			/* fib lookup not necessary when going over tunnel. */
-			if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0)
-				return DROP_WRITE_ERROR;
-			if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0)
-				return DROP_WRITE_ERROR;
+			if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto drop_err;
+			}
+			if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto drop_err;
+			}
 		}
 	}
 #endif

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -425,8 +425,10 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 		struct remote_endpoint_info *info;
 		union v6addr *dst;
 
-		if (!revalidate_data(ctx, &data, &data_end, &ip6))
-			return DROP_INVALID;
+		if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
+			ret = DROP_INVALID;
+			goto drop_err;
+		}
 
 		dst = (union v6addr *)&ip6->daddr;
 		info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
@@ -434,16 +436,20 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						  SECLABEL, TRACE_PAYLOAD_LEN);
 			if (ret)
-				return ret;
+				goto drop_err;
 
 			BPF_V6(target.addr, ROUTER_IP);
 			fib_params.l.ifindex = ENCAP_IFINDEX;
 
 			/* fib lookup not necessary when going over tunnel. */
-			if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0)
-				return DROP_WRITE_ERROR;
-			if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0)
-				return DROP_WRITE_ERROR;
+			if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto drop_err;
+			}
+			if (eth_store_saddr(ctx, fib_params.l.smac, 0) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto drop_err;
+			}
 		}
 	}
 #endif

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+IMAGES=(cilium clustermesh-apiserver docker-plugin hubble-relay operator operator-generic operator-aws operator-azure)
+REGISTRIES=(docker.io quay.io)
+
+usage() {
+    logecho "usage: $0 <VERSION>"
+    logecho "VERSION    Target version"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 2; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+    fi
+}
+
+main() {
+    handle_args "$@"
+
+    local ersion="$(echo $1 | sed 's/^v//')"
+    local version="v$ersion"
+
+    >&2 echo n "Fetching docker images for $version"
+    for image in ${IMAGES[@]}; do
+        for registry in ${REGISTRIES[@]}; do
+            >&2 $CONTAINER_ENGINE pull $registry/cilium/$image:$version
+        done
+    done
+
+    >&2 echo "Generating manifest text for $version release notes"
+    >&2
+    echo "Docker Manifests"
+    echo "----------------"
+    for image in ${IMAGES[@]}; do
+        echo; echo "## $image"; echo
+        for registry in ${REGISTRIES[@]}; do
+            digest="$(docker inspect $registry/cilium/$image:$version | jq -r '.[0].RepoDigests[0]')"
+            if ! echo $digest | grep -q $registry; then
+                digest="$registry/$digest"
+            fi
+            echo "\`$digest\`"
+        done
+    done
+}
+
+main "$@"
+

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -11,8 +11,8 @@ ACTS_YAML=".github/cilium-actions.yml"
 
 usage() {
     logecho "usage: $0 <VERSION> <GH-PROJECT>"
-    logecho "VERSION    Target release version"
-    logecho "GH-PROJECT Project ID for next release"
+    logecho "VERSION    Target release version (format: X.Y.Z)"
+    logecho "GH-PROJECT Project Number for next (X.Y.Z+1) development release"
     logecho
     logecho "--help     Print this help message"
 }

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -45,16 +45,17 @@ func initKubeProxyReplacementOptions() (strict bool) {
 	}
 
 	if option.Config.KubeProxyReplacement == option.KubeProxyReplacementDisabled {
-		log.Infof("Auto-disabling %q, %q, %q, %q, %q features",
+		log.Infof("Auto-disabling %q, %q, %q, %q, %q features and falling back to %q",
 			option.EnableNodePort, option.EnableExternalIPs,
 			option.EnableHostReachableServices, option.EnableHostPort,
-			option.EnableSessionAffinity)
+			option.EnableSessionAffinity, option.EnableHostLegacyRouting)
 
 		disableNodePort()
 		option.Config.EnableHostReachableServices = false
 		option.Config.EnableHostServicesTCP = false
 		option.Config.EnableHostServicesUDP = false
 		option.Config.EnableSessionAffinity = false
+		option.Config.EnableHostLegacyRouting = true
 
 		return
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -176,6 +176,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
 | hubble.relay.resources | object | `{}` | Specifies the resources for the hubble-relay pods |
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
+| hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
 | hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
 | hubble.relay.sortBufferLenMax | string | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
 | hubble.relay.tls | object | `{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"key":""}}` | TLS configuration for Hubble Relay |
@@ -205,6 +206,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.proxy.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/envoyproxy/envoy","tag":"v1.14.5"}` | Hubble-ui ingress proxy image. |
 | hubble.ui.proxy.resources | object | `{}` |  |
 | hubble.ui.replicas | int | `1` |  |
+| hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
 | hubble.ui.securityContext.enabled | bool | `true` |  |
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
@@ -275,6 +277,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
 | operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |
@@ -310,6 +313,7 @@ contributors across the globe, there is almost always someone available to help.
 | remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
 | securityContext | object | `{}` | Security context to be added to agent pods |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.certgen | object | `{"annotations":{},"create":true}` | Certgen is used if hubble.tls.auto.method=cronJob |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -39,6 +39,10 @@ spec:
         prometheus.io/port: "{{ .Values.prometheus.port }}"
         prometheus.io/scrape: "true"
 {{- end }}
+{{- if .Values.rollOutCiliumPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -317,7 +317,7 @@ spec:
           {{- toYaml .Values.monitor.resources | trim | nindent 10 }}
 {{- end }}
 {{- end }}
-{{- if .Values.etcd.managed }}
+{{- if (and .Values.etcd.managed (not .Values.etcd.k8sService)) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -192,7 +192,7 @@ spec:
           {{- toYaml .Values.operator.resources | trim | nindent 10 }}
 {{- end }}
       hostNetwork: true
-{{- if .Values.etcd.managed }}
+{{- if (and .Values.etcd.managed (not .Values.etcd.k8sService)) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -27,6 +27,10 @@ spec:
   template:
     metadata:
       annotations:
+{{- if .Values.operator.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
 {{- if and .Values.operator.prometheus.enabled (not .Values.operator.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: {{ .Values.operator.prometheus.port | quote }}
         prometheus.io/scrape: "true"

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -16,8 +16,9 @@ spec:
 {{- end }}
   template:
     metadata:
+      annotations:
 {{- with .Values.clustermesh.apiserver.podAnnotations }}
-      annotations: {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
 {{- end }}
       labels:
         k8s-app: clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -18,9 +18,13 @@ spec:
 {{- end }}
   template:
     metadata:
-{{- with .Values.hubble.relay.podAnnotations }}
       annotations:
-        {{ toYaml . | trim | indent 8 }}
+{{- if .Values.hubble.relay.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/hubble-relay-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-relay-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
+{{- with .Values.hubble.relay.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
 {{- end }}
       labels:
         k8s-app: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -13,8 +13,12 @@ spec:
       k8s-app: hubble-ui
   template:
     metadata:
-{{- with .Values.hubble.ui.podAnnotations }}
       annotations:
+{{- if .Values.hubble.ui.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/hubble-ui-envoy-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-ui-configmap.yaml") . | sha256sum | quote }}
+{{- end }}
+{{- with .Values.hubble.ui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
 {{- end }}
       labels:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -64,6 +64,9 @@ agent: true
 # -- Agent container name.
 name: cilium
 
+# -- Roll out cilium agent pods automatically when configmap is updated.
+rollOutCiliumPods: false
+
 # -- Agent container image.
 image:
   repository: quay.io/cilium/cilium
@@ -536,6 +539,9 @@ hubble:
     # -- Enable Hubble Relay (requires hubble.enabled=true)
     enabled: false
 
+    # -- Roll out Hubble Relay pods automatically when configmap is updated.
+    rollOutPods: false
+
     # -- Hubble-relay container image.
     image:
       repository: quay.io/cilium/hubble-relay
@@ -612,6 +618,9 @@ hubble:
 
   ui:
     enabled: false
+
+    # -- Roll out Hubble-ui pods automatically when configmap is updated.
+    rollOutPods: false
 
     backend:
       # -- Hubble-ui backend image.
@@ -1045,6 +1054,9 @@ etcd:
 operator:
   # -- Enable the cilium-operator component (required).
   enabled: true
+
+  # -- Roll out cilium-operator pods automatically when configmap is updated.
+  rollOutPods: false
 
   # -- cilium-operator image.
   image:

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -1065,6 +1065,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-relay
     spec:
@@ -1151,6 +1152,7 @@ spec:
       k8s-app: hubble-ui
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-ui
     spec:

--- a/install/kubernetes/quick-hubble-install.yaml
+++ b/install/kubernetes/quick-hubble-install.yaml
@@ -306,6 +306,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-relay
     spec:
@@ -392,6 +393,7 @@ spec:
       k8s-app: hubble-ui
   template:
     metadata:
+      annotations:
       labels:
         k8s-app: hubble-ui
     spec:

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -295,15 +295,19 @@ func (n *linuxNodeHandler) deleteDirectRoute(CIDR *cidr.CIDR, nodeIP net.IP) {
 	}
 }
 
-// createNodeRoute creates a route that points the specified prefix to the host
-// device via the router IP
+// createNodeRouteSpec creates a route spec that points the specified prefix to the host
+// device via the router IP. The route is configured with a computed MTU for non-local
+// nodes (i.e isLocalNode is set to false).
 //
 // Example:
 // 10.10.0.0/24 via 10.10.0.1 dev cilium_host src 10.10.0.1
 // f00d::a0a:0:0:0/112 via f00d::a0a:0:0:1 dev cilium_host src fd04::11 metric 1024 pref medium
 //
-func (n *linuxNodeHandler) createNodeRoute(prefix *cidr.CIDR) (route.Route, error) {
-	var local, nexthop net.IP
+func (n *linuxNodeHandler) createNodeRouteSpec(prefix *cidr.CIDR, isLocalNode bool) (route.Route, error) {
+	var (
+		local, nexthop net.IP
+		mtu            int
+	)
 	if prefix.IP.To4() != nil {
 		if n.nodeAddressing.IPv4() == nil {
 			return route.Route{}, fmt.Errorf("IPv4 addressing unavailable")
@@ -332,22 +336,26 @@ func (n *linuxNodeHandler) createNodeRoute(prefix *cidr.CIDR) (route.Route, erro
 		local = n.nodeAddressing.IPv6().PrimaryExternal()
 	}
 
+	if !isLocalNode {
+		mtu = n.nodeConfig.MtuConfig.GetRouteMTU()
+	}
+
 	// The default routing table accounts for encryption overhead for encrypt-node traffic
 	return route.Route{
 		Nexthop: &nexthop,
 		Local:   local,
 		Device:  n.datapathConfig.HostDevice,
 		Prefix:  *prefix.IPNet,
-		MTU:     n.nodeConfig.MtuConfig.GetRouteMTU(),
+		MTU:     mtu,
 	}, nil
 }
 
-func (n *linuxNodeHandler) lookupNodeRoute(prefix *cidr.CIDR) (*route.Route, error) {
+func (n *linuxNodeHandler) lookupNodeRoute(prefix *cidr.CIDR, isLocalNode bool) (*route.Route, error) {
 	if prefix == nil {
 		return nil, nil
 	}
 
-	routeSpec, err := n.createNodeRoute(prefix)
+	routeSpec, err := n.createNodeRouteSpec(prefix, isLocalNode)
 	if err != nil {
 		return nil, err
 	}
@@ -355,12 +363,12 @@ func (n *linuxNodeHandler) lookupNodeRoute(prefix *cidr.CIDR) (*route.Route, err
 	return route.Lookup(routeSpec)
 }
 
-func (n *linuxNodeHandler) updateNodeRoute(prefix *cidr.CIDR, addressFamilyEnabled bool) error {
+func (n *linuxNodeHandler) updateNodeRoute(prefix *cidr.CIDR, addressFamilyEnabled bool, isLocalNode bool) error {
 	if prefix == nil || !addressFamilyEnabled {
 		return nil
 	}
 
-	nodeRoute, err := n.createNodeRoute(prefix)
+	nodeRoute, err := n.createNodeRouteSpec(prefix, isLocalNode)
 	if err != nil {
 		return err
 	}
@@ -372,12 +380,12 @@ func (n *linuxNodeHandler) updateNodeRoute(prefix *cidr.CIDR, addressFamilyEnabl
 	return nil
 }
 
-func (n *linuxNodeHandler) deleteNodeRoute(prefix *cidr.CIDR) error {
+func (n *linuxNodeHandler) deleteNodeRoute(prefix *cidr.CIDR, isLocalNode bool) error {
 	if prefix == nil {
 		return nil
 	}
 
-	nodeRoute, err := n.createNodeRoute(prefix)
+	nodeRoute, err := n.createNodeRouteSpec(prefix, isLocalNode)
 	if err != nil {
 		return err
 	}
@@ -393,16 +401,16 @@ func (n *linuxNodeHandler) familyEnabled(c *cidr.CIDR) bool {
 	return (c.IP.To4() != nil && n.nodeConfig.EnableIPv4) || (c.IP.To4() == nil && n.nodeConfig.EnableIPv6)
 }
 
-func (n *linuxNodeHandler) updateOrRemoveNodeRoutes(old, new []*cidr.CIDR) {
+func (n *linuxNodeHandler) updateOrRemoveNodeRoutes(old, new []*cidr.CIDR, isLocalNode bool) {
 	addedAuxRoutes, removedAuxRoutes := cidr.DiffCIDRLists(old, new)
 	for _, prefix := range addedAuxRoutes {
 		if prefix != nil {
-			n.updateNodeRoute(prefix, n.familyEnabled(prefix))
+			n.updateNodeRoute(prefix, n.familyEnabled(prefix), isLocalNode)
 		}
 	}
 	for _, prefix := range removedAuxRoutes {
-		if rt, _ := n.lookupNodeRoute(prefix); rt != nil {
-			n.deleteNodeRoute(prefix)
+		if rt, _ := n.lookupNodeRoute(prefix, isLocalNode); rt != nil {
+			n.deleteNodeRoute(prefix, isLocalNode)
 		}
 	}
 }
@@ -826,6 +834,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		newIP4                 = newNode.GetNodeIP(false)
 		newIP6                 = newNode.GetNodeIP(true)
 		oldKey, newKey         uint8
+		isLocalNode            = false
 	)
 
 	if oldNode != nil {
@@ -856,9 +865,10 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 	}
 
 	if newNode.IsLocal() {
+		isLocalNode = true
 		if n.nodeConfig.EnableLocalNodeRoute {
-			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP4Cidr}, []*cidr.CIDR{newNode.IPv4AllocCIDR})
-			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP6Cidr}, []*cidr.CIDR{newNode.IPv6AllocCIDR})
+			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP4Cidr}, []*cidr.CIDR{newNode.IPv4AllocCIDR}, isLocalNode)
+			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP6Cidr}, []*cidr.CIDR{newNode.IPv6AllocCIDR}, isLocalNode)
 		}
 		if n.subnetEncryption() {
 			n.enableSubnetIPsec(n.nodeConfig.IPv4PodSubnets, n.nodeConfig.IPv6PodSubnets)
@@ -881,8 +891,8 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		updateTunnelMapping(oldIP6Cidr, newNode.IPv6AllocCIDR, oldIP4, newIP4, firstAddition, n.nodeConfig.EnableIPv6, oldKey, newKey)
 
 		if !n.nodeConfig.UseSingleClusterRoute {
-			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP4Cidr}, []*cidr.CIDR{newNode.IPv4AllocCIDR})
-			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP6Cidr}, []*cidr.CIDR{newNode.IPv6AllocCIDR})
+			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP4Cidr}, []*cidr.CIDR{newNode.IPv4AllocCIDR}, isLocalNode)
+			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP6Cidr}, []*cidr.CIDR{newNode.IPv6AllocCIDR}, isLocalNode)
 		}
 
 		return nil
@@ -892,11 +902,11 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		deleteTunnelMapping(newNode.IPv4AllocCIDR, true)
 		deleteTunnelMapping(newNode.IPv6AllocCIDR, true)
 
-		if rt, _ := n.lookupNodeRoute(newNode.IPv4AllocCIDR); rt != nil {
-			n.deleteNodeRoute(newNode.IPv4AllocCIDR)
+		if rt, _ := n.lookupNodeRoute(newNode.IPv4AllocCIDR, isLocalNode); rt != nil {
+			n.deleteNodeRoute(newNode.IPv4AllocCIDR, isLocalNode)
 		}
-		if rt, _ := n.lookupNodeRoute(newNode.IPv6AllocCIDR); rt != nil {
-			n.deleteNodeRoute(newNode.IPv6AllocCIDR)
+		if rt, _ := n.lookupNodeRoute(newNode.IPv6AllocCIDR, isLocalNode); rt != nil {
+			n.deleteNodeRoute(newNode.IPv6AllocCIDR, isLocalNode)
 		}
 	}
 
@@ -938,8 +948,8 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 		deleteTunnelMapping(oldNode.IPv6AllocCIDR, false)
 
 		if !n.nodeConfig.UseSingleClusterRoute {
-			n.deleteNodeRoute(oldNode.IPv4AllocCIDR)
-			n.deleteNodeRoute(oldNode.IPv6AllocCIDR)
+			n.deleteNodeRoute(oldNode.IPv4AllocCIDR, false)
+			n.deleteNodeRoute(oldNode.IPv6AllocCIDR, false)
 		}
 	}
 
@@ -957,9 +967,9 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 func (n *linuxNodeHandler) updateOrRemoveClusterRoute(addressing datapath.NodeAddressingFamily, addressFamilyEnabled bool) {
 	allocCIDR := addressing.AllocationCIDR()
 	if addressFamilyEnabled {
-		n.updateNodeRoute(allocCIDR, addressFamilyEnabled)
-	} else if rt, _ := n.lookupNodeRoute(allocCIDR); rt != nil {
-		n.deleteNodeRoute(allocCIDR)
+		n.updateNodeRoute(allocCIDR, addressFamilyEnabled, false)
+	} else if rt, _ := n.lookupNodeRoute(allocCIDR, false); rt != nil {
+		n.deleteNodeRoute(allocCIDR, false)
 	}
 }
 
@@ -1249,7 +1259,7 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		(option.Config.EnableNodePort ||
 			(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled))
 
-	n.updateOrRemoveNodeRoutes(prevConfig.AuxiliaryPrefixes, newConfig.AuxiliaryPrefixes)
+	n.updateOrRemoveNodeRoutes(prevConfig.AuxiliaryPrefixes, newConfig.AuxiliaryPrefixes, true)
 
 	if newConfig.EnableIPSec {
 		if err := n.replaceHostRules(); err != nil {
@@ -1268,8 +1278,8 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		n.updateOrRemoveClusterRoute(n.nodeAddressing.IPv6(), newConfig.EnableIPv6)
 	} else if prevConfig.UseSingleClusterRoute {
 		// single cluster route has been disabled, remove route
-		n.deleteNodeRoute(n.nodeAddressing.IPv4().AllocationCIDR())
-		n.deleteNodeRoute(n.nodeAddressing.IPv6().AllocationCIDR())
+		n.deleteNodeRoute(n.nodeAddressing.IPv4().AllocationCIDR(), false)
+		n.deleteNodeRoute(n.nodeAddressing.IPv6().AllocationCIDR(), false)
 	}
 
 	if !n.isInitialized {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -201,34 +201,34 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 
 	if s.enableIPv4 {
 		// add & remove IPv4 node route
-		err = linuxNodeHandler.updateNodeRoute(ip4CIDR, true)
+		err = linuxNodeHandler.updateNodeRoute(ip4CIDR, true, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4CIDR)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 
-		err = linuxNodeHandler.deleteNodeRoute(ip4CIDR)
+		err = linuxNodeHandler.deleteNodeRoute(ip4CIDR, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4CIDR)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
 		// add & remove IPv6 node route
-		err = linuxNodeHandler.updateNodeRoute(ip6CIDR, true)
+		err = linuxNodeHandler.updateNodeRoute(ip6CIDR, true, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6CIDR)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 
-		err = linuxNodeHandler.deleteNodeRoute(ip6CIDR)
+		err = linuxNodeHandler.deleteNodeRoute(ip6CIDR, false)
 		c.Assert(err, check.IsNil)
 
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6CIDR)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6CIDR, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -249,13 +249,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -267,12 +267,12 @@ func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR())
+	foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
 	c.Assert(err, check.IsNil)
 	c.Assert(foundRoute, check.IsNil)
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -286,13 +286,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR())
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -315,13 +315,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -335,13 +335,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -355,13 +355,13 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(net2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -411,7 +411,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -421,7 +421,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -450,7 +450,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -460,7 +460,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -497,12 +497,12 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc1 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -514,12 +514,12 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc1 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc1, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err = linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -543,14 +543,14 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv4 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -580,7 +580,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -592,7 +592,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
 		// node routes for alloc2 ranges should have been installed
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.Not(check.IsNil))
 	}
@@ -617,14 +617,14 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv4 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip4Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
 
 	if s.enableIPv6 {
 		// node routes for alloc2 ranges should be gone
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2)
+		foundRoute, err := linuxNodeHandler.lookupNodeRoute(ip6Alloc2, false)
 		c.Assert(err, check.IsNil)
 		c.Assert(foundRoute, check.IsNil)
 	}
@@ -872,7 +872,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 }
 
 func insertFakeRoute(c *check.C, n *linuxNodeHandler, prefix *cidr.CIDR) {
-	nodeRoute, err := n.createNodeRoute(prefix)
+	nodeRoute, err := n.createNodeRouteSpec(prefix, false)
 	c.Assert(err, check.IsNil)
 
 	nodeRoute.Device = dummyExternalDeviceName
@@ -882,7 +882,7 @@ func insertFakeRoute(c *check.C, n *linuxNodeHandler, prefix *cidr.CIDR) {
 }
 
 func lookupFakeRoute(c *check.C, n *linuxNodeHandler, prefix *cidr.CIDR) bool {
-	routeSpec, err := n.createNodeRoute(prefix)
+	routeSpec, err := n.createNodeRouteSpec(prefix, false)
 	c.Assert(err, check.IsNil)
 
 	routeSpec.Device = dummyExternalDeviceName

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -153,10 +153,16 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	}
 
 	ether, ip, l4, srcIP, dstIP, srcPort, dstPort, summary := decodeLayers(p.packet)
-	if tn != nil && !tn.OriginalIP().IsUnspecified() {
-		srcIP = tn.OriginalIP()
+	if tn != nil {
+		if !tn.OriginalIP().IsUnspecified() {
+			srcIP = tn.OriginalIP()
+			if ip != nil {
+				ip.Source = srcIP.String()
+			}
+		}
+
 		if ip != nil {
-			ip.Source = srcIP.String()
+			ip.Encrypted = (tn.Reason & monitor.TraceReasonEncryptMask) != 0
 		}
 	}
 

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -57,8 +57,14 @@ func TestL34Decode(t *testing.T) {
 	//SOURCE          					DESTINATION           TYPE   SUMMARY
 	//192.168.33.11:6443(sun-sr-https)  10.16.236.178:54222   L3/4   TCP Flags: ACK
 	d := []byte{
-		4, 7, 0, 0, 7, 124, 26, 57, 66, 0, 0, 0, 66, 0, 0, 0, 1, 0, 0, 0, 0, 0,
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 246, 141, 178, 45, 33, 217, 246, 141, 178,
+		4, 7, 0, 0, 7, 124, 26, 57, 66, 0, 0, 0, 66, 0, 0, 0, // NOTIFY_CAPTURE_HDR
+		1, 0, 0, 0, // source labels
+		0, 0, 0, 0, // destination labels
+		0, 0, // destination ID
+		0x80,       // encrypt  bit
+		0,          // flags
+		0, 0, 0, 0, // ifindex
+		246, 141, 178, 45, 33, 217, 246, 141, 178,
 		45, 33, 217, 8, 0, 69, 0, 0, 52, 234, 28, 64, 0, 64, 6, 120, 49, 192,
 		168, 33, 11, 10, 16, 236, 178, 25, 43, 211, 206, 42, 239, 210, 28, 180,
 		152, 129, 103, 128, 16, 1, 152, 216, 156, 0, 0, 1, 1, 8, 10, 0, 90, 176,
@@ -138,6 +144,7 @@ func TestL34Decode(t *testing.T) {
 
 	assert.Equal(t, []string{"host-192.168.33.11"}, f.GetSourceNames())
 	assert.Equal(t, "192.168.33.11", f.GetIP().GetSource())
+	assert.True(t, f.GetIP().GetEncrypted())
 	assert.Equal(t, uint32(6443), f.L4.GetTCP().GetSourcePort())
 	assert.Equal(t, "pod-192.168.33.11", f.GetSource().GetPodName())
 	assert.Equal(t, "remote", f.GetSource().GetNamespace())

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -339,6 +339,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	netNs, err = ns.GetNS(args.Netns)
 	if err != nil {
 		err = fmt.Errorf("failed to open netns %q: %s", args.Netns, err)
+		return
 	}
 	defer netNs.Close()
 


### PR DESCRIPTION
* #14645 -- cilium-cni: Fix error handling for bad netns (@joestringer)
 * #14647 -- docs: fix typo (@sslavic)
 * #14626 -- helm: set dnsPolicy based on etcd.k8sService (@aanm)
 * #14540 -- ensure pods roll when configmap is updated, better support for gitops (@travisghansen)
 * #14684 -- contrib/release: clarify project number for release process (@aanm)
 * #14679 -- pkg/node: Skip setting MTU on local node routes (@aditighag)
 * #14649 -- bpf: Send packet drop notify for LB DSR mode failures. (@hzhou8)
   * Minor conflict in tail_nodeport_ipv4_dsr(), please take a look.
 * #14689 -- bpf: Correctly use revalidate_data_pull() in do_decrypt() (@tgraf)
 * #14677 -- hubble: parser: Set Encrypted bit correctly (@tgraf)
 * #14673 -- docs: Add section in external etcd about identity-allocation-mode (@christarazi)
 * #14737 -- bpf: do not enable host routing when kpr is disabled (@borkmann)
 * #14730 -- bpf: Send packet drop notify for ipv6 lb nat mode failures. (@hzhou8)
 * #14707 -- contrib: Add script to fetch docker manifests (@joestringer)

Skipped:
 * #14451 -- Extend K8sVerifier to maximize program sizes on 4.19 and net-next kernels (@pchaigno)
 * #14607 -- daemon, lbmap: Avoid premature initialization of BPF maps (@christarazi)


Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14645 14647 14626 14540 14684 14679 14649 14689 14677 14673 14737 14730 14707; do contrib/backporting/set-labels.py $pr done 1.9; done
```