### PR TITLE
ci: use separate Jenkins jobs for daily master tests

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -214,9 +214,9 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_ (where ``X.XX`` is a K8s version)        | test-X.XX-4.9     | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| All non-required `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_                         | test-older-k8s    | No                 |
+| All non-required `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_                         | test-older-k8s    | Backports          |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-K8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/>`_                      | test-missed-k8s   | No                 |
+| `Cilium-PR-Ginkgo-Tests-K8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/>`_                      | test-missed-k8s   | Backports          |
 |                                                                                                                | **(deprecated)**  |                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-me-please,   | Yes                |
@@ -236,15 +236,13 @@ If a specific K8s version fails, it can be re-run using ``retest-X.XX-4.9``.
 
 ``test-missed-k8s`` is deprecated and superseded by ``test-older-k8s``:
 
-- For new branches: it triggers a ``Cilium-PR-Ginkgo-Tests-K8s`` which does
-  exactly the same thing (triggers all ``Cilium-PR-K8s-X.XX-kernel-4.9`` jobs),
-  except that the compound job (and not the individual jobs) will be displayed
-  on the PR page. This makes it more cumbersome to detect which specific K8s
-  version failed in case of failure.
-- For older branches (where ``test-missed-k8s`` is unavailable): triggers a
+- For new branches: it triggers a ``Cilium-PR-Ginkgo-Tests-K8s`` that will
+  automatically abort, warning you that ``test-missed-k8s`` is deprecated and
+  you should use ``test-older-k8s`` instead.
+- For older branches (where ``test-older-k8s`` is unavailable): triggers a
   ``Cilium-PR-Ginkgo-Tests-K8s`` testing older K8s versions by itself.
-  It should not be used for new branches, only for Backport PRs for which
-  ``test-older-k8s`` is unavailable.
+  It should only be used on Backport PRs for which ``test-older-k8s`` is
+  unavailable.
 
 For Backport PRs, the phrase ``test-backport-x.x`` (with ``x.x`` being the target Cilium version) should be used to
 trigger all of the above jobs which are marked as required to validate changes

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -212,7 +212,7 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Kubernetes-Upstream <https://jenkins.cilium.io/job/Cilium-PR-Kubernetes-Upstream/>`_                | test-upstream-k8s | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_ (where ``X.XX`` is a K8s version)        | test-X.XX-4.9     | No                 |
+| `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_ (``X.XX`` = K8s version)                 | test-X.XX-4.9     | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | All non-required `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_                         | test-older-k8s    | Backports          |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
@@ -244,9 +244,9 @@ If a specific K8s version fails, it can be re-run using ``retest-X.XX-4.9``.
   It should only be used on Backport PRs for which ``test-older-k8s`` is
   unavailable.
 
-For Backport PRs, the phrase ``test-backport-x.x`` (with ``x.x`` being the target Cilium version) should be used to
-trigger all of the above jobs which are marked as required to validate changes
-to existing releases.
+For Backport PRs, the phrase ``test-backport-x.x`` (with ``x.x`` being the
+target Cilium version) should be used to trigger all of the above jobs which are
+marked as required to validate changes to existing releases.
 
 There are some feature flags based on Pull Requests labels, the list of labels
 are the following:

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -14,58 +14,75 @@ pipeline {
     }
 
     stages {
+        // Abort build if not triggered against master branch
+        //
+        // `ginkgo-kubernetes-all.Jenkinsfile` is used in both
+        // `cilium-master-K8s-all` and `Cilium-PR-Ginkgo-Tests-K8s`.
+        // The former is triggered automatically daily, the latter is triggered
+        // from PRs with `test-missed-k8s` but is now deprecated and superseded
+        // by `test-older-k8s`, which directly runs other PR jobs.
+        //
+        // PRs for older branches (e.g. backports) still need `test-missed-k8s`,
+        // hence we can't remove `Cilium-PR-Ginkgo-Tests-K8s` for now.
+        // This guard's purpose is to prevent accidental triggering of master
+        // jobs when using `test-missed-k8s` from PRs of recent branches.
+        stage('Parameter check') {
+            when {
+                not { environment name: 'GIT_BRANCH', value: 'origin/master' }
+            }
+            steps {
+                script {
+                    currentBuild.result = 'ABORTED'
+                }
+                error("Aborting due to invalid target branch. Note: 'test-missed-k8s' is deprecated on new branches, please use 'test-older-k8s' instead. See documentation for details: https://docs.cilium.io/en/latest/contributing/testing/ci/#trigger-phrases")
+            }
+        }
         stage('Trigger parallel baremetal K8s builds') {
             parallel {
                 stage('K8s-1.14-kernel-4.9') {
                     steps {
-                        build(job: "Cilium-PR-K8s-1.14-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
-                        ])
+                        build(job: "Cilium-Master-K8s-1.14", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}")
+                        ])  
                     }
                 }
 
                 stage('K8s-1.15-kernel-4.9') {
                     steps {
-                        build(job: "Cilium-PR-K8s-1.15-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        build(job: "Cilium-Master-K8s-1.15", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}")
                         ])
                     }
                 }
 
                 stage('K8s-1.16-kernel-4.9') {
                     steps {
-                        build(job: "Cilium-PR-K8s-1.16-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        build(job: "Cilium-Master-K8s-1.16", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}")
                         ])
                     }
                 }
 
                 stage('K8s-1.17-kernel-4.9') {
                     steps {
-                        build(job: "Cilium-PR-K8s-1.17-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        build(job: "Cilium-Master-K8s-1.17", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}")
                         ])
                     }
                 }
 
                 stage('K8s-1.18-kernel-4.9') {
                     steps {
-                        build(job: "Cilium-PR-K8s-1.18-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        build(job: "Cilium-Master-K8s-1.18", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}")
                         ])
                     }
                 }
 
                 stage('K8s-1.19-kernel-4.9') {
                     steps {
-                        build(job: "Cilium-PR-K8s-1.19-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
+                        build(job: "Cilium-Master-K8s-1.19", parameters: [
+                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}")
                         ])
                     }
                 }


### PR DESCRIPTION
When splitting `ginkgo-kubernetes-all.Jenkinsfile` in #14861, we offloaded the actual work to PR jobs.
    
However, this means daily `cilium-master-K8s-all`-triggered job results are mixed in with PR-triggered job results. For tracking purposes, separate jobs have been created and are now triggered from `ginkgo-kubernetes-all.Jenkinsfile`: https://jenkins.cilium.io/job/cilium-master-K8s-all-jobs/
    
To avoid `Cilium-PR-Ginkgo-Tests-K8s` triggering these jobs when itself triggered by usage of deprecated `test-missed-k8s` on new branches, a condition filter is added to refuse building when not on `master`.