### PR TITLE
helm: Fix and add missing podLabels

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -66,7 +66,8 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries for the NAT table. natMax: 524288 -- Configure the maximum number of entries for the neighbor table. neighMax: 524288 -- Configure the maximum number of entries in endpoint policy map. (per endpoint) |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.waitForMount | bool | `false` | Force the cilium-agent DaemonSet to wait in an initContainer until the eBPF filesystem has been mounted. |
-| certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.3"},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.3"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |
 | certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet. WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true. WARNING: Use with care! |
@@ -76,6 +77,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver","tag":"latest"}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
+| clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
 | clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as     resources:       limits:         cpu: 1000m         memory: 1024M       requests:         cpu: 100m         memory: 64Mi |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
@@ -183,6 +185,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
+| hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
 | hubble.relay.resources | object | `{}` | Specifies the resources for the hubble-relay pods |
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
@@ -213,6 +216,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
+| hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
 | hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.14.5"}` | Hubble-ui ingress proxy image. |
 | hubble.ui.proxy.resources | object | `{}` |  |
 | hubble.ui.replicas | int | `1` |  |

--- a/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
@@ -5,6 +5,9 @@ spec:
     metadata:
       labels:
         k8s-app: clustermesh-apiserver-generate-certs
+        {{- with .Values.clustermesh.apiserver.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccount: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}

--- a/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
@@ -5,6 +5,9 @@ spec:
     metadata:
       labels:
         k8s-app: hubble-generate-certs
+        {{- with .Values.certgen.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccount: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -75,6 +75,9 @@ spec:
 {{- if .Values.keepDeprecatedLabels }}
         kubernetes.io/cluster-service: "true"
 {{- end }}
+{{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
 {{- if .Values.affinity }}
       affinity:

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
@@ -46,6 +46,9 @@ spec:
       labels:
         io.cilium/app: etcd-operator
         name: cilium-etcd-operator
+{{- with .Values.etcd.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
 {{- if .Values.etcd.affinity }}
       affinity:

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -38,6 +38,9 @@ spec:
 {{- end }}
       labels:
         app: cilium-node-init
+{{- with .Values.nodeinit.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
 {{- with .Values.tolerations }}
       tolerations:

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -61,6 +61,9 @@ spec:
       labels:
         io.cilium/app: operator
         name: cilium-operator
+{{- with .Values.operator.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
 {{- if or (ge $k8sMinor "14") (gt $k8sMajor "1") }}
       # In HA mode, cilium-operator pods must not be scheduled on the same

--- a/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         k8s-app: cilium-pre-flight-check
         kubernetes.io/cluster-service: "true"
+{{- with .Values.preflight.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         k8s-app: cilium-pre-flight-check-deployment
         kubernetes.io/cluster-service: "true"
+{{- with .Values.preflight.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
       affinity:
         podAffinity:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -22,6 +22,9 @@ spec:
 {{- end }}
       labels:
         k8s-app: clustermesh-apiserver
+{{- with .Values.clustermesh.apiserver.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -28,6 +28,9 @@ spec:
 {{- end }}
       labels:
         k8s-app: hubble-relay
+{{- with .Values.hubble.relay.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
       affinity:
         podAffinity:

--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -23,6 +23,9 @@ spec:
 {{- end }}
       labels:
         k8s-app: hubble-ui
+{{- with .Values.hubble.ui.podLabels }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
     spec:
       {{- if .Values.hubble.ui.securityContext.enabled }}
       securityContext:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -489,6 +489,8 @@ certgen:
     pullPolicy: Always
   # -- Seconds after which the completed job pod will be deleted
   ttlSecondsAfterFinished: 1800
+  # -- Labels to be added to hubble-certgen pods
+  podLabels: {}
 
 hubble:
   # -- Enable Hubble (true by default).
@@ -612,6 +614,10 @@ hubble:
     #
     podAnnotations: {}
 
+    # -- Labels to be added to hubble-relay pods
+    #
+    podLabels: {}
+
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     #
@@ -725,6 +731,10 @@ hubble:
     # -- Annotations to be added to hubble-ui pods
     #
     podAnnotations: {}
+
+    # -- Labels to be added to hubble-ui pods
+    #
+    podLabels: {}
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -1461,6 +1471,9 @@ clustermesh:
 
     # -- Annotations to be added to clustermesh-apiserver pods
     podAnnotations: {}
+
+    # -- Labels to be added to clustermesh-apiserver pods
+    podLabels: {}
 
     # -- Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as
     #     resources:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -611,11 +611,9 @@ hubble:
     nodeSelector: {}
 
     # -- Annotations to be added to hubble-relay pods
-    #
     podAnnotations: {}
 
     # -- Labels to be added to hubble-relay pods
-    #
     podLabels: {}
 
     # -- Node tolerations for pod assignment on nodes with taints
@@ -729,11 +727,9 @@ hubble:
     replicas: 1
 
     # -- Annotations to be added to hubble-ui pods
-    #
     podAnnotations: {}
 
     # -- Labels to be added to hubble-ui pods
-    #
     podLabels: {}
 
     # -- Node labels for pod assignment
@@ -1055,11 +1051,9 @@ etcd:
   nodeSelector: {}
 
   # -- Annotations to be added to cilium-etcd-operator pods
-  #
   podAnnotations: {}
 
   # -- Labels to be added to cilium-etcd-operator pods
-  #
   podLabels: {}
 
   # -- PodDisruptionBudget settings
@@ -1197,11 +1191,9 @@ operator:
   nodeSelector: {}
 
   # -- Annotations to be added to cilium-operator pods
-  #
   podAnnotations: {}
 
   # -- Labels to be added to cilium-operator pods
-  #
   podLabels: {}
 
   # -- PodDisruptionBudget settings
@@ -1294,11 +1286,9 @@ nodeinit:
   nodeSelector: {}
 
   # -- Annotations to be added to node-init pods
-  #
   podAnnotations: {}
 
   # -- Labels to be added to node-init pods
-  #
   podLabels: {}
 
   # -- PodDisruptionBudget settings
@@ -1384,11 +1374,9 @@ preflight:
   nodeSelector: {}
 
   # -- Annotations to be added to preflight pods
-  #
   podAnnotations: {}
 
   # Labels to be added to preflight pods
-  #
   podLabels: {}
 
   # -- PodDisruptionBudget settings


### PR DESCRIPTION
- Pod Labels defined in `values` file were not propagated to actual manifests
- Some of the Pods were missing `podLabels` definition in `values` file and in actual manifests (i.e. certgen jobs Pods)