### PR TITLE
v1.9 backports for bpf map handling 2021-02-24

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1126,7 +1126,7 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 // Returns true if the map was upgraded.
 func (m *Map) CheckAndUpgrade(desired *MapInfo) bool {
 	desiredMapType := GetMapType(desired.MapType)
-	desired.Flags |= GetPreAllocateMapFlags(desired.MapType)
+	desired.Flags |= GetPreAllocateMapFlags(desiredMapType)
 
 	return objCheck(
 		m.fd,


### PR DESCRIPTION
* #14853 -- Fix BPF map handling on upgrade when disabling the preallocation of BPF maps (@christarazi)
   * Notes: Backported only 7e5a97f5dddb59394484d401c230cbaba4e6a686. The first commit of the PR modifies CI which we don't want to do otherwise we would need to backport this to all other versions. The second commit doesn't apply to the code in the v1.9 tree. See https://github.com/cilium/cilium/issues/15059.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14853; do contrib/backporting/set-labels.py $pr done 1.9; done
```