### PR TITLE
v1.8 backports 2021-02-20

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1055,6 +1055,10 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		e.owner.Datapath().Loader().Unload(e.createEpInfoCache(""))
 	}
 
+	// Remove policy references from shared policy structures
+	e.desiredPolicy.Detach()
+	e.realizedPolicy.Detach()
+
 	// Remove restored rules of cleaned endpoint
 	e.owner.RemoveRestoredDNSRules(e.ID)
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -458,6 +458,8 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		e.syncPolicyMapController()
 	}
 
+	// Remove references to the old policy
+	e.realizedPolicy.Detach()
 	// Set realized state to desired state.
 	e.realizedPolicy = e.desiredPolicy
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -458,10 +458,12 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		e.syncPolicyMapController()
 	}
 
-	// Remove references to the old policy
-	e.realizedPolicy.Detach()
-	// Set realized state to desired state.
-	e.realizedPolicy = e.desiredPolicy
+	if e.desiredPolicy != e.realizedPolicy {
+		// Remove references to the old policy
+		e.realizedPolicy.Detach()
+		// Set realized state to desired state.
+		e.realizedPolicy = e.desiredPolicy
+	}
 
 	// Mark the endpoint to be running the policy revision it was
 	// compiled for

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -829,6 +829,20 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 	l4.mutex.Unlock()
 }
 
+// removeUser removes a user that no longer needs incremental updates
+// from the L4Policy.
+func (l4 *L4Policy) removeUser(user *EndpointPolicy) {
+	// 'users' is set to nil when the policy is detached. This
+	// happens to the old policy when it is being replaced with a
+	// new one, or when the last endpoint using this policy is
+	// removed.
+	l4.mutex.Lock()
+	if l4.users != nil {
+		delete(l4.users, user)
+	}
+	l4.mutex.Unlock()
+}
+
 // AccumulateMapChanges distributes the given changes to the registered users.
 //
 // The caller is responsible for making sure the same identity is not

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -98,6 +98,14 @@ func (p *selectorPolicy) insertUser(user *EndpointPolicy) {
 	}
 }
 
+// removeUser removes a user from the L4Policy so the EndpointPolicy
+// can be freed when not needed any more
+func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
+	if p.L4Policy != nil {
+		p.L4Policy.removeUser(user)
+	}
+}
+
 // Detach releases resources held by a selectorPolicy to enable
 // successful eventual GC.  Note that the selectorPolicy itself if not
 // modified in any way, so that it can be used concurrently.
@@ -146,6 +154,13 @@ func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *En
 	}
 
 	return calculatedPolicy
+}
+
+// Detach removes EndpointPolicy references from selectorPolicy
+// to allow the EndpointPolicy to be GC'd.
+// PolicyOwner (aka Endpoint) is also locked during this call.
+func (p *EndpointPolicy) Detach() {
+	p.selectorPolicy.removeUser(p)
 }
 
 // computeDesiredL4PolicyMapEntries transforms the EndpointPolicy.L4Policy into


### PR DESCRIPTION
 * #15042 -- policy: Clear references to old EndpointPolicies (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15042; do contrib/backporting/set-labels.py $pr done 1.8; done
```
