### PR TITLE
docs: Fix upgrade docs link for api ratelimiting

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -436,7 +436,7 @@ IMPORTANT: Changes required before upgrading to 1.8.0
   could be enabled. For more information, see section :ref:`kubeproxyfree_hostport`.
 
 * The Cilium agent is now enforcing API rate limits for certain API calls. See
-  :ref:``api_rate_limiting`` for more information.
+  :ref:`api_rate_limiting` for more information.
 
 Upgrading from >=1.7.0 to 1.8.y
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This release note was intended to link to the relevant section, but only
quoted the text instead.

```release-note
Fix upgrade docs link to API ratelimiting page
```
