### PR TITLE
ipcache: Add ExternalIP of the local node to ipcache

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -302,7 +302,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	}
 
 	var mtuConfig mtu.Configuration
-	externalIP := node.GetExternalIPv4()
+	externalIP := node.GetIPv4()
 	if externalIP == nil {
 		externalIP = node.GetIPv6()
 	}
@@ -649,7 +649,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			logfields.V6Prefix:       node.GetIPv6AllocRange(),
 			logfields.V4HealthIP:     d.nodeDiscovery.LocalNode.IPv4HealthIP,
 			logfields.V6HealthIP:     d.nodeDiscovery.LocalNode.IPv6HealthIP,
-			logfields.V4CiliumHostIP: node.GetInternalIPv4(),
+			logfields.V4CiliumHostIP: node.GetInternalIPv4Router(),
 			logfields.V6CiliumHostIP: node.GetIPv6Router(),
 		}).Info("Annotating k8s node")
 
@@ -657,7 +657,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			encryptKeyID,
 			node.GetIPv4AllocRange(), node.GetIPv6AllocRange(),
 			d.nodeDiscovery.LocalNode.IPv4HealthIP, d.nodeDiscovery.LocalNode.IPv6HealthIP,
-			node.GetInternalIPv4(), node.GetIPv6Router())
+			node.GetInternalIPv4Router(), node.GetIPv6Router())
 		if err != nil {
 			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
 		}
@@ -855,7 +855,7 @@ func (d *Daemon) GetNodeSuffix() string {
 
 	switch {
 	case option.Config.EnableIPv4:
-		ip = node.GetExternalIPv4()
+		ip = node.GetIPv4()
 	case option.Config.EnableIPv6:
 		ip = node.GetIPv6()
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1283,7 +1283,7 @@ func initEnv(cmd *cobra.Command) {
 		if ip := net.ParseIP(option.Config.IPv4NodeAddr); ip == nil {
 			log.WithField(logfields.IPAddr, option.Config.IPv4NodeAddr).Fatal("Invalid IPv4 node address")
 		} else {
-			node.SetExternalIPv4(ip)
+			node.SetIPv4(ip)
 		}
 	}
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -258,7 +258,7 @@ func (d *Daemon) allocateIPs() error {
 			return err
 		}
 		if routerIP != nil {
-			node.SetInternalIPv4(routerIP)
+			node.SetInternalIPv4Router(routerIP)
 		}
 	}
 
@@ -292,8 +292,8 @@ func (d *Daemon) allocateIPs() error {
 		}
 	}
 
-	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
-	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4())
+	log.Infof("  External-Node IPv4: %s", node.GetIPv4())
+	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4Router())
 
 	if option.Config.EnableIPv4 {
 		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -161,8 +161,8 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			// the local host, then the ipcache should be populated
 			// with the hostIP so that this traffic can be guided
 			// to a tunnel endpoint destination.
-			externalIP := node.GetExternalIPv4()
-			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(externalIP) {
+			nodeIPv4 := node.GetIPv4()
+			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
 				copy(value.TunnelEndpoint[:], ip4)
 			}
 		}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -85,14 +85,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		fmt.Fprintf(fw, " cilium.v6.nodeport.str %s\n", node.GetNodePortIPv6Addrs())
 		fmt.Fprintf(fw, "\n")
 	}
-	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetExternalIPv4().String())
-	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4Router().String())
 	fmt.Fprintf(fw, " cilium.v4.nodeport.str %s\n", node.GetNodePortIPv4Addrs())
 	fmt.Fprintf(fw, "\n")
 	if option.Config.EnableIPv6 {
 		fw.WriteString(dumpRaw(defaults.RestoreV6Addr, node.GetIPv6Router()))
 	}
-	fw.WriteString(dumpRaw(defaults.RestoreV4Addr, node.GetInternalIPv4()))
+	fw.WriteString(dumpRaw(defaults.RestoreV4Addr, node.GetInternalIPv4Router()))
 	fmt.Fprintf(fw, " */\n\n")
 
 	cDefinesMap["KERNEL_HZ"] = fmt.Sprintf("%d", option.Config.KernelHz)
@@ -103,7 +103,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 
 	if option.Config.EnableIPv4 {
-		ipv4GW := node.GetInternalIPv4()
+		ipv4GW := node.GetInternalIPv4Router()
 		loopbackIPv4 := node.GetIPv4Loopback()
 		ipv4Range := node.GetIPv4AllocRange()
 		cDefinesMap["IPV4_GATEWAY"] = fmt.Sprintf("%#x", byteorder.HostSliceToNetwork(ipv4GW, reflect.Uint32).(uint32))

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -53,12 +53,12 @@ func (s *ConfigSuite) SetUpTest(c *C) {
 	err := bpf.ConfigureResourceLimits()
 	c.Assert(err, IsNil)
 	node.InitDefaultPrefix("")
-	node.SetInternalIPv4(ipv4DummyAddr)
+	node.SetInternalIPv4Router(ipv4DummyAddr)
 	node.SetIPv4Loopback(ipv4DummyAddr)
 }
 
 func (s *ConfigSuite) TearDownTest(c *C) {
-	node.SetInternalIPv4(nil)
+	node.SetInternalIPv4Router(nil)
 	node.SetIPv4Loopback(nil)
 }
 

--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -70,11 +70,11 @@ func listLocalAddresses(family int) ([]net.IP, error) {
 type addressFamilyIPv4 struct{}
 
 func (a *addressFamilyIPv4) Router() net.IP {
-	return node.GetInternalIPv4()
+	return node.GetInternalIPv4Router()
 }
 
 func (a *addressFamilyIPv4) PrimaryExternal() net.IP {
-	return node.GetExternalIPv4()
+	return node.GetIPv4()
 }
 
 func (a *addressFamilyIPv4) AllocationCIDR() *cidr.CIDR {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -223,7 +223,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgBpffsRoot] = bpf.GetMapRoot()
 
 	if option.Config.EnableIPv4 {
-		args[initArgIPv4NodeIP] = node.GetInternalIPv4().String()
+		args[initArgIPv4NodeIP] = node.GetInternalIPv4Router().String()
 	} else {
 		args[initArgIPv4NodeIP] = "<nil>"
 	}

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -35,6 +35,6 @@ func Test(t *testing.T) {
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
 	node.InitDefaultPrefix("")
-	node.SetInternalIPv4(templateIPv4)
+	node.SetInternalIPv4Router(templateIPv4)
 	node.SetIPv4Loopback(templateIPv4)
 }

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -132,7 +132,7 @@ func getEndpointNetworking(mdlNetworking *models.EndpointNetworking) (networking
 	}
 
 	if option.Config.EnableIPv4 {
-		networking.NodeIP = node.GetExternalIPv4().String()
+		networking.NodeIP = node.GetIPv4().String()
 	} else {
 		networking.NodeIP = node.GetIPv6().String()
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -729,7 +729,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 
 				IP := endpointIP.IP()
 				ID := e.SecurityIdentity.ID
-				hostIP := node.GetExternalIPv4()
+				hostIP := node.GetIPv4()
 				key := node.GetIPsecKeyIdentity()
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -236,7 +236,7 @@ func WaitForNodeInformation() error {
 		// addressing, e.g. an IPv6 only PodCIDR running over
 		// IPv4 encapsulation.
 		if nodeIP4 != nil {
-			node.SetExternalIPv4(nodeIP4)
+			node.SetIPv4(nodeIP4)
 		}
 
 		if nodeIP6 != nil {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -245,6 +245,9 @@ func WaitForNodeInformation() error {
 
 		node.SetLabels(n.Labels)
 
+		node.SetK8sExternalIPv4(n.GetExternalIP(false))
+		node.SetK8sExternalIPv6(n.GetExternalIP(true))
+
 		// K8s Node IP is used by BPF NodePort devices auto-detection
 		node.SetK8sNodeIP(k8sNodeIP)
 	} else {

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -47,6 +47,10 @@ var (
 	ipv4AllocRange    *cidr.CIDR
 	ipv6AllocRange    *cidr.CIDR
 
+	// k8s Node External IP
+	ipv4ExternalAddress net.IP
+	ipv6ExternalAddress net.IP
+
 	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is preferred)
 	k8sNodeIP net.IP
 
@@ -250,6 +254,18 @@ func GetInternalIPv4Router() net.IP {
 	return ipv4RouterAddress
 }
 
+// SetK8sExternalIPv4 sets the external IPv4 node address. It must be a public IP that is routable
+// on the network as well as the internet.
+func SetK8sExternalIPv4(ip net.IP) {
+	ipv4ExternalAddress = ip
+}
+
+// GetK8sExternalIPv4 returns the external IPv4 node address. It must be a public IP that is routable
+// on the network as well as the internet. It can return nil if no External IPv4 address is assigned.
+func GetK8sExternalIPv4() net.IP {
+	return ipv4ExternalAddress
+}
+
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading
 // any traffic that is being forwarded from the host into the Cilium cluster.
 func GetHostMasqueradeIPv4() net.IP {
@@ -377,6 +393,16 @@ func GetIPv6Router() net.IP {
 // SetIPv6Router returns the IPv6 address of the node
 func SetIPv6Router(ip net.IP) {
 	ipv6RouterAddress = ip
+}
+
+// SetK8sExternalIPv6 sets the external IPv6 node address. It must be a public IP.
+func SetK8sExternalIPv6(ip net.IP) {
+	ipv6ExternalAddress = ip
+}
+
+// GetK8sExternalIPv6 returns the external IPv6 node address.
+func GetK8sExternalIPv6() net.IP {
+	return ipv6ExternalAddress
 }
 
 // IsHostIPv4 returns true if the IP specified is a host IP

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -214,7 +214,7 @@ func SetInternalIPv4From(ifaceName string) error {
 	}
 	for _, ip := range v4Addrs {
 		if netlink.Scope(ip.Scope) == netlink.SCOPE_UNIVERSE {
-			SetInternalIPv4(ip.IP)
+			SetInternalIPv4Router(ip.IP)
 			return nil
 		}
 	}

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -44,9 +44,9 @@ func (s *NodeSuite) TestMaskCheck(c *C) {
 
 	allocCIDR := cidr.MustParseCIDR("1.1.1.1/16")
 	SetIPv4AllocRange(allocCIDR)
-	SetInternalIPv4(allocCIDR.IP)
-	c.Assert(IsHostIPv4(GetInternalIPv4()), Equals, true)
-	c.Assert(IsHostIPv4(GetExternalIPv4()), Equals, true)
+	SetInternalIPv4Router(allocCIDR.IP)
+	c.Assert(IsHostIPv4(GetInternalIPv4Router()), Equals, true)
+	c.Assert(IsHostIPv4(GetIPv4()), Equals, true)
 	c.Assert(IsHostIPv6(GetIPv6()), Equals, true)
 }
 

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -247,6 +247,21 @@ func (n *Node) getNodeIP(ipv6 bool) (net.IP, addressing.AddressType) {
 	return backupIP, ipType
 }
 
+// GetExternalIP returns ExternalIP of k8s Node. If not present, then it
+// returns nil;
+func (n *Node) GetExternalIP(ipv6 bool) net.IP {
+	for _, addr := range n.IPAddresses {
+		if (ipv6 && addr.IP.To4() != nil) || (!ipv6 && addr.IP.To4() == nil) {
+			continue
+		}
+		if addr.Type == addressing.NodeExternalIP {
+			return addr.IP
+		}
+	}
+
+	return nil
+}
+
 // GetK8sNodeIPs returns k8s Node IP (either InternalIP or ExternalIP or nil;
 // the former is preferred).
 func (n *Node) GetK8sNodeIP() net.IP {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -178,6 +178,13 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.Labels = node.GetLabels()
 	n.LocalNode.NodeIdentity = identity.GetLocalNodeID().Uint32()
 
+	if node.GetK8sExternalIPv4() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeExternalIP,
+			IP:   node.GetK8sExternalIPv4(),
+		})
+	}
+
 	if node.GetIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeInternalIP,
@@ -203,6 +210,13 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,
 			IP:   node.GetIPv6Router(),
+		})
+	}
+
+	if node.GetK8sExternalIPv6() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeExternalIP,
+			IP:   node.GetK8sExternalIPv6(),
 		})
 	}
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -178,10 +178,10 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.Labels = node.GetLabels()
 	n.LocalNode.NodeIdentity = identity.GetLocalNodeID().Uint32()
 
-	if node.GetExternalIPv4() != nil {
+	if node.GetIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeInternalIP,
-			IP:   node.GetExternalIPv4(),
+			IP:   node.GetIPv4(),
 		})
 	}
 
@@ -192,10 +192,10 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		})
 	}
 
-	if node.GetInternalIPv4() != nil {
+	if node.GetInternalIPv4Router() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,
-			IP:   node.GetInternalIPv4(),
+			IP:   node.GetInternalIPv4Router(),
 		})
 	}
 

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -98,7 +98,7 @@ func NewLogRecord(endpointInfoRegistry EndpointInfoRegistry, localEndpointInfoSo
 		localEndpointInfo:    getEndpointInfo(localEndpointInfoSource),
 	}
 
-	if ip := node.GetExternalIPv4(); ip != nil {
+	if ip := node.GetIPv4(); ip != nil {
 		lr.LogRecord.NodeAddressInfo.IPv4 = ip.String()
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -625,7 +625,7 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 	defer proxyPortsMutex.Unlock()
 
 	result := &models.ProxyStatus{
-		IP:             node.GetInternalIPv4().String(),
+		IP:             node.GetInternalIPv4Router().String(),
 		PortRange:      fmt.Sprintf("%d-%d", p.rangeMin, p.rangeMax),
 		TotalRedirects: int64(len(p.redirects)),
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3658,7 +3658,7 @@ func (kub *Kubectl) GetNodeInfo(label string) (nodeName, nodeIP string) {
 	nodeName, err := kub.GetNodeNameByLabel(label)
 	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), "Cannot get node by label "+label)
 	nodeIP, err = kub.GetNodeIPByLabel(label, false)
-	gomega.ExpectWithOffset(1, err).Should(gomega.BeNil(), "Can not retrieve Node IP for "+label)
+	gomega.ExpectWithOffset(1, err).Should(gomega.BeNil(), "Can not retrieve Node Internal IP for "+label)
 	return nodeName, nodeIP
 }
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1124,6 +1124,17 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			}
 
 			if helpers.RunsOnGKE() {
+				k8s1ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s1, true)
+				Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s1)
+				k8s2ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s2, true)
+				Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s2)
+				testURLsFromPods = append(testURLsFromPods,
+					getHTTPLink(k8s1ExternalIP, data.Spec.Ports[0].NodePort),
+					getTFTPLink(k8s1ExternalIP, data.Spec.Ports[1].NodePort),
+					getHTTPLink(k8s2ExternalIP, data.Spec.Ports[0].NodePort),
+					getTFTPLink(k8s2ExternalIP, data.Spec.Ports[1].NodePort),
+				)
+
 				// Testing LoadBalancer types subject to bpf_sock.
 				lbIP, err := kubectl.GetLoadBalancerIP(helpers.DefaultNamespace, "test-lb", 60*time.Second)
 				Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

ExternalIP of the local k8s node is not added to the IPCache. So when a client inside the cluster tries to connect to a NodePort Service via ExternalIP of the local k8s node, no service resolution happens.

Fixes: #14765 

```release-note
Fix a bug that affects connectivity to NodePort service via ExternalIP of the local k8s node.
```
