### PR TITLE
test: Extend coverage for host policies enforcement

### DIFF
--- a/test/k8sT/manifests.go
+++ b/test/k8sT/manifests.go
@@ -48,6 +48,12 @@ var (
 		LabelSelector: "zgroup=http-clients",
 	}
 
+	DemoHostFirewall = helpers.Manifest{
+		Filename:       "demo_hostfw.yaml",
+		DaemonSetNames: []string{"testserver", "testclient", "testserver-host", "testclient-host"},
+		LabelSelector:  "zgroup=DS",
+	}
+
 	IPSecSecret = helpers.Manifest{
 		Filename: "ipsec_secret.yaml",
 	}

--- a/test/k8sT/manifests/demo_hostfw.yaml
+++ b/test/k8sT/manifests/demo_hostfw.yaml
@@ -1,0 +1,121 @@
+# Deploys client and server pods on all nodes (using DaemonSets) both in host
+# and dedicated network namespaces.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testserver
+spec:
+  selector:
+    matchLabels:
+      zgroup: testServer
+  template:
+    metadata:
+      labels:
+        zgroup: testServer
+    spec:
+      containers:
+      - name: web
+        image: docker.io/cilium/echoserver:1.10.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      - name: udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 69
+          protocol: UDP
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testclient
+spec:
+  selector:
+    matchLabels:
+      zgroup: testClient
+  template:
+    metadata:
+      labels:
+        zgroup: testClient
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: web
+        image: docker.io/cilium/demo-client:1.0
+        imagePullPolicy: IfNotPresent
+        command: [ "sleep" ]
+        args:
+          - "1000h"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testserver-host
+spec:
+  selector:
+    matchLabels:
+      zgroup: testServerHost
+  template:
+    metadata:
+      labels:
+        zgroup: testServerHost
+    spec:
+      hostNetwork: true
+      containers:
+      - name: web
+        image: docker.io/cilium/echoserver:1.10.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      - name: udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 69
+          protocol: UDP
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testclient-host
+spec:
+  selector:
+    matchLabels:
+      zgroup: testClientHost
+  template:
+    metadata:
+      labels:
+        zgroup: testClientHost
+    spec:
+      hostNetwork: true
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: web
+        image: docker.io/cilium/demo-client:1.0
+        imagePullPolicy: IfNotPresent
+        command: [ "sleep" ]
+        args:
+          - "1000h"

--- a/test/k8sT/manifests/host-policies.yaml
+++ b/test/k8sT/manifests/host-policies.yaml
@@ -1,0 +1,93 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-policy"
+specs:
+  - description: "Allow only test client <-> server communications on node <-> pod paths (local and remote pods)"
+    nodeSelector: {}
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          zgroup: testClient
+      toPorts:
+      - ports:
+        - port: "80"
+          protocol: TCP
+    - fromEndpoints:
+      - matchExpressions:
+        - key: zgroup
+          operator: NotIn
+          values: [testClient]
+    egress:
+    - toEndpoints:
+      - matchLabels:
+          zgroup: testServer
+      toPorts:
+      - ports:
+        - port: "80"
+          protocol: TCP
+    - toEndpoints:
+      - matchExpressions:
+        - key: zgroup
+          operator: NotIn
+          values: [testServer]
+  - description: "Open required ports + test application's port between nodes"
+    nodeSelector: {}
+    ingress:
+    - fromEntities:
+      - remote-node
+      toPorts:
+      - ports:
+        - port: "80"
+          protocol: TCP
+        # VXLAN tunnels between nodes
+        - port: "8472"
+          protocol: UDP
+        # etcd connections
+        - port: "2379"
+          protocol: TCP
+        - port: "2380"
+          protocol: TCP
+        # kube-api server
+        - port: "6443"
+          protocol: TCP
+        # kubelet
+        - port: "10250"
+          protocol: TCP
+        # Health checks
+        - port: "4240"
+          protocol: TCP
+    egress:
+    - toEntities:
+      - remote-node
+      toPorts:
+      - ports:
+        - port: "80"
+          protocol: TCP
+        # VXLAN tunnels between nodes
+        - port: "8472"
+          protocol: UDP
+        # etcd connections
+        - port: "2379"
+          protocol: TCP
+        - port: "2380"
+          protocol: TCP
+        # kube-api server
+        - port: "6443"
+          protocol: TCP
+        # kubelet
+        - port: "10250"
+          protocol: TCP
+        # Health checks
+        - port: "4240"
+          protocol: TCP
+  - description: "Allow all to/from health and world"
+    nodeSelector: {}
+    ingress:
+    - fromEntities:
+      - health
+      - world
+    egress:
+    - toEntities:
+      - health
+      - world


### PR DESCRIPTION
We currently have a couple of host firewall tests, but they don't cover all possible packet paths. https://github.com/cilium/cilium/pull/12621 added two tests for the path node <-> world (one with fromCIDR+toPorts and one combined with NodePort handling). Other firewall tests (cf. https://github.com/cilium/cilium/pull/14255) are only validating correct loading without enforcing policies.

This pull request fills this gap by adding VXLAN and direct routing tests for the host firewall, with L3+L4 policies enforced on the paths node <-> local pod, node <-> remote pod, and node <-> remote node.

The test design draws inspiration from early host firewall bugs and regressions:
- Test ingress and egress at the same time with restrictions on allowed ports. This is meant to ensure we detect a regression where only one direction bypasses policy enforcement. If such a case arises, we will fail because the source port won't be allowed and the connection will be dropped.
- Allow connections to/from world and pods not used in tests. This is meant to reduce the risk of bricking the nodes. Node to node
  communications are still strongly restricted, but the ports defined there have been stable for a while.
- Test connections to local and remote pods separately. They follow very different paths through our datapath.