### PR TITLE
v1.9 backports 2021-02-20

### DIFF
--- a/contrib/k8s/install-external-workload.sh
+++ b/contrib/k8s/install-external-workload.sh
@@ -86,7 +86,7 @@ if [ -n "$(docker ps -a -q -f name=cilium)" ]; then
 fi
 
 echo "Launching Cilium agent..."
-sudo docker run --name cilium $DOCKER_OPTS cilium/cilium:latest cilium-agent $CILIUM_OPTS
+sudo docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE cilium-agent $CILIUM_OPTS
 
 # Copy Cilium CLI
 sudo docker cp cilium:/usr/bin/cilium /usr/bin/cilium

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1060,6 +1060,10 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		e.owner.Datapath().Loader().Unload(e.createEpInfoCache(""))
 	}
 
+	// Remove policy references from shared policy structures
+	e.desiredPolicy.Detach()
+	e.realizedPolicy.Detach()
+
 	// Remove restored rules of cleaned endpoint
 	e.owner.RemoveRestoredDNSRules(e.ID)
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -458,6 +458,8 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		e.syncPolicyMapController()
 	}
 
+	// Remove references to the old policy
+	e.realizedPolicy.Detach()
 	// Set realized state to desired state.
 	e.realizedPolicy = e.desiredPolicy
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -458,10 +458,12 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		e.syncPolicyMapController()
 	}
 
-	// Remove references to the old policy
-	e.realizedPolicy.Detach()
-	// Set realized state to desired state.
-	e.realizedPolicy = e.desiredPolicy
+	if e.desiredPolicy != e.realizedPolicy {
+		// Remove references to the old policy
+		e.realizedPolicy.Detach()
+		// Set realized state to desired state.
+		e.realizedPolicy = e.desiredPolicy
+	}
 
 	// Mark the endpoint to be running the policy revision it was
 	// compiled for

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -794,7 +794,8 @@ func (n *Node) update(origNode, node *v2.CiliumNode, attempts int, status bool) 
 	} else if updateErr != nil {
 		scopedLog.WithError(updateErr).WithFields(logrus.Fields{
 			logfields.Attempt: attempts,
-		}).Warning("Failed to update CiliumNode spec")
+			"updateStatus":    status,
+		}).Warning("Failed to update CiliumNode")
 
 		var newNode *v2.CiliumNode
 		newNode, err = n.manager.k8sAPI.Get(node.Name)

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -16,6 +16,7 @@ package nodediscovery
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -45,7 +46,7 @@ import (
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,7 +55,7 @@ const (
 	AutoCIDR = "auto"
 
 	nodeDiscoverySubsys = "nodediscovery"
-	maxRetryCount       = 5
+	maxRetryCount       = 10
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, nodeDiscoverySubsys)
@@ -290,23 +291,37 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 
 	ciliumClient := k8s.CiliumClient()
 
+	performGet := true
 	for retryCount := 0; retryCount < maxRetryCount; retryCount++ {
+		var nodeResource *ciliumv2.CiliumNode
 		performUpdate := true
-		nodeResource, err := ciliumClient.CiliumV2().CiliumNodes().Get(context.TODO(), nodeTypes.GetName(), metav1.GetOptions{})
-		if err != nil {
-			performUpdate = false
-			nodeResource = &ciliumv2.CiliumNode{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeTypes.GetName(),
-				},
+		if performGet {
+			var err error
+			nodeResource, err = ciliumClient.CiliumV2().CiliumNodes().Get(context.TODO(), nodeTypes.GetName(), metav1.GetOptions{})
+			if err != nil {
+				performUpdate = false
+				nodeResource = &ciliumv2.CiliumNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeTypes.GetName(),
+					},
+				}
+			} else {
+				performGet = false
 			}
 		}
 
-		n.mutateNodeResource(nodeResource)
+		if err := n.mutateNodeResource(nodeResource); err != nil {
+			log.WithError(err).WithField("retryCount", retryCount).Warning("Unable to mutate nodeResource")
+			continue
+		}
 
+		// if we retry after this point, is due to a conflict. We will do
+		// a new GET  to ensure we have the latest information before
+		// updating.
+		performGet = true
 		if performUpdate {
 			if _, err := ciliumClient.CiliumV2().CiliumNodes().Update(context.TODO(), nodeResource, metav1.UpdateOptions{}); err != nil {
-				if errors.IsConflict(err) {
+				if k8serrors.IsConflict(err) {
 					log.WithError(err).Warn("Unable to update CiliumNode resource, will retry")
 					continue
 				}
@@ -315,8 +330,8 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 				return
 			}
 		} else {
-			if _, err = ciliumClient.CiliumV2().CiliumNodes().Create(context.TODO(), nodeResource, metav1.CreateOptions{}); err != nil {
-				if errors.IsConflict(err) {
+			if _, err := ciliumClient.CiliumV2().CiliumNodes().Create(context.TODO(), nodeResource, metav1.CreateOptions{}); err != nil {
+				if k8serrors.IsConflict(err) {
 					log.WithError(err).Warn("Unable to create CiliumNode resource, will retry")
 					continue
 				}
@@ -330,7 +345,7 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 	log.Fatal("Could not create or update CiliumNode resource, despite retries")
 }
 
-func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
+func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) error {
 	var (
 		providerID       string
 		k8sNodeAddresses []nodeTypes.Address
@@ -428,6 +443,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
 			log.WithError(err).Fatal("Unable to retrieve InstanceID of own EC2 instance")
 		}
 
+		if instanceID == "" {
+			return errors.New("InstanceID of own EC2 instance is empty")
+		}
+
 		// It is important to determine the interface index here because this
 		// function (mutateNodeResource) will be called when the agent is first
 		// coming up and is initializing the IPAM layer (CRD allocator in this
@@ -500,6 +519,8 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) {
 			}
 		}
 	}
+
+	return nil
 }
 
 // determineFirstInterfaceIndex determines the appropriate default interface

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -933,6 +933,20 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 	l4.mutex.Unlock()
 }
 
+// removeUser removes a user that no longer needs incremental updates
+// from the L4Policy.
+func (l4 *L4Policy) removeUser(user *EndpointPolicy) {
+	// 'users' is set to nil when the policy is detached. This
+	// happens to the old policy when it is being replaced with a
+	// new one, or when the last endpoint using this policy is
+	// removed.
+	l4.mutex.Lock()
+	if l4.users != nil {
+		delete(l4.users, user)
+	}
+	l4.mutex.Unlock()
+}
+
 // AccumulateMapChanges distributes the given changes to the registered users.
 //
 // The caller is responsible for making sure the same identity is not

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -99,6 +99,14 @@ func (p *selectorPolicy) insertUser(user *EndpointPolicy) {
 	}
 }
 
+// removeUser removes a user from the L4Policy so the EndpointPolicy
+// can be freed when not needed any more
+func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
+	if p.L4Policy != nil {
+		p.L4Policy.removeUser(user)
+	}
+}
+
 // Detach releases resources held by a selectorPolicy to enable
 // successful eventual GC.  Note that the selectorPolicy itself if not
 // modified in any way, so that it can be used concurrently.
@@ -147,6 +155,13 @@ func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *En
 	}
 
 	return calculatedPolicy
+}
+
+// Detach removes EndpointPolicy references from selectorPolicy
+// to allow the EndpointPolicy to be GC'd.
+// PolicyOwner (aka Endpoint) is also locked during this call.
+func (p *EndpointPolicy) Detach() {
+	p.selectorPolicy.removeUser(p)
 }
 
 // computeDesiredL4PolicyMapEntries transforms the EndpointPolicy.L4Policy into


### PR DESCRIPTION
 * #15020 -- contrib/k8s: use provided image when installing external workload (@tklauser)
 * #15012 -- Avoid an empty instanceID on EC2 (@kkourt)
 * #15042 -- policy: Clear references to old EndpointPolicies (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15020 15012 15042; do contrib/backporting/set-labels.py $pr done 1.9; done
```
