### PR TITLE
Fix BPF map handling on upgrade when disabling the preallocation of BPF maps

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1124,7 +1124,7 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 // Returns true if the map was upgraded.
 func (m *Map) CheckAndUpgrade(desired *MapInfo) bool {
 	desiredMapType := GetMapType(desired.MapType)
-	desired.Flags |= GetPreAllocateMapFlags(desired.MapType)
+	desired.Flags |= GetPreAllocateMapFlags(desiredMapType)
 
 	return objCheck(
 		m.fd,

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -67,6 +67,9 @@ func (m *Map) OpenOrCreate() error {
 		PinPath: bpf.MapPrefixPath(),
 	}
 
+	mapType := bpf.GetMapType(bpf.MapType(m.spec.Type))
+	m.spec.Flags = m.spec.Flags | bpf.GetPreAllocateMapFlags(mapType)
+
 	newMap, err := ciliumebpf.NewMapWithOptions(m.spec, opts)
 	if err != nil {
 		return fmt.Errorf("unable to create map: %w", err)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -104,7 +104,7 @@ var (
 		"k8s.requireIPv4PodCIDR":        "true",
 		"pprof.enabled":                 "true",
 		"logSystemLoad":                 "true",
-		"bpf.preallocateMaps":           "true",
+		"bpf.preallocateMaps":           "false",
 		"etcd.leaseTTL":                 "30s",
 		"ipv4.enabled":                  "true",
 		"ipv6.enabled":                  "true",


### PR DESCRIPTION
See commit msgs.
