### PR TITLE
Change default ENI property FirstInterfaceIndex to 0 and improve IPAM logic in ENI & Azure modes

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -131,7 +131,7 @@ allocation:
 
 ``spec.eni.first-interface-index``
   The index of the first ENI to use for IP allocation, e.g. if the node has
-  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 1, then only
+  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 0, then only
   ``eth1`` and ``eth2`` will be used for IP allocation, ``eth0`` will be
   ignored for PodIP allocation.
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -330,6 +330,13 @@ Annotations:
   See https://github.com/cilium/cilium/pull/14192 for context and related issues.
 * Helm option ``serviceAccounts.certgen`` is removed, please use ``serviceAccounts.clustermeshcertgen``
   for Clustermesh certificate generation and ``serviceAccounts.hubblecertgen`` for Hubble certificate generation.
+* For AWS ENI IPAM mode, Cilium has changed the ``first-interface-index``
+  default from ``1`` to ``0``. This means that pods will start using IPs of
+  ``eth0`` instead of ``eth1``. This allows using the maximum number of IPs
+  available on an instance by default. Be aware: Depending on your security
+  groups configuration of the ``eth0`` interface, pods may be associated with a
+  different security group all of a sudden. In order to stay with Cilium's
+  current behavior, set the value to ``1`` in the ``CiliumNode`` resource.
 
 Removed Metrics/Labels
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -90,13 +90,13 @@ func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 
-	mngr.Update(newCiliumNode("node1", "i-testGetNodeNames-1", "m4.large", "us-west-1", "vpc-1", 1, 0, 0, 0))
+	mngr.Update(newCiliumNode("node1", "i-testGetNodeNames-1", "m4.large", "us-west-1", "vpc-1", 0, 0, 0, 0))
 
 	names := mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
 	c.Assert(names[0], check.Equals, "node1")
 
-	mngr.Update(newCiliumNode("node2", "i-testGetNodeNames-2", "m4.large", "us-west-1", "vpc-1", 1, 0, 0, 0))
+	mngr.Update(newCiliumNode("node2", "i-testGetNodeNames-2", "m4.large", "us-west-1", "vpc-1", 0, 0, 0, 0))
 
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 2)
@@ -122,7 +122,7 @@ func (e *ENISuite) TestNodeManagerGet(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 
-	mngr.Update(newCiliumNode("node1", "i-testNodeManagerGet-1", "m4.large", "us-west-1", "vpc-1", 1, 0, 0, 0))
+	mngr.Update(newCiliumNode("node1", "i-testNodeManagerGet-1", "m4.large", "us-west-1", "vpc-1", 0, 0, 0, 0))
 
 	c.Assert(mngr.Get("node1"), check.Not(check.IsNil))
 	c.Assert(mngr.Get("node2"), check.IsNil)
@@ -242,7 +242,7 @@ func reachedAddressesNeeded(mngr *ipam.NodeManager, nodeName string, needed int)
 // - MinAllocate 0
 // - MaxAllocate 0
 // - PreAllocate 8
-// - FirstInterfaceIndex 1
+// - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
@@ -257,7 +257,7 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node1", "i-testNodeManagerDefaultAllocation-0", "m5.large", "us-west-1", "vpc-1", 1, 8, 0, 0)
+	cn := newCiliumNode("node1", "i-testNodeManagerDefaultAllocation-0", "m5.large", "us-west-1", "vpc-1", 0, 8, 0, 0)
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
@@ -282,7 +282,7 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 // - MinAllocate 0
 // - MaxAllocate 0
 // - PreAllocate 8
-// - FirstInterfaceIndex 1
+// - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
@@ -300,7 +300,7 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 	sgTags := map[string]string{
 		"test-sg-1": "yes",
 	}
-	cn := newCiliumNodeWithSGTags("node1", "i-testNodeManagerDefaultAllocation-0", "m5.large", "us-west-1", "vpc-1", sgTags, 1, 8, 0, 0)
+	cn := newCiliumNodeWithSGTags("node1", "i-testNodeManagerDefaultAllocation-0", "m5.large", "us-west-1", "vpc-1", sgTags, 0, 8, 0, 0)
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
@@ -337,7 +337,7 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 // - MinAllocate 10
 // - MaxAllocate 0
 // - PreAllocate -1
-// - FirstInterfaceIndex 1
+// - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
@@ -352,7 +352,7 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node2", "i-testNodeManagerMinAllocate20-1", "m5.4xlarge", "us-west-1", "vpc-1", 1, -1, 10, 0)
+	cn := newCiliumNode("node2", "i-testNodeManagerMinAllocate20-1", "m5.4xlarge", "us-west-1", "vpc-1", 0, -1, 10, 0)
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
@@ -370,7 +370,7 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 	c.Assert(node.Stats().UsedIPs, check.Equals, 8)
 
 	// Change MinAllocate to 20
-	cn = newCiliumNode("node2", "i-testNodeManagerMinAllocate20-1", "m5.4xlarge", "us-west-1", "vpc-1", 1, 0, 20, 0)
+	cn = newCiliumNode("node2", "i-testNodeManagerMinAllocate20-1", "m5.4xlarge", "us-west-1", "vpc-1", 0, 0, 20, 0)
 	mngr.Update(updateCiliumNode(cn, 20, 8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
@@ -387,7 +387,7 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 // - MinAllocate 10
 // - MaxAllocate 0
 // - PreAllocate 1
-// - FirstInterfaceIndex 1
+// - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
@@ -402,7 +402,7 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node2", "i-testNodeManagerMinAllocateAndPreallocate-1", "m3.large", "us-west-1", "vpc-1", 1, 1, 10, 0)
+	cn := newCiliumNode("node2", "i-testNodeManagerMinAllocateAndPreallocate-1", "m3.large", "us-west-1", "vpc-1", 0, 1, 10, 0)
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
@@ -444,7 +444,7 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 // - MaxAllocate 0
 // - PreAllocate 4
 // - MaxAboveWatermark 4
-// - FirstInterfaceIndex 1
+// - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
@@ -459,7 +459,7 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node3", "i-testNodeManagerReleaseAddress-1", "m4.xlarge", "us-west-1", "vpc-1", 1, 4, 10, 0)
+	cn := newCiliumNode("node3", "i-testNodeManagerReleaseAddress-1", "m4.xlarge", "us-west-1", "vpc-1", 0, 4, 10, 0)
 	cn.Spec.IPAM.MaxAboveWatermark = 4
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
@@ -518,11 +518,11 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 
 // TestNodeManagerExceedENICapacity tests exceeding ENI capacity
 //
-// - m4.xlarge (4x ENIs, 3x15 IPs)
+// - t2.xlarge (3x ENIs, 3x15 IPs)
 // - MinAllocate 20
 // - MaxAllocate 0
 // - PreAllocate 8
-// - FirstInterfaceIndex 1
+// - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
@@ -537,7 +537,7 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node2", "i-testNodeManagerExceedENICapacity-1", "m4.xlarge", "us-west-1", "vpc-1", 1, 8, 20, 0)
+	cn := newCiliumNode("node2", "i-testNodeManagerExceedENICapacity-1", "t2.xlarge", "us-west-1", "vpc-1", 0, 8, 20, 0)
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
@@ -546,8 +546,8 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	c.Assert(node.Stats().AvailableIPs, check.Equals, 20)
 	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
 
-	// Use 40 out of 42 available IPs, we should reach 0 address needed once
-	// we assigned the remaining 3 that the m4.xlarge instance type supports (45 max)
+	// Use 40 out of 42 available IPs, we should reach 0 address needed once we
+	// assigned the remaining 3 that the t2.xlarge instance type supports (45 max)
 	mngr.Update(updateCiliumNode(cn, 42, 40))
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
@@ -565,7 +565,7 @@ type nodeState struct {
 
 // TestNodeManagerManyNodes tests IP allocation of 100 nodes across 3 subnets
 //
-// - m4.large (2x ENIs, 1x10 IPs)
+// - c3.xlarge (4x ENIs, 4x15 IPs)
 // - MinAllocate 10
 // - MaxAllocate 0
 // - PreAllocate 1
@@ -598,7 +598,7 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 		c.Assert(err, check.IsNil)
 		instancesManager.Resync(context.TODO())
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-testNodeManagerManyNodes-%d", i)}
-		s.cn = newCiliumNode(s.name, s.instanceName, "m4.large", "us-west-1", "vpc-1", 1, 1, minAllocate, 0)
+		s.cn = newCiliumNode(s.name, s.instanceName, "c3.xlarge", "us-west-1", "vpc-1", 1, 1, minAllocate, 0)
 		state[i] = s
 		mngr.Update(s.cn)
 	}
@@ -643,6 +643,8 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 
 // TestNodeManagerInstanceNotRunning verifies that allocation correctly detects
 // instances which are no longer running
+//
+// - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	metricsMock := metricsmock.NewMockMetrics()
@@ -682,8 +684,8 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 // TestInstanceBeenDeleted verifies that instance deletion is correctly detected
 // and no further action is taken
 //
-// - m4.large (2x ENIs, 1x10 IPs)
-// - FirstInterfaceIndex 1
+// - m4.large (2x ENIs, 2x10 IPs)
+// - FirstInterfaceIndex 0
 func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
@@ -701,13 +703,13 @@ func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
-	cn := newCiliumNode("node1", "i-testInstanceBeenDeleted-0", "m4.large", "us-west-1", "vpc-1", 1, 8, 0, 0)
+	cn := newCiliumNode("node1", "i-testInstanceBeenDeleted-0", "m4.large", "us-west-1", "vpc-1", 0, 8, 0, 0)
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 9)
 	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
 
 	// Delete all enis attached to instance, this mocks the operation of
@@ -718,11 +720,11 @@ func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 	c.Assert(err, check.IsNil)
 	// Resync instances from mocked AWS
 	instances.Resync(context.TODO())
-	// Use 2 out of 8 IPs
-	mngr.Update(updateCiliumNode(cn, 8, 2))
+	// Use 2 out of 9 IPs
+	mngr.Update(updateCiliumNode(cn, 9, 2))
 
 	// Instance deletion detected, no allocation happened despite of the IP deficit.
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 9)
 	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
 	c.Assert(node.Stats().NeededIPs, check.Equals, 0)
 	c.Assert(node.Stats().ExcessIPs, check.Equals, 0)
@@ -752,7 +754,7 @@ func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLi
 		c.Assert(err, check.IsNil)
 		instances.Resync(context.TODO())
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-benchmarkAllocWorker-%d", i)}
-		s.cn = newCiliumNode(s.name, s.instanceName, "m4.large", "us-west-1", "vpc-1", 1, 1, 10, 0)
+		s.cn = newCiliumNode(s.name, s.instanceName, "m4.large", "us-west-1", "vpc-1", 0, 1, 10, 0)
 		state[i] = s
 		mngr.Update(s.cn)
 	}

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/azure/types"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -193,4 +194,10 @@ func (n *Node) GetMaximumAllocatableIPv4() int {
 	// An Azure node can allocate up to 256 private IP addresses
 	// source: https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/azure-virtual-network-limits.md#networking-limits---azure-resource-manager
 	return types.InterfaceAddressLimit
+}
+
+// GetMinimumAllocatableIPv4 returns the minimum amount of IPv4 addresses that
+// must be allocated to the instance.
+func (n *Node) GetMinimumAllocatableIPv4() int {
+	return defaults.IPAMPreAllocation
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -329,8 +329,8 @@ const (
 	IPAMPreAllocation = 8
 
 	// ENIFirstInterfaceIndex is the default value for
-	// CiliumNode.Spec.ENI.FirstInterfaceIndex if no value is set
-	ENIFirstInterfaceIndex = 1
+	// CiliumNode.Spec.ENI.FirstInterfaceIndex if no value is set.
+	ENIFirstInterfaceIndex = 0
 
 	// ParallelAllocWorkers is the default max number of parallel workers doing allocation in the operator
 	ParallelAllocWorkers = 50

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -20,15 +20,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cilium/cilium/pkg/aws/eni/limits"
 	"github.com/cilium/cilium/pkg/defaults"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/math"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/sirupsen/logrus"
@@ -693,9 +690,9 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 // [(*Node).resource)] with the K8s apiserver. This operation occurs on an
 // interval to refresh the CiliumNode resource.
 //
-// For Azure and ENI IPAM modes, this function serves two purposes: (1) as the
-// entry point to initialize the CiliumNode resource and (2) to keep the
-// resource up-to-date with K8s.
+// For Azure and ENI IPAM modes, this function serves two purposes: (1)
+// finalizes the initialization of the CiliumNode resource (setting
+// PreAllocate) and (2) to keep the resource up-to-date with K8s.
 //
 // To initialize, or seed, the CiliumNode resource, the PreAllocate field is
 // populated with a default value and then is adjusted as necessary.
@@ -743,8 +740,13 @@ func (n *Node) syncToAPIServer() (err error) {
 		node.Spec.IPAM.Pool = n.Pool()
 		scopedLog.WithField("poolSize", len(node.Spec.IPAM.Pool)).Debug("Updating node in apiserver")
 
+		// The PreAllocate value is added here rather than where the CiliumNode
+		// resource is created ((*NodeDiscovery).mutateNodeResource() inside
+		// pkg/nodediscovery), because mutateNodeResource() does not have
+		// access to the ipam.Node object. Since we are in the CiliumNode
+		// update sync loop, we can compute the value.
 		if node.Spec.IPAM.PreAllocate == 0 {
-			adjustPreAllocateIfNeeded(node)
+			node.Spec.IPAM.PreAllocate = n.ops.GetMinimumAllocatableIPv4()
 		}
 
 		err = n.update(origNode, node, retry, false)
@@ -819,32 +821,4 @@ func (n *Node) update(origNode, node *v2.CiliumNode, attempts int, status bool) 
 	}
 
 	return err
-}
-
-// adjustPreAllocateIfNeeded adjusts IPAM values depending on the instance
-// type. This is needed when the instance type is on the smaller side which
-// requires us to lower the PreAllocate value and include eth0 as an ENI device
-// because the instance type does not allow for additional ENIs to be attached
-// (hence limited).
-//
-// For now, this function is only needed in ENI IPAM mode. In the future, this
-// may also be needed for Azure IPAM as well.
-func adjustPreAllocateIfNeeded(node *v2.CiliumNode) {
-	if option.Config.IPAM != ipamOption.IPAMENI {
-		return
-	}
-
-	// Auto set the PreAllocate to the default value and we'll determine if we
-	// need to adjust it below.
-	node.Spec.IPAM.PreAllocate = defaults.IPAMPreAllocation
-
-	if lim, ok := limits.Get(node.Spec.ENI.InstanceType); ok {
-		max := lim.Adapters * lim.IPv4
-		if node.Spec.IPAM.PreAllocate > max {
-			node.Spec.IPAM.PreAllocate = max
-
-			var i int = 0
-			node.Spec.ENI.FirstInterfaceIndex = &i // Include eth0
-		}
-	}
 }

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -92,6 +92,10 @@ type NodeOperations interface {
 	// GetMaximumAllocatableIPv4 returns the maximum amount of IPv4 addresses
 	// that can be allocated to the instance
 	GetMaximumAllocatableIPv4() int
+
+	// GetMinimumAllocatableIPv4 returns the minimum amount of IPv4 addresses that
+	// must be allocated to the instance.
+	GetMinimumAllocatableIPv4() int
 }
 
 // AllocationImplementation is the interface an implementation must provide.

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -206,7 +206,6 @@ func (n *NodeManager) Start(ctx context.Context) error {
 	// event driven trigger fails, and also release excess IP addresses
 	// if release-excess-ips is enabled
 	go func() {
-		time.Sleep(time.Minute)
 		mngr := controller.NewManager()
 		mngr.UpdateController("ipam-node-interval-refresh",
 			controller.ControllerParams{

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	metricsmock "github.com/cilium/cilium/pkg/ipam/metrics/mock"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -154,6 +155,10 @@ func (n *nodeOperationsMock) ReleaseIPs(ctx context.Context, release *ReleaseAct
 
 func (n *nodeOperationsMock) GetMaximumAllocatableIPv4() int {
 	return 0
+}
+
+func (n *nodeOperationsMock) GetMinimumAllocatableIPv4() int {
+	return defaults.IPAMPreAllocation
 }
 
 func (e *IPAMSuite) TestGetNodeNames(c *check.C) {


### PR DESCRIPTION
See commit msgs.

Fixes: https://github.com/cilium/cilium/pull/13865
Fixes: https://github.com/cilium/cilium/issues/13217