### PR TITLE
CODEOWNERS: Update required reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,7 @@
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/janitors
+/CODEOWNERS @cilium/contributing
 /.github/ @cilium/contributing
 /.github/workflows/ @cilium/maintainers @cilium/ci-structure
 /api/ @cilium/api

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@
 # is not properly picked up in Github.
 * @cilium/janitors
 /.github/ @cilium/contributing
-/.github/workflows/ @cilium/maintainers
+/.github/workflows/ @cilium/maintainers @cilium/ci-structure
 /api/ @cilium/api
 /api/v1/flow/ @cilium/api @cilium/hubble
 /api/v1/observer/ @cilium/api @cilium/hubble


### PR DESCRIPTION
- `.github/workflows/` requires a review from maintainers as changes in that directory can have security implications. We should also request a review from the CI team as these files are part of CI after all.
- Also request a review from @cilium/contributing on changes to `CODEOWNERS`.