### PR TITLE
docs: Remove incorrect configuration advice for native routing

### DIFF
--- a/Documentation/concepts/networking/routing.rst
+++ b/Documentation/concepts/networking/routing.rst
@@ -130,7 +130,6 @@ The following configuration options must be set to run the datapath in native
 routing mode:
 
 * ``tunnel: disabled``: Enable native routing mode.
-* ``enable-endpoint-routes: true``: Enable per-endpoint routing on the node
 * ``native-routing-cidr: x.x.x.x/y``: Set the CIDR in which native routing
   can be performed.
 


### PR DESCRIPTION
The `enable-endpoint-routes` option actually causes routing to fall
back to legacy mode, so this advice is incorrect.

Signed-off-by: Calum MacRae <hi@cmacr.ae>