### PR TITLE
bpf: added --bpf-lb-bypass-fib-lookup flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -30,6 +30,7 @@ cilium-agent [flags]
       --bpf-fragments-map-max int                            Maximum number of entries in fragments tracking map (default 8192)
       --bpf-lb-acceleration string                           BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
       --bpf-lb-algorithm string                              BPF load balancing algorithm ("random", "maglev") (default "random")
+      --bpf-lb-bypass-fib-lookup                             Enable FIB lookup bypass optimization for nodeport reverse NAT handling (default true)
       --bpf-lb-dev-ip-addr-inherit string                    Device name which IP addr is inherited by devices running LB BPF program (--devices)
       --bpf-lb-dsr-dispatch string                           BPF load balancing DSR dispatch method ("opt", "ipip") (default "opt")
       --bpf-lb-maglev-hash-seed string                       Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -104,6 +104,11 @@ static __always_inline bool nodeport_lb_hairpin(void)
 	return is_defined(ENABLE_NODEPORT_HAIRPIN);
 }
 
+static __always_inline bool fib_lookup_bypass(void)
+{
+	return is_defined(ENABLE_FIB_LOOKUP_BYPASS);
+}
+
 static __always_inline void
 bpf_mark_snat_done(struct __ctx_buff *ctx __maybe_unused)
 {
@@ -763,7 +768,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 	struct csum_offset csum_off = {};
 	struct ct_state ct_state = {};
 	struct bpf_fib_lookup fib_params = {};
-	union macaddr *dmac;
+	union macaddr *dmac = NULL;
 	__u32 monitor = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -820,7 +825,8 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 		}
 #endif
 
-		dmac = map_lookup_elem(&NODEPORT_NEIGH6, &tuple.daddr);
+		if (fib_lookup_bypass())
+			dmac = map_lookup_elem(&NODEPORT_NEIGH6, &tuple.daddr);
 		if (dmac) {
 			union macaddr mac = NATIVE_DEV_MAC_BY_IFINDEX(*ifindex);
 
@@ -1596,7 +1602,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 	int ret, ret2, l3_off = ETH_HLEN, l4_off;
 	struct ct_state ct_state = {};
 	struct bpf_fib_lookup fib_params = {};
-	union macaddr *dmac;
+	union macaddr *dmac = NULL;
 	__u32 monitor = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
@@ -1649,7 +1655,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 		}
 #endif
 
-		dmac = map_lookup_elem(&NODEPORT_NEIGH4, &ip4->daddr);
+		if (fib_lookup_bypass())
+			dmac = map_lookup_elem(&NODEPORT_NEIGH4, &ip4->daddr);
 		if (dmac) {
 			union macaddr mac = NATIVE_DEV_MAC_BY_IFINDEX(*ifindex);
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -920,6 +920,9 @@ func init() {
 		"Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.")
 	option.BindEnv(option.EgressMultiHomeIPRuleCompat)
 
+	flags.Bool(option.EnableBPFBypassFIBLookup, defaults.EnableBPFBypassFIBLookup, "Enable FIB lookup bypass optimization for nodeport reverse NAT handling")
+	option.BindEnv(option.EnableBPFBypassFIBLookup)
+
 	viper.BindPFlags(flags)
 
 	CustomCommandHelpFormat(RootCmd, option.HelpFlagSections)

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -276,6 +276,11 @@ data:
   # backend and affinity maps.
   bpf-lb-map-max: "{{ .Values.bpf.lbMapMax }}"
 {{- end }}
+  # bpf-lb-bypass-fib-lookup instructs Cilium to enable the FIB lookup bypass
+  # optimization for nodeport reverse NAT handling.
+{{- if hasKey .Values.bpf "lbBypassFIBLookup" }}
+  bpf-lb-bypass-fib-lookup: {{ .Values.bpf.lbBypassFIBLookup | quote }}
+{{- end }}
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -272,6 +272,10 @@ bpf:
   # for implementing Layer 7 policy.
   # tproxy: true
 
+  # -- Configure the FIB lookup bypass optimization for nodeport reverse
+  # NAT handling.
+  # lbBypassFIBLookup: true
+
 # -- Clean all eBPF datapath state from the initContainer of the cilium-agent
 # DaemonSet.
 #

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -98,6 +98,8 @@ data:
   # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
   # backend and affinity maps.
   bpf-lb-map-max: "65536"
+  # bpf-lb-bypass-fib-lookup instructs Cilium to enable the FIB lookup bypass
+  # optimization for nodeport reverse NAT handling.
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -77,6 +77,8 @@ data:
   # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
   # backend and affinity maps.
   bpf-lb-map-max: "65536"
+  # bpf-lb-bypass-fib-lookup instructs Cilium to enable the FIB lookup bypass
+  # optimization for nodeport reverse NAT handling.
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -334,6 +334,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 					fmt.Sprintf("%d", lbmap.SourceRange6Map.MapInfo.MaxEntries)
 			}
 		}
+		if option.Config.EnableBPFBypassFIBLookup {
+			cDefinesMap["ENABLE_FIB_LOOKUP_BYPASS"] = "1"
+		}
 
 		cDefinesMap["NODEPORT_PORT_MIN"] = fmt.Sprintf("%d", option.Config.NodePortMin)
 		cDefinesMap["NODEPORT_PORT_MAX"] = fmt.Sprintf("%d", option.Config.NodePortMax)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -405,4 +405,7 @@ const (
 
 	// KubeProxyReplacementHealthzBindAddr is the default kubeproxyReplacement healthz server bind addr
 	KubeProxyReplacementHealthzBindAddr = ""
+
+	// EnableBPFBypassFIBLookup instructs Cilium to enable the FIB lookup bypass optimization for nodeport reverse NAT handling.
+	EnableBPFBypassFIBLookup = true
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -896,6 +896,9 @@ const (
 	// store rules and routes under ENI and Azure IPAM modes, if false.
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat = "egress-multi-home-ip-rule-compat"
+
+	// EnableBPFBypassFIBLookup instructs Cilium to enable the FIB lookup bypass optimization for nodeport reverse NAT handling.
+	EnableBPFBypassFIBLookup = "bpf-lb-bypass-fib-lookup"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -925,6 +928,7 @@ var HelpFlagSections = []FlagsSection{
 			EnableBPFClockProbe,
 			EnableBPFMasquerade,
 			EnableIdentityMark,
+			EnableBPFBypassFIBLookup,
 			LBMapEntriesName,
 		},
 	},
@@ -2096,6 +2100,9 @@ type DaemonConfig struct {
 	// store rules and routes under ENI and Azure IPAM modes, if false.
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat bool
+
+	// EnableBPFBypassFIBLookup instructs Cilium to enable the FIB lookup bypass optimization for nodeport reverse NAT handling.
+	EnableBPFBypassFIBLookup bool
 }
 
 var (
@@ -2640,6 +2647,7 @@ func (c *DaemonConfig) Populate() {
 	c.LoadBalancerDSRDispatch = viper.GetString(LoadBalancerDSRDispatch)
 	c.LoadBalancerRSSv4CIDR = viper.GetString(LoadBalancerRSSv4CIDR)
 	c.LoadBalancerRSSv6CIDR = viper.GetString(LoadBalancerRSSv6CIDR)
+	c.EnableBPFBypassFIBLookup = viper.GetBool(EnableBPFBypassFIBLookup)
 
 	err = c.populateMasqueradingSettings()
 	if err != nil {


### PR DESCRIPTION
This commit adds a boolean flag, which when enabled will cause the BPF nodeport reverse NAT handling to attempt to use a MAC address which was previously associated with the remote endpoint when sending its reply, instead of doing a FIB lookup.

If the flag is toggled off, this optimization is disabled, and a FIB lookup is always done.

This is useful if Cilium is to be used on nodes which default gateway is a FHRP VIP/MAC, such as with VRRP or Cisco's HSRP.

Fixes: #14911

Signed-off-by: Danni Skov Høglund <skuffe@pwnz.dk>

```release-note
Added --bpf-lb-bypass-fib-lookup flag, which toggles the BPF nodeport reverse NAT FIB lookup optimization
```