### PR TITLE
v1.8 backports 2021-02-02

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -59,6 +59,7 @@ cilium-agent [flags]
       --disable-iptables-feeder-rules strings         Chains to ignore when installing feeder rules.
       --dns-max-ips-per-restored-rule int             Maximum number of IPs to maintain for each restored DNS rule (default 1000)
       --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
+      --egress-multi-home-ip-rule-compat              Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.
       --enable-api-rate-limit                         Enables the use of the API rate limiting configuration
       --enable-auto-protect-node-port-range           Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bpf-clock-probe                        Enable BPF clock source probing for more efficient tick retrieval

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -28,6 +28,9 @@ type DaemonConfigurationStatus struct {
 	// MTU on workload facing devices
 	DeviceMTU int64 `json:"deviceMTU,omitempty"`
 
+	// Configured compatibility mode for --egress-multi-home-ip-rule-compat
+	EgressMultiHomeIPRuleCompat bool `json:"egress-multi-home-ip-rule-compat,omitempty"`
+
 	// Immutable configuration (read-only)
 	Immutable ConfigurationMap `json:"immutable,omitempty"`
 

--- a/api/v1/models/ip_a_m_address_response.go
+++ b/api/v1/models/ip_a_m_address_response.go
@@ -26,6 +26,10 @@ type IPAMAddressResponse struct {
 	// IP of gateway
 	Gateway string `json:"gateway,omitempty"`
 
+	// InterfaceNumber is a field for generically identifying an interface. This is only useful in ENI mode.
+	//
+	InterfaceNumber string `json:"interface-number,omitempty"`
+
 	// Allocated IP for endpoint
 	IP string `json:"ip,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1925,6 +1925,9 @@ definitions:
       masquerade:
         description: Status of masquerading feature
         type: boolean
+      egress-multi-home-ip-rule-compat:
+        description: Configured compatibility mode for --egress-multi-home-ip-rule-compat
+        type: boolean
   DatapathMode:
     description: Datapath mode
     type: string

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1398,6 +1398,10 @@ definitions:
         description: |
           The UUID for the expiration timer. Set when expiration has been
           enabled while allocating.
+      interface-number:
+        type: string
+        description: |
+          InterfaceNumber is a field for generically identifying an interface. This is only useful in ENI mode.
   AddressPair:
     description: Addressing information of an endpoint
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2326,6 +2326,10 @@ func init() {
           "description": "IP of gateway",
           "type": "string"
         },
+        "interface-number": {
+          "description": "InterfaceNumber is a field for generically identifying an interface. This is only useful in ENI mode.\n",
+          "type": "string"
+        },
         "ip": {
           "description": "Allocated IP for endpoint",
           "type": "string"
@@ -5960,6 +5964,10 @@ func init() {
         },
         "gateway": {
           "description": "IP of gateway",
+          "type": "string"
+        },
+        "interface-number": {
+          "description": "InterfaceNumber is a field for generically identifying an interface. This is only useful in ENI mode.\n",
           "type": "string"
         },
         "ip": {

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1678,6 +1678,10 @@ func init() {
           "description": "MTU on workload facing devices",
           "type": "integer"
         },
+        "egress-multi-home-ip-rule-compat": {
+          "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
+          "type": "boolean"
+        },
         "immutable": {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
@@ -5309,6 +5313,10 @@ func init() {
         "deviceMTU": {
           "description": "MTU on workload facing devices",
           "type": "integer"
+        },
+        "egress-multi-home-ip-rule-compat": {
+          "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
+          "type": "boolean"
         },
         "immutable": {
           "description": "Immutable configuration (read-only)",

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -346,8 +346,11 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
-		if err := routingConfig.Configure(healthIP, mtuConfig.GetDeviceMTU()); err != nil {
-
+		if err := routingConfig.Configure(
+			healthIP,
+			mtuConfig.GetDeviceMTU(),
+			option.Config.EgressMultiHomeIPRuleCompat,
+		); err != nil {
 			return nil, fmt.Errorf("Error while configuring health endpoint rules and routes: %s", err)
 		}
 	}
@@ -373,5 +376,5 @@ func LaunchAsEndpoint(baseCtx context.Context,
 }
 
 type routingConfigurer interface {
-	Configure(ip net.IP, mtu int) error
+	Configure(ip net.IP, mtu int, compat bool) error
 }

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -346,9 +346,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
-		if err := routingConfig.Configure(healthIP,
-			mtuConfig.GetDeviceMTU(),
-			option.Config.Masquerade); err != nil {
+		if err := routingConfig.Configure(healthIP, mtuConfig.GetDeviceMTU()); err != nil {
 
 			return nil, fmt.Errorf("Error while configuring health endpoint rules and routes: %s", err)
 		}
@@ -375,5 +373,5 @@ func LaunchAsEndpoint(baseCtx context.Context,
 }
 
 type routingConfigurer interface {
-	Configure(ip net.IP, mtu int, masq bool) error
+	Configure(ip net.IP, mtu int) error
 }

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -132,8 +132,9 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 			MasterDeviceIndex: int64(option.Config.Ipvlan.MasterDeviceIndex),
 			OperationMode:     option.Config.Ipvlan.OperationMode,
 		},
-		IpamMode:   option.Config.IPAM,
-		Masquerade: option.Config.Masquerade,
+		IpamMode:                    option.Config.IPAM,
+		Masquerade:                  option.Config.Masquerade,
+		EgressMultiHomeIPRuleCompat: option.Config.EgressMultiHomeIPRuleCompat,
 	}
 
 	cfg := &models.DaemonConfiguration{

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -838,6 +838,10 @@ func init() {
 	flags.Bool(option.EnableAPIRateLimit, false, "Enables the use of the API rate limiting configuration")
 	option.BindEnv(option.EnableAPIRateLimit)
 
+	flags.Bool(option.EgressMultiHomeIPRuleCompat, false,
+		"Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.")
+	option.BindEnv(option.EgressMultiHomeIPRuleCompat)
+
 	viper.BindPFlags(flags)
 
 	CustomCommandHelpFormat(RootCmd, option.HelpFlagSections)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1220,6 +1220,18 @@ func initEnv(cmd *cobra.Command) {
 			}
 		}
 	}
+
+	if option.Config.IPAM == ipamOption.IPAMAzure {
+		option.Config.EgressMultiHomeIPRuleCompat = true
+		log.WithFields(logrus.Fields{
+			"URL": "https://github.com/cilium/cilium/issues/14705",
+		}).Infof(
+			"Auto-set %q to `true` because the Azure datapath has not been migrated over to a new scheme. "+
+				"A future version of Cilium will support a newer Azure datapath. "+
+				"Connectivity is not affected.",
+			option.EgressMultiHomeIPRuleCompat,
+		)
+	}
 }
 
 func (d *Daemon) initKVStore() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/api/v1/server/restapi"
+	enitypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/cleanup"
@@ -39,6 +40,7 @@ import (
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/maps"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
@@ -49,6 +51,7 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -78,6 +81,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -1399,6 +1403,31 @@ func runDaemon() {
 		}()
 	}
 
+	// Migrating the ENI datapath must happen before the API is served to
+	// prevent endpoints from being created. It also must be before the health
+	// initialization logic which creates the health endpoint, for the same
+	// reasons as the API being served. We want to ensure that this migration
+	// logic runs before any endpoint creates.
+	if option.Config.IPAM == ipamOption.IPAMENI {
+		migrated, failed := linuxrouting.NewMigrator(
+			&interfaceNumberGetter{},
+		).MigrateENIDatapath(option.Config.EgressMultiHomeIPRuleCompat)
+		switch {
+		case failed == -1:
+			// No need to handle this case specifically because it is handled
+			// in the call already.
+		case migrated >= 0 && failed > 0:
+			log.Errorf("Failed to migrate ENI datapath. "+
+				"%d endpoints were successfully migrated and %d failed to migrate completely. "+
+				"The original datapath is still in-place, however it is recommended to retry the migration.",
+				migrated, failed)
+
+		case migrated >= 0 && failed == 0:
+			log.Infof("Migration of ENI datapath successful, %d endpoints were migrated and none failed.",
+				migrated)
+		}
+	}
+
 	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking {
 		d.initHealth()
@@ -1618,4 +1647,86 @@ func initClockSourceOption() {
 			}
 		}
 	}
+}
+
+// GetInterfaceNumberByMAC implements the linuxrouting.interfaceDB interface.
+// It retrieves the number associated with the ENI device for the given MAC
+// address. The interface number is retrieved from the CiliumNode resource, as
+// this functionality is needed for ENI mode.
+func (in *interfaceNumberGetter) GetInterfaceNumberByMAC(mac string) (int, error) {
+	// Update the cache on the first run. After retrieving the CiliumNode
+	// resource, we use the cached result for the remainder of the migration.
+	if len(in.cache.ENIs) == 0 {
+		cn, err := in.fetchFromK8s(nodeTypes.GetName())
+		if err != nil {
+			return -1, err
+		}
+
+		in.cache = cn.Status.ENI
+	}
+
+	var (
+		eni   enitypes.ENI
+		found bool
+	)
+	for _, e := range in.cache.ENIs {
+		if e.MAC == mac {
+			eni = e
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return -1, fmt.Errorf("could not find interface with MAC %q in CiliumNode resource", mac)
+	}
+
+	return eni.Number, nil
+}
+
+// GetInterfaceNumberByMAC retrieves the number associated with the ENI device
+// for the given MAC address. The interface number is retrieved from the
+// CiliumNode resource, as this functionality is needed for ENI mode. This
+// implements the linuxrouting.interfaceDB interface.
+func (in *interfaceNumberGetter) GetMACByInterfaceNumber(ifaceNum int) (string, error) {
+	// Update the cache on the first run. After retrieving the CiliumNode
+	// resource, we use the cached result for the remainder of the migration.
+	if len(in.cache.ENIs) == 0 {
+		cn, err := in.fetchFromK8s(nodeTypes.GetName())
+		if err != nil {
+			return "", err
+		}
+
+		in.cache = cn.Status.ENI
+	}
+
+	var (
+		eni   enitypes.ENI
+		found bool
+	)
+	for _, e := range in.cache.ENIs {
+		if e.Number == ifaceNum {
+			eni = e
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return "", fmt.Errorf("could not find interface with number %q in CiliumNode resource", ifaceNum)
+	}
+
+	return eni.MAC, nil
+}
+
+func (in *interfaceNumberGetter) fetchFromK8s(name string) (*v2.CiliumNode, error) {
+	return k8s.CiliumClient().CiliumV2().CiliumNodes().Get(
+		context.TODO(),
+		nodeTypes.GetName(),
+		v1.GetOptions{},
+	)
+}
+
+type interfaceNumberGetter struct {
+	cache enitypes.ENIStatus
 }

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -374,6 +374,7 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 		result.GatewayIP,
 		result.CIDRs,
 		result.Master,
+		result.InterfaceNumber,
 		option.Config.Masquerade,
 	)
 	return err

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -68,22 +68,24 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 	if ipv4Result != nil {
 		resp.Address.IPV4 = ipv4Result.IP.String()
 		resp.IPV4 = &models.IPAMAddressResponse{
-			Cidrs:          ipv4Result.CIDRs,
-			IP:             ipv4Result.IP.String(),
-			MasterMac:      ipv4Result.Master,
-			Gateway:        ipv4Result.GatewayIP,
-			ExpirationUUID: ipv4Result.ExpirationUUID,
+			Cidrs:           ipv4Result.CIDRs,
+			IP:              ipv4Result.IP.String(),
+			MasterMac:       ipv4Result.Master,
+			Gateway:         ipv4Result.GatewayIP,
+			ExpirationUUID:  ipv4Result.ExpirationUUID,
+			InterfaceNumber: ipv4Result.InterfaceNumber,
 		}
 	}
 
 	if ipv6Result != nil {
 		resp.Address.IPV6 = ipv6Result.IP.String()
 		resp.IPV6 = &models.IPAMAddressResponse{
-			Cidrs:          ipv6Result.CIDRs,
-			IP:             ipv6Result.IP.String(),
-			MasterMac:      ipv6Result.Master,
-			Gateway:        ipv6Result.GatewayIP,
-			ExpirationUUID: ipv6Result.ExpirationUUID,
+			Cidrs:           ipv6Result.CIDRs,
+			IP:              ipv6Result.IP.String(),
+			MasterMac:       ipv6Result.Master,
+			Gateway:         ipv6Result.GatewayIP,
+			ExpirationUUID:  ipv6Result.ExpirationUUID,
+			InterfaceNumber: ipv6Result.InterfaceNumber,
 		}
 	}
 
@@ -368,9 +370,11 @@ func (d *Daemon) bootstrapIPAM() {
 
 func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 	var err error
-	d.healthEndpointRouting, err = linuxrouting.NewRoutingInfo(result.GatewayIP,
+	d.healthEndpointRouting, err = linuxrouting.NewRoutingInfo(
+		result.GatewayIP,
 		result.CIDRs,
 		result.Master,
-		option.Config.Masquerade)
+		option.Config.Masquerade,
+	)
 	return err
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -23,6 +23,12 @@ const (
 	// RouteTableIPSec is the default table ID to use for IPSec routing rules
 	RouteTableIPSec = 200
 
+	// RouteTableInterfacesOffset is the offset for the per-ENI routing tables.
+	// Each ENI interface will have its own table starting with this offset. It
+	// is 10 because it is highly unlikely to collide with the main routing
+	// table which is between 253-255. See ip-route(8).
+	RouteTableInterfacesOffset = 10
+
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.
 	RouteMarkDecrypt = 0x0D00

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -55,6 +55,14 @@ const (
 	// of endpoints. This priority is after the local table priority.
 	RulePriorityEgress = 110
 
+	// RulePriorityEgress is the v2 of the priority of the rule used for egress
+	// routing of endpoints. This priority is after the local table priority.
+	//
+	// Because of https://github.com/cilium/cilium/issues/14336, we must use a
+	// new priority value to disambiguate which rules are still under the old
+	// scheme.
+	RulePriorityEgressv2 = 111
+
 	// RulePriorityNodeport is the priority of the rule used with AWS ENI to
 	// make sure that lookups for multi-node NodePort traffic are NOT done
 	// from the table for the VPC to which the endpoint's CIDR is

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -41,6 +41,11 @@ type RoutingInfo struct {
 	// traffic is directed to. This is the MAC of the interface itself which
 	// corresponds to the IPv4Gateway IP addr.
 	MasterIfMAC mac.MAC
+
+	// InterfaceNumber is the generic number of the master interface that
+	// egress traffic is directed to. This is used to compute the table ID for
+	// the per-ENI tables.
+	InterfaceNumber int
 }
 
 // NewRoutingInfo creates a new RoutingInfo struct, from data that will be

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -42,6 +42,9 @@ type RoutingInfo struct {
 	// corresponds to the IPv4Gateway IP addr.
 	MasterIfMAC mac.MAC
 
+	// Masquerade represents whether masquerading is enabled or not.
+	Masquerade bool
+
 	// InterfaceNumber is the generic number of the master interface that
 	// egress traffic is directed to. This is used to compute the table ID for
 	// the per-ENI tables.
@@ -86,5 +89,6 @@ func parse(gateway string, cidrs []string, macAddr string, masquerade bool) (*Ro
 		IPv4Gateway: ip,
 		IPv4CIDRs:   parsedCIDRs,
 		MasterIfMAC: parsedMAC,
+		Masquerade:  masquerade,
 	}, nil
 }

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -49,6 +49,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 		cidrs     []string
 		macAddr   string
 		masq      bool
+		ifaceNum  string
 		wantRInfo *RoutingInfo
 		wantErr   bool
 	}{
@@ -107,24 +108,35 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 			wantErr:   true,
 		},
 		{
-			name:    "valid IPv4 input",
-			gateway: "192.168.1.1",
-			cidrs:   []string{"192.168.0.0/16"},
-			macAddr: "11:22:33:44:55:66",
-			masq:    true,
+			name:      "invalid interface number",
+			gateway:   "192.168.1.1",
+			cidrs:     []string{"192.168.0.0/16"},
+			macAddr:   "11:22:33:44:55:zz",
+			ifaceNum:  "a",
+			wantRInfo: nil,
+			wantErr:   true,
+		},
+		{
+			name:     "valid IPv4 input",
+			gateway:  "192.168.1.1",
+			cidrs:    []string{"192.168.0.0/16"},
+			macAddr:  "11:22:33:44:55:66",
+			ifaceNum: "1",
 			wantRInfo: &RoutingInfo{
-				IPv4Gateway: net.ParseIP("192.168.1.1"),
-				IPv4CIDRs:   validCIDRs,
-				MasterIfMAC: fakeMAC,
+				IPv4Gateway:     net.ParseIP("192.168.1.1"),
+				IPv4CIDRs:       validCIDRs,
+				MasterIfMAC:     fakeMAC,
+				InterfaceNumber: 1,
 			},
 			wantErr: false,
 		},
 		{
-			name:    "disabled masquerade",
-			gateway: "192.168.1.1",
-			cidrs:   []string{},
-			macAddr: "11:22:33:44:55:66",
-			masq:    false,
+			name:     "disabled masquerade",
+			gateway:  "192.168.1.1",
+			cidrs:    []string{},
+			macAddr:  "11:22:33:44:55:66",
+			masq:     false,
+			ifaceNum: "0",
 			wantRInfo: &RoutingInfo{
 				IPv4Gateway: net.ParseIP("192.168.1.1"),
 				IPv4CIDRs:   []net.IPNet{},
@@ -144,7 +156,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 	}
 	for _, tt := range tests {
 		c.Log(tt.name)
-		rInfo, err := NewRoutingInfo(tt.gateway, tt.cidrs, tt.macAddr, tt.masq)
+		rInfo, err := NewRoutingInfo(tt.gateway, tt.cidrs, tt.macAddr, tt.ifaceNum, tt.masq)
 		c.Assert(rInfo, checker.DeepEquals, tt.wantRInfo)
 		c.Assert((err != nil), check.Equals, tt.wantErr)
 	}

--- a/pkg/datapath/linux/routing/migrate.go
+++ b/pkg/datapath/linux/routing/migrate.go
@@ -1,0 +1,628 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linuxrouting
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/revert"
+
+	"github.com/vishvananda/netlink"
+)
+
+// MigrateENIDatapath migrates the egress rules inside the Linux routing policy
+// database (RPDB) for ENI IPAM mode. It will return the number of rules that
+// were successfully migrated and the number of rules we've failed to migrated.
+// A -1 is returned for the failed number of rules if we couldn't even start
+// the migration.
+//
+// The compat flag will control what Cilium will do in the migration process.
+// If the flag is false, this instructs Cilium to ensure the datapath is newer
+// (or v2). If the flag is true, Cilium will ensure the original datapath (v1)
+// is in-place.
+//
+// Because this migration is on a best-effort basis, we ensure that each rule
+// (or endpoint), at the end, has either the new datapath or the original
+// in-place and serviceable. Otherwise we risk breaking connectivity.
+//
+// We rely on the ability to fetch the CiliumNode resource because we need to
+// fetch the number associated with the ENI device. The CiliumNode resource
+// contains this information in the Status field. This fetch is abstracted away
+// in the (*migrator).getter interface to avoid bringing in K8s logic to this
+// low-level datapath code.
+//
+// This function should be invoked before any endpoints are created.
+// Concretely, this function should be invoked before exposing the Cilium API
+// and health initialization logic because we want to ensure that no workloads
+// are scheduled while this modification is taking place. This migration is
+// related to a bug (https://github.com/cilium/cilium/issues/14336) where an
+// ENI has an ifindex that equals the main routing table number (253-255),
+// causing the rules and routes to be created using the wrong table ID, which
+// could end up blackholing most traffic on the node.
+func (m *migrator) MigrateENIDatapath(compat bool) (int, int) {
+	rules, err := m.rpdb.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to migrate ENI datapath due to a failure in listing the existing rules. " +
+				"The original datapath is still in-place, however it is recommended to retry the migration.")
+		return 0, -1
+	}
+
+	v1Rules := filterRulesByPriority(rules, linux_defaults.RulePriorityEgress)
+	v2Rules := filterRulesByPriority(rules, linux_defaults.RulePriorityEgressv2)
+
+	// (1) If compat=false and the current set of rules are under the older
+	// priority, then this is an upgrade migration.
+	//
+	// (2) If compat=false and the current set of rules are under the newer
+	// priority, then there is nothing to do.
+	//
+	// (3) If compat=true and the current set of rules are under the older
+	// priority, then there is nothing to do.
+	//
+	// (4) If compat=true and the current set of rules are under the newer
+	// priority, then this is a downgrade migration.
+
+	// Exit if there's nothing to do.
+	switch {
+	case !compat && len(v1Rules) == 0 && len(v2Rules) > 0: // 2
+		fallthrough
+	case compat && len(v1Rules) > 0 && len(v2Rules) == 0: // 3
+		return 0, 0
+	}
+
+	isUpgrade := !compat && len(v1Rules) > 0  // 1
+	isDowngrade := compat && len(v2Rules) > 0 // 4
+
+	// The following operation will be done on a per-rule basis (or
+	// per-endpoint, assuming that each egress rule has a unique IP addr
+	// associated with the endpoint).
+	//
+	// In both the upgrade and downgrade scenario, the following happens in a
+	// specific order to guarantee that any failure at any point won't cause
+	// connectivity disruption for the endpoint. Any errors encountered do not
+	// stop the migration process because we want to ensure that we conform to
+	// either the new state or the old state, and want to avoid being
+	// in-between datapath states.
+	//   1) Copy over new routes from the old routes
+	//   2) Insert new rule
+	//   3) Delete old rule
+	//   4) Delete old routes
+	// Doing (1) & (2) before (3) & (4) allows us to essentially perform an
+	// "atomic" swap-in for the new state.
+	//
+	// (4) is attempted separately outside the main loop because we want to
+	// avoid deleting routes for endpoints that share the same table ID. We
+	// will delete the routes, if and only if, all endpoints that share the
+	// same table ID succeeded in migrating. If an endpoint failed to migrate,
+	// then any routes that reference the table ID associated with the
+	// endpoint's egress rule will be skipped. This is to prevent disrupting
+	// endpoints who relying on the old state to be in-place.
+	//
+	// If a failure occurs at (1), then the old state can continue to service
+	// the endpoint. Similarly with (2) because routes without rules are likely
+	// to not have any effect.
+	//
+	// If a failure occurs at (3), we have already succeeded in getting the new
+	// state in-place to direct traffic for the endpoint. In any case of
+	// upgrade or downgrade, it is possible for both states to be in-place if
+	// there are any failures, especially if there were any failures in
+	// reverting. The datapath selected will depend on the rule priority.
+	//
+	// Concretely, for upgrades, the newer rule will have a lower priority, so
+	// the original datapath will be selected. The migration is deemed a
+	// failure because the original datapath (with a rule that has a higher
+	// priority) is being selected for the endpoint. It is necessary to attempt
+	// reverting the failed migration work [(1) & (2)], as leaving the state
+	// could block a user's from retrying this upgrade again.
+	//
+	// For downgrades, the newer rule will have a higher priority, so the newer
+	// datapath will be selected. The migration is deemed a success and we
+	// explicitly avoid reverting, because it's not necessary to revert this
+	// work merely because we failed to cleanup old, ineffectual state.
+	//
+	// In either case, no connectivity is affected for the endpoint.
+	//
+	// If we fail at (4), then the old rule will have been deleted and the new
+	// state is in-place, which would be servicing the endpoint. The old routes
+	// would just be leftover state to be cleaned up at a later point.
+	//
+	// It is also important to note that we only revert what we've done on a
+	// per-rule basis if we fail at (2) or (3). This is by design because we
+	// want to ensure that each iteration of the loop is atomic to each
+	// endpoint. Meaning, either the endpoint ends up with the new datapath or
+	// the original.
+
+	var (
+		// Number of rules (endpoints) successfully migrated and how many failed.
+		migrated, failed int
+		// Store the routes to cleanup in a set after successful migration
+		// because routes are only unique per table ID, meaning many endpoints
+		// share the same route table if the endpoint's IP is allocated from
+		// the same ENI device.
+		cleanup = make(map[netlink.Rule][]netlink.Route)
+		// Store the table IDs of the routes whose migration failed. This is
+		// important because to prevent deleting routes for endpoints that
+		// share the same table ID. An example: let's say we have 2 endpoints
+		// that have rules and routes that refer to the same table ID. If 1
+		// endpoint fails the migration and the other succeeded, we must not
+		// remove the routes for the endpoint that failed because it's still
+		// relying on them for connectivity.
+		failedTableIDs = make(map[int]struct{})
+	)
+
+	if isUpgrade {
+		for _, r := range v1Rules {
+			if routes, err := m.upgradeRule(r); err != nil {
+				log.WithError(err).WithField("rule", r).Warn("Failed to migrate endpoint to new ENI datapath. " +
+					"Previous datapath is still intact and endpoint connectivity is not affected.")
+				failedTableIDs[r.Table] = struct{}{}
+				failed++
+			} else {
+				if rs, found := cleanup[r]; found {
+					rs = append(rs, routes...)
+					cleanup[r] = rs
+				} else {
+					cleanup[r] = routes
+				}
+				migrated++
+			}
+		}
+	} else if isDowngrade {
+		for _, r := range v2Rules {
+			if routes, err := m.downgradeRule(r); err != nil {
+				log.WithError(err).WithField("rule", r).Warn("Failed to downgrade endpoint to original ENI datapath. " +
+					"Previous datapath is still intact and endpoint connectivity is not affected.")
+				failedTableIDs[r.Table] = struct{}{}
+				failed++
+			} else {
+				if rs, found := cleanup[r]; found {
+					rs = append(rs, routes...)
+					cleanup[r] = rs
+				} else {
+					cleanup[r] = routes
+				}
+				migrated++
+			}
+		}
+	}
+
+	// We store the routes that have already been deleted to de-duplicate and
+	// avoid netlink returning "no such process" for a route that has already
+	// been deleted. Note the map key is a string representation of a
+	// netlink.Route because netlink.Route is not a valid map key because it is
+	// incomparable due to containing a slice inside it.
+	deleted := make(map[string]struct{}, len(cleanup))
+
+	for rule, routes := range cleanup {
+		toDelete := make([]netlink.Route, 0, len(routes))
+		for _, ro := range routes {
+			if _, skip := failedTableIDs[rule.Table]; skip {
+				continue
+			}
+
+			if _, already := deleted[ro.String()]; !already {
+				// Declare the routes deleted here before the actual deletion
+				// below because we don't care if deletion succeeds or not. See
+				// comment below on why.
+				deleted[ro.String()] = struct{}{}
+				toDelete = append(toDelete, ro)
+			}
+		}
+
+		// This function does not return a revert stack unlike the others
+		// because this operation is best-effort. If we fail to delete old
+		// routes, then it simply means there is just leftover state left
+		// behind, but it has no impact on the datapath whatsoever. We can make
+		// that assumption because by the time we call this function, we'd have
+		// successfully deleted the old rule which would steer traffic towards
+		// these routes.
+		//
+		// We also don't want to revert here because at this point, the new
+		// datapath is in-place and it wouldn't make sense to risk reverting in
+		// case of a failure, just to merely cleanup the previous state. We'll
+		// live with the leftover state, however the user should be advised to
+		// eventually clean this up.
+		if err := m.deleteOldRoutes(toDelete); err != nil {
+			version := "new"
+			if rule.Priority == linux_defaults.RulePriorityEgressv2 {
+				version = "original"
+			}
+
+			scopedLog := log.WithField("rule", rule)
+			scopedLog.WithError(err).WithField("routes", routes).
+				Warnf("Failed to cleanup after successfully migrating endpoint to %s ENI datapath. "+
+					"It is recommended that theses routes are cleaned up, as it is possible in the future "+
+					"to collide with another endpoint with the same IP.", version)
+		}
+	}
+
+	return migrated, failed
+}
+
+// NewMigrator constructs a migrator object with the default implementation to
+// use the underlying upstream netlink library to manipulate the Linux RPDB.
+// It accepts a getter for retrieving the interface number by MAC address and
+// vice versa.
+func NewMigrator(getter interfaceDB) *migrator {
+	return &migrator{
+		rpdb:   defaultRPDB{},
+		getter: getter,
+	}
+}
+
+// upgradeRule migrates the given rule (and endpoint) to the new ENI datapath,
+// using the new table ID scheme derived from the ENI interface number. It
+// returns the old routes that the caller should remove at a later time, along
+// with an error.
+func (m *migrator) upgradeRule(rule netlink.Rule) ([]netlink.Route, error) {
+	// Let's say we have an ENI device attached to the node with ifindex 3 and
+	// interface number 2. The following rule will exist on the node _before_
+	// migration.
+	//   110:    from 192.168.11.171 to 192.168.0.0/16 lookup 3
+	// After the migration, this rule will become:
+	//   111:    from 192.168.11.171 to 192.168.0.0/16 lookup 12
+	// The priority has been updated to 111 and the table ID is 12 because the
+	// interface number is 2 plus the routing table offset
+	// (linux_defaults.RouteTableInterfacesOffset). See copyRoutes() for what
+	// happens with routes.
+
+	scopedLog := log.WithField("rule", rule)
+
+	routes, err := m.rpdb.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+		Table: rule.Table,
+	}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list routes associated with rule: %w", err)
+	}
+
+	// If there are no routes under the same table as the rule, then
+	// skip.
+	if len(routes) == 0 {
+		scopedLog.Debug("Skipping migration of egress rule due to no routes found")
+		return nil, nil
+	}
+
+	// It is sufficient to grab the first route that matches because we
+	// are assuming all routes created under a rule will have the same
+	// ifindex (LinkIndex).
+	ifindex := routes[0].LinkIndex
+	newTable, err := m.retrieveTableIDFromIfIndex(ifindex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve new table ID from ifindex %q: %w",
+			ifindex, err)
+	}
+
+	var (
+		stack revert.RevertStack
+
+		oldTable = rule.Table
+	)
+
+	revert, err := m.copyRoutes(routes, oldTable, newTable)
+	stack.Extend(revert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new routes: %w", err)
+	}
+
+	revert, err = m.createNewRule(
+		rule,
+		linux_defaults.RulePriorityEgressv2,
+		newTable,
+	)
+	stack.Extend(revert)
+	if err != nil {
+		// We revert here because we want to ensure that the new routes
+		// are removed as they'd have no effect, but may conflict with
+		// others in the future.
+		if revErr := stack.Revert(); revErr != nil {
+			scopedLog.WithError(err).WithField("revertError", revErr).Warn(upgradeRevertWarning)
+		}
+
+		return nil, fmt.Errorf("failed to create new rule: %w", err)
+	}
+
+	if err := m.rpdb.RuleDel(&rule); err != nil {
+		// We revert here because we want to ensure that the new state that we
+		// just created above is reverted. See long comment describing the
+		// migration in MigrateENIDatapath().
+		if revErr := stack.Revert(); revErr != nil {
+			scopedLog.WithError(err).WithField("revertError", revErr).Warn(upgradeRevertWarning)
+		}
+
+		return nil, fmt.Errorf("failed to delete old rule: %w", err)
+	}
+
+	return routes, nil
+}
+
+// downgradeRule migrates the given rule (and endpoint) to the original ENI
+// datapath, using the old table ID scheme that was simply the ifindex of the
+// attached ENI device on the node. It returns the "old" routes (new datapath)
+// that the caller should remove at a later time, along with an error.
+func (m *migrator) downgradeRule(rule netlink.Rule) ([]netlink.Route, error) {
+	// Let's say we have an ENI device attached to the node with ifindex 9 and
+	// interface number 3. The following rule will exist on the node _before_
+	// migration.
+	//   111:    from 192.168.11.171 to 192.168.0.0/16 lookup 13
+	// After the migration, this rule will become:
+	//   110:    from 192.168.11.171 to 192.168.0.0/16 lookup 9
+	// The priority has been reverted back to 110 and the table ID back to 9
+	// because the ifindex is 9. See copyRoutes() for what happens with routes.
+
+	scopedLog := log.WithField("rule", rule)
+
+	oldTable := rule.Table
+	ifaceNumber := oldTable - linux_defaults.RouteTableInterfacesOffset
+
+	newTable, err := m.retrieveTableIDFromInterfaceNumber(ifaceNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve new table ID from interface-number %q: %w",
+			ifaceNumber, err)
+	}
+
+	routes, err := m.rpdb.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+		Table: oldTable,
+	}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list routes associated with rule: %w", err)
+	}
+
+	var stack revert.RevertStack
+
+	revert, err := m.copyRoutes(routes, oldTable, newTable)
+	stack.Extend(revert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new routes: %w", err)
+	}
+
+	// We don't need the revert stack return value because the next operation
+	// to delete the rule will not revert the stack. See below comment on why.
+	_, err = m.createNewRule(
+		rule,
+		linux_defaults.RulePriorityEgress,
+		newTable,
+	)
+	if err != nil {
+		if revErr := stack.Revert(); revErr != nil {
+			scopedLog.WithError(err).WithField("revertError", revErr).Warn(downgradeRevertWarning)
+		}
+
+		return nil, fmt.Errorf("failed to create new rule: %w", err)
+	}
+
+	if err := m.rpdb.RuleDel(&rule); err != nil {
+		// We avoid reverting and returning an error here because the newer
+		// datapath is already in-place. See long comment describing the
+		// migration in MigrateENIDatapath().
+		scopedLog.WithError(err).Warn(downgradeFailedRuleDeleteWarning)
+		return nil, nil
+	}
+
+	return routes, nil
+}
+
+const (
+	upgradeRevertWarning = "Reverting the new ENI datapath failed. However, the previous datapath is still intact. " +
+		"Endpoint connectivity should not be affected. It is advised to retry the migration."
+	downgradeRevertWarning = "Reverting the new ENI datapath failed. However, both the new and previous datapaths are still intact. " +
+		"Endpoint connectivity should not be affected. It is advised to retry the migration."
+	downgradeFailedRuleDeleteWarning = "Downgrading the datapath has succeeded, but failed to cleanup the original datapath. " +
+		"It is advised to manually remove the old rule."
+)
+
+// retrieveTableIDFromIfIndex computes the correct table ID based on the
+// ifindex provided. The table ID is comprised of the number associated with an
+// ENI device that corresponds to the ifindex, plus the specific table offset
+// value.
+func (m *migrator) retrieveTableIDFromIfIndex(ifindex int) (int, error) {
+	link, err := m.rpdb.LinkByIndex(ifindex)
+	if err != nil {
+		return -1, fmt.Errorf("failed to find link by index: %w", err)
+	}
+
+	mac := link.Attrs().HardwareAddr.String()
+	ifaceNum, err := m.getter.GetInterfaceNumberByMAC(mac)
+	if err != nil {
+		return -1, fmt.Errorf("failed to get interface-number by MAC %q: %w", mac, err)
+	}
+
+	// This is guaranteed to avoid conflicting with the main routing table ID
+	// (253-255) because the maximum number of ENI devices on a node is 15 (see
+	// pkg/aws/eni/limits.go). Because the interface number is monotonically
+	// increasing and the lowest available number is reused when devices are
+	// added / removed. This means that the max possible table ID is 25.
+	return linux_defaults.RouteTableInterfacesOffset + ifaceNum, nil
+}
+
+// retrieveTableIDFromInterfaceNumber returns the table ID based on the
+// interface number. The table ID is the ifindex of the device corresponding to
+// the ENI with the given interface number. This is used for downgrading /
+// using the old ENI datapath.
+func (m *migrator) retrieveTableIDFromInterfaceNumber(ifaceNum int) (int, error) {
+	mac, err := m.getter.GetMACByInterfaceNumber(ifaceNum)
+	if err != nil {
+		return -1, fmt.Errorf("failed to get interface-number by MAC %q: %w", mac, err)
+	}
+
+	links, err := m.rpdb.LinkList()
+	if err != nil {
+		return -1, fmt.Errorf("failed to list links: %w", err)
+	}
+
+	var (
+		link  netlink.Link
+		found bool
+	)
+	for _, l := range links {
+		if l.Attrs().HardwareAddr.String() == mac {
+			link = l
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return -1, fmt.Errorf("could not find link with MAC %q by interface-number %q", mac, ifaceNum)
+	}
+
+	return link.Attrs().Index, nil
+}
+
+// copyRoutes upserts `routes` under the `from` table ID to `to` table ID. It
+// returns a RevertStack and an error. The RevertStack contains functions that
+// would revert all the successful operations that occurred in this function.
+// The caller of this function MUST revert the stack when this function returns
+// an error.
+func (m *migrator) copyRoutes(routes []netlink.Route, from, to int) (revert.RevertStack, error) {
+	var revertStack revert.RevertStack
+
+	// In ENI mode, we only expect two rules:
+	//   1) Link scoped route with a gateway IP
+	//   2) Default route via gateway IP
+	// We need to add the link-local scope route to the gateway first, then
+	// routes that depend on that as a next-hop later. If we didn't do this,
+	// then the kernel would complain with "Error: Nexthop has invalid
+	// gateway." with an errno of ENETUNREACH.
+	for _, r := range routes {
+		if r.Scope == netlink.SCOPE_LINK {
+			route := r
+			route.Table = to
+			if err := m.rpdb.RouteReplace(&route); err != nil {
+				return revertStack, fmt.Errorf("unable to replace link scoped route under table ID: %w", err)
+			}
+
+			revertStack.Push(func() error {
+				if err := m.rpdb.RouteDel(&route); err != nil {
+					return fmt.Errorf("failed to revert route upsert: %w", err)
+				}
+				return nil
+			})
+		}
+	}
+
+	for _, r := range routes {
+		if r.Scope == netlink.SCOPE_LINK {
+			// Skip over these because we already upserted it above.
+			continue
+		}
+
+		route := r
+		route.Table = to
+		if err := m.rpdb.RouteReplace(&route); err != nil {
+			return revertStack, fmt.Errorf("unable to replace route under table ID: %w", err)
+		}
+
+		revertStack.Push(func() error {
+			if err := m.rpdb.RouteDel(&route); err != nil {
+				return fmt.Errorf("failed to revert route upsert: %w", err)
+			}
+			return nil
+		})
+	}
+
+	return revertStack, nil
+}
+
+// createNewRule inserts `rule` with the table ID of `newTable` and a priority
+// of `toPrio`. It returns a RevertStack and an error. The RevertStack contains
+// functions that would revert all the successful operations that occurred in
+// this function. The caller of this function MUST revert the stack when this
+// function returns an error.
+func (m *migrator) createNewRule(rule netlink.Rule, toPrio, newTable int) (revert.RevertStack, error) {
+	var revertStack revert.RevertStack
+
+	r := rule
+	r.Priority = toPrio
+	r.Table = newTable
+	if err := m.rpdb.RuleAdd(&r); err != nil {
+		return revertStack, fmt.Errorf("unable to add new rule: %w", err)
+	}
+
+	revertStack.Push(func() error {
+		if err := m.rpdb.RuleDel(&r); err != nil {
+			return fmt.Errorf("failed to revert rule insert: %w", err)
+		}
+		return nil
+	})
+
+	return revertStack, nil
+}
+
+func (m *migrator) deleteOldRoutes(routes []netlink.Route) error {
+	for _, r := range routes {
+		if err := m.rpdb.RouteDel(&r); err != nil {
+			return fmt.Errorf("unable to delete old route: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func filterRulesByPriority(rules []netlink.Rule, prio int) []netlink.Rule {
+	candidates := make([]netlink.Rule, 0, len(rules))
+	for _, r := range rules {
+		if r.Priority == prio {
+			candidates = append(candidates, r)
+		}
+	}
+
+	return candidates
+}
+
+type migrator struct {
+	rpdb   rpdb
+	getter interfaceDB
+}
+
+// defaultRPDB is a simple, default implementation of the rpdb interface which
+// forwards all RPDB operations to netlink.
+type defaultRPDB struct{}
+
+func (defaultRPDB) RuleList(family int) ([]netlink.Rule, error) { return netlink.RuleList(family) }
+func (defaultRPDB) RuleAdd(rule *netlink.Rule) error            { return netlink.RuleAdd(rule) }
+func (defaultRPDB) RuleDel(rule *netlink.Rule) error            { return netlink.RuleDel(rule) }
+func (defaultRPDB) RouteListFiltered(family int, filter *netlink.Route, mask uint64) ([]netlink.Route, error) {
+	return netlink.RouteListFiltered(family, filter, mask)
+}
+func (defaultRPDB) RouteAdd(route *netlink.Route) error     { return netlink.RouteAdd(route) }
+func (defaultRPDB) RouteDel(route *netlink.Route) error     { return netlink.RouteDel(route) }
+func (defaultRPDB) RouteReplace(route *netlink.Route) error { return netlink.RouteReplace(route) }
+func (defaultRPDB) LinkList() ([]netlink.Link, error)       { return netlink.LinkList() }
+func (defaultRPDB) LinkByIndex(ifindex int) (netlink.Link, error) {
+	return netlink.LinkByIndex(ifindex)
+}
+
+// rpdb abstracts the underlying Linux RPDB operations. This is an interface
+// mostly for testing purposes.
+type rpdb interface {
+	RuleList(int) ([]netlink.Rule, error)
+	RuleAdd(*netlink.Rule) error
+	RuleDel(*netlink.Rule) error
+
+	RouteListFiltered(int, *netlink.Route, uint64) ([]netlink.Route, error)
+	RouteAdd(*netlink.Route) error
+	RouteDel(*netlink.Route) error
+	RouteReplace(*netlink.Route) error
+
+	LinkList() ([]netlink.Link, error)
+	LinkByIndex(int) (netlink.Link, error)
+}
+
+type interfaceDB interface {
+	GetInterfaceNumberByMAC(mac string) (int, error)
+	GetMACByInterfaceNumber(ifaceNum int) (string, error)
+}

--- a/pkg/datapath/linux/routing/migrate_test.go
+++ b/pkg/datapath/linux/routing/migrate_test.go
@@ -1,0 +1,575 @@
+// Copyright 2016-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build privileged_tests
+
+package linuxrouting
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os/exec"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&MigrateSuite{})
+
+type MigrateSuite struct {
+	// rpdb interface mock
+	OnRuleList func(int) ([]netlink.Rule, error)
+	OnRuleAdd  func(*netlink.Rule) error
+	OnRuleDel  func(*netlink.Rule) error
+
+	OnRouteListFiltered func(int, *netlink.Route, uint64) ([]netlink.Route, error)
+	OnRouteAdd          func(*netlink.Route) error
+	OnRouteDel          func(*netlink.Route) error
+	OnRouteReplace      func(*netlink.Route) error
+
+	OnLinkList    func() ([]netlink.Link, error)
+	OnLinkByIndex func(int) (netlink.Link, error)
+
+	// interfaceDB interface mock
+	OnGetInterfaceNumberByMAC func(mac string) (int, error)
+	OnGetMACByInterfaceNumber func(ifaceNum int) (string, error)
+
+	origNetNS, newNetNS netns.NsHandle
+}
+
+// n is the number of devices, routes, and rules that will be created in
+// setUpRoutingTable() as fixtures for this test suite.
+const n = 5
+
+func (m *MigrateSuite) TestMigrateENIDatapathUpgradeSuccess(c *C) {
+	// First, we need to setup the Linux routing policy database to mimic a
+	// broken setup (1). Then we will call MigrateENIDatapath (2).
+
+	// This test case will cover the successful path. We will create:
+	//   - One rule with the old priority referencing the old table ID.
+	//   - One route with the old table ID.
+	// After we call MigrateENIDatapath(), we assert that:
+	//   - The rule has switched to the new priority and references the new
+	//     table ID.
+	//   - The route has the new table ID.
+
+	runFuncInNetNS(c, func() {
+		// (1) Setting up the routing table.
+
+		// Pick an arbitrary iface index. In the old table ID scheme, we used this
+		// index as the table ID. All the old rules and routes will be set up with
+		// this table ID.
+		index := 5
+		tableID := 11
+
+		// (1) Setting up the routing table for testing upgrade.
+		//
+		// The reason we pass index twice is because we want to use the ifindex as
+		// the table ID.
+		devIfNumLookup, _ := setUpRoutingTable(c, index, index, linux_defaults.RulePriorityEgress)
+
+		// Set up the rpdb mocks to just forward to netlink implementation.
+		m.defaultNetlinkMock()
+
+		// Set up the interfaceDB mock. We don't actually need to search by MAC
+		// address in this test because we only have just one device. The actual
+		// implementation will search the CiliumNode resource for the ENI device
+		// matching.
+		m.OnGetInterfaceNumberByMAC = func(mac string) (int, error) {
+			// In setUpRoutingTable(), we used an arbitrary scheme that maps
+			// each device created with an interface number of loop count (i)
+			// plus one.
+			return devIfNumLookup[mac], nil
+		}
+
+		// (2) Make the call to modifying the routing table.
+		mig := migrator{rpdb: m, getter: m}
+		migrated, failed := mig.MigrateENIDatapath(false)
+		c.Assert(migrated, Equals, n)
+		c.Assert(failed, Equals, 0)
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: index,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 0) // We don't expect any routes with the old table ID.
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: tableID,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 1) // We only expect one route that we created above in the setup.
+		c.Assert(routes[0].Table, Not(Equals), index)
+
+		rules, err := findRulesByPriority(linux_defaults.RulePriorityEgress)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 0) // We don't expect any rules from old priority.
+
+		rules, err = findRulesByPriority(linux_defaults.RulePriorityEgressv2)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 5) // We expect all rules to be migrated to new priority.
+		c.Assert(rules[0].Table, Not(Equals), index)
+	})
+}
+
+func (m *MigrateSuite) TestMigrateENIDatapathUpgradeFailure(c *C) {
+	// This test case will cover one failure path where we successfully migrate
+	// all the old rules and routes, but fail to cleanup the old rule. This
+	// test case will be set up identically to the successful case. After we
+	// call MigrateENIDatapath(), we assert that we failed to migrate 1 rule.
+	// We assert that the revert of the upgrade was successfully as well,
+	// meaning we expect the old rules and routes to be reinstated.
+
+	runFuncInNetNS(c, func() {
+		index := 5
+		devIfNumLookup, _ := setUpRoutingTable(c, index, index, linux_defaults.RulePriorityEgress)
+
+		m.defaultNetlinkMock()
+
+		// Here we inject the error on deleting a rule. The first call we want to
+		// fail, but the second we want to succeed, because that will be the
+		// revert.
+		var onRuleDelCount int
+		m.OnRuleDel = func(r *netlink.Rule) error {
+			if onRuleDelCount == 0 {
+				onRuleDelCount++
+				return errors.New("fake error")
+			}
+			return netlink.RuleDel(r)
+		}
+
+		// Set up the interfaceDB mock. We don't actually need to search by MAC
+		// address in this test because we only have just one device. The actual
+		// implementation will search the CiliumNode resource for the ENI device
+		// matching.
+		m.OnGetInterfaceNumberByMAC = func(mac string) (int, error) {
+			// In setUpRoutingTable(), we used an arbitrary scheme that maps
+			// each device created with an interface number of loop count (i)
+			// plus one.
+			return devIfNumLookup[mac], nil
+		}
+
+		mig := migrator{rpdb: m, getter: m}
+		migrated, failed := mig.MigrateENIDatapath(false)
+		c.Assert(migrated, Equals, 4)
+		c.Assert(failed, Equals, 1)
+
+		tableID := 11
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: index,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 1) // We expect old route to be untouched b/c we failed.
+		c.Assert(routes[0].Table, Equals, index)
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: tableID,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 0) // We don't expect any routes under new table ID b/c of revert.
+
+		rules, err := findRulesByPriority(linux_defaults.RulePriorityEgress)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 1) // We expect the old rule to be reinstated.
+		c.Assert(rules[0].Table, Equals, index)
+
+		rules, err = findRulesByPriority(linux_defaults.RulePriorityEgressv2)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 4) // We expect the rest of the rules to be upgraded.
+	})
+}
+
+func (m *MigrateSuite) TestMigrateENIDatapathDowngradeSuccess(c *C) {
+	// This test case will cover the successful downgrade path. We will create:
+	//   - One rule with the new priority referencing the new table ID.
+	//   - One route with the new table ID.
+	// After we call MigrateENIDatapath(), we assert that:
+	//   - The rule has switched to the old priority and references the old
+	//     table ID.
+	//   - The route has the old table ID.
+
+	runFuncInNetNS(c, func() {
+		// (1) Setting up the routing table.
+
+		// Pick an arbitrary table ID. In the new table ID scheme, it is the
+		// interface number + an offset of 10
+		// (linux_defaults.RouteTableInterfacesOffset).
+		//
+		// Pick an ifindex and table ID.
+		index := 5
+		tableID := 11
+
+		// (1) Setting up the routing table for testing downgrade, hence creating
+		// rules with RulePriorityEgressv2.
+		_, devMACLookup := setUpRoutingTable(c, index, tableID, linux_defaults.RulePriorityEgressv2)
+
+		// Set up the rpdb mocks to just forward to netlink implementation.
+		m.defaultNetlinkMock()
+
+		// Set up the interfaceDB mock. The MAC address returned is coming from the
+		// dummy ENI device we set up in setUpRoutingTable(). The actual
+		// implementation will search the CiliumNode resource for the ENI device
+		// matching.
+		m.OnGetMACByInterfaceNumber = func(i int) (string, error) {
+			// In setUpRoutingTable(), we used an arbitrary scheme for the
+			// device name. It is simply the loop counter.
+			return devMACLookup[fmt.Sprintf("gotestdummy%d", i)], nil
+		}
+
+		// (2) Make the call to modifying the routing table.
+		mig := migrator{rpdb: m, getter: m}
+		migrated, failed := mig.MigrateENIDatapath(true)
+		c.Assert(migrated, Equals, n)
+		c.Assert(failed, Equals, 0)
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: tableID,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 0) // We don't expect any routes with the new table ID.
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: index,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 1) // We only expect one route with the old table ID.
+		c.Assert(routes[0].Table, Not(Equals), tableID)
+
+		rules, err := findRulesByPriority(linux_defaults.RulePriorityEgressv2)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 0) // We don't expect any rules with this priority.
+
+		rules, err = findRulesByPriority(linux_defaults.RulePriorityEgress)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 5) // We expect all rules to have the original priority.
+		c.Assert(rules[0].Table, Not(Equals), tableID)
+	})
+}
+
+func (m *MigrateSuite) TestMigrateENIDatapathDowngradeFailure(c *C) {
+	// This test case will cover one downgrade failure path where we failed to
+	// migrate the rule to the old scheme. This test case will be set up
+	// identically to the successful case. "New" meaning the rules and routes
+	// using the new datapath scheme, hence downgrading. After we call
+	// MigrateENIDatapath(), we assert that we failed to migrate 1 rule. We
+	// assert that the revert of the downgrade was successfully as well,
+	// meaning we expect the "newer" rules and routes to be reinstated.
+
+	runFuncInNetNS(c, func() {
+		index := 5
+		tableID := 11
+		_, devMACLookup := setUpRoutingTable(c, index, tableID, linux_defaults.RulePriorityEgressv2)
+
+		m.defaultNetlinkMock()
+
+		// Here we inject the error on adding a rule. The first call we want to
+		// fail, but the second we want to succeed, because that will be the
+		// revert.
+		var onRuleAddCount int
+		m.OnRuleAdd = func(r *netlink.Rule) error {
+			if onRuleAddCount == 0 {
+				onRuleAddCount++
+				return errors.New("fake error")
+			}
+			return netlink.RuleAdd(r)
+		}
+
+		// Set up the interfaceDB mock. The MAC address returned is coming from the
+		// dummy ENI device we set up in setUpRoutingTable().
+		m.OnGetMACByInterfaceNumber = func(i int) (string, error) {
+			// In setUpRoutingTable(), we used an arbitrary scheme for the
+			// device name. It is simply the loop counter.
+			return devMACLookup[fmt.Sprintf("gotestdummy%d", i)], nil
+		}
+
+		mig := migrator{rpdb: m, getter: m}
+		migrated, failed := mig.MigrateENIDatapath(true)
+		c.Assert(migrated, Equals, n-1) // One failed migration.
+		c.Assert(failed, Equals, 1)
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: tableID,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 1) // We expect "new" route to be untouched b/c we failed to delete.
+		c.Assert(routes[0].Table, Equals, tableID)
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: index,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 0) // We don't expect routes under original table ID b/c of revert.
+
+		rules, err := findRulesByPriority(linux_defaults.RulePriorityEgressv2)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 1) // We expect the "new" rule to be reinstated.
+		c.Assert(rules[0].Table, Equals, tableID)
+
+		rules, err = findRulesByPriority(linux_defaults.RulePriorityEgress)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, n-1) // Successfully migrated rules.
+	})
+}
+
+func (m *MigrateSuite) TestMigrateENIDatapathPartial(c *C) {
+	// This test case will cover one case where we find a partial rule. It will
+	// be set up with a rule with the newer priority and the user has indicated
+	// compatbility=false, meaning they intend to upgrade. The fact that
+	// there's already a rule with a newer priority indicates that a previous
+	// migration has taken place and potentially failed. This simulates Cilium
+	// starting up from a potentially failed previous migration.
+	// After we call MigrateENIDatapath(), we assert that:
+	//   - We still upgrade the remaining rules that need to be migrated.
+	//   - We ignore the partially migrated rule.
+
+	runFuncInNetNS(c, func() {
+		index := 5
+		// ifaceNumber := 1
+		newTableID := 11
+
+		devIfNumLookup, _ := setUpRoutingTable(c, index, index, linux_defaults.RulePriorityEgress)
+
+		// Insert fake rule that has the newer priority to simulate it as
+		// "partially migrated".
+		err := exec.Command("ip", "rule", "add",
+			"from", "10.1.0.0/24",
+			"to", "all",
+			"table", fmt.Sprintf("%d", newTableID),
+			"priority", fmt.Sprintf("%d", linux_defaults.RulePriorityEgressv2)).Run()
+		c.Assert(err, IsNil)
+
+		m.defaultNetlinkMock()
+
+		m.OnGetInterfaceNumberByMAC = func(mac string) (int, error) {
+			return devIfNumLookup[mac], nil
+		}
+
+		mig := migrator{rpdb: m, getter: m}
+		migrated, failed := mig.MigrateENIDatapath(false)
+		c.Assert(migrated, Equals, n)
+		c.Assert(failed, Equals, 0)
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: newTableID,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 1) // We expect one migrated route.
+		c.Assert(routes[0].Table, Equals, newTableID)
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: index,
+		}, netlink.RT_FILTER_TABLE)
+		c.Assert(err, IsNil)
+		c.Assert(routes, HasLen, 0) // We don't expect any routes under old table ID.
+
+		rules, err := findRulesByPriority(linux_defaults.RulePriorityEgressv2)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, n+1) // We expect all migrated rules and the partially migrated rule.
+		c.Assert(rules[0].Table, Equals, newTableID)
+		c.Assert(rules[1].Table, Equals, newTableID)
+
+		rules, err = findRulesByPriority(linux_defaults.RulePriorityEgress)
+		c.Assert(err, IsNil)
+		c.Assert(rules, HasLen, 0) // We don't expect any rules with the old priority.
+	})
+}
+
+// setUpRoutingTable initializes the routing table for this test suite. The
+// starting ifindex, tableID, and the priority are passed in to give contron to
+// the caller on the setup. The two return values are:
+//   1) Map of string to int, representing a mapping from MAC addrs to
+//      interface numbers.
+//   2) Map of string to string, representing a mapping from device name to MAC
+//      addrs.
+// (1) is used for the upgrade test cases where the GetInterfaceNumberByMAC
+// mock is used. (2) is used for the downgrade test cases where the
+// GetMACByInterfaceNumber mock is used. These maps are used in their
+// respectives mocks to return the desired result data depending on the test.
+func setUpRoutingTable(c *C, ifindex, tableID, priority int) (map[string]int, map[string]string) {
+	devIfNum := make(map[string]int)
+	devMAC := make(map[string]string)
+
+	// Create n sets of a dummy interface, a route, and a rule.
+	//
+	// Each dummy interface has a /24 from the private range of 172.16.0.0/20.
+	//
+	// Each route will be a default route to the gateway IP of the interface's
+	// subnet.
+	//
+	// Each rule will be from the interface's subnet to all.
+	for i := 1; i <= n; i++ {
+		devName := fmt.Sprintf("gotestdummy%d", i)
+
+		gw := net.ParseIP(fmt.Sprintf("172.16.%d.1", i))
+		_, linkCIDR, err := net.ParseCIDR(fmt.Sprintf("172.16.%d.2/24", i))
+		c.Assert(err, IsNil)
+
+		linkIndex := ifindex + (i - 1)
+		newTableID := tableID + (i - 1)
+
+		dummyTmpl := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:  devName,
+				Index: linkIndex,
+			},
+		}
+		c.Assert(netlink.LinkAdd(dummyTmpl), IsNil)
+		c.Assert(netlink.LinkSetUp(dummyTmpl), IsNil)
+		c.Assert(netlink.AddrAdd(dummyTmpl, &netlink.Addr{
+			IPNet: linkCIDR,
+		}), IsNil)
+		c.Assert(netlink.RouteAdd(&netlink.Route{
+			Dst:       &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+			Gw:        gw,
+			LinkIndex: dummyTmpl.Index,
+			Table:     newTableID,
+		}), IsNil)
+
+		// _, cidr, err := net.ParseCIDR("172.16.0.2/24")
+		// c.Assert(err, IsNil)
+		// c.Assert(netlink.RuleAdd(&netlink.Rule{
+		// 	// Src:      &net.IPNet{IP: net.ParseIP("172.16.0.2"), Mask: net.CIDRMask(24, 32)},
+		// 	Src: cidr,
+		// 	// Dst:      &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+		// 	Priority: linux_defaults.RulePriorityEgress,
+		// 	Table:    dummyTmpl.Index,
+		// }), IsNil)
+
+		// TODO(christarazi): Must shell out here due to netlink request (above)
+		// resulting in EINVAL. See https://github.com/cilium/cilium/issues/14383.
+		err = exec.Command("ip", "rule", "add",
+			"from", linkCIDR.String(),
+			"to", "all",
+			"table", fmt.Sprintf("%d", newTableID),
+			"priority", fmt.Sprintf("%d", priority)).Run()
+		c.Assert(err, IsNil)
+
+		// Return the MAC address of the dummy device, which acts as the ENI.
+		link, err := netlink.LinkByName(devName)
+		c.Assert(err, IsNil)
+
+		mac := link.Attrs().HardwareAddr.String()
+
+		// Arbitrarily use an offset of 1 as the interface number. It doesn't
+		// matter as long as we're consistent.
+		devIfNum[mac] = i
+		devMAC[devName] = mac
+	}
+
+	return devIfNum, devMAC
+}
+
+func findRulesByPriority(prio int) ([]netlink.Rule, error) {
+	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		return nil, err
+	}
+
+	return filterRulesByPriority(rules, prio), nil
+}
+
+func (m *MigrateSuite) defaultNetlinkMock() {
+	m.OnRuleList = func(family int) ([]netlink.Rule, error) { return netlink.RuleList(family) }
+	m.OnRuleAdd = func(rule *netlink.Rule) error { return netlink.RuleAdd(rule) }
+	m.OnRuleDel = func(rule *netlink.Rule) error { return netlink.RuleDel(rule) }
+	m.OnRouteListFiltered = func(family int, filter *netlink.Route, mask uint64) ([]netlink.Route, error) {
+		return netlink.RouteListFiltered(family, filter, mask)
+	}
+	m.OnRouteAdd = func(route *netlink.Route) error { return netlink.RouteAdd(route) }
+	m.OnRouteDel = func(route *netlink.Route) error { return netlink.RouteDel(route) }
+	m.OnRouteReplace = func(route *netlink.Route) error { return netlink.RouteReplace(route) }
+	m.OnLinkList = func() ([]netlink.Link, error) { return netlink.LinkList() }
+	m.OnLinkByIndex = func(ifindex int) (netlink.Link, error) { return netlink.LinkByIndex(ifindex) }
+}
+
+func (m *MigrateSuite) RuleList(family int) ([]netlink.Rule, error) {
+	if m.OnRuleList != nil {
+		return m.OnRuleList(family)
+	}
+	panic("OnRuleList should not have been called")
+}
+
+func (m *MigrateSuite) RuleAdd(rule *netlink.Rule) error {
+	if m.OnRuleAdd != nil {
+		return m.OnRuleAdd(rule)
+	}
+	panic("OnRuleAdd should not have been called")
+}
+
+func (m *MigrateSuite) RuleDel(rule *netlink.Rule) error {
+	if m.OnRuleDel != nil {
+		return m.OnRuleDel(rule)
+	}
+	panic("OnRuleDel should not have been called")
+}
+
+func (m *MigrateSuite) RouteListFiltered(family int, filter *netlink.Route, mask uint64) ([]netlink.Route, error) {
+	if m.OnRouteListFiltered != nil {
+		return m.OnRouteListFiltered(family, filter, mask)
+	}
+	panic("OnRouteListFiltered should not have been called")
+}
+
+func (m *MigrateSuite) RouteAdd(route *netlink.Route) error {
+	if m.OnRouteAdd != nil {
+		return m.OnRouteAdd(route)
+	}
+	panic("OnRouteAdd should not have been called")
+}
+
+func (m *MigrateSuite) RouteDel(route *netlink.Route) error {
+	if m.OnRouteDel != nil {
+		return m.OnRouteDel(route)
+	}
+	panic("OnRouteDel should not have been called")
+}
+
+func (m *MigrateSuite) RouteReplace(route *netlink.Route) error {
+	if m.OnRouteReplace != nil {
+		return m.OnRouteReplace(route)
+	}
+	panic("OnRouteReplace should not have been called")
+}
+
+func (m *MigrateSuite) LinkList() ([]netlink.Link, error) {
+	if m.OnLinkList != nil {
+		return m.OnLinkList()
+	}
+	panic("OnLinkList should not have been called")
+}
+
+func (m *MigrateSuite) LinkByIndex(ifindex int) (netlink.Link, error) {
+	if m.OnLinkByIndex != nil {
+		return m.OnLinkByIndex(ifindex)
+	}
+	panic("OnLinkByIndex should not have been called")
+}
+
+func (m *MigrateSuite) GetInterfaceNumberByMAC(mac string) (int, error) {
+	if m.OnGetInterfaceNumberByMAC != nil {
+		return m.OnGetInterfaceNumberByMAC(mac)
+	}
+	panic("OnGetInterfaceNumberByMAC should not have been called")
+}
+
+func (m *MigrateSuite) GetMACByInterfaceNumber(ifaceNum int) (string, error) {
+	if m.OnGetMACByInterfaceNumber != nil {
+		return m.OnGetMACByInterfaceNumber(ifaceNum)
+	}
+	panic("OnGetMACByInterfaceNumber should not have been called")
+}

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -41,8 +41,7 @@ var (
 // ip: The endpoint IP address to direct traffic out / from interface.
 // info: The interface routing info used to create rules and routes.
 // mtu: The interface MTU.
-// masq: Whether masquerading is enabled.
-func (info *RoutingInfo) Configure(ip net.IP, mtu int, masq bool) error {
+func (info *RoutingInfo) Configure(ip net.IP, mtu int) error {
 	if ip.To4() == nil {
 		log.WithFields(logrus.Fields{
 			"endpointIP": ip,
@@ -68,7 +67,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, masq bool) error {
 		return fmt.Errorf("unable to install ip rule: %s", err)
 	}
 
-	if masq {
+	if info.Masquerade {
 		// Lookup a VPC specific table for all traffic from an endpoint to the
 		// CIDR configured for the VPC on which the endpoint has the IP on.
 		for _, cidr := range info.IPv4CIDRs {

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -255,10 +255,13 @@ func getFakes(c *C) (net.IP, RoutingInfo) {
 	c.Assert(err, IsNil)
 	c.Assert(fakeMAC, NotNil)
 
-	fakeRoutingInfo, err := parse(fakeGateway.String(),
+	fakeRoutingInfo, err := parse(
+		fakeGateway.String(),
 		[]string{fakeCIDR.String()},
 		fakeMAC.String(),
-		true)
+		"1",
+		true,
+	)
 	c.Assert(err, IsNil)
 	c.Assert(fakeRoutingInfo, NotNil)
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -60,7 +60,7 @@ func (e *LinuxRoutingSuite) TestConfigureRoutewithIncompatibleIP(c *C) {
 	_, ri := getFakes(c)
 	ipv6 := net.ParseIP("fd00::2").To16()
 	c.Assert(ipv6, NotNil)
-	err := ri.Configure(ipv6, 1500)
+	err := ri.Configure(ipv6, 1500, false)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "IP not compatible")
 }
@@ -68,7 +68,7 @@ func (e *LinuxRoutingSuite) TestConfigureRoutewithIncompatibleIP(c *C) {
 func (e *LinuxRoutingSuite) TestDeleteRoutewithIncompatibleIP(c *C) {
 	ipv6 := net.ParseIP("fd00::2").To16()
 	c.Assert(ipv6, NotNil)
-	err := Delete(ipv6)
+	err := Delete(ipv6, false)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "IP not compatible")
 }
@@ -137,7 +137,7 @@ func (e *LinuxRoutingSuite) TestDelete(c *C) {
 			defer ifaceCleanup()
 
 			ip := tt.preRun()
-			err := Delete(ip)
+			err := Delete(ip, false)
 			c.Assert((err != nil), Equals, tt.wantErr)
 		})
 	}
@@ -183,12 +183,12 @@ func runConfigureThenDelete(c *C, ri RoutingInfo, ip net.IP, mtu int) {
 }
 
 func runConfigure(c *C, ri RoutingInfo, ip net.IP, mtu int) {
-	err := ri.Configure(ip, mtu)
+	err := ri.Configure(ip, mtu, false)
 	c.Assert(err, IsNil)
 }
 
 func runDelete(c *C, ip net.IP) {
-	err := Delete(ip)
+	err := Delete(ip, false)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2273,7 +2273,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 		// ingress rule and one egress rule. If we find more than one rule in
 		// either case, then the rules will be left as-is because there was
 		// likely manual intervention.
-		if err := linuxrouting.Delete(e.IPv4.IP()); err != nil {
+		if err := linuxrouting.Delete(e.IPv4.IP(), option.Config.EgressMultiHomeIPRuleCompat); err != nil {
 			errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %s", err))
 		}
 	}

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -499,6 +500,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 				if eni.Subnet.CIDR != "" {
 					result.GatewayIP = deriveGatewayIP(eni)
 				}
+				result.InterfaceNumber = strconv.Itoa(eni.Number)
 
 				return
 			}

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -48,6 +48,10 @@ type AllocationResult struct {
 	// ExpirationUUID is the UUID of the expiration timer. This field is
 	// only set if AllocateNextWithExpiration is used.
 	ExpirationUUID string
+
+	// InterfaceNumber is a field for generically identifying an interface.
+	// This is only useful in ENI mode.
+	InterfaceNumber string
 }
 
 // Allocator is the interface for an IP allocator implementation

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -828,6 +828,11 @@ const (
 
 	// EnableAPIRateLimit enables the use of API rate limiting.
 	EnableAPIRateLimit = "enable-api-rate-limit"
+
+	// EgressMultiHomeIPRuleCompat instructs Cilium to use a new scheme to
+	// store rules and routes under ENI and Azure IPAM modes, if false.
+	// Otherwise, it will use the old scheme.
+	EgressMultiHomeIPRuleCompat = "egress-multi-home-ip-rule-compat"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -1927,6 +1932,11 @@ type DaemonConfig struct {
 
 	// EnableAPIRateLimit enables the use of API rate limiting.
 	EnableAPIRateLimit bool
+
+	// EgressMultiHomeIPRuleCompat instructs Cilium to use a new scheme to
+	// store rules and routes under ENI and Azure IPAM modes, if false.
+	// Otherwise, it will use the old scheme.
+	EgressMultiHomeIPRuleCompat bool
 }
 
 var (
@@ -2440,6 +2450,7 @@ func (c *DaemonConfig) Populate() {
 	c.FragmentsMapEntries = viper.GetInt(FragmentsMapEntriesName)
 	c.K8sServiceProxyName = viper.GetString(K8sServiceProxyName)
 	c.EnableAPIRateLimit = viper.GetBool(EnableAPIRateLimit)
+	c.EgressMultiHomeIPRuleCompat = viper.GetBool(EgressMultiHomeIPRuleCompat)
 
 	c.populateDevices()
 

--- a/pkg/revert/revert.go
+++ b/pkg/revert/revert.go
@@ -47,3 +47,10 @@ func (s *RevertStack) Revert() error {
 	}
 	return nil
 }
+
+// Extend extends the revert stack by the given stack.
+func (s *RevertStack) Extend(t RevertStack) {
+	for _, f := range t.revertFuncs {
+		s.Push(f)
+	}
+}

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -46,7 +46,13 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		cidrs = append(cidrs, cidr.String())
 	}
 
-	routingInfo, err := linuxrouting.NewRoutingInfo(ipam.Gateway, cidrs, ipam.MasterMac, conf.Masquerade)
+	routingInfo, err := linuxrouting.NewRoutingInfo(
+		ipam.Gateway,
+		cidrs,
+		ipam.MasterMac,
+		ipam.InterfaceNumber,
+		conf.Masquerade,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to parse routing info: %v", err)
 	}

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -51,9 +51,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		return fmt.Errorf("unable to parse routing info: %v", err)
 	}
 
-	if err := routingInfo.Configure(ipConfig.Address.IP,
-		int(conf.DeviceMTU),
-		conf.Masquerade); err != nil {
+	if err := routingInfo.Configure(ipConfig.Address.IP, int(conf.DeviceMTU)); err != nil {
 		return fmt.Errorf("unable to install ip rules and routes: %s", err)
 	}
 

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -57,7 +57,11 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		return fmt.Errorf("unable to parse routing info: %v", err)
 	}
 
-	if err := routingInfo.Configure(ipConfig.Address.IP, int(conf.DeviceMTU)); err != nil {
+	if err := routingInfo.Configure(
+		ipConfig.Address.IP,
+		int(conf.DeviceMTU),
+		conf.EgressMultiHomeIPRuleCompat,
+	); err != nil {
 		return fmt.Errorf("unable to install ip rules and routes: %s", err)
 	}
 


### PR DESCRIPTION
* #14269 -- routing: Fix route collisions in AWS ENI (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14269; do contrib/backporting/set-labels.py $pr done 1.8; done
```