### PR TITLE
test: Always select nodes by label

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3637,9 +3637,9 @@ func (kub *Kubectl) GeneratePodLogGatheringCommands(ctx context.Context, reportC
 	}
 }
 
-// GetCiliumPodOnNode returns the name of the Cilium pod that is running on / in
+// getCiliumPodOnNodeByName returns the name of the Cilium pod that is running on / in
 //the specified node / namespace.
-func (kub *Kubectl) GetCiliumPodOnNode(node string) (string, error) {
+func (kub *Kubectl) getCiliumPodOnNodeByName(node string) (string, error) {
 	filter := fmt.Sprintf(
 		"-o jsonpath='{.items[?(@.spec.nodeName == \"%s\")].metadata.name}'", node)
 
@@ -3662,14 +3662,14 @@ func (kub *Kubectl) GetNodeInfo(label string) (nodeName, nodeIP string) {
 	return nodeName, nodeIP
 }
 
-// GetCiliumPodOnNodeWithLabel returns the name of the Cilium pod that is running on node with cilium.io/ci-node label
-func (kub *Kubectl) GetCiliumPodOnNodeWithLabel(label string) (string, error) {
+// GetCiliumPodOnNode returns the name of the Cilium pod that is running on node with cilium.io/ci-node label
+func (kub *Kubectl) GetCiliumPodOnNode(label string) (string, error) {
 	node, err := kub.GetNodeNameByLabel(label)
 	if err != nil {
 		return "", fmt.Errorf("Unable to get nodes with label '%s': %s", label, err)
 	}
 
-	return kub.GetCiliumPodOnNode(node)
+	return kub.getCiliumPodOnNodeByName(node)
 }
 
 func (kub *Kubectl) validateCilium() error {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -185,7 +185,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		validateBPFTunnelMap := func() {
 			By("Checking that BPF tunnels are in place")
-			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			ExpectWithOffset(1, err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
 			status := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, "cilium bpf tunnel list | wc -l")
 
@@ -863,7 +863,7 @@ func monitorConnectivityAcrossNodes(kubectl *helpers.Kubectl) (monitorRes *helpe
 		By("Performing multinode connectivity check within a single node")
 	}
 
-	ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+	ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 
 	By(fmt.Sprintf("Launching cilium monitor on %q", ciliumPodK8s1))

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -58,7 +58,7 @@ var _ = Describe("K8sHealthTest", func() {
 		})
 
 		getCilium := func(node string) (pod, ip string) {
-			pod, err := kubectl.GetCiliumPodOnNodeWithLabel(node)
+			pod, err := kubectl.GetCiliumPodOnNode(node)
 			Expect(err).Should(BeNil())
 
 			res, err := kubectl.Get(

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -203,7 +203,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
-			ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			Expect(err).Should(BeNil(), "cannot get CiliumPod")
 
 			clusterIP, _, err = kubectl.GetServiceHostPort(namespaceForTest, app1Service)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -348,7 +348,7 @@ var _ = Describe("K8sServicesTest", func() {
 				serviceNames = append(serviceNames, serviceNameIPv6)
 			}
 
-			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 			monitorRes, monitorCancel := kubectl.MonitorStart(ciliumPodK8s1)
 			defer func() {
@@ -904,9 +904,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 				blockSize  = 5120
 				blockCount = 1
 			)
-			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
-			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
+			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 			ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 
 			_, dstPodIPK8s1 := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDS, 1)
@@ -1483,7 +1483,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 					podIPs, err := kubectl.GetPodsIPs(helpers.DefaultNamespace, testDS)
 					ExpectWithOffset(1, err).Should(BeNil(), "Cannot get pod IP addrs for -l %s pods", testDS)
 					for _, ipAddr := range podIPs {
-						err = kubectl.WaitForIPCacheEntry(k8s1NodeName, ipAddr)
+						err = kubectl.WaitForIPCacheEntry(helpers.K8s1, ipAddr)
 						ExpectWithOffset(1, err).Should(BeNil(), "Failed waiting for %s ipcache entry on k8s1", ipAddr)
 					}
 				}
@@ -1551,7 +1551,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 				count := 10
 
-				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
+				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 				ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 
 				if helpers.ExistNodeWithoutCilium() {
@@ -1751,7 +1751,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			// Destination address and port for fragmented datagram
 			// are not DNAT-ed with kube-proxy but without bpf_sock.
 			if helpers.RunsWithKubeProxy() {
-				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 				hasDNAT = kubectl.HasHostReachableServices(ciliumPodK8s1, false, true)
 			}
@@ -1789,7 +1789,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			// from previous tests with --node-port-algorithm=random
 			// won't interfere the backend selection.
 			for _, label := range []string{helpers.K8s1, helpers.K8s2} {
-				pod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+				pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				ExpectWithOffset(1, err).Should(BeNil(), "cannot get cilium pod name %s", label)
 				kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium bpf ct flush global", "Unable to flush CT maps")
 			}
@@ -1989,9 +1989,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 			BeforeAll(func() {
 				var err error
-				ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+				ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				Expect(err).Should(BeNil(), "Cannot get cilium pod on %s", helpers.K8s1)
-				ciliumPodK8s2, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
+				ciliumPodK8s2, err = kubectl.GetCiliumPodOnNode(helpers.K8s2)
 				Expect(err).Should(BeNil(), "Cannot get cilium pod on %s", helpers.K8s2)
 
 				// Find out the DNS proxy ports in use
@@ -2076,10 +2076,10 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 
 			It("Tests NodePort with L4 Policy", func() {
-				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 				monitorRes1, monitorCancel1 := kubectl.MonitorStart(ciliumPodK8s1)
-				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
+				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 				Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 				monitorRes2, monitorCancel2 := kubectl.MonitorStart(ciliumPodK8s2)
 				defer func() {
@@ -2102,10 +2102,10 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 
 			It("Tests NodePort with L7 Policy", func() {
-				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 				monitorRes1, monitorCancel1 := kubectl.MonitorStart(ciliumPodK8s1)
-				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
+				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 				Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 				monitorRes2, monitorCancel2 := kubectl.MonitorStart(ciliumPodK8s2)
 				defer func() {
@@ -2980,7 +2980,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 			By("Checking that policies were correctly imported into Cilium")
 
-			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPodK8s1, policyCmd)
 			res.ExpectSuccess("Policy %s is not imported", policyCmd)

--- a/test/k8sT/StressPolicy.go
+++ b/test/k8sT/StressPolicy.go
@@ -94,7 +94,7 @@ var _ = Describe("NightlyPolicyStress", func() {
 			randomNamespace := deploymentManager.DeployRandomNamespace(ConnectivityCheck)
 			deploymentManager.WaitUntilReady()
 
-			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			Expect(err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
 
 			By("Stressing Cilium policy engine by inserting 20000 identities into kvstore...")

--- a/test/k8sT/cli.go
+++ b/test/k8sT/cli.go
@@ -72,7 +72,7 @@ var _ = Describe("K8sCLI", func() {
 				err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l id", helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "The pods were not ready after timeout")
 
-				ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel(fooNode)
+				ciliumPod, err = kubectl.GetCiliumPodOnNode(fooNode)
 				Expect(err).Should(BeNil())
 
 				err := kubectl.WaitForCEPIdentity(helpers.DefaultNamespace, fooID)
@@ -138,9 +138,9 @@ var _ = Describe("K8sCLI", func() {
 					namespaceForTest, l3L4DenyPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot apply L3 Deny Policy")
 
-				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
-				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
+				ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 				ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 
 				countBeforeK8s1, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s1, "Policy denied by denylist", "ingress")
@@ -175,7 +175,7 @@ var _ = Describe("K8sCLI", func() {
 			)
 
 			BeforeAll(func() {
-				ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel("k8s1")
+				ciliumPod, err = kubectl.GetCiliumPodOnNode("k8s1")
 				Expect(err).Should(BeNil())
 			})
 

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -124,10 +124,10 @@ var _ = Describe("K8sFQDNTest", func() {
 		// - On restart) Cilium will restore the IPS that were white-listted in
 		// the FQDN and connection will work as normal.
 
-		ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+		ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 		monitorRes1, monitorCancel1 := kubectl.MonitorStart(ciliumPodK8s1)
-		ciliumPodK8s2, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s2)
+		ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 		monitorRes2, monitorCancel2 := kubectl.MonitorStart(ciliumPodK8s2)
 		defer func() {

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -142,7 +142,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			})
 
 			var err error
-			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.K8s1)
+			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
 
 			ExpectHubbleRelayReady(kubectl, hubbleRelayNamespace)


### PR DESCRIPTION
The node name for nodes in e.g. GKE is not fixed as in Packet nodes. So selecting nodes based on their name, as done in `GetCiliumPodOnNode` doesn't work there. This commit renames `GetCiliumPodOnNode` to `GetCiliumPodOnNodeWithLabels` and ensures we always select nodes by label in tests.
