### PR TITLE
cli: Rename kpr Protocols status field

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -579,7 +579,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 		tab := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 		fmt.Fprintf(tab, "  Status:\t%s\n", sr.KubeProxyReplacement.Mode)
 		if protocols != "" {
-			fmt.Fprintf(tab, "  Protocols:\t%s\n", protocols)
+			fmt.Fprintf(tab, "  Socket LB Protocols:\t%s\n", protocols)
 		}
 		if kubeProxyDevices != "" {
 			fmt.Fprintf(tab, "  Devices:\t%s\n", kubeProxyDevices)


### PR DESCRIPTION
This commit renames the "Protocols" field to Socket LB Protocols" to better reflect the fact that the field indicates which protocols are handled by the host reachable svc (aka socket-lb).

The example output:

        $ cilium status --verbose
        [..]
        KubeProxyReplacement Details:
          Status:              Strict
          Socket LB Protocols: TCP, UDP
          Devices:             wlp3s0 192.168.178.29 (Direct Routing)
          Mode:                SNAT
          Backend Selection:   Random
          Session Affinity:    Enabled
          XDP Acceleration:    Disabled
          Services:
          - ClusterIP:      Enabled
          - NodePort:       Enabled (Range: 30000-32767)
          - LoadBalancer:   Enabled
          - externalIPs:    Enabled
          - HostPort:       Enabled

Also, I'm using socket-lb instead of host-reachable svc, as in v1.10 we are planning to rename the feature (it's used not only for reaching services from a host nents).