### PR TITLE
node-neigh: add metric to count arping requests

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,6 +71,9 @@ const (
 	// SubsystemAPILimiter is the subsystem to scope metrics related to the API limiter package.
 	SubsystemAPILimiter = "api_limiter"
 
+	// SubsystemNodeNeigh is the subsystem to scope metrics related to management of node neighbor.
+	SubsystemNodeNeigh = "node_neigh"
+
 	// Namespace is used to scope metrics from cilium. It is prepended to metric
 	// names and separated with a '_'
 	Namespace = "cilium"
@@ -439,6 +442,10 @@ var (
 	// APILimiterProcessedRequests is the counter of the number of
 	// processed (successful and failed) requests
 	APILimiterProcessedRequests = NoOpCounterVec
+
+	// ArpingRequestsTotal is the counter of the number of sent
+	// (successful and failed) arping requests
+	ArpingRequestsTotal = NoOpCounterVec
 )
 
 type Configuration struct {
@@ -503,6 +510,7 @@ type Configuration struct {
 	APILimiterRateLimit                     bool
 	APILimiterAdjustmentFactor              bool
 	APILimiterProcessedRequests             bool
+	ArpingRequestsTotalEnabled              bool
 }
 
 func DefaultMetrics() map[string]struct{} {
@@ -563,6 +571,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemAPILimiter + "_rate_limit":                        {},
 		Namespace + "_" + SubsystemAPILimiter + "_adjustment_factor":                 {},
 		Namespace + "_" + SubsystemAPILimiter + "_processed_requests_total":          {},
+		Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":              {},
 	}
 }
 
@@ -1235,6 +1244,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, APILimiterProcessedRequests)
 			c.APILimiterProcessedRequests = true
+
+		case Namespace + "_arping_requests_total":
+			ArpingRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemNodeNeigh,
+				Name:      "arping_requests_total",
+				Help:      "Number of arping requests sent labeled by status",
+			}, []string{LabelStatus})
+
+			collectors = append(collectors, ArpingRequestsTotal)
+			c.ArpingRequestsTotalEnabled = true
 		}
 	}
 


### PR DESCRIPTION
Could be used to decide if the arping refresh interval needs to be
adjusted in order to limit spams.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>