### PR TITLE
service: Skip upsert of service for disabled IP family

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -271,6 +271,16 @@ func (s *Service) UpsertService(params *lb.SVC) (bool, lb.ID, error) {
 			option.EnableSVCSourceRangeCheck)
 	}
 
+	ipv6Svc := params.Frontend.IsIPv6()
+	if ipv6Svc && !option.Config.EnableIPv6 {
+		err := fmt.Errorf("Unable to upsert service %s as IPv6 is disabled", params.Frontend.L3n4Addr.String())
+		return false, lb.ID(0), err
+	}
+	if !ipv6Svc && !option.Config.EnableIPv4 {
+		err := fmt.Errorf("Unable to upsert service %s as IPv4 is disabled", params.Frontend.L3n4Addr.String())
+		return false, lb.ID(0), err
+	}
+
 	// In case we do DSR + IPIP, then it's required that the backends use
 	// the same destination port as the frontend service.
 	if option.Config.NodePortMode == option.NodePortModeDSR &&


### PR DESCRIPTION
The following panic can happen when trying to upsert e.g. an IPv6 service in the datapath when IPv6 is disabled in the agent. The corresponding IPv6 lbmap doesn't exist so we get a nil pointer reference.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1cd5900]

    goroutine 147 [running]:
    github.com/cilium/cilium/pkg/bpf.(*Map).OpenOrCreate(0x0, 0x0, 0x0, 0x0)
            /go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:464 +0x40
    github.com/cilium/cilium/pkg/maps/lbmap.updateRevNatLocked(0x2b1b5a0, 0xc000b365fc, 0x2b07380, 0xc000ae7e80, 0xc000b365f0, 0x1)
            /go/src/github.com/cilium/cilium/pkg/maps/lbmap/lbmap.go:331 +0x68
    github.com/cilium/cilium/pkg/maps/lbmap.(*LBBPFMap).UpsertService(0xc0009f5040, 0xc000b3a1e0, 0x0, 0xc000b47470)
            /go/src/github.com/cilium/cilium/pkg/maps/lbmap/lbmap.go:130 +0x5b7
    github.com/cilium/cilium/pkg/service.(*Service).upsertServiceIntoLBMaps(0xc00065a280, 0xc00066b420, 0x421e500, 0x0, 0x421e540, 0x0, 0x0, 0x421e540, 0x0, 0x0, ...)
            /go/src/github.com/cilium/cilium/pkg/service/service.go:749 +0x3de
    github.com/cilium/cilium/pkg/service.(*Service).UpsertService(0xc00065a280, 0xc000661a40, 0x0, 0x0, 0x0)
            /go/src/github.com/cilium/cilium/pkg/service/service.go:324 +0xc85
    github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).addK8sSVCs(0xc000974480, 0xc0009a34c0, 0x1d, 0xc0009b2a96, 0x7, 0x0, 0xc000b22f30, 0xc00012be48, 0x10, 0x7ffff7fb9108)
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:743 +0x47b
    github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).k8sServiceHandler.func1(0x0, 0xc0009a34c0, 0x1d, 0xc0009b2a96, 0x7, 0xc000b22f30, 0x0, 0xc00012be48, 0xc0009b0390)
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:447 +0xbc7
    github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).k8sServiceHandler(0xc000974480)
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:490 +0x95
    created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).RunK8sServiceHandler
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/watcher.go:495 +0x3f

This commit fixes it by exiting early from `UpsertService` if trying to upsert a service for an IP family that is disabled in the agent.

Fixes: https://github.com/cilium/cilium/issues/15000
Fixes: https://github.com/cilium/cilium/pull/14607