### PR TITLE
docs: Document hostport requirements in eni

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -77,6 +77,11 @@ Limitations
 * When applying L7 policies at egress, the source identity context is lost as
   it is currently not carried in the packet. This means that traffic will look
   like it is coming from outside of the cluster to the receiving pod.
+* HostPort type services additionally require either of the following
+  configurations:
+
+   * :ref:`k8s_install_portmap`
+   * :ref:`kubeproxyfree_hostport`
 
 Troubleshooting
 ===============


### PR DESCRIPTION
Strictly speaking this is a general truth for all environments, but we don't
have a dedicated section for explaining services and users have begun
reporting specifically in relation to AWS / ENI mode. Put this somewhere
in the docs, we can always move it around to somewhere more generic when
we have a better location for these links to live.

Fixes: #14109
