### PR TITLE
v1.9 backports 2021-02-05

### DIFF
--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -63,6 +63,14 @@ func (s *MaglevSuite) SetUpSuite(c *C) {
 	// Otherwise opening the map might fail with EPERM
 	err = unix.Setrlimit(unix.RLIMIT_MEMLOCK, &tmpLim)
 	c.Assert(err, IsNil)
+
+	Init(InitParams{
+		IPv4: option.Config.EnableIPv4,
+		IPv6: option.Config.EnableIPv6,
+
+		MaxSockRevNatMapEntries: option.Config.SockRevNatEntries,
+		MaxEntries:              option.Config.LBMapEntries,
+	})
 }
 
 func (s *MaglevSuite) TeadDownTest(c *C) {

--- a/test/k8sT/Verifier.go
+++ b/test/k8sT/Verifier.go
@@ -62,7 +62,9 @@ var _ = Describe("K8sVerifier", func() {
 	})
 
 	AfterFailed(func() {
-		res := kubectl.Exec("kubectl describe pod")
+		res := kubectl.Exec("kubectl describe nodes")
+		GinkgoPrint(res.CombineOutput().String())
+		res = kubectl.Exec("kubectl describe pods")
 		GinkgoPrint(res.CombineOutput().String())
 	})
 

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -37,3 +37,5 @@ spec:
   - key: "node.kubernetes.io/unreachable"
     operator: "Exists"
   hostNetwork: true
+  nodeSelector:
+    "cilium.io/ci-node": k8s1


### PR DESCRIPTION
* #14842 -- lbmap: Initialize maps before test suite runs (@christarazi)
 * #14803 -- test: K8sVerifier Fix test-verifier's scheduling (@pchaigno)

Skipped:

 * #14622 -- maglev: Allocate permutations slice ahead of time (@christarazi)
   Does not apply, because 72b755d59be8 (`maglev: Parallelize calculation of permutations`) has not been backported, not sure if we want to. [EDIT:] Chris says #14622 should not be backported anyway, was likely labelled by mistake.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14842 14803; do contrib/backporting/set-labels.py $pr done 1.9; done
```