### PR TITLE
node/manager: remove unused *Manager methods

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -507,14 +507,6 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	entry.mutex.Unlock()
 }
 
-// Exists returns true if a node with the name exists
-func (m *Manager) Exists(id nodeTypes.Identity) bool {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	_, ok := m.nodes[id]
-	return ok
-}
-
 // GetNodeIdentities returns a list of all node identities store in node
 // manager.
 func (m *Manager) GetNodeIdentities() []nodeTypes.Identity {
@@ -542,20 +534,6 @@ func (m *Manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 	}
 
 	return nodes
-}
-
-// DeleteAllNodes deletes all nodes from the node manager.
-func (m *Manager) DeleteAllNodes() {
-	m.mutex.Lock()
-	for _, entry := range m.nodes {
-		entry.mutex.Lock()
-		m.Iter(func(nh datapath.NodeHandler) {
-			nh.NodeDelete(entry.node)
-		})
-		entry.mutex.Unlock()
-	}
-	m.nodes = map[nodeTypes.Identity]*nodeEntry{}
-	m.mutex.Unlock()
 }
 
 // StartNeighborRefresh spawns a controller which refreshes neighbor table

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -91,9 +91,6 @@ type NodeManager interface {
 
 	// NodeDeleted is called when the store detects a deletion of a node
 	NodeDeleted(n nodeTypes.Node)
-
-	// Exists is called to verify if a node exists
-	Exists(id nodeTypes.Identity) bool
 }
 
 // NodeRegistrar is a wrapper around store.SharedStore.


### PR DESCRIPTION
`DeleteAllNodes` is unused since commit a71dfb49bb55 ("pkg/k8s: use
official k8s library to watch events from kube-apiserver")

`Exists` is unused since commit 07312c6d155d ("pkg/{kvstore,node}: delay
node delete event in kvstore")