### PR TITLE
hubble: distinguish AUDIT policy verdict from FORWARDED

### DIFF
--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -398,6 +398,9 @@ func decodeVerdict(dn *monitor.DropNotify, tn *monitor.TraceNotify, pvn *monitor
 		if pvn.Verdict < 0 {
 			return pb.Verdict_DROPPED
 		}
+		if pvn.IsTrafficAudited() {
+			return pb.Verdict_AUDIT
+		}
 		return pb.Verdict_FORWARDED
 	}
 	return pb.Verdict_VERDICT_UNKNOWN

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1571,7 +1571,7 @@ var _ = Describe("RuntimePolicies", func() {
 				// Checks for a ingress policy verdict event (type 5)
 				err := hubbleRes.WaitUntilMatchFilterLine(
 					`{.source.labels} -> {.IP.destination} : {.verdict} {.event_type.type}`,
-					fmt.Sprintf(`["reserved:host"] -> %s : FORWARDED 5`, endpointIP.IPV4))
+					fmt.Sprintf(`["reserved:host"] -> %s : AUDIT 5`, endpointIP.IPV4))
 				Expect(err).To(BeNil(), "Default policy verdict on ingress failed")
 				// Checks for the subsequent trace:to-endpoint event (type 4)
 				hubbleRes.ExpectContainsFilterLine(
@@ -1617,7 +1617,7 @@ var _ = Describe("RuntimePolicies", func() {
 				// Checks for a ingress policy verdict event (type 5)
 				hubbleRes.ExpectContainsFilterLine(
 					`{.source.ID} -> {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
-					fmt.Sprintf(`%s -> ["reserved:host"] %s : FORWARDED 5`, endpointID, hostIP),
+					fmt.Sprintf(`%s -> ["reserved:host"] %s : AUDIT 5`, endpointID, hostIP),
 					"Default policy verdict on egress failed")
 
 				By("Testing cilium monitor output")


### PR DESCRIPTION
This patch allows hubble to distinguish whether a packet is allowed
due to the audit mode or because it complies with the security policy.
Only affect events of type `policy-verdict` in L3/L4.

Fixes: #14692


~~#### Note: This PR is ready to be reviewed but requires the following to pass CI runtime tests:~~
~~1. The API changes in https://github.com/cilium/cilium/pull/14785 are bumped in cilium/hubble vendor~~
~~2. A new hubble CLI is released and shipped into test VM image~~
