### PR TITLE
ipam/aws: fixed a bug causing the operator to hang indefinitely when the ENI limits for an instance type could not be determined

### DIFF
--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -65,7 +65,7 @@ func NewInstancesManager(api EC2API) *InstancesManager {
 // CreateNode is called on discovery of a new node and returns the ENI node
 // allocation implementation for the new node
 func (m *InstancesManager) CreateNode(obj *v2.CiliumNode, n *ipam.Node) ipam.NodeOperations {
-	return &Node{k8sObj: obj, manager: m, node: n}
+	return NewNode(n, obj, m)
 }
 
 // GetPoolQuota returns the number of available IPs in all IP pools

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -59,6 +59,19 @@ type Node struct {
 
 	// manager is the EC2 node manager responsible for this node
 	manager *InstancesManager
+
+	// instanceID of the node
+	instanceID string
+}
+
+// NewNode returns a new Node
+func NewNode(node *ipam.Node, k8sObj *v2.CiliumNode, manager *InstancesManager) *Node {
+	return &Node{
+		node:       node,
+		k8sObj:     k8sObj,
+		manager:    manager,
+		instanceID: node.InstanceID(),
+	}
 }
 
 // UpdatedNode is called when an update to the CiliumNode is received.
@@ -69,11 +82,11 @@ func (n *Node) UpdatedNode(obj *v2.CiliumNode) {
 }
 
 func (n *Node) loggerLocked() *logrus.Entry {
-	if n == nil || n.node == nil {
+	if n == nil || n.instanceID == "" {
 		return log
 	}
 
-	return log.WithField("instanceID", n.node.InstanceID())
+	return log.WithField("instanceID", n.instanceID)
 }
 
 // PopulateStatusFields fills in the status field of the CiliumNode custom

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/aws/eni/limits"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/metadata"
@@ -525,6 +526,13 @@ func determineFirstInterfaceIndex(instanceType string) *int {
 		if defaults.IPAMPreAllocation > max {
 			idx = 0 // Include eth0
 		}
+	} else {
+		log.WithFields(logrus.Fields{
+			"instance-type": instanceType,
+		}).Warningf(
+			"Unable to find limits for instance type, consider setting --%s=true on the Operator",
+			operatorOption.UpdateEC2AdapterLimitViaAPI,
+		)
 	}
 
 	return &idx


### PR DESCRIPTION
Fixes: #14802

With the current implementation, there is a race condition which causes the operator to completely hang if one of the EC2 instance of the cluster has a type for which the operator cannot determine the limits. This PR sorts this situation by removing the attempt for getting a readlock over the node mutex which already has a readwrite lock at this time.

Here is the pprof trace of the hanging goroutine:
```
1 @ 0x43a4a5 0x44afc5 0x44afae 0x46c0e7 0x25c769a 0x25c75e2 0x2649a7b 0x264da08 0x25c7302 0x25c7a6c 0x25c7758 0x25ce2bc 0x25cc525 0x25cc375 0x2660af1 0x19ec99a 0x1b1b61f 0x19dece2 0x19dc3a2 0x1116ebf 0x1115ced 0x1115c18 0x19dc105 0x19dc0a6 0x46fe81
#	0x46c0e6	sync.runtime_SemacquireMutex+0x46						/usr/local/go/src/runtime/sema.go:71
#	0x25c7699	sync.(*RWMutex).RLock+0xd9							/usr/local/go/src/sync/rwmutex.go:50
#	0x25c75e1	github.com/cilium/cilium/pkg/ipam.(*Node).InstanceID+0x21			/go/src/github.com/cilium/cilium/pkg/ipam/node.go:311
#	0x2649a7a	github.com/cilium/cilium/pkg/aws/eni.(*Node).loggerLocked+0x7a			/go/src/github.com/cilium/cilium/pkg/aws/eni/node.go:76
#	0x264da07	github.com/cilium/cilium/pkg/aws/eni.(*Node).GetMaximumAllocatableIPv4+0x67	/go/src/github.com/cilium/cilium/pkg/aws/eni/node.go:503
#	0x25c7301	github.com/cilium/cilium/pkg/ipam.(*Node).getMaxAllocate+0x41			/go/src/github.com/cilium/cilium/pkg/ipam/node.go:222
#	0x25c7a6b	github.com/cilium/cilium/pkg/ipam.(*Node).recalculate+0x18b			/go/src/github.com/cilium/cilium/pkg/ipam/node.go:378
#	0x25c7757	github.com/cilium/cilium/pkg/ipam.(*Node).UpdatedResource+0x97			/go/src/github.com/cilium/cilium/pkg/ipam/node.go:337
#	0x25ce2bb	github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update.func1+0x5b		/go/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:263
#	0x25cc524	github.com/cilium/cilium/pkg/ipam.(*NodeManager).Update+0x184			/go/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:321
#	0x25cc374	github.com/cilium/cilium/pkg/ipam.(*NodeManager).Create+0x34			/go/src/github.com/cilium/cilium/pkg/ipam/node_manager.go:251
#	0x2660af0	main.startSynchronizingCiliumNodes.func1+0x70					/go/src/github.com/cilium/cilium/operator/cilium_node.go:59
#	0x19ec999	k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd+0x59		/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:231
#	0x1b1b61e	github.com/cilium/cilium/pkg/k8s/informer.NewInformerWithStore.func1+0x25e	/go/src/github.com/cilium/cilium/pkg/k8s/informer/informer.go:119
```

As we discussed with @christarazi in the releated issue, I also took this opportunity to improve the associated logging!

```release-note
ipam/aws: fixed a bug causing the operator to hang indefinitely when the ENI limits for an instance type could not be determined
```
