### PR TITLE
contrib/k8s: use provided image when installing external workload

### DIFF
--- a/contrib/k8s/install-external-workload.sh
+++ b/contrib/k8s/install-external-workload.sh
@@ -86,7 +86,7 @@ if [ -n "$(docker ps -a -q -f name=cilium)" ]; then
 fi
 
 echo "Launching Cilium agent..."
-sudo docker run --name cilium $DOCKER_OPTS cilium/cilium:latest cilium-agent $CILIUM_OPTS
+sudo docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE cilium-agent $CILIUM_OPTS
 
 # Copy Cilium CLI
 sudo docker cp cilium:/usr/bin/cilium /usr/bin/cilium


### PR DESCRIPTION
When installing external workloads, launch Cilium agent from the
provided, versioned image instead of hardcoding cilium/cilium:latest.
The following command will now use Cilium 1.9.4 instead of latest:

    CLUSTER_ADDR=<ip> CILIUM_IMAGE=cilium/cilium:v1.9.4 ./install-external-workload.sh`

Fixes: a1fac6aa2b56 ("contrib/k8s: Add scripts for provisioning VMs")