### PR TITLE
v1.9 backports 2021-02-11

### DIFF
--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -23,6 +23,7 @@ datapath instead of the default veth-based one.
 
     - IPVLAN L2 mode
     - L7 policy enforcement
+    - FQDN Policies
     - NAT64
     - IPVLAN with tunneling
     - eBPF-based masquerading

--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -23,6 +23,7 @@ By default, Cilium evaluates the following labels:
 =================================== ==================================================
 Label                               Description
 ----------------------------------- --------------------------------------------------
+``reserved:.*``                     Include all ``reserved`` labels
 ``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
 ``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
 ``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -514,7 +514,7 @@ func (mgr *EndpointManager) AddHostEndpoint(ctx context.Context, owner regenerat
 	// Give the endpoint a security identity
 	newCtx, cancel := context.WithTimeout(ctx, launchTime)
 	defer cancel()
-	ep.UpdateLabels(newCtx, epLabels, nil, true)
+	ep.UpdateLabels(newCtx, epLabels, epLabels, true)
 	if errors.Is(newCtx.Err(), context.DeadlineExceeded) {
 		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for host endpoint")
 	}


### PR DESCRIPTION
* #14114 -- labelsfilter: add reserved labels to default identity label list (@ArthurChiao)
 * #14893 -- docs: Add FQDN limitation to IPVLAN docs (@joestringer)

Skipped:

 * #14793 -- ipcache: Add ExternalIP of the local node to ipcache (@AnishShah)
 * #14913 -- iptables: Fix incorrect SNAT bypass with endpoint routes and tunneling (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14114 14893; do contrib/backporting/set-labels.py $pr done 1.9; done
```