### PR TITLE
Fix encryption in IPAM ENI mode

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -70,7 +70,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 		resp.IPV4 = &models.IPAMAddressResponse{
 			Cidrs:           ipv4Result.CIDRs,
 			IP:              ipv4Result.IP.String(),
-			MasterMac:       ipv4Result.Master,
+			MasterMac:       ipv4Result.PrimaryMAC,
 			Gateway:         ipv4Result.GatewayIP,
 			ExpirationUUID:  ipv4Result.ExpirationUUID,
 			InterfaceNumber: ipv4Result.InterfaceNumber,
@@ -82,7 +82,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 		resp.IPV6 = &models.IPAMAddressResponse{
 			Cidrs:           ipv6Result.CIDRs,
 			IP:              ipv6Result.IP.String(),
-			MasterMac:       ipv6Result.Master,
+			MasterMac:       ipv6Result.PrimaryMAC,
 			Gateway:         ipv6Result.GatewayIP,
 			ExpirationUUID:  ipv6Result.ExpirationUUID,
 			InterfaceNumber: ipv6Result.InterfaceNumber,
@@ -374,7 +374,7 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 	d.healthEndpointRouting, err = linuxrouting.NewRoutingInfo(
 		result.GatewayIP,
 		result.CIDRs,
-		result.Master,
+		result.PrimaryMAC,
 		result.InterfaceNumber,
 		option.Config.EnableIPv4Masquerade,
 	)

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -343,7 +343,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	var err error
 
 	if option.Config.EnableIPv6 && ep.IPv6 != nil {
-		err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %s", ep.IPv6.IP(), err)
 		}
@@ -356,7 +356,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4 != nil {
-		if err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
+		if _, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv4 address: %s", ep.IPv4.IP(), err)
 		}
 	}

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -52,6 +52,18 @@ type RoutingInfo struct {
 	InterfaceNumber int
 }
 
+func (info *RoutingInfo) GetIPv4CIDRs() []net.IPNet {
+	return info.IPv4CIDRs
+}
+
+func (info *RoutingInfo) GetMac() mac.MAC {
+	return info.MasterIfMAC
+}
+
+func (info *RoutingInfo) GetInterfaceNumber() int {
+	return info.InterfaceNumber
+}
+
 // NewRoutingInfo creates a new RoutingInfo struct, from data that will be
 // parsed and validated. Note, this code assumes IPv4 values because IPv4
 // (on either ENI or Azure interface) is the only supported path currently.

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -223,6 +223,17 @@ func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
 	})
 }
 
+// RetrieveIfaceNameFromMAC finds the corresponding device name for a
+// given MAC address.
+func RetrieveIfaceNameFromMAC(mac string) (string, error) {
+	iface, err := retrieveIfaceFromMAC(mac)
+	if err != nil {
+		err = fmt.Errorf("failed to get iface name with MAC %w", err)
+		return "", err
+	}
+	return iface.Attrs().Name, nil
+}
+
 func deleteRule(r route.Rule) error {
 	rules, err := route.ListRules(netlink.FAMILY_V4, &r)
 	if err != nil {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -195,6 +196,33 @@ func Delete(ip net.IP, compat bool) error {
 	return nil
 }
 
+// SetupRules installs routing rules based on the passed attributes. It accounts
+// for option.Config.EgressMultiHomeIPRuleCompat while configuring the rules.
+func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
+	var (
+		prio    int
+		tableId int
+	)
+
+	if option.Config.EgressMultiHomeIPRuleCompat {
+		prio = linux_defaults.RulePriorityEgress
+		ifindex, err := retrieveIfaceIdxFromMAC(mac)
+		if err != nil {
+			return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+		}
+		tableId = ifindex
+	} else {
+		prio = linux_defaults.RulePriorityEgressv2
+		tableId = computeTableIDFromIfaceNumber(ifaceNum)
+	}
+	return route.ReplaceRule(route.Rule{
+		Priority: prio,
+		From:     from,
+		To:       to,
+		Table:    tableId,
+	})
+}
+
 func deleteRule(r route.Rule) error {
 	rules, err := route.ListRules(netlink.FAMILY_V4, &r)
 	if err != nil {
@@ -255,6 +283,41 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (index int, err error) {
 	return
 }
 
+// computeTableIDFromIfaceNumber returns a computed per-ENI route table ID for the given
+// ENI interface number.
 func computeTableIDFromIfaceNumber(num int) int {
 	return linux_defaults.RouteTableInterfacesOffset + num
+}
+
+// retrieveIfaceIdxFromMAC finds the corresponding interface index for a
+// given MAC address.
+// It returns -1 as the index for error conditions.
+func retrieveIfaceIdxFromMAC(mac string) (int, error) {
+	iface, err := retrieveIfaceFromMAC(mac)
+	if err != nil {
+		err = fmt.Errorf("failed to get iface index with MAC %w", err)
+		return -1, err
+	}
+	return iface.Attrs().Index, nil
+}
+
+// retrieveIfaceFromFromMAC finds the corresponding interface for a
+// given MAC address.
+func retrieveIfaceFromMAC(mac string) (link netlink.Link, err error) {
+	var links []netlink.Link
+
+	links, err = netlink.LinkList()
+	if err != nil {
+		err = fmt.Errorf("unable to list interfaces: %w", err)
+		return
+	}
+	for _, l := range links {
+		if l.Attrs().HardwareAddr.String() == mac {
+			link = l
+			return
+		}
+	}
+
+	err = fmt.Errorf("interface with MAC not found")
+	return
 }

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -483,7 +483,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 	case ipamOption.IPAMENI:
 		for _, eni := range a.store.ownNode.Status.ENI.ENIs {
 			if eni.ID == ipInfo.Resource {
-				result.Master = eni.MAC
+				result.PrimaryMAC = eni.MAC
 				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
 				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
 				// Add manually configured Native Routing CIDR
@@ -507,7 +507,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 	case ipamOption.IPAMAzure:
 		for _, iface := range a.store.ownNode.Status.Azure.Interfaces {
 			if iface.ID == ipInfo.Resource {
-				result.Master = iface.MAC
+				result.PrimaryMAC = iface.MAC
 				result.GatewayIP = iface.GatewayIP
 				return
 			}

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -34,11 +34,11 @@ type AllocationResult struct {
 	// the IP is routable.
 	CIDRs []string
 
-	// Master is the MAC address of the master interface. This is useful
+	// PrimaryMAC is the MAC address of the primary interface. This is useful
 	// when the IP is a secondary address of an interface which is
 	// represented on the node as a Linux device and all routing of the IP
 	// must occur through that master interface.
-	Master string
+	PrimaryMAC string
 
 	// GatewayIP is the IP of the gateway which must be used for this IP.
 	// If the allocated IP is derived from a VPC, then the gateway

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
@@ -46,6 +47,7 @@ var (
 	ipv6NodePortAddrs map[string]net.IP // iface name => ip addr
 	ipv4AllocRange    *cidr.CIDR
 	ipv6AllocRange    *cidr.CIDR
+	routerInfo        RouterInfo
 
 	// k8s Node External IP
 	ipv4ExternalAddress net.IP
@@ -56,6 +58,12 @@ var (
 
 	ipsecKeyIdentity uint8
 )
+
+type RouterInfo interface {
+	GetIPv4CIDRs() []net.IPNet
+	GetMac() mac.MAC
+	GetInterfaceNumber() int
+}
 
 func makeIPv6HostIP() net.IP {
 	ipstr := "fc00::10CA:1"
@@ -264,6 +272,18 @@ func SetK8sExternalIPv4(ip net.IP) {
 // on the network as well as the internet. It can return nil if no External IPv4 address is assigned.
 func GetK8sExternalIPv4() net.IP {
 	return ipv4ExternalAddress
+}
+
+// GetRouterEniInfo returns additional information for the router. It is applicable
+// only in the ENI IPAM mode.
+func GetRouterInfo() RouterInfo {
+	return routerInfo
+}
+
+// SetRouterEniInfo sets additional information for the router. It is applicable
+// only in the ENI IPAM mode.
+func SetRouterInfo(info RouterInfo) {
+	routerInfo = info
 }
 
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading


### PR DESCRIPTION
The PR consists of two main fixes to make encryption functional on EKS - 

- Add routing rules for cilium_host ENI secondary IP address
- Attach `bpf_network` program to the correct interface for decryption to work

Following is out of scope of the PR, and will be addressed in follow-up PRs to simplify backporting :

- Refactor `loader.Reinitialize(...)`
- Review back-and-forth type conversions for `RoutingInfo`
- Writing datapath header defines (`IPV4_ENCRYPT_IFACE` and `ENCRYPT_IFACE`) 

**Release note**
```release-note
Make pod-to-pod encryption functional in the IPAM ENI mode.
```