### PR TITLE
ci: fix checking for pr git sha in jenkinsfiles

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         stage('Set programmatic env vars') {
             steps {
                 script {
-                    if (env.ghprbActualCommit != "") {
+                    if (env.ghprbActualCommit?.trim()) {
                         env.DOCKER_TAG = env.ghprbActualCommit
                     } else {
                         env.DOCKER_TAG = env.GIT_COMMIT

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                             echo -n "K8s"
                         fi''', returnStdout: true
 
-                    if (env.ghprbActualCommit != "") {
+                    if (env.ghprbActualCommit?.trim()) {
                         env.DOCKER_TAG = env.ghprbActualCommit
                     } else {
                         env.DOCKER_TAG = env.GIT_COMMIT


### PR DESCRIPTION
builds running on master didn't have `ghprbActualCommit` env var, which
resulted in it being `null` in `env` object. This change changes the
check to make sure that in case this env var is not existing, correct
value is set as `DOCKER_TAG`