### PR TITLE
v1.8 backports 2021-02-12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,6 @@ RUN groupadd -f cilium \
     && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 
 ENV INITSYSTEM="SYSTEMD"
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium"]

--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -77,6 +77,11 @@ Limitations
 * When applying L7 policies at egress, the source identity context is lost as
   it is currently not carried in the packet. This means that traffic will look
   like it is coming from outside of the cluster to the receiving pod.
+* HostPort type services additionally require either of the following
+  configurations:
+
+   * :ref:`k8s_install_portmap`
+   * :ref:`kubeproxyfree_hostport`
 
 Troubleshooting
 ===============

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -23,6 +23,7 @@ datapath instead of the default veth-based one.
 
     - IPVLAN L2 mode
     - L7 policy enforcement
+    - FQDN Policies
     - NAT64
     - IPVLAN with tunneling
     - BPF-based masquerading

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -69,6 +69,8 @@ by using the following commands:
 .. code:: bash
 
       kubectl -n kube-system delete ds kube-proxy
+      # Delete the configmap as well to avoid kube-proxy being reinstalled during a kubeadm upgrade (works only for K8s 1.19 and newer)
+      kubectl -n kube-system delete cm kube-proxy
       # Run on each node:
       iptables-restore <(iptables-save | grep -v KUBE)
 

--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -23,6 +23,7 @@ By default, Cilium evaluates the following labels:
 =================================== ==================================================
 Label                               Description
 ----------------------------------- --------------------------------------------------
+``reserved:.*``                     Include all ``reserved`` labels
 ``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
 ``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
 ``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels

--- a/Documentation/operations/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/scalability/identity-relevant-labels.rst
@@ -18,24 +18,41 @@ when included in evaluation, cause Cilium to generate a unique identity for each
 pod instead of a single identity for all of the pods that comprise a service or
 application.
 
-By default, Cilium evaluates the following labels:
+By default, Cilium considers all labels to be relevant for identities, with the
+following exceptions:
 
-=================================== ==================================================
+================================== ==============================================
 Label                               Description
------------------------------------ --------------------------------------------------
-``reserved:.*``                     Include all ``reserved`` labels
-``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
-``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
-``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels
-``k8s:!kubernetes.io``              Ignore all other ``kubernetes.io`` labels
-``k8s:!beta.kubernetes.io``         Ignore all ``beta.kubernetes.io`` labels
-``k8s:!k8s.io``                     Ignore all ``k8s.io`` labels
-``k8s:!pod-template-generation``    Ignore all ``pod-template-generation`` labels
-``k8s:!pod-template-hash``          Ignore all ``pod-template-hash`` labels
-``k8s:!controller-revision-hash``   Ignore all ``controller-revision-hash`` labels
-``k8s:!annotation.*``               Ignore all ``annotation labels``
-``k8s:!etcd_node``                  Ignore all ``etcd_node`` labels
-=================================== ==================================================
+---------------------------------- ----------------------------------------------
+``any:!io.kubernetes``             Ignore all ``io.kubernetes`` labels
+``any:!kubernetes.io``             Ignore all other ``kubernetes.io`` labels
+``any:!beta.kubernetes.io``        Ignore all ``beta.kubernetes.io`` labels
+``any:!k8s.io``                    Ignore all ``k8s.io`` labels
+``any:!pod-template-generation``   Ignore all ``pod-template-generation`` labels
+``any:!pod-template-hash``         Ignore all ``pod-template-hash`` labels
+``any:!controller-revision-hash``  Ignore all ``controller-revision-hash`` labels
+``any:!annotation.*``              Ignore all ``annotation labels``
+``any:!etcd_node``                 Ignore all ``etcd_node`` labels
+================================== ==============================================
+
+The above label examples are all *exclusive labels*, that is to say they define
+which label keys should be ignored. These are identified by the presence of the
+``!`` character.
+
+Label configurations that do not contain the ``!`` character are *inclusive
+labels*. Once at least one inclusive label is added, only labels that match the
+inclusive label configuration may be considered relevant for identities.
+Additionally, when at least one inclusive label is configured, the following
+inclusive labels are automatically added to the configuration:
+
+====================================== =====================================================
+Label                                  Description
+-------------------------------------- -----------------------------------------------------
+``reserved:.*``                        Include all ``reserved`` labels
+``any:io.kubernetes.pod.namespace``    Include all ``io.kubernetes.pod.namespace`` labels
+``any:io.cilium.k8s.namespace.labels`` Include all ``io.cilium.k8s.namespace.labels`` labels
+``any:app.kubernetes.io``              Include all ``app.kubernetes.io`` labels
+====================================== =====================================================
 
 
 
@@ -79,29 +96,35 @@ Including Labels
 ----------------
 
 Labels can be defined as a list of labels to include. Only the labels specified
-will be used to evaluate Cilium identities:
+and the default inclusive labels will be used to evaluate Cilium identities:
 
 .. code-block:: bash
 
     labels: "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
 
-The above configuration would only include the following labels when evaluating
-Cilium identities:
+The above configuration would only include the following label keys when
+evaluating Cilium identities:
 
-- io.kubernetes.pod.namespace*=.*
-- k8s-app*=*
-- app*=*
-- name*=*
+- k8s:k8s-app
+- k8s:app
+- k8s:name
+- reserved:.*
+- io.kubernetes.pod.namespace
+- io.cilium.k8s.namespace.labels
+- app.kubernetes.io
+
+Note that ``k8s:io.kubernetes.pod.namespace`` is already included in default
+label ``io.kubernetes.pod.namespace``.
 
 Labels with the same prefix as defined in the configuration will also be
-considered. This lists some examples of labels that would also be evaluated for
-Cilium identities:
+considered. This lists some examples of label keys that would also be evaluated
+for Cilium identities:
 
-- k8s-app-team*=*
-- app-production*=*
-- name-defined*=*
+- k8s-app-team
+- app-production
+- name-defined
 
-When a single "inclusive label" is added to the filter, all labels not defined
+When a single inclusive label is added to the filter, all labels not defined
 in the default list will be excluded. For example, pods running with the
 security labels ``team=team-1, env=prod`` will have the label ``env=prod``
 ignored as soon Cilium is started with the filter ``k8s:team``.
@@ -121,5 +144,5 @@ exclude any matches in the provided list when evaluating Cilium identities:
 The provided example would cause Cilium to exclude any of the following label
 matches:
 
-- k8s:controller-uid=*
-- k8s:job-name=*
+- k8s:controller-uid
+- k8s:job-name

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -147,9 +147,9 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 				 __u32 seclabel, __u32 monitor)
 {
 	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
-
 	if (ret != 0)
 		return ret;
+
 	return redirect(ENCAP_IFINDEX, 0);
 }
 
@@ -193,7 +193,18 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 			return encap_and_redirect_ipsec(ctx, tunnel_endpoint,
 							encrypt_key, seclabel);
 #endif
+#if !defined(ENABLE_NODEPORT) && (defined(ENABLE_IPSEC) || defined(ENABLE_HOST_FIREWALL))
+		/* For IPSec and the host firewall, traffic from a pod to a remote node
+		 * is sent through the tunnel. In the case of node --> VIP@remote pod,
+		 * packets may be DNATed when they enter the remote node. If kube-proxy
+		 * is used, the response needs to go through the stack on the way to
+		 * the tunnel, to apply the correct reverse DNAT.
+		 * See #14674 for details.
+		 */
+		return __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+#else
 		return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+#endif /* !ENABLE_NODEPORT && (ENABLE_IPSEC || ENABLE_HOST_FIREWALL) */
 	}
 
 	tunnel = map_lookup_elem(&TUNNEL_MAP, key);

--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -36,4 +36,6 @@ COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-aw
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-aws"]

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -36,4 +36,6 @@ COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-az
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-azure"]

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -36,4 +36,6 @@ COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-ge
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-generic"]

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -36,4 +36,6 @@ COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /u
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator"]

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -341,6 +341,8 @@ sleep 2s
 if [ -n "\${K8S}" ]; then
     echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
 fi
+# FIXME Remove me once we add support for Go 1.16
+echo 'GODEBUG="madvdontneed=1"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPTS="${cilium_options}"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPERATOR_OPTS="${cilium_operator_options}"' >> /etc/sysconfig/cilium
 echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -290,7 +290,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	}
 
 	var mtuConfig mtu.Configuration
-	externalIP := node.GetExternalIPv4()
+	externalIP := node.GetIPv4()
 	if externalIP == nil {
 		externalIP = node.GetIPv6()
 	}
@@ -579,7 +579,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			logfields.V6Prefix:       node.GetIPv6AllocRange(),
 			logfields.V4HealthIP:     d.nodeDiscovery.LocalNode.IPv4HealthIP,
 			logfields.V6HealthIP:     d.nodeDiscovery.LocalNode.IPv6HealthIP,
-			logfields.V4CiliumHostIP: node.GetInternalIPv4(),
+			logfields.V4CiliumHostIP: node.GetInternalIPv4Router(),
 			logfields.V6CiliumHostIP: node.GetIPv6Router(),
 		}).Info("Annotating k8s node")
 
@@ -587,7 +587,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			encryptKeyID,
 			node.GetIPv4AllocRange(), node.GetIPv6AllocRange(),
 			d.nodeDiscovery.LocalNode.IPv4HealthIP, d.nodeDiscovery.LocalNode.IPv6HealthIP,
-			node.GetInternalIPv4(), node.GetIPv6Router())
+			node.GetInternalIPv4Router(), node.GetIPv6Router())
 		if err != nil {
 			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
 		}
@@ -775,7 +775,7 @@ func (d *Daemon) GetNodeSuffix() string {
 
 	switch {
 	case option.Config.EnableIPv4:
-		ip = node.GetExternalIPv4()
+		ip = node.GetIPv4()
 	case option.Config.EnableIPv6:
 		ip = node.GetIPv6()
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1203,7 +1203,7 @@ func initEnv(cmd *cobra.Command) {
 		if ip := net.ParseIP(option.Config.IPv4NodeAddr); ip == nil {
 			log.WithField(logfields.IPAddr, option.Config.IPv4NodeAddr).Fatal("Invalid IPv4 node address")
 		} else {
-			node.SetExternalIPv4(ip)
+			node.SetIPv4(ip)
 		}
 	}
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -379,7 +379,7 @@ func (d *Daemon) pollerResponseNotify(lookupTime time.Time, qname string, respon
 		},
 	}
 
-	if ip := node.GetExternalIPv4(); ip != nil {
+	if ip := node.GetIPv4(); ip != nil {
 		record.LogRecord.NodeAddressInfo.IPv4 = ip.String()
 	}
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -260,7 +260,7 @@ func (d *Daemon) allocateIPs() error {
 			return err
 		}
 		if routerIP != nil {
-			node.SetInternalIPv4(routerIP)
+			node.SetInternalIPv4Router(routerIP)
 		}
 	}
 
@@ -294,8 +294,8 @@ func (d *Daemon) allocateIPs() error {
 		}
 	}
 
-	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
-	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4())
+	log.Infof("  External-Node IPv4: %s", node.GetIPv4())
+	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4Router())
 
 	if option.Config.EnableIPv4 {
 		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -70,7 +70,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 		resp.IPV4 = &models.IPAMAddressResponse{
 			Cidrs:           ipv4Result.CIDRs,
 			IP:              ipv4Result.IP.String(),
-			MasterMac:       ipv4Result.Master,
+			MasterMac:       ipv4Result.PrimaryMAC,
 			Gateway:         ipv4Result.GatewayIP,
 			ExpirationUUID:  ipv4Result.ExpirationUUID,
 			InterfaceNumber: ipv4Result.InterfaceNumber,
@@ -82,7 +82,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 		resp.IPV6 = &models.IPAMAddressResponse{
 			Cidrs:           ipv6Result.CIDRs,
 			IP:              ipv6Result.IP.String(),
-			MasterMac:       ipv6Result.Master,
+			MasterMac:       ipv6Result.PrimaryMAC,
 			Gateway:         ipv6Result.GatewayIP,
 			ExpirationUUID:  ipv6Result.ExpirationUUID,
 			InterfaceNumber: ipv6Result.InterfaceNumber,
@@ -373,7 +373,7 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 	d.healthEndpointRouting, err = linuxrouting.NewRoutingInfo(
 		result.GatewayIP,
 		result.CIDRs,
-		result.Master,
+		result.PrimaryMAC,
 		result.InterfaceNumber,
 		option.Config.Masquerade,
 	)

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -182,9 +182,10 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 	// In that case, removal and re-creation of the cilium_host is
 	// required. It will also cause disruption of networking until all
 	// endpoints have been regenerated.
+	var result *ipam.AllocationResult
 	routerIP = family.Router()
 	if routerIP != nil {
-		err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router")
+		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router")
 		if err != nil {
 			log.Warn("Router IP could not be re-allocated. Need to re-allocate. This will cause brief network disruption")
 
@@ -200,7 +201,6 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 	}
 
 	if routerIP == nil {
-		var result *ipam.AllocationResult
 		family := ipam.DeriveFamily(family.PrimaryExternal())
 		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, "router")
 		if err != nil {
@@ -208,6 +208,16 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 			return
 		}
 		routerIP = result.IP
+	}
+	if option.Config.IPAM == ipamOption.IPAMENI && result != nil {
+		var routingInfo *linuxrouting.RoutingInfo
+		routingInfo, err = linuxrouting.NewRoutingInfo(result.GatewayIP, result.CIDRs,
+			result.PrimaryMAC, result.InterfaceNumber, option.Config.Masquerade)
+		if err != nil {
+			err = fmt.Errorf("failed to create router info %w", err)
+			return
+		}
+		node.SetRouterInfo(routingInfo)
 	}
 
 	return

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -331,7 +331,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	var err error
 
 	if option.Config.EnableIPv6 && ep.IPv6 != nil {
-		err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %s", ep.IPv6.IP(), err)
 		}
@@ -344,7 +344,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4 != nil {
-		if err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
+		if _, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv4 address: %s", ep.IPv4.IP(), err)
 		}
 	}

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -32,4 +32,6 @@ COPY --from=builder /go/src/github.com/cilium/cilium/hubble-relay/hubble-relay /
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops
 ENTRYPOINT ["/usr/bin/hubble-relay"]
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["serve"]

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -161,8 +161,8 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			// the local host, then the ipcache should be populated
 			// with the hostIP so that this traffic can be guided
 			// to a tunnel endpoint destination.
-			externalIP := node.GetExternalIPv4()
-			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(externalIP) {
+			nodeIPv4 := node.GetIPv4()
+			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
 				copy(value.TunnelEndpoint[:], ip4)
 			}
 		}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -338,6 +338,7 @@ var ciliumChains = []customChain{
 		table:      "filter",
 		hook:       "FORWARD",
 		feederArgs: []string{""},
+		ipv6:       true,
 	},
 }
 
@@ -734,6 +735,19 @@ func getDeliveryInterface(ifName string) string {
 }
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
+	if option.Config.EnableIPv4 {
+		err := m.installForwardChainRulesIpX("iptables", ifName, localDeliveryInterface, forwardChain)
+		if err != nil {
+			return err
+		}
+	}
+	if option.Config.EnableIPv6 {
+		return m.installForwardChainRulesIpX("ip6tables", ifName, localDeliveryInterface, forwardChain)
+	}
+	return nil
+}
+
+func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliveryInterface, forwardChain string) error {
 	transient := ""
 	if forwardChain == ciliumTransientForwardChain {
 		transient = " (transient)"
@@ -760,7 +774,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 	//  - Node running backend:
 	//       IN=eno1 OUT=cilium_host
 	//       IN=lxc... OUT=eno1
-	if err := runProg("iptables", append(
+	if err := runProg(prog, append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-o", ifName,
@@ -768,7 +782,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg("iptables", append(
+	if err := runProg(prog, append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", ifName,
@@ -776,7 +790,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg("iptables", append(
+	if err := runProg(prog, append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", "lxc+",
@@ -788,7 +802,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 	// TODO: Make 'cilium_net' configurable if we ever support other than "cilium_host" as the Cilium host device.
 	if ifName == "cilium_host" {
 		ifPeerName := "cilium_net"
-		if err := runProg("iptables", append(
+		if err := runProg(prog, append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", ifPeerName,
@@ -801,7 +815,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 	// same (enable-endpoint-routes), a separate set of rules to allow
 	// from/to delivery interface is required.
 	if localDeliveryInterface != ifName {
-		if err := runProg("iptables", append(
+		if err := runProg(prog, append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
@@ -809,7 +823,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
-		if err := runProg("iptables", append(
+		if err := runProg(prog, append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
@@ -887,11 +901,11 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 
 	localDeliveryInterface := getDeliveryInterface(ifName)
 
-	if option.Config.EnableIPv4 {
-		if err := m.installForwardChainRules(ifName, localDeliveryInterface, ciliumForwardChain); err != nil {
-			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
-		}
+	if err := m.installForwardChainRules(ifName, localDeliveryInterface, ciliumForwardChain); err != nil {
+		return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
+	}
 
+	if option.Config.EnableIPv4 {
 		// Mark all packets sourced from processes running on the host with a
 		// special marker so that we can differentiate traffic sourced locally
 		// vs. traffic from the outside world that was masqueraded to appear

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -971,28 +971,16 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				}
 			}
 
-			// The following rules exclude traffic from the remaining rules in this chain.
-			// If any of these rules match, none of the remaining rules in this chain
-			// are considered.
-			// Exclude traffic for other than interface from the masquarade rules.
-			// RETURN fro the chain as it is possible that other rules need to be matched.
-			if err := runProg("iptables", append(
-				m.waitArgs,
-				"-t", "nat",
-				"-A", ciliumPostNatChain,
-				"!", "-o", localDeliveryInterface,
-				"-m", "comment", "--comment", "exclude non-"+ifName+" traffic from masquerade",
-				"-j", "RETURN"), false); err != nil {
-				return err
-			}
+			// The following rule exclude traffic from the remaining rules in this chain.
+			// If this rule matches, none of the remaining rules in this chain
 
-			// Exclude proxy return traffic from the masquarade rules
+			// Exclude proxy return traffic from the masquerade rules
 			if err := runProg("iptables", append(
 				m.waitArgs,
 				"-t", "nat",
 				"-A", ciliumPostNatChain,
 				"-m", "mark", "--mark", matchFromProxy, // Don't match proxy (return) traffic
-				"-m", "comment", "--comment", "exclude proxy return traffic from masquarade",
+				"-m", "comment", "--comment", "exclude proxy return traffic from masquerade",
 				"-j", "ACCEPT"), false); err != nil {
 				return err
 			}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -83,14 +83,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		fmt.Fprintf(fw, " cilium.v6.nodeport.str %s\n", node.GetNodePortIPv6Addrs())
 		fmt.Fprintf(fw, "\n")
 	}
-	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetExternalIPv4().String())
-	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4Router().String())
 	fmt.Fprintf(fw, " cilium.v4.nodeport.str %s\n", node.GetNodePortIPv4Addrs())
 	fmt.Fprintf(fw, "\n")
 	if option.Config.EnableIPv6 {
 		fw.WriteString(dumpRaw(defaults.RestoreV6Addr, node.GetIPv6Router()))
 	}
-	fw.WriteString(dumpRaw(defaults.RestoreV4Addr, node.GetInternalIPv4()))
+	fw.WriteString(dumpRaw(defaults.RestoreV4Addr, node.GetInternalIPv4Router()))
 	fmt.Fprintf(fw, " */\n\n")
 
 	cDefinesMap["KERNEL_HZ"] = fmt.Sprintf("%d", option.Config.KernelHz)
@@ -101,7 +101,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 
 	if option.Config.EnableIPv4 {
-		ipv4GW := node.GetInternalIPv4()
+		ipv4GW := node.GetInternalIPv4Router()
 		loopbackIPv4 := node.GetIPv4Loopback()
 		ipv4Range := node.GetIPv4AllocRange()
 		cDefinesMap["IPV4_GATEWAY"] = fmt.Sprintf("%#x", byteorder.HostSliceToNetwork(ipv4GW, reflect.Uint32).(uint32))

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -53,12 +53,12 @@ func (s *ConfigSuite) SetUpTest(c *C) {
 	err := bpf.ConfigureResourceLimits()
 	c.Assert(err, IsNil)
 	node.InitDefaultPrefix("")
-	node.SetInternalIPv4(ipv4DummyAddr)
+	node.SetInternalIPv4Router(ipv4DummyAddr)
 	node.SetIPv4Loopback(ipv4DummyAddr)
 }
 
 func (s *ConfigSuite) TearDownTest(c *C) {
-	node.SetInternalIPv4(nil)
+	node.SetInternalIPv4Router(nil)
 	node.SetIPv4Loopback(nil)
 }
 

--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -70,11 +70,11 @@ func listLocalAddresses(family int) ([]net.IP, error) {
 type addressFamilyIPv4 struct{}
 
 func (a *addressFamilyIPv4) Router() net.IP {
-	return node.GetInternalIPv4()
+	return node.GetInternalIPv4Router()
 }
 
 func (a *addressFamilyIPv4) PrimaryExternal() net.IP {
-	return node.GetExternalIPv4()
+	return node.GetIPv4()
 }
 
 func (a *addressFamilyIPv4) AllocationCIDR() *cidr.CIDR {

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -52,6 +52,18 @@ type RoutingInfo struct {
 	InterfaceNumber int
 }
 
+func (info *RoutingInfo) GetIPv4CIDRs() []net.IPNet {
+	return info.IPv4CIDRs
+}
+
+func (info *RoutingInfo) GetMac() mac.MAC {
+	return info.MasterIfMAC
+}
+
+func (info *RoutingInfo) GetInterfaceNumber() int {
+	return info.InterfaceNumber
+}
+
 // NewRoutingInfo creates a new RoutingInfo struct, from data that will be
 // parsed and validated. Note, this code assumes IPv4 values because IPv4
 // (on either ENI or Azure interface) is the only supported path currently.

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -223,6 +223,17 @@ func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
 	})
 }
 
+// RetrieveIfaceNameFromMAC finds the corresponding device name for a
+// given MAC address.
+func RetrieveIfaceNameFromMAC(mac string) (string, error) {
+	iface, err := retrieveIfaceFromMAC(mac)
+	if err != nil {
+		err = fmt.Errorf("failed to get iface name with MAC %w", err)
+		return "", err
+	}
+	return iface.Attrs().Name, nil
+}
+
 func deleteRule(r route.Rule) error {
 	rules, err := route.ListRules(netlink.FAMILY_V4, &r)
 	if err != nil {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -195,6 +196,33 @@ func Delete(ip net.IP, compat bool) error {
 	return nil
 }
 
+// SetupRules installs routing rules based on the passed attributes. It accounts
+// for option.Config.EgressMultiHomeIPRuleCompat while configuring the rules.
+func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
+	var (
+		prio    int
+		tableId int
+	)
+
+	if option.Config.EgressMultiHomeIPRuleCompat {
+		prio = linux_defaults.RulePriorityEgress
+		ifindex, err := retrieveIfaceIdxFromMAC(mac)
+		if err != nil {
+			return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+		}
+		tableId = ifindex
+	} else {
+		prio = linux_defaults.RulePriorityEgressv2
+		tableId = computeTableIDFromIfaceNumber(ifaceNum)
+	}
+	return route.ReplaceRule(route.Rule{
+		Priority: prio,
+		From:     from,
+		To:       to,
+		Table:    tableId,
+	})
+}
+
 func deleteRule(r route.Rule) error {
 	rules, err := route.ListRules(netlink.FAMILY_V4, &r)
 	if err != nil {
@@ -255,6 +283,41 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (index int, err error) {
 	return
 }
 
+// computeTableIDFromIfaceNumber returns a computed per-ENI route table ID for the given
+// ENI interface number.
 func computeTableIDFromIfaceNumber(num int) int {
 	return linux_defaults.RouteTableInterfacesOffset + num
+}
+
+// retrieveIfaceIdxFromMAC finds the corresponding interface index for a
+// given MAC address.
+// It returns -1 as the index for error conditions.
+func retrieveIfaceIdxFromMAC(mac string) (int, error) {
+	iface, err := retrieveIfaceFromMAC(mac)
+	if err != nil {
+		err = fmt.Errorf("failed to get iface index with MAC %w", err)
+		return -1, err
+	}
+	return iface.Attrs().Index, nil
+}
+
+// retrieveIfaceFromFromMAC finds the corresponding interface for a
+// given MAC address.
+func retrieveIfaceFromMAC(mac string) (link netlink.Link, err error) {
+	var links []netlink.Link
+
+	links, err = netlink.LinkList()
+	if err != nil {
+		err = fmt.Errorf("unable to list interfaces: %w", err)
+		return
+	}
+	for _, l := range links {
+		if l.Attrs().HardwareAddr.String() == mac {
+			link = l
+			return
+		}
+	}
+
+	err = fmt.Errorf("interface with MAC not found")
+	return
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -222,7 +222,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgBpffsRoot] = bpf.GetMapRoot()
 
 	if option.Config.EnableIPv4 {
-		args[initArgIPv4NodeIP] = node.GetInternalIPv4().String()
+		args[initArgIPv4NodeIP] = node.GetInternalIPv4Router().String()
 	} else {
 		args[initArgIPv4NodeIP] = "<nil>"
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -363,6 +363,16 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initBPFCPU], clockSource[option.Config.ClockSource])
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
+		// For the ENI ipam mode on EKS, this will be the interface that
+		// the router (cilium_host) IP is associated to.
+		if info := node.GetRouterInfo(); info != nil {
+			mac := info.GetMac()
+			iface, err := linuxrouting.RetrieveIfaceNameFromMAC(mac.String())
+			if err != nil {
+				log.WithError(err).WithField("mac", mac).Fatal("Failed to set encrypt interface in the ENI ipam mode")
+			}
+			args[initArgEncryptInterface] = iface
+		}
 		var err error
 		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -117,7 +119,7 @@ type setting struct {
 	ignoreErr bool
 }
 
-func addENIRules(sysSettings []setting) ([]setting, error) {
+func addENIRules(sysSettings []setting, nodeAddressing datapath.NodeAddressing) ([]setting, error) {
 	// AWS ENI mode requires symmetric routing, see
 	// iptables.addCiliumENIRules().
 	// The default AWS daemonset installs the following rules that are used
@@ -156,6 +158,19 @@ func addENIRules(sysSettings []setting) ([]setting, error) {
 		Table:    route.MainTable,
 	}); err != nil {
 		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+	}
+
+	// Add rules for router (cilium_host).
+	info := node.GetRouterInfo()
+	cidrs := info.GetIPv4CIDRs()
+	routerIP := net.IPNet{
+		IP:   nodeAddressing.IPv4().Router(),
+		Mask: net.CIDRMask(32, 32),
+	}
+	for _, cidr := range cidrs {
+		if err = linuxrouting.SetupRules(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
+			return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)
+		}
 	}
 
 	return retSettings, nil
@@ -349,7 +364,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		var err error
-		if sysSettings, err = addENIRules(sysSettings); err != nil {
+		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
 		}
 	}

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -35,6 +35,6 @@ func Test(t *testing.T) {
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
 	node.InitDefaultPrefix("")
-	node.SetInternalIPv4(templateIPv4)
+	node.SetInternalIPv4Router(templateIPv4)
 	node.SetIPv4Loopback(templateIPv4)
 }

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -133,7 +133,7 @@ func getEndpointNetworking(mdlNetworking *models.EndpointNetworking) (networking
 	}
 
 	if option.Config.EnableIPv4 {
-		networking.NodeIP = node.GetExternalIPv4().String()
+		networking.NodeIP = node.GetIPv4().String()
 	} else {
 		networking.NodeIP = node.GetIPv6().String()
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -739,7 +739,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 
 				IP := endpointIP.IP()
 				ID := e.SecurityIdentity.ID
-				hostIP := node.GetExternalIPv4()
+				hostIP := node.GetIPv4()
 				key := node.GetIPsecKeyIdentity()
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -488,7 +488,7 @@ func (mgr *EndpointManager) AddHostEndpoint(ctx context.Context, owner regenerat
 	// Give the endpoint a security identity
 	newCtx, cancel := context.WithTimeout(ctx, launchTime)
 	defer cancel()
-	ep.UpdateLabels(newCtx, epLabels, nil, true)
+	ep.UpdateLabels(newCtx, epLabels, epLabels, true)
 	if newCtx.Err() == context.DeadlineExceeded {
 		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for host endpoint")
 	}

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -490,7 +490,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 	case ipamOption.IPAMENI:
 		for _, eni := range a.store.ownNode.Status.ENI.ENIs {
 			if eni.ID == ipInfo.Resource {
-				result.Master = eni.MAC
+				result.PrimaryMAC = eni.MAC
 				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
 				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
 				// Add manually configured Native Routing CIDR
@@ -514,7 +514,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 	case ipamOption.IPAMAzure:
 		for _, iface := range a.store.ownNode.Status.Azure.Interfaces {
 			if iface.ID == ipInfo.Resource {
-				result.Master = iface.MAC
+				result.PrimaryMAC = iface.MAC
 				result.GatewayIP = iface.GatewayIP
 				return
 			}

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -34,11 +34,11 @@ type AllocationResult struct {
 	// the IP is routable.
 	CIDRs []string
 
-	// Master is the MAC address of the master interface. This is useful
+	// PrimaryMAC is the MAC address of the primary interface. This is useful
 	// when the IP is a secondary address of an interface which is
 	// represented on the node as a Linux device and all routing of the IP
 	// must occur through that master interface.
-	Master string
+	PrimaryMAC string
 
 	// GatewayIP is the IP of the gateway which must be used for this IP.
 	// If the allocated IP is derived from a VPC, then the gateway

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -233,7 +233,7 @@ func WaitForNodeInformation() error {
 		// addressing, e.g. an IPv6 only PodCIDR running over
 		// IPv4 encapsulation.
 		if nodeIP4 != nil {
-			node.SetExternalIPv4(nodeIP4)
+			node.SetIPv4(nodeIP4)
 		}
 
 		if nodeIP6 != nil {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -242,6 +242,9 @@ func WaitForNodeInformation() error {
 
 		node.SetLabels(n.Labels)
 
+		node.SetK8sExternalIPv4(n.GetExternalIP(false))
+		node.SetK8sExternalIPv6(n.GetExternalIP(true))
+
 		// K8s Node IP is used by BPF NodePort devices auto-detection
 		node.SetK8sNodeIP(k8sNodeIP)
 	} else {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -87,3 +87,88 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", "I can change this and doesn't affect any one")
 	c.Assert(filtered, checker.DeepEquals, wanted)
 }
+
+func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
+	wanted := labels.Labels{
+		"app.kubernetes.io":           labels.NewLabel("app.kubernetes.io", "my-nginx", labels.LabelSourceContainer),
+		"id.lizards.k8s":              labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
+		"id.lizards":                  labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer),
+		"ignorE":                      labels.NewLabel("ignorE", "foo", labels.LabelSourceContainer),
+		"ignore":                      labels.NewLabel("ignore", "foo", labels.LabelSourceContainer),
+		"reserved:host":               labels.NewLabel("reserved:host", "", labels.LabelSourceAny),
+		"io.kubernetes.pod.namespace": labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
+	}
+
+	err := ParseLabelPrefixCfg([]string{}, "")
+	c.Assert(err, IsNil)
+	dlpcfg := validLabelPrefixes
+	allNormalLabels := map[string]string{
+		"io.kubernetes.container.hash":                              "cf58006d",
+		"io.kubernetes.container.name":                              "POD",
+		"io.kubernetes.container.restartCount":                      "0",
+		"io.kubernetes.container.terminationMessagePath":            "",
+		"io.kubernetes.pod.name":                                    "my-nginx-3800858182-07i3n",
+		"io.kubernetes.pod.namespace":                               "default",
+		"app.kubernetes.io":                                         "my-nginx",
+		"kubernetes.io.foo":                                         "foo",
+		"beta.kubernetes.io.foo":                                    "foo",
+		"annotation.kubectl.kubernetes.io":                          "foo",
+		"annotation.hello":                                          "world",
+		"annotation." + k8sConst.CiliumIdentityAnnotationDeprecated: "12356",
+		"io.kubernetes.pod.terminationGracePeriod":                  "30",
+		"io.kubernetes.pod.uid":                                     "c2e22414-dfc3-11e5-9792-080027755f5a",
+		"ignore":                                                    "foo",
+		"ignorE":                                                    "foo",
+		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
+		"controller-revision-hash":                                  "123456",
+	}
+	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
+	allLabels["reserved:host"] = labels.NewLabel("reserved:host", "", labels.LabelSourceAny)
+	filtered, _ := dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
+	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer)
+	allLabels["id.lizards.k8s"] = labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 7)
+	c.Assert(filtered, checker.DeepEquals, wanted)
+}
+
+func (s *LabelsPrefCfgSuite) TestFilterLabelsDocExample(c *C) {
+	wanted := labels.Labels{
+		"io.cilium.k8s.namespace.labels": labels.NewLabel("io.cilium.k8s.namespace.labels", "foo", labels.LabelSourceK8s),
+		"k8s-app-team":                   labels.NewLabel("k8s-app-team", "foo", labels.LabelSourceK8s),
+		"app-production":                 labels.NewLabel("app-production", "foo", labels.LabelSourceK8s),
+		"name-defined":                   labels.NewLabel("name-defined", "foo", labels.LabelSourceK8s),
+		"host":                           labels.NewLabel("host", "", labels.LabelSourceReserved),
+		"io.kubernetes.pod.namespace":    labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceAny),
+	}
+
+	err := ParseLabelPrefixCfg([]string{"k8s:io.kubernetes.pod.namespace", "k8s:k8s-app", "k8s:app", "k8s:name"}, "")
+	c.Assert(err, IsNil)
+	dlpcfg := validLabelPrefixes
+	allNormalLabels := map[string]string{
+		"io.cilium.k8s.namespace.labels": "foo",
+		"k8s-app-team":                   "foo",
+		"app-production":                 "foo",
+		"name-defined":                   "foo",
+	}
+	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceK8s)
+	filtered, _ := dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 4)
+
+	// Reserved labels are included.
+	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
+
+	// io.kubernetes.pod.namespace=docker matches because the default list has any:io.kubernetes.pod.namespace.
+	allLabels["io.kubernetes.pod.namespace"] = labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceAny)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 6)
+
+	// container:k8s-app-role=foo doesn't match because it doesn't have source k8s.
+	allLabels["k8s-app-role"] = labels.NewLabel("k8s-app-role", "foo", labels.LabelSourceContainer)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 6)
+	c.Assert(filtered, checker.DeepEquals, wanted)
+}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
@@ -43,6 +44,7 @@ var (
 	ipv6NodePortAddrs map[string]net.IP // iface name => ip addr
 	ipv4AllocRange    *cidr.CIDR
 	ipv6AllocRange    *cidr.CIDR
+	routerInfo        RouterInfo
 
 	// k8s Node External IP
 	ipv4ExternalAddress net.IP
@@ -53,6 +55,12 @@ var (
 
 	ipsecKeyIdentity uint8
 )
+
+type RouterInfo interface {
+	GetIPv4CIDRs() []net.IPNet
+	GetMac() mac.MAC
+	GetInterfaceNumber() int
+}
 
 func makeIPv6HostIP() net.IP {
 	ipstr := "fc00::10CA:1"
@@ -219,6 +227,18 @@ func SetK8sExternalIPv4(ip net.IP) {
 // on the network as well as the internet. It can return nil if no External IPv4 address is assigned.
 func GetK8sExternalIPv4() net.IP {
 	return ipv4ExternalAddress
+}
+
+// GetRouterEniInfo returns additional information for the router. It is applicable
+// only in the ENI IPAM mode.
+func GetRouterInfo() RouterInfo {
+	return routerInfo
+}
+
+// SetRouterEniInfo sets additional information for the router. It is applicable
+// only in the ENI IPAM mode.
+func SetRouterInfo(info RouterInfo) {
+	routerInfo = info
 }
 
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -34,15 +34,15 @@ import (
 )
 
 var (
-	ipv4Loopback        net.IP
-	ipv4ExternalAddress net.IP
-	ipv4InternalAddress net.IP
-	ipv4NodePortAddrs   map[string]net.IP // iface name => ip addr
-	ipv6Address         net.IP
-	ipv6RouterAddress   net.IP
-	ipv6NodePortAddrs   map[string]net.IP // iface name => ip addr
-	ipv4AllocRange      *cidr.CIDR
-	ipv6AllocRange      *cidr.CIDR
+	ipv4Loopback      net.IP
+	ipv4Address       net.IP
+	ipv4RouterAddress net.IP
+	ipv4NodePortAddrs map[string]net.IP // iface name => ip addr
+	ipv6Address       net.IP
+	ipv6RouterAddress net.IP
+	ipv6NodePortAddrs map[string]net.IP // iface name => ip addr
+	ipv4AllocRange    *cidr.CIDR
+	ipv6AllocRange    *cidr.CIDR
 
 	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is prefered)
 	k8sNodeIP net.IP
@@ -66,13 +66,13 @@ func makeIPv6HostIP() net.IP {
 // scope will be regarded as the system's node address.
 func InitDefaultPrefix(device string) {
 	if option.Config.EnableIPv4 {
-		ip, err := firstGlobalV4Addr(device, GetInternalIPv4())
+		ip, err := firstGlobalV4Addr(device, GetInternalIPv4Router())
 		if err != nil {
 			return
 		}
 
-		if ipv4ExternalAddress == nil {
-			ipv4ExternalAddress = ip
+		if ipv4Address == nil {
+			ipv4Address = ip
 		}
 
 		if ipv4AllocRange == nil {
@@ -171,30 +171,44 @@ func GetIPv6AllocRange() *cidr.CIDR {
 	return ipv6AllocRange
 }
 
-// SetExternalIPv4 sets the external IPv4 node address. It must be reachable on the network.
-func SetExternalIPv4(ip net.IP) {
-	ipv4ExternalAddress = ip
+// SetIPv4 sets the IPv4 node address. It must be reachable on the network.
+// It is set based on the following priority:
+// - NodeInternalIP
+// - NodeExternalIP
+// - other IP address type
+func SetIPv4(ip net.IP) {
+	ipv4Address = ip
 }
 
-// GetExternalIPv4 returns the external IPv4 node address
-func GetExternalIPv4() net.IP {
-	return ipv4ExternalAddress
+// GetIPv4 returns one of the IPv4 node address available with the following
+// priority:
+// - NodeInternalIP
+// - NodeExternalIP
+// - other IP address type.
+// It must be reachable on the network.
+func GetIPv4() net.IP {
+	return ipv4Address
 }
 
-// SetInternalIPv4 sets the internal IPv4 node address, it is allocated from the node prefix
-func SetInternalIPv4(ip net.IP) {
-	ipv4InternalAddress = ip
+// SetInternalIPv4Router sets the cilium internal IPv4 node address, it is allocated from the node prefix.
+// This must not be conflated with k8s internal IP as this IP address is only relevant within the
+// Cilium-managed network (this means within the node for direct routing mode and on the overlay
+// for tunnel mode).
+func SetInternalIPv4Router(ip net.IP) {
+	ipv4RouterAddress = ip
 }
 
-// GetInternalIPv4 returns the internal IPv4 node address
-func GetInternalIPv4() net.IP {
-	return ipv4InternalAddress
+// GetInternalIPv4Router returns the cilium internal IPv4 node address. This must not be conflated with
+// k8s internal IP as this IP address is only relevant within the Cilium-managed network (this means
+// within the node for direct routing mode and on the overlay for tunnel mode).
+func GetInternalIPv4Router() net.IP {
+	return ipv4RouterAddress
 }
 
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading
 // any traffic that is being forwarded from the host into the Cilium cluster.
 func GetHostMasqueradeIPv4() net.IP {
-	return ipv4InternalAddress
+	return ipv4RouterAddress
 }
 
 // SetIPv4AllocRange sets the IPv4 address pool to use when allocating
@@ -264,7 +278,7 @@ func AutoComplete() error {
 		ipv4GW, ipv6Router := getCiliumHostIPs()
 
 		if ipv4GW != nil && option.Config.EnableIPv4 {
-			SetInternalIPv4(ipv4GW)
+			SetInternalIPv4Router(ipv4GW)
 		}
 
 		if ipv6Router != nil && option.Config.EnableIPv6 {
@@ -289,12 +303,12 @@ func AutoComplete() error {
 // required
 func ValidatePostInit() error {
 	if option.Config.EnableIPv4 || option.Config.Tunnel != option.TunnelDisabled {
-		if ipv4ExternalAddress == nil {
+		if ipv4Address == nil {
 			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
 		}
 	}
 
-	if option.Config.EnableIPv4 && ipv4InternalAddress == nil {
+	if option.Config.EnableIPv4 && ipv4RouterAddress == nil {
 		return fmt.Errorf("BUG: Internal IPv4 node address was not configured")
 	}
 
@@ -323,7 +337,7 @@ func SetIPv6Router(ip net.IP) {
 
 // IsHostIPv4 returns true if the IP specified is a host IP
 func IsHostIPv4(ip net.IP) bool {
-	return ip.Equal(GetInternalIPv4()) || ip.Equal(GetExternalIPv4())
+	return ip.Equal(GetInternalIPv4Router()) || ip.Equal(GetIPv4())
 }
 
 // IsHostIPv6 returns true if the IP specified is a host IP
@@ -346,7 +360,7 @@ func GetNodeAddressing() *models.NodeAddressing {
 	if option.Config.EnableIPv4 {
 		a.IPV4 = &models.NodeAddressingElement{
 			Enabled:    option.Config.EnableIPv4,
-			IP:         GetInternalIPv4().String(),
+			IP:         GetInternalIPv4Router().String(),
 			AllocRange: GetIPv4AllocRange().String(),
 		}
 	}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -44,6 +44,10 @@ var (
 	ipv4AllocRange    *cidr.CIDR
 	ipv6AllocRange    *cidr.CIDR
 
+	// k8s Node External IP
+	ipv4ExternalAddress net.IP
+	ipv6ExternalAddress net.IP
+
 	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is prefered)
 	k8sNodeIP net.IP
 
@@ -205,6 +209,18 @@ func GetInternalIPv4Router() net.IP {
 	return ipv4RouterAddress
 }
 
+// SetK8sExternalIPv4 sets the external IPv4 node address. It must be a public IP that is routable
+// on the network as well as the internet.
+func SetK8sExternalIPv4(ip net.IP) {
+	ipv4ExternalAddress = ip
+}
+
+// GetK8sExternalIPv4 returns the external IPv4 node address. It must be a public IP that is routable
+// on the network as well as the internet. It can return nil if no External IPv4 address is assigned.
+func GetK8sExternalIPv4() net.IP {
+	return ipv4ExternalAddress
+}
+
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading
 // any traffic that is being forwarded from the host into the Cilium cluster.
 func GetHostMasqueradeIPv4() net.IP {
@@ -333,6 +349,16 @@ func GetIPv6Router() net.IP {
 // SetIPv6Router returns the IPv6 address of the node
 func SetIPv6Router(ip net.IP) {
 	ipv6RouterAddress = ip
+}
+
+// SetK8sExternalIPv6 sets the external IPv6 node address. It must be a public IP.
+func SetK8sExternalIPv6(ip net.IP) {
+	ipv6ExternalAddress = ip
+}
+
+// GetK8sExternalIPv6 returns the external IPv6 node address.
+func GetK8sExternalIPv6() net.IP {
+	return ipv6ExternalAddress
 }
 
 // IsHostIPv4 returns true if the IP specified is a host IP

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -210,7 +210,7 @@ func SetInternalIPv4From(ifaceName string) error {
 	}
 	for _, ip := range v4Addrs {
 		if netlink.Scope(ip.Scope) == netlink.SCOPE_UNIVERSE {
-			SetInternalIPv4(ip.IP)
+			SetInternalIPv4Router(ip.IP)
 			return nil
 		}
 	}

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -44,9 +44,9 @@ func (s *NodeSuite) TestMaskCheck(c *C) {
 
 	allocCIDR := cidr.MustParseCIDR("1.1.1.1/16")
 	SetIPv4AllocRange(allocCIDR)
-	SetInternalIPv4(allocCIDR.IP)
-	c.Assert(IsHostIPv4(GetInternalIPv4()), Equals, true)
-	c.Assert(IsHostIPv4(GetExternalIPv4()), Equals, true)
+	SetInternalIPv4Router(allocCIDR.IP)
+	c.Assert(IsHostIPv4(GetInternalIPv4Router()), Equals, true)
+	c.Assert(IsHostIPv4(GetIPv4()), Equals, true)
 	c.Assert(IsHostIPv6(GetIPv6()), Equals, true)
 }
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -71,6 +71,7 @@ type IPCache interface {
 type Configuration interface {
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
+	EncryptionEnabled() bool
 }
 
 // Notifier is the interaface the wraps Subscribe and Unsubscribe. An
@@ -331,7 +332,7 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	// ipcache. This resulted in a behavioral change. New deployments will
 	// provide this behavior out of the gate, existing deployments will
 	// have to opt into this by enabling remote-node identities.
-	return !m.conf.NodeEncryptionEnabled() && !m.conf.RemoteNodeIdentitiesEnabled()
+	return !m.conf.EncryptionEnabled() && !m.conf.RemoteNodeIdentitiesEnabled()
 }
 
 // NodeUpdated is called after the information of a node has been updated. The
@@ -351,10 +352,13 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 
 	for _, address := range n.IPAddresses {
 		var tunnelIP net.IP
+		key := n.EncryptionKey
+
 		// If the host firewall is enabled, all traffic to remote nodes must go
 		// through the tunnel to preserve the source identity as part of the
-		// encapsulation.
-		if address.Type == addressing.NodeCiliumInternalIP || m.conf.NodeEncryptionEnabled() ||
+		// encapsulation. In encryption case we also want to use vxlan device
+		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
+		if address.Type == addressing.NodeCiliumInternalIP || m.conf.EncryptionEnabled() ||
 			option.Config.EnableHostFirewall {
 			tunnelIP = nodeIP
 		}
@@ -363,7 +367,17 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			continue
 		}
 
-		isOwning, _ := m.ipcache.Upsert(address.IP.String(), tunnelIP, n.EncryptionKey, nil, ipcache.Identity{
+		// If we are doing encryption, but not node based encryption, then do not
+		// add a key to the nodeIPs so that we avoid a trip through stack and attempting
+		// to encrypt something we know does not have an encryption policy installed
+		// in the datapath. By setting key=0 and tunnelIP this will result in traffic
+		// being sent unencrypted over overlay device.
+		if !m.conf.NodeEncryptionEnabled() &&
+			(address.Type == addressing.NodeExternalIP || address.Type == addressing.NodeInternalIP) {
+			key = 0
+		}
+
+		isOwning, _ := m.ipcache.Upsert(address.IP.String(), tunnelIP, key, nil, ipcache.Identity{
 			ID:     remoteHostIdentity,
 			Source: n.Source,
 		})

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -46,6 +46,7 @@ var _ = check.Suite(&managerTestSuite{})
 type configMock struct {
 	RemoteNodeIdentity bool
 	NodeEncryption     bool
+	Encryption         bool
 }
 
 func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
@@ -54,6 +55,10 @@ func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
 
 func (c *configMock) NodeEncryptionEnabled() bool {
 	return c.NodeEncryption
+}
+
+func (c *configMock) EncryptionEnabled() bool {
+	return c.Encryption
 }
 
 type nodeEvent struct {
@@ -556,7 +561,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true})
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true, Encryption: true})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -225,6 +225,21 @@ func (n *Node) getNodeIP(ipv6 bool) (net.IP, addressing.AddressType) {
 	return backupIP, ipType
 }
 
+// GetExternalIP returns ExternalIP of k8s Node. If not present, then it
+// returns nil;
+func (n *Node) GetExternalIP(ipv6 bool) net.IP {
+	for _, addr := range n.IPAddresses {
+		if (ipv6 && addr.IP.To4() != nil) || (!ipv6 && addr.IP.To4() == nil) {
+			continue
+		}
+		if addr.Type == addressing.NodeExternalIP {
+			return addr.IP
+		}
+	}
+
+	return nil
+}
+
 // GetK8sNodeIPs returns k8s Node IP (either InternalIP or ExternalIP or nil;
 // the former is prefered).
 func (n *Node) GetK8sNodeIP() net.IP {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -137,10 +137,10 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.EncryptionKey = node.GetIPsecKeyIdentity()
 	n.LocalNode.Labels = node.GetLabels()
 
-	if node.GetExternalIPv4() != nil {
+	if node.GetIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeInternalIP,
-			IP:   node.GetExternalIPv4(),
+			IP:   node.GetIPv4(),
 		})
 	}
 
@@ -151,10 +151,10 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		})
 	}
 
-	if node.GetInternalIPv4() != nil {
+	if node.GetInternalIPv4Router() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,
-			IP:   node.GetInternalIPv4(),
+			IP:   node.GetInternalIPv4Router(),
 		})
 	}
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -137,6 +137,13 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.EncryptionKey = node.GetIPsecKeyIdentity()
 	n.LocalNode.Labels = node.GetLabels()
 
+	if node.GetK8sExternalIPv4() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeExternalIP,
+			IP:   node.GetK8sExternalIPv4(),
+		})
+	}
+
 	if node.GetIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeInternalIP,
@@ -162,6 +169,13 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,
 			IP:   node.GetIPv6Router(),
+		})
+	}
+
+	if node.GetK8sExternalIPv6() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeExternalIP,
+			IP:   node.GetK8sExternalIPv6(),
 		})
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2049,6 +2049,11 @@ func (c *DaemonConfig) NodeEncryptionEnabled() bool {
 	return c.EncryptNode
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (c *DaemonConfig) EncryptionEnabled() bool {
+	return c.EnableIPSec
+}
+
 // IPv4Enabled returns true if IPv4 is enabled
 func (c *DaemonConfig) IPv4Enabled() bool {
 	return c.EnableIPv4

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -33,6 +33,11 @@ func (f *Config) RemoteNodeIdentitiesEnabled() bool {
 	return true
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (f *Config) EncryptionEnabled() bool {
+	return true
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -98,7 +98,7 @@ func NewLogRecord(endpointInfoRegistry EndpointInfoRegistry, localEndpointInfoSo
 		localEndpointInfo:    getEndpointInfo(localEndpointInfoSource),
 	}
 
-	if ip := node.GetExternalIPv4(); ip != nil {
+	if ip := node.GetIPv4(); ip != nil {
 		lr.LogRecord.NodeAddressInfo.IPv4 = ip.String()
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -641,7 +641,7 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 	defer proxyPortsMutex.Unlock()
 
 	result := &models.ProxyStatus{
-		IP:             node.GetInternalIPv4().String(),
+		IP:             node.GetInternalIPv4Router().String(),
 		PortRange:      fmt.Sprintf("%d-%d", p.rangeMin, p.rangeMax),
 		TotalRedirects: int64(len(p.redirects)),
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3527,7 +3527,7 @@ func (kub *Kubectl) GetNodeInfo(label string) (nodeName, nodeIP string) {
 	nodeName, err := kub.GetNodeNameByLabel(label)
 	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), "Cannot get node by label "+label)
 	nodeIP, err = kub.GetNodeIPByLabel(label, false)
-	gomega.ExpectWithOffset(1, err).Should(gomega.BeNil(), "Can not retrieve Node IP for "+label)
+	gomega.ExpectWithOffset(1, err).Should(gomega.BeNil(), "Can not retrieve Node Internal IP for "+label)
 	return nodeName, nodeIP
 }
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -762,6 +762,17 @@ var _ = Describe("K8sServicesTest", func() {
 			}
 
 			if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
+				k8s1ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s1, true)
+				Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s1)
+				k8s2ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s2, true)
+				Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s2)
+				testURLsFromPods = append(testURLsFromPods,
+					getHTTPLink(k8s1ExternalIP, data.Spec.Ports[0].NodePort),
+					getTFTPLink(k8s1ExternalIP, data.Spec.Ports[1].NodePort),
+					getHTTPLink(k8s2ExternalIP, data.Spec.Ports[0].NodePort),
+					getTFTPLink(k8s2ExternalIP, data.Spec.Ports[1].NodePort),
+				)
+
 				// Testing LoadBalancer types subject to bpf_sock.
 				lbIP, err := kubectl.GetLoadBalancerIP(helpers.DefaultNamespace, "test-lb", 30*time.Second)
 				Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")


### PR DESCRIPTION
* #14611 -- cilium: Send pod->node traffic through tunnel in IPSec+vxlan case (@jrfastab)
     - Minor conflict in `pkg/node/manager/manager.go`.
 * #14114 -- labelsfilter: add reserved labels to default identity label list (@ArthurChiao)
     - Minor conflict in `pkg/endpointmanager/manager.go`.
 * #14793 -- ipcache: Add ExternalIP of the local node to ipcache (@AnishShah, @brb)
     - Many minor conflicts.
 * #14893 -- docs: Add FQDN limitation to IPVLAN docs (@joestringer)
 * #14913 -- iptables: Fix incorrect SNAT bypass with endpoint routes and tunneling (@pchaigno)
     - Conflict (the code changed has been refactored).
 * #14920 -- docs: Document hostport requirements in eni (@joestringer)
 * #14634 -- Makefile: build Cilium with madvdontneed=1 (@aanm)
     - Remove change on `clustermesh-apiserver.Dockerfile` which doesn't exist in v1.8.
 * #14675 -- bpf: Do not bypass conntrack if running kube-proxy+vxlan+endpoint routes (@pchaigno)
     - All changed files conflicted.
 * #14847 -- docs: Added instruction to also delete kube-proxy configmap (@yoshz)
 * #14756 -- Fix reverse DNAT for externalTrafficPolicy=Local service with kube-proxy (@pchaigno)
     - Many conflicts.
 * #14924 -- Fix encryption in IPAM ENI mode (@aditighag)
     - Couple of conflicts.
     - I changed `EnableIPv4Masquerade` to `Masquerade` in `daemon/cmd/ipam.go`. Please double check.
 * #14338 -- labelsfilter: Update documentation and add unit tests (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14611 14114 14793 14893 14913 14920 14634 14675 14847 14756 14924 14338; do contrib/backporting/set-labels.py $pr done 1.8; done
```