### PR TITLE
Drop GODEBUG='madvdontneed=1' setting with Go 1.16

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -348,8 +348,6 @@ sleep 2s
 if [ -n "\${K8S}" ]; then
     echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
 fi
-# FIXME Remove me once we add support for Go 1.16
-echo 'GODEBUG="madvdontneed=1"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPTS="${cilium_options}"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPERATOR_OPTS="${cilium_operator_options}"' >> /etc/sysconfig/cilium
 echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium

--- a/images/cilium-docker-plugin/Dockerfile
+++ b/images/cilium-docker-plugin/Dockerfile
@@ -32,6 +32,4 @@ ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-docker /usr/bin/cilium-docker
 WORKDIR /
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-docker"]

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -88,6 +88,4 @@ COPY --from=builder /tmp/install/${TARGETOS}/${TARGETARCH} /
 WORKDIR /home/cilium
 
 ENV INITSYSTEM="SYSTEMD"
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium"]

--- a/images/clustermesh-apiserver/Dockerfile
+++ b/images/clustermesh-apiserver/Dockerfile
@@ -63,6 +63,4 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/clustermesh-apiserver
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 WORKDIR /
 ENV GOPS_CONFIG_DIR=/
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 ENTRYPOINT ["/usr/bin/clustermesh-apiserver"]

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -61,6 +61,4 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 WORKDIR /
 ENV GOPS_CONFIG_DIR=/
 ENTRYPOINT ["/usr/bin/hubble-relay"]
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 CMD ["serve"]

--- a/images/operator-aws/Dockerfile
+++ b/images/operator-aws/Dockerfile
@@ -60,6 +60,4 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-operator-aws /
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 WORKDIR /
 ENV GOPS_CONFIG_DIR=/
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-aws"]

--- a/images/operator-azure/Dockerfile
+++ b/images/operator-azure/Dockerfile
@@ -60,6 +60,4 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-operator-azure
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 WORKDIR /
 ENV GOPS_CONFIG_DIR=/
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-azure"]

--- a/images/operator-generic/Dockerfile
+++ b/images/operator-generic/Dockerfile
@@ -60,6 +60,4 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-operator-gener
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 WORKDIR /
 ENV GOPS_CONFIG_DIR=/
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator-generic"]

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -60,6 +60,4 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-operator /usr/
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 WORKDIR /
 ENV GOPS_CONFIG_DIR=/
-# FIXME Remove me once we add support for Go 1.16
-ENV GODEBUG="madvdontneed=1"
 CMD ["/usr/bin/cilium-operator"]


### PR DESCRIPTION
Go 1.16 switched back to `madvdontneed=1` by default, see
https://golang.org/doc/go1.16#runtime. Thus we no longer need to set
this explicitly at runtime after switching to Go 1.16 in commit
0cf2cff55ba5 `("Update Go to 1.16")`

This reverts the `GODEBUG` setting introduced by commit 83cb61004bfe
`("Makefile: build Cilium with madvdontneed=1")`