### PR TITLE
v1.9 backports 2021-02-12

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -136,7 +136,7 @@ jobs:
           cilium_pod=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].metadata.name}' )
           kubectl -n kube-system exec $cilium_pod -- sh -c "apt update && apt install curl -y"
           kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9090/metrics > metrics.prom
-          go get -u github.com/prometheus/prometheus/cmd/promtool
+          GO111MODULE=on go get github.com/prometheus/prometheus/cmd/promtool@e4487274853c587717006eeda8804e597d120340 # This is commit hash for v2.24.1
           egrep -v "${{ env.DEPRECATED_METRICS }}" metrics.prom | $HOME/go/bin/promtool check metrics
 
       - name: Capture cilium-sysdump

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,6 @@ RUN groupadd -f cilium \
     && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 
 ENV INITSYSTEM="SYSTEMD"
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium"]

--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -77,6 +77,11 @@ Limitations
 * When applying L7 policies at egress, the source identity context is lost as
   it is currently not carried in the packet. This means that traffic will look
   like it is coming from outside of the cluster to the receiving pod.
+* HostPort type services additionally require either of the following
+  configurations:
+
+   * :ref:`k8s_install_portmap`
+   * :ref:`kubeproxyfree_hostport`
 
 Troubleshooting
 ===============

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -69,6 +69,8 @@ by using the following commands:
 .. code:: bash
 
       kubectl -n kube-system delete ds kube-proxy
+      # Delete the configmap as well to avoid kube-proxy being reinstalled during a kubeadm upgrade (works only for K8s 1.19 and newer)
+      kubectl -n kube-system delete cm kube-proxy
       # Run on each node:
       iptables-restore <(iptables-save | grep -v KUBE)
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -868,7 +868,8 @@ out:
 #ifdef ENABLE_IPV6
 static __always_inline int
 ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
-	    struct ipv6_ct_tuple *tuple_out, __u16 *proxy_port, bool from_host)
+	    struct ipv6_ct_tuple *tuple_out, __u16 *proxy_port,
+	    bool from_host __maybe_unused)
 {
 	struct ipv6_ct_tuple tuple = {};
 	void *data, *data_end;
@@ -998,9 +999,14 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	send_trace_notify6(ctx, TRACE_TO_LXC, src_label, SECLABEL, &orig_sip,
 			   LXC_ID, ifindex, *reason, monitor);
 
+#if !defined(ENABLE_ROUTING) && defined(ENCAP_IFINDEX) && !defined(ENABLE_NODEPORT)
+	/* See comment in IPv4 path. */
+	ctx_change_type(ctx, PACKET_HOST);
+#else
 	ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	if (ifindex)
 		return redirect_ep(ifindex, from_host);
+#endif /* ENABLE_ROUTING && ENCAP_IFINDEX && !ENABLE_NODEPORT */
 
 	return CTX_ACT_OK;
 }
@@ -1096,7 +1102,8 @@ out:
 #ifdef ENABLE_IPV4
 static __always_inline int
 ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
-	    struct ipv4_ct_tuple *tuple_out, __u16 *proxy_port, bool from_host)
+	    struct ipv4_ct_tuple *tuple_out, __u16 *proxy_port,
+	    bool from_host __maybe_unused)
 {
 	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
@@ -1242,9 +1249,21 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	send_trace_notify4(ctx, TRACE_TO_LXC, src_label, SECLABEL, orig_sip,
 			   LXC_ID, ifindex, *reason, monitor);
 
+#if !defined(ENABLE_ROUTING) && defined(ENCAP_IFINDEX) && !defined(ENABLE_NODEPORT)
+	/* In tunneling mode, we execute this code to send the packet from
+	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
+	 * redirect() because that would bypass conntrack and the reverse DNAT.
+	 * Thus, we send packets to the stack, but since they have the wrong
+	 * Ethernet addresses, we need to mark them as PACKET_HOST or the kernel
+	 * will drop them.
+	 * See #14646 for details.
+	 */
+	ctx_change_type(ctx, PACKET_HOST);
+#else
 	ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	if (ifindex)
 		return redirect_ep(ifindex, from_host);
+#endif /* ENABLE_ROUTING && ENCAP_IFINDEX && !ENABLE_NODEPORT */
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -147,9 +147,9 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 				 __u32 seclabel, __u32 monitor)
 {
 	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
-
 	if (ret != 0)
 		return ret;
+
 	return redirect(ENCAP_IFINDEX, 0);
 }
 
@@ -193,7 +193,18 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 			return encap_and_redirect_ipsec(ctx, tunnel_endpoint,
 							encrypt_key, seclabel);
 #endif
+#if !defined(ENABLE_NODEPORT) && (defined(ENABLE_IPSEC) || defined(ENABLE_HOST_FIREWALL))
+		/* For IPSec and the host firewall, traffic from a pod to a remote node
+		 * is sent through the tunnel. In the case of node --> VIP@remote pod,
+		 * packets may be DNATed when they enter the remote node. If kube-proxy
+		 * is used, the response needs to go through the stack on the way to
+		 * the tunnel, to apply the correct reverse DNAT.
+		 * See #14674 for details.
+		 */
+		return __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+#else
 		return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+#endif /* !ENABLE_NODEPORT && (ENABLE_IPSEC || ENABLE_HOST_FIREWALL) */
 	}
 
 	tunnel = map_lookup_elem(&TUNNEL_MAP, key);

--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -42,4 +42,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-aws"]

--- a/cilium-operator-aws.Dockerfile
+++ b/cilium-operator-aws.Dockerfile
@@ -37,6 +37,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-aws /usr/bin/cilium-operator-aws
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -37,6 +37,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-azure /usr/bin/cilium-operator-azure
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/cilium-operator-azure.Dockerfile
+++ b/cilium-operator-azure.Dockerfile
@@ -42,4 +42,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-azure"]

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -42,4 +42,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-generic"]

--- a/cilium-operator-generic.Dockerfile
+++ b/cilium-operator-generic.Dockerfile
@@ -37,6 +37,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator-generic /usr/bin/cilium-operator-generic
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -42,4 +42,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 WORKDIR /
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator"]

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -37,6 +37,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/clustermesh-apiserver.Dockerfile
+++ b/clustermesh-apiserver.Dockerfile
@@ -41,4 +41,6 @@ COPY --from=builder /go/src/github.com/cilium/cilium/clustermesh-apiserver/clust
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 ENTRYPOINT ["/usr/bin/clustermesh-apiserver"]

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -349,6 +349,8 @@ sleep 2s
 if [ -n "\${K8S}" ]; then
     echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
 fi
+# FIXME Remove me once we add support for Go 1.16
+echo 'GODEBUG="madvdontneed=1"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPTS="${cilium_options}"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPERATOR_OPTS="${cilium_operator_options}"' >> /etc/sysconfig/cilium
 echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -302,7 +302,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	}
 
 	var mtuConfig mtu.Configuration
-	externalIP := node.GetExternalIPv4()
+	externalIP := node.GetIPv4()
 	if externalIP == nil {
 		externalIP = node.GetIPv6()
 	}
@@ -651,7 +651,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			logfields.V6Prefix:       node.GetIPv6AllocRange(),
 			logfields.V4HealthIP:     d.nodeDiscovery.LocalNode.IPv4HealthIP,
 			logfields.V6HealthIP:     d.nodeDiscovery.LocalNode.IPv6HealthIP,
-			logfields.V4CiliumHostIP: node.GetInternalIPv4(),
+			logfields.V4CiliumHostIP: node.GetInternalIPv4Router(),
 			logfields.V6CiliumHostIP: node.GetIPv6Router(),
 		}).Info("Annotating k8s node")
 
@@ -659,7 +659,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			encryptKeyID,
 			node.GetIPv4AllocRange(), node.GetIPv6AllocRange(),
 			d.nodeDiscovery.LocalNode.IPv4HealthIP, d.nodeDiscovery.LocalNode.IPv6HealthIP,
-			node.GetInternalIPv4(), node.GetIPv6Router())
+			node.GetInternalIPv4Router(), node.GetIPv6Router())
 		if err != nil {
 			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
 		}
@@ -855,7 +855,7 @@ func (d *Daemon) GetNodeSuffix() string {
 
 	switch {
 	case option.Config.EnableIPv4:
-		ip = node.GetExternalIPv4()
+		ip = node.GetIPv4()
 	case option.Config.EnableIPv6:
 		ip = node.GetIPv6()
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1260,7 +1260,7 @@ func initEnv(cmd *cobra.Command) {
 		if ip := net.ParseIP(option.Config.IPv4NodeAddr); ip == nil {
 			log.WithField(logfields.IPAddr, option.Config.IPv4NodeAddr).Fatal("Invalid IPv4 node address")
 		} else {
-			node.SetExternalIPv4(ip)
+			node.SetIPv4(ip)
 		}
 	}
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -260,7 +260,7 @@ func (d *Daemon) allocateIPs() error {
 			return err
 		}
 		if routerIP != nil {
-			node.SetInternalIPv4(routerIP)
+			node.SetInternalIPv4Router(routerIP)
 		}
 	}
 
@@ -294,8 +294,8 @@ func (d *Daemon) allocateIPs() error {
 		}
 	}
 
-	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
-	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4())
+	log.Infof("  External-Node IPv4: %s", node.GetIPv4())
+	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4Router())
 
 	if option.Config.EnableIPv4 {
 		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -70,7 +70,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 		resp.IPV4 = &models.IPAMAddressResponse{
 			Cidrs:           ipv4Result.CIDRs,
 			IP:              ipv4Result.IP.String(),
-			MasterMac:       ipv4Result.Master,
+			MasterMac:       ipv4Result.PrimaryMAC,
 			Gateway:         ipv4Result.GatewayIP,
 			ExpirationUUID:  ipv4Result.ExpirationUUID,
 			InterfaceNumber: ipv4Result.InterfaceNumber,
@@ -82,7 +82,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 		resp.IPV6 = &models.IPAMAddressResponse{
 			Cidrs:           ipv6Result.CIDRs,
 			IP:              ipv6Result.IP.String(),
-			MasterMac:       ipv6Result.Master,
+			MasterMac:       ipv6Result.PrimaryMAC,
 			Gateway:         ipv6Result.GatewayIP,
 			ExpirationUUID:  ipv6Result.ExpirationUUID,
 			InterfaceNumber: ipv6Result.InterfaceNumber,
@@ -374,7 +374,7 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 	d.healthEndpointRouting, err = linuxrouting.NewRoutingInfo(
 		result.GatewayIP,
 		result.CIDRs,
-		result.Master,
+		result.PrimaryMAC,
 		result.InterfaceNumber,
 		option.Config.Masquerade,
 	)

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -182,9 +182,10 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 	// In that case, removal and re-creation of the cilium_host is
 	// required. It will also cause disruption of networking until all
 	// endpoints have been regenerated.
+	var result *ipam.AllocationResult
 	routerIP = family.Router()
 	if routerIP != nil {
-		err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router")
+		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router")
 		if err != nil {
 			log.Warn("Router IP could not be re-allocated. Need to re-allocate. This will cause brief network disruption")
 
@@ -200,7 +201,6 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 	}
 
 	if routerIP == nil {
-		var result *ipam.AllocationResult
 		family := ipam.DeriveFamily(family.PrimaryExternal())
 		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, "router")
 		if err != nil {
@@ -208,6 +208,16 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 			return
 		}
 		routerIP = result.IP
+	}
+	if option.Config.IPAM == ipamOption.IPAMENI && result != nil {
+		var routingInfo *linuxrouting.RoutingInfo
+		routingInfo, err = linuxrouting.NewRoutingInfo(result.GatewayIP, result.CIDRs,
+			result.PrimaryMAC, result.InterfaceNumber, option.Config.Masquerade)
+		if err != nil {
+			err = fmt.Errorf("failed to create router info %w", err)
+			return
+		}
+		node.SetRouterInfo(routingInfo)
 	}
 
 	return

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -343,7 +343,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	var err error
 
 	if option.Config.EnableIPv6 && ep.IPv6 != nil {
-		err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %s", ep.IPv6.IP(), err)
 		}
@@ -356,7 +356,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4 != nil {
-		if err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
+		if _, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv4 address: %s", ep.IPv4.IP(), err)
 		}
 	}

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -34,6 +34,7 @@ FROM ${BASE_IMAGE}
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
+ENV GOPS_CONFIG_DIR=/
 COPY --from=builder /go/src/github.com/cilium/cilium/hubble-relay/hubble-relay /usr/bin/hubble-relay
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /go/bin/gops /bin/gops

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -39,4 +39,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /go/bin/gops /bin/gops
 COPY --from=builder /go/src/github.com/cilium/cilium/LICENSE.all /LICENSE.all
 ENTRYPOINT ["/usr/bin/hubble-relay"]
+# FIXME Remove me once we add support for Go 1.16
+ENV GODEBUG="madvdontneed=1"
 CMD ["serve"]

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -30,6 +30,7 @@ ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 
 WORKDIR /
+ENV GOPS_CONFIG_DIR=/
 
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH} .
 

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -30,6 +30,7 @@ ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 
 WORKDIR /
+ENV GOPS_CONFIG_DIR=/
 
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH} .
 

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -161,8 +161,8 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			// the local host, then the ipcache should be populated
 			// with the hostIP so that this traffic can be guided
 			// to a tunnel endpoint destination.
-			externalIP := node.GetExternalIPv4()
-			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(externalIP) {
+			nodeIPv4 := node.GetIPv4()
+			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
 				copy(value.TunnelEndpoint[:], ip4)
 			}
 		}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -978,28 +978,17 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				}
 			}
 
-			// The following rules exclude traffic from the remaining rules in this chain.
-			// If any of these rules match, none of the remaining rules in this chain
+			// The following rule exclude traffic from the remaining rules in this chain.
+			// If this rule matches, none of the remaining rules in this chain
 			// are considered.
-			// Exclude traffic for other than interface from the masquarade rules.
-			// RETURN fro the chain as it is possible that other rules need to be matched.
-			if err := runProg("iptables", append(
-				m.waitArgs,
-				"-t", "nat",
-				"-A", ciliumPostNatChain,
-				"!", "-o", localDeliveryInterface,
-				"-m", "comment", "--comment", "exclude non-"+ifName+" traffic from masquerade",
-				"-j", "RETURN"), false); err != nil {
-				return err
-			}
 
-			// Exclude proxy return traffic from the masquarade rules
+			// Exclude proxy return traffic from the masquerade rules.
 			if err := runProg("iptables", append(
 				m.waitArgs,
 				"-t", "nat",
 				"-A", ciliumPostNatChain,
 				"-m", "mark", "--mark", matchFromProxy, // Don't match proxy (return) traffic
-				"-m", "comment", "--comment", "exclude proxy return traffic from masquarade",
+				"-m", "comment", "--comment", "exclude proxy return traffic from masquerade",
 				"-j", "ACCEPT"), false); err != nil {
 				return err
 			}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -338,6 +338,7 @@ var ciliumChains = []customChain{
 		table:      "filter",
 		hook:       "FORWARD",
 		feederArgs: []string{""},
+		ipv6:       true,
 	},
 }
 
@@ -741,6 +742,19 @@ func getDeliveryInterface(ifName string) string {
 }
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
+	if option.Config.EnableIPv4 {
+		err := m.installForwardChainRulesIpX("iptables", ifName, localDeliveryInterface, forwardChain)
+		if err != nil {
+			return err
+		}
+	}
+	if option.Config.EnableIPv6 {
+		return m.installForwardChainRulesIpX("ip6tables", ifName, localDeliveryInterface, forwardChain)
+	}
+	return nil
+}
+
+func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliveryInterface, forwardChain string) error {
 	transient := ""
 	if forwardChain == ciliumTransientForwardChain {
 		transient = " (transient)"
@@ -767,7 +781,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 	//  - Node running backend:
 	//       IN=eno1 OUT=cilium_host
 	//       IN=lxc... OUT=eno1
-	if err := runProg("iptables", append(
+	if err := runProg(prog, append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-o", ifName,
@@ -775,7 +789,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg("iptables", append(
+	if err := runProg(prog, append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", ifName,
@@ -783,7 +797,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg("iptables", append(
+	if err := runProg(prog, append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", "lxc+",
@@ -795,7 +809,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 	// TODO: Make 'cilium_net' configurable if we ever support other than "cilium_host" as the Cilium host device.
 	if ifName == "cilium_host" {
 		ifPeerName := "cilium_net"
-		if err := runProg("iptables", append(
+		if err := runProg(prog, append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", ifPeerName,
@@ -808,7 +822,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 	// same (enable-endpoint-routes), a separate set of rules to allow
 	// from/to delivery interface is required.
 	if localDeliveryInterface != ifName {
-		if err := runProg("iptables", append(
+		if err := runProg(prog, append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
@@ -816,7 +830,7 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
-		if err := runProg("iptables", append(
+		if err := runProg(prog, append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
@@ -894,11 +908,11 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 
 	localDeliveryInterface := getDeliveryInterface(ifName)
 
-	if option.Config.EnableIPv4 {
-		if err := m.installForwardChainRules(ifName, localDeliveryInterface, ciliumForwardChain); err != nil {
-			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
-		}
+	if err := m.installForwardChainRules(ifName, localDeliveryInterface, ciliumForwardChain); err != nil {
+		return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
+	}
 
+	if option.Config.EnableIPv4 {
 		// Mark all packets sourced from processes running on the host with a
 		// special marker so that we can differentiate traffic sourced locally
 		// vs. traffic from the outside world that was masqueraded to appear

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1009,20 +1009,17 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 
 			if option.Config.Tunnel != option.TunnelDisabled {
 				// Masquerade all traffic from the host into the ifName
-				// interface if the source is not the internal IP
+				// interface if the source is not in the node's pod CIDR.
 				//
 				// The following conditions must be met:
 				// * Must be targeted for the ifName interface
 				// * Must be targeted to an IP that is not local
-				// * Tunnel mode:
-				//   * May not already be originating from the masquerade IP
-				// * Non-tunnel mode:
-				//   * May not orignate from any IP inside of the cluster range
+				// * May not already be originating from the node's pod CIDR.
 				if err := runProg("iptables", append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
-					"!", "-s", node.GetHostMasqueradeIPv4().String(),
+					"!", "-s", node.GetIPv4AllocRange().String(),
 					"!", "-d", node.GetIPv4AllocRange().String(),
 					"-o", "cilium_host",
 					"-m", "comment", "--comment", "cilium host->cluster masquerade",

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -85,14 +85,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		fmt.Fprintf(fw, " cilium.v6.nodeport.str %s\n", node.GetNodePortIPv6Addrs())
 		fmt.Fprintf(fw, "\n")
 	}
-	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetExternalIPv4().String())
-	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4Router().String())
 	fmt.Fprintf(fw, " cilium.v4.nodeport.str %s\n", node.GetNodePortIPv4Addrs())
 	fmt.Fprintf(fw, "\n")
 	if option.Config.EnableIPv6 {
 		fw.WriteString(dumpRaw(defaults.RestoreV6Addr, node.GetIPv6Router()))
 	}
-	fw.WriteString(dumpRaw(defaults.RestoreV4Addr, node.GetInternalIPv4()))
+	fw.WriteString(dumpRaw(defaults.RestoreV4Addr, node.GetInternalIPv4Router()))
 	fmt.Fprintf(fw, " */\n\n")
 
 	cDefinesMap["KERNEL_HZ"] = fmt.Sprintf("%d", option.Config.KernelHz)
@@ -103,7 +103,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 
 	if option.Config.EnableIPv4 {
-		ipv4GW := node.GetInternalIPv4()
+		ipv4GW := node.GetInternalIPv4Router()
 		loopbackIPv4 := node.GetIPv4Loopback()
 		ipv4Range := node.GetIPv4AllocRange()
 		cDefinesMap["IPV4_GATEWAY"] = fmt.Sprintf("%#x", byteorder.HostSliceToNetwork(ipv4GW, reflect.Uint32).(uint32))

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -53,12 +53,12 @@ func (s *ConfigSuite) SetUpTest(c *C) {
 	err := bpf.ConfigureResourceLimits()
 	c.Assert(err, IsNil)
 	node.InitDefaultPrefix("")
-	node.SetInternalIPv4(ipv4DummyAddr)
+	node.SetInternalIPv4Router(ipv4DummyAddr)
 	node.SetIPv4Loopback(ipv4DummyAddr)
 }
 
 func (s *ConfigSuite) TearDownTest(c *C) {
-	node.SetInternalIPv4(nil)
+	node.SetInternalIPv4Router(nil)
 	node.SetIPv4Loopback(nil)
 }
 

--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -70,11 +70,11 @@ func listLocalAddresses(family int) ([]net.IP, error) {
 type addressFamilyIPv4 struct{}
 
 func (a *addressFamilyIPv4) Router() net.IP {
-	return node.GetInternalIPv4()
+	return node.GetInternalIPv4Router()
 }
 
 func (a *addressFamilyIPv4) PrimaryExternal() net.IP {
-	return node.GetExternalIPv4()
+	return node.GetIPv4()
 }
 
 func (a *addressFamilyIPv4) AllocationCIDR() *cidr.CIDR {

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -52,6 +52,18 @@ type RoutingInfo struct {
 	InterfaceNumber int
 }
 
+func (info *RoutingInfo) GetIPv4CIDRs() []net.IPNet {
+	return info.IPv4CIDRs
+}
+
+func (info *RoutingInfo) GetMac() mac.MAC {
+	return info.MasterIfMAC
+}
+
+func (info *RoutingInfo) GetInterfaceNumber() int {
+	return info.InterfaceNumber
+}
+
 // NewRoutingInfo creates a new RoutingInfo struct, from data that will be
 // parsed and validated. Note, this code assumes IPv4 values because IPv4
 // (on either ENI or Azure interface) is the only supported path currently.

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -223,6 +223,17 @@ func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
 	})
 }
 
+// RetrieveIfaceNameFromMAC finds the corresponding device name for a
+// given MAC address.
+func RetrieveIfaceNameFromMAC(mac string) (string, error) {
+	iface, err := retrieveIfaceFromMAC(mac)
+	if err != nil {
+		err = fmt.Errorf("failed to get iface name with MAC %w", err)
+		return "", err
+	}
+	return iface.Attrs().Name, nil
+}
+
 func deleteRule(r route.Rule) error {
 	rules, err := route.ListRules(netlink.FAMILY_V4, &r)
 	if err != nil {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -195,6 +196,33 @@ func Delete(ip net.IP, compat bool) error {
 	return nil
 }
 
+// SetupRules installs routing rules based on the passed attributes. It accounts
+// for option.Config.EgressMultiHomeIPRuleCompat while configuring the rules.
+func SetupRules(from, to *net.IPNet, mac string, ifaceNum int) error {
+	var (
+		prio    int
+		tableId int
+	)
+
+	if option.Config.EgressMultiHomeIPRuleCompat {
+		prio = linux_defaults.RulePriorityEgress
+		ifindex, err := retrieveIfaceIdxFromMAC(mac)
+		if err != nil {
+			return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+		}
+		tableId = ifindex
+	} else {
+		prio = linux_defaults.RulePriorityEgressv2
+		tableId = computeTableIDFromIfaceNumber(ifaceNum)
+	}
+	return route.ReplaceRule(route.Rule{
+		Priority: prio,
+		From:     from,
+		To:       to,
+		Table:    tableId,
+	})
+}
+
 func deleteRule(r route.Rule) error {
 	rules, err := route.ListRules(netlink.FAMILY_V4, &r)
 	if err != nil {
@@ -255,6 +283,41 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (index int, err error) {
 	return
 }
 
+// computeTableIDFromIfaceNumber returns a computed per-ENI route table ID for the given
+// ENI interface number.
 func computeTableIDFromIfaceNumber(num int) int {
 	return linux_defaults.RouteTableInterfacesOffset + num
+}
+
+// retrieveIfaceIdxFromMAC finds the corresponding interface index for a
+// given MAC address.
+// It returns -1 as the index for error conditions.
+func retrieveIfaceIdxFromMAC(mac string) (int, error) {
+	iface, err := retrieveIfaceFromMAC(mac)
+	if err != nil {
+		err = fmt.Errorf("failed to get iface index with MAC %w", err)
+		return -1, err
+	}
+	return iface.Attrs().Index, nil
+}
+
+// retrieveIfaceFromFromMAC finds the corresponding interface for a
+// given MAC address.
+func retrieveIfaceFromMAC(mac string) (link netlink.Link, err error) {
+	var links []netlink.Link
+
+	links, err = netlink.LinkList()
+	if err != nil {
+		err = fmt.Errorf("unable to list interfaces: %w", err)
+		return
+	}
+	for _, l := range links {
+		if l.Attrs().HardwareAddr.String() == mac {
+			link = l
+			return
+		}
+	}
+
+	err = fmt.Errorf("interface with MAC not found")
+	return
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -124,7 +126,7 @@ type setting struct {
 	ignoreErr bool
 }
 
-func addENIRules(sysSettings []setting) ([]setting, error) {
+func addENIRules(sysSettings []setting, nodeAddressing datapath.NodeAddressing) ([]setting, error) {
 	// AWS ENI mode requires symmetric routing, see
 	// iptables.addCiliumENIRules().
 	// The default AWS daemonset installs the following rules that are used
@@ -163,6 +165,19 @@ func addENIRules(sysSettings []setting) ([]setting, error) {
 		Table:    route.MainTable,
 	}); err != nil {
 		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+	}
+
+	// Add rules for router (cilium_host).
+	info := node.GetRouterInfo()
+	cidrs := info.GetIPv4CIDRs()
+	routerIP := net.IPNet{
+		IP:   nodeAddressing.IPv4().Router(),
+		Mask: net.CIDRMask(32, 32),
+	}
+	for _, cidr := range cidrs {
+		if err = linuxrouting.SetupRules(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
+			return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)
+		}
 	}
 
 	return retSettings, nil
@@ -357,7 +372,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		var err error
-		if sysSettings, err = addENIRules(sysSettings); err != nil {
+		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
 		}
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -230,7 +230,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgBpffsRoot] = bpf.GetMapRoot()
 
 	if option.Config.EnableIPv4 {
-		args[initArgIPv4NodeIP] = node.GetInternalIPv4().String()
+		args[initArgIPv4NodeIP] = node.GetInternalIPv4Router().String()
 	} else {
 		args[initArgIPv4NodeIP] = "<nil>"
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -371,6 +371,16 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}).Info("Setting up BPF datapath")
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
+		// For the ENI ipam mode on EKS, this will be the interface that
+		// the router (cilium_host) IP is associated to.
+		if info := node.GetRouterInfo(); info != nil {
+			mac := info.GetMac()
+			iface, err := linuxrouting.RetrieveIfaceNameFromMAC(mac.String())
+			if err != nil {
+				log.WithError(err).WithField("mac", mac).Fatal("Failed to set encrypt interface in the ENI ipam mode")
+			}
+			args[initArgEncryptInterface] = iface
+		}
 		var err error
 		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -35,6 +35,6 @@ func Test(t *testing.T) {
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
 	node.InitDefaultPrefix("")
-	node.SetInternalIPv4(templateIPv4)
+	node.SetInternalIPv4Router(templateIPv4)
 	node.SetIPv4Loopback(templateIPv4)
 }

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -132,7 +132,7 @@ func getEndpointNetworking(mdlNetworking *models.EndpointNetworking) (networking
 	}
 
 	if option.Config.EnableIPv4 {
-		networking.NodeIP = node.GetExternalIPv4().String()
+		networking.NodeIP = node.GetIPv4().String()
 	} else {
 		networking.NodeIP = node.GetIPv6().String()
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -729,7 +729,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 
 				IP := endpointIP.IP()
 				ID := e.SecurityIdentity.ID
-				hostIP := node.GetExternalIPv4()
+				hostIP := node.GetIPv4()
 				key := node.GetIPsecKeyIdentity()
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -483,7 +483,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 	case ipamOption.IPAMENI:
 		for _, eni := range a.store.ownNode.Status.ENI.ENIs {
 			if eni.ID == ipInfo.Resource {
-				result.Master = eni.MAC
+				result.PrimaryMAC = eni.MAC
 				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
 				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
 				// Add manually configured Native Routing CIDR
@@ -507,7 +507,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 	case ipamOption.IPAMAzure:
 		for _, iface := range a.store.ownNode.Status.Azure.Interfaces {
 			if iface.ID == ipInfo.Resource {
-				result.Master = iface.MAC
+				result.PrimaryMAC = iface.MAC
 				result.GatewayIP = iface.GatewayIP
 				return
 			}

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -34,11 +34,11 @@ type AllocationResult struct {
 	// the IP is routable.
 	CIDRs []string
 
-	// Master is the MAC address of the master interface. This is useful
+	// PrimaryMAC is the MAC address of the primary interface. This is useful
 	// when the IP is a secondary address of an interface which is
 	// represented on the node as a Linux device and all routing of the IP
 	// must occur through that master interface.
-	Master string
+	PrimaryMAC string
 
 	// GatewayIP is the IP of the gateway which must be used for this IP.
 	// If the allocated IP is derived from a VPC, then the gateway

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -236,7 +236,7 @@ func WaitForNodeInformation() error {
 		// addressing, e.g. an IPv6 only PodCIDR running over
 		// IPv4 encapsulation.
 		if nodeIP4 != nil {
-			node.SetExternalIPv4(nodeIP4)
+			node.SetIPv4(nodeIP4)
 		}
 
 		if nodeIP6 != nil {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -245,6 +245,9 @@ func WaitForNodeInformation() error {
 
 		node.SetLabels(n.Labels)
 
+		node.SetK8sExternalIPv4(n.GetExternalIP(false))
+		node.SetK8sExternalIPv6(n.GetExternalIP(true))
+
 		// K8s Node IP is used by BPF NodePort devices auto-detection
 		node.SetK8sNodeIP(k8sNodeIP)
 	} else {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -87,3 +87,88 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", "I can change this and doesn't affect any one")
 	c.Assert(filtered, checker.DeepEquals, wanted)
 }
+
+func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
+	wanted := labels.Labels{
+		"app.kubernetes.io":           labels.NewLabel("app.kubernetes.io", "my-nginx", labels.LabelSourceContainer),
+		"id.lizards.k8s":              labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
+		"id.lizards":                  labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer),
+		"ignorE":                      labels.NewLabel("ignorE", "foo", labels.LabelSourceContainer),
+		"ignore":                      labels.NewLabel("ignore", "foo", labels.LabelSourceContainer),
+		"reserved:host":               labels.NewLabel("reserved:host", "", labels.LabelSourceAny),
+		"io.kubernetes.pod.namespace": labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
+	}
+
+	err := ParseLabelPrefixCfg([]string{}, "")
+	c.Assert(err, IsNil)
+	dlpcfg := validLabelPrefixes
+	allNormalLabels := map[string]string{
+		"io.kubernetes.container.hash":                              "cf58006d",
+		"io.kubernetes.container.name":                              "POD",
+		"io.kubernetes.container.restartCount":                      "0",
+		"io.kubernetes.container.terminationMessagePath":            "",
+		"io.kubernetes.pod.name":                                    "my-nginx-3800858182-07i3n",
+		"io.kubernetes.pod.namespace":                               "default",
+		"app.kubernetes.io":                                         "my-nginx",
+		"kubernetes.io.foo":                                         "foo",
+		"beta.kubernetes.io.foo":                                    "foo",
+		"annotation.kubectl.kubernetes.io":                          "foo",
+		"annotation.hello":                                          "world",
+		"annotation." + k8sConst.CiliumIdentityAnnotationDeprecated: "12356",
+		"io.kubernetes.pod.terminationGracePeriod":                  "30",
+		"io.kubernetes.pod.uid":                                     "c2e22414-dfc3-11e5-9792-080027755f5a",
+		"ignore":                                                    "foo",
+		"ignorE":                                                    "foo",
+		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
+		"controller-revision-hash":                                  "123456",
+	}
+	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
+	allLabels["reserved:host"] = labels.NewLabel("reserved:host", "", labels.LabelSourceAny)
+	filtered, _ := dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
+	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer)
+	allLabels["id.lizards.k8s"] = labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 7)
+	c.Assert(filtered, checker.DeepEquals, wanted)
+}
+
+func (s *LabelsPrefCfgSuite) TestFilterLabelsDocExample(c *C) {
+	wanted := labels.Labels{
+		"io.cilium.k8s.namespace.labels": labels.NewLabel("io.cilium.k8s.namespace.labels", "foo", labels.LabelSourceK8s),
+		"k8s-app-team":                   labels.NewLabel("k8s-app-team", "foo", labels.LabelSourceK8s),
+		"app-production":                 labels.NewLabel("app-production", "foo", labels.LabelSourceK8s),
+		"name-defined":                   labels.NewLabel("name-defined", "foo", labels.LabelSourceK8s),
+		"host":                           labels.NewLabel("host", "", labels.LabelSourceReserved),
+		"io.kubernetes.pod.namespace":    labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceAny),
+	}
+
+	err := ParseLabelPrefixCfg([]string{"k8s:io.kubernetes.pod.namespace", "k8s:k8s-app", "k8s:app", "k8s:name"}, "")
+	c.Assert(err, IsNil)
+	dlpcfg := validLabelPrefixes
+	allNormalLabels := map[string]string{
+		"io.cilium.k8s.namespace.labels": "foo",
+		"k8s-app-team":                   "foo",
+		"app-production":                 "foo",
+		"name-defined":                   "foo",
+	}
+	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceK8s)
+	filtered, _ := dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 4)
+
+	// Reserved labels are included.
+	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
+
+	// io.kubernetes.pod.namespace=docker matches because the default list has any:io.kubernetes.pod.namespace.
+	allLabels["io.kubernetes.pod.namespace"] = labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceAny)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 6)
+
+	// container:k8s-app-role=foo doesn't match because it doesn't have source k8s.
+	allLabels["k8s-app-role"] = labels.NewLabel("k8s-app-role", "foo", labels.LabelSourceContainer)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 6)
+	c.Assert(filtered, checker.DeepEquals, wanted)
+}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -36,16 +36,16 @@ import (
 const preferPublicIP bool = true
 
 var (
-	ipv4Loopback        net.IP
-	ipv4ExternalAddress net.IP
-	ipv4InternalAddress net.IP
-	ipv4NodePortAddrs   map[string]net.IP // iface name => ip addr
-	ipv4MasqAddrs       map[string]net.IP // iface name => ip addr
-	ipv6Address         net.IP
-	ipv6RouterAddress   net.IP
-	ipv6NodePortAddrs   map[string]net.IP // iface name => ip addr
-	ipv4AllocRange      *cidr.CIDR
-	ipv6AllocRange      *cidr.CIDR
+	ipv4Loopback      net.IP
+	ipv4Address       net.IP
+	ipv4RouterAddress net.IP
+	ipv4NodePortAddrs map[string]net.IP // iface name => ip addr
+	ipv4MasqAddrs     map[string]net.IP // iface name => ip addr
+	ipv6Address       net.IP
+	ipv6RouterAddress net.IP
+	ipv6NodePortAddrs map[string]net.IP // iface name => ip addr
+	ipv4AllocRange    *cidr.CIDR
+	ipv6AllocRange    *cidr.CIDR
 
 	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is preferred)
 	k8sNodeIP net.IP
@@ -69,13 +69,13 @@ func makeIPv6HostIP() net.IP {
 // scope will be regarded as the system's node address.
 func InitDefaultPrefix(device string) {
 	if option.Config.EnableIPv4 {
-		ip, err := firstGlobalV4Addr(device, GetInternalIPv4(), preferPublicIP)
+		ip, err := firstGlobalV4Addr(device, GetInternalIPv4Router(), preferPublicIP)
 		if err != nil {
 			return
 		}
 
-		if ipv4ExternalAddress == nil {
-			ipv4ExternalAddress = ip
+		if ipv4Address == nil {
+			ipv4Address = ip
 		}
 
 		if ipv4AllocRange == nil {
@@ -192,30 +192,44 @@ func GetIPv6AllocRange() *cidr.CIDR {
 	return ipv6AllocRange
 }
 
-// SetExternalIPv4 sets the external IPv4 node address. It must be reachable on the network.
-func SetExternalIPv4(ip net.IP) {
-	ipv4ExternalAddress = ip
+// SetIPv4 sets the IPv4 node address. It must be reachable on the network.
+// It is set based on the following priority:
+// - NodeInternalIP
+// - NodeExternalIP
+// - other IP address type
+func SetIPv4(ip net.IP) {
+	ipv4Address = ip
 }
 
-// GetExternalIPv4 returns the external IPv4 node address
-func GetExternalIPv4() net.IP {
-	return ipv4ExternalAddress
+// GetIPv4 returns one of the IPv4 node address available with the following
+// priority:
+// - NodeInternalIP
+// - NodeExternalIP
+// - other IP address type.
+// It must be reachable on the network.
+func GetIPv4() net.IP {
+	return ipv4Address
 }
 
-// SetInternalIPv4 sets the internal IPv4 node address, it is allocated from the node prefix
-func SetInternalIPv4(ip net.IP) {
-	ipv4InternalAddress = ip
+// SetInternalIPv4Router sets the cilium internal IPv4 node address, it is allocated from the node prefix.
+// This must not be conflated with k8s internal IP as this IP address is only relevant within the
+// Cilium-managed network (this means within the node for direct routing mode and on the overlay
+// for tunnel mode).
+func SetInternalIPv4Router(ip net.IP) {
+	ipv4RouterAddress = ip
 }
 
-// GetInternalIPv4 returns the internal IPv4 node address
-func GetInternalIPv4() net.IP {
-	return ipv4InternalAddress
+// GetInternalIPv4Router returns the cilium internal IPv4 node address. This must not be conflated with
+// k8s internal IP as this IP address is only relevant within the Cilium-managed network (this means
+// within the node for direct routing mode and on the overlay for tunnel mode).
+func GetInternalIPv4Router() net.IP {
+	return ipv4RouterAddress
 }
 
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading
 // any traffic that is being forwarded from the host into the Cilium cluster.
 func GetHostMasqueradeIPv4() net.IP {
-	return ipv4InternalAddress
+	return ipv4RouterAddress
 }
 
 // SetIPv4AllocRange sets the IPv4 address pool to use when allocating
@@ -278,7 +292,7 @@ func AutoComplete() error {
 		ipv4GW, ipv6Router := getCiliumHostIPs()
 
 		if ipv4GW != nil && option.Config.EnableIPv4 {
-			SetInternalIPv4(ipv4GW)
+			SetInternalIPv4Router(ipv4GW)
 		}
 
 		if ipv6Router != nil && option.Config.EnableIPv6 {
@@ -303,12 +317,12 @@ func AutoComplete() error {
 // required
 func ValidatePostInit() error {
 	if option.Config.EnableIPv4 || option.Config.Tunnel != option.TunnelDisabled {
-		if ipv4ExternalAddress == nil {
+		if ipv4Address == nil {
 			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
 		}
 	}
 
-	if option.Config.EnableIPv4 && ipv4InternalAddress == nil {
+	if option.Config.EnableIPv4 && ipv4RouterAddress == nil {
 		return fmt.Errorf("BUG: Internal IPv4 node address was not configured")
 	}
 
@@ -337,7 +351,7 @@ func SetIPv6Router(ip net.IP) {
 
 // IsHostIPv4 returns true if the IP specified is a host IP
 func IsHostIPv4(ip net.IP) bool {
-	return ip.Equal(GetInternalIPv4()) || ip.Equal(GetExternalIPv4())
+	return ip.Equal(GetInternalIPv4Router()) || ip.Equal(GetIPv4())
 }
 
 // IsHostIPv6 returns true if the IP specified is a host IP
@@ -360,7 +374,7 @@ func GetNodeAddressing() *models.NodeAddressing {
 	if option.Config.EnableIPv4 {
 		a.IPV4 = &models.NodeAddressingElement{
 			Enabled:    option.Config.EnableIPv4,
-			IP:         GetInternalIPv4().String(),
+			IP:         GetInternalIPv4Router().String(),
 			AllocRange: GetIPv4AllocRange().String(),
 		}
 	}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
@@ -46,6 +47,7 @@ var (
 	ipv6NodePortAddrs map[string]net.IP // iface name => ip addr
 	ipv4AllocRange    *cidr.CIDR
 	ipv6AllocRange    *cidr.CIDR
+	routerInfo        RouterInfo
 
 	// k8s Node External IP
 	ipv4ExternalAddress net.IP
@@ -56,6 +58,12 @@ var (
 
 	ipsecKeyIdentity uint8
 )
+
+type RouterInfo interface {
+	GetIPv4CIDRs() []net.IPNet
+	GetMac() mac.MAC
+	GetInterfaceNumber() int
+}
 
 func makeIPv6HostIP() net.IP {
 	ipstr := "fc00::10CA:1"
@@ -240,6 +248,18 @@ func SetK8sExternalIPv4(ip net.IP) {
 // on the network as well as the internet. It can return nil if no External IPv4 address is assigned.
 func GetK8sExternalIPv4() net.IP {
 	return ipv4ExternalAddress
+}
+
+// GetRouterEniInfo returns additional information for the router. It is applicable
+// only in the ENI IPAM mode.
+func GetRouterInfo() RouterInfo {
+	return routerInfo
+}
+
+// SetRouterEniInfo sets additional information for the router. It is applicable
+// only in the ENI IPAM mode.
+func SetRouterInfo(info RouterInfo) {
+	routerInfo = info
 }
 
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -47,6 +47,10 @@ var (
 	ipv4AllocRange    *cidr.CIDR
 	ipv6AllocRange    *cidr.CIDR
 
+	// k8s Node External IP
+	ipv4ExternalAddress net.IP
+	ipv6ExternalAddress net.IP
+
 	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is preferred)
 	k8sNodeIP net.IP
 
@@ -226,6 +230,18 @@ func GetInternalIPv4Router() net.IP {
 	return ipv4RouterAddress
 }
 
+// SetK8sExternalIPv4 sets the external IPv4 node address. It must be a public IP that is routable
+// on the network as well as the internet.
+func SetK8sExternalIPv4(ip net.IP) {
+	ipv4ExternalAddress = ip
+}
+
+// GetK8sExternalIPv4 returns the external IPv4 node address. It must be a public IP that is routable
+// on the network as well as the internet. It can return nil if no External IPv4 address is assigned.
+func GetK8sExternalIPv4() net.IP {
+	return ipv4ExternalAddress
+}
+
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading
 // any traffic that is being forwarded from the host into the Cilium cluster.
 func GetHostMasqueradeIPv4() net.IP {
@@ -347,6 +363,16 @@ func GetIPv6Router() net.IP {
 // SetIPv6Router returns the IPv6 address of the node
 func SetIPv6Router(ip net.IP) {
 	ipv6RouterAddress = ip
+}
+
+// SetK8sExternalIPv6 sets the external IPv6 node address. It must be a public IP.
+func SetK8sExternalIPv6(ip net.IP) {
+	ipv6ExternalAddress = ip
+}
+
+// GetK8sExternalIPv6 returns the external IPv6 node address.
+func GetK8sExternalIPv6() net.IP {
+	return ipv6ExternalAddress
 }
 
 // IsHostIPv4 returns true if the IP specified is a host IP

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -214,7 +214,7 @@ func SetInternalIPv4From(ifaceName string) error {
 	}
 	for _, ip := range v4Addrs {
 		if netlink.Scope(ip.Scope) == netlink.SCOPE_UNIVERSE {
-			SetInternalIPv4(ip.IP)
+			SetInternalIPv4Router(ip.IP)
 			return nil
 		}
 	}

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -44,9 +44,9 @@ func (s *NodeSuite) TestMaskCheck(c *C) {
 
 	allocCIDR := cidr.MustParseCIDR("1.1.1.1/16")
 	SetIPv4AllocRange(allocCIDR)
-	SetInternalIPv4(allocCIDR.IP)
-	c.Assert(IsHostIPv4(GetInternalIPv4()), Equals, true)
-	c.Assert(IsHostIPv4(GetExternalIPv4()), Equals, true)
+	SetInternalIPv4Router(allocCIDR.IP)
+	c.Assert(IsHostIPv4(GetInternalIPv4Router()), Equals, true)
+	c.Assert(IsHostIPv4(GetIPv4()), Equals, true)
 	c.Assert(IsHostIPv6(GetIPv6()), Equals, true)
 }
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -71,6 +71,7 @@ type IPCache interface {
 type Configuration interface {
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
+	EncryptionEnabled() bool
 }
 
 // Notifier is the interface the wraps Subscribe and Unsubscribe. An
@@ -331,7 +332,7 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	// ipcache. This resulted in a behavioral change. New deployments will
 	// provide this behavior out of the gate, existing deployments will
 	// have to opt into this by enabling remote-node identities.
-	return !m.conf.NodeEncryptionEnabled() && !m.conf.RemoteNodeIdentitiesEnabled()
+	return !m.conf.EncryptionEnabled() && !m.conf.RemoteNodeIdentitiesEnabled()
 }
 
 // NodeUpdated is called after the information of a node has been updated. The
@@ -356,10 +357,13 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 
 	for _, address := range n.IPAddresses {
 		var tunnelIP net.IP
+		key := n.EncryptionKey
+
 		// If the host firewall is enabled, all traffic to remote nodes must go
 		// through the tunnel to preserve the source identity as part of the
-		// encapsulation.
-		if address.Type == addressing.NodeCiliumInternalIP || m.conf.NodeEncryptionEnabled() ||
+		// encapsulation. In encryption case we also want to use vxlan device
+		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
+		if address.Type == addressing.NodeCiliumInternalIP || m.conf.EncryptionEnabled() ||
 			option.Config.EnableHostFirewall || option.Config.JoinCluster {
 			tunnelIP = nodeIP
 		}
@@ -368,7 +372,17 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			continue
 		}
 
-		isOwning, _ := m.ipcache.Upsert(address.IP.String(), tunnelIP, n.EncryptionKey, nil, ipcache.Identity{
+		// If we are doing encryption, but not node based encryption, then do not
+		// add a key to the nodeIPs so that we avoid a trip through stack and attempting
+		// to encrypt something we know does not have an encryption policy installed
+		// in the datapath. By setting key=0 and tunnelIP this will result in traffic
+		// being sent unencrypted over overlay device.
+		if !m.conf.NodeEncryptionEnabled() &&
+			(address.Type == addressing.NodeExternalIP || address.Type == addressing.NodeInternalIP) {
+			key = 0
+		}
+
+		isOwning, _ := m.ipcache.Upsert(address.IP.String(), tunnelIP, key, nil, ipcache.Identity{
 			ID:     remoteHostIdentity,
 			Source: n.Source,
 		})

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -46,6 +46,7 @@ var _ = check.Suite(&managerTestSuite{})
 type configMock struct {
 	RemoteNodeIdentity bool
 	NodeEncryption     bool
+	Encryption         bool
 }
 
 func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
@@ -54,6 +55,10 @@ func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
 
 func (c *configMock) NodeEncryptionEnabled() bool {
 	return c.NodeEncryption
+}
+
+func (c *configMock) EncryptionEnabled() bool {
+	return c.Encryption
 }
 
 type nodeEvent struct {
@@ -556,7 +561,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true})
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true, Encryption: true})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -247,6 +247,21 @@ func (n *Node) getNodeIP(ipv6 bool) (net.IP, addressing.AddressType) {
 	return backupIP, ipType
 }
 
+// GetExternalIP returns ExternalIP of k8s Node. If not present, then it
+// returns nil;
+func (n *Node) GetExternalIP(ipv6 bool) net.IP {
+	for _, addr := range n.IPAddresses {
+		if (ipv6 && addr.IP.To4() != nil) || (!ipv6 && addr.IP.To4() == nil) {
+			continue
+		}
+		if addr.Type == addressing.NodeExternalIP {
+			return addr.IP
+		}
+	}
+
+	return nil
+}
+
 // GetK8sNodeIPs returns k8s Node IP (either InternalIP or ExternalIP or nil;
 // the former is preferred).
 func (n *Node) GetK8sNodeIP() net.IP {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -182,10 +182,10 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.Labels = node.GetLabels()
 	n.LocalNode.NodeIdentity = identity.GetLocalNodeID().Uint32()
 
-	if node.GetExternalIPv4() != nil {
+	if node.GetIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeInternalIP,
-			IP:   node.GetExternalIPv4(),
+			IP:   node.GetIPv4(),
 		})
 	}
 
@@ -196,10 +196,10 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		})
 	}
 
-	if node.GetInternalIPv4() != nil {
+	if node.GetInternalIPv4Router() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,
-			IP:   node.GetInternalIPv4(),
+			IP:   node.GetInternalIPv4Router(),
 		})
 	}
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -182,6 +182,13 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.Labels = node.GetLabels()
 	n.LocalNode.NodeIdentity = identity.GetLocalNodeID().Uint32()
 
+	if node.GetK8sExternalIPv4() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeExternalIP,
+			IP:   node.GetK8sExternalIPv4(),
+		})
+	}
+
 	if node.GetIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeInternalIP,
@@ -207,6 +214,13 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,
 			IP:   node.GetIPv6Router(),
+		})
+	}
+
+	if node.GetK8sExternalIPv6() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeExternalIP,
+			IP:   node.GetK8sExternalIPv6(),
 		})
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2167,6 +2167,11 @@ func (c *DaemonConfig) NodeEncryptionEnabled() bool {
 	return c.EncryptNode
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (c *DaemonConfig) EncryptionEnabled() bool {
+	return c.EnableIPSec
+}
+
 // IPv4Enabled returns true if IPv4 is enabled
 func (c *DaemonConfig) IPv4Enabled() bool {
 	return c.EnableIPv4

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -33,6 +33,11 @@ func (f *Config) RemoteNodeIdentitiesEnabled() bool {
 	return true
 }
 
+// EncryptionEnabled returns true if encryption is enabled
+func (f *Config) EncryptionEnabled() bool {
+	return true
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -98,7 +98,7 @@ func NewLogRecord(endpointInfoRegistry EndpointInfoRegistry, localEndpointInfoSo
 		localEndpointInfo:    getEndpointInfo(localEndpointInfoSource),
 	}
 
-	if ip := node.GetExternalIPv4(); ip != nil {
+	if ip := node.GetIPv4(); ip != nil {
 		lr.LogRecord.NodeAddressInfo.IPv4 = ip.String()
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -625,7 +625,7 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 	defer proxyPortsMutex.Unlock()
 
 	result := &models.ProxyStatus{
-		IP:             node.GetInternalIPv4().String(),
+		IP:             node.GetInternalIPv4Router().String(),
 		PortRange:      fmt.Sprintf("%d-%d", p.rangeMin, p.rangeMax),
 		TotalRedirects: int64(len(p.redirects)),
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3621,7 +3621,7 @@ func (kub *Kubectl) GetNodeInfo(label string) (nodeName, nodeIP string) {
 	nodeName, err := kub.GetNodeNameByLabel(label)
 	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), "Cannot get node by label "+label)
 	nodeIP, err = kub.GetNodeIPByLabel(label, false)
-	gomega.ExpectWithOffset(1, err).Should(gomega.BeNil(), "Can not retrieve Node IP for "+label)
+	gomega.ExpectWithOffset(1, err).Should(gomega.BeNil(), "Can not retrieve Node Internal IP for "+label)
 	return nodeName, nodeIP
 }
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -961,6 +961,17 @@ var _ = Describe("K8sServicesTest", func() {
 			}
 
 			if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
+				k8s1ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s1, true)
+				Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s1)
+				k8s2ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s2, true)
+				Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s2)
+				testURLsFromPods = append(testURLsFromPods,
+					getHTTPLink(k8s1ExternalIP, data.Spec.Ports[0].NodePort),
+					getTFTPLink(k8s1ExternalIP, data.Spec.Ports[1].NodePort),
+					getHTTPLink(k8s2ExternalIP, data.Spec.Ports[0].NodePort),
+					getTFTPLink(k8s2ExternalIP, data.Spec.Ports[1].NodePort),
+				)
+
 				// Testing LoadBalancer types subject to bpf_sock.
 				lbIP, err := kubectl.GetLoadBalancerIP(helpers.DefaultNamespace, "test-lb", 60*time.Second)
 				Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")


### PR DESCRIPTION
* #14611 -- cilium: Send pod->node traffic through tunnel in IPSec+vxlan case (@jrfastab)
 * #14793 -- ipcache: Add ExternalIP of the local node to ipcache (@AnishShah, @brb)
 * #14913 -- iptables: Fix incorrect SNAT bypass with endpoint routes and tunneling (@pchaigno)
     - Conflict (the code changed has been refactored).
 * #14920 -- docs: Document hostport requirements in eni (@joestringer)
 * #14634 -- Makefile: build Cilium with madvdontneed=1 (@aanm)
 * #14675 -- bpf: Do not bypass conntrack if running kube-proxy+vxlan+endpoint routes (@pchaigno)
     - Conflicts in `pkg/datapath/iptables/iptables.go`.
 * #14847 -- docs: Added instruction to also delete kube-proxy configmap (@yoshz)
 * #14756 -- Fix reverse DNAT for externalTrafficPolicy=Local service with kube-proxy (@pchaigno)
     - Conflicts in `pkg/datapath/iptables/iptables.go` and in tests.
 * #14886 -- images: Set GOPS_CONFIG_DIR in scratch images (@gandro)
 * #14924 -- Fix encryption in IPAM ENI mode (@aditighag)
     - Couple of conflicts.
     - I changed `EnableIPv4Masquerade` to `Masquerade` in `daemon/cmd/ipam.go`. Please double check.
 * #14338 -- labelsfilter: Update documentation and add unit tests (@pchaigno)
 * #14954 -- ci(smoketest): Pin promtool version in GHA (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14611 14793 14913 14920 14634 14675 14847 14756 14886 14924 14338 14954; do contrib/backporting/set-labels.py $pr done 1.9; done
```