### PR TITLE
Fix error propagation in (*K8sWatcher).addK8sPodV1

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -238,12 +238,7 @@ func (k *K8sWatcher) addK8sPodV1(pod *slim_corev1.Pod) error {
 		logger.WithError(err).Debug("Skipped ipcache map update on pod add")
 		return nil
 	case err != nil:
-		msg := "Unable to update ipcache map entry on pod add"
-		if errors.Is(err, errIPCacheOwnedByNonK8s) {
-			logger.WithError(err).Debug(msg)
-		} else {
-			logger.WithError(err).Warning(msg)
-		}
+		logger.WithError(err).Warning("Unable to update ipcache map entry on pod add")
 	default:
 		logger.Debug("Updated ipcache map entry on pod add")
 	}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -106,8 +106,6 @@ var (
 	importMetadataCache = ruleImportMetadataCache{
 		ruleImportMetadataMap: make(map[string]policyImportMetadata),
 	}
-
-	errIPCacheOwnedByNonK8s = fmt.Errorf("ipcache entry owned by kvstore or agent")
 )
 
 type endpointManager interface {


### PR DESCRIPTION
The first commit is a preparatory cleanup of an unused sentinel error var.

The second commit fixes the error propagation issue (as per the commit message):

In `(*K8sWatcher).addK8sPodV1`, the `error` return value of
`(*K8sWatcher).updatePodHostData` is ignored due to the fact that the `bool`
return value is always `true` if there was an error. This leads to
a debug message being printed rather than a warning. Also the
error is not propagated to callers of `(*K8sWatcher).addK8sPodV1`, which
in one case in `(*K8sWatcher).createPodController` leads to metrics not
being updated appropriately.

The `bool` return value of `(*K8sWatcher).createPodController` is anyway
redundant, so remove it. Instead, check the error explicitly at the call
site and log and propagate it accordingly.