### PR TITLE
daemon: don't install cilium-node-monitor symlink

### DIFF
--- a/contrib/packaging/rpm/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cilium.spec.envsubst
@@ -142,7 +142,6 @@ exec %{buildroot}/%{_bindir}/cilium completion > \
 %{_bindir}/cilium
 %{_bindir}/cilium-agent
 %{_bindir}/cilium-docker
-%{_bindir}/cilium-node-monitor
 %{_bindir}/cilium-bugtool
 %{_bindir}/cilium-health
 %{_bindir}/cilium-envoy

--- a/daemon/.gitignore
+++ b/daemon/.gitignore
@@ -1,3 +1,2 @@
 cilium
 cilium-agent
-cilium-node-monitor

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -4,24 +4,19 @@
 include ../Makefile.defs
 
 TARGET := cilium-agent
-LINKS := cilium-node-monitor
 
-all: $(TARGET) links
+all: $(TARGET)
 
-.PHONY: all $(TARGET) links
+.PHONY: all $(TARGET)
 
 $(TARGET): ../Dockerfile ../Makefile ../Makefile.defs Makefile
 	@$(ECHO_GO)
 	$(QUIET)$(GO_BUILD) -o $(TARGET)
 
-links:
-	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(link) || cp $(TARGET) $(link);)
-
 clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO_CLEAN)
-	$(foreach link,$(LINKS), $(QUIET)rm -f $(link);)
 
 ifeq ("$(PKG_BUILD)","")
 
@@ -29,13 +24,11 @@ install:
 	groupadd -f cilium
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(DESTDIR)$(BINDIR)/$(link) || cp $(TARGET) $(DESTDIR)$(BINDIR)/$(link);)
 
 else
 
 install:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(DESTDIR)$(BINDIR)/$(link) || cp $(TARGET) $(DESTDIR)$(BINDIR)/$(link);)
 
 endif

--- a/test/runtime/chaos_agent.go
+++ b/test/runtime/chaos_agent.go
@@ -54,7 +54,7 @@ var agentChaosTests = func() {
 
 	It("Checking for file-descriptor leak", func() {
 		threshold := 5000
-		fds, err := vm.Exec("sudo lsof -p `pidof cilium-node-monitor` -p `pidof cilium-agent` -p `pidof cilium-docker` 2>/dev/null | wc -l").IntOutput()
+		fds, err := vm.Exec("sudo lsof -p `pidof cilium-agent` -p `pidof cilium-docker` 2>/dev/null | wc -l").IntOutput()
 		Expect(err).Should(BeNil())
 
 		Expect(fds).To(BeNumerically("<", threshold),


### PR DESCRIPTION
cilium-node-monitor was moved back into the agent in commit c0a86a377604
("monitor: Move cilium-node-monitor into cilium-agent"), so invoking the
binary via the symlink no longer has any effect different from invoking
the agent binary directly. It also seems, like we don't need to keep it
for backwards compatibility e.g. on downgrade since this was already
part of Cilium 1.6 which is no longer supported.