### PR TITLE
iptables: Skip CILIUM_TRANSIENT_FORWARD for IPv6

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1124,7 +1124,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 		if err := transientChain.add(m.waitArgs); err != nil {
 			return fmt.Errorf("cannot add custom chain %s: %s", transientChain.name, err)
 		}
-		if err := m.installForwardChainRules(ifName, localDeliveryInterface, transientChain.name); err != nil {
+		if err := m.installForwardChainRulesIpX("iptables", ifName, localDeliveryInterface, transientChain.name); err != nil {
 			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
 		}
 		if err := transientChain.installFeeder(m.waitArgs); err != nil {


### PR DESCRIPTION
Commit 317a671 ("iptables: Populate `CILIUM_FORWARD` chain for IPv6") fixed the agent to add IPv6 counterparts to the Cilium IPv4 rules in `CILIUM_FORWARD`. The same method is however used to install rules in `CILIUM_FORWARD` and `CILIUM_TRANSIENT_FORWARD`. The IPv6 chain for `CILIUM_TRANSIENT_FORWARD` doesn't exist, resulting in the following error message:

    level=error msg="Command execution failed" cmd="[ip6tables -w 5 -A CILIUM_TRANSIENT_FORWARD -o cilium_host -m comment --comment cilium (transient): any->cluster on cilium_host forward accept -j ACCEPT]" error="exit status 1" subsys=iptables
    level=warning msg="ip6tables: No chain/target/match by that name." subsys=iptables
    level=warning msg="failed to install transient iptables rules" error="cannot install forward chain rules to CILIUM_TRANSIENT_FORWARD: exit status 1" subsys=datapath-loader

This pull request fixes it by skipping the installation of IPv6 rules in `CILIUM_TRANSIENT_FORWARD`. If we want those rules, more work is required.

Fixes: https://github.com/cilium/cilium/pull/14675