### PR TITLE
Helm: fixed operator extra-args

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -78,6 +78,13 @@ spec:
       - args:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
+{{- range $key, $value := .Values.operator.extraArgs }}
+{{- if $value }}
+        - --{{ $key }}={{ $value }}
+{{- else }}
+        - --{{ $key }}
+{{- end }}
+{{- end }}
         command:
 {{- if .Values.eni.enabled }}
         - cilium-operator-aws


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

This fix, adds extra-args for the cilium-operator to the helm chart
