### PR TITLE
ci: use separate Jenkins jobs for daily master tests + CI documentation overhaul

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -153,31 +153,12 @@ packet.net before the branch is merged.
 Testing matrix
 ^^^^^^^^^^^^^^
 
-We are currently testing following kernel - k8s version pairs in our CI:
+Up to date CI testing information regarding k8s - kernel version pairs can
+always be found in the `Cilium CI matrix`_.
 
-+--------------------+------------------+
-| Kubernetes version | Kernel version   |
-+====================+==================+
-| Vagrant k8s clusters per PR           |
-+--------------------+------------------+
-| 1.13               | 5.x.x (net-next) |
-+--------------------+------------------+
-| 1.19               | 4.19.57          |
-+--------------------+------------------+
-| 1.20               | 4.9              |
-+--------------------+------------------+
-| Vagrant k8s clusters per backport     |
-| (in addition to PR)                   |
-+--------------------+------------------+
-| 1.{13-19}          | 4.9              |
-+--------------------+------------------+
-| GKE clusters                          |
-+--------------------+------------------+
-| 1.15.12            | 4.19.112+        |
-+--------------------+------------------+
+.. _Cilium CI matrix: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0
 
 .. _trigger_phrases:
-
 
 Triggering Pull-Request Builds With Jenkins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,70 +166,36 @@ Triggering Pull-Request Builds With Jenkins
 To ensure that build resources are used judiciously, builds on Jenkins
 are manually triggered via comments on each pull-request that contain
 "trigger-phrases". Only members of the Cilium GitHub organization are
-allowed to trigger these jobs. Refer to the table below for information
-regarding which phrase triggers which build, which build is required for
-a pull-request to be merged, etc. Each linked job contains a description
-illustrating which subset of tests the job runs.
+allowed to trigger these jobs.
 
+Depending on the PR target branch, a specific set of jobs is marked as required,
+as per the `Cilium CI matrix`_. They will be automatically featured in PR checks
+directly on the PR page. The following trigger phrases may be used to trigger
+them all at once:
 
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| Jenkins Job                                                                                                    | Trigger Phrases   | Required To Merge? |
-+================================================================================================================+===================+====================+
-| `Cilium-PR-K8s-1.20-kernel-4.9 <https://jenkins.cilium.io/job/Cilium-PR-K8s-1.20-kernel-4.9/>`_                | test-me-please,   | Yes                |
-|                                                                                                                | retest-4.9        |                    |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-Kernel <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Kernel/>`_                | test-me-please,   | Yes                |
-|                                                                                                                | retest-4.19       |                    |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-K8s-1.13-net-next <https://jenkins.cilium.io/job/Cilium-PR-K8s-1.13-net-next/>`_                    | test-me-please,   | Yes                |
-|                                                                                                                | retest-net-next   |                    |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Runtime-4.9 <https://jenkins.cilium.io/job/Cilium-PR-Runtime-4.9/>`_                                | test-me-please,   | Yes                |
-|                                                                                                                | retest-runtime    |                    |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-Kernel-Focus <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Kernel-Focus/>`_    | test-only         | No                 |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-Validated <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/>`_          | restart-ginkgo    | No                 |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Kubernetes-Upstream <https://jenkins.cilium.io/job/Cilium-PR-Kubernetes-Upstream/>`_                | test-upstream-k8s | No                 |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_ (where ``X.XX`` is a K8s version)        | test-X.XX-4.9     | No                 |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| All non-required `Cilium-PR-K8s-X.XX-kernel-4.9 <https://jenkins.cilium.io/view/PR/>`_                         | test-older-k8s    | No                 |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-K8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/>`_                      | test-missed-k8s   | No                 |
-|                                                                                                                | **(deprecated)**  |                    |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-me-please,   | Yes                |
-|                                                                                                                | retest-gke        |                    |
-+----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
++------------------+--------------------------+
+| PR target branch | Trigger required PR jobs |
++==================+==========================+
+| master           | test-me-please           |
++------------------+--------------------------+
+| v1.9             | test-backport-1.9        |
++------------------+--------------------------+
+| v1.8             | test-backport-1.8        |
++------------------+--------------------------+
+| v1.7             | test-backport-1.7        |
++------------------+--------------------------+
 
-For a full list of Jenkins Jobs, see `Jenkins
+For ``master`` PRs: on top of ``test-me-please``, one may use 
+``test-missed-k8s`` to trigger all non-required K8s versions on Kernel 4.9 as
+per the `Cilium CI matrix`_.
+
+For all PRs: one may manually retrigger a specific job (e.g. in case of a flake)
+with the individual trigger featured directly in the PR check's name (e.g. for
+``K8s-1.20-kernel-4.9 (test-1.20-4.9)``, use ``test-1.20-4.9``).
+
+For a full list of Jenkins PR jobs, see `Jenkins
 <https://jenkins.cilium.io/view/PR/>`_. Trigger phrases are configured within
 each job's build triggers advanced options.
-
-``test-older-k8s`` allows testing older supported K8s versions, i.e. all
-non-required K8s jobs, by triggering all appropriate
-``Cilium-PR-K8s-X.XX-kernel-4.9`` jobs.
-For example, at the time of writing, it is identical to manually running
-``test-X.XX-4.9`` for versions 1.14 through 1.19.
-If a specific K8s version fails, it can be re-run using ``retest-X.XX-4.9``.
-
-``test-missed-k8s`` is deprecated and superseded by ``test-older-k8s``:
-
-- For new branches: it triggers a ``Cilium-PR-Ginkgo-Tests-K8s`` which does
-  exactly the same thing (triggers all ``Cilium-PR-K8s-X.XX-kernel-4.9`` jobs),
-  except that the compound job (and not the individual jobs) will be displayed
-  on the PR page. This makes it more cumbersome to detect which specific K8s
-  version failed in case of failure.
-- For older branches (where ``test-missed-k8s`` is unavailable): triggers a
-  ``Cilium-PR-Ginkgo-Tests-K8s`` testing older K8s versions by itself.
-  It should not be used for new branches, only for Backport PRs for which
-  ``test-older-k8s`` is unavailable.
-
-For Backport PRs, the phrase ``test-backport-x.x`` (with ``x.x`` being the target Cilium version) should be used to
-trigger all of the above jobs which are marked as required to validate changes
-to existing releases.
 
 There are some feature flags based on Pull Requests labels, the list of labels
 are the following:

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -713,6 +713,7 @@ reproducibility
 requireIPv
 retpoline
 retransmission
+retrigger
 retryTimeout
 rn
 roadmap

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -1,10 +1,63 @@
 @Library('cilium') _
 
 pipeline {
-    agent none
+    agent {
+        label 'baremetal'
+    }
 
     parameters {
-        string(defaultValue: 'origin/master', name: 'GIT_BRANCH')
+        string(defaultValue: '${ghprbPullDescription}', name: 'ghprbPullDescription')
+        string(defaultValue: '${ghprbActualCommit}', name: 'ghprbActualCommit')
+        string(defaultValue: '${ghprbTriggerAuthorLoginMention}', name: 'ghprbTriggerAuthorLoginMention')
+        string(defaultValue: '${ghprbPullAuthorLoginMention}', name: 'ghprbPullAuthorLoginMention')
+        string(defaultValue: '${ghprbGhRepository}', name: 'ghprbGhRepository')
+        string(defaultValue: '${ghprbPullLongDescription}', name: 'ghprbPullLongDescription')
+        string(defaultValue: '${ghprbCredentialsId}', name: 'ghprbCredentialsId')
+        string(defaultValue: '${ghprbTriggerAuthorLogin}', name: 'ghprbTriggerAuthorLogin')
+        string(defaultValue: '${ghprbPullAuthorLogin}', name: 'ghprbPullAuthorLogin')
+        string(defaultValue: '${ghprbTriggerAuthor}', name: 'ghprbTriggerAuthor')
+        string(defaultValue: '${ghprbCommentBody}', name: 'ghprbCommentBody')
+        string(defaultValue: '${ghprbPullTitle}', name: 'ghprbPullTitle')
+        string(defaultValue: '${ghprbPullLink}', name: 'ghprbPullLink')
+        string(defaultValue: '${ghprbAuthorRepoGitUrl}', name: 'ghprbAuthorRepoGitUrl')
+        string(defaultValue: '${ghprbTargetBranch}', name: 'ghprbTargetBranch')
+        string(defaultValue: '${ghprbPullId}', name: 'ghprbPullId')
+        string(defaultValue: '${ghprbActualCommitAuthor}', name: 'ghprbActualCommitAuthor')
+        string(defaultValue: '${ghprbActualCommitAuthorEmail}', name: 'ghprbActualCommitAuthorEmail')
+        string(defaultValue: '${ghprbTriggerAuthorEmail}', name: 'ghprbTriggerAuthorEmail')
+        string(defaultValue: '${GIT_BRANCH}', name: 'GIT_BRANCH')
+        string(defaultValue: '${ghprbPullAuthorEmail}', name: 'ghprbPullAuthorEmail')
+        string(defaultValue: '${sha1}', name: 'sha1')
+        string(defaultValue: '${ghprbSourceBranch}', name: 'ghprbSourceBranch')
+    }
+
+    environment {
+        PROJ_PATH = "src/github.com/cilium/cilium"
+        VM_MEMORY = "4096"
+        TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+        GOPATH="${WORKSPACE}"
+        SERVER_BOX = "cilium/ubuntu"
+        FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
+        CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
+        HOST_FIREWALL=setIfLabel("ci/host-firewall", "1", "0")
+        GINKGO_TIMEOUT="118m"
+        RACE="""${sh(
+                returnStdout: true,
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n ""; else echo -n "1"; fi'
+            )}"""
+        LOCKDEBUG="""${sh(
+                returnStdout: true,
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n ""; else echo -n "1"; fi'
+            )}"""
+        BASE_IMAGE="""${sh(
+                returnStdout: true,
+                script: 'if [ "${run_with_race_detection}" = "" ]; then echo -n "scratch"; else echo -n "quay.io/cilium/cilium-runtime:2021-01-20@sha256:247eff116cc5d0b3a4931eabd67ea2e8679f7c12877729a73929d3f30753065b"; fi'
+            )}"""
+        RUN_QUARANTINED="""${sh(
+                returnStdout: true,
+                script: 'if [ "${RunQuarantined}" = "" ]; then echo -n "false"; else echo -n "${RunQuarantined}"; fi'
+            )}"""
+		KUBECONFIG="vagrant-kubeconfig"
     }
 
     options {
@@ -14,65 +67,527 @@ pipeline {
     }
 
     stages {
-        stage('Trigger parallel baremetal K8s builds') {
+        stage('Set build name') {
+            when {
+                not {environment name: 'GIT_BRANCH', value: 'origin/master'}
+            }
+            steps {
+                   script {
+                       currentBuild.displayName = env.getProperty('ghprbPullTitle') + '  ' + env.getProperty('ghprbPullLink') + '  ' + currentBuild.displayName
+                   }
+            }
+        }
+        stage('Checkout') {
+            options {
+                timeout(time: 20, unit: 'MINUTES')
+            }
+
+            steps {
+                sh 'env'
+                Status("PENDING", "${env.JOB_NAME}")
+                checkout scm
+                sh 'mkdir -p ${PROJ_PATH}'
+                sh 'ls -A | grep -v src | xargs mv -t ${PROJ_PATH}'
+                sh '/usr/local/bin/cleanup || true'
+            }
+        }
+        stage('Log in to dockerhub') {
+            steps{
+                withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                    sh 'echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_LOGIN} --password-stdin'
+                }
+            }
+        }
+        stage('Make Cilium images') {
+            environment {
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            steps {
+                sh 'cd ${TESTDIR}; ./make-images-push-to-local-registry.sh $(./print-node-ip.sh) latest'
+            }
+            post {
+                unsuccessful {
+                    script {
+                        if  (!currentBuild.displayName.contains('fail')) {
+                            currentBuild.displayName = 'building or pushing Cilium images failed ' + currentBuild.displayName
+                        }
+                    }
+                }
+            }
+        }
+        stage('Preload vagrant boxes') {
+            steps {
+                sh '/usr/local/bin/add_vagrant_box ${WORKSPACE}/${PROJ_PATH}/vagrant_box_defaults.rb'
+            }
+            post {
+                unsuccessful {
+                    script {
+                        if  (!currentBuild.displayName.contains('fail')) {
+                            currentBuild.displayName = 'preload vagrant boxes fail' + currentBuild.displayName
+                        }
+                    }
+                }
+            }
+        }
+        stage('Copy code and boot VMs 1.{14,15}'){
+
+            options {
+                timeout(time: 60, unit: 'MINUTES')
+            }
+
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+
             parallel {
-                stage('K8s-1.14-kernel-4.9') {
+                stage('Boot vms 1.14') {
+                    environment {
+                        K8S_VERSION="1.14"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
                     steps {
-                        build(job: "Cilium-PR-K8s-1.14-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
-                        ])
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 30, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.14 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
                     }
                 }
-
-                stage('K8s-1.15-kernel-4.9') {
+                stage('Boot vms 1.15') {
+                    environment {
+                        K8S_VERSION="1.15"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
                     steps {
-                        build(job: "Cilium-PR-K8s-1.15-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
-                        ])
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 30, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.15 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
                     }
                 }
-
-                stage('K8s-1.16-kernel-4.9') {
+            }
+        }
+        stage('BDD-Test-k8s-1.14-and-1.15') {
+            environment {
+                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
+                CILIUM_IMAGE = """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/cilium'
+                        )}"""
+                CILIUM_TAG = "latest"
+                CILIUM_OPERATOR_IMAGE= """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator'
+                        )}"""
+                CILIUM_OPERATOR_TAG = "latest"
+                HUBBLE_RELAY_IMAGE= """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/hubble-relay'
+                        )}"""
+                HUBBLE_RELAY_TAG = "latest"
+                KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
+            }
+            options {
+                timeout(time: 360, unit: 'MINUTES')
+            }
+            parallel {
+                stage('BDD-Test-k8s-1.14') {
+                    environment {
+                        K8S_VERSION="1.14"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
                     steps {
-                        build(job: "Cilium-PR-K8s-1.16-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
-                        ])
+                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.14 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
                     }
                 }
-
-                stage('K8s-1.17-kernel-4.9') {
+                stage('BDD-Test-k8s-1.15') {
+                    environment {
+                        K8S_VERSION="1.15"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
                     steps {
-                        build(job: "Cilium-PR-K8s-1.17-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
-                        ])
+                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.15 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
                     }
                 }
+            }
+        }
 
-                stage('K8s-1.18-kernel-4.9') {
+        stage('Copy code and boot VMs 1.{15,16}'){
+
+            options {
+                timeout(time: 60, unit: 'MINUTES')
+            }
+
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+
+            parallel {
+                stage('Boot vms 1.16') {
+                    environment {
+                        K8S_VERSION="1.16"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
                     steps {
-                        build(job: "Cilium-PR-K8s-1.18-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
-                        ])
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 30, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.16 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
                     }
                 }
-
-                stage('K8s-1.19-kernel-4.9') {
+                stage('Boot vms 1.17') {
+                    environment {
+                        K8S_VERSION="1.17"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
                     steps {
-                        build(job: "Cilium-PR-K8s-1.19-kernel-4.9", parameters: [
-                            string(name: 'GIT_BRANCH', value: "${GIT_BRANCH}"),
-                            string(name: 'sha1', value: "${GIT_BRANCH}")
-                        ])
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 30, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.17 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('BDD-Test-k8s-1.16-and-1.17') {
+            environment {
+                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
+                CILIUM_IMAGE = """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/cilium'
+                        )}"""
+                CILIUM_TAG = "latest"
+                CILIUM_OPERATOR_IMAGE= """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator'
+                        )}"""
+                CILIUM_OPERATOR_TAG = "latest"
+                HUBBLE_RELAY_IMAGE= """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/hubble-relay'
+                        )}"""
+                HUBBLE_RELAY_TAG = "latest"
+                KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
+            }
+            options {
+                timeout(time: 300, unit: 'MINUTES')
+            }
+            parallel {
+                stage('BDD-Test-k8s-1.16') {
+                    environment {
+                        K8S_VERSION="1.16"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.16 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+                stage('BDD-Test-k8s-1.17') {
+                    environment {
+                        K8S_VERSION="1.17"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.17 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Copy code and boot VMs 1.{18,19}'){
+
+            options {
+                timeout(time: 60, unit: 'MINUTES')
+            }
+
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+
+            parallel {
+                stage('Boot vms 1.18') {
+                    environment {
+                        K8S_VERSION="1.18"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 30, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.18 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+                stage('Boot vms 1.19') {
+                    environment {
+                        K8S_VERSION="1.19"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
+                            retry(3) {
+                                timeout(time: 30, unit: 'MINUTES'){
+                                    dir("${TESTDIR}") {
+                                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.19 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('BDD-Test-k8s-1.18-and-1.19') {
+            environment {
+                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
+                CILIUM_IMAGE = """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/cilium'
+                        )}"""
+                CILIUM_TAG = "latest"
+                CILIUM_OPERATOR_IMAGE= """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/operator'
+                        )}"""
+                CILIUM_OPERATOR_TAG = "latest"
+                HUBBLE_RELAY_IMAGE= """${sh(
+                        returnStdout: true,
+                        script: 'echo -n $(${TESTDIR}/print-node-ip.sh)/cilium/hubble-relay'
+                        )}"""
+                KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
+            }
+            options {
+                timeout(time: 180, unit: 'MINUTES')
+            }
+            parallel {
+                stage('BDD-Test-k8s-1.18') {
+                    environment {
+                        K8S_VERSION="1.18"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.18 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+                stage('BDD-Test-k8s-1.19') {
+                    environment {
+                        K8S_VERSION="1.19"
+                        GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; ginkgo --focus="K8s" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.19 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
     }
     post {
+        always {
+            sh 'lscpu'
+            archiveArtifacts artifacts: '*.zip'
+            junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
+            cleanWs()
+            sh '/usr/local/bin/cleanup || true'
+        }
         success {
             Status("SUCCESS", "${env.JOB_NAME}")
         }


### PR DESCRIPTION
Following today's cartography and multiple fixes, documentation has been updated accordingly.

# Context

When splitting `ginkgo-kubernetes-all.Jenkinsfile` in #14861, we offloaded the actual work to PR jobs. However, this means daily `cilium-master-K8s-all`-triggered job results were mixed in with PR-triggered job results. For tracking purposes, separate jobs needed to be setup.

We took this oppurtunity to review, document, and accordingly fix a big part of the CI jobs, notably:
- What to test automatically at regular intervals.
- Which jobs are required for which PRs.
- Which phrases trigger which jobs.

# Detailed recap of changes made so far

- Creation and publication of The Table of Truth:tm:: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0
- Master jobs
  - Automated testing jobs running every 4 hours or daily have been setup according to the Table of Truth:tm:.
  - Most jobs have been renamed to make it clear which K8s version and Kernel version they're running.
  - `cilium-master-K8s-all`, now superseded by individual jobs, has been disabled and moved to the `Obsolete` view.
- PR jobs
  - All jobs marked as required for a PR in the Table of Truth:tm: have been setup accordingly on GitHub.
  - All the triggers in required PR jobs have been reviewed, fixed according to the Table of Truth:tm:, and documented below the Table of Truth:tm:.
  - `Cilium-PR-Ginkgo-Tests-Kernel` (job for K8s 1.19 / Kernel 4.19) edited to correctly use K8s version 1.19 (and not 1.18, which seems to be a leftover).

Note: unlike 1.8 and 1.9, `test-backport-1.7` does not trigger individual jobs. It still triggers the old `Cilium-PR-Ginkgo-Tests-K8s`,
because we were unsure of the robustness of `ginkgo-kernel.Jenkinsfile` on 1.7. We may backport the updated `ginkgo-kernel.Jenkinsfile` to 1.7 in a future PR.

# Partial revert of #14861

The previous changes to `ginkgo-kubernetes-all.Jenkinsfile` in #14861 are now unneeded. These changes were reverted as part of this PR to help with the transition, since another job is still dependent upon `ginkgo-kubernetes-all.Jenkinsfile`: https://jenkins.cilium.io/view/Quarantine%20Pipelines/job/cilium-master-K8s-all-Quarantine/