### PR TITLE
crypto/certloader: fix tests comparing crypto/x509.CertPool for Go 1.16

### DIFF
--- a/pkg/crypto/certloader/client_test.go
+++ b/pkg/crypto/certloader/client_test.go
@@ -112,7 +112,7 @@ func TestNewWatchedClientConfig(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, keypair)
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, tlsConfig.RootCAs)
+	assert.Equal(t, expectedCaCertPool.Subjects(), tlsConfig.RootCAs.Subjects())
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
 }
@@ -148,7 +148,7 @@ func TestWatchedClientConfigRotation(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, keypair)
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, tlsConfig.RootCAs)
+	assert.Equal(t, expectedCaCertPool.Subjects(), tlsConfig.RootCAs.Subjects())
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
 }

--- a/pkg/crypto/certloader/reloader_test.go
+++ b/pkg/crypto/certloader/reloader_test.go
@@ -391,7 +391,11 @@ func TestKeypairAndCACertPool(t *testing.T) {
 			}
 			keypair, caCertPool := r.KeypairAndCACertPool()
 			assert.Equal(t, tt.expectedKeypair, keypair)
-			assert.Equal(t, tt.expectedCaCertPool, caCertPool)
+			if tt.expectedCaCertPool != nil {
+				assert.Equal(t, tt.expectedCaCertPool.Subjects(), caCertPool.Subjects())
+			} else {
+				assert.Nil(t, caCertPool)
+			}
 		})
 	}
 }
@@ -461,11 +465,19 @@ func TestReload(t *testing.T) {
 			keypair, caCertPool, err := r.Reload()
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expectedKeypair, keypair)
-			assert.Equal(t, tt.expectedCaCertPool, caCertPool)
+			if tt.expectedCaCertPool != nil {
+				assert.Equal(t, tt.expectedCaCertPool.Subjects(), caCertPool.Subjects())
+			} else {
+				assert.Nil(t, caCertPool)
+			}
 
 			keypair, caCertPool = r.KeypairAndCACertPool()
 			assert.Equal(t, tt.expectedKeypair, keypair)
-			assert.Equal(t, tt.expectedCaCertPool, caCertPool)
+			if tt.expectedCaCertPool != nil {
+				assert.Equal(t, tt.expectedCaCertPool.Subjects(), caCertPool.Subjects())
+			} else {
+				assert.Nil(t, caCertPool)
+			}
 		})
 	}
 }
@@ -588,11 +600,19 @@ func TestReloadCA(t *testing.T) {
 			}
 			caCertPool, err := r.ReloadCA()
 			assert.Nil(t, err)
-			assert.Equal(t, tt.expectedCaCertPool, caCertPool)
+			if tt.expectedCaCertPool != nil {
+				assert.Equal(t, tt.expectedCaCertPool.Subjects(), caCertPool.Subjects())
+			} else {
+				assert.Nil(t, caCertPool)
+			}
 
 			keypair, caCertPool := r.KeypairAndCACertPool()
 			assert.Nil(t, keypair)
-			assert.Equal(t, tt.expectedCaCertPool, caCertPool)
+			if tt.expectedCaCertPool != nil {
+				assert.Equal(t, tt.expectedCaCertPool.Subjects(), caCertPool.Subjects())
+			} else {
+				assert.Nil(t, caCertPool)
+			}
 		})
 	}
 }
@@ -618,7 +638,7 @@ func TestReloadError(t *testing.T) {
 
 	keypair, caCertPool := r.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, caCertPool)
+	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
 
 	// delete one of the keypair file, so that reloading the keypair should
 	// fail.
@@ -632,5 +652,5 @@ func TestReloadError(t *testing.T) {
 	// we expect keypair and caCertPool to not have changed on failed reload.
 	keypair, caCertPool = r.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, caCertPool)
+	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
 }

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -140,7 +140,7 @@ func TestNewWatchedServerConfig(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, tlsConfig)
 	assert.Equal(t, []tls.Certificate{expectedKeypair}, tlsConfig.Certificates)
-	assert.Equal(t, expectedCaCertPool, tlsConfig.ClientCAs)
+	assert.Equal(t, expectedCaCertPool.Subjects(), tlsConfig.ClientCAs.Subjects())
 	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
@@ -177,7 +177,7 @@ func TestWatchedServerConfigRotation(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, tlsConfig)
 	assert.Equal(t, []tls.Certificate{expectedKeypair}, tlsConfig.Certificates)
-	assert.Equal(t, expectedCaCertPool, tlsConfig.ClientCAs)
+	assert.Equal(t, expectedCaCertPool.Subjects(), tlsConfig.ClientCAs.Subjects())
 	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)

--- a/pkg/crypto/certloader/watcher_test.go
+++ b/pkg/crypto/certloader/watcher_test.go
@@ -56,7 +56,7 @@ func TestNewWatcher(t *testing.T) {
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, caCertPool)
+	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
 }
 
 func TestRotation(t *testing.T) {
@@ -83,7 +83,7 @@ func TestRotation(t *testing.T) {
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, caCertPool)
+	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
 }
 
 func TestFutureWatcherImmediately(t *testing.T) {
@@ -115,7 +115,7 @@ func TestFutureWatcherImmediately(t *testing.T) {
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, caCertPool)
+	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
 }
 
 func TestFutureWatcher(t *testing.T) {
@@ -157,7 +157,7 @@ func TestFutureWatcher(t *testing.T) {
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool, caCertPool)
+	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
 }
 
 func TestKubernetesMount(t *testing.T) {
@@ -198,7 +198,7 @@ func TestKubernetesMount(t *testing.T) {
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
 	assert.Equal(t, &expectedInitialKeypair, keypair)
-	assert.Equal(t, expectedInitialCaCertPool, caCertPool)
+	assert.Equal(t, expectedInitialCaCertPool.Subjects(), caCertPool.Subjects())
 
 	k8sRotate(t, dir)
 	<-time.After(testReloadDelay)
@@ -214,5 +214,5 @@ func TestKubernetesMount(t *testing.T) {
 
 	keypair, caCertPool = w.KeypairAndCACertPool()
 	assert.Equal(t, &expectedRotatedKeypair, keypair)
-	assert.Equal(t, expectedRotatedCaCertPool, caCertPool)
+	assert.Equal(t, expectedRotatedCaCertPool.Subjects(), caCertPool.Subjects())
 }


### PR DESCRIPTION
Using Go 1.16rc1, the tests in crypto/certloader comparing x509.CertPool
fail due to the fact that certs are loaded lazily now (see
https://golang.org/cl/229917 for details) and internal state of the
compared CertPools thus differing despite containing the same certs.

To fix this, instead of comparing the complete CertPool objects
including unexported internal state, compare them using the DER-encoded
certs as returned by the Subjects method. This is all the tests should
really care about.
