### PR TITLE
make: add help target to root Makefile for printing info about availble targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # Copyright 2017-2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-all: precheck build postcheck
+##@ Default
+all: precheck build postcheck ## Default make target that perform precheck -> build -> postcheck
 	@echo "Build finished."
 
-debug: export NOOPT=1
+##@ Build, Install and Test
+debug: export NOOPT=1 ## Builds Cilium by disabling inlining, compiler optimizations and without stripping debug symbols, useful for debugging.
 debug: export NOSTRIP=1
 debug: all
 
@@ -67,6 +69,10 @@ TEST_UNITTEST_LDFLAGS= -ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulD
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 \
 	-X github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr=$(LOGLEVEL)"
 
+define print_help_line
+	@printf "  \033[36m%-29s\033[0m %s.\n" $(1) $(2)
+endef
+
 define generate_k8s_api
 	cd "./vendor/k8s.io/code-generator" && \
 	GO111MODULE=off bash ./generate-groups.sh $(1) \
@@ -122,17 +128,17 @@ define generate_k8s_protobuf
 	    --go-header-file "$(PWD)/hack/custom-boilerplate.go.txt"
 endef
 
-build: $(SUBDIRS)
+build: $(SUBDIRS) ## Builds all the components for Cilium by executing make in the respective sub directories.
 
-build-container:
+build-container: ## Builds components required for cilium-agent container.
 	for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i all; done
 
-$(SUBDIRS): force
+$(SUBDIRS): force ## Execute default make target(make all) for the provided subdirectory.
 	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
 
 PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $$pkg; done | xargs grep --include='*.go' -ril '+build [^!]*privileged_tests' | xargs dirname | sort | uniq)
 PRIV_TEST_PKGS ?= $(PRIV_TEST_PKGS_EVAL)
-tests-privileged: GO_TAGS_FLAGS+=privileged_tests
+tests-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run unit-tests for Cilium that requires elevated privileges.
 tests-privileged:
 	# cilium-map-migrate is a dependency of some unit tests.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf cilium-map-migrate
@@ -144,7 +150,7 @@ tests-privileged:
 	done
 	$(MAKE) generate-cov
 
-start-kvstores:
+start-kvstores: ## Start running kvstores required for running Cilium unit-tests. More specifically this will run etcd and consul containers.
 ifeq ($(SKIP_KVSTORES),"false")
 	@echo Starting key-value store containers...
 	-$(QUIET)$(CONTAINER_ENGINE) rm -f "cilium-etcd-test-container" 2> /dev/null
@@ -173,17 +179,14 @@ ifeq ($(SKIP_KVSTORES),"false")
 		agent -client=0.0.0.0 -server -bootstrap-expect 1 -config-file=/cilium-consul/consul-config.json
 endif
 
-stop-kvstores:
+stop-kvstores: ## Forcefully removes running kvstore components for Cilium unit-testing(etcd and consul containers).
 ifeq ($(SKIP_KVSTORES),"false")
 	$(QUIET)$(CONTAINER_ENGINE) rm -f "cilium-etcd-test-container"
 	$(QUIET)$(CONTAINER_ENGINE) rm -f "cilium-consul-test-container"
 	$(QUIET)rm -rf /tmp/cilium-consul-certs
 endif
 
-tests: force
-	$(MAKE) unit-tests
-
-generate-cov:
+generate-cov: ## Generate coverage report for Cilium unit-tests.
 	# Remove generated code from coverage
 	$(QUIET) grep -Ev '(^github.com/cilium/cilium/api/v1)|(generated.deepcopy.go)|(^github.com/cilium/cilium/pkg/k8s/client/)' \
 		coverage-all-tmp.out > coverage-all.out
@@ -191,11 +194,11 @@ generate-cov:
 	$(QUIET) rm coverage.out coverage-all-tmp.out
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
 
-init-coverage:
+init-coverage: ## Initialize converage report for Cilium unit-tests.
 	$(QUIET) echo "mode: count" > coverage-all-tmp.out
 	$(QUIET) echo "mode: count" > coverage.out
 
-unit-tests: start-kvstores
+unit-tests: start-kvstores ## Runs all unit-tests for Cilium.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tools/maptool/
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C test/bpf/
 	test/bpf/unit-test
@@ -215,9 +218,9 @@ endif
 	$(MAKE) generate-cov
 	$(MAKE) stop-kvstores
 
-bench: start-kvstores
+bench: start-kvstores ## Run benchmarks for Cilium unit-tests in the repository.
 	# Process the packages in different subshells. See comment in the
-	# "unit-tests" target above for an explanation.
+	# "unit-tests" target above for an explanation.## Builds components required for cilium-agent container.
 	$(QUIET)for pkg in $(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)); do \
 		$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) \
 			$$pkg \
@@ -225,7 +228,7 @@ bench: start-kvstores
 	done
 	$(MAKE) stop-kvstores
 
-bench-privileged: GO_TAGS_FLAGS+=privileged_tests
+bench-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run benchmarks for priviliged tests.
 bench-privileged:
 	# Process the packages in different subshells. See comment in the
 	# "unit-tests" target above for an explanation.
@@ -234,46 +237,47 @@ bench-privileged:
 		|| exit 1; \
 	done
 
-clean-tags:
+clean-tags: ## Remove all the tags files from the repository.
 	@$(ECHO_CLEAN) tags
 	@-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
 
-cscope.files: $(GOLANG_SRCFILES) $(BPF_SRCFILES)
+cscope.files: $(GOLANG_SRCFILES) $(BPF_SRCFILES) ## Generate cscope.files with the list of all files to generate ctags for.
 	@echo $(GOLANG_SRCFILES) $(BPF_SRCFILES) | sed 's/ /\n/g' | sort > cscope.files
 
-tags: $(GOLANG_SRCFILES) $(BPF_SRCFILES) cscope.files
+tags: $(GOLANG_SRCFILES) $(BPF_SRCFILES) cscope.files ## Generate tags for Go and BPF source files.
 	@ctags $(GOLANG_SRCFILES) $(BPF_SRCFILES)
 	cscope -R -b -q
 
-clean-container:
-	-$(QUIET) for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i clean; done
+clean-container: ## Perform `make clean` for each component required in cilium-agent container.
+	-$(QUIET) for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i clean; done
 
-clean: clean-container
+clean: ## Perform overall cleanup for Cilium.
+	-$(QUIET) for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i clean; done
 	-$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/deb clean
 	-$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/rpm clean
 
-veryclean:
+veryclean: ## Perform complete cleanup for container engine images(including build cache).
 	-$(QUIET) $(CONTAINER_ENGINE) image prune -af
 	-$(QUIET) $(CONTAINER_ENGINE) builder prune -af
 
-install-bpf:
+install-bpf: ## Copies over the BPF source files from bpf/ to /var/lib/cilium/bpf/
 	$(QUIET)$(INSTALL) -m 0750 -d $(DESTDIR)$(LOCALSTATEDIR)/lib/cilium
 	-rm -rf $(DESTDIR)$(LOCALSTATEDIR)/lib/cilium/bpf/*
 	$(foreach bpfsrc,$(BPF_SRCFILES), $(INSTALL) -D -m 0644 $(bpfsrc) $(DESTDIR)$(LOCALSTATEDIR)/lib/cilium/$(bpfsrc);)
 
-install: install-bpf
+install: install-bpf ## Performs install for all the Cilium sub components (daemon, operator, relay etc.)
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i install; done
 
-install-container: install-bpf
+install-container: install-bpf ## Performs install for all components required for cilium-agent container.
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i install; done
 
-install-container-binary: install-bpf
+install-container-binary: install-bpf ## Install binaries for all components required for cilium-agent container.
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i install-binary; done
 
-install-bash-completion:
+install-bash-completion: ## Install bash completion for all components required for cilium-agent container.
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i install-bash-completion; done
 
@@ -282,11 +286,23 @@ install-bash-completion:
 GIT_VERSION: force
 	@if [ "$(GIT_VERSION)" != "`cat 2>/dev/null GIT_VERSION`" ] ; then echo "$(GIT_VERSION)" >GIT_VERSION; fi
 
+build-deb: ## Build deb package of cilium.
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/deb
+
+build-rpm: ## Build rpm package of cilium.
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/rpm
+
+runtime-tests: ## Run runtime-tests for Cilium.
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tests runtime-tests
+
+k8s-tests:
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tests k8s-tests
+
 -include Makefile.docker
 
+##@ API targets
 CRD_OPTIONS ?= "crd:crdVersions=v1"
-# Generate manifests e.g. CRD, RBAC etc.
-manifests:
+manifests: ## Generate K8s manifests e.g. CRD, RBAC etc.
 	$(eval TMPDIR := $(shell mktemp -d))
 	cd "./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen" && \
 	go run ./... $(CRD_OPTIONS) paths="$(PWD)/pkg/k8s/apis/cilium.io/v2" output:crd:artifacts:config="$(TMPDIR)";
@@ -299,19 +315,7 @@ manifests:
 	mv ${TMPDIR}/cilium.io_ciliumlocalredirectpolicies.yaml ./examples/crds/ciliumlocalredirectpolicies.yaml
 	rm -rf $(TMPDIR)
 
-build-deb:
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/deb
-
-build-rpm:
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/rpm
-
-runtime-tests:
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tests runtime-tests
-
-k8s-tests:
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tests k8s-tests
-
-generate-api: api/v1/openapi.yaml
+generate-api: api/v1/openapi.yaml ## Generate cilium-agent client, model and server code from openapi spec.
 	@$(ECHO_GEN)api/v1/openapi.yaml
 	-$(QUIET)$(SWAGGER) generate server -s server -a restapi \
 		-t api/v1 \
@@ -328,7 +332,7 @@ generate-api: api/v1/openapi.yaml
 	-$(QUIET) find api/v1/models/ -type f -name "*.go" -print | PATH="$(PWD)/tools:$(PATH)" xargs goimports -w
 	-$(QUIET) find api/v1/server/ -type f -name "*.go" -print | PATH="$(PWD)/tools:$(PATH)" xargs goimports -w
 
-generate-health-api: api/v1/health/openapi.yaml
+generate-health-api: api/v1/health/openapi.yaml ## Generate cilium-health client, model and server code from openapi spec.
 	@$(ECHO_GEN)api/v1/health/openapi.yaml
 	-$(QUIET)$(SWAGGER) generate server -s server -a restapi \
 		-t api/v1 \
@@ -345,7 +349,7 @@ generate-health-api: api/v1/health/openapi.yaml
 	@# sort goimports automatically
 	-$(QUIET) find api/v1/health/ -type f -name "*.go" -print | PATH="$(PWD)/tools:$(PATH)" xargs goimports -w
 
-generate-operator-api: api/v1/operator/openapi.yaml
+generate-operator-api: api/v1/operator/openapi.yaml ## Generate cilium-operator client, model and server code from openapi spec.
 	@$(ECHO_GEN)api/v1/operator/openapi.yaml
 	-$(QUIET)$(SWAGGER) generate server -s server -a restapi \
 		-t api/v1 \
@@ -362,10 +366,10 @@ generate-operator-api: api/v1/operator/openapi.yaml
 	@# sort goimports automatically
 	-$(QUIET) find api/v1/operator/ -type f -name "*.go" -print | PATH="$(PWD)/tools:$(PATH)" xargs goimports -w
 
-generate-hubble-api: api/v1/flow/flow.proto api/v1/peer/peer.proto api/v1/observer/observer.proto api/v1/relay/relay.proto
+generate-hubble-api: api/v1/flow/flow.proto api/v1/peer/peer.proto api/v1/observer/observer.proto api/v1/relay/relay.proto ## Generate hubble proto Go sources.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C api/v1
 
-generate-k8s-api:
+generate-k8s-api: ## Generate Cilium k8s API client, deepcopy and deepequal Go sources.
 	$(call generate_k8s_protobuf,$\
 	github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1$(comma)$\
 	github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1$(comma)$\
@@ -437,17 +441,18 @@ go-bindata: $(K8S_CRD_FILES)
 		$(GO_BINDATA) -o $(ROOT_DIR)/pkg/k8s/apis/cilium.io/v2/client/bindata.go \
 		$(K8S_CRD_FILES)
 
-vps:
+##@ Development
+vps: ## List all the running vagrant VMs.
 	VBoxManage list runningvms
 
-reload:
+reload: ## Reload cilium-agent and cilium-docker systemd service after installing built binaries.
 	sudo systemctl stop cilium cilium-docker
 	sudo $(MAKE) install
 	sudo systemctl start cilium cilium-docker
 	sleep 6
 	cilium status
 
-release:
+release: ## Perform a Git release for Cilium.
 	$(eval TAG_VERSION := $(shell git tag | grep v$(VERSION) > /dev/null; echo $$?))
 	$(eval BRANCH := $(shell git rev-parse --abbrev-ref HEAD))
 	$(info Checking if tag $(VERSION) is created '$(TAG_VERSION)' $(BRANCH))
@@ -458,10 +463,10 @@ release:
 	git tag v$(VERSION)
 	git archive --format tar $(BRANCH) | gzip > ../cilium_$(VERSION).orig.tar.gz
 
-gofmt:
+gofmt: ## Run gofmt on Go source files in the repository.
 	$(QUIET)for pkg in $(GOFILES); do $(GO) fmt $$pkg; done
 
-govet:
+govet: ## Run govet on Go source files in the repository.
 	@$(ECHO_CHECK) vetting all GOFILES...
 	$(QUIET) $(GO_VET) \
     ./api/... \
@@ -482,15 +487,15 @@ govet:
     ./test/k8sT/... \
     ./tools/...
 
-lint:
+lint: ## Run golangci-lint.
 	@$(ECHO_CHECK) golangci-lint
 	$(QUIET) golangci-lint run
 
-logging-subsys-field:
+logging-subsys-field: ## Validate logrus subsystem field for logs in Go source code.
 	@$(ECHO_CHECK) contrib/scripts/check-logging-subsys-field.sh
 	$(QUIET) contrib/scripts/check-logging-subsys-field.sh
 
-check-microk8s:
+check-microk8s: ## Validate if microk8s is ready to install cilium.
 	@$(ECHO_CHECK) microk8s is ready...
 	$(QUIET)microk8s.status >/dev/null \
 		|| (echo "Error: Microk8s is not running" && exit 1)
@@ -499,13 +504,13 @@ check-microk8s:
 
 LOCAL_IMAGE_TAG=local
 LOCAL_IMAGE=localhost:32000/cilium/cilium:$(LOCAL_IMAGE_TAG)
-microk8s: check-microk8s
+microk8s: check-microk8s ## Build cilium-dev docker image and import to mircrok8s
 	$(QUIET)$(MAKE) dev-docker-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
 	@echo "  DEPLOY image to microk8s ($(LOCAL_IMAGE))"
 	$(QUIET)$(CONTAINER_ENGINE) tag $(IMAGE_REPOSITORY)/cilium-dev:$(LOCAL_IMAGE_TAG) $(LOCAL_IMAGE)
 	$(QUIET)./contrib/scripts/microk8s-import.sh $(LOCAL_IMAGE)
 
-precheck: logging-subsys-field
+precheck: logging-subsys-field ## Peform build precheck for the source code.
 ifeq ($(SKIP_K8S_CODE_GEN_CHECK),"false")
 	@$(ECHO_CHECK) contrib/scripts/check-k8s-code-gen.sh
 	$(QUIET) contrib/scripts/check-k8s-code-gen.sh
@@ -527,31 +532,22 @@ endif
 	@$(ECHO_CHECK) contrib/scripts/rand-check.sh
 	$(QUIET) contrib/scripts/rand-check.sh
 
-pprof-help:
-	@echo "Available pprof targets:"
-	@echo "  pprof-heap"
-	@echo "  pprof-profile"
-	@echo "  pprof-block"
-	@echo "  pprof-trace-5s"
-	@echo "  pprof-mutex"
-
-pprof-heap:
+pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap
 
-pprof-profile:
+pprof-profile: ## Get Go pprof profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/profile
 
-
-pprof-block:
+pprof-block: ## Get Go pprof block profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/block
 
-pprof-trace-5s:
+pprof-trace-5s: ## Get Go pprof trace for a duration of 5 seconds.
 	curl http://localhost:6060/debug/pprof/trace?seconds=5
 
-pprof-mutex:
+pprof-mutex: ## Get Go pprof mutex profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/mutex
 
-update-authors:
+update-authors: ## Update AUTHORS file for Cilium repository.
 	@echo "Updating AUTHORS file..."
 	@echo "The following people, in alphabetical order, have either authored or signed" > AUTHORS
 	@echo "off on commits in the Cilium repository:" >> AUTHORS
@@ -559,60 +555,73 @@ update-authors:
 	@contrib/scripts/extract_authors.sh >> AUTHORS
 	@cat .authors.aux >> AUTHORS
 
-test-docs:
+test-docs: ## Build HTML documentation.
 	$(MAKE) -C Documentation html
 
-render-docs: test-docs
+render-docs: test-docs ## Run server to render documentation.
 	$(MAKE) -C Documentation run-server
 
-render-docs-live-preview:
+render-docs-live-preview: ## Run server with live preview to render documentation.
 	$(MAKE) -C Documentation live-preview
 
-manpages:
+manpages: ## Generate manpage for Cilium CLI.
 	-rm -r man
 	mkdir -p man
 	cilium cmdman -d man
 
-install-manpages:
+install-manpages: ## Install manpages the Cilium CLI.
 	cp man/* /usr/local/share/man/man1/
 	mandb
 
-postcheck: build
+postcheck: build ## Run Cilium build postcheck (update-cmdref, build documentation etc.).
 	$(QUIET)$(MAKE) $(SUBMAKEOPTS) -C Documentation update-cmdref check
 
-minikube:
+minikube: ## Setup a minikube with Cilium installed.
 	$(QUIET) contrib/scripts/minikube.sh
 
-licenses-all:
+licenses-all: ## Generate file with all the License from dependencies.
 	@$(GO) run ./tools/licensegen > LICENSE.all || ( rm -f LICENSE.all ; false )
 
-update-go-version: update-dev-doctor-go-version update-gh-actions-go-version update-travis-go-version update-test-go-version update-images-go-version
+update-go-version: update-dev-doctor-go-version update-gh-actions-go-version update-travis-go-version update-test-go-version update-images-go-version ## Update Go version for all the components (travis, dev-doctor, gh-actions etc.).
 
-update-dev-doctor-go-version:
+update-dev-doctor-go-version: ## Update dev-doctor Go version.
 	$(QUIET) sed -i 's/^const minGoVersionStr = ".*"/const minGoVersionStr = "$(GO_MAJOR_AND_MINOR_VERSION)"/' tools/dev-doctor/config.go
 	@echo "Updated go version in tools/dev-doctor to $(GO_MAJOR_AND_MINOR_VERSION)"
 
-update-gh-actions-go-version:
+update-gh-actions-go-version: ## Update Go version in GitHub action config.
 	$(QUIET) for fl in $(shell find .github/workflows -name "*.yaml" -print) ; do sed -i 's/go-version: .*/go-version: $(GO_IMAGE_VERSION)/g' $$fl ; done
 	@echo "Updated go version in GitHub Actions to $(GO_IMAGE_VERSION)"
 
-update-travis-go-version:
+update-travis-go-version: ## Update Go version in TravisCI config.
 	$(QUIET) sed -i 's/go: ".*/go: "$(GO_VERSION)"/g' .travis.yml
 	@echo "Updated go version in .travis.yml to $(GO_VERSION)"
 
-update-test-go-version:
+update-test-go-version: ## Update Go version in test scripts.
 	$(QUIET) sed -i 's/GO_VERSION=.*/GO_VERSION="$(GO_VERSION)"/g' test/kubernetes-test.sh
 	$(QUIET) sed -i 's/GOLANG_VERSION=.*/GOLANG_VERSION="$(GO_VERSION)"/g' test/packet/scripts/install.sh
 	@echo "Updated go version in test scripts to $(GO_VERSION)"
 
-update-images-go-version:
+update-images-go-version: ## Update Go version in Dockerfiles.
 	$(QUIET) sed -i 's/^go_version=.*/go_version=$(GO_IMAGE_VERSION)/g' images/scripts/update-golang-image.sh
 	$(QUIET) $(MAKE) -C images update-golang-image
 	@echo "Updated go version in image Dockerfiles to $(GO_IMAGE_VERSION)"
 
-dev-doctor:
+dev-doctor: ## Run Cilium dev-doctor to validate local development environment.
 	$(QUIET)$(GO) version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )
 	$(QUIET)$(GO) run ./tools/dev-doctor
 
-.PHONY: clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean
+help: Makefile ## Display help for the Makefile, from https://www.thapaliya.com/en/writings/well-documented-makefiles/
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@# There is also a list of target we have to manually put the information about.
+	@# These are templated targets.
+	$(call print_help_line,"docker-cilium-image","Build cilium-agent docker image")
+	$(call print_help_line,"dev-docker-image","Build cilium-agent development docker image")
+	$(call print_help_line,"docker-plugin-image","Build cilium-docker plugin image")
+	$(call print_help_line,"docker-hubble-relay-image","Build hubble-relay docker image")
+	$(call print_help_line,"docker-clustermesh-apiserver-image","Build docker image for Cilium clustermesh APIServer")
+	$(call print_help_line,"docker-opeartor-image","Build cilium-operator docker image")
+	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(aws, azure, generic)")
+	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
+
+.PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean
 force :;

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -32,8 +32,9 @@ else
 endif
 DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
 
+##@ Docker Images
 .PHONY: builder-info
-builder-info:
+builder-info: ## Print information about the docker builder that will be used for building images.
 	@echo "Using Docker Buildx builder \"$(DOCKER_BUILDER)\" with build flags \"$(DOCKER_FLAGS)\"."
 
 # Generic rule for augmented .dockerignore files.
@@ -122,10 +123,10 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image,images/opera%/Docker
 #
 # docker-*-all targets are mainly used from the CI
 #
-docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all
+docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all ## Build all Cilium related docker images.
 
-docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped
+docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped ## Build all Cilium related unstripped docker images. 
 
-docker-operator-images-all: docker-operator-image docker-operator-aws-image docker-operator-azure-image docker-operator-generic-image
+docker-operator-images-all: docker-operator-image docker-operator-aws-image docker-operator-azure-image docker-operator-generic-image ## Build all variants of cilium-operator images.
 
-docker-operator-images-all-unstripped: docker-operator-image-unstripped docker-operator-aws-image-unstripped docker-operator-azure-image-unstripped docker-operator-generic-image-unstripped
+docker-operator-images-all-unstripped: docker-operator-image-unstripped docker-operator-aws-image-unstripped docker-operator-azure-image-unstripped docker-operator-generic-image-unstripped ## Build all variants of unstripped cilium-operator images.


### PR DESCRIPTION
Adds a new help target to the root Makefile that can be used to print information about the available targets from the Makefile. This can be pretty useful given the large number of make targets we have. 

Sample: 

![image](https://user-images.githubusercontent.com/21292343/108904337-5fada000-7644-11eb-9fc1-81eb3767ac1f.png)
