### PR TITLE
ci: Bump vagrant boxes

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,10 +3,10 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "188"
+$SERVER_VERSION= "190"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "83"
 @v419_SERVER_BOX= "cilium/ubuntu-4-19"
-@v419_SERVER_VERSION= "30"
+@v419_SERVER_VERSION= "31"
 @v49_SERVER_BOX= "cilium/ubuntu"
-@v49_SERVER_VERSION= "188"
+@v49_SERVER_VERSION= "190"


### PR DESCRIPTION
This bumps the vagrant boxes to the latest version, which updates Go to
1.15.8 and pulls in the latest Hubble API changes.