### PR TITLE
.github: add GitHub actions to build images

### DIFF
--- a/.github/workflows/images-legacy-releases.yaml
+++ b/.github/workflows/images-legacy-releases.yaml
@@ -1,0 +1,100 @@
+name: Image Release Build
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+
+jobs:
+  build-and-push:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    environment: release
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - name: cilium
+            dockerfile: ./Dockerfile
+          - name: operator
+            dockerfile: ./cilium-operator.Dockerfile
+          - name: operator-aws
+            dockerfile: ./cilium-operator-aws.Dockerfile
+          - name: operator-azure
+            dockerfile: ./cilium-operator-azure.Dockerfile
+          - name: operator-generic
+            dockerfile: ./cilium-operator-generic.Dockerfile
+          - name: hubble-relay
+            dockerfile: ./hubble-relay.Dockerfile
+          - name: clustermesh-apiserver
+            dockerfile: ./clustermesh-apiserver.Dockerfile
+          - name: docker-plugin
+            dockerfile: ./cilium-docker-plugin.Dockerfile
+    steps:
+      - name: Set output
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF##*/}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32 # v1.1.1
+
+      - name: Checkout Stable Branch Source Code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - name: Login to DockerHub
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_RELEASE_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_RELEASE_PASSWORD }}
+      - name: Login to quay.io
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_RELEASE_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD_RELEASE_PASSWORD }}
+      - name: Release Build ${{ matrix.name }}
+        uses: docker/build-push-action@4a531fa5a603bab87dfa56578bd82b28508c9547 # v2.2.2
+        id: docker_build_release
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.vars.outputs.tag }}
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.vars.outputs.tag }}
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+      - name: Image Release Digest
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
+          echo "" >> image-digest/${{ matrix.name }}.txt
+          echo "\`docker.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.vars.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.vars.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "" >> image-digest/${{ matrix.name }}.txt
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2
+        with:
+          name: image-digest ${{ matrix.name }}
+          path: image-digest
+          retention-days: 1
+  image-digests:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    name: Display Digests
+    runs-on: ubuntu-20.04
+    needs: build-and-push
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+      - name: Download digests of all images built
+        uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843 # v2.0.8
+        with:
+          path: image-digest/
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -1,0 +1,122 @@
+name: Image CI Build
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push-prs:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - name: cilium
+            dockerfile: ./Dockerfile
+          - name: operator
+            dockerfile: ./cilium-operator.Dockerfile
+          - name: operator-aws
+            dockerfile: ./cilium-operator-aws.Dockerfile
+          - name: operator-azure
+            dockerfile: ./cilium-operator-azure.Dockerfile
+          - name: operator-generic
+            dockerfile: ./cilium-operator-generic.Dockerfile
+          - name: hubble-relay
+            dockerfile: ./hubble-relay.Dockerfile
+          - name: clustermesh-apiserver
+            dockerfile: ./clustermesh-apiserver.Dockerfile
+          - name: docker-plugin
+            dockerfile: ./cilium-docker-plugin.Dockerfile
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32 # v1.1.1
+      - name: Login to DockerHub to avoid rate limit
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
+      - name: Login to quay.io for CI
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_CI }}
+          password: ${{ secrets.QUAY_PASSWORD_CI }}
+
+      # master branch pushes
+      - name: Checkout Master Branch Source Code
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - name: CI Build ${{ matrix.name }}
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: docker/build-push-action@4a531fa5a603bab87dfa56578bd82b28508c9547 # v2.2.2
+        id: docker_build_ci
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+      - name: CI Image Releases digests
+        if: ${{ github.event_name != 'pull_request_target' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_ci.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+
+      # PR updates
+      - name: Checkout PR Source Code
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+         ref: ${{ github.event.pull_request.head.sha }}
+      - name: CI Build ${{ matrix.name }}
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: docker/build-push-action@4a531fa5a603bab87dfa56578bd82b28508c9547 # v2.2.2
+        id: docker_build_ci
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.event.pull_request.head.sha }}
+      - name: CI Image Releases digests
+        if: ${{ github.event_name == 'pull_request_target' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.event.pull_request.head.sha }}@${{ steps.docker_build_ci.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2
+        with:
+          name: image-digest ${{ matrix.name }}
+          path: image-digest
+          retention-days: 1
+  image-digests:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    name: Display Digests
+    runs-on: ubuntu-20.04
+    needs: build-and-push-prs
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+      - name: Download digests of all images built
+        uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843 # v2.0.8
+        with:
+          path: image-digest/
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,10 +28,7 @@
 # is not properly picked up in Github.
 * @cilium/janitors
 /.github/ @cilium/contributing
-/.github/workflows/ @cilium/ci-structure
-/.github/workflows/coccicheck.yaml @cilium/ci-structure @cilium/bpf
-/.github/workflows/docs.yaml @cilium/ci-structure @cilium/docs-structure
-/.github/workflows/images.yaml @cilium/ci-structure @cilium/build
+/.github/workflows/ @cilium/maintainers
 /api/ @cilium/api
 /api/v1/flow/ @cilium/api @cilium/hubble
 /api/v1/observer/ @cilium/api @cilium/hubble


### PR DESCRIPTION
These GH actions will be able to push images into quay.io/cilium/*-ci.
In follow up PRs, Jenkins jobs and GH actions will stop building images
and the GH action will push the images into quay.io making them
available.

Signed-off-by: André Martins <andre@cilium.io>

With this PR `quay.io/cilium/*-ci:latest` will contain the latest changes from master branch.

@joestringer @christarazi for the next release (doesn't matter the tag) we will do a dry-run and publish the images in `quay.io/cilium/*-dev`. If that is successful we will move to the real repositories. Sounds good?

Follow up GH issue: https://github.com/cilium/cilium/issues/14928

edit, output of the digests for the **release** GH action:

## cilium

`docker.io/cilium/cilium-dev:test-docker-images-legacy@sha256:de6003244ceef3c52da8e186cff6fda2fa3533c74af7a149b3b1e4ff1329ce8d`
`quay.io/cilium/cilium-dev:test-docker-images-legacy@sha256:de6003244ceef3c52da8e186cff6fda2fa3533c74af7a149b3b1e4ff1329ce8d`

## clustermesh-apiserver

`docker.io/cilium/clustermesh-apiserver-dev:test-docker-images-legacy@sha256:8e8e6eb7f2ed75e402f0d5bbe265fb50bd47502a601858c4c3b7cd7e630d5540`
`quay.io/cilium/clustermesh-apiserver-dev:test-docker-images-legacy@sha256:8e8e6eb7f2ed75e402f0d5bbe265fb50bd47502a601858c4c3b7cd7e630d5540`

## docker-plugin

`docker.io/cilium/docker-plugin-dev:test-docker-images-legacy@sha256:a0445eac6738adca9693baf7a33bfb8251467f3a5a377467810c6b42d9a96252`
`quay.io/cilium/docker-plugin-dev:test-docker-images-legacy@sha256:a0445eac6738adca9693baf7a33bfb8251467f3a5a377467810c6b42d9a96252`

## hubble-relay

`docker.io/cilium/hubble-relay-dev:test-docker-images-legacy@sha256:d1dba2f62d9d5fb41169cbb1f412e0e565708c9848c11c6acb300904491c68b8`
`quay.io/cilium/hubble-relay-dev:test-docker-images-legacy@sha256:d1dba2f62d9d5fb41169cbb1f412e0e565708c9848c11c6acb300904491c68b8`

## operator-aws

`docker.io/cilium/operator-aws-dev:test-docker-images-legacy@sha256:2ec42cc0d62315dfa1dcb440d71d09f9a660ce838e6dbd87ff0a5b37f99c1ef5`
`quay.io/cilium/operator-aws-dev:test-docker-images-legacy@sha256:2ec42cc0d62315dfa1dcb440d71d09f9a660ce838e6dbd87ff0a5b37f99c1ef5`

## operator-azure

`docker.io/cilium/operator-azure-dev:test-docker-images-legacy@sha256:7e74d4787565e635728296357a98ca3a8ed2254b1461b2bc484baeab3246f3c7`
`quay.io/cilium/operator-azure-dev:test-docker-images-legacy@sha256:7e74d4787565e635728296357a98ca3a8ed2254b1461b2bc484baeab3246f3c7`

## operator-generic

`docker.io/cilium/operator-generic-dev:test-docker-images-legacy@sha256:a711ec9b858862140e1a1086cff7a77b507a63abb3bff6e605e315677d2985ce`
`quay.io/cilium/operator-generic-dev:test-docker-images-legacy@sha256:a711ec9b858862140e1a1086cff7a77b507a63abb3bff6e605e315677d2985ce`

## operator

`docker.io/cilium/operator-dev:test-docker-images-legacy@sha256:1aab307576cee0250778c5f24de1b206b1f51c153f5be1edb569195e9609999a`
`quay.io/cilium/operator-dev:test-docker-images-legacy@sha256:1aab307576cee0250778c5f24de1b206b1f51c153f5be1edb569195e9609999a`