### PR TITLE
Add extraArgsList to helm cart

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -153,6 +153,7 @@ contributors across the globe, there is almost always someone available to help.
 | externalWorkloads | object | `{"enabled":false}` | Configure external workloads support |
 | externalWorkloads.enabled | bool | `false` | Enable support for external workloads, such as VMs (false by default). |
 | extraArgs | object | `{}` | Additional agent container arguments |
+| extraArgsList | list | `[]` | Additional agent container arguments in list form (allows for duplicate arguments). |
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
 | extraConfigmapMounts | list | `[]` | Additional agent ConfigMap mounts |
 | extraEnv | object | `{}` | Additional agent container environment variables |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -153,7 +153,7 @@ contributors across the globe, there is almost always someone available to help.
 | externalWorkloads | object | `{"enabled":false}` | Configure external workloads support |
 | externalWorkloads.enabled | bool | `false` | Enable support for external workloads, such as VMs (false by default). |
 | extraArgs | object | `{}` | Additional agent container arguments |
-| extraArgsList | list | `[]` | Additional agent container arguments in list form (allows for duplicate arguments). |
+| extraArgsList | list | `[]` | Additional agent container arguments in list form (augments extraArgs above, and allows for duplicate arguments) |
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
 | extraConfigmapMounts | list | `[]` | Additional agent ConfigMap mounts |
 | extraEnv | object | `{}` | Additional agent container environment variables |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -106,6 +106,9 @@ spec:
         - --{{ $key }}
 {{- end }}
 {{- end }}
+{{- range .Values.extraArgsList }}
+        - --{{ . }}
+{{- end }}
         command:
         - cilium-agent
 {{- if semverCompare ">=1.20-0" $k8sVersion }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -116,6 +116,12 @@ priorityClassName: ""
 
 # -- Additional agent container arguments
 extraArgs: {}
+  # foo: bar
+  
+# -- Additional agent container arguments in list form (augments extraArgs above, and allows for duplicate arguments)
+extraArgsList: []
+  # - "foo=bar"
+  # - "foo=bar2"
 
 # -- Additional agent container environment variables
 extraEnv: {}


### PR DESCRIPTION
This commit introduces an extra helm value, `extraArgsList`,
which permits passing extra arguments to the cilium-agent, and allows
for duplication of arguments.

An new value was chosen to avoid breaking existing configurations/documentation.

Fixes: #14944

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Add extraArgsList to helm chart to permit duplicate arguments to be passed to cilium-agent
```
