### PR TITLE
 hubble/metrics: Add support for fallback labels, ip addresses and dns names

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -447,7 +447,17 @@ Option Value   Description
 ``namespace``  Kubernetes namespace name
 ``pod``        Kubernetes pod name
 ``pod-short``  Short version of the Kubernetes pod name. Typically the deployment/replicaset name.
+``dns``        All known DNS names of the source or destination (comma-separated)
+``ip``         The IPv4 or IPv6 address
 ============== ====================================================================================
+
+When specifying the source and/or destination context, multiple contexts can be
+specified by separating them via the ``|`` symbol.
+When multiple are specified, then the first non-empty value is added to the
+metric as a label. For example, a metric configuration of
+``flow:destinationContext=dns|ip`` will first try to use the DNS name of the
+target for the label. If no DNS name is known for the target, it will fall back
+and use the IP address of the target instead.
 
 .. _hubble_exported_metrics:
 

--- a/pkg/hubble/api/v1/flow.go
+++ b/pkg/hubble/api/v1/flow.go
@@ -36,7 +36,8 @@ func FlowProtocol(flow *pb.Flow) string {
 		}
 		return "Unknown L7"
 
-	case monitorAPI.MessageTypeDrop, monitorAPI.MessageTypeTrace:
+	case monitorAPI.MessageTypeDrop, monitorAPI.MessageTypeTrace,
+		monitorAPI.MessageTypePolicyVerdict, monitorAPI.MessageTypeCapture:
 		if l4 := flow.GetL4(); l4 != nil {
 			switch {
 			case l4.GetTCP() != nil:

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -61,6 +61,15 @@ func TestParseContextOptions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.EqualValues(t, opts.Status(), "destination=dns")
 	assert.EqualValues(t, opts.GetLabelNames(), []string{"destination"})
+
+	opts, err = ParseContextOptions(Options{"sourceContext": "pod-short|dns"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, opts.Status(), "source=pod-short|dns")
+	assert.EqualValues(t, opts.GetLabelNames(), []string{"source"})
+
+	opts, err = ParseContextOptions(Options{"destinationContext": "namespace|invalid"})
+	assert.NotNil(t, err)
+	assert.Nil(t, opts)
 }
 
 func TestParseGetLabelValues(t *testing.T) {
@@ -102,6 +111,32 @@ func TestParseGetLabelValues(t *testing.T) {
 	opts, err = ParseContextOptions(Options{"destinationContext": "dns"})
 	assert.Nil(t, err)
 	assert.EqualValues(t, opts.GetLabelValues(&pb.Flow{DestinationNames: []string{"bar"}}), []string{"bar"})
+
+	opts, err = ParseContextOptions(Options{"sourceContext": "namespace|dns", "destinationContext": "identity|pod-short"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, opts.GetLabelValues(&pb.Flow{
+		Source: &pb.Endpoint{
+			Namespace: "foo",
+		},
+		SourceNames: []string{"cilium.io"},
+		Destination: &pb.Endpoint{
+			Namespace: "bar",
+			PodName:   "foo-123",
+		},
+	}), []string{"foo", "bar/foo"})
+	assert.EqualValues(t, opts.GetLabelValues(&pb.Flow{
+		SourceNames: []string{"cilium.io"},
+		Destination: &pb.Endpoint{
+			Namespace: "bar",
+			PodName:   "foo-123",
+			Labels:    []string{"a", "b"},
+		},
+	}), []string{"cilium.io", "a,b"})
+	assert.EqualValues(t, opts.GetLabelValues(&pb.Flow{
+		Destination: &pb.Endpoint{
+			Labels: []string{"a", "b"},
+		},
+	}), []string{"", "a,b"})
 }
 
 func TestShortenPodName(t *testing.T) {

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -56,6 +56,11 @@ func TestParseContextOptions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.EqualValues(t, opts.Status(), "source=pod")
 	assert.EqualValues(t, opts.GetLabelNames(), []string{"source"})
+
+	opts, err = ParseContextOptions(Options{"destinationContext": "dns"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, opts.Status(), "destination=dns")
+	assert.EqualValues(t, opts.GetLabelNames(), []string{"destination"})
 }
 
 func TestParseGetLabelValues(t *testing.T) {
@@ -89,6 +94,14 @@ func TestParseGetLabelValues(t *testing.T) {
 	opts, err = ParseContextOptions(Options{"destinationContext": "pod-short"})
 	assert.Nil(t, err)
 	assert.EqualValues(t, opts.GetLabelValues(&pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-bar-123-123"}}), []string{"foo/bar-bar"})
+
+	opts, err = ParseContextOptions(Options{"sourceContext": "dns"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, opts.GetLabelValues(&pb.Flow{SourceNames: []string{"foo", "bar"}}), []string{"foo,bar"})
+
+	opts, err = ParseContextOptions(Options{"destinationContext": "dns"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, opts.GetLabelValues(&pb.Flow{DestinationNames: []string{"bar"}}), []string{"bar"})
 }
 
 func TestShortenPodName(t *testing.T) {

--- a/pkg/hubble/metrics/flow/handler.go
+++ b/pkg/hubble/metrics/flow/handler.go
@@ -78,6 +78,8 @@ func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
 	case monitorAPI.MessageTypeTrace:
 		typeName = "Trace"
 		subType = monitorAPI.TraceObservationPoints[uint8(flow.GetEventType().SubType)]
+	case monitorAPI.MessageTypePolicyVerdict:
+		typeName = "PolicyVerdict"
 	default:
 		typeName = "Unknown"
 		subType = fmt.Sprintf("%d", eventType)

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -35,7 +35,7 @@ Metrics:
 Options:
  sourceContext          := identifier , { "|", identifier }
  destinationContext     := identifier , { "|", identifier }
- identifier             := identity | namespace | pod | pod-short | dns
+ identifier             := identity | namespace | pod | pod-short | dns | ip
 `
 	assert.Equal(t, expected, plugin.HelpText())
 }

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -33,7 +33,9 @@ Metrics:
   http_request_duration_seconds - Median, 90th and 99th percentile of request duration.
 
 Options:
- sourceContext          := { identity | namespace | pod | pod-short | dns }
- destinationContext     := { identity | namespace | pod | pod-short | dns }`
+ sourceContext          := identifier , { "|", identifier }
+ destinationContext     := identifier , { "|", identifier }
+ identifier             := identity | namespace | pod | pod-short | dns
+`
 	assert.Equal(t, expected, plugin.HelpText())
 }

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -33,7 +33,7 @@ Metrics:
   http_request_duration_seconds - Median, 90th and 99th percentile of request duration.
 
 Options:
- sourceContext          := { identity | namespace | pod }
- destinationContext     := { identity | namespace | pod }`
+ sourceContext          := { identity | namespace | pod | pod-short | dns }
+ destinationContext     := { identity | namespace | pod | pod-short | dns }`
 	assert.Equal(t, expected, plugin.HelpText())
 }


### PR DESCRIPTION
This adds a two context option to the Hubble metrics, `dns` and `ip`.

`dns` adds the DNS name as the source or destination label. If multiple DNS names are associated with an IP address, all of them are added.
`ip` adds the IPv4 or IPv6 address as the source or destination label.

In addition, this PR also fixes some missing cases around policy verdict and capture events. It also add support for specifying multiple contexts to support fall-back. For example, a metric configuration of `flow:destinationContext=dns|ip` will first try to use the DNS name of the target for the label, but if no DNS name is known, it will fall back and use the IP address of the target instead.


Except from `--hubble-metrics=flow:destinationContext=dns|ip` against the `connectivity-check.yaml`:

```
hubble_flows_processed_total{destination="1.1.1.1",protocol="TCP",subtype="to-stack",type="Trace",verdict="FORWARDED"} 42
hubble_flows_processed_total{destination="www.google.com",protocol="TCP",subtype="to-stack",type="Trace",verdict="FORWARDED"} 63

```
