### PR TITLE
docs: Advise running ginkgo in verbose for e2e tests

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -64,7 +64,7 @@ To run all of the runtime tests, execute the following command from the ``test``
 
 ::
 
-    ginkgo --focus="Runtime" -noColor
+    ginkgo -v --focus="Runtime" -noColor
 
 Ginkgo searches for all tests in all subdirectories that are "named" beginning
 with the string "Runtime" and contain any characters after it. For instance,
@@ -72,7 +72,7 @@ here is an example showing what tests will be ran using Ginkgo's dryRun option:
 
 ::
 
-    $ ginkgo --focus="Runtime" -noColor -v -dryRun
+    $ ginkgo -v --focus="Runtime" -noColor -dryRun
     Running Suite: runtime
     ======================
     Random Seed: 1516125117
@@ -115,14 +115,14 @@ To run all of the Kubernetes tests, run the following command from the ``test`` 
 
 ::
 
-    ginkgo --focus="K8s" -noColor
+    ginkgo -v --focus="K8s" -noColor
 
 To run a specific test from the Kubernetes tests suite, run the following command
 from the ``test`` directory:
 
 ::
 
-    ginkgo --focus="K8s.*Check iptables masquerading with random-fully"
+    ginkgo -v --focus="K8s.*Check iptables masquerading with random-fully"
 
 Similar to the Runtime test suite, Ginkgo searches for all tests in all
 subdirectories that are "named" beginning with the string "K8s" and
@@ -144,7 +144,7 @@ supported version of Kubernetes, run the test suite with the following format:
 
 ::
 
-    K8S_VERSION=<version> ginkgo --focus="K8s" -noColor
+    K8S_VERSION=<version> ginkgo -v --focus="K8s" -noColor
 
 .. note::
 
@@ -177,7 +177,7 @@ To run all of the Nightly tests, run the following command from the ``test`` dir
 
 ::
 
-    ginkgo --focus="Nightly"  -noColor
+    ginkgo -v --focus="Nightly"  -noColor
 
 Similar to the other test suites, Ginkgo searches for all tests in all
 subdirectories that are "named" beginning with the string "Nightly" and contain
@@ -268,7 +268,7 @@ If you want to run one specified test, there are a few options:
 
 ::
 
-    ginkgo --focus "Runtime.*L7"
+    ginkgo -v --focus "Runtime.*L7"
 
 
 This will focus on tests that contain "Runtime", followed by any
@@ -415,18 +415,10 @@ Test execution flow:
 Debugging:
 ~~~~~~~~~~
 
-Ginkgo provides to us different ways of debugging. In case that you want to see
-all the logs messages in the console you can run the test in verbose mode using
-the option ``-v``:
-
-::
-
-	ginkgo --focus "Runtime" -v
-
-In case that the verbose mode is not enough, you can retrieve all run commands
-and their output in the report directory (``./test/test_results``). Each test
-creates a new folder, which contains a file called log where all information is
-saved, in case of a failing test an exhaustive data will be added.
+You can retrieve all run commands and their output in the report directory
+(``./test/test_results``). Each test creates a new folder, which contains
+a file called log where all information is saved, in case of a failing
+test an exhaustive data will be added.
 
 ::
 
@@ -490,7 +482,7 @@ An example invocation is
 
 ::
 
-  CNI_INTEGRATION=eks K8S_VERSION=1.13 ginkgo --focus="K8s" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium" -cilium.operator-image="docker.io/cilium/operator" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=eks K8S_VERSION=1.13 ginkgo -v --focus="K8s" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="docker.io/cilium/cilium" -cilium.operator-image="docker.io/cilium/operator" -cilium.passCLIEnvironment=true
 
 Running in GKE
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
We should always recommend to run end-to-end tests with ginkgo in verbose mode. Otherwise the provisioning may get stuck downloading some image without the contributor noticing.