### PR TITLE
Overlay Tunnel Endpoint Manual Setting by CIDR

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -235,6 +235,7 @@ cilium-agent [flags]
       --tofqdns-proxy-response-max-delay duration            The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
       --trace-payloadlen int                                 Length of payload to capture when tracing (default 128)
   -t, --tunnel string                                        Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --tunnel-endpoint-ipv4-cidr string                     Allows to explicitly specify the CIDR for the tunnel endpoint IP which the user desires.
       --version                                              Print version information
       --write-cni-conf-when-ready string                     Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -329,7 +329,13 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	var mtuConfig mtu.Configuration
-	externalIP := node.GetIPv4()
+	//If tunnel endpoint IP is manually set in tunnel mode, we just use it here
+	//If not, fallback to node IP address
+	externalIP := node.GetTunnelEndpointIPv4()
+	if externalIP == nil || option.Config.Tunnel == option.TunnelDisabled {
+		externalIP = node.GetIPv4()
+	}
+
 	if externalIP == nil {
 		externalIP = node.GetIPv6()
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -29,6 +29,8 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/cleanup"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
@@ -633,6 +635,9 @@ func init() {
 
 	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.")
 	option.BindEnv(option.IPv4NativeRoutingCIDR)
+
+	flags.String(option.TunnelEndpointIPv4CIDR, "", "Allows to explicitly specify the CIDR for the tunnel endpoint IP which the user desires.")
+	option.BindEnv(option.TunnelEndpointIPv4CIDR)
 
 	flags.String(option.LibDir, defaults.LibraryPath, "Directory path to store runtime build environment")
 	option.BindEnv(option.LibDir)
@@ -1365,6 +1370,17 @@ func initEnv(cmd *cobra.Command) {
 			log.WithField(logfields.IPAddr, option.Config.IPv4NodeAddr).Fatal("Invalid IPv4 node address")
 		} else {
 			node.SetIPv4(ip)
+		}
+	}
+
+	// Setting node endpoint tunnel code here
+	tunnelEndpointIPv4CIDR := option.Config.GetTunnelEndpointIPv4CIDR()
+	if tunnelEndpointIPv4CIDR != nil && option.Config.Tunnel != option.TunnelDisabled && option.Config.EnableIPv4 {
+		if _, intfIP, _, err := cidr.DetectCIDRByCIDR(tunnelEndpointIPv4CIDR, 4); err != nil {
+			log.WithField(logfields.CIDR, tunnelEndpointIPv4CIDR.IPNet.String()).Fatal("Can't detect the cidr for an actual interface IP")
+		} else {
+			// Now set the node tunnel address to the deteced IP
+			node.SetTunnelEndpointIPv4(intfIP)
 		}
 	}
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -697,7 +697,16 @@ func detectNodePortDevices(ifidxByAddr map[string]int) (map[string]struct{}, err
 }
 
 func detectNodeDevice(ifidxByAddr map[string]int) (string, error) {
-	nodeIP := node.GetK8sNodeIP()
+	// nodeIP here is the tunnel endpoint IP when option.Config.Tunnel == option.TunnelDisabled
+	// and the tunnel endpoint address is manually set
+	// Here we should set the device to where the tunnel endpoint IP address locates since
+	// the actual data path device for bpf_host uses this device when the tunnel endpoint is manually
+	// selected, which is different from the default value of just the k8s nodeIP.
+	nodeIP := node.GetTunnelEndpointIPv4()
+	if nodeIP == nil || option.Config.Tunnel == option.TunnelDisabled {
+		nodeIP = node.GetK8sNodeIP()
+	}
+
 	if nodeIP == nil {
 		return "", fmt.Errorf("K8s Node IP is not set")
 	}

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -161,9 +161,13 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			// with the hostIP so that this traffic can be guided
 			// to a tunnel endpoint destination.
 			nodeIPv4 := node.GetIPv4()
-			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
-				copy(value.TunnelEndpoint[:], ip4)
+			// If the tunnel endpoint IPv4 address is manually set, don't change value.TunnelEndpoint
+			if tunnelIP := node.GetTunnelEndpointIPv4(); tunnelIP == nil {
+				if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
+					copy(value.TunnelEndpoint[:], ip4)
+				}
 			}
+
 		}
 		err := l.bpfMap.Update(&key, &value)
 		if err != nil {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -94,6 +94,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetIPv4().String())
 	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4Router().String())
 	fmt.Fprintf(fw, " cilium.v4.nodeport.str %s\n", node.GetNodePortIPv4Addrs())
+	if tunnelIP := node.GetTunnelEndpointIPv4(); tunnelIP != nil {
+		fmt.Fprintf(fw, " cilium.v4.tunnelendpoint.str %s\n", tunnelIP.String())
+	}
+
 	fmt.Fprintf(fw, "\n")
 	if option.Config.EnableIPv6 {
 		fw.WriteString(dumpRaw(defaults.RestoreV6Addr, node.GetIPv6Router()))
@@ -442,6 +446,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			extraMacrosMap["IPV6_DIRECT_ROUTING"] = directRoutingIPv6.String()
 			fw.WriteString(FmtDefineAddress("IPV6_DIRECT_ROUTING", directRoutingIPv6))
 		}
+	}
+
+	// Manually defined a tunnel endpoint IPv4 CIDR
+	if tunnelEndpointIPv4CIDR := option.Config.GetTunnelEndpointIPv4CIDR(); tunnelEndpointIPv4CIDR != nil {
+		cDefinesMap["TUNNEL_ENDPOINT_IPV4_CIDR"] = tunnelEndpointIPv4CIDR.String()
 	}
 
 	if option.Config.EnableBandwidthManager {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -143,6 +143,14 @@ func useNodeCIDR(n *nodeTypes.Node) {
 	}
 }
 
+// setNodeTunnelEndpointIPv4 sets the tunnel endpoint IPv4 addr defined
+// in the given node
+func setNodeTunnelEndpointIPv4(n *nodeTypes.Node) {
+	if tAddr := n.GetNodeTunnelEndpointIPv4(); tAddr != nil {
+		node.SetTunnelEndpointIPv4(tAddr)
+	}
+}
+
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
 func Init(conf k8sconfig.Configuration) error {
@@ -233,6 +241,8 @@ func WaitForNodeInformation() error {
 		}).Info("Received own node information from API server")
 
 		useNodeCIDR(n)
+		// Set node tunnel endpoint IPv4 address
+		setNodeTunnelEndpointIPv4(n)
 
 		// Note: Node IPs are derived regardless of
 		// option.Config.EnableIPv4 and

--- a/pkg/node/addressing/addresstype.go
+++ b/pkg/node/addressing/addresstype.go
@@ -26,4 +26,5 @@ const (
 	NodeExternalDNS      AddressType = "ExternalDNS"
 	NodeInternalDNS      AddressType = "InternalDNS"
 	NodeCiliumInternalIP AddressType = "CiliumInternalIP"
+	NodeTunnelEndpointIP AddressType = "TunnelEndpointIP"
 )

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -368,7 +368,10 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
 		if address.Type == addressing.NodeCiliumInternalIP || m.conf.EncryptionEnabled() ||
 			option.Config.EnableHostFirewall || option.Config.JoinCluster {
-			tunnelIP = nodeIP
+			if tunnelIP = n.GetNodeTunnelEndpointIPv4(); tunnelIP == nil {
+				// No tunnelIP manually defined, just use the nodeIP
+				tunnelIP = nodeIP
+			}
 		}
 
 		if skipIPCache(address) {

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -266,6 +266,23 @@ func (n *Node) GetExternalIP(ipv6 bool) net.IP {
 	return nil
 }
 
+// get node tunnel endpoint IPv4 address
+func (n *Node) getNodeTunnelEndpointIPv4() net.IP {
+	for _, addr := range n.IPAddresses {
+		switch addr.Type {
+		// Always chooses a tunnel endpoint address
+		case addressing.NodeTunnelEndpointIP:
+			return addr.IP
+		default:
+		}
+	}
+	return nil
+}
+
+func (n *Node) GetNodeTunnelEndpointIPv4() net.IP {
+	return n.getNodeTunnelEndpointIPv4()
+}
+
 // GetK8sNodeIPs returns k8s Node IP (either InternalIP or ExternalIP or nil;
 // the former is preferred).
 func (n *Node) GetK8sNodeIP() net.IP {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -210,6 +210,14 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		})
 	}
 
+	// Add the tunnel endpoint address here
+	if node.GetTunnelEndpointIPv4() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeTunnelEndpointIP,
+			IP:   node.GetTunnelEndpointIPv4(),
+		})
+	}
+
 	if node.GetIPv6Router() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,


### PR DESCRIPTION
This feature enhancement enables the user to set the desired
outgoing interface and its tunnel endpoint IP(v4) address by
a designated CIDR, which may be different from the default
which currently is just the Kubernetes node IP.

The usage of the this feature is just by adding the following
declaration in the installation yaml file:

apiVersion: v1
kind: ConfigMap
metadata:
  name: cilium-config
  namespace: kube-system
data:
  ...
  tunnel-endpoint-ipv4-cidr: "xxx.xxx.xxx.xxx/yyy"

This feature supports VXLAN overlay tunnel, which would lead the
data traffic and tunnel selection from the default k8s node IP
and related interface to the IP address which matches the setted
IPv4 CIDR and its interface.

If this feature is enabled by setting the desired CIDR,
the MTU and NodePort (physical) device would also be changed to this
matching interface(device) to enable the working of BPF on it.

This feature currently doesn't support IPSEC or node encryption.
This feature is still in its initial state currently which just
support 1 CIDR specified, and the multi-CIDRs case would be
supported if needed.

For further information, please look for:
https://github.com/cilium/cilium/issues/14520

Signed-off-by: trevor tao <trevor.tao@arm.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #14520

```release-note
Add a new feature to enable setting/selecting the overlay tunnel endpoint IPv4 address manually by specifying CIDR
```
