### PR TITLE
cni-(un)install: don't touch CNI dir if CILIUM_CUSTOM_CNI_CONF is set

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -339,14 +339,15 @@ Annotations:
 * When using the ENI-based IPAM in conjunction with the ``--eni-tags``, failures
   to create tags are treated as errors which will result in ENIs not being
   created. Ensure that the ``ec2:CreateTags`` IAM permissions are granted.
-* To prevent Pods being scheduled by other CNI plugins during Cilium agent
-  downtime (upgrades, crashes,..), Cilium now assumes ownership of the node's
-  CNI configuration directory (``/etc/cni/net.d``) by default.
-  Existing CNI configurations are renamed to ``*.cilium_bak``, which will
-  disable solutions like [CNI-Genie](https://github.com/cni-genie/CNI-Genie)
-  as well as the default CNI plugins shipped by most managed Kubernetes
-  distributions. Set the ``cni.exclusive=false`` Helm flag to disable this
-  behaviour.
+* Cilium now takes ownership of the ``/etc/cni/net.d/`` directory on the host
+  by default. During agent startup, Cilium replaces all CNI configuration files
+  containing the word ``cilium``, and non-Cilium CNI configuration files are
+  renamed to ``*.cilium_bak``. During agent shutdown, all Cilium CNI configs
+  are removed. To disable the ``*.cilium_bak`` behaviour, set the
+  ``cni.exclusive=false`` Helm flag. To disable CNI config installation and
+  removal altogether, set the ``cni.customConf=true`` Helm flag.
+  This is useful for managing CNI configs externally.
+  See https://github.com/cilium/cilium/pull/14192 for context and related issues.
 * Helm option ``serviceAccounts.certgen`` is removed, please use ``serviceAccounts.clustermeshcertgen``
   for Clustermesh certificate generation and ``serviceAccounts.hubblecertgen`` for Hubble certificate generation.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -286,6 +286,7 @@ committers
 conf
 confPath
 config
+configs
 conntrack
 conntrackGCInterval
 containerRuntime

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -55,6 +55,7 @@ BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 CNI_CONF_DIR="$(dirname "$CILIUM_CNI_CONF")"
+CILIUM_CUSTOM_CNI_CONF=${CILIUM_CUSTOM_CNI_CONF:-false}
 
 if [ ! -d "${CNI_DIR}/bin" ]; then
 	mkdir -p "${CNI_DIR}/bin"
@@ -78,6 +79,15 @@ if [ -f "${CNI_DIR}/bin/${BIN_NAME}" ]; then
 fi
 
 cp "/opt/cni/bin/${BIN_NAME}" "${CNI_DIR}/bin/"
+
+# The CILIUM_CUSTOM_CNI_CONF env is set by the `cni.customConf` Helm option.
+# It stops this script from touching the host's CNI config directory.
+# However, the agent will still write to the location specified by the
+# `--write-cni-conf-when-ready` flag when `cni.configMap` is set.
+if [ "${CILIUM_CUSTOM_CNI_CONF}" == "true" ]; then
+	echo "User is managing Cilium's CNI config externally, exiting..."
+	exit 0
+fi
 
 # Remove any active Cilium CNI configurations left over from previous installs
 # to make sure the one we're installing later will take effect.
@@ -107,15 +117,6 @@ if [ "${CNI_EXCLUSIVE}" != "false" ]; then
      -not \( -name '*.cilium_bak' \
      -or -name "${CNI_CONF_NAME}" \) \
      -exec mv {} {}.cilium_bak \;
-fi
-
-# The CILIUM_CUSTOM_CNI_CONF env is set if the user specifies a custom
-# CNI config in a ConfigMap and if the cni.customConf Helm option is set.
-# Skip the remainder of the script, since this custom config is written
-# to disk by the Cilium agent itself after initialization.
-if [ "${CILIUM_CUSTOM_CNI_CONF}" = "true" ]; then
-	echo "Using custom ${CILIUM_CNI_CONF}, exiting..."
-	exit 0
 fi
 
 echo "Installing new ${CILIUM_CNI_CONF}..."

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -30,17 +30,22 @@ HOST_PREFIX=${HOST_PREFIX:-/host}
 BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 CNI_CONF_DIR=${CNI_CONF_DIR:-${HOST_PREFIX}/etc/cni/net.d}
+CILIUM_CUSTOM_CNI_CONF=${CILIUM_CUSTOM_CNI_CONF:-false}
 
-# .conf/.conflist/.json (undocumented) are read by kubelet/dockershim's CNI implementation.
-# Remove any active Cilium CNI configurations to prevent scheduling Pods during agent
-# downtime. Configs belonging to other CNI implementations have already been renamed
-# to *.cilium_bak during agent startup.
-echo "Removing active Cilium CNI configurations from ${CNI_CONF_DIR}..."
-find "${CNI_CONF_DIR}" -maxdepth 1 -type f \
-  -name '*cilium*' -and \( \
-    -name '*.conf' -or \
-    -name '*.conflist' \
-  \) -delete
+# Do not interact with the host's CNI directory when the user specified they
+# are managing CNI configs externally.
+if [ "${CILIUM_CUSTOM_CNI_CONF}" != "true" ]; then
+    # .conf/.conflist/.json (undocumented) are read by kubelet/dockershim's CNI implementation.
+    # Remove any active Cilium CNI configurations to prevent scheduling Pods during agent
+    # downtime. Configs belonging to other CNI implementations have already been renamed
+    # to *.cilium_bak during agent startup.
+    echo "Removing active Cilium CNI configurations from ${CNI_CONF_DIR}..."
+    find "${CNI_CONF_DIR}" -maxdepth 1 -type f \
+    -name '*cilium*' -and \( \
+        -name '*.conf' -or \
+        -name '*.conflist' \
+    \) -delete
+fi
 
 echo "Removing ${CNI_DIR}/bin/cilium-cni..."
 rm -f "${CNI_DIR}/bin/${BIN_NAME}"


### PR DESCRIPTION
<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/14838.

See commit messages. I've created a blueprint with a more structural rework to improve this long-term: https://github.com/cilium/cilium/issues/14892.

@joestringer Please give some feedback about the upgrade notes. Not sure if this warrants a more drastic `Breaking Changes` section, although users that had `cni.customConf` set before will see consistent behaviour between 1.9 and 1.10.

Also, this should fix microk8s without requiring any further changes there, since `cni.customConf` sets `CILIUM_CUSTOM_CNI_CONF=true` on the container. (might also want to remove the `global.` prefix from Helm options in the install script there)

```release-note
cni-(un)install: don't touch CNI dir if CILIUM_CUSTOM_CNI_CONF is set
```

Thanks @mvisonneau!