### PR TITLE
PR-v1.7-backport-2021-02-19

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -86,7 +86,7 @@ One-time setup
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
    | `PyGithub <https://pypi.org/project/PyGithub/>`_             | No        | ``pip3 install PyGithub``                               |
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
-   | `Github hub CLI <https://github.com/github/hub>`_            | No        | N/A (OS-specific)                                       |
+   | `Github hub CLI (>= 2.8.3) <https://github.com/github/hub>`_ | No        | N/A (OS-specific)                                       |
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
 
 Preparation
@@ -169,8 +169,28 @@ the labels for the PRs that are backported, based on the
 
       # contrib/backporting/submit-backport
 
-Via GitHub web interface
+The script takes up to three positional arguments:
+
+   .. code-block:: bash
+
+      usage: submit-backport [branch version] [pr-summary] [your remote]
+
+- The first parameter is the version of the branch against which the PR should
+  be done, and defaults to the version passed to ``start-backport``.
+- The second one is the name of the file containing the text summary to use for
+  the PR, and defaults to the file created by ``start-backport``.
+- The third one is the name of the git remote of your (forked) repository to
+  which your changes will be pushed. It defaults to the git remote
+  which matches ``github.com/<your github username>/cilium``.
+
+Via GitHub Web Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Push your backports branch to your fork of the Cilium repo.
+
+   .. code-block:: bash
+
+      $ git push -u <remote_for_your_fork> HEAD
 
 #. Create a new PR from your branch towards the feature branch you are
    backporting to. Note that by default Github creates PRs against the

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 Authors of Cilium
+# Copyright 2019-2021 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@ set -e
 
 get_remote () {
   local remote
+  local org=${1:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]cilium/cilium" | \
+    grep "github.com[/:]${org}/cilium" | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
-      echo "No remote git@github.com:cilium/cilium.git or https://github.com/cilium/cilium found" 1>&2
+      echo "No remote git@github.com:${org}/cilium.git or https://github.com/${org}/cilium found" 1>&2
       return 1
   fi
   echo "$remote"

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 Authors of Cilium
+# Copyright 2019-2021 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ BRANCH=$(echo "$BRANCH" | sed 's/^v//')
 # have the same conflicting branch name.
 SUFFIX="${2}"
 
-git fetch origin
-if ! git branch -a | grep -q "origin/v$BRANCH$" ; then
+REMOTE=$(get_remote)
+git fetch "${REMOTE}"
+if ! git branch -a | grep -q "${REMOTE}/v$BRANCH$" ; then
     echo "usage: start-backport <branch version> [suffix]" 1>&2
     echo "  (detected branch $BRANCH)" 1>&2
     common::exit 1
@@ -50,5 +51,5 @@ if (git --no-pager branch | grep -q "${PRBRANCH}"); then
     common::exit 1
 fi
 
-git checkout -b "${PRBRANCH}" origin/v$BRANCH
+git checkout -b "${PRBRANCH}" "${REMOTE}/v${BRANCH}"
 contrib/backporting/check-stable $BRANCH v$BRANCH-backport-$DATE.txt

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2020 Authors of Cilium
+# Copyright 2020-2021 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,14 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/../release/lib/common.sh
 source $DIR/common.sh
 
+require_linux
+
+if ! hub help | grep -q "api"; then
+    echo "This tool relies on a recent version of 'hub' from https://github.com/github/hub." 1>&2
+    echo "Please install this tool first." 1>&2
+    exit 1
+fi
+
 BRANCH="${1:-}"
 if [ "$BRANCH" = "" ]; then
     BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
@@ -29,16 +37,23 @@ if [ "$SUMMARY" = "" ]; then
     SUMMARY="v$BRANCH-backport-$(date --rfc-3339=date).txt"
 fi
 
-if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
-    echo "usage: $0 [branch version] [pr-summary]" 1>&2
-    echo 1>&2
-    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
-    exit 1
+USER_REMOTE=${3:-}
+if [ "$USER_REMOTE" = "" ]; then
+    gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
+    if [ "$gh_username" = "" ]; then
+        echo "Error: could not get user info from hub" 1>&2
+        exit 1
+    fi
+    USER_REMOTE=$(get_remote "$gh_username")
+    echo "Using GitHub repository ${gh_username}/cilium (git remote: ${USER_REMOTE})"
 fi
 
-if ! hub help | grep -q "pull-request"; then
-    echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
-    echo "Please install this tool first." 1>&2
+UPSTREAM_REMOTE=$(get_remote)
+if ! git branch -a | grep -q "${UPSTREAM_REMOTE}/v${BRANCH}$" || [ ! -e "$SUMMARY" ]; then
+    echo "usage: $0 [branch version] [pr-summary] [your remote]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'upstream remote'/cilium and the summary file exists" 1>&2
+    echo "(branch version: ${BRANCH}, pr-summary: ${SUMMARY}, upstream remote: ${UPSTREAM_REMOTE})" 1>&2
     exit 1
 fi
 
@@ -46,7 +61,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-git push origin "$PR_BRANCH"
+git push "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')


### PR DESCRIPTION
v1.7 backports 2021-02-19

 * #15008 -- backporting: Add support for forked cilium repositories  (@gandro)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15008; do contrib/backporting/set-labels.py $pr done 1.7; done
```