### PR TITLE
.github: add stable tag for v1.9 releases

### DIFF
--- a/.github/workflows/images-legacy-releases.yaml
+++ b/.github/workflows/images-legacy-releases.yaml
@@ -61,6 +61,8 @@ jobs:
             ${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.vars.outputs.tag }}
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.vars.outputs.tag }}
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+            ${{ github.repository_owner }}/${{ matrix.name }}:stable
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:stable
       - name: Image Release Digest
         shell: bash
         run: |
@@ -69,6 +71,8 @@ jobs:
           echo "" >> image-digest/${{ matrix.name }}.txt
           echo "\`docker.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.vars.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.vars.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`docker.io/${{ github.repository_owner }}/${{ matrix.name }}:stable@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}:stable@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests


### PR DESCRIPTION
At this moment, stable should point to the latest v1.9 release. Adding
this in the GH action as we are building the images using GitHub
Actions.

Signed-off-by: André Martins <andre@cilium.io>