### PR TITLE
v1.8 backports 2021-02-25

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -66,9 +66,10 @@ func getIPSecKeys(ip net.IP) *ipSecKey {
 
 func ipSecNewState() *netlink.XfrmState {
 	state := netlink.XfrmState{
-		Mode:  netlink.XFRM_MODE_TUNNEL,
-		Proto: netlink.XFRM_PROTO_ESP,
-		ESN:   false,
+		Mode:         netlink.XFRM_MODE_TUNNEL,
+		Proto:        netlink.XFRM_PROTO_ESP,
+		ESN:          true,
+		ReplayWindow: 1024,
 	}
 	return &state
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -469,7 +469,9 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 		spi, err = ipsec.UpsertIPsecEndpoint(ipsecIPv4Wildcard, cidr, ipsec.IPSecDirOut)
 		upsertIPsecLog(err, "CNI Out IPv4", ipsecIPv4Wildcard, cidr, spi)
 
-		n.replaceNodeExternalIPSecOutRoute(cidr)
+		if n.nodeConfig.EncryptNode {
+			n.replaceNodeExternalIPSecOutRoute(cidr)
+		}
 	}
 
 	for _, cidr := range v6CIDR {
@@ -481,7 +483,9 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 		spi, err := ipsec.UpsertIPsecEndpoint(ipsecIPv6Wildcard, cidr, ipsec.IPSecDirOut)
 		upsertIPsecLog(err, "CNI Out IPv6", cidr, ipsecIPv6Wildcard, spi)
 
-		n.replaceNodeExternalIPSecOutRoute(cidr)
+		if n.nodeConfig.EncryptNode {
+			n.replaceNodeExternalIPSecOutRoute(cidr)
+		}
 	}
 }
 
@@ -846,7 +850,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		n.insertNeighbor(context.Background(), newNode, ifaceName, false)
 	}
 
-	if n.nodeConfig.EnableIPSec {
+	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
 		n.encryptNode(newNode)
 	}
 


### PR DESCRIPTION
* #14999 -- cilium: encryption fix, ipv4-pod-subnets without encryptnode fails (@jrfastab)
 * #15039 -- ipsec: Use 64bits for XFRM output sequence number (@pchaigno)

Skipped due to non-trivial conflicts - 
 * #15048 -- cilium: encryption, fixes for ENI & Azure mode with shared podIPs and networkIPs (@jrfastab)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14999 15039; do contrib/backporting/set-labels.py $pr done 1.8; done
```