### PR TITLE
Adds an option to specify Cilium router device IP

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -174,6 +174,7 @@ cilium-agent [flags]
       --label-prefix-file string                             Valid label prefixes file path
       --labels strings                                       List of label prefixes used to determine identity of an endpoint
       --lib-dir string                                       Directory path to store runtime build environment (default "/var/lib/cilium")
+      --local-router-ip string                               Link-local IP used for Cilium's router devices
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium (default map[])
       --log-system-load                                      Enable periodic logging of system load

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -910,6 +910,9 @@ func init() {
 	flags.Int(option.LBMapEntriesName, lbmap.MaxEntries, "Maximum number of entries in Cilium BPF lbmap")
 	option.BindEnv(option.LBMapEntriesName)
 
+	flags.String(option.LocalRouterIP, "", "Link-local IP used for Cilium's router devices")
+	option.BindEnv(option.LocalRouterIP)
+
 	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
 	option.BindEnv(option.K8sServiceProxyName)
 
@@ -1336,6 +1339,21 @@ func initEnv(cmd *cobra.Command) {
 
 	if !probes.NewProbeManager().GetMisc().HaveLargeInsnLimit {
 		option.Config.NeedsRelaxVerifier = true
+	}
+
+	if option.Config.LocalRouterIP != "" {
+		if option.Config.IPAM != "" {
+			log.Fatalf("Cannot specify %s along with %s, leave router IP unspecified if Cilium is handling IPAM.", option.LocalRouterIP, option.IPAM)
+		}
+		if option.Config.Tunnel != option.TunnelDisabled {
+			log.Fatalf("Cannot specify %s in tunnel mode.", option.LocalRouterIP)
+		}
+		if !option.Config.EnableEndpointRoutes {
+			log.Fatalf("Cannot specify %s without %s.", option.LocalRouterIP, option.EnableEndpointRoutes)
+		}
+		if option.Config.EnableIPSec {
+			log.Fatalf("Cannot specify %s with %s.", option.LocalRouterIP, option.EnableIPSecName)
+		}
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMAzure {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -700,6 +700,9 @@ const (
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 = "ipv4-service-loopback-address"
 
+	// LocalRouterIP is the link-local IP address to use for Cilium router device
+	LocalRouterIP = "local-router-ip"
+
 	// EndpointInterfaceNamePrefix is the prefix name of the interface
 	// names shared by all endpoints
 	EndpointInterfaceNamePrefix = "endpoint-interface-name-prefix"
@@ -995,6 +998,7 @@ var HelpFlagSections = []FlagsSection{
 			EnableEndpointRoutes,
 			EnableLocalNodeRoute,
 			EnableAutoDirectRoutingName,
+			LocalRouterIP,
 		},
 	},
 	{
@@ -1802,6 +1806,9 @@ type DaemonConfig struct {
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 string
 
+	// LocalRouterIP is the link-local IP address used for Cilium's router device
+	LocalRouterIP string
+
 	// EndpointInterfaceNamePrefix is the prefix name of the interface
 	// names shared by all endpoints
 	EndpointInterfaceNamePrefix string
@@ -2607,6 +2614,7 @@ func (c *DaemonConfig) Populate() {
 	c.LogSystemLoadConfig = viper.GetBool(LogSystemLoadConfigName)
 	c.Logstash = viper.GetBool(Logstash)
 	c.LoopbackIPv4 = viper.GetString(LoopbackIPv4)
+	c.LocalRouterIP = viper.GetString(LocalRouterIP)
 	c.EnableBPFClockProbe = viper.GetBool(EnableBPFClockProbe)
 	c.EnableIPMasqAgent = viper.GetBool(EnableIPMasqAgent)
 	c.EnableEgressGateway = viper.GetBool(EnableEgressGateway)


### PR DESCRIPTION
When `local-router-ip` is specified, this makes Cilium allocate the
provided IP to `cilium_host` device, user is supposed to provide a
"good" IP.

Signed-off-by: Weilong Cui <cuiwl@google.com>

This is a workaround for #13387

```release-note
Adds an option to specify Cilium router device IP
```
