### PR TITLE
helm: add .Values.registry

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -104,17 +104,17 @@ update-versions:
 		# image.tag operator.image.tag preflight.image.tag hubble.relay.image.tag;					\
 		sed -i 's/tag: .*/tag: '$$cilium_version'/g' $(CILIUM_VALUES);							\
 		# hubble.ui.frontend.image.tag hubble.ui.backend.image.tag;							\
-		sed -i '/repository.*hubble-ui.*/{!b;n;s/tag.*/tag: '$$hubble_version'/}' $(CILIUM_VALUES);			\
+		sed -i '/^ *\(name\|repository\):.*hubble-ui.*/{!b;n;s/tag: .*/tag: '$$hubble_version'/}' $(CILIUM_VALUES);	\
 		# etcd.image.tag												\
-		sed -i '/repository.*etcd-operator.*/{!b;n;s/tag.*/tag: '$(MANAGED_ETCD_VERSION)'/}' $(CILIUM_VALUES)		\
+		sed -i '/^ *\(name\|repository\):.*etcd-operator.*/{!b;n;s/tag: .*/tag: '$(MANAGED_ETCD_VERSION)'/}' $(CILIUM_VALUES)\
 		# clustermesh.apiserver.etcd.image.tag										\
-		sed -i '/repository.*etcd$$/{!b;n;s/tag.*/tag: '$(ETCD_VERSION)'/}' $(CILIUM_VALUES)			\
+		sed -i '/^ *\(name\|repository\):.*etcd$$/{!b;n;s/tag: .*/tag: '$(ETCD_VERSION)'/}' $(CILIUM_VALUES)		\
 		# hubble.ui.proxy.image.tag											\
-		sed -i '/repository.*envoy.*/{!b;n;s/tag.*/tag: '$(HUBBLE_PROXY_VERSION)'/}' $(CILIUM_VALUES)			\
+		sed -i '/^ *\(name\|repository\):.*envoy.*/{!b;n;s/tag: .*/tag: '$(HUBBLE_PROXY_VERSION)'/}' $(CILIUM_VALUES)	\
 		# nodeinit.image.tag												\
-		sed -i '/repository.*cilium\/startup-script.*/{!b;n;s/tag.*/tag: '$(NODEINIT_VERSION)'/}' $(CILIUM_VALUES)	\
+		sed -i '/^ *\(name\|repository\):.*startup-script.*/{!b;n;s/tag: .*/tag: '$(NODEINIT_VERSION)'/}' $(CILIUM_VALUES)\
 		# certgen.image.tag												\
-		sed -i '/repository.*certgen.*/{!b;n;s/tag.*/tag: '$(CERTGEN_VERSION)'/}' $(CILIUM_VALUES);			\
+		sed -i '/^ *\(name\|repository\):.*certgen.*/{!b;n;s/tag: .*/tag: '$(CERTGEN_VERSION)'/}' $(CILIUM_VALUES);	\
 		sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 '$$pull_policy'/' $(CILIUM_VALUES);
 
 lint:

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -66,14 +66,14 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries for the NAT table. natMax: 524288 -- Configure the maximum number of entries for the neighbor table. neighMax: 524288 -- Configure the maximum number of entries in endpoint policy map. (per endpoint) |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.waitForMount | bool | `false` | Force the cilium-agent DaemonSet to wait in an initContainer until the eBPF filesystem has been mounted. |
-| certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.3"},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"image":{"name":"certgen","pullPolicy":"Always","tag":"v0.1.3"},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet. WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true. WARNING: Use with care! |
 | cluster.id | int | `nil` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh. |
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh. |
 | clustermesh.apiserver.etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.4.13"}` | Clustermesh API server etcd image. |
-| clustermesh.apiserver.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver","tag":"latest"}` | Clustermesh API server image. |
+| clustermesh.apiserver.image | object | `{"name":"clustermesh-apiserver","pullPolicy":"Always","tag":"latest"}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
@@ -136,7 +136,7 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.extraConfigmapMounts | list | `[]` | Additional cilium-etcd-operator ConfigMap mounts |
 | etcd.extraHostPathMounts | list | `[]` | Additional cilium-etcd-operator hostPath mounts |
 | etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod |
-| etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7"}` | cilium-etcd-operator image. |
+| etcd.image | object | `{"name":"cilium-etcd-operator","pullPolicy":"Always","tag":"v2.0.7"}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.managed | bool | `false` | Enable managed etcd mode based on the cilium-etcd-operator. |
 | etcd.nodeSelector | object | `{}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -178,7 +178,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metricsServer | string | `""` |  |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
-| hubble.relay.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay","tag":"latest"}` | Hubble-relay container image. |
+| hubble.relay.image | object | `{"name":"hubble-relay","pullPolicy":"Always","tag":"latest"}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -205,10 +205,10 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.ca.key | string | `""` | The CA private key (optional). If it is provided, then it will be used by hubble.tls.auto.method=cronJob to generate all other certificates. Otherwise, a ephemeral CA is generated if hubble.tls.auto.enabled=true. |
 | hubble.tls.enabled | bool | `true` | Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network. |
 | hubble.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
-| hubble.ui.backend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"latest"}` | Hubble-ui backend image. |
+| hubble.ui.backend.image | object | `{"name":"hubble-ui-backend","pullPolicy":"Always","tag":"latest"}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` |  |
 | hubble.ui.enabled | bool | `false` |  |
-| hubble.ui.frontend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"latest"}` | Hubble-ui frontend image. |
+| hubble.ui.frontend.image | object | `{"name":"hubble-ui","pullPolicy":"Always","tag":"latest"}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` |  |
 | hubble.ui.ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -221,7 +221,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
 | identityAllocationMode | string | `"crd"` |  |
-| image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest"}` | Agent container image. |
+| image | object | `{"name":"cilium","pullPolicy":"Always","tag":"latest"}` | Agent container image. |
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
 | installIptablesRules | bool | `true` |  |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
@@ -256,7 +256,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.extraEnv | object | `{}` |  |
 | nodeinit.extraHostPathMounts | list | `[]` |  |
 | nodeinit.extraInitContainers | list | `[]` |  |
-| nodeinit.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
+| nodeinit.image | object | `{"name":"startup-script","pullPolicy":"Always","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods |
 | nodeinit.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
@@ -276,7 +276,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod |
 | operator.identityGCInterval | string | `"15m0s"` |  |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` |  |
-| operator.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest"}` | cilium-operator image. |
+| operator.image | object | `{"name":"operator","pullPolicy":"Always","suffix":"","tag":"latest"}` | cilium-operator image. |
 | operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
@@ -302,7 +302,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.extraEnv | object | `{}` |  |
 | preflight.extraHostPathMounts | list | `[]` |  |
 | preflight.extraInitContainers | list | `[]` |  |
-| preflight.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest"}` | Cilium pre-flight image. |
+| preflight.image | object | `{"name":"cilium","pullPolicy":"Always","tag":"latest"}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
@@ -321,6 +321,7 @@ contributors across the globe, there is almost always someone available to help.
 | proxy | object | `{"prometheus":{"enabled":true,"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
 | proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
+| registry | string | `"quay.io/cilium"` | Default container images registry |
 | remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |

--- a/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       containers:
         - name: certgen
-          image: {{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.certgen.image) }}
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
           command:
             - "/usr/bin/cilium-certgen"

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -36,6 +36,17 @@ backend:
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the container image based on either .image.repository or .registry/.image.name.
+*/}}
+{{- define "container.image" -}}
+{{-  if .image.repository -}}
+{{- printf "%s%s:%s" .image.repository (.image.suffix | default "") (required ".tag is required" .image.tag) | quote -}}
+{{- else -}}
+{{- printf "%s/%s%s:%s" (required ".registry is required" .registry) (required ".name is required" .image.name) (.image.suffix | default "") (required ".tag is required" .image.tag) | quote -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Generate TLS certificates for Hubble Server and Hubble Relay.

--- a/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
       containers:
         - name: certgen
-          image: {{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.certgen.image) }}
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
           command:
             - "/usr/bin/cilium-certgen"

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -236,7 +236,7 @@ spec:
 {{- with .Values.extraEnv }}
 {{ toYaml . | trim | indent 8 }}
 {{- end }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.image) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- if .Values.cni.install }}
         lifecycle:
@@ -357,7 +357,7 @@ spec:
 {{- range $type := .Values.monitor.eventTypes }}
         - --type={{ $type }}
 {{- end }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.image) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -377,7 +377,7 @@ spec:
 {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
       - name: wait-for-node-init
         command: ['sh', '-c', 'until stat {{ .Values.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.image) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: {{ .Values.nodeinit.bootstrapFile }}
@@ -415,7 +415,7 @@ spec:
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}
 {{- end }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.image) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: clean-cilium-state
         securityContext:

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           value: "revision"
         - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
           value: "25000"
-        image: {{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.etcd.image) }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
 {{- end }}
       containers:
         - name: node-init
-          image: {{ .Values.nodeinit.image.repository }}:{{ .Values.nodeinit.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.nodeinit.image) }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -155,13 +155,30 @@ spec:
         - name: {{ $key }}
           value: {{ $value }}
 {{- end }}
+{{- $image := deepCopy .Values.operator.image -}}
 {{- if .Values.eni.enabled }}
-        image: {{ .Values.operator.image.repository }}-aws{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}
+    {{- if get $image "repository" -}}
+        {{- $_ := set $image "repository" (printf "%s-%s" (get $image "repository") "aws") -}}
+    {{- end -}}
+    {{- if get $image "name" -}}
+        {{- $_ := set $image "name" (printf "%s-%s" (get $image "name") "aws") -}}
+    {{- end -}}
 {{- else if .Values.azure.enabled }}
-        image: {{ .Values.operator.image.repository }}-azure{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}
+    {{- if get $image "repository" -}}
+        {{- $_ := set $image "repository" (printf "%s-%s" (get $image "repository") "azure") -}}
+    {{- end -}}
+    {{- if get $image "name" -}}
+        {{- $_ := set $image "name" (printf "%s-%s" (get $image "name") "azure") -}}
+    {{- end -}}
 {{- else }}
-        image: {{ .Values.operator.image.repository }}-generic{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}
+    {{- if get $image "repository" -}}
+        {{- $_ := set $image "repository" (printf "%s-%s" (get $image "repository") "generic") -}}
+    {{- end -}}
+    {{- if get $image "name" -}}
+        {{- $_ := set $image "name" (printf "%s-%s" (get $image "name") "generic") -}}
+    {{- end -}}
 {{- end }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" $image) }}
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         name: cilium-operator
 {{- if .Values.operator.prometheus.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
@@ -25,14 +25,14 @@ spec:
 {{- end }}
       initContainers:
         - name: clean-cilium-state
-          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.preflight.image) }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/echo"]
           args:
           - "hello"
       containers:
         - name: cilium-pre-flight-check
-          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.preflight.image) }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:
@@ -68,7 +68,7 @@ spec:
 
 {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
-          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.preflight.image) }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]

--- a/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
 {{- if .Values.preflight.validateCNPs }}
         - name: cnp-validator
-          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.preflight.image) }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
       initContainers:
       - name: etcd-init
-        image: {{ .Values.clustermesh.apiserver.etcd.image.repository }}:{{ .Values.clustermesh.apiserver.etcd.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.clustermesh.apiserver.etcd.image) }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         env:
         - name: ETCDCTL_API
@@ -68,7 +68,7 @@ spec:
           name: etcd-data-dir
       containers:
       - name: etcd
-        image: {{ .Values.clustermesh.apiserver.etcd.image.repository }}:{{ .Values.clustermesh.apiserver.etcd.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.clustermesh.apiserver.etcd.image) }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         env:
         - name: ETCDCTL_API
@@ -97,7 +97,7 @@ spec:
         - mountPath: /var/run/etcd
           name: etcd-data-dir
       - name: "apiserver"
-        image: {{ .Values.clustermesh.apiserver.image.repository }}:{{ .Values.clustermesh.apiserver.image.tag }}
+        image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.clustermesh.apiserver.image) }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
           - /usr/bin/clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -45,7 +45,7 @@ spec:
 {{- end }}
       containers:
         - name: hubble-relay
-          image: {{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.hubble.relay.image) }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -40,7 +40,7 @@ spec:
 {{- end }}
       containers:
         - name: frontend
-          image: "{{ .Values.hubble.ui.frontend.image.repository }}:{{ .Values.hubble.ui.frontend.image.tag }}"
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.hubble.ui.frontend.image) }}
           imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
           ports:
             - containerPort: 8080
@@ -48,7 +48,7 @@ spec:
           resources:
             {{- toYaml .Values.hubble.ui.frontend.resources | trim | nindent 12 }}
         - name: backend
-          image: "{{ .Values.hubble.ui.backend.image.repository }}:{{ .Values.hubble.ui.backend.image.tag }}"
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.hubble.ui.backend.image) }}
           imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
           env:
             - name: EVENTS_SERVER_PORT
@@ -61,7 +61,7 @@ spec:
           resources:
             {{- toYaml .Values.hubble.ui.backend.resources  | trim | nindent 12 }}
         - name: proxy
-          image: "{{ .Values.hubble.ui.proxy.image.repository }}:{{ .Values.hubble.ui.proxy.image.tag }}"
+          image: {{ template "container.image" (dict "registry" $.Values.registry "image" .Values.hubble.ui.proxy.image) }}
           imagePullPolicy: {{ .Values.hubble.ui.proxy.image.pullPolicy }}
           ports:
             - containerPort: 8081

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -14,6 +14,9 @@ rbac:
   # -- Enable creation of Resource-Based Access Control configuration.
   create: true
 
+# -- Default container images registry
+registry: quay.io/cilium
+
 # -- Configure image pull secrets for pulling container images
 imagePullSecrets:
 # - name: "image-pull-secret"
@@ -82,7 +85,8 @@ rollOutCiliumPods: false
 
 # -- Agent container image.
 image:
-  repository: quay.io/cilium/cilium
+  # repository: quay.io/cilium/cilium
+  name: cilium
   tag: latest
   pullPolicy: Always
 
@@ -488,7 +492,8 @@ hostServices:
 # (re)generate any certificates not provided manually.
 certgen:
   image:
-    repository: quay.io/cilium/certgen
+    # repository: quay.io/cilium/certgen
+    name: certgen
     tag: v0.1.3
     pullPolicy: Always
   # -- Seconds after which the completed job pod will be deleted
@@ -598,7 +603,8 @@ hubble:
 
     # -- Hubble-relay container image.
     image:
-      repository: quay.io/cilium/hubble-relay
+      # repository: quay.io/cilium/hubble-relay
+      name: hubble-relay
       tag: latest
       pullPolicy: Always
 
@@ -679,7 +685,8 @@ hubble:
     backend:
       # -- Hubble-ui backend image.
       image:
-        repository: quay.io/cilium/hubble-ui-backend
+        # repository: quay.io/cilium/hubble-ui-backend
+        name: hubble-ui-backend
         tag: latest
         pullPolicy: Always
       # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
@@ -695,7 +702,8 @@ hubble:
     frontend:
       # -- Hubble-ui frontend image.
       image:
-        repository: quay.io/cilium/hubble-ui
+        # repository: quay.io/cilium/hubble-ui
+        name: hubble-ui
         tag: latest
         pullPolicy: Always
       # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
@@ -1005,7 +1013,8 @@ etcd:
 
   # -- cilium-etcd-operator image.
   image:
-    repository: quay.io/cilium/cilium-etcd-operator
+    # repository: quay.io/cilium/cilium-etcd-operator
+    name: cilium-etcd-operator
     tag: v2.0.7
     pullPolicy: Always
 
@@ -1122,7 +1131,8 @@ operator:
 
   # -- cilium-operator image.
   image:
-    repository: quay.io/cilium/operator
+    # repository: quay.io/cilium/operator
+    name: operator
     tag: latest
     pullPolicy: Always
     suffix: ""
@@ -1249,7 +1259,8 @@ nodeinit:
 
   # -- node-init image.
   image:
-    repository: quay.io/cilium/startup-script
+    # repository: quay.io/cilium/startup-script
+    name: startup-script
     tag: 62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
     pullPolicy: Always
 
@@ -1331,7 +1342,8 @@ preflight:
 
   # -- Cilium pre-flight image.
   image:
-    repository: quay.io/cilium/cilium
+    # repository: quay.io/cilium/cilium
+    name: cilium
     tag: latest
     pullPolicy: Always
 
@@ -1439,7 +1451,8 @@ clustermesh:
   apiserver:
     # -- Clustermesh API server image.
     image:
-      repository: quay.io/cilium/clustermesh-apiserver
+      # repository: quay.io/cilium/clustermesh-apiserver
+      name: clustermesh-apiserver
       tag: latest
       pullPolicy: Always
 

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -815,7 +815,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:latest
+        image: "quay.io/cilium/cilium:latest"
         imagePullPolicy: Always
         lifecycle:
           postStart:
@@ -887,7 +887,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:latest
+        image: "quay.io/cilium/cilium:latest"
         imagePullPolicy: Always
         name: clean-cilium-state
         securityContext:
@@ -1035,7 +1035,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-        image: quay.io/cilium/operator-generic:latest
+        image: "quay.io/cilium/operator-generic:latest"
         imagePullPolicy: Always
         name: cilium-operator
         livenessProbe:
@@ -1100,7 +1100,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: hubble-relay
-          image: quay.io/cilium/hubble-relay:latest
+          image: "quay.io/cilium/hubble-relay:latest"
           imagePullPolicy: Always
           command:
             - hubble-relay
@@ -1244,7 +1244,7 @@ spec:
       serviceAccountName: "hubble-generate-certs"
       containers:
         - name: certgen
-          image: quay.io/cilium/certgen:v0.1.3
+          image: "quay.io/cilium/certgen:v0.1.3"
           imagePullPolicy: Always
           command:
             - "/usr/bin/cilium-certgen"
@@ -1293,7 +1293,7 @@ spec:
           serviceAccountName: "hubble-generate-certs"
           containers:
             - name: certgen
-              image: quay.io/cilium/certgen:v0.1.3
+              image: "quay.io/cilium/certgen:v0.1.3"
               imagePullPolicy: Always
               command:
                 - "/usr/bin/cilium-certgen"

--- a/install/kubernetes/quick-hubble-install.yaml
+++ b/install/kubernetes/quick-hubble-install.yaml
@@ -322,7 +322,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: hubble-relay
-          image: quay.io/cilium/hubble-relay:latest
+          image: "quay.io/cilium/hubble-relay:latest"
           imagePullPolicy: Always
           command:
             - hubble-relay
@@ -466,7 +466,7 @@ spec:
       serviceAccountName: "hubble-generate-certs"
       containers:
         - name: certgen
-          image: quay.io/cilium/certgen:v0.1.3
+          image: "quay.io/cilium/certgen:v0.1.3"
           imagePullPolicy: Always
           command:
             - "/usr/bin/cilium-certgen"
@@ -515,7 +515,7 @@ spec:
           serviceAccountName: "hubble-generate-certs"
           containers:
             - name: certgen
-              image: quay.io/cilium/certgen:v0.1.3
+              image: "quay.io/cilium/certgen:v0.1.3"
               imagePullPolicy: Always
               command:
                 - "/usr/bin/cilium-certgen"

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -493,7 +493,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:latest
+        image: "quay.io/cilium/cilium:latest"
         imagePullPolicy: Always
         lifecycle:
           postStart:
@@ -560,7 +560,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:latest
+        image: "quay.io/cilium/cilium:latest"
         imagePullPolicy: Always
         name: clean-cilium-state
         securityContext:
@@ -708,7 +708,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-        image: quay.io/cilium/operator-generic:latest
+        image: "quay.io/cilium/operator-generic:latest"
         imagePullPolicy: Always
         name: cilium-operator
         livenessProbe:


### PR DESCRIPTION
Before this patch, using another repository base than `quay.io/cilium` (e.g. `quay.io/kaworu`) was difficult as it required to override every image repository independently.

This patch introduce a base registry (default to `quay.io/cilium`) Helm value allowing to simply use `helm --set registry=quay.io/kaworu` for the above use-case. Overriding repository on a per-image basis is still supported as previously.