### PR TITLE
ci: set sha1 based on github master branch

### DIFF
--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -3,8 +3,11 @@
 pipeline {
     agent none
 
-    parameters {
-        string(defaultValue: 'origin/master', name: 'GIT_BRANCH')
+    environment{
+        sha1="""${sh(
+                returnStdout: true,
+                script: 'git ls-remote https://github.com/cilium/cilium.git master | cut -f 1'
+            )}"""
     }
 
     options {
@@ -19,8 +22,7 @@ pipeline {
                 stage('K8s-1.14-kernel-4.9') {
                     steps {
                         build(job: "Cilium-PR-K8s-1.14-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                            string(name: 'sha1', value: "${sha1}")
                         ])
                     }
                 }
@@ -28,8 +30,7 @@ pipeline {
                 stage('K8s-1.15-kernel-4.9') {
                     steps {
                         build(job: "Cilium-PR-K8s-1.15-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                            string(name: 'sha1', value: "${sha1}")
                         ])
                     }
                 }
@@ -37,8 +38,7 @@ pipeline {
                 stage('K8s-1.16-kernel-4.9') {
                     steps {
                         build(job: "Cilium-PR-K8s-1.16-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                            string(name: 'sha1', value: "${sha1}")
                         ])
                     }
                 }
@@ -46,8 +46,7 @@ pipeline {
                 stage('K8s-1.17-kernel-4.9') {
                     steps {
                         build(job: "Cilium-PR-K8s-1.17-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                            string(name: 'sha1', value: "${sha1}")
                         ])
                     }
                 }
@@ -55,8 +54,7 @@ pipeline {
                 stage('K8s-1.18-kernel-4.9') {
                     steps {
                         build(job: "Cilium-PR-K8s-1.18-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                            string(name: 'sha1', value: "${sha1}")
                         ])
                     }
                 }
@@ -64,8 +62,7 @@ pipeline {
                 stage('K8s-1.19-kernel-4.9') {
                     steps {
                         build(job: "Cilium-PR-K8s-1.19-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                            string(name: 'sha1', value: "${sha1}")
                         ])
                     }
                 }


### PR DESCRIPTION
sha1 needs to be specified explicitly for the derived builds to run
correctly. This change sets it as an env var and propagates it to
children jobs as a parameter.