### PR TITLE
dependabot: limit number of open PRs to 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
     rebase-strategy: "disabled"
     ignore:
         # cannot be updated until the etcd library is updated
@@ -19,6 +20,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
     rebase-strategy: "disabled"
     labels:
     - kind/enhancement


### PR DESCRIPTION
By default, dependabot opens up to 5 PRs for version updates, see
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit

This can leads to merge conflicts between these PRs (e.g. as recently
seen with the openapi updates) and need to rebase and retest these PRs.
In order to simplify the review process and avoid frequent rebases,
limit the maximum number of open PRs to 1, so they will keep coming in
one at a time.