### PR TITLE
Revert "azure, policy: Add JSON tags to CRD fields"

### DIFF
--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,29 +110,20 @@ type AzureInterface struct {
 	// SecurityGroup is the security group associated with the interface
 	SecurityGroup string `json:"security-group,omitempty"`
 
-	// TODO: The following fields were exported to stop govet warnings. The
-	// govet warnings were because the CRD generation tool needs every struct
-	// field that's within a CRD, to have a json tag. JSON tags cannot be
-	// applied to unexported fields, hence this change. Refactor these fields
-	// out of this struct. GH issue:
-	// https://github.com/cilium/cilium/issues/12697. Once
-	// https://go-review.googlesource.com/c/tools/+/245857 is merged, this
-	// would no longer be required.
-
 	// GatewayIP is the interface subnet's default route
 	//
 	// +optional
 	GatewayIP string `json:"-"`
 
-	// VMSSName is the name of the virtual machine scale set. This field is
+	// vmssName is the name of the virtual machine scale set. This field is
 	// set by extractIDs()
-	VMSSName string `json:"-"`
+	vmssName string `json:"-"`
 
-	// VMID is the ID of the virtual machine
-	VMID string `json:"-"`
+	// vmID is the ID of the virtual machine
+	vmID string `json:"-"`
 
-	// ResourceGroup is the resource group the interface belongs to
-	ResourceGroup string `json:"-"`
+	// resourceGroup is the resource group the interface belongs to
+	resourceGroup string `json:"-"`
 }
 
 // InterfaceID returns the identifier of the interface
@@ -147,46 +138,46 @@ func (a *AzureInterface) extractIDs() {
 	case strings.Contains(a.ID, "virtualMachineScaleSets"):
 		segs := strings.Split(a.ID, "/")
 		if len(segs) >= 5 {
-			a.ResourceGroup = segs[4]
+			a.resourceGroup = segs[4]
 		}
 		if len(segs) >= 9 {
-			a.VMSSName = segs[8]
+			a.vmssName = segs[8]
 		}
 		if len(segs) >= 11 {
-			a.VMID = segs[10]
+			a.vmID = segs[10]
 		}
 	// Interface from a standalone instance:
 	// //subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Network/networkInterfaces/iii
 	case strings.Contains(a.ID, "/Microsoft.Network/"):
 		segs := strings.Split(a.ID, "/")
 		if len(segs) >= 5 {
-			a.ResourceGroup = segs[4]
+			a.resourceGroup = segs[4]
 		}
 	}
 }
 
 // GetResourceGroup returns the resource group the interface belongs to
 func (a *AzureInterface) GetResourceGroup() string {
-	if a.ResourceGroup == "" {
+	if a.resourceGroup == "" {
 		a.extractIDs()
 	}
-	return a.ResourceGroup
+	return a.resourceGroup
 }
 
 // GetVMScaleSetName returns the VM scale set name the interface belongs to
 func (a *AzureInterface) GetVMScaleSetName() string {
-	if a.VMSSName == "" {
+	if a.vmssName == "" {
 		a.extractIDs()
 	}
-	return a.VMSSName
+	return a.vmssName
 }
 
 // GetVMID returns the VM ID the interface belongs to
 func (a *AzureInterface) GetVMID() string {
-	if a.VMID == "" {
+	if a.vmID == "" {
 		a.extractIDs()
 	}
-	return a.VMID
+	return a.vmID
 }
 
 // ForeachAddress iterates over all addresses and calls fn

--- a/pkg/azure/types/zz_generated.deepequal.go
+++ b/pkg/azure/types/zz_generated.deepequal.go
@@ -80,13 +80,13 @@ func (in *AzureInterface) DeepEqual(other *AzureInterface) bool {
 	if in.GatewayIP != other.GatewayIP {
 		return false
 	}
-	if in.VMSSName != other.VMSSName {
+	if in.vmssName != other.vmssName {
 		return false
 	}
-	if in.VMID != other.VMID {
+	if in.vmID != other.vmID {
 		return false
 	}
-	if in.ResourceGroup != other.ResourceGroup {
+	if in.resourceGroup != other.resourceGroup {
 		return false
 	}
 

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,26 +34,17 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "policy-api")
 type EndpointSelector struct {
 	*slim_metav1.LabelSelector `json:",inline"`
 
-	// TODO: The following fields were exported to stop govet warnings. The
-	// govet warnings were because the CRD generation tool needs every struct
-	// field that's within a CRD, to have a json tag. JSON tags cannot be
-	// applied to unexported fields, hence this change. Refactor these fields
-	// out of this struct. GH issue:
-	// https://github.com/cilium/cilium/issues/12697. Once
-	// https://go-review.googlesource.com/c/tools/+/245857 is merged, this
-	// would no longer be required.
-
-	// Requirements provides a cache for a k8s-friendly format of the
+	// requirements provides a cache for a k8s-friendly format of the
 	// LabelSelector, which allows more efficient matching in Matches().
 	//
 	// Kept as a pointer to allow EndpointSelector to be used as a map key.
-	Requirements *k8sLbls.Requirements `json:"-"`
+	requirements *k8sLbls.Requirements `json:"-"`
 
-	// CachedLabelSelectorString is the cached representation of the
+	// cachedLabelSelectorString is the cached representation of the
 	// LabelSelector for this EndpointSelector. It is populated when
 	// EndpointSelectors are created via `NewESFromMatchRequirements`. It is
 	// immutable after its creation.
-	CachedLabelSelectorString string `json:"-"`
+	cachedLabelSelectorString string `json:"-"`
 }
 
 // LabelSelectorString returns a user-friendly string representation of
@@ -74,7 +65,7 @@ func (n EndpointSelector) String() string {
 // CachedString returns the cached string representation of the LabelSelector
 // for this EndpointSelector.
 func (n EndpointSelector) CachedString() string {
-	return n.CachedLabelSelectorString
+	return n.cachedLabelSelectorString
 }
 
 // UnmarshalJSON unmarshals the endpoint selector from the byte array.
@@ -99,8 +90,8 @@ func (n *EndpointSelector) UnmarshalJSON(b []byte) error {
 		}
 		n.MatchExpressions = newMatchExpr
 	}
-	n.Requirements = labelSelectorToRequirements(n.LabelSelector)
-	n.CachedLabelSelectorString = n.LabelSelector.String()
+	n.requirements = labelSelectorToRequirements(n.LabelSelector)
+	n.cachedLabelSelectorString = n.LabelSelector.String()
 	return nil
 }
 
@@ -220,8 +211,8 @@ func NewESFromMatchRequirements(matchLabels map[string]string, reqs []slim_metav
 	}
 	return EndpointSelector{
 		LabelSelector:             labelSelector,
-		Requirements:              labelSelectorToRequirements(labelSelector),
-		CachedLabelSelectorString: labelSelector.String(),
+		requirements:              labelSelectorToRequirements(labelSelector),
+		cachedLabelSelectorString: labelSelector.String(),
 	}
 }
 
@@ -231,7 +222,7 @@ func NewESFromMatchRequirements(matchLabels map[string]string, reqs []slim_metav
 // updated without concurrently updating the requirements, so the two fields can
 // become out of sync.
 func (n *EndpointSelector) SyncRequirementsWithLabelSelector() {
-	n.Requirements = labelSelectorToRequirements(n.LabelSelector)
+	n.requirements = labelSelectorToRequirements(n.LabelSelector)
 }
 
 // newReservedEndpointSelector returns a selector that matches on all
@@ -293,8 +284,8 @@ func (n *EndpointSelector) AddMatch(key, value string) {
 		n.MatchLabels = map[string]string{}
 	}
 	n.MatchLabels[key] = value
-	n.Requirements = labelSelectorToRequirements(n.LabelSelector)
-	n.CachedLabelSelectorString = n.LabelSelector.String()
+	n.requirements = labelSelectorToRequirements(n.LabelSelector)
+	n.cachedLabelSelectorString = n.LabelSelector.String()
 }
 
 // AddMatchExpression adds a match expression to label selector of the endpoint selector.
@@ -307,8 +298,8 @@ func (n *EndpointSelector) AddMatchExpression(key string, op slim_metav1.LabelSe
 
 	// Update cache of the EndopintSelector from the embedded label selector.
 	// This is to make sure we have updates caches containing the required selectors.
-	n.Requirements = labelSelectorToRequirements(n.LabelSelector)
-	n.CachedLabelSelectorString = n.LabelSelector.String()
+	n.requirements = labelSelectorToRequirements(n.LabelSelector)
+	n.cachedLabelSelectorString = n.LabelSelector.String()
 }
 
 // Matches returns true if the endpoint selector Matches the `lblsToMatch`.
@@ -316,16 +307,16 @@ func (n *EndpointSelector) AddMatchExpression(key string, op slim_metav1.LabelSe
 // "all".
 func (n *EndpointSelector) Matches(lblsToMatch k8sLbls.Labels) bool {
 	// Try to update cached requirements for this EndpointSelector if possible.
-	if n.Requirements == nil {
-		n.Requirements = labelSelectorToRequirements(n.LabelSelector)
+	if n.requirements == nil {
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
 		// Nil indicates that requirements failed validation in some way,
 		// so we cannot parse the labels for matching purposes; thus, we cannot
 		// match if labels cannot be parsed, so return false.
-		if n.Requirements == nil {
+		if n.requirements == nil {
 			return false
 		}
 	}
-	for _, req := range *n.Requirements {
+	for _, req := range *n.requirements {
 		if !req.Matches(lblsToMatch) {
 			return false
 		}

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -168,8 +168,8 @@ func (in *EgressCommonRule) DeepCopyInto(out *EgressCommonRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.AggregatedSelectors != nil {
-		in, out := &in.AggregatedSelectors, &out.AggregatedSelectors
+	if in.aggregatedSelectors != nil {
+		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
 		*out = make(EndpointSelectorSlice, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
@@ -249,8 +249,8 @@ func (in *EndpointSelector) DeepCopyInto(out *EndpointSelector) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Requirements != nil {
-		in, out := &in.Requirements, &out.Requirements
+	if in.requirements != nil {
+		in, out := &in.requirements, &out.requirements
 		*out = new(labels.Requirements)
 		if **in != nil {
 			in, out := *in, *out
@@ -406,8 +406,8 @@ func (in *IngressCommonRule) DeepCopyInto(out *IngressCommonRule) {
 		*out = make(EntitySlice, len(*in))
 		copy(*out, *in)
 	}
-	if in.AggregatedSelectors != nil {
-		in, out := &in.AggregatedSelectors, &out.AggregatedSelectors
+	if in.aggregatedSelectors != nil {
+		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
 		*out = make(EndpointSelectorSlice, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
@@ -863,8 +863,8 @@ func (in *ServiceSelector) DeepCopyInto(out *ServiceSelector) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Requirements != nil {
-		in, out := &in.Requirements, &out.Requirements
+	if in.requirements != nil {
+		in, out := &in.requirements, &out.requirements
 		*out = new(labels.Requirements)
 		if **in != nil {
 			in, out := *in, *out

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -267,8 +267,8 @@ func (in *EgressCommonRule) DeepEqual(other *EgressCommonRule) bool {
 		}
 	}
 
-	if ((in.AggregatedSelectors != nil) && (other.AggregatedSelectors != nil)) || ((in.AggregatedSelectors == nil) != (other.AggregatedSelectors == nil)) {
-		in, other := &in.AggregatedSelectors, &other.AggregatedSelectors
+	if ((in.aggregatedSelectors != nil) && (other.aggregatedSelectors != nil)) || ((in.aggregatedSelectors == nil) != (other.aggregatedSelectors == nil)) {
+		in, other := &in.aggregatedSelectors, &other.aggregatedSelectors
 		if other == nil {
 			return false
 		}
@@ -381,15 +381,15 @@ func (in *EndpointSelector) DeepEqual(other *EndpointSelector) bool {
 		}
 	}
 
-	if (in.Requirements == nil) != (other.Requirements == nil) {
+	if (in.requirements == nil) != (other.requirements == nil) {
 		return false
-	} else if in.Requirements != nil {
-		if !in.Requirements.DeepEqual(other.Requirements) {
+	} else if in.requirements != nil {
+		if !in.requirements.DeepEqual(other.requirements) {
 			return false
 		}
 	}
 
-	if in.CachedLabelSelectorString != other.CachedLabelSelectorString {
+	if in.cachedLabelSelectorString != other.cachedLabelSelectorString {
 		return false
 	}
 
@@ -563,8 +563,8 @@ func (in *IngressCommonRule) DeepEqual(other *IngressCommonRule) bool {
 		}
 	}
 
-	if ((in.AggregatedSelectors != nil) && (other.AggregatedSelectors != nil)) || ((in.AggregatedSelectors == nil) != (other.AggregatedSelectors == nil)) {
-		in, other := &in.AggregatedSelectors, &other.AggregatedSelectors
+	if ((in.aggregatedSelectors != nil) && (other.aggregatedSelectors != nil)) || ((in.aggregatedSelectors == nil) != (other.aggregatedSelectors == nil)) {
+		in, other := &in.aggregatedSelectors, &other.aggregatedSelectors
 		if other == nil || !in.DeepEqual(other) {
 			return false
 		}
@@ -1165,15 +1165,15 @@ func (in *ServiceSelector) DeepEqual(other *ServiceSelector) bool {
 		}
 	}
 
-	if (in.Requirements == nil) != (other.Requirements == nil) {
+	if (in.requirements == nil) != (other.requirements == nil) {
 		return false
-	} else if in.Requirements != nil {
-		if !in.Requirements.DeepEqual(other.Requirements) {
+	} else if in.requirements != nil {
+		if !in.requirements.DeepEqual(other.requirements) {
 			return false
 		}
 	}
 
-	if in.CachedLabelSelectorString != other.CachedLabelSelectorString {
+	if in.cachedLabelSelectorString != other.cachedLabelSelectorString {
 		return false
 	}
 


### PR DESCRIPTION
Now that go 1.16 contains the necessary change to avoid this warning
from go-vet, we can revert this commit.

This reverts commit 8de6dc5a02b1af20d95bcc9c3783c9b08b2157c0.

Signed-off-by: André Martins <andre@cilium.io>