### PR TITLE
lbmap: Initialize maps before test suite runs

### DIFF
--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -63,6 +63,14 @@ func (s *MaglevSuite) SetUpSuite(c *C) {
 	// Otherwise opening the map might fail with EPERM
 	err = unix.Setrlimit(unix.RLIMIT_MEMLOCK, &tmpLim)
 	c.Assert(err, IsNil)
+
+	Init(InitParams{
+		IPv4: option.Config.EnableIPv4,
+		IPv6: option.Config.EnableIPv6,
+
+		MaxSockRevNatMapEntries: option.Config.SockRevNatEntries,
+		MaxEntries:              option.Config.LBMapEntries,
+	})
 }
 
 func (s *MaglevSuite) TeadDownTest(c *C) {


### PR DESCRIPTION
This commit adds the missing initialization needed for BPF maps à la
d9fa628ea ("daemon, lbmap: Avoid premature init of BPF maps"). This
fixes the following test failure in the privileged tests:

```
$ sudo -E make -j $(nproc) TESTPKGS=pkg/maps/lbmap tests-privileged
...
=== RUN   Test
START: maglev_test.go:43: MaglevSuite.SetUpSuite
PASS: maglev_test.go:43: MaglevSuite.SetUpSuite 0.000s

START: maglev_test.go:73: MaglevSuite.TestInitMaps
level=info msg="Deleting Maglev outer map due to different M or empty map" bpfMapName=cilium_lb4_maglev subsys=map-lb
level=info msg="Deleting Maglev outer map due to different M or empty map" bpfMapName=cilium_lb4_maglev subsys=map-lb
level=info msg="Deleting Maglev outer map due to different M or empty map" bpfMapName=cilium_lb4_maglev subsys=map-lb
... Panic: runtime error: invalid memory address or nil pointer dereference (PC=0x4399D8)

/usr/lib/go/src/runtime/panic.go:969
  in gopanic
/usr/lib/go/src/runtime/panic.go:212
  in panicmem
/usr/lib/go/src/runtime/signal_unix.go:742
  in sigpanic
/home/chris/code/cilium/cilium/pkg/bpf/map_linux.go:464
  in Map.OpenOrCreate
lbmap.go:551
  in updateServiceEndpoint
lbmap.go:119
  in LBBPFMap.UpsertService
maglev_test.go:103
  in MaglevSuite.TestInitMaps
/usr/lib/go/src/reflect/value.go:337
  in Value.Call
/usr/lib/go/src/runtime/asm_amd64.s:1374
  in goexit
PANIC: maglev_test.go:73: MaglevSuite.TestInitMaps

OOPS: 0 passed, 1 PANICKED
--- FAIL: Test (0.11s)
FAIL
coverage: 10.4% of statements in github.com/cilium/cilium/pkg/maps/lbmap
FAIL    github.com/cilium/cilium/pkg/maps/lbmap 0.123s
FAIL
make: *** [Makefile:146: tests-privileged] Error 1
```

Fixes: d9fa628ea

Signed-off-by: Chris Tarazi <chris@isovalent.com>
