### PR TITLE
dependabot: ignore ginkgo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - dependency-name: "google.golang.org/grpc"
         # using a cilium-specific fork
       - dependency-name: "github.com/miekg/dns"
+        # newer versions break our CI
+      - dependency-name: "github.com/onsi/ginkgo"
     labels:
     - kind/enhancement
     - release-note/misc


### PR DESCRIPTION
Updating ginkgo to newer versions leads to CI breakages. Ignore updates
for now until we have time to investigate these.

Also see https://github.com/cilium/cilium/pull/14820#issuecomment-770993659
