### PR TITLE
v1.7 backports 2021-02-17

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -77,6 +77,9 @@ Limitations
 * When applying L7 policies at egress, the source identity context is lost as
   it is currently not carried in the packet. This means that traffic will look
   like it is coming from outside of the cluster to the receiving pod.
+* HostPort type services additionally requires the following configuration:
+
+   * :ref:`k8s_install_portmap`
 
 Troubleshooting
 ===============

--- a/Documentation/gettingstarted/cni-chaining-portmap.rst
+++ b/Documentation/gettingstarted/cni-chaining-portmap.rst
@@ -4,6 +4,8 @@
     Please use the official rendered version released here:
     http://docs.cilium.io
 
+.. _k8s_install_portmap:
+
 ******************
 Portmap (HostPort)
 ******************

--- a/Documentation/gettingstarted/identity-relevant-labels.rst
+++ b/Documentation/gettingstarted/identity-relevant-labels.rst
@@ -18,24 +18,40 @@ when included in evaluation, cause Cilium to generate a unique identity for each
 pod instead of a single identity for all of the pods that comprise a service or
 application.
 
-By default, Cilium evaluates the following labels:
+By default, Cilium considers all labels to be relevant for identities, with the
+following exceptions:
 
-=================================== ==================================================
+================================== ==============================================
 Label                               Description
------------------------------------ --------------------------------------------------
-``k8s:io.kubernetes.pod.namespace`` Include all ``io.kubernetes.pod.namespace`` labels
-``k8s:app.kubernetes.io``           Include all ``app.kubernetes.io`` labels
-``k8s:!io.kubernetes``              Ignore all ``io.kubernetes`` labels
-``k8s:!kubernetes.io``              Ignore all other ``kubernetes.io`` labels
-``k8s:!beta.kubernetes.io``         Ignore all ``beta.kubernetes.io`` labels
-``k8s:!k8s.io``                     Ignore all ``k8s.io`` labels
-``k8s:!pod-template-generation``    Ignore all ``pod-template-generation`` labels
-``k8s:!pod-template-hash``          Ignore all ``pod-template-hash`` labels
-``k8s:!controller-revision-hash``   Ignore all ``controller-revision-hash`` labels
-``k8s:!annotation.*``               Ignore all ``annotation labels``
-``k8s:!etcd_node``                  Ignore all ``etcd_node`` labels
-=================================== ==================================================
+---------------------------------- ----------------------------------------------
+``any:!io.kubernetes``             Ignore all ``io.kubernetes`` labels
+``any:!kubernetes.io``             Ignore all other ``kubernetes.io`` labels
+``any:!beta.kubernetes.io``        Ignore all ``beta.kubernetes.io`` labels
+``any:!k8s.io``                    Ignore all ``k8s.io`` labels
+``any:!pod-template-generation``   Ignore all ``pod-template-generation`` labels
+``any:!pod-template-hash``         Ignore all ``pod-template-hash`` labels
+``any:!controller-revision-hash``  Ignore all ``controller-revision-hash`` labels
+``any:!annotation.*``              Ignore all ``annotation labels``
+``any:!etcd_node``                 Ignore all ``etcd_node`` labels
+================================== ==============================================
 
+The above label examples are all *exclusive labels*, that is to say they define
+which label keys should be ignored. These are identified by the presence of the
+``!`` character.
+
+Label configurations that do not contain the ``!`` character are *inclusive
+labels*. Once at least one inclusive label is added, only labels that match the
+inclusive label configuration may be considered relevant for identities.
+Additionally, when at least one inclusive label is configured, the following
+inclusive labels are automatically added to the configuration:
+
+====================================== =====================================================
+Label                                  Description
+-------------------------------------- -----------------------------------------------------
+``any:io.kubernetes.pod.namespace``    Include all ``io.kubernetes.pod.namespace`` labels
+``any:io.cilium.k8s.namespace.labels`` Include all ``io.cilium.k8s.namespace.labels`` labels
+``any:app.kubernetes.io``              Include all ``app.kubernetes.io`` labels
+====================================== =====================================================
 
 
 Configuring Identity-Relevant Labels
@@ -78,29 +94,34 @@ Including Labels
 ----------------
 
 Labels can be defined as a list of labels to include. Only the labels specified
-will be used to evaluate Cilium identities:
+and the default inclusive labels will be used to evaluate Cilium identities:
 
 .. code-block:: bash
 
     labels: "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
 
-The above configuration would only include the following labels when evaluating
-Cilium identities:
+The above configuration would only include the following label keys when
+evaluating Cilium identities:
 
-- io.kubernetes.pod.namespace*=.*
-- k8s-app*=*
-- app*=*
-- name*=*
+- k8s:k8s-app
+- k8s:app
+- k8s:name
+- io.kubernetes.pod.namespace
+- io.cilium.k8s.namespace.labels
+- app.kubernetes.io
+
+Note that ``k8s:io.kubernetes.pod.namespace`` is already included in default
+label ``io.kubernetes.pod.namespace``.
 
 Labels with the same prefix as defined in the configuration will also be
-considered. This lists some examples of labels that would also be evaluated for
-Cilium identities:
+considered. This lists some examples of label keys that would also be evaluated
+for Cilium identities:
 
-- k8s-app-team*=*
-- app-production*=*
-- name-defined*=*
+- k8s-app-team
+- app-production
+- name-defined
 
-When a single "inclusive label" is added to the filter, all labels not defined
+When a single inclusive label is added to the filter, all labels not defined
 in the default list will be excluded. For example, pods running with the
 security labels ``team=team-1, env=prod`` will have the label ``env=prod``
 ignored as soon Cilium is started with the filter ``k8s:team``.
@@ -120,5 +141,5 @@ exclude any matches in the provided list when evaluating Cilium identities:
 The provided example would cause Cilium to exclude any of the following label
 matches:
 
-- k8s:controller-uid=*
-- k8s:job-name=*
+- k8s:controller-uid
+- k8s:job-name

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -23,6 +23,7 @@ datapath instead of the default veth-based one.
 
     - IPVLAN L2 mode
     - L7 policy enforcement
+    - FQDN Policies
     - NAT64
     - IPVLAN with tunneling
 

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -19,7 +19,6 @@ package labels
 import (
 	"github.com/cilium/cilium/pkg/checker"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-
 	. "gopkg.in/check.v1"
 )
 
@@ -78,5 +77,89 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	c.Assert(filtered, checker.DeepEquals, wanted)
 	// Making sure we are deep copying the labels
 	allLabels["id.lizards"] = NewLabel("id.lizards", "web", "I can change this and doesn't affect any one")
+	c.Assert(filtered, checker.DeepEquals, wanted)
+}
+
+func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
+	wanted := Labels{
+		"app.kubernetes.io":           NewLabel("app.kubernetes.io", "my-nginx", LabelSourceContainer),
+		"id.lizards.k8s":              NewLabel("id.lizards.k8s", "web", LabelSourceK8s),
+		"id.lizards":                  NewLabel("id.lizards", "web", LabelSourceContainer),
+		"ignorE":                      NewLabel("ignorE", "foo", LabelSourceContainer),
+		"ignore":                      NewLabel("ignore", "foo", LabelSourceContainer),
+		"reserved:host":               NewLabel("reserved:host", "", LabelSourceAny),
+		"io.kubernetes.pod.namespace": NewLabel("io.kubernetes.pod.namespace", "default", LabelSourceContainer),
+	}
+
+	err := ParseLabelPrefixCfg([]string{}, "")
+	c.Assert(err, IsNil)
+	dlpcfg := validLabelPrefixes
+	allNormalLabels := map[string]string{
+		"io.kubernetes.container.hash":                              "cf58006d",
+		"io.kubernetes.container.name":                              "POD",
+		"io.kubernetes.container.restartCount":                      "0",
+		"io.kubernetes.container.terminationMessagePath":            "",
+		"io.kubernetes.pod.name":                                    "my-nginx-3800858182-07i3n",
+		"io.kubernetes.pod.namespace":                               "default",
+		"app.kubernetes.io":                                         "my-nginx",
+		"kubernetes.io.foo":                                         "foo",
+		"beta.kubernetes.io.foo":                                    "foo",
+		"annotation.kubectl.kubernetes.io":                          "foo",
+		"annotation.hello":                                          "world",
+		"annotation." + k8sConst.CiliumIdentityAnnotationDeprecated: "12356",
+		"io.kubernetes.pod.terminationGracePeriod":                  "30",
+		"io.kubernetes.pod.uid":                                     "c2e22414-dfc3-11e5-9792-080027755f5a",
+		"ignore":                                                    "foo",
+		"ignorE":                                                    "foo",
+		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
+		"controller-revision-hash":                                  "123456",
+	}
+	allLabels := Map2Labels(allNormalLabels, LabelSourceContainer)
+	allLabels["reserved:host"] = NewLabel("reserved:host", "", LabelSourceAny)
+	filtered, _ := dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
+	allLabels["id.lizards"] = NewLabel("id.lizards", "web", LabelSourceContainer)
+	allLabels["id.lizards.k8s"] = NewLabel("id.lizards.k8s", "web", LabelSourceK8s)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 7)
+	c.Assert(filtered, checker.DeepEquals, wanted)
+}
+
+func (s *LabelsPrefCfgSuite) TestFilterLabelsDocExample(c *C) {
+	wanted := Labels{
+		"io.cilium.k8s.namespace.labels": NewLabel("io.cilium.k8s.namespace.labels", "foo", LabelSourceK8s),
+		"k8s-app-team":                   NewLabel("k8s-app-team", "foo", LabelSourceK8s),
+		"app-production":                 NewLabel("app-production", "foo", LabelSourceK8s),
+		"name-defined":                   NewLabel("name-defined", "foo", LabelSourceK8s),
+		"io.kubernetes.pod.namespace":    NewLabel("io.kubernetes.pod.namespace", "docker", LabelSourceAny),
+	}
+
+	err := ParseLabelPrefixCfg([]string{"k8s:io.kubernetes.pod.namespace", "k8s:k8s-app", "k8s:app", "k8s:name"}, "")
+	c.Assert(err, IsNil)
+	dlpcfg := validLabelPrefixes
+	allNormalLabels := map[string]string{
+		"io.cilium.k8s.namespace.labels": "foo",
+		"k8s-app-team":                   "foo",
+		"app-production":                 "foo",
+		"name-defined":                   "foo",
+	}
+	allLabels := Map2Labels(allNormalLabels, LabelSourceK8s)
+	filtered, _ := dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 4)
+
+	// Reserved labels are not included.
+	allLabels["host"] = NewLabel("host", "", LabelSourceReserved)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 4)
+
+	// io.kubernetes.pod.namespace=docker matches because the default list has any:io.kubernetes.pod.namespace.
+	allLabels["io.kubernetes.pod.namespace"] = NewLabel("io.kubernetes.pod.namespace", "docker", LabelSourceAny)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
+
+	// container:k8s-app-role=foo doesn't match because it doesn't have source k8s.
+	allLabels["k8s-app-role"] = NewLabel("k8s-app-role", "foo", LabelSourceContainer)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	c.Assert(len(filtered), Equals, 5)
 	c.Assert(filtered, checker.DeepEquals, wanted)
 }


### PR DESCRIPTION
* #14893 -- docs: Add FQDN limitation to IPVLAN docs (@joestringer)
 * #14920 -- docs: Document hostport requirements in eni (@joestringer)
 * #14338 -- labelsfilter: Update documentation and add unit tests (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14893 14920 14338; do contrib/backporting/set-labels.py $pr done 1.7; done
```