### PR TITLE
datapath: Do not log when kernel config not found

### DIFF
--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -148,9 +148,8 @@ func CheckMinRequirements() {
 		probeManager := probes.NewProbeManager()
 		if err := probeManager.SystemConfigProbes(); err != nil {
 			errMsg := "BPF system config check: NOT OK."
-			if errors.Is(err, probes.ErrKernelConfigNotFound) {
-				log.WithError(err).Info(errMsg)
-			} else {
+			// TODO(brb) warn after GH#14314 has been resolved
+			if !errors.Is(err, probes.ErrKernelConfigNotFound) {
 				log.WithError(err).Warn(errMsg)
 			}
 		}


### PR DESCRIPTION
Previously, when cilium-agent couldn't find a kernel config (a case for
distros which do not expose the config via /proc/config.gz, but instead
they store it in /boot, which is not mounted into a cilium container),
we logged the following message:
```
level=info msg="BPF system config check: NOT OK." error="Kernel Config
file not found" subsys=linux-datapath
```
This confused users making them to think that the missing kernel config
was to blame for their connectivity issues. Thus, this commit silences
the message (missing CONFIG_BPF would anyway result in a non-cryptic error
message).

We can bring the message back once https://github.com/cilium/cilium/issues/14314 has been resolved.