### PR TITLE
envoy: use errors.Is(..., net.ErrClosed) instead of string matching

### DIFF
--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -26,11 +26,19 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.4.0
+      - name: Install Go
+        uses: actions/setup-go@v2.1.3
         with:
-          version: v1.31
+          go-version: 1.16.0
+      - uses: actions/checkout@v2
+      - run: go version
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.0
+        with:
+          version: v1.37.1
+          skip-go-installation: true
+      - run: go version
+      - run: which golangci-lint
 
   precheck:
     runs-on: ubuntu-latest

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -15,11 +15,12 @@
 package envoy
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
+	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -72,8 +73,7 @@ func StartAccessLogServer(stateDir string, xdsServer *XDSServer, endpointInfoReg
 			uc, err := accessLogListener.AcceptUnix()
 			if err != nil {
 				// These errors are expected when we are closing down
-				if strings.Contains(err.Error(), "closed network connection") ||
-					strings.Contains(err.Error(), "invalid argument") {
+				if errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.EINVAL) {
 					break
 				}
 				log.WithError(err).Warn("Envoy: Failed to accept access log connection")

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/cilium/cilium/pkg/envoy/xds"
@@ -60,7 +59,7 @@ func startXDSGRPCServer(listener net.Listener, ldsConfig, npdsConfig, nphdsConfi
 
 	go func() {
 		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener.Addr())
-		if err := grpcServer.Serve(listener); err != nil && !strings.Contains(err.Error(), "closed network connection") {
+		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, net.ErrClosed) {
 			log.WithError(err).Fatal("Envoy: Failed to serve xDS gRPC API")
 		}
 	}()

--- a/proxylib/test/accesslog_server.go
+++ b/proxylib/test/accesslog_server.go
@@ -15,12 +15,13 @@
 package test
 
 import (
+	"errors"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/inctimer"
@@ -103,8 +104,8 @@ func StartAccessLogServer(accessLogName string, bufSize int) *AccessLogServer {
 			if err != nil {
 				// These errors are expected when we are closing down
 				if atomic.LoadUint32(&server.closing) != 0 ||
-					strings.Contains(err.Error(), "closed network connection") ||
-					strings.Contains(err.Error(), "invalid argument") {
+					errors.Is(err, net.ErrClosed) ||
+					errors.Is(err, syscall.EINVAL) {
 					break
 				}
 				log.WithError(err).Warn("Failed to accept access log connection")


### PR DESCRIPTION
Instead of comparing error strings use `errors.Is` to check whether `err` or
some error that it wraps is `net.ErrClosed` (available since Go 1.16, see
https://golang.org/pkg/net/#ErrClosed).

Same for `syscall.EINVAL`.

EDIT: pushed an additional commit to bump the `golangci-lint` GH action so it supports Go 1.16.