### PR TITLE
docs: Added instruction to also delete kube-proxy configmap

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -69,6 +69,8 @@ by using the following commands:
 .. code:: bash
 
       kubectl -n kube-system delete ds kube-proxy
+      # Delete the configmap as well to avoid kube-proxy being reinstalled during a kubeadm upgrade (works only for K8s 1.19 and newer)
+      kubectl -n kube-system delete cm kube-proxy
       # Run on each node:
       iptables-restore <(iptables-save | grep -v KUBE)
 


### PR DESCRIPTION
This makes sure that kube-proxy is not reinstalled again on kubeadm upgrades from > 1.19.
