### PR TITLE
Dockerfile: Bump cilium-runtime image dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2021-01-27-v1.7@sha256:2e6dabee4595b5146b60cd51148cfd88d9c7971b29ccbda183c4c194d3fa99c7
+FROM quay.io/cilium/cilium-runtime:2021-02-24-v1.7@sha256:804acd4b79c03fea879ea81d200050ab818d2a82e28f16beed9a8d5c1a1e97cb
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -1,8 +1,11 @@
+ARG CILIUM_RUNTIME_TAG=2020-02-24
+
 #
 # Cilium runtime base image
 #
 FROM docker.io/library/ubuntu:18.04 as runtime-base
-RUN apt-get update && \
+RUN echo "Updated on "${ARG} && \
+apt-get update && \
 apt-get upgrade -y && \
 #
 # Prepackaged Cilium runtime dependencies


### PR DESCRIPTION
Canonical are not always on top of generating new versions of their main
docker images, so we can't just bump the image sha here. We actually
need to make sure that we don't just use the cached image from the prior
"apt upgrade" that was run in Quay.io, or we'll ship images with
outdated packages.

Introduce an arbitrary date-based arg here to invalidate the Quay cache.
Then we can bump the date, build the cilium-runtime image, and pull in
the latest (up-to-date) runtime image into the main container creation.
