### PR TITLE
test: Redeploy registry during Vagrant provision

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -124,6 +124,9 @@ Vagrant.configure("2") do |config|
                 :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
             server.vm.provision "file", source: "provision/", destination: "/tmp/"
             server.vm.provision "shell" do |sh|
+                sh.path = "./provision/registry.sh"
+            end
+            server.vm.provision "shell" do |sh|
                 sh.path = "./provision/k8s_install.sh"
                 sh.args = [
                     "k8s#{i}", "192.168.36.1#{i}", "#{$K8S_VERSION}",

--- a/test/provision/registry.sh
+++ b/test/provision/registry.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+source "${ENV_FILEPATH}"
+
+set -e
+
+CERTS_DIR=/certs/
+
+echo '{"insecure-registries": ["k8s1:5000"]}' > /etc/docker/daemon.json
+sudo pkill -SIGHUP docker
+
+docker kill registry
+docker rm registry
+
+# Docker registry - certs
+
+sudo mkdir -p $CERTS_DIR
+sudo chmod 777 $CERTS_DIR
+cd $HOME
+rm -rfv certs
+mkdir certs
+
+cat <<EOF > server.conf
+prompt = no
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+
+[ req_distinguished_name ]
+C                      = UK
+ST                     = UK
+L                      = London
+O                      = cilium
+OU                     = experimental
+CN                     = cilium.io
+emailAddress           = ian@cilium.io
+
+[ v3_req ]
+# Extensions to add to a certificate request
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = cilium.io
+DNS.2 = *.cilium.io
+DNS.3 = k8s1
+IP.1 = 192.168.36.11
+IP.2 = 10.0.2.15
+EOF
+
+openssl genrsa -out certs/ca.key 4096
+openssl req -new -x509 -days 3650 -key certs/ca.key -out certs/ca.crt \
+    -subj "/C=uk/ST=uk/L=London/O=cilium/CN=cilium.io"
+
+openssl genrsa -out certs/cilium.key 4096
+openssl req -new -nodes \
+    -key certs/cilium.key \
+    -out certs/cilium.request -config server.conf
+
+openssl x509 -req -days 366 \
+    -in certs/cilium.request \
+    -CA certs/ca.crt \
+    -CAkey certs/ca.key \
+    -set_serial 01 \
+    -out certs/cilium.cert \
+    -extensions v3_req -extfile server.conf
+
+mkdir -p /usr/local/share/ca-certificates
+
+cp -rfv certs/* /certs/
+cp certs/ca.crt /usr/local/share/ca-certificates/
+sudo update-ca-certificates
+
+docker run -d -p 5000:5000 --name registry -v ${CERTS_DIR}:/certs \
+        -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/cilium.cert \
+        -e REGISTRY_HTTP_TLS_KEY=/certs/cilium.key \
+        --restart=always \
+        docker.io/library/registry:2.6.2


### PR DESCRIPTION
Cherry-pick #13111 to v1.7 branch.

[ upstream commit 2035ba3ae6a2c9a725a93e05b92b9d4f5798e527 ]

The vagrant box we ship & use with Cilium 1.7 uses certs generated over one
year ago. Rather than regenerating the certs & box, and dealing with updating
the box image and so on for this branch, instead here we just copy the
registry.sh from the latest cilium/packer-ci-build repository as of today and
call it directly during vagrant provisioning.

Fixes: #11641
