### PR TITLE
v1.9: ipsec: Use 64bits for XFRM output sequence number

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -66,9 +66,10 @@ func getIPSecKeys(ip net.IP) *ipSecKey {
 
 func ipSecNewState() *netlink.XfrmState {
 	state := netlink.XfrmState{
-		Mode:  netlink.XFRM_MODE_TUNNEL,
-		Proto: netlink.XFRM_PROTO_ESP,
-		ESN:   false,
+		Mode:         netlink.XFRM_MODE_TUNNEL,
+		Proto:        netlink.XFRM_PROTO_ESP,
+		ESN:          true,
+		ReplayWindow: 1024,
 	}
 	return &state
 }


### PR DESCRIPTION
Temporary backport PR for https://github.com/cilium/cilium/pull/15039, to run e2e tests.