### PR TITLE
Makefile: Fix missing BASE_IMAGE in docker builds

### DIFF
--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -339,11 +339,23 @@ To debug data races, Golang allows ``-race`` to be passed to the compiler to
 compile Cilium with race detection. Additionally, the flag can be provided to
 ``go test`` to detect data races in a testing context.
 
+.. _compile-cilium-with-race-detection:
+
+~~~~~~~~~~~~~~
+Race detection
+~~~~~~~~~~~~~~
+
 To compile a Cilium binary with race detection, you can do:
 
 .. code:: bash
 
     $ make RACE=1
+
+.. Note::
+
+    For building the Operator with race detection, you must also provide
+    ``BASE_IMAGE`` which can be the ``cilium/cilium-runtime`` image from the
+    root Dockerfile found in the Cilium repository.
 
 To run unit tests with race detection, you can do:
 

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -37,6 +37,13 @@ You can then push the image tag to your own registry for development builds:
 
     docker push quay.io/myaccount/cilium-dev:jane-developer-my-fix-amd64
 
+~~~~~~~~~~~~~~
+Race detection
+~~~~~~~~~~~~~~
+
+See section on :ref:`compiling Cilium with race detection
+<compile-cilium-with-race-detection>`.
+
 Official release images
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -24,6 +24,7 @@ $(1): GIT_VERSION $(BUILD_DIR)/$(2) build-context-update builder-info
 	$(eval IMAGE_NAME := $(subst %,$$$$*,$(3))$(UNSTRIPPED))
 	$(QUIET)$(CONTAINER_ENGINE) build -f $(BUILD_DIR)/$(subst %,$$*,$(2)) \
 		$(DOCKER_FLAGS) \
+		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg RACE=${RACE}\


### PR DESCRIPTION
When compiling with race detection (`RACE=1`), the `BASE_IMAGE` must be
passed for the Operator because race mode requires cgo which makes the
resulting binary dynamically linked. The default `BASE_IMAGE` was set to
`scratch` which means there is nothing in the resulting image's
filesystem, other than the Operator binary.

Example error:

```
$ docker run -it christarazi/operator-aws:latest /usr/bin/cilium-operator-aws
standard_init_linux.go:219: exec user process caused: no such file or directory
```

The `BASE_IMAGE` was introduced in f4aa36221 ("run with race detector").
However, the code to build the Operator changed in 7d67a820d5 ("Docker:
Multi-arch & cross-compile build with docker buildx"), where the
`BASE_IMAGE` should have been passed as a build argument. This is what
the commit adds.

Fixes: 7d67a820d5

Signed-off-by: Chris Tarazi <chris@isovalent.com>
