### PR TITLE
docs: Update our community docs page

### DIFF
--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -4,6 +4,68 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+Weekly Community Meeting
+========================
+
+The Cilium contributors gather every Monday at 8am PDT, 17:00 CEST, for a
+one-hour Zoom call open to everyone. During that time, we discuss:
+
+- the statuses of the next releases for each supported Cilium release
+- the current state of our CI: flakes being investigated and upcoming
+  changes
+- the development items for the next release
+- miscellaneous topics during the open session
+
+If you want to discuss something during the next meeting's open session,
+you can add it to `the meeting's Google doc
+<https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#>`_.
+The Zoom link to the meeting is available in the #development Slack
+channel and in `the meeting notes
+<https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#>`_.
+
+Slack
+=====
+
+Our Cilium & eBPF Slack is the main discussion space for the Cilium community.
+Click `here <https://cilium.herokuapp.com>`_ to request an invite. 
+
+Slack channels
+--------------
+
+==================== ====================================
+Name                 Purpose
+==================== ====================================
+#general             General user discussions & questions
+#hubble              Questions on Hubble
+#kubernetes          Kubernetes-specific questions
+#networkpolicy       Questions on network policies
+#release             Release announcements only
+==================== ====================================
+
+You can join the following channels if you are looking to contribute to
+Cilium:
+
+==================== ====================================
+Name                 Purpose
+==================== ====================================
+#development         Development discussions
+#git                 GitHub notifications
+#sig-*               SIG-specific discussions (see below)
+#testing             Testing and CI discussions
+==================== ====================================
+
+If you are interested in eBPF, then the following channels are for you:
+
+==================== ====================================================================
+Name                 Purpose
+==================== ====================================================================
+#ebpf                eBPF-specific questions
+#ebpf-lsm            Questions on BPF LSM
+#ebpf-news           Contributions to the `eBPF Updates <https://ebpf.io/blog>`_
+#libbpf-go           Questions on the `eBPF Go library <https://github.com/cilium/ebpf>`_
+==================== ====================================================================
+
+
 Special Interest Groups
 =======================
 
@@ -19,8 +81,8 @@ SIG                    Meeting                               Slack         Descr
 ====================== ===================================== ============= ================================================================================
 Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
 Documentation          None                                  #sig-docs     All documentation related discussions
-Envoy                  Biweekly on Thursdays, 09:00 PT       #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
-Hubble                 Thursdays, 09:00 PT                   #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.
+Envoy                  On demand                             #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
+Hubble                 During community meeting              #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.
 Policy                 None                                  #sig-policy   All topics related to policy. The SIG is responsible for all security relevant APIs and the enforcement logic.
 Release Management     None                                  #launchpad    Responsible for the release management and backport process.
 ====================== ===================================== ============= ================================================================================
@@ -34,27 +96,3 @@ How to create a SIG
 4. Find two Cilium committers to support the SIG.
 5. Ask on #development to get the Slack channel and Zoom meeting created
 6. Submit a PR to update the documentation to get your new SIG listed
-
-Slack
-=====
-
-The Cilium community is maintaining an active Slack channel. Click `here
-<https://cilium.herokuapp.com>`_ to request an invite. 
-
-Slack channels
---------------
-
-
-==================== ============================================================
-Name                 Purpose
-==================== ============================================================
-#development         Development discussions
-#ebpf                eBPF-specific questions
-#general             General user discussions & questions
-#git                 GitHub notifications
-#kubernetes          Kubernetes specific questions
-#sig-*               SIG specific discussions
-#testing             CI and testing related discussions
-==================== ============================================================
-
-.. _`Policy-Zoom`: https://zoom.us/j/878657504

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -559,6 +559,7 @@ lookup
 lookups
 loopback
 lrp
+lsm
 lspci
 luke
 lwt
@@ -616,6 +617,7 @@ netfilter
 netperf
 netsec
 netvsc
+networkpolicy
 newproto
 newprotoparser
 nfp


### PR DESCRIPTION
- Update the information on SIGs.
- Split the Slack channels in three categories and add a few new suggestions.
- Add a section on the Weekly Community Meeting.