### PR TITLE
Fixes 14722: add network policy generator/tester

### DIFF
--- a/.github/workflows/cyclonus-netpol-test.yaml
+++ b/.github/workflows/cyclonus-netpol-test.yaml
@@ -1,0 +1,110 @@
+name: Cyclonus network policy test
+
+on:
+  schedule:
+    # run once a day at midnight
+    - cron: '0 0 * * *'
+
+env:
+  KIND_VERSION: v0.9.0
+  KIND_CONFIG: .github/kind-config.yaml
+  CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
+  TIMEOUT: 2m
+  LOG_TIME: 30m
+
+jobs:
+  preflight-clusterrole:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check pre-flight clusterrole
+        run: |
+          cd install/kubernetes/cilium/templates
+          echo "Checking for differences between preflight and agent clusterrole"
+          diff \
+             -I '^[ ]\{2\}name: cilium.*' \
+             -I '^Keep file in synced with.*' \
+             -I '{{- if.*' \
+             cilium-agent-clusterrole.yaml \
+             cilium-preflight-clusterrole.yaml
+
+  cyclonus-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Precheck generated connectivity manifest files
+        run: |
+          make -C examples/kubernetes/connectivity-check fmt
+          make -C examples/kubernetes/connectivity-check all
+          git diff --exit-code || (echo "please run 'make -C examples/kubernetes/connectivity-check all' and submit your changes"; exit 1)
+
+      - name: Set image tag
+        id: vars
+        run: |
+          if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
+            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+          else
+            echo ::set-output name=tag::${{ github.sha }}
+          fi
+
+      - name: Wait for images to be available
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.1.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          config: ${{ env.KIND_CONFIG }}
+
+      - name: Install cilium chart
+        run: |
+          helm install cilium ./install/kubernetes/cilium \
+             --wait \
+             --namespace kube-system \
+             --set nodeinit.enabled=true \
+             --set kubeProxyReplacement=partial \
+             --set hostServices.enabled=false \
+             --set externalIPs.enabled=true \
+             --set nodePort.enabled=true \
+             --set hostPort.enabled=true \
+             --set bpf.masquerade=false \
+             --set ipam.mode=kubernetes \
+             --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+             --set image.tag=${{ steps.vars.outputs.tag }} \
+             --set image.pullPolicy=IfNotPresent \
+             --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+             --set operator.image.suffix=-ci \
+             --set operator.image.tag=${{ steps.vars.outputs.tag }} \
+             --set operator.image.pullPolicy=IfNotPresent \
+             --set prometheus.enabled=true \
+             --set operator.prometheus.enabled=true \
+             --set hubble.enabled=true \
+             --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}"
+
+          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
+          # To make sure that cilium CRD is available (default timeout is 5m)
+          # https://github.com/cilium/cilium/blob/master/operator/crd.go#L34
+          kubectl wait --for condition=Established crd/ciliumnetworkpolicies.cilium.io --timeout=5m
+
+      - name: Run cyclonus network policy test
+        working-directory: tests/netpol-cyclonus
+        run: ./test-cyclonus.sh
+
+      - name: Capture cilium-sysdump
+        if: ${{ failure() }}
+        run: |
+          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
+          python cilium-sysdump.zip --output cilium-sysdump-out
+
+      - name: Upload cilium-sysdump
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip

--- a/tests/netpol-cyclonus/install-cyclonus.yml
+++ b/tests/netpol-cyclonus/install-cyclonus.yml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cyclonus
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - command:
+            - ./cyclonus
+            - generate
+            - --mode=upstream
+            - --noisy=true
+            - --ignore-loopback=true
+            - --cleanup-namespaces=true
+          name: cyclonus
+          imagePullPolicy: IfNotPresent
+          image: mfenwick100/cyclonus:v0.2.0
+      serviceAccount: cyclonus

--- a/tests/netpol-cyclonus/test-cyclonus.sh
+++ b/tests/netpol-cyclonus/test-cyclonus.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -xv
+
+# set up cyclonus
+kubectl create clusterrolebinding cyclonus --clusterrole=cluster-admin --serviceaccount=kube-system:cyclonus
+kubectl create sa cyclonus -n kube-system
+kubectl create -f ./install-cyclonus.yml
+
+time kubectl wait --for=condition=complete --timeout=240m -n kube-system job.batch/cyclonus
+
+# grab the job logs
+LOG_FILE=$(mktemp)
+kubectl logs -n kube-system job.batch/cyclonus > "$LOG_FILE"
+cat "$LOG_FILE"
+
+# if 'failure' is in the logs, fail; otherwise succeed
+rc=0
+cat "$LOG_FILE" | grep "failure" > /dev/null 2>&1 || rc=$?
+if [ $rc -eq 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
TODOs before merging:

 - [x] read the output from the job to determine success/failure
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Handle TODOs in the code

<!-- Description of change -->

Fixes: #14722 

```release-note
Add cyclonus network policy tester.
```

## Future plans

This is a PoC -- the tests run cover some network policy features but not all.  The goal of this PR is just to get the ball rolling with Cyclonus: make sure the tests are stable and work as expected.

When future Cyclonus releases include additional tests, it'll be an easy update -- we can bump the version in the Cyclonus job yaml to pull in those new tests.