### PR TITLE
[v1.7] backporting: Stop scripts from running on non-Linux

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -24,6 +24,8 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
+require_linux
+
 # Validate command-line
 common::argc_validate 2
 

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -3,6 +3,8 @@ set -e
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
+require_linux
+
 cleanup () {
   if [ -n "$TMPF" ]; then
     rm $TMPF

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -28,3 +28,10 @@ get_remote () {
   fi
   echo "$remote"
 }
+
+require_linux() {
+  if [ "$(uname)" != "Linux" ]; then
+      echo "$0: Linux required"
+      exit 1
+  fi
+}

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -18,6 +18,8 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
+require_linux
+
 # Validate command-line
 common::argc_validate 1
 


### PR DESCRIPTION
Manual (partial) backport of 

 * #14027 -- Minor backporting script tweaks  (@twpayne )

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14027; do contrib/backporting/set-labels.py $pr done 1.7; done
```

---

This does not need a full CI run, as it only touches the backport scripts which are not part of CI.