### PR TITLE
v1.8 backports 2021-02-05

### DIFF
--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -16,7 +16,9 @@ package constants
 
 const (
 	// NetperfImage is the Docker image used for performance testing
-	NetperfImage = "docker.io/tgraf/netperf:v1.0"
+	// NB: this image includes netperf and a utility named xping that works
+	// like ping but it also allows to specify the ICMP id.
+	NetperfImage = "quay.io/cilium/net-test:v1.0.0"
 
 	// HttpdImage is the image used for starting an HTTP server.
 	HttpdImage = "docker.io/cilium/demo-httpd:latest"

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -58,6 +58,14 @@ func Ping6(endpoint string) string {
 	return fmt.Sprintf("ping6 -c %d %s", PingCount, endpoint)
 }
 
+func Ping6WithID(endpoint string, icmpID uint16) string {
+	return fmt.Sprintf("xping -6 -W %d -c %d -x %d %s", PingTimeout, PingCount, icmpID, endpoint)
+}
+
+func PingWithID(endpoint string, icmpID uint16) string {
+	return fmt.Sprintf("xping -W %d -c %d -x %d %s", PingTimeout, PingCount, icmpID, endpoint)
+}
+
 // Wrk runs a standard wrk test for http
 func Wrk(endpoint string) string {
 	return fmt.Sprintf("wrk -t2 -c100 -d30s -R2000 http://%s", endpoint)

--- a/test/k8sT/Verifier.go
+++ b/test/k8sT/Verifier.go
@@ -62,7 +62,9 @@ var _ = Describe("K8sVerifier", func() {
 	})
 
 	AfterFailed(func() {
-		res := kubectl.Exec("kubectl describe pod")
+		res := kubectl.Exec("kubectl describe nodes")
+		GinkgoPrint(res.CombineOutput().String())
+		res = kubectl.Exec("kubectl describe pods")
 		GinkgoPrint(res.CombineOutput().String())
 	})
 

--- a/test/k8sT/manifests/netperf-deployment.yaml
+++ b/test/k8sT/manifests/netperf-deployment.yaml
@@ -14,6 +14,9 @@ spec:
     readinessProbe:
       exec:
         command: ["netperf", "-H", "127.0.0.1", "-l", "1"]
+      # This timeout needs to be higher than the time netperf command takes to
+      # finish its execution
+      timeoutSeconds: 5
 ---
 apiVersion: v1
 kind: Pod

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -37,3 +37,5 @@ spec:
   - key: "node.kubernetes.io/unreachable"
     operator: "Exists"
   hostNetwork: true
+  nodeSelector:
+    "cilium.io/ci-node": k8s1


### PR DESCRIPTION
* #13989 -- runtime: specify ICMP ids on connectivity test (@kkourt)
 * #14803 -- test: K8sVerifier Fix test-verifier's scheduling (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 13989 14803; do contrib/backporting/set-labels.py $pr done 1.8; done
```