### PR TITLE
Update bpf.rst

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -1119,7 +1119,7 @@ following commands can be used:
 
 ::
 
-    $ git clone https://git.llvm.org/git/llvm.git
+    $ git clone https://github.com/llvm/llvm-project.git
     $ cd llvm/tools
     $ git clone --depth 1 https://git.llvm.org/git/clang.git
     $ cd ..; mkdir build; cd build

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -1120,9 +1120,9 @@ following commands can be used:
 ::
 
     $ git clone https://github.com/llvm/llvm-project.git
-    $ cd llvm/tools
-    $ git clone --depth 1 https://git.llvm.org/git/clang.git
-    $ cd ..; mkdir build; cd build
+    $ mv llvm-project/clang llvm-project/llvm/tools/
+    $ cd llvm-project/llvm/
+    $ mkdir build; cd build
     $ cmake .. -DLLVM_TARGETS_TO_BUILD="BPF;X86" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_RUNTIME=OFF
     $ make -j $(getconf _NPROCESSORS_ONLN)
 


### PR DESCRIPTION
Hello there!
I'm opening this PR to fix a non-working repo on the documentation [here ](https://docs.cilium.io/en/v1.8/bpf/) related to the LLVM section:
```
# git clone https://git.llvm.org/git/llvm.git
Cloning into 'llvm'...
fatal: repository 'https://git.llvm.org/git/llvm.git/' not found
```

If the repo is the correct one i think we should fix it also for all other branches 1.9,1.7,stable and so on
Have a great day
