### PR TITLE
Wire agent securityContext from values.yaml

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -283,6 +283,7 @@ spec:
             - NET_ADMIN
             - SYS_MODULE
           privileged: true
+          {{- toYaml .Values.securityContext | trim | nindent 10 }}
         volumeMounts:
 {{- /* CRI-O already mounts the BPF filesystem */ -}}
 {{- if not (eq .Values.containerRuntime.integration "crio") }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:


The published values.yaml for the helm chart advertises the ability to add additional values to the agent securityContext, but set values were not used in the chart. The current reason to use this is to set specific seLinuxOptions.

See the current values.yaml: https://github.com/cilium/cilium/blob/265d6775c2e0eb4e9d1dfef3ebeaa19a9b976e5f/install/kubernetes/cilium/values.yaml#L169-L171
