### PR TITLE
test: Avoid unnecessary restarts of unmanaged pods

### DIFF
--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -178,8 +178,9 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationGKE:
-		vm.RestartUnmanagedPodsInNamespace(helpers.KubeSystemNamespace)
-		vm.RestartUnmanagedPodsInNamespace(helpers.CiliumNamespace)
+		if helpers.LogGathererNamespace != helpers.KubeSystemNamespace {
+			vm.RestartUnmanagedPodsInNamespace(helpers.KubeSystemNamespace)
+		}
 	}
 
 	switch helpers.GetCurrentIntegration() {


### PR DESCRIPTION
In tests, after Cilium installations, we often restart unmanaged pods to ensure they are managed by Cilium. In particular, on GKE, we used to restart unmanaged pods from both the `kube-system` and the `cilium` namespaces.

However, commit 48be458 ("test: GKE: Install Cilium in kube-system namespace") removed the cilium namespace to install Cilium in the `kube-system` namespace. One of the two calls to `RestartUnmanagedPodsInNamespace()` is therefore unnecessary. In addition, we also already restart pods in the namespace of the log-gatherer pods for all CI environments (vs. just GKE). If that last namespace is the `kube-system` namespace, then we don't need any call to `RestartUnmanagedPodsInNamespace()` for GKE.

I expect this will fix flake #14915. In that flake, some pods are not found while attempting to restart unmanaged pods. The flake started appearing in master when we merged commit 48be458. The theory is that the two quick calls to `RestartUnmanagedPodsInNamespace()` for the same namespace lead us, in the second call, to select pods that have already
been restarted by the first call. Such pods may disappear between the time we select them and the time we actually execute `kubectl delete`, resulting in the error:

    Error from server (NotFound): pods "kube-dns-66d6b7c877-dp4q2" not found

Fixes: https://github.com/cilium/cilium/pull/14899