### PR TITLE
allocator: Quieten local key allocation logging

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -508,9 +508,9 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		}
 
 		if firstUse {
-			log.WithField(fieldKey, k).Info("Reserved new local key")
+			log.WithField(fieldKey, k).Debug("Reserved new local key")
 		} else {
-			log.WithField(fieldKey, k).Info("Reusing existing local key")
+			log.WithField(fieldKey, k).Debug("Reusing existing local key")
 		}
 	}
 


### PR DESCRIPTION
These logs were intended for developer use and are not important for
user logging[0], reduce the logging level to Debug.

[0] https://github.com/cilium/cilium/pull/12313#discussion_r566581165
