### PR TITLE
ci: retry gke cluster scale up, don't clear cluster at start

### DIFF
--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -77,9 +77,6 @@ gcloud container clusters describe --project "${project}" --region "${region}" -
   | sed -E 's/([0-9]+\.[0-9]+)\..*/\1/' | tr -d '\n' > "${script_dir}/cluster-version"
 gcloud container clusters describe --project "${project}" --region "${region}" --format='value(clusterIpv4Cidr)' "${cluster_uri}" > "${script_dir}/cluster-cidr"
 
-echo "cleaning cluster before tests"
-"${script_dir}"/clean-cluster.sh
-
 echo "scaling ${cluster_uri} to 2"
 "${script_dir}"/resize-cluster.sh 2 "${cluster_uri}"
 


### PR DESCRIPTION
This step sometimes fails due to another operation (possible started by
gke) working on a cluster, this will allow us to wait through this
operation and properly scale cluster up.