### PR TITLE
images/cilium: set IMAGE_CROSS_TARGET_PLATFORM for right arch

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,9 +1,12 @@
 # Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:57f235db9a07e81c5b60c536498ecbf2501dd267@sha256:080245ac0d7d061e05613e6bf887dc3c8bb07392cd2ce265b8a4aaaad17f2125
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:e76fdafb3d78e9a9869220b66962c84cc293457d@sha256:e210ac325f326084cf7cd73e863159b198657a62a972c8c90aae42e1c5c236ca
 ARG TESTER_IMAGE=docker.io/cilium/image-tester:70724309b859786e0a347605e407c5261f316eb0@sha256:89cc1f577d995021387871d3dbeb771b75ab4d70073d9bcbc42e532792719781
 ARG GOLANG_IMAGE=docker.io/library/golang:1.16.0@sha256:f3f90f4d30866c1bdae90012b506bd5e557ce27ccd2510ed30a011c44c1affc8
+
+FROM ${COMPILERS_IMAGE} as compilers-image
 
 FROM ${GOLANG_IMAGE} as golang-dist
 
@@ -36,6 +39,8 @@ RUN \
 # Change the number to force the generation of a new git-tree SHA. Useful when
 # we want to re-run 'apt-get upgrade' for stale images.
 ENV FORCE_BUILD=1
+
+COPY --from=compilers-image /usr/lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu
 
 COPY --from=golang-dist /usr/local/go /usr/local/go
 RUN mkdir -p /go

--- a/images/cilium-test/Dockerfile
+++ b/images/cilium-test/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:6fe0cc8e74607c48e92758e1ff13bd267b70a29d@sha256:3a82c1bc13cf940524546d510643542d8cf63925ca9dc07ee8d2a63b7d14451b
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:49d080085964fb729628fdf27418b554a4e905f3@sha256:7cc9b9809357528031d82ab357a537b8d905e635035091ce8447d7ed3b222fba
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
 
 FROM ${UBUNTU_IMAGE} as rootfs

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:6fe0cc8e74607c48e92758e1ff13bd267b70a29d@sha256:3a82c1bc13cf940524546d510643542d8cf63925ca9dc07ee8d2a63b7d14451b
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:49d080085964fb729628fdf27418b554a4e905f3@sha256:7cc9b9809357528031d82ab357a537b8d905e635035091ce8447d7ed3b222fba
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:e76fdafb3d78e9a9869220b66962c84cc293457d@sha256:e210ac325f326084cf7cd73e863159b198657a62a972c8c90aae42e1c5c236ca
 
 # cilium-envoy from github.com/cilium/proxy

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -47,7 +47,7 @@ ARG LIBNETWORK_PLUGIN
 #
 WORKDIR /go/src/github.com/cilium/cilium
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-    make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+    make IMAGE_CROSS_TARGET_PLATFORM=${TARGETOS}/${TARGETARCH} GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
     SKIP_DOCS=true DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} build-container install-container-binary
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:6fe0cc8e74607c48e92758e1ff13bd267b70a29d@sha256:3a82c1bc13cf940524546d510643542d8cf63925ca9dc07ee8d2a63b7d14451b
+    image: quay.io/cilium/cilium-builder:49d080085964fb729628fdf27418b554a4e905f3@sha256:7cc9b9809357528031d82ab357a537b8d905e635035091ce8447d7ed3b222fba
     workingDir: /cilium
     command: ["sleep"]
     args:


### PR DESCRIPTION
This variable is used to cross compile certain targets. Fixes the build
of 'cilium-map-migrate' in multi-arch.

Fixes: 706fc4269eec ("add multi-arch support into all images")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: #15073