### PR TITLE
docs: Document update-cmdref make target usage

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -100,6 +100,15 @@ requirements have been met:
       the first 12 characters of the git SHA followed by the full commit title
       as seen above without breaking the line.
 
+#. If you change CLI arguments of any binaries in this repo, the CI will reject your PR if you don't
+   also update the command reference docs. To do so, make sure to run the ``postcheck`` make target.
+
+   .. code-block:: shell-session
+
+      $ make postcheck
+      $ git add Documentation/cmdref
+      $ git commit
+
 #. All commits are signed off. See the section :ref:`dev_coo`.
 
 #. Document any user-facing or breaking changes in ``Documentation/install/upgrade.rst``.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -276,6 +276,7 @@ clusterDomain
 clusterPoolIPv
 clusterSize
 clustermesh
+cmdref
 cni
 cnp
 cnpStatusUpdates
@@ -662,6 +663,7 @@ policyEnforcementMode
 policyMapMax
 poller
 portmap
+postcheck
 pprof
 pre
 preallocateMaps


### PR DESCRIPTION
This make target needs to be used by contributors who make changes to
CLI.