### PR TITLE
Add new metrics for dump_interrupts

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -213,7 +213,7 @@ Datapath
 ============================================= ================================================== ========================================================
 Name                                          Labels                                             Description
 ============================================= ================================================== ========================================================
-``datapath_errors_total``                     ``area``, ``name``, ``family``                     Total number of errors occurred in datapath management
+``datapath_conntrack_dump_resets_total``      ``area``, ``name``, ``family``                     Number of conntrack dump resets. Happens when a BPF entry gets removed while dumping the map is in progress.
 ``datapath_conntrack_gc_runs_total``          ``status``                                         Number of times that the conntrack garbage collector process was run
 ``datapath_conntrack_gc_key_fallbacks_total``                                                    The number of alive and deleted conntrack entries at the end of a garbage collector run labeled by datapath family
 ``datapath_conntrack_gc_entries``             ``family``                                         The number of alive and deleted conntrack entries at the end of a garbage collector run

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -357,7 +357,8 @@ The following metrics have been removed:
 * ``cilium_k8s_client_api_calls_counter`` is removed. Please use ``cilium_k8s_client_api_calls_total`` instead.
 * ``cilium_identity_count`` is removed. Please use ``cilium_identity`` instead.
 * ``cilium_policy_count`` is removed. Please use ``cilium_policy`` instead.
-* ``cilium_policy_import_errors`` removed. Please use ``cilium_policy_import_errors_total`` instead.
+* ``cilium_policy_import_errors`` is removed. Please use ``cilium_policy_import_errors_total`` instead.
+* ``cilium_datapath_errors_total`` is removed. Please use ``cilium_datapth_conntrack_dump_resets_total`` instead.
 * Label ``mapName`` in ``cilium_bpf_map_ops_total`` is removed. Please use label ``map_name`` instead.
 * Label ``eventType`` in ``cilium_nodes_all_events_received_total`` removed. Please use label ``event_type`` instead.
 * Label ``responseCode`` in ``*api_duration_seconds`` removed. Please use label ``response_code`` instead.
@@ -365,6 +366,12 @@ The following metrics have been removed:
 * Label ``subnetId`` in ``cilium_operator_ipam_release_ops`` is removed. Please use label ``subnet_id`` instead.
 * Label ``subnetId`` and ``availabilityZone`` in ``cilium_operator_ipam_available_ips_per_subnet`` are removed. Please
   use label ``subnet_id`` and ``availability_zone`` instead.
+
+New Metrics
+~~~~~~~~~~~
+
+  * ``cilium_datapath_conntrack_dump_resets_total`` Number of conntrack dump resets. Happens when a BPF entry gets removed
+    while dumping the map is in progress.
 
 New Options
 ~~~~~~~~~~~

--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
@@ -3687,7 +3687,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(cilium_datapath_errors_total{k8s_app=\"cilium\"}) by (pod, area, family, name)",
+          "expr": "sum(cilium_datapath_conntrack_dump_resets_total{k8s_app=\"cilium\"}) by (pod, area, family, name)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{name}} {{area}} {{family}}",
@@ -3698,7 +3698,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Datapath Errors",
+      "title": "Datapath Conntrack Dump Resets",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -4039,7 +4039,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cilium_datapath_errors_total{k8s_app=\"cilium\"}) by (pod, area, family, name)",
+              "expr": "sum(cilium_datapath_conntrack_dump_resets_total{k8s_app=\"cilium\"}) by (pod, area, family, name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{name}} {{area}} {{family}}",
@@ -4050,7 +4050,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Datapath Errors",
+          "title": "Datapath Conntrack Dump Resets",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -98,9 +98,9 @@ func (s *gcStats) finish() {
 	family := s.family.String()
 	switch s.family {
 	case gcFamilyIPv6:
-		metrics.DatapathErrors.With(labelIPv6CTDumpInterrupts).Add(float64(s.Interrupted))
+		metrics.ConntrackDumpResets.With(labelIPv6CTDumpInterrupts).Add(float64(s.Interrupted))
 	case gcFamilyIPv4:
-		metrics.DatapathErrors.With(labelIPv4CTDumpInterrupts).Add(float64(s.Interrupted))
+		metrics.ConntrackDumpResets.With(labelIPv4CTDumpInterrupts).Add(float64(s.Interrupted))
 	}
 	proto := s.proto.String()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -300,10 +300,6 @@ var (
 
 	// Datapath statistics
 
-	// DatapathErrors is the number of errors managing datapath components
-	// such as BPF maps.
-	DatapathErrors = NoOpCounterVec
-
 	// ConntrackGCRuns is the number of times that the conntrack GC
 	// process was run.
 	ConntrackGCRuns = NoOpCounterVec
@@ -319,6 +315,9 @@ var (
 
 	// ConntrackGCDuration the duration of the conntrack GC process in milliseconds.
 	ConntrackGCDuration = NoOpObserverVec
+
+	// ConntrackDumpReset marks the count for conntrack dump resets
+	ConntrackDumpResets = NoOpCounterVec
 
 	// Signals
 
@@ -469,11 +468,11 @@ type Configuration struct {
 	DropBytesEnabled                        bool
 	NoOpCounterVecEnabled                   bool
 	ForwardBytesEnabled                     bool
-	DatapathErrorsEnabled                   bool
 	ConntrackGCRunsEnabled                  bool
 	ConntrackGCKeyFallbacksEnabled          bool
 	ConntrackGCSizeEnabled                  bool
 	ConntrackGCDurationEnabled              bool
+	ConntrackDumpResetsEnabled              bool
 	SignalsHandledEnabled                   bool
 	ServicesCountEnabled                    bool
 	ErrorsWarningsEnabled                   bool
@@ -531,7 +530,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_drop_bytes_total":                                              {},
 		Namespace + "_forward_count_total":                                           {},
 		Namespace + "_forward_bytes_total":                                           {},
-		Namespace + "_" + SubsystemDatapath + "_errors_total":                        {},
+		Namespace + "_" + SubsystemDatapath + "_conntrack_dump_resets_total":         {},
 		Namespace + "_" + SubsystemDatapath + "_conntrack_gc_runs_total":             {},
 		Namespace + "_" + SubsystemDatapath + "_conntrack_gc_key_fallbacks_total":    {},
 		Namespace + "_" + SubsystemDatapath + "_conntrack_gc_entries":                {},
@@ -855,17 +854,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			collectors = append(collectors, ForwardBytes)
 			c.ForwardBytesEnabled = true
 
-		case Namespace + "_" + SubsystemDatapath + "_errors_total":
-			DatapathErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemDatapath,
-				Name:      "errors_total",
-				Help:      "Number of errors that occurred in the datapath or datapath management",
-			}, []string{LabelDatapathArea, LabelDatapathName, LabelDatapathFamily})
-
-			collectors = append(collectors, DatapathErrors)
-			c.DatapathErrorsEnabled = true
-
 		case Namespace + "_" + SubsystemDatapath + "_conntrack_gc_runs_total":
 			ConntrackGCRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
 				Namespace: Namespace,
@@ -922,6 +910,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, ConntrackGCDuration)
 			c.ConntrackGCDurationEnabled = true
+
+		case Namespace + "_" + SubsystemDatapath + "_conntrack_dump_resets_total":
+			ConntrackDumpResets = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemDatapath,
+				Name:      "conntrack_dump_resets_total",
+				Help:      "Number of conntrack dump resets. Happens when a BPF entry gets removed while dumping the map is in progress",
+			}, []string{LabelDatapathArea, LabelDatapathName, LabelDatapathFamily})
+
+			collectors = append(collectors, ConntrackDumpResets)
+			c.ConntrackDumpResetsEnabled = true
 
 		case Namespace + "_" + SubsystemDatapath + "_signals_handled_total":
 			SignalsHandled = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Current metric `cilium_datapath_errors_total` is confusing.
This is not an error. The `dump_interrupts` happens when a BPF entry
gets removed while dumping the map is in progress.
This PR introduces a new metric name in order to make it clearer for the
users.

Fixes: #9212

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

```release-note
Metrics: Add cilium_datapath_dump_resets for dump_interrupts count
```
