### PR TITLE
bugtool: Record attached BPF programs

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -91,6 +91,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"sysctl -a",
 		"bpftool map show",
 		"bpftool prog show",
+		"bpftool net show",
 		"taskset -pc 1",
 		// iptables
 		"iptables-save -c",


### PR DESCRIPTION
bpftool net show command lists all the attached programs.
We sometimes need to get a summary of BPF programs/SECs
attached to different interfaces in order to debug datapath related issues.

Sample output -

bpftool net show
xdp:

tc:
eth0(2) clsact/ingress bpf_network.o:[from-network] id 221
cilium_net(4) clsact/ingress bpf_host_cilium_net.o:[to-host] id 230
cilium_host(5) clsact/ingress bpf_host.o:[to-host] id 222
cilium_host(5) clsact/egress bpf_host.o:[from-host] id 226
lxc_health(7) clsact/ingress bpf_lxc.o:[from-container] id 242
lxc_health(7) clsact/egress bpf_lxc.o:[to-container] id 246
lxc37bff36e0cd2(9) clsact/ingress bpf_lxc.o:[from-container] id 234
lxc37bff36e0cd2(9) clsact/egress bpf_lxc.o:[to-container] id 238
lxc2686a607b303(12) clsact/ingress bpf_lxc.o:[from-container] id 250
lxc2686a607b303(12) clsact/egress bpf_lxc.o:[to-container] id 254
lxc33d2535b88de(14) clsact/ingress bpf_lxc.o:[from-container] id 258
lxc33d2535b88de(14) clsact/egress bpf_lxc.o:[to-container] id 262

flow_dissector:

