### PR TITLE
CODEOWNERS: Remove docs-structure review from helm

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,8 +133,8 @@ Dockerfile* @cilium/build
 /hubble-relay/ @cilium/hubble
 /hubble-relay.Dockerfile @cilium/hubble
 /images @cilium/build
-/install/kubernetes/ @cilium/kubernetes @cilium/docs-structure @cilium/helm
-/install/kubernetes/cilium/templates/hubble* @cilium/kubernetes @cilium/docs-structure @cilium/helm @cilium/hubble
+/install/kubernetes/ @cilium/kubernetes @cilium/helm
+/install/kubernetes/cilium/templates/hubble* @cilium/kubernetes @cilium/helm @cilium/hubble
 jenkinsfiles @cilium/ci-structure
 Jenkinsfile.nightly @cilium/ci-structure
 /operator/ @cilium/operator


### PR DESCRIPTION
The intent of having docs-structure codeowners review helm changes was
to check whether the changes necessitate documentation updates, but in
practice the majority of these changes don't require updates to the
docs so the docs-structure review is a no-op. We can instead rely on the
cilium/helm team codeowners to call out when a change should also update
the docs.
