### PR TITLE
images/runtime: fix loopback CNI installation plugin

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG CILIUM_BUILDER_IMAGE=docker.io/cilium/cilium-builder-dev:879b19d3b784fdd0dda9f91310107c6fe209ffac
-ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:1a7ffa9f03bf728837a1139ada1e35089e4299aa
+ARG CILIUM_RUNTIME_IMAGE=docker.io/cilium/cilium-runtime-dev:0609ab6cc05c0dd78499c417c9ce3d0dc24c7f54
 
 FROM ${CILIUM_BUILDER_IMAGE} as builder
 

--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -16,7 +16,7 @@ FROM ${CILIUM_LLVM_IMAGE} as llvm-dist
 FROM ${CILIUM_BPFTOOL_IMAGE} as bpftool-dist
 FROM ${CILIUM_IPROUTE2_IMAGE} as iproute2-dist
 
-FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
+FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as cni-builder
 
 COPY cni-version.sh /tmp/cni-version.sh
 COPY download-cni.sh /tmp/download-cni.sh
@@ -41,7 +41,7 @@ COPY --from=bpftool-dist /usr/local /usr/local
 COPY --from=iproute2-dist /usr/local /usr/local
 
 ARG TARGETPLATFORM
-COPY --from=builder /out/${TARGETPLATFORM}/bin /bin
+COPY --from=cni-builder /out/${TARGETPLATFORM}/bin /cni
 COPY --from=go-builder /out/${TARGETPLATFORM}/bin /bin
 
 FROM ${TESTER_IMAGE} as test


### PR DESCRIPTION
Fixes: f4dd2d7de1da ("build: New runtime image with multi-platform support")
Signed-off-by: André Martins <andre@cilium.io>

Fix: https://github.com/cilium/cilium/issues/14827

```release-note
Fix missing loopback CNI plugin in multi-arch images
```