### PR TITLE
Added build comment to oss-fuzz build file

### DIFF
--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -1,3 +1,3 @@
 #/bin/bash -eu
 
-compile_go_fuzzer github.com/cilium/cilium/test/fuzzing Fuzz fuzz
+compile_go_fuzzer github.com/cilium/cilium/test/fuzzing Fuzz fuzz gofuzz


### PR DESCRIPTION
This PR adds a build comment to the build file which will fix the failing integration tests.

Signed-off-by: AdamKorcz <adam@adalogics.com>