### PR TITLE
pkg/loadbalancer: Optimize L3n4Addr.Hash for performance (2)

### DIFF
--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -374,6 +374,11 @@ func BenchmarkL3n4Addr_Hash_IPv4(b *testing.B) {
 	benchmarkHash(b, addr)
 }
 
+func BenchmarkL3n4Addr_Hash_IPv4_4bytes(b *testing.B) {
+	addr := NewL3n4Addr(TCP, net.IPv4(1, 2, 3, 4).To4(), 8080, ScopeInternal)
+	benchmarkHash(b, addr)
+}
+
 func BenchmarkL3n4Addr_Hash_IPv6_Short(b *testing.B) {
 	addr := NewL3n4Addr(TCP, net.ParseIP("fd00::1:36c6"), 8080, ScopeInternal)
 	benchmarkHash(b, addr)


### PR DESCRIPTION
The output of the L3n4Addr.Hash function is used as a key in maps. In particular, it is used during service lookup in Hubble's hot path.

Commit 6754e8e9b already optimized it. This commit goes even further by assuming that the resulting string does not have to be printable/human readable as it is only used as a key in maps.

Before this commit:

    BenchmarkL3n4Addr_Hash_IPv4-32                   8503980               140.9 ns/op
    BenchmarkL3n4Addr_Hash_IPv4_4bytes-32            9090421               131.9 ns/op  
    BenchmarkL3n4Addr_Hash_IPv6_Short-32             5407434               222.5 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Long-32              3053773               397.3 ns/op  
    BenchmarkL3n4Addr_Hash_IPv6_Max-32               2272474               517.8 ns/op

After this commit:

    BenchmarkL3n4Addr_Hash_IPv4-32                  26500321                50.62 ns/op
    BenchmarkL3n4Addr_Hash_IPv4_4bytes-32           21352604                57.11 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Short-32            23257256                50.77 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Long-32             24479526                51.06 ns/op
    BenchmarkL3n4Addr_Hash_IPv6_Max-32              23630030                50.47 ns/op