### PR TITLE
ci: offload baremetal "K8s all" builds to sub-jobs

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -194,7 +194,8 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | Jenkins Job                                                                                                    | Trigger Phrases   | Required To Merge? |
 +================================================================================================================+===================+====================+
-| `Cilium-PR-K8s-1.19-kernel-4.9 <https://jenkins.cilium.io/job/Cilium-PR-K8s-1.19-kernel-4.9/>`_                | test-1.19-4.9     | Yes                |
+| `Cilium-PR-K8s-1.20-kernel-4.9 <https://jenkins.cilium.io/job/Cilium-PR-K8s-1.20-kernel-4.9/>`_                | test-me-please,   | Yes                |
+|                                                                                                                | retest-4.9        |                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Ginkgo-Tests-Kernel <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Kernel/>`_                | test-me-please,   | Yes                |
 |                                                                                                                | retest-4.19       |                    |
@@ -207,7 +208,7 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Ginkgo-Tests-Kernel-Focus <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Kernel-Focus/>`_    | test-only         | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-Validated <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/>`_          | restart-ginkgo    | Yes                |
+| `Cilium-PR-Ginkgo-Tests-Validated <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/>`_          | restart-ginkgo    | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Kubernetes-Upstream <https://jenkins.cilium.io/job/Cilium-PR-Kubernetes-Upstream/>`_                | test-upstream-k8s | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
@@ -218,7 +219,7 @@ illustrating which subset of tests the job runs.
 | `Cilium-PR-Ginkgo-Tests-K8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/>`_                      | test-missed-k8s   | No                 |
 |                                                                                                                | **(deprecated)**  |                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-me-please    | Yes                |
+| `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-me-please,   | Yes                |
 |                                                                                                                | retest-gke        |                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -211,7 +211,12 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Kubernetes-Upstream <https://jenkins.cilium.io/job/Cilium-PR-Kubernetes-Upstream/>`_                | test-upstream-k8s | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
+| `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_ (where ``X.XX`` is a K8s version)        | test-X.XX-4.9     | No                 |
++----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
+| All non-required `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_                         | test-older-k8s    | No                 |
++----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Ginkgo-Tests-K8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/>`_                      | test-missed-k8s   | No                 |
+|                                                                                                                | **(deprecated)**  |                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-me-please    | Yes                |
 |                                                                                                                | retest-gke        |                    |
@@ -220,6 +225,25 @@ illustrating which subset of tests the job runs.
 For a full list of Jenkins Jobs, see `Jenkins
 <https://jenkins.cilium.io/view/PR/>`_. Trigger phrases are configured within
 each job's build triggers advanced options.
+
+``test-older-k8s`` allows testing older supported K8s versions, i.e. all
+non-required K8s jobs, by triggering all appropriate
+``Cilium-PR-K8s-X.XX-kernel-4.9`` jobs.
+For example, at the time of writing, it is identical to manually running
+``test-X.XX-4.9`` for versions 1.14 through 1.19.
+If a specific K8s version fails, it can be re-run using ``retest-X.XX-4.9``.
+
+``test-missed-k8s`` is deprecated and superseded by ``test-older-k8s``:
+
+- For new branches: it triggers a ``Cilium-PR-Ginkgo-Tests-K8s`` which does
+  exactly the same thing (triggers all ``Cilium-PR-K8s-X.XX-kernel-4.9`` jobs),
+  except that the compound job (and not the individual jobs) will be displayed
+  on the PR page. This makes it more cumbersome to detect which specific K8s
+  version failed in case of failure.
+- For older branches (where ``test-missed-k8s`` is unavailable): triggers a
+  ``Cilium-PR-Ginkgo-Tests-K8s`` testing older K8s versions by itself.
+  It should not be used for new branches, only for Backport PRs for which
+  ``test-older-k8s`` is unavailable.
 
 For Backport PRs, the phrase ``test-backport-x.x`` (with ``x.x`` being the target Cilium version) should be used to
 trigger all of the above jobs which are marked as required to validate changes

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -1,63 +1,10 @@
 @Library('cilium') _
 
 pipeline {
-    agent {
-        label 'baremetal'
-    }
+    agent none
 
     parameters {
-        string(defaultValue: '${ghprbPullDescription}', name: 'ghprbPullDescription')
-        string(defaultValue: '${ghprbActualCommit}', name: 'ghprbActualCommit')
-        string(defaultValue: '${ghprbTriggerAuthorLoginMention}', name: 'ghprbTriggerAuthorLoginMention')
-        string(defaultValue: '${ghprbPullAuthorLoginMention}', name: 'ghprbPullAuthorLoginMention')
-        string(defaultValue: '${ghprbGhRepository}', name: 'ghprbGhRepository')
-        string(defaultValue: '${ghprbPullLongDescription}', name: 'ghprbPullLongDescription')
-        string(defaultValue: '${ghprbCredentialsId}', name: 'ghprbCredentialsId')
-        string(defaultValue: '${ghprbTriggerAuthorLogin}', name: 'ghprbTriggerAuthorLogin')
-        string(defaultValue: '${ghprbPullAuthorLogin}', name: 'ghprbPullAuthorLogin')
-        string(defaultValue: '${ghprbTriggerAuthor}', name: 'ghprbTriggerAuthor')
-        string(defaultValue: '${ghprbCommentBody}', name: 'ghprbCommentBody')
-        string(defaultValue: '${ghprbPullTitle}', name: 'ghprbPullTitle')
-        string(defaultValue: '${ghprbPullLink}', name: 'ghprbPullLink')
-        string(defaultValue: '${ghprbAuthorRepoGitUrl}', name: 'ghprbAuthorRepoGitUrl')
-        string(defaultValue: '${ghprbTargetBranch}', name: 'ghprbTargetBranch')
-        string(defaultValue: '${ghprbPullId}', name: 'ghprbPullId')
-        string(defaultValue: '${ghprbActualCommitAuthor}', name: 'ghprbActualCommitAuthor')
-        string(defaultValue: '${ghprbActualCommitAuthorEmail}', name: 'ghprbActualCommitAuthorEmail')
-        string(defaultValue: '${ghprbTriggerAuthorEmail}', name: 'ghprbTriggerAuthorEmail')
-        string(defaultValue: '${GIT_BRANCH}', name: 'GIT_BRANCH')
-        string(defaultValue: '${ghprbPullAuthorEmail}', name: 'ghprbPullAuthorEmail')
-        string(defaultValue: '${sha1}', name: 'sha1')
-        string(defaultValue: '${ghprbSourceBranch}', name: 'ghprbSourceBranch')
-    }
-
-    environment {
-        PROJ_PATH = "src/github.com/cilium/cilium"
-        VM_MEMORY = "4096"
-        TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-        GOPATH="${WORKSPACE}"
-        SERVER_BOX = "cilium/ubuntu"
-        FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
-        CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
-        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
-        GINKGO_TIMEOUT="118m"
-        RACE="""${sh(
-                returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n ""; else echo -n "1"; fi'
-            )}"""
-        LOCKDEBUG="""${sh(
-                returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n ""; else echo -n "1"; fi'
-            )}"""
-        BASE_IMAGE="""${sh(
-                returnStdout: true,
-                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-20@sha256:247eff116cc5d0b3a4931eabd67ea2e8679f7c12877729a73929d3f30753065b"; fi'
-            )}"""
-        RUN_QUARANTINED="""${sh(
-                returnStdout: true,
-                script: 'if [ "${RunQuarantined}" = "" ]; then echo -n "false"; else echo -n "${RunQuarantined}"; fi'
-            )}"""
-		KUBECONFIG="vagrant-kubeconfig"
+        string(defaultValue: 'origin/master', name: 'GIT_BRANCH')
     }
 
     options {
@@ -67,527 +14,65 @@ pipeline {
     }
 
     stages {
-        stage('Set build name') {
-            when {
-                not {environment name: 'GIT_BRANCH', value: 'origin/master'}
-            }
-            steps {
-                   script {
-                       currentBuild.displayName = env.getProperty('ghprbPullTitle') + '  ' + env.getProperty('ghprbPullLink') + '  ' + currentBuild.displayName
-                   }
-            }
-        }
-        stage('Checkout') {
-            options {
-                timeout(time: 20, unit: 'MINUTES')
-            }
-
-            steps {
-                sh 'env'
-                Status("PENDING", "${env.JOB_NAME}")
-                checkout scm
-                sh 'mkdir -p ${PROJ_PATH}'
-                sh 'ls -A | grep -v src | xargs mv -t ${PROJ_PATH}'
-                sh '/usr/local/bin/cleanup || true'
-            }
-        }
-        stage('Log in to dockerhub') {
-            steps{
-                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
-                }
-            }
-        }
-        stage('Make Cilium images') {
-            environment {
-                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-            }
-            steps {
-                sh 'cd ${TESTDIR}; ./make-images-push-to-local-registry.sh $(./print-node-ip.sh) latest'
-            }
-            post {
-                unsuccessful {
-                    script {
-                        if  (!currentBuild.displayName.contains('fail')) {
-                            currentBuild.displayName = 'building or pushing Cilium images failed ' + currentBuild.displayName
-                        }
-                    }
-                }
-            }
-        }
-        stage('Preload vagrant boxes') {
-            steps {
-                sh '/usr/local/bin/add_vagrant_box ${WORKSPACE}/${PROJ_PATH}/vagrant_box_defaults.rb'
-            }
-            post {
-                unsuccessful {
-                    script {
-                        if  (!currentBuild.displayName.contains('fail')) {
-                            currentBuild.displayName = 'preload vagrant boxes fail' + currentBuild.displayName
-                        }
-                    }
-                }
-            }
-        }
-        stage('Copy code and boot VMs 1.{14,15}'){
-
-            options {
-                timeout(time: 60, unit: 'MINUTES')
-            }
-
-            environment {
-                GOPATH="${WORKSPACE}"
-                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-            }
-
+        stage('Trigger parallel baremetal K8s builds') {
             parallel {
-                stage('Boot vms 1.14') {
-                    environment {
-                        K8S_VERSION="1.14"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
+                stage('K8s-1.14-kernel-4.9') {
                     steps {
-                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
-                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                timeout(time: 30, unit: 'MINUTES'){
-                                    dir("${TESTDIR}") {
-                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8S 1.14 vm provisioning fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
+                        build(job: "Cilium-PR-K8s-1.14-kernel-4.9", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
+                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        ])
                     }
                 }
-                stage('Boot vms 1.15') {
-                    environment {
-                        K8S_VERSION="1.15"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
-                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                timeout(time: 30, unit: 'MINUTES'){
-                                    dir("${TESTDIR}") {
-                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8S 1.15 vm provisioning fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        stage('BDD-Test-k8s-1.14-and-1.15') {
-            environment {
-                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
-                CILIUM_IMAGE = """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/cilium'
-                        )}"""
-                CILIUM_TAG = "latest"
-                CILIUM_OPERATOR_IMAGE= """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator'
-                        )}"""
-                CILIUM_OPERATOR_TAG = "latest"
-                HUBBLE_RELAY_IMAGE= """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/hubble-relay'
-                        )}"""
-                HUBBLE_RELAY_TAG = "latest"
-                KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
-            }
-            options {
-                timeout(time: 360, unit: 'MINUTES')
-            }
-            parallel {
-                stage('BDD-Test-k8s-1.14') {
-                    environment {
-                        K8S_VERSION="1.14"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
-                    }
-                    post {
-                        always {
-                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
-                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
-                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
-                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
-                        }
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.14 tests fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-                stage('BDD-Test-k8s-1.15') {
-                    environment {
-                        K8S_VERSION="1.15"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
-                    }
-                    post {
-                        always {
-                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
-                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
-                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
-                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
-                        }
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.15 tests fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
 
-        stage('Copy code and boot VMs 1.{15,16}'){
+                stage('K8s-1.15-kernel-4.9') {
+                    steps {
+                        build(job: "Cilium-PR-K8s-1.15-kernel-4.9", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
+                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        ])
+                    }
+                }
 
-            options {
-                timeout(time: 60, unit: 'MINUTES')
-            }
+                stage('K8s-1.16-kernel-4.9') {
+                    steps {
+                        build(job: "Cilium-PR-K8s-1.16-kernel-4.9", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
+                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        ])
+                    }
+                }
 
-            environment {
-                GOPATH="${WORKSPACE}"
-                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-            }
+                stage('K8s-1.17-kernel-4.9') {
+                    steps {
+                        build(job: "Cilium-PR-K8s-1.17-kernel-4.9", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
+                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        ])
+                    }
+                }
 
-            parallel {
-                stage('Boot vms 1.16') {
-                    environment {
-                        K8S_VERSION="1.16"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
+                stage('K8s-1.18-kernel-4.9') {
                     steps {
-                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
-                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                timeout(time: 30, unit: 'MINUTES'){
-                                    dir("${TESTDIR}") {
-                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8S 1.16 vm provisioning fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
+                        build(job: "Cilium-PR-K8s-1.18-kernel-4.9", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
+                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        ])
                     }
                 }
-                stage('Boot vms 1.17') {
-                    environment {
-                        K8S_VERSION="1.17"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
-                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                timeout(time: 30, unit: 'MINUTES'){
-                                    dir("${TESTDIR}") {
-                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8S 1.17 vm provisioning fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        stage('BDD-Test-k8s-1.16-and-1.17') {
-            environment {
-                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
-                CILIUM_IMAGE = """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/cilium'
-                        )}"""
-                CILIUM_TAG = "latest"
-                CILIUM_OPERATOR_IMAGE= """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator'
-                        )}"""
-                CILIUM_OPERATOR_TAG = "latest"
-                HUBBLE_RELAY_IMAGE= """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/hubble-relay'
-                        )}"""
-                HUBBLE_RELAY_TAG = "latest"
-                KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
-            }
-            options {
-                timeout(time: 300, unit: 'MINUTES')
-            }
-            parallel {
-                stage('BDD-Test-k8s-1.16') {
-                    environment {
-                        K8S_VERSION="1.16"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
-                    }
-                    post {
-                        always {
-                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
-                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
-                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
-                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
-                        }
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.16 tests fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-                stage('BDD-Test-k8s-1.17') {
-                    environment {
-                        K8S_VERSION="1.17"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
-                    }
-                    post {
-                        always {
-                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
-                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
-                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
-                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
-                        }
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.17 tests fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        stage('Copy code and boot VMs 1.{18,19}'){
 
-            options {
-                timeout(time: 60, unit: 'MINUTES')
-            }
-
-            environment {
-                GOPATH="${WORKSPACE}"
-                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-            }
-
-            parallel {
-                stage('Boot vms 1.18') {
-                    environment {
-                        K8S_VERSION="1.18"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
+                stage('K8s-1.19-kernel-4.9') {
                     steps {
-                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
-                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                timeout(time: 30, unit: 'MINUTES'){
-                                    dir("${TESTDIR}") {
-                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8S 1.18 vm provisioning fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-                stage('Boot vms 1.19') {
-                    environment {
-                        K8S_VERSION="1.19"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
-                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                timeout(time: 30, unit: 'MINUTES'){
-                                    dir("${TESTDIR}") {
-                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8S 1.19 vm provisioning fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        stage('BDD-Test-k8s-1.18-and-1.19') {
-            environment {
-                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
-                CILIUM_IMAGE = """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/cilium'
-                        )}"""
-                CILIUM_TAG = "latest"
-                CILIUM_OPERATOR_IMAGE= """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator'
-                        )}"""
-                CILIUM_OPERATOR_TAG = "latest"
-                HUBBLE_RELAY_IMAGE= """${sh(
-                        returnStdout: true,
-                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/hubble-relay'
-                        )}"""
-                KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
-            }
-            options {
-                timeout(time: 180, unit: 'MINUTES')
-            }
-            parallel {
-                stage('BDD-Test-k8s-1.18') {
-                    environment {
-                        K8S_VERSION="1.18"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
-                    }
-                    post {
-                        always {
-                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
-                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
-                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
-                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
-                        }
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.18 tests fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
-                    }
-                }
-                stage('BDD-Test-k8s-1.19') {
-                    environment {
-                        K8S_VERSION="1.19"
-                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
-                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                    }
-                    steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
-                    }
-                    post {
-                        always {
-                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
-                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
-                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
-                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
-                        }
-                        unsuccessful {
-                            script {
-                                if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.19 tests fail\n' + currentBuild.displayName
-                                }
-                            }
-                        }
+                        build(job: "Cilium-PR-K8s-1.19-kernel-4.9", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
+                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        ])
                     }
                 }
             }
         }
     }
     post {
-        always {
-            sh 'lscpu'
-            archiveArtifacts artifacts: '*.zip'
-            junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
-            cleanWs()
-            sh '/usr/local/bin/cleanup || true'
-        }
         success {
             Status("SUCCESS", "${env.JOB_NAME}")
         }


### PR DESCRIPTION
Previously, `ginkgo-kubernetes-all.Jenkinsfile` was a compound pipeline sequentially running tests on K8s 1.14 through 1.19, with a copy/pasted version of `ginkgo-kernel.Jenkinsfile` contents. It was used by both the nightly `cilium-master-K8s-all` Jenkins job, and the manually triggered (`test-missed-k8s`) `Cilium-PR-Ginkgo-Tests-K8s` Jenkins job.

This modification offloads responsibility to individual sub-jobs, which are triggered from `ginkgo-kubernetes-all.Jenkinsfile`.

Impacts on nightly tests:
- Functionally none: even though responsibility is offloaded to individual sub-jobs, a fail in any one will result in a fail of the
  global pipeline.

Impacts on PR tests:
- `test-missed-k8s` is deprecated and superseded by `test-older-k8s`, which will trigger `Cilium-PR-K8s-X.XX-kernel-4.9`. Going forward, `Cilium-PR-Ginkgo-Tests-K8s` will progressively stop being used entirely (except for backports), as it is replaced by these jobs.
- `test-X.XX-4.9` may be used to retry a specific Kubernetes version when it fails, rather than restarting the whole compound pipeline.
- `test-backport-X.X` are now more specific and target the appropriate jobs rather than triggering a compound pipeline, according to the following table at the present time:

EDIT: table has been fixed, [see below](https://github.com/cilium/cilium/pull/14861#issuecomment-775824883).

| Job | Trigger |
| - | - |
| Cilium-PR-K8s-1.14-kernel-4.9 | `(re)*(test-1\.14-4\.9\|test-backport-1\.6\|test-older-k8s)` |
| Cilium-PR-K8s-1.15-kernel-4.9 | `(re)*(test-1\.15-4\.9\|test-backport-1\.6\|test-older-k8s)` |
| Cilium-PR-K8s-1.16-kernel-4.9 | `(re)*(test-1\.16-4\.9\|test-backport-1\.6\test-older-k8s)` |
| Cilium-PR-K8s-1.17-kernel-4.9 | `(re)*(test-1\.17-4\.9\|test-backport-1\.7\|test-older-k8s)` |
| Cilium-PR-K8s-1.18-kernel-4.9 | `(re)*(test-1\.18-4\.9\|test-backport-1\.8\|test-older-k8s)` |
| Cilium-PR-K8s-1.19-kernel-4.9 | `(re)*(test-1\.19-4\.9\|test-backport-1\.9\|test-older-k8s)` |
| Cilium-PR-K8s-1.20-kernel-4.9 | `(re)*(test-me-please\|test-4\.9\|test-backport-1\.10)` |

Signed-off-by: Nicolas Busseneau <nicolas@isovalent.com>