### PR TITLE
kpr: Make it possible to run bpf_sock on Kind

### DIFF
--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -53,6 +53,12 @@ Then, install Cilium release via Helm:
       --set image.pullPolicy=IfNotPresent \\
       --set ipam.mode=kubernetes
 
+.. note::
+
+   To fully enable Cilium's kube-proxy replacement (:ref:`kubeproxy-free`), cgroup v1
+   controllers ``net_cls`` and ``net_prio`` have to be disabled, or cgroup v1 has
+   to be disabled (e.g. by setting the kernel ``cgroup_no_v1="all"`` parameter).
+
 .. include:: k8s-install-validate.rst
 .. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -28,6 +28,7 @@ import (
 	health "github.com/cilium/cilium/cilium-health/launch"
 	"github.com/cilium/cilium/pkg/bandwidth"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
@@ -536,6 +537,11 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// which can be modified after the device detection.
 	handleNativeDevices(isKubeProxyReplacementStrict)
 	finishKubeProxyReplacementInit(isKubeProxyReplacementStrict)
+
+	// Cgroup v2 hierarchy root used for attachment is different when running on Kind.
+	runsOnKind := option.Config.EnableHostReachableServices &&
+		strings.HasPrefix(node.GetProviderID(), "kind://")
+	cgroups.CheckOrMountCgrpFS(option.Config.CGroupRoot, runsOnKind)
 
 	// Launch the K8s watchers in parallel as we continue to process other
 	// daemon options.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	enitypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/cleanup"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/components"
@@ -1132,7 +1131,6 @@ func initEnv(cmd *cobra.Command) {
 	// useful if the daemon is being round inside a namespace and the
 	// BPF filesystem is mapped into the slave namespace.
 	bpf.CheckOrMountFS(option.Config.BPFRoot, k8s.IsEnabled())
-	cgroups.CheckOrMountCgrpFS(option.Config.CGroupRoot)
 
 	option.Config.Opts.SetBool(option.Debug, debugDatapath)
 	option.Config.Opts.SetBool(option.DebugLB, debugDatapath)

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -65,19 +65,19 @@ func GetCgroupRoot() string {
 // the same LB BPF map which is not shared among Kind nodes.
 //
 // To fix this, we need to attach the program to cgroup v2 root of each Kind node.
-// Pods on a Kind node belong a cgroup v2 which name format is the following:
+// Pods on a Kind node belong to a cgroup v2 which name format is the following:
 //
 //		0::/system.slice/docker-$(SOME_NODE_ID).scope/kubelet/kubepods/burstable/pod-$(SOME_POD_ID)
 //
 // So if we attach the program to "$(CGROUP_MOUNT_DIR)/system.slice/docker-$(SOME_NODE_ID).scope/kubelet/",
-// it's guaranteed that it will be ran for all pods on that node.
+// it's guaranteed that it will be run for all pods on that node.
 //
 // However, there is one problem when net_cls or net_prio of the legacy cgroup (v1)
 // is enabled together with cgroup v2. If any of these controllers store class_id
 // or prioridx (which is the case for Docker) in the socket cgroup data struct,
 // the kernel won't be able to retrieve the exact root, and it will fallback to
 // the default hierarchy of cgroup v2 (aka the mount path) [1]. This renders the
-// programs attached in a sub-hierarchy to be ineffective.
+// programs attached in a sub-hierarchy ineffective.
 //
 // [1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/cgroup.h?h=v5.10#n837
 func getCgroupRootForKind() (string, error) {
@@ -169,8 +169,8 @@ func cgrpCheckOrMountLocation(cgroupRoot string) error {
 // BPFFS case we simply mount at the cilium default regardless if the system
 // has another mount created by systemd or otherwise.
 //
-// runsOnKind indicates whether cilium-agent runs on Kind (see getCgroupRootForKind)
-// for details.
+// runsOnKind indicates whether cilium-agent runs on Kind (see getCgroupRootForKind
+// for details).
 func CheckOrMountCgrpFS(mapRoot string, runsOnKind bool) {
 	cgrpMountOnce.Do(func() {
 		if mapRoot == "" {

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -15,14 +15,19 @@
 package cgroups
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"path"
+	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mountinfo"
+	"github.com/cilium/cilium/pkg/option"
 
 	"golang.org/x/sys/unix"
 )
@@ -45,6 +50,71 @@ func setCgroupRoot(path string) {
 // GetCgroupRoot returns the path for the cgroupv2 mount
 func GetCgroupRoot() string {
 	return cgroupRoot
+}
+
+// getCgroupRootForKind tries to determine a cgroup v2 root path for attaching
+// the BPF cgroup programs when Cilium is running on Kind. The determined path
+// is not used for mounting, and it is set to "cgroupRoot" after the mounting
+// has succeeded.
+//
+// When running on Kind, each k8s node runs in a separate non-host netns container
+// on the same host. This means, that there might be multiple cilium-agent
+// instances on the single host. When bpf_sock LB is enabled, each cilium-agent
+// would try to attach the program to the same cgroup v2 root. In such case,
+// the bpf_sock based LB would not work because the program would try to access
+// the same LB BPF map which is not shared among Kind nodes.
+//
+// To fix this, we need to attach the program to cgroup v2 root of each Kind node.
+// Pods on a Kind node belong a cgroup v2 which name format is the following:
+//
+//		0::/system.slice/docker-$(SOME_NODE_ID).scope/kubelet/kubepods/burstable/pod-$(SOME_POD_ID)
+//
+// So if we attach the program to "$(CGROUP_MOUNT_DIR)/system.slice/docker-$(SOME_NODE_ID).scope/kubelet/",
+// it's guaranteed that it will be ran for all pods on that node.
+//
+// However, there is one problem when net_cls or net_prio of the legacy cgroup (v1)
+// is enabled together with cgroup v2. If any of these controllers store class_id
+// or prioridx (which is the case for Docker) in the socket cgroup data struct,
+// the kernel won't be able to retrieve the exact root, and it will fallback to
+// the default hierarchy of cgroup v2 (aka the mount path) [1]. This renders the
+// programs attached in a sub-hierarchy to be ineffective.
+//
+// [1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/cgroup.h?h=v5.10#n837
+func getCgroupRootForKind() (string, error) {
+	f, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	cgroupPath := ""
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "net_cls") || strings.Contains(line, "net_prio") {
+			return "", fmt.Errorf("cgroups v1 net_cls or net_prio detected which interferes with cgroup v2")
+		}
+
+		if strings.HasPrefix(line, "0::") { // cgroup v2 starts with "0::"
+			re := regexp.MustCompile(`^.*kubelet`)
+			p := path.Join(cgroupRoot, strings.Split(line, "::")[1])
+			match := re.FindString(p)
+			if match == "" {
+				return "", fmt.Errorf("cannot find \"kubelet\" in cgroup v2 path: %q", p)
+			}
+			cgroupPath = match
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	if cgroupPath == "" {
+		return "", fmt.Errorf("cgroup v2 not found")
+	}
+
+	return cgroupPath, nil
 }
 
 // mountCgroup mounts the Cgroup v2 filesystem into the desired cgroupRoot directory.
@@ -98,7 +168,10 @@ func cgrpCheckOrMountLocation(cgroupRoot string) error {
 // location. It is harmless to have multiple cgroupv2 root mounts so unlike
 // BPFFS case we simply mount at the cilium default regardless if the system
 // has another mount created by systemd or otherwise.
-func CheckOrMountCgrpFS(mapRoot string) {
+//
+// runsOnKind indicates whether cilium-agent runs on Kind (see getCgroupRootForKind)
+// for details.
+func CheckOrMountCgrpFS(mapRoot string, runsOnKind bool) {
 	cgrpMountOnce.Do(func() {
 		if mapRoot == "" {
 			mapRoot = cgroupRoot
@@ -107,6 +180,17 @@ func CheckOrMountCgrpFS(mapRoot string) {
 		// Failed cgroup2 mount is not a fatal error, sockmap will be disabled however
 		if err == nil {
 			log.Infof("Mounted cgroupv2 filesystem at %s", mapRoot)
+
+			if runsOnKind {
+				p, err := getCgroupRootForKind()
+				if err != nil {
+					log.WithError(err).
+						Warnf("Failed to determine cgroup v2 hierarchy for Kind node. Socket-based LB (--%s) will not work.",
+							option.EnableHostReachableServices)
+				} else {
+					setCgroupRoot(p)
+				}
+			}
 		}
 	})
 }

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -102,6 +102,12 @@ func retrieveNodeInformation(nodeName string) (*nodeTypes.Node, error) {
 
 		}
 
+		// This is going to be used to detect whether cilium-agent is running on KIND
+		// to set a cgroup v2 root. The provider ID cannot be retrieved from CiliumNode
+		// object (a case above for IPAM == ClusterPool). This is fine, as long as
+		// we recommend to use IPAM = Kubernetes in the KIND getting started guide.
+		node.SetProviderID(k8sNode.Spec.ProviderID)
+
 		nodeInterface := ConvertToNode(k8sNode)
 		if nodeInterface == nil {
 			// This will never happen and the GetNode on line 63 will be soon

--- a/pkg/node/providerid.go
+++ b/pkg/node/providerid.go
@@ -1,0 +1,29 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+var (
+	providerID string
+)
+
+// GetProviderID returns provider ID of this node.
+func GetProviderID() string {
+	return providerID
+}
+
+// SetProviderID sets provider ID of this node.
+func SetProviderID(p string) {
+	providerID = p
+}


### PR DESCRIPTION
Please see commit msgs.

Marked to be backported to v1.9, because this will resolve the BPF complexity issues when the host-reachable svc is disabled.

On lack of unit tests - unfortunately, we cannot control whether the unit tests will run on a host with or without cgroup v1 which can influence the results. Anyway, I'm planning to enable kpr test suite on Kind.

```release-note
Support kube-proxy-replacement when running on Kind
```