### PR TITLE
dependabot: ignore grpc and miekg/dns updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+        # cannot be updated until the etcd library is updated
+      - dependency-name: "google.golang.org/grpc"
+        # using a cilium-specific fork
+      - dependency-name: "github.com/miekg/dns"
     labels:
     - kind/enhancement
     - release-note/misc


### PR DESCRIPTION
We cannot update the grpc beyond 1.29.1 until we bump etcd to 3.5.0, see
https://github.com/cilium/cilium/pull/13405#issuecomment-704766707, https://github.com/etcd-io/etcd/issues/12124 and https://github.com/cilium/cilium/pull/14787#issuecomment-769681327 for more
information.

We also ignore github.com/miekg/dns because we use our own fork of it
via replace and it seems the long-term plan is to replace the DNS proxy
with Envoy, see https://github.com/cilium/cilium/pull/14790#issuecomment-769738905