### PR TITLE
Helm: add eni option to use iam-role

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -125,6 +125,7 @@ contributors across the globe, there is almost always someone available to help.
 | eni.ec2APIEndpoint | string | `""` | EC2 API endpoint to usee |
 | eni.enabled | bool | `false` | Enable Elastic Network Interface (ENI) integration. |
 | eni.eniTags | object | `{}` | Tags to apply to the newly created ENIs |
+| eni.iamRole | string | `""` | If using IAM role for Service Accounts will not try to inject identity values from cilium-aws kubernetes secret. Adds annotation to service account if managed by Helm. See https://github.com/aws/amazon-eks-pod-identity-webhook |
 | eni.subnetIDsFilter | string | `""` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs |
 | eni.subnetTagsFilter | string | `""` | Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs |
 | eni.updateEC2AdapterLimitViaAPI | bool | `false` | Update ENI Adapter limits from the EC2 API |

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -103,7 +103,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-{{- if .Values.eni.enabled }}
+{{- if (and .Values.eni.enabled (not .Values.eni.iamRole )) }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/install/kubernetes/cilium/templates/cilium-operator-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-serviceaccount.yaml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.operator.name | quote }}
   namespace: {{ .Release.Namespace }}
+  {{- if and .Values.eni.enabled .Values.eni.iamRole }}
+  {{ $_ := set .Values.serviceAccounts.operator.annotations "eks.amazonaws.com/role-arn" .Values.eni.iamRole }}
+  {{- end}}
   {{- if .Values.serviceAccounts.operator.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccounts.operator.annotations | indent 4 }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -428,6 +428,11 @@ eni:
   ec2APIEndpoint: ""
   # -- Tags to apply to the newly created ENIs
   eniTags: {}
+  # -- If using IAM role for Service Accounts will not try to
+  # inject identity values from cilium-aws kubernetes secret.
+  # Adds annotation to service account if managed by Helm.
+  # See https://github.com/aws/amazon-eks-pod-identity-webhook
+  iamRole: ""
   # -- Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs
   subnetIDsFilter: ""
   # -- Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs


### PR DESCRIPTION
Prevents helm from adding secret env in particular `AWS_DEFAULT_REGION` for AWS pod identity if using an iam-role.

It seems that this prevents the [eks-pod-identity-webhook](https://github.com/aws/amazon-eks-pod-identity-webhook/blob/599cfe7cfc8c72d48a8870e675e19a8169b3dafe/pkg/handler/handler.go#L212-L224) from adding the entry if missing.
```
level=warning msg="Unable to synchronize EC2 VPC list" error="operation error EC2: DescribeVpcs, failed to sign request: failed to retrieve credentials: failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, failed to resolve service endpoint, an AWS region is required, but was not found" subsys=eni
level=fatal msg="Unable to start eni allocator" error="Initial synchronization with instances API failed" subsys=cilium-operator-aws
```

Fixes: #13270 

```release-note
Add iamRole option to eni in Helm chart values to allow using serviceaccounts for iam roles on cilium-operator
```
