### PR TITLE
cilium: encryption fix, ipv4-pod-subnets without encryptnode fails

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -473,7 +473,9 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 		spi, err = ipsec.UpsertIPsecEndpoint(ipsecIPv4Wildcard, cidr, ipsec.IPSecDirOut)
 		upsertIPsecLog(err, "CNI Out IPv4", ipsecIPv4Wildcard, cidr, spi)
 
-		n.replaceNodeExternalIPSecOutRoute(cidr)
+		if n.nodeConfig.EncryptNode {
+			n.replaceNodeExternalIPSecOutRoute(cidr)
+		}
 	}
 
 	for _, cidr := range v6CIDR {
@@ -485,7 +487,9 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 		spi, err := ipsec.UpsertIPsecEndpoint(ipsecIPv6Wildcard, cidr, ipsec.IPSecDirOut)
 		upsertIPsecLog(err, "CNI Out IPv6", cidr, ipsecIPv6Wildcard, spi)
 
-		n.replaceNodeExternalIPSecOutRoute(cidr)
+		if n.nodeConfig.EncryptNode {
+			n.replaceNodeExternalIPSecOutRoute(cidr)
+		}
 	}
 }
 
@@ -847,7 +851,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		n.insertNeighbor(context.Background(), newNode, ifaceName, false)
 	}
 
-	if n.nodeConfig.EnableIPSec {
+	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
 		n.encryptNode(newNode)
 	}
 


### PR DESCRIPTION
In the default mode encryption picks the outer IP headers to use
based on the destination IP of the packet to be encrypted. This
works because we create a IPSec rule that matches the destination
IP of the packet using the node CIDR IP used to allocate IPs for
that node. This allows us to scale rules with number of nodes
instead of number of pods.

However, in modes where a global IP pool is used for any pods we
no longer have a subnet -> pod mapping that we use above. To
handle this case, instead of adding a rule per pod, we rewrite
the srcIP,dstIP after encryption using the ipcache. The ipcache
has the pod->node mapping so we can use this reliable. Then we
do a fib lookup to rewrite the src/dst MAC and redirect out the
correct egress interface.

But, we have a bug where nodeEncrypt routing rules are added
even if encryptNode is not enabled. Additionally, when encryptNode
is enabled we add wrong and possibly conflicting rules from the
normal path.

To fix ensure we only add encryptNode routes correctlyy from the
subnetEncryption path with ipv4-pod-subnets is enabled.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>