### PR TITLE
Improve pod deletion resiliency

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -241,9 +241,8 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 }
 
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
-func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
+func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointmanager.EndpointManager, dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
-	dCtx, cancel := context.WithCancel(ctx)
 	// Pass the cancel to our signal handler directly so that it's canceled
 	// before we run the cleanup functions (see `cleanup.go` for implementation).
 	cleaner.SetCancelFunc(cancel)
@@ -326,7 +325,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	nd := nodediscovery.NewNodeDiscovery(nodeMngr, mtuConfig, netConf)
 
 	d := Daemon{
-		ctx:               dCtx,
+		ctx:               ctx,
 		cancel:            cancel,
 		prefixLengths:     createPrefixLengthCounter(),
 		buildEndpointSem:  semaphore.NewWeighted(int64(numWorkerThreads())),
@@ -751,8 +750,12 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 
 // WithDefaultEndpointManager creates the default endpoint manager with a
 // functional endpoint synchronizer.
-func WithDefaultEndpointManager() *endpointmanager.EndpointManager {
-	return WithCustomEndpointManager(&watchers.EndpointSynchronizer{})
+func WithDefaultEndpointManager(ctx context.Context, checker endpointmanager.EndpointCheckerFunc) *endpointmanager.EndpointManager {
+	mgr := WithCustomEndpointManager(&watchers.EndpointSynchronizer{})
+	if option.Config.EndpointGCInterval > 0 {
+		mgr = mgr.WithPeriodicEndpointGC(ctx, checker, option.Config.EndpointGCInterval)
+	}
+	return mgr
 }
 
 // WithCustomEndpointManager creates the custom endpoint manager with the

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1509,6 +1509,8 @@ func runDaemon() {
 			ms.CollectStaleMapGarbage()
 			ms.RemoveDisabledMaps()
 		}()
+		d.endpointManager.Subscribe(d)
+		defer d.endpointManager.Unsubscribe(d)
 	}
 
 	// Migrating the ENI datapath must happen before the API is served to

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -140,7 +140,8 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
 
-	d, _, err := NewDaemon(context.Background(),
+	ctx, cancel := context.WithCancel(context.Background())
+	d, _, err := NewDaemon(ctx, cancel,
 		WithCustomEndpointManager(&dummyEpSyncher{}),
 		fakedatapath.NewDatapath())
 	c.Assert(err, IsNil)

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy"
 
@@ -689,7 +690,7 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 // Specific users such as the cilium-health EP may choose not to release the IP
 // when deleting the endpoint. Most users should pass true for releaseIP.
 func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
-	return d.endpointManager.RemoveEndpoint(d, d.ipam, ep, conf)
+	return d.endpointManager.RemoveEndpoint(d.ipam, ep, conf)
 }
 
 func (d *Daemon) DeleteEndpoint(id string) (int, error) {
@@ -723,6 +724,7 @@ func (d *Daemon) DeleteEndpoint(id string) (int, error) {
 //
 // It is called after Daemon calls into d.endpointManager.RemoveEndpoint().
 func (d *Daemon) EndpointDeleted(ep *endpoint.Endpoint) {
+	d.SendNotification(monitorAPI.EndpointDeleteMessage(ep))
 }
 
 // EndpointDeleted is a callback to satisfy EndpointManager.Subscriber,
@@ -732,6 +734,7 @@ func (d *Daemon) EndpointDeleted(ep *endpoint.Endpoint) {
 //
 // It is called after Daemon calls into d.endpointManager.AddEndpoint().
 func (d *Daemon) EndpointCreated(ep *endpoint.Endpoint) {
+	d.SendNotification(monitorAPI.EndpointCreateMessage(ep))
 }
 
 type deleteEndpointID struct {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -716,6 +716,24 @@ func (d *Daemon) DeleteEndpoint(id string) (int, error) {
 	}
 }
 
+// EndpointDeleted is a callback to satisfy EndpointManager.Subscriber,
+// which works around the difficulties in initializing various subsystems
+// involved in managing endpoints, such as the EndpointManager, IPAM and
+// the Monitor.
+//
+// It is called after Daemon calls into d.endpointManager.RemoveEndpoint().
+func (d *Daemon) EndpointDeleted(ep *endpoint.Endpoint) {
+}
+
+// EndpointDeleted is a callback to satisfy EndpointManager.Subscriber,
+// allowing the EndpointManager to be the primary implementer of the core
+// endpoint management functionality while deferring other responsibilities
+// to the daemon.
+//
+// It is called after Daemon calls into d.endpointManager.AddEndpoint().
+func (d *Daemon) EndpointCreated(ep *endpoint.Endpoint) {
+}
+
 type deleteEndpointID struct {
 	daemon *Daemon
 }

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -822,7 +822,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	c.Assert(qaBarNetworkPolicy, Not(IsNil))
 
 	// Delete the endpoint.
-	e.Delete(ds.d.ipam, endpoint.DeleteConfig{})
+	e.Delete(endpoint.DeleteConfig{})
 
 	// Check that the policy has been removed from the xDS cache.
 	networkPolicies = ds.getXDSNetworkPolicies(c, nil)
@@ -970,7 +970,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	})
 
 	// Delete the endpoint.
-	e.Delete(ds.d.ipam, endpoint.DeleteConfig{})
+	e.Delete(endpoint.DeleteConfig{})
 
 	// Check that the policy has been removed from the xDS cache.
 	networkPolicies = ds.getXDSNetworkPolicies(c, nil)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -523,6 +523,18 @@ func (e *Endpoint) GetID16() uint16 {
 	return e.ID
 }
 
+// HostInterface returns the name of the link-layer interface used for
+// communicating with the endpoint from the host (if available).
+//
+// In some datapath modes, it may return an empty string as there is no unique
+// host netns network interface for this endpoint.
+func (e *Endpoint) HostInterface() string {
+	if e.HasIpvlanDataPath() {
+		return ""
+	}
+	return e.ifName
+}
+
 // getK8sPodLabels returns all labels that exist in the endpoint and were
 // derived from k8s pod.
 func (e *Endpoint) getK8sPodLabels() labels.Labels {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2070,10 +2070,6 @@ func (e *Endpoint) SyncEndpointHeaderFile() error {
 	return nil
 }
 
-type IPReleaser interface {
-	ReleaseIP(net.IP) error
-}
-
 // Delete cleans up all resources associated with this endpoint, including the
 // following:
 // * all goroutines managed by this Endpoint (EventQueue, Controllers)
@@ -2082,7 +2078,7 @@ type IPReleaser interface {
 // * cleanup of datapath state (BPF maps, proxy configuration, directories)
 // * releasing IP addresses allocated for the endpoint
 // * releasing of the reference to its allocated security identity
-func (e *Endpoint) Delete(ipam IPReleaser, conf DeleteConfig) []error {
+func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	errs := []error{}
 
 	e.Stop()
@@ -2104,19 +2100,6 @@ func (e *Endpoint) Delete(ipam IPReleaser, conf DeleteConfig) []error {
 
 		if errs2 := e.deleteMaps(); errs2 != nil {
 			errs = append(errs, errs2...)
-		}
-	}
-
-	if !conf.NoIPRelease {
-		if option.Config.EnableIPv4 {
-			if err := ipam.ReleaseIP(e.IPv4.IP()); err != nil {
-				errs = append(errs, fmt.Errorf("unable to release ipv4 address: %s", err))
-			}
-		}
-		if option.Config.EnableIPv6 {
-			if err := ipam.ReleaseIP(e.IPv6.IP()); err != nil {
-				errs = append(errs, fmt.Errorf("unable to release ipv6 address: %s", err))
-			}
 		}
 	}
 

--- a/pkg/endpointmanager/gc.go
+++ b/pkg/endpointmanager/gc.go
@@ -1,0 +1,102 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpointmanager
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/sirupsen/logrus"
+)
+
+// EndpointCheckerFunc can verify whether an endpoint is currently healthy.
+type EndpointCheckerFunc func(*endpoint.Endpoint) error
+
+// markAndSweep performs a two-phase garbage collection of endpoints using the
+// configured EndpointChecker.
+//
+// 1) Mark all endpoints that require GC. Do not GC these endpoints this round.
+// 2) Sweep all endpoints marked as requiring GC during the previous iteration.
+//
+// This way, if there is a temporary condition that will be resolved by other
+// components in the system, then we will not flag warnings about the system
+// getting out-of-sync.
+func (mgr *EndpointManager) markAndSweep(ctx context.Context) error {
+	marked := mgr.markEndpoints()
+
+	mgr.mutex.Lock()
+	toSweep := mgr.markedEndpoints
+	mgr.markedEndpoints = marked
+	mgr.mutex.Unlock()
+
+	// Avoid returning an error which would cause the calling controller to
+	// re-run the garbage collection more frequently than the RunInterval.
+	mgr.sweepEndpoints(toSweep)
+	return nil
+}
+
+// markEndpoints runs all endpoints in the manager against the configured
+// EndpointChecker and returns a slice of endpoint ids that require garbage
+// collection.
+func (mgr *EndpointManager) markEndpoints() []uint16 {
+	mgr.mutex.RLock()
+	defer mgr.mutex.RUnlock()
+
+	needsGC := make([]uint16, 0, len(mgr.endpoints))
+	for eid, ep := range mgr.endpoints {
+		if err := mgr.checkHealth(ep); err != nil {
+			needsGC = append(needsGC, eid)
+		}
+	}
+	return needsGC
+}
+
+// sweepEndpoints iterates through the specified list of endpoints marked for
+// deletion and attempts to garbage-collect them if they still exist.
+func (mgr *EndpointManager) sweepEndpoints(markedEndpoints []uint16) {
+	toSweep := make([]*endpoint.Endpoint, 0, len(markedEndpoints))
+
+	// 'markedEndpoints' were marked during the previous mark round, so
+	// they may no longer be valid endpoints. Narrow the list to only the
+	// endpoints that remain. Then, release the lock so RemoveEndpoint()
+	// below can independently grab it.
+	mgr.mutex.RLock()
+	for _, id := range markedEndpoints {
+		if ep, ok := mgr.endpoints[id]; ok {
+			toSweep = append(toSweep, ep)
+		}
+	}
+	mgr.mutex.RUnlock()
+
+	for _, ep := range toSweep {
+		log.WithFields(logrus.Fields{
+			logfields.EndpointID:  ep.StringID(),
+			logfields.ContainerID: ep.GetShortContainerID(),
+			logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+			logfields.URL:         "https://github.com/kubernetes/kubernetes/issues/86944",
+		}).Warning("Stray endpoint found. You may be affected by upstream Kubernetes issue #86944.")
+		errs := mgr.RemoveEndpoint(ep, endpoint.DeleteConfig{
+			NoIPRelease: ep.DatapathConfiguration.ExternalIpam,
+		})
+		if len(errs) > 0 {
+			scopedLog := log.WithField(logfields.EndpointID, ep.GetID())
+			for _, err := range errs {
+				scopedLog.WithError(err).Warn("Ignoring error while garbage collecting endpoint")
+			}
+		}
+	}
+}

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package endpointmanager
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/testutils/allocator"
+
+	. "gopkg.in/check.v1"
+)
+
+// fakeCheck detects endpoints as unhealthy if they have an even EndpointID.
+func fakeCheck(ep *endpoint.Endpoint) error {
+	if ep.GetID()%2 == 0 {
+		return fmt.Errorf("Endpoint has an even EndpointID")
+	}
+	return nil
+}
+
+func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
+	// Open-code WithPeriodicGC() to avoid running the controller
+	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr.checkHealth = fakeCheck
+	mgr.deleteEndpoint = endpointDeleteFunc(mgr.waitEndpointRemoved)
+
+	timeout := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	endpointIDToDelete := uint16(2)
+	healthyEndpointIDs := []uint16{1, 3, 5, 7}
+	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
+	for _, id := range allEndpointIDs {
+		ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, id, endpoint.StateReady)
+		mgr.expose(ep)
+	}
+	c.Assert(len(mgr.GetEndpoints()), Equals, len(allEndpointIDs))
+
+	// Two-phase mark and sweep: Mark should not yet delete any endpoints.
+	err := mgr.markAndSweep(ctx)
+	c.Assert(mgr.EndpointExists(endpointIDToDelete), Equals, true)
+	c.Assert(err, IsNil)
+	c.Assert(len(mgr.GetEndpoints()), Equals, len(allEndpointIDs))
+
+	// Second phase: endpoint should be marked now and we should only sweep
+	// that particular endpoint.
+	err = mgr.markAndSweep(ctx)
+	c.Assert(mgr.EndpointExists(endpointIDToDelete), Equals, false)
+	c.Assert(err, IsNil)
+	c.Assert(len(mgr.GetEndpoints()), Equals, len(healthyEndpointIDs))
+}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -342,9 +342,9 @@ func (mgr *EndpointManager) unexpose(ep *endpoint.Endpoint) {
 
 // RemoveEndpoint stops the active handling of events by the specified endpoint,
 // and prevents the endpoint from being globally acccessible via other packages.
-func (mgr *EndpointManager) RemoveEndpoint(ipam endpoint.IPReleaser, ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
+func (mgr *EndpointManager) RemoveEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	mgr.unexpose(ep)
-	result := ep.Delete(ipam, conf)
+	result := ep.Delete(conf)
 
 	mgr.mutex.RLock()
 	for s := range mgr.subscribers {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mcastmanager"
 	"github.com/cilium/cilium/pkg/metrics"
-	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -343,9 +342,7 @@ func (mgr *EndpointManager) unexpose(ep *endpoint.Endpoint) {
 
 // RemoveEndpoint stops the active handling of events by the specified endpoint,
 // and prevents the endpoint from being globally acccessible via other packages.
-func (mgr *EndpointManager) RemoveEndpoint(monitor regeneration.Owner, ipam endpoint.IPReleaser, ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
-	defer monitor.SendNotification(monitorAPI.EndpointDeleteMessage(ep))
-
+func (mgr *EndpointManager) RemoveEndpoint(ipam endpoint.IPReleaser, ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	mgr.unexpose(ep)
 	result := ep.Delete(ipam, conf)
 
@@ -576,8 +573,6 @@ func (mgr *EndpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.E
 		s.EndpointCreated(ep)
 	}
 	mgr.mutex.RUnlock()
-
-	owner.SendNotification(monitorAPI.EndpointCreateMessage(ep))
 
 	return nil
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -70,6 +70,9 @@ type EndpointManager struct {
 	// EndpointSynchronizer updates external resources (e.g., Kubernetes) with
 	// up-to-date information about endpoints managed by the endpoint manager.
 	EndpointResourceSynchronizer
+
+	// subscribers are notified when events occur in the EndpointManager.
+	subscribers map[Subscriber]struct{}
 }
 
 // EndpointResourceSynchronizer is an interface which synchronizes CiliumEndpoint
@@ -86,6 +89,7 @@ func NewEndpointManager(epSynchronizer EndpointResourceSynchronizer) *EndpointMa
 		endpointsAux:                 make(map[string]*endpoint.Endpoint),
 		mcastManager:                 mcastmanager.New(option.Config.IPv6MCastDevice),
 		EndpointResourceSynchronizer: epSynchronizer,
+		subscribers:                  make(map[Subscriber]struct{}),
 	}
 
 	return &mgr
@@ -343,7 +347,15 @@ func (mgr *EndpointManager) RemoveEndpoint(monitor regeneration.Owner, ipam endp
 	defer monitor.SendNotification(monitorAPI.EndpointDeleteMessage(ep))
 
 	mgr.unexpose(ep)
-	return ep.Delete(ipam, conf)
+	result := ep.Delete(ipam, conf)
+
+	mgr.mutex.RLock()
+	for s := range mgr.subscribers {
+		s.EndpointDeleted(ep, conf)
+	}
+	mgr.mutex.RUnlock()
+
+	return result
 }
 
 // WaitEndpointRemoved waits until all operations associated with Remove of
@@ -558,6 +570,13 @@ func (mgr *EndpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.E
 	if err != nil {
 		return err
 	}
+
+	mgr.mutex.RLock()
+	for s := range mgr.subscribers {
+		s.EndpointCreated(ep)
+	}
+	mgr.mutex.RUnlock()
+
 	owner.SendNotification(monitorAPI.EndpointCreateMessage(ep))
 
 	return nil

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -43,6 +43,19 @@ import (
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) { TestingT(t) }
 
+func (mgr *EndpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
+	mgr.unexpose(ep)
+	ep.Stop()
+	return nil
+}
+
+// WaitEndpointRemoved waits until all operations associated with Remove of
+// the endpoint have been completed.
+// Note: only used for unit tests, to avoid ep.Delete()
+func (mgr *EndpointManager) WaitEndpointRemoved(ep *endpoint.Endpoint) {
+	mgr.waitEndpointRemoved(ep, endpoint.DeleteConfig{})
+}
+
 type EndpointManagerSuite struct {
 	repo *policy.Repository
 }

--- a/pkg/endpointmanager/subscribe.go
+++ b/pkg/endpointmanager/subscribe.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpointmanager
+
+import "github.com/cilium/cilium/pkg/endpoint"
+
+// Subscribers may register via Subscribe() to be notified when events occur.
+type Subscriber interface {
+	// EndpointCreated is called at the end of endpoint creation.
+	// Implementations must not attempt write operations on the
+	// EndpointManager from this callback.
+	EndpointCreated(ep *endpoint.Endpoint)
+
+	// EndpointDeleted is called at the end of endpoint deletion.
+	// Implementations must not attempt write operations on the
+	// EndpointManager from this callback.
+	EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig)
+}
+
+func (mgr *EndpointManager) Subscribe(s Subscriber) {
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+
+	mgr.subscribers[s] = struct{}{}
+}
+
+func (mgr *EndpointManager) Unsubscribe(s Subscriber) {
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+	delete(mgr.subscribers, s)
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -474,6 +474,9 @@ const (
 	// Key is the identity of the encryption key
 	Key = "key"
 
+	// URL represents a Uniform Resource Locator.
+	URL = "url"
+
 	// SysParamName is the name of the kernel parameter (sysctl)
 	SysParamName = "sysParamName"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -679,6 +679,10 @@ const (
 	// EndpointQueueSize is the size of the EventQueue per-endpoint.
 	EndpointQueueSize = "endpoint-queue-size"
 
+	// EndpointGCInterval interval to attempt garbage collection of
+	// endpoints that are no longer alive and healthy.
+	EndpointGCInterval = "endpoint-gc-interval"
+
 	// SelectiveRegeneration specifies whether only the endpoints which policy
 	// changes select should be regenerated upon policy changes.
 	SelectiveRegeneration = "enable-selective-regeneration"
@@ -1763,6 +1767,10 @@ type DaemonConfig struct {
 	// events, specifically those which cause many regenerations.
 	EndpointQueueSize int
 
+	// EndpointGCInterval is interval to attempt garbage collection of
+	// endpoints that are no longer alive and healthy.
+	EndpointGCInterval time.Duration
+
 	// SelectiveRegeneration, when true, enables the functionality to only
 	// regenerate endpoints which are selected by the policy rules that have
 	// been changed (added, deleted, or updated). If false, then all endpoints
@@ -2828,6 +2836,7 @@ func (c *DaemonConfig) Populate() {
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)
+	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)


### PR DESCRIPTION
*This PR was originally proposed against v1.7 branch in PR #14541.*

This PR does some minor refactoring of the way that the `Daemon` and
`EndpointManager` objects interact by introducing the notion of a
`Subscriber` into the `EndpointManager` and then shifting some
responsibilities around endpoint creation/deletion into the daemon,
such as sending monitor notifications and handling IPAM release.

With that in place, forward-port the rest of PR #14541 to master,
adding a new background controller that periodically monitors endpoints
to see whether the devices have disappeared in the background, and
initiate cleanup if this case is detected. This can occasionally occur
if other components in the system such as kubelet unexpectedly initiate
deletion without fulfilling the CNI contract to initiate the deletion
from Cilium prior to the rest of the cleanup (or in the case of a
cilium-cni bug such as the one found in #14645).

Commits:
- endpointmanager: Subscribe daemon to events (new)
- daemon: Move monitor notifications to daemon (new)
- daemon: Shift endpoint IPAM to daemon (new)
- endpointmanager: Add garbage collection routine (rebased)
- daemon: Plumb the endpoint garbage collector (rebased)

I have not nominated this for backport at this time as it relies on
#14745, which does some quite invasive refactoring in the daemon.
