### PR TITLE
datapath: Support NodePort BPF on L2-less devices

### DIFF
--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -37,6 +37,8 @@ static int BPF_FUNC(skb_change_proto, struct __sk_buff *skb, __u32 proto,
 		    __u32 flags);
 static int BPF_FUNC(skb_change_tail, struct __sk_buff *skb, __u32 nlen,
 		    __u32 flags);
+static int BPF_FUNC(skb_change_head, struct __sk_buff *skb, __u32 head_room,
+		    __u64 flags);
 
 static int BPF_FUNC(skb_pull_data, struct __sk_buff *skb, __u32 len);
 

--- a/bpf/include/linux/if_ether.h
+++ b/bpf/include/linux/if_ether.h
@@ -29,7 +29,12 @@
  */
 
 #define ETH_ALEN	6		/* Octets in one ethernet addr	 */
-#define ETH_HLEN	14		/* Total octets in header.	 */
+/* __ETH_HLEN is out of sync with the kernel's if_ether.h. In Cilium datapath
+ * we use ETH_HLEN which can be loaded via static data, and for L2-less devs
+ * it's 0. To avoid replacing every occurrence of ETH_HLEN in the datapath,
+ * we prefixed the kernel's ETH_HLEN instead.
+ */
+#define __ETH_HLEN	14		/* Total octets in header.	 */
 #define ETH_ZLEN	60		/* Min. octets in frame sans FCS */
 #define ETH_DATA_LEN	1500		/* Max. octets in payload	 */
 #define ETH_FRAME_LEN	1514		/* Max. octets in frame sans FCS */

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -405,7 +405,7 @@ case "${MODE}" in
 	__mac; })"
 			for NATIVE_DEV in ${NATIVE_DEVS//;/ }; do
 				IDX=$(cat /sys/class/net/${NATIVE_DEV}/ifindex)
-				MAC=$(ip link show $NATIVE_DEV | grep ether | awk '{print $2}')
+				MAC=$(ip link show $NATIVE_DEV | grep ether | awk '{print $2}' || echo "00:00:00:00:00:00")
 				MAC=$(mac2array $MAC)
 				MAC_BY_IFINDEX_MACRO="${MAC_BY_IFINDEX_MACRO}	case ${IDX}: {union macaddr __tmp = {.addr = ${MAC}}; __mac=__tmp;} break; \\\\\n"
 			done

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -7,7 +7,7 @@
 #include <linux/if_ether.h>
 
 #ifndef ETH_HLEN
-#define ETH_HLEN 14
+#define ETH_HLEN __ETH_HLEN
 #endif
 
 #ifndef ETH_ALEN
@@ -107,6 +107,13 @@ static __always_inline int eth_store_daddr(struct __ctx_buff *ctx,
 	__bpf_memcpy_builtin(data + off, mac, ETH_ALEN);
 	return 0;
 #endif
+}
+
+static __always_inline int eth_store_proto(struct __ctx_buff *ctx,
+					   const __u16 proto, int off)
+{
+	return ctx_store_bytes(ctx, off + ETH_ALEN + ETH_ALEN,
+			       &proto, sizeof(proto), 0);
 }
 
 #endif /* __LIB_ETH__ */

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -137,4 +137,10 @@ ctx_set_xfer(struct __sk_buff *ctx __maybe_unused, __u32 meta __maybe_unused)
 	/* Only possible from XDP -> SKB. */
 }
 
+static __always_inline __maybe_unused int
+ctx_change_head(struct __sk_buff *ctx, __u32 head_room, __u64 flags)
+{
+	return skb_change_head(ctx, head_room, flags);
+}
+
 #endif /* __LIB_OVERLOADABLE_SKB_H_ */

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -93,4 +93,12 @@ static __always_inline __maybe_unused void ctx_set_xfer(struct xdp_md *ctx,
 	ctx_store_meta(ctx, XFER_MARKER, meta);
 }
 
+static __always_inline __maybe_unused int
+ctx_change_head(struct xdp_md *ctx __maybe_unused,
+		__u32 head_room __maybe_unused,
+		__u64 flags __maybe_unused)
+{
+	return 0; /* Only intended for SKB context. */
+}
+
 #endif /* __LIB_OVERLOADABLE_XDP_H_ */

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -159,6 +159,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #  define IPV6_RSS_PREFIX IPV6_DIRECT_ROUTING
 #  define IPV6_RSS_PREFIX_BITS 128
 # endif
+#define IS_L3_DEV(ifindex) false
 #endif
 
 #ifdef ENABLE_SRC_RANGE_CHECK

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -521,14 +521,6 @@ func disableNodePort() {
 	option.Config.EnableSVCSourceRangeCheck = false
 }
 
-func hasHardwareAddress(ifIndex int) bool {
-	iface, err := netlink.LinkByIndex(ifIndex)
-	if err != nil {
-		return false
-	}
-	return len(iface.Attrs().HardwareAddr) > 0
-}
-
 // detectDevices tries to detect device names which are going to be used for
 // (a) NodePort BPF, (b) direct routing in NodePort BPF.
 //
@@ -547,9 +539,7 @@ func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 			"Cannot retrieve host IP addrs for BPF NodePort device detection")
 	} else {
 		for _, a := range addrs {
-			if hasHardwareAddress(a.LinkIndex) {
-				ifidxByAddr[a.IP.String()] = a.LinkIndex
-			}
+			ifidxByAddr[a.IP.String()] = a.LinkIndex
 		}
 	}
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -434,6 +435,8 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) {
 		case (option.Config.EnableIPv4Masquerade || option.Config.EnableIPv6Masquerade) &&
 			!option.Config.EnableBPFMasquerade:
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
+		case !mac.HaveMACAddr(option.Config.Devices):
+			msg = fmt.Sprintf("BPF host routing is currently not supported with devices without L2 addr.")
 		default:
 			probesManager := probes.NewProbeManager()
 			foundNeigh := false

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
@@ -345,6 +346,12 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["NODEPORT_PORT_MAX"] = fmt.Sprintf("%d", option.Config.NodePortMax)
 		cDefinesMap["NODEPORT_PORT_MIN_NAT"] = fmt.Sprintf("%d", option.Config.NodePortMax+1)
 		cDefinesMap["NODEPORT_PORT_MAX_NAT"] = "65535"
+
+		macro, err := isL3DevMacro()
+		if err != nil {
+			return err
+		}
+		cDefinesMap["IS_L3_DEV(ifindex)"] = macro
 	}
 	const (
 		selectionRandom = iota + 1
@@ -510,6 +517,32 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	return fw.Flush()
 }
 
+// isL3DevMacro is used to generate a macro function which is written to
+// node_config.h, and it is used to determine whether a given netdev is L2-less.
+func isL3DevMacro() (string, error) {
+	anyL3Dev := false
+
+	macro := `({ \
+	bool is_l3 = false; \
+	switch (ifindex) { \`
+	for _, iface := range option.Config.Devices {
+		if link, err := netlink.LinkByName(iface); err != nil {
+			return "", err
+		} else if link.Attrs().HardwareAddr == nil {
+			anyL3Dev = true
+			macro += fmt.Sprintf("\ncase %d: is_l3 = true; break; \\", link.Attrs().Index)
+		}
+	}
+	macro += "\ndefault: break; \\"
+	macro += "\n} \\\n is_l3; })\n"
+
+	if !anyL3Dev {
+		return "false", nil
+	}
+
+	return macro, nil
+}
+
 func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, cfg datapath.DeviceConfiguration) {
 	fmt.Fprint(w, cfg.GetOptions().GetFmtList())
 	if option.Config.IsFlannelMasterDeviceSet() {
@@ -566,6 +599,9 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 		// Dummy value to avoid being optimized when 0
 		fmt.Fprint(fw, defineUint32("SECCTX_FROM_IPCACHE", 1))
 		fmt.Fprint(fw, defineUint32("HOST_EP_ID", uint32(e.GetID())))
+
+		// L2 hdr len (for L2-less devices it will be replaced with "0")
+		fmt.Fprint(fw, defineUint32("ETH_HLEN", mac.EthHdrLen))
 	} else {
 		// We want to ensure that the template BPF program always has "LXC_IP"
 		// defined and present as a symbol in the resulting object file after

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -600,8 +600,11 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 		fmt.Fprint(fw, defineUint32("SECCTX_FROM_IPCACHE", 1))
 		fmt.Fprint(fw, defineUint32("HOST_EP_ID", uint32(e.GetID())))
 
-		// L2 hdr len (for L2-less devices it will be replaced with "0")
-		fmt.Fprint(fw, defineUint32("ETH_HLEN", mac.EthHdrLen))
+		// Use templating for ETH_HLEN only if there is any L2-less device
+		if !mac.HaveMACAddr(option.Config.Devices) {
+			// L2 hdr len (for L2-less devices it will be replaced with "0")
+			fmt.Fprint(fw, defineUint32("ETH_HLEN", mac.EthHdrLen))
+		}
 	} else {
 		// We want to ensure that the template BPF program always has "LXC_IP"
 		// defined and present as a symbol in the resulting object file after

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -76,6 +76,9 @@ var ignoredELFPrefixes = []string{
 	// these symbols while the endpoint doesn't, if IPv6 was just enabled and
 	// the endpoint restored.
 	"LXC_IP_",
+	// The default val (14) is used for all devices except for L2-less devices
+	// for which we set ETH_HLEN=0 during load time.
+	"ETH_HLEN",
 }
 
 // RestoreTemplates populates the object cache from templates on the filesystem

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -154,6 +154,11 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	if err != nil {
 		return err
 	}
+	if mac == nil {
+		// L2-less device
+		mac = make([]byte, 6)
+		opts["ETH_HLEN"] = uint32(0)
+	}
 	opts["NODE_MAC_1"] = sliceToBe32(mac[0:4])
 	opts["NODE_MAC_2"] = uint32(sliceToBe16(mac[4:6]))
 

--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -20,6 +20,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+
+	"github.com/vishvananda/netlink"
 )
 
 // Untagged ethernet (IEEE 802.3) frame header len
@@ -108,4 +110,18 @@ func GenerateRandMAC() (MAC, error) {
 	buf[0] = (buf[0] | 0x02) & 0xfe
 
 	return MAC(buf), nil
+}
+
+// HaveMACAddr return true if all given network interfaces have L2 addr.
+func HaveMACAddr(ifaces []string) bool {
+	for _, iface := range ifaces {
+		iface, err := netlink.LinkByName(iface)
+		if err != nil {
+			return false
+		}
+		if len(iface.Attrs().HardwareAddr) == 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -22,6 +22,9 @@ import (
 	"net"
 )
 
+// Untagged ethernet (IEEE 802.3) frame header len
+const EthHdrLen = 14
+
 // MAC address is an net.HardwareAddr encapsulation to force cilium to only use MAC-48.
 type MAC net.HardwareAddr
 

--- a/test/k8sT/manifests/kube-wireguarder.yaml
+++ b/test/k8sT/manifests/kube-wireguarder.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-wireguarder
+  namespace: kube-system
+  labels:
+    app: kube-wireguarder
+spec:
+  selector:
+    matchLabels:
+      app: kube-wireguarder
+  template:
+    metadata:
+      labels:
+        app: kube-wireguarder
+    spec:
+      hostNetwork: true
+      containers:
+      - name: kube-wireguarder
+        image: quay.io/cilium/kube-wireguarder:0.0.2
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "k8s1"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "6443"
+        - name: SETUP_DIRECT_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              name: kube-wireguarder-config
+              key: setup-direct-routes
+
+      serviceAccountName: kube-wireguarder
+      tolerations:
+      - operator: Exists
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-wireguarder-config
+  namespace: kube-system
+data:
+  setup-direct-routes: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-wireguarder
+  labels:
+    app: kube-wireguarder
+rules:
+- apiGroups:
+  - ''
+  - cilium.io
+  resources:
+  - nodes
+  - ciliumnodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-wireguarder
+  labels:
+    app: kube-wireguarder
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-wireguarder
+  labels:
+    app: kube-wireguarder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-wireguarder
+subjects:
+- kind: ServiceAccount
+  name: kube-wireguarder
+  namespace: kube-system


### PR DESCRIPTION
See commit msgs.

I haven't added IPv6 tests, as I'd need to extend https://github.com/cilium/kube-wireguarder to support it. At this point, it would be a waste of time, as we are planning to add the native Wireguard support in this release cycle. So we can add the tests once https://github.com/cilium/cilium/issues/15075 has been resolved.

To fix L2-less with the fast redirect I've opened https://github.com/cilium/cilium/issues/15075.

Fix #12317

```release-note
Add NodePort BPF support to L2-less devices (wireguard, tun, etc)
```