### PR TITLE
docs: Add FQDN limitation to IPVLAN docs

### DIFF
--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -23,6 +23,7 @@ datapath instead of the default veth-based one.
 
     - IPVLAN L2 mode
     - L7 policy enforcement
+    - FQDN Policies
     - NAT64
     - IPVLAN with tunneling
     - eBPF-based masquerading


### PR DESCRIPTION
Extend the IPVLAN docs to make the FQDN policies limitation clearer.
