### PR TITLE
bpf: Fix compilation of bpf_ct_tests

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -252,9 +252,12 @@ bpf_lxc.o: bpf_lxc.ll
 	@$(ECHO_CC)
 	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
 
+CT_TEST_OPTIONS = -DENABLE_IPV4 -DENABLE_IPV6 -DENABLE_HOST_REDIRECT -DENABLE_NAT46 \
+	-DENABLE_ROUTING -DENABLE_IPSEC -DPOLICY_VERDICT_NOTIFY
+
 tests/bpf_ct_tests.ll: tests/bpf_ct_tests.c $(LIB)
 	@$(ECHO_CC)
-	$(QUIET) ${CLANG} $(patsubst %,%=1,${MAX_LXC_OPTIONS}) ${CLANG_FLAGS} -c $< -o $@
+	$(QUIET) ${CLANG} $(patsubst %,%=1,${CT_TEST_OPTIONS}) ${CLANG_FLAGS} -c $< -o $@
 
 tests/bpf_ct_tests.o: tests/bpf_ct_tests.ll
 	@$(ECHO_CC)
@@ -262,7 +265,7 @@ tests/bpf_ct_tests.o: tests/bpf_ct_tests.ll
 
 .PHONY: go_prog_test
 go_prog_test: $(BPF_TEST)
-	sudo go test -tags noci ./tests/prog_test
+	sudo go test -tags privileged_tests ./tests/prog_test
 
 subdirs: $(SUBDIRS)
 	$(QUIET) $(foreach TARGET,$(SUBDIRS), \

--- a/bpf/tests/prog_test/prog_test.go
+++ b/bpf/tests/prog_test/prog_test.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// NB: leave this out from the CI for now.
-// +build noci
+// +build privileged_tests
 
 package bpfprogtester
 


### PR DESCRIPTION
b905f0d ("bpf: Compile test with tunneling disabled") broke the compilation of `bpf/tests/bpf_ct_tests` as shown below:

    In file included from tests/bpf_ct_tests.c:41:
    In file included from /home/ubuntu/go/src/github.com/cilium/cilium/bpf/lib/conntrack.h:14:
    In file included from /home/ubuntu/go/src/github.com/cilium/cilium/bpf/lib/ipv4.h:10:
    In file included from /home/ubuntu/go/src/github.com/cilium/cilium/bpf/lib/metrics.h:13:
    /home/ubuntu/go/src/github.com/cilium/cilium/bpf/lib/maps.h:96:14: error: use of undeclared identifier 'TUNNEL_ENDPOINT_MAP_SIZE'
            .max_elem       = TUNNEL_ENDPOINT_MAP_SIZE,
                              ^
    In file included from tests/bpf_ct_tests.c:41:
    In file included from /home/ubuntu/go/src/github.com/cilium/cilium/bpf/lib/conntrack.h:14:
    /home/ubuntu/go/src/github.com/cilium/cilium/bpf/lib/ipv4.h:31:14: error: use of undeclared identifier 'CILIUM_IPV4_FRAG_MAP_MAX_ENTRIES'
            .max_elem       = CILIUM_IPV4_FRAG_MAP_MAX_ENTRIES,
                              ^
    2 errors generated.

The error was not detected because this test doesn't run in CI.

This pull request fixes it by restoring the set of compile options used for `bpf_ct_tests` before b905f0d.

Fixes: https://github.com/cilium/cilium/pull/14451