### PR TITLE
ipsec: Use 64bits for XFRM output sequence number

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -66,9 +66,10 @@ func getIPSecKeys(ip net.IP) *ipSecKey {
 
 func ipSecNewState() *netlink.XfrmState {
 	state := netlink.XfrmState{
-		Mode:  netlink.XFRM_MODE_TUNNEL,
-		Proto: netlink.XFRM_PROTO_ESP,
-		ESN:   false,
+		Mode:         netlink.XFRM_MODE_TUNNEL,
+		Proto:        netlink.XFRM_PROTO_ESP,
+		ESN:          true,
+		ReplayWindow: 1024,
 	}
 	return &state
 }


### PR DESCRIPTION
The anti-replay mechanism of IPSec has [several implementations in the Linux kernel](https://elixir.bootlin.com/linux/v5.11/source/net/xfrm/xfrm_replay.c#L707). The legacy implementation, which we are currently using, relies on a 32bit output sequence number. On cluster with a high packet throughput and less frequent key rotations, this number can reach its maximum value quickly. In such cases, [the RFC states](https://tools.ietf.org/html/rfc4303#page-25) that the packet should be dropped and userspace should take care of replacing the xfrm state entry.

To reduce the likelihood of that happening, we can use the ESN implementation of the anti-replay mechanism, which relies on a 64bits sequence number.

Regardless of the sequence number size, we currently rely on the user to implement key management outside of Cilium. To prevent issues as described above from happening in the longer term, we may want to handle the key management ourselves.

Co-authored-by: John Fastabend <john.fastabend@gmail.com>
Signed-off-by: Paul Chaignon <paul@cilium.io>