### PR TITLE
images: Set GOPS_CONFIG_DIR in scratch images

### DIFF
--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -48,6 +48,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-aws /usr/bin/cilium-operator-aws
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -48,6 +48,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-azure /usr/bin/cilium-operator-azure
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -48,6 +48,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-generic /usr/bin/cilium-operator-generic
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -48,6 +48,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -43,6 +43,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/hubble-relay/hubble-relay /usr/bin/hubble-relay
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -30,6 +30,7 @@ ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 
 WORKDIR /
+ENV GOPS_CONFIG_DIR=/
 
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH} .
 

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -30,6 +30,7 @@ ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 
 WORKDIR /
+ENV GOPS_CONFIG_DIR=/
 
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH} .
 


### PR DESCRIPTION
This sets the `GOPS_CONFIG_DIR` environment variable in all images which
use gops and are based on a scratch image.

This fixes an issue with `crun` where due to missing environment
variables, cilium-operator and hubble-relay would error out when
starting the gops agent with the following error:

```
Error: failed to start gops agent: unable to get current user home
directory: os/user lookup failed; $HOME is empty
```

This only seems to occur on `crun`, which sets `HOME` to an empty
variable in scratch images. In non-scratch images, it sets HOME
according to `/etc/passwd` (see https://github.com/containers/crun/pull/104),
so this currently only affects the cilium-operator and hubble-relay images
when deployed with crun. Most other container runtimes
seem to set `HOME` to `/` in scratch images, which works for gops.

I have manually verified that this fixes the issue with `podman --runtime /usr/bin/crun run`

Fixes: #14301 (check this issue for additional context)

