### PR TITLE
Optimize Label.String()

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -252,9 +252,9 @@ func (l *Label) matches(target *Label) bool {
 // Source:Key if Value is empty.
 func (l *Label) String() string {
 	if len(l.Value) != 0 {
-		return fmt.Sprintf("%s:%s=%s", l.Source, l.Key, l.Value)
+		return l.Source + ":" + l.Key + "=" + l.Value
 	}
-	return fmt.Sprintf("%s:%s", l.Source, l.Key)
+	return l.Source + ":" + l.Key
 }
 
 // IsValid returns true if Key != "".

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 )
 
@@ -371,4 +372,22 @@ func TestLabels_GetFromSource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkLabel_String(b *testing.B) {
+	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = l.String()
+	}
+}
+
+func TestLabel_String(t *testing.T) {
+	// with value
+	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")
+	assert.Equal(t, "k8s:io.kubernetes.pod.namespace=kube-system", l.String())
+	// without value
+	l = NewLabel("io.kubernetes.pod.namespace", "", "k8s")
+	assert.Equal(t, "k8s:io.kubernetes.pod.namespace", l.String())
 }


### PR DESCRIPTION
Currently Hubble calls Label.String() for each label in every flow. This
PR micro-optimizes Label.String() by using the plus operator instead of
fmt.Sprintf.

```
// Before
BenchmarkLabel_String-8     5566522  214 ns/op  96B/op   4 allocs/op

// After
BenchmarkLabel_String-8     19522693 60.6 ns/op 48 B/op  1 allocs/op
```

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>