### PR TITLE
dependabot: disable automatic rebasing of PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: "disabled"
     ignore:
         # cannot be updated until the etcd library is updated
       - dependency-name: "google.golang.org/grpc"
@@ -16,6 +17,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: "disabled"
     labels:
     - kind/enhancement
     - release-note/misc


### PR DESCRIPTION
dependabot will automatically rebase PRs by default, however this might
interfere with PRs which are currently run through Jenkins CI as the CI
jobs might be canceled in the middle of the run and would need to be
restarted, potentially wasting a lot of CI cycles.

dependabot can still be instructed to rebase PRs manually using
`@dependabot rebase` comments if needed.
