### PR TITLE
test: Use Endpoint instead of EndpointSlice in 1.17

### DIFF
--- a/test/k8sT/manifests/1.17/external_endpoint.yaml
+++ b/test/k8sT/manifests/1.17/external_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-service
+  namespace: default
+subsets:
+- addresses:
+  - ip: 198.49.23.144
+  ports:
+  - port: 80
+    protocol: TCP


### PR DESCRIPTION
GKE keeps EndpointSlice controller disabled by default on 1.17 clusters.
This change causes tests to use `Endpoint` object instead of
`EndpointSlice` on 1.17 clusters.

fixes #14996