### PR TITLE
v1.8 backports 2021-01-29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2021-01-20-v1.8@sha256:545a7837bc135a6f3193c791a0569a2897cf75a418b27e996a51c451cd245df6 as builder
+FROM quay.io/cilium/cilium-builder:2021-02-03-v1.8@sha256:5341db57e74f4e45c16a4705501eb73b1515129c1b84ee84a6e6447ba133bbd8 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGI
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2021-01-21-v1.8@sha256:b1a90e3dc41307f62b1860d89db910b0a707ba0d31aa930ec06c83f47d09c4cb
+FROM quay.io/cilium/cilium-runtime:2021-02-03-v1.8@sha256:44c7e985ba0317726ae6960c3211456d9c076677cbad39439fcc16c81cdc813c
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,6 @@
 #
 # Cilium build-time base image (image created from this file is used to build Cilium)
+FROM docker.io/cilium/cilium-llvm:33c302266cecc264febfca95129ce8dad9397c81 as cilium-llvm
 
 FROM quay.io/cilium/cilium-runtime:2021-02-03-v1.8@sha256:44c7e985ba0317726ae6960c3211456d9c076677cbad39439fcc16c81cdc813c
 LABEL maintainer="maintainer@cilium.io"
@@ -32,6 +33,11 @@ RUN apt-get update && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+#
+# Retrieve llvm-objcopy binary
+#
+COPY --from=cilium-llvm /bin/llvm-objcopy /bin/
 
 #
 # Install Go

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,7 +1,7 @@
 #
 # Cilium build-time base image (image created from this file is used to build Cilium)
 
-FROM quay.io/cilium/cilium-runtime:2021-01-20-v1.8@sha256:b1a90e3dc41307f62b1860d89db910b0a707ba0d31aa930ec06c83f47d09c4cb
+FROM quay.io/cilium/cilium-runtime:2021-02-03-v1.8@sha256:44c7e985ba0317726ae6960c3211456d9c076677cbad39439fcc16c81cdc813c
 LABEL maintainer="maintainer@cilium.io"
 ARG ARCH=amd64
 WORKDIR /go/src/github.com/cilium/cilium

--- a/bpf/netdev_config.h
+++ b/bpf/netdev_config.h
@@ -11,3 +11,4 @@
 #endif
 #define SECLABEL 2
 #define SECLABEL_NB 0xfffff
+#define CALLS_MAP test_cilium_calls_65535

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -3,7 +3,7 @@
 # development environmennt
 FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
-FROM quay.io/cilium/cilium-runtime:2021-01-20-v1.8@sha256:b1a90e3dc41307f62b1860d89db910b0a707ba0d31aa930ec06c83f47d09c4cb
+FROM quay.io/cilium/cilium-runtime:2021-02-03-v1.8@sha256:44c7e985ba0317726ae6960c3211456d9c076677cbad39439fcc16c81cdc813c
 LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -52,7 +52,7 @@ RUN apt-get update && \
     sha512sum -c cni-plugins-linux-${ARCH}-v0.8.6.tgz.sha512 && \
     tar -xvf cni-plugins-linux-${ARCH}-v0.8.6.tgz ./loopback && \
     strip -s ./loopback
-COPY --from=docker.io/cilium/cilium-llvm:178583d8925906270379830fb44641c38f7cc062 /bin/clang /bin/llc /bin/
+COPY --from=docker.io/cilium/cilium-llvm:33c302266cecc264febfca95129ce8dad9397c81 /bin/clang /bin/llc /bin/
 COPY --from=docker.io/cilium/cilium-bpftool:f0bbd0cb389ce92b33ff29f0489c17c8e33f9da7 /bin/bpftool /bin/
 COPY --from=docker.io/cilium/cilium-iproute2:f873abca8c7128f48206c6aecbbcdc6315d3d79d /usr/local/bin/tc /usr/local/bin/ip /usr/local/bin/ss /bin/
 COPY --from=gops /go/bin/gops /bin/

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         PROJ_PATH = "src/github.com/cilium/cilium"
         VM_MEMORY = "8192"
         VM_CPUS = "4"
+        NFS = "0"
         GINKGO_TIMEOUT="150m"
         DEFAULT_KERNEL="""${sh(
             returnStdout: true,

--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -128,6 +128,7 @@ pipeline {
                         TESTED_SUITE="runtime"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                        NFS="0"
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -227,6 +228,7 @@ pipeline {
                         TESTED_SUITE="runtime"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                        NFS="0"
                     }
                     steps {
                         sh 'cd ${TESTDIR}; ginkgo --focus="$(echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -61,9 +61,14 @@ Vagrant.configure("2") do |config|
         server.vm.hostname = "runtime"
 
         # This network is only used by NFS
-        server.vm.network "private_network", type: "dhcp"
-        server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
-            nfs: $NFS
+        if $NFS
+            # This network is only used by NFS
+            server.vm.network "private_network", ip: "192.168.38.10"
+            server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
+                type: "nfs", nfs_udp: false
+        else
+            server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium"
+        end
 
         # Provision section
         server.vm.provision :shell,
@@ -121,10 +126,14 @@ Vagrant.configure("2") do |config|
                 run: "always",
                 inline: "ip -6 a a fd05::1#{i}/96 dev enp0s9 || true"
 
-            # This network is only used by NFS
-            server.vm.network "private_network", type: "dhcp"
-            server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
-                nfs: $NFS
+            if $NFS
+                # This network is only used by NFS
+                server.vm.network "private_network", ip: "192.168.38.1#{i}"
+                server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
+                    type: "nfs", nfs_udp: false
+            else
+                server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium"
+            end
             # Provision section
             server.vm.provision :shell,
                 :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=1"

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -14,7 +14,7 @@ $BUILD_NUMBER = ENV['BUILD_NUMBER'] || "0"
 $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.18"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
-$NFS = ENV['NFS']=="1"? true : false
+$NFS = ENV['NFS']=="0"? false : true
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2021-01-20-v1.8@sha256:545a7837bc135a6f3193c791a0569a2897cf75a418b27e996a51c451cd245df6"
+    image: "quay.io/cilium/cilium-builder:2021-02-03-v1.8@sha256:5341db57e74f4e45c16a4705501eb73b1515129c1b84ee84a6e6447ba133bbd8"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:2021-01-20-v1.8@sha256:545a7837bc135a6f3193c791a0569a2897cf75a418b27e996a51c451cd245df6
+    image: quay.io/cilium/cilium-builder:2021-02-03-v1.8@sha256:5341db57e74f4e45c16a4705501eb73b1515129c1b84ee84a6e6447ba133bbd8
     command: ["sleep"]
     args:
       - "1000h"


### PR DESCRIPTION
 * #13527 -- test/vagrant: Fix NFS setup for test VMs (@pchaigno)
    - Fixed a minor conflict.
 * #13983 -- test: Use NFS by default in test VMs (@pchaigno)
 * #13953 -- test: Enable K8sVerifier on 4.19 and net-next CI (@pchaigno)
    - Fixed a minor conflict.
 * #13934 -- bpf: Replace CALLS_MAP symbol in compile-tested binaries (@pchaigno)
 * #13958 -- docker: Pull llvm-objcopy in cilium-builder (@pchaigno)
    - Rebuilt the chain of Docker images from https://github.com/cilium/image-tools/tree/v1.8.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13527 13983 13953 13934 13958; do contrib/backporting/set-labels.py $pr done 1.8; done
```