### PR TITLE
Hubble-ui now supports imagePullSecrets

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
       {{- toYaml . | trim | nindent 6 }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 6 }}
+{{- end }}
       containers:
         - name: frontend
           image: "{{ .Values.hubble.ui.frontend.image.repository }}:{{ .Values.hubble.ui.frontend.image.tag }}"


### PR DESCRIPTION
Currently there is no way to specify pull secrets for the hubble ui deployment.

```release-note
Hubble-ui now supports imagePullSecrets being passed in
```