### PR TITLE
checkpatch: update image (skip backports, add a check, suppress one report type)

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://cilium/cilium-checkpatch:e6a6843cef50a43c38819badb55a21061967ce64
+        uses: docker://quay.io/cilium/cilium-checkpatch:cc7e6b5811f46d7b040dedfe2f6b0010c2c51a12@sha256:9160b6ca58eb99a3ed5d567a494b2e2001325ebad32029c5bd17a8ae4df01044
   coccicheck:
     name: coccicheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the checkpatch image tag (and switch to quay.io) to benefit from the following changes:

- Skip checkpatch validation on backport branches
- Suppress reports of type `COMMIT_LOG_LONG_LINE`
- Add a repo-wide check on commit subject length
- Use $GITHUB_REPOSITORY variable when retrieving commits

For skipping backports we could instead update the conditions for running the job in the current repo, but that would be troublesome if we want to mark the action as required in the future. Therefore, we delegate the decision to the shell script in the checkpatch image: it returns early if a PR is not based on the 'master' branch.

Checkpatch updates available at https://github.com/cilium/image-tools/pull/104/files and https://github.com/cilium/image-tools/pull/109/files.

Tested [here](https://github.com/cilium/cilium/pull/15079/checks?check_run_id=1975049150) for the new check and the suppressed report, and [there](https://github.com/cilium/cilium/pull/15083/checks?check_run_id=1975056704) for skipping the backports.

Marking for backports for 1.9, where the checkpatch action is run but where we want to skip it.

No CI test needed, other than having the checkpatch verification still working.