### PR TITLE
v1.7 backports 2021-02-05

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -142,7 +142,8 @@ const (
 	StateTerminating = "Terminating"
 	StateRunning     = "Running"
 
-	PingCount = 5
+	PingCount   = 5
+	PingTimeout = 5
 
 	// CurlConnectTimeout is the timeout for the connect() call that curl
 	// invokes

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -16,7 +16,9 @@ package constants
 
 const (
 	// NetperfImage is the Docker image used for performance testing
-	NetperfImage = "docker.io/tgraf/netperf:v1.0"
+	// NB: this image includes netperf and a utility named xping that works
+	// like ping but it also allows to specify the ICMP id.
+	NetperfImage = "quay.io/cilium/net-test:v1.0.0"
 
 	// HttpdImage is the image used for starting an HTTP server.
 	HttpdImage = "docker.io/cilium/demo-httpd:latest"

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -52,6 +52,14 @@ func Ping6(endpoint string) string {
 	return fmt.Sprintf("ping6 -c %d %s", PingCount, endpoint)
 }
 
+func Ping6WithID(endpoint string, icmpID uint16) string {
+	return fmt.Sprintf("xping -6 -W %d -c %d -x %d %s", PingTimeout, PingCount, icmpID, endpoint)
+}
+
+func PingWithID(endpoint string, icmpID uint16) string {
+	return fmt.Sprintf("xping -W %d -c %d -x %d %s", PingTimeout, PingCount, icmpID, endpoint)
+}
+
 // Wrk runs a standard wrk test for http
 func Wrk(endpoint string) string {
 	return fmt.Sprintf("wrk -t2 -c100 -d30s -R2000 http://%s", endpoint)

--- a/test/k8sT/manifests/netperf-deployment.yaml
+++ b/test/k8sT/manifests/netperf-deployment.yaml
@@ -14,6 +14,9 @@ spec:
     readinessProbe:
       exec:
         command: ["netperf", "-H", "127.0.0.1", "-l", "1"]
+      # This timeout needs to be higher than the time netperf command takes to
+      # finish its execution
+      timeoutSeconds: 5
 ---
 apiVersion: v1
 kind: Pod

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -480,14 +480,16 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 					assert:      BeFalse,
 				},
 				{
+					// see comment below about ICMP ids
 					from:        helpers.Client,
-					to:          helpers.Ping6(serverDockerNetworking[helpers.IPv6]),
+					to:          helpers.Ping6WithID(serverDockerNetworking[helpers.IPv6], 1111),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
 				{
+					// see comment below about ICMP ids
 					from:        helpers.Client,
-					to:          helpers.Ping(serverDockerNetworking[helpers.IPv4]),
+					to:          helpers.PingWithID(serverDockerNetworking[helpers.IPv4], 1111),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
@@ -539,13 +541,19 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 
 			By("Testing bidirectional connectivity from client to server")
 
+			// NB: Previous versions of this test did not specify the ICMP id, which
+			// presumably caused transient errors (see #12891) when the ICMP ids for the
+			// valid direction (client->server) matched the ICMP ids for the invalid
+			// direction (server->client). We now ensure that the ICMP ids do not match.
+			// Furthermore, the original issue can be now easily reproduced by changing
+			// 2222 to 1111 below.
 			By("container %s pinging %s IPv6 (should NOT work)", helpers.Server, helpers.Client)
-			res = vm.ContainerExec(helpers.Server, helpers.Ping6(clientDockerNetworking[helpers.IPv6]))
+			res = vm.ContainerExec(helpers.Server, helpers.Ping6WithID(clientDockerNetworking[helpers.IPv6], 2222))
 			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
 				"container %q unexpectedly was able to ping to %q IP:%q", helpers.Server, helpers.Client, clientDockerNetworking[helpers.IPv6])
 
 			By("container %s pinging %s IPv4 (should NOT work)", helpers.Server, helpers.Client)
-			res = vm.ContainerExec(helpers.Server, helpers.Ping(clientDockerNetworking[helpers.IPv4]))
+			res = vm.ContainerExec(helpers.Server, helpers.PingWithID(clientDockerNetworking[helpers.IPv4], 2222))
 			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
 				"%q was unexpectedly able to ping to %q IP:%q", helpers.Server, helpers.Client, clientDockerNetworking[helpers.IPv4])
 


### PR DESCRIPTION
* #13989 -- runtime: specify ICMP ids on connectivity test (@kkourt)
  Add definition for `PingTimeout`, created in commit e1e1f50.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13989; do contrib/backporting/set-labels.py $pr done 1.7; done
```