### PR TITLE
Pr/v1.8 backport 2021 02 19

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -86,7 +86,7 @@ One-time setup
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
    | `PyGithub <https://pypi.org/project/PyGithub/>`_             | No        | ``pip3 install PyGithub``                               |
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
-   | `Github hub CLI <https://github.com/github/hub>`_            | No        | N/A (OS-specific)                                       |
+   | `Github hub CLI (>= 2.8.3) <https://github.com/github/hub>`_ | No        | N/A (OS-specific)                                       |
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
 
 Preparation
@@ -182,8 +182,28 @@ the labels for the PRs that are backported, based on the
 
       # contrib/backporting/submit-backport
 
-Via GitHub web interface
+The script takes up to three positional arguments:
+
+   .. code-block:: bash
+
+      usage: submit-backport [branch version] [pr-summary] [your remote]
+
+- The first parameter is the version of the branch against which the PR should
+  be done, and defaults to the version passed to ``start-backport``.
+- The second one is the name of the file containing the text summary to use for
+  the PR, and defaults to the file created by ``start-backport``.
+- The third one is the name of the git remote of your (forked) repository to
+  which your changes will be pushed. It defaults to the git remote
+  which matches ``github.com/<your github username>/cilium``.
+
+Via GitHub Web Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Push your backports branch to your fork of the Cilium repo.
+
+   .. code-block:: bash
+
+      $ git push -u <remote_for_your_fork> HEAD
 
 #. Create a new PR from your branch towards the feature branch you are
    backporting to. Note that by default Github creates PRs against the

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -24,6 +24,8 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
+require_linux
+
 # Validate command-line
 common::argc_validate 2
 

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -3,6 +3,8 @@ set -e
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
+require_linux
+
 cleanup () {
   if [ -n "$TMPF" ]; then
     rm $TMPF

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 Authors of Cilium
+# Copyright 2019-2021 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@ set -e
 
 get_remote () {
   local remote
+  local org=${1:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]cilium/cilium" | \
+    grep "github.com[/:]${org}/cilium" | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
-      echo "No remote git@github.com:cilium/cilium.git or https://github.com/cilium/cilium found" 1>&2
+      echo "No remote git@github.com:${org}/cilium.git or https://github.com/${org}/cilium found" 1>&2
       return 1
   fi
   echo "$remote"

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -28,3 +28,10 @@ get_remote () {
   fi
   echo "$remote"
 }
+
+require_linux() {
+  if [ "$(uname)" != "Linux" ]; then
+      echo "$0: Linux required"
+      exit 1
+  fi
+}

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -18,6 +18,8 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
+require_linux
+
 # Validate command-line
 common::argc_validate 1
 

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 Authors of Cilium
+# Copyright 2019-2021 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ BRANCH=$(echo "$BRANCH" | sed 's/^v//')
 # have the same conflicting branch name.
 SUFFIX="${2}"
 
-git fetch origin
-if ! git branch -a | grep -q "origin/v$BRANCH$" ; then
+REMOTE=$(get_remote)
+git fetch "${REMOTE}"
+if ! git branch -a | grep -q "${REMOTE}/v$BRANCH$" ; then
     echo "usage: start-backport <branch version> [suffix]" 1>&2
     echo "  (detected branch $BRANCH)" 1>&2
     common::exit 1
@@ -50,5 +51,5 @@ if (git --no-pager branch | grep -q "${PRBRANCH}"); then
     common::exit 1
 fi
 
-git checkout -b "${PRBRANCH}" origin/v$BRANCH
+git checkout -b "${PRBRANCH}" "${REMOTE}/v${BRANCH}"
 contrib/backporting/check-stable $BRANCH v$BRANCH-backport-$DATE.txt

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -18,8 +18,6 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/../release/lib/common.sh
 source $DIR/common.sh
 
-require_linux
-
 if ! hub help | grep -q "api"; then
     echo "This tool relies on a recent version of 'hub' from https://github.com/github/hub." 1>&2
     echo "Please install this tool first." 1>&2

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -24,6 +24,7 @@ if ! hub help | grep -q "api"; then
     exit 1
 fi
 
+require_linux
 
 BRANCH="${1:-}"
 if [ "$BRANCH" = "" ]; then

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2020 Authors of Cilium
+# Copyright 2020-2021 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,15 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/../release/lib/common.sh
 source $DIR/common.sh
 
+require_linux
+
+if ! hub help | grep -q "api"; then
+    echo "This tool relies on a recent version of 'hub' from https://github.com/github/hub." 1>&2
+    echo "Please install this tool first." 1>&2
+    exit 1
+fi
+
+
 BRANCH="${1:-}"
 if [ "$BRANCH" = "" ]; then
     BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
@@ -29,16 +38,23 @@ if [ "$SUMMARY" = "" ]; then
     SUMMARY="v$BRANCH-backport-$(date --rfc-3339=date).txt"
 fi
 
-if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
-    echo "usage: $0 [branch version] [pr-summary]" 1>&2
-    echo 1>&2
-    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
-    exit 1
+USER_REMOTE=${3:-}
+if [ "$USER_REMOTE" = "" ]; then
+    gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
+    if [ "$gh_username" = "" ]; then
+        echo "Error: could not get user info from hub" 1>&2
+        exit 1
+    fi
+    USER_REMOTE=$(get_remote "$gh_username")
+    echo "Using GitHub repository ${gh_username}/cilium (git remote: ${USER_REMOTE})"
 fi
 
-if ! hub help | grep -q "pull-request"; then
-    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
-    echo "Please install this tool first." 1>&2
+UPSTREAM_REMOTE=$(get_remote)
+if ! git branch -a | grep -q "${UPSTREAM_REMOTE}/v${BRANCH}$" || [ ! -e "$SUMMARY" ]; then
+    echo "usage: $0 [branch version] [pr-summary] [your remote]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'upstream remote'/cilium and the summary file exists" 1>&2
+    echo "(branch version: ${BRANCH}, pr-summary: ${SUMMARY}, upstream remote: ${UPSTREAM_REMOTE})" 1>&2
     exit 1
 fi
 
@@ -46,7 +62,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-git push origin "$PR_BRANCH"
+git push "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -40,6 +40,10 @@ var (
 	probeManager *ProbeManager
 )
 
+// ErrKernelConfigNotFound is the error returned if the kernel config is unavailable
+// to the cilium agent.
+var ErrKernelConfigNotFound = errors.New("Kernel Config file not found")
+
 // KernelParam is a type based on string which represents CONFIG_* kernel
 // parameters which usually have values "y", "n" or "m".
 type KernelParam string

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -15,6 +15,7 @@
 package linux
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -176,7 +177,11 @@ func CheckMinRequirements() {
 	if !option.Config.DryMode {
 		probeManager := probes.NewProbeManager()
 		if err := probeManager.SystemConfigProbes(); err != nil {
-			log.WithError(err).Warning("BPF system config check: NOT OK.")
+			errMsg := "BPF system config check: NOT OK."
+			// TODO(brb) warn after GH#14314 has been resolved
+			if !errors.Is(err, probes.ErrKernelConfigNotFound) {
+				log.WithError(err).Warn(errMsg)
+			}
 		}
 		if err := probeManager.CreateHeadersFile(); err != nil {
 			log.WithError(err).Fatal("BPF check: NOT OK.")

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -795,7 +795,8 @@ func (n *Node) update(
 	} else if updateErr != nil {
 		scopedLog.WithError(updateErr).WithFields(logrus.Fields{
 			logfields.Attempt: attempts,
-		}).Warning("Failed to update CiliumNode spec")
+			"updateStatus":    status,
+		}).Warning("Failed to update CiliumNode")
 
 		node, err = n.manager.k8sAPI.Get(node.Name)
 		if err != nil {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -16,6 +16,7 @@ package nodediscovery
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -44,7 +45,7 @@ import (
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,7 +54,7 @@ const (
 	AutoCIDR = "auto"
 
 	nodeDiscoverySubsys = "nodediscovery"
-	maxRetryCount       = 5
+	maxRetryCount       = 10
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, nodeDiscoverySubsys)
@@ -245,23 +246,37 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 
 	ciliumClient := k8s.CiliumClient()
 
+	performGet := true
 	for retryCount := 0; retryCount < maxRetryCount; retryCount++ {
+		var nodeResource *ciliumv2.CiliumNode
 		performUpdate := true
-		nodeResource, err := ciliumClient.CiliumV2().CiliumNodes().Get(context.TODO(), nodeTypes.GetName(), metav1.GetOptions{})
-		if err != nil {
-			performUpdate = false
-			nodeResource = &ciliumv2.CiliumNode{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeTypes.GetName(),
-				},
+		if performGet {
+			var err error
+			nodeResource, err = ciliumClient.CiliumV2().CiliumNodes().Get(context.TODO(), nodeTypes.GetName(), metav1.GetOptions{})
+			if err != nil {
+				performUpdate = false
+				nodeResource = &ciliumv2.CiliumNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeTypes.GetName(),
+					},
+				}
+			} else {
+				performGet = false
 			}
 		}
 
-		n.mutateNodeResource(nodeResource)
+		if err := n.mutateNodeResource(nodeResource); err != nil {
+			log.WithError(err).WithField("retryCount", retryCount).Warning("Unable to mutate nodeResource")
+			continue
+		}
 
+		// if we retry after this point, is due to a conflict. We will do
+		// a new GET  to ensure we have the latest information before
+		// updating.
+		performGet = true
 		if performUpdate {
 			if _, err := ciliumClient.CiliumV2().CiliumNodes().Update(context.TODO(), nodeResource, metav1.UpdateOptions{}); err != nil {
-				if errors.IsConflict(err) {
+				if k8serrors.IsConflict(err) {
 					log.WithError(err).Warn("Unable to update CiliumNode resource, will retry")
 					continue
 				}
@@ -270,8 +285,8 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 				return
 			}
 		} else {
-			if _, err = ciliumClient.CiliumV2().CiliumNodes().Create(context.TODO(), nodeResource, metav1.CreateOptions{}); err != nil {
-				if errors.IsConflict(err) {
+			if _, err := ciliumClient.CiliumV2().CiliumNodes().Create(context.TODO(), nodeResource, metav1.CreateOptions{}); err != nil {
+				if k8serrors.IsConflict(err) {
 					log.WithError(err).Warn("Unable to create CiliumNode resource, will retry")
 					continue
 				}
@@ -285,7 +300,7 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 	log.Fatal("Could not create or update CiliumNode resource, despite retries")
 }
 
-func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
+func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) error {
 	var (
 		providerID       string
 		k8sNodeAddresses []nodeTypes.Address
@@ -383,6 +398,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
 			log.WithError(err).Fatal("Unable to retrieve InstanceID of own EC2 instance")
 		}
 
+		if instanceID == "" {
+			return errors.New("InstanceID of own EC2 instance is empty")
+		}
+
 		// It is important to determine the interface index here because this
 		// function (mutateNodeResource) will be called when the agent is first
 		// coming up and is initializing the IPAM layer (CRD allocator in this
@@ -465,6 +484,8 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
 			}
 		}
 	}
+
+	return nil
 }
 
 // determineFirstInterfaceIndex determines the appropriate default interface


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

v1.8 backports 2021-02-19

 * #15008 -- backporting: Add support for forked cilium repositories  (@gandro)
 * #14902 -- datapath: Do not log when kernel config not found (@brb)
 * #15012 -- Avoid an empty instanceID on EC2 (@kkourt)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15008 14902 15012; do contrib/backporting/set-labels.py $pr done 1.8; done
```

