### PR TITLE
Move regex to a global variable to not compile it every time

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -38,6 +38,9 @@ var (
 
 	// Only mount a single instance
 	cgrpMountOnce sync.Once
+
+	// Regex to match 'kubelet'
+	kubeletRegex = regexp.MustCompile(`^.*kubelet`)
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cgroups")
@@ -96,9 +99,8 @@ func getCgroupRootForKind() (string, error) {
 		}
 
 		if strings.HasPrefix(line, "0::") { // cgroup v2 starts with "0::"
-			re := regexp.MustCompile(`^.*kubelet`)
 			p := path.Join(cgroupRoot, strings.Split(line, "::")[1])
-			match := re.FindString(p)
+			match := kubeletRegex.FindString(p)
 			if match == "" {
 				return "", fmt.Errorf("cannot find \"kubelet\" in cgroup v2 path: %q", p)
 			}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Here the check is in a for loop so we are compiling the regex every time. Moving it to a global variable makes it faster.