### PR TITLE
.github: fix correct sha for images build

### DIFF
--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -60,9 +60,8 @@ jobs:
 
       - name: Getting image tag
         id: tag
-        shell: bash
         run: |
-          if ${{ github.event_name }} -eq "pull_request_target"; then
+          if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
             echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
           else
             echo ::set-output name=tag::${{ github.sha }}


### PR DESCRIPTION
This commit sets the correct tag for the images build depending on the
event type from GH actions.

Fixes: 84bc5652b7d4 (".github/workflows: cleanup images-legacy workflow")
Signed-off-by: André Martins <andre@cilium.io>
