### PR TITLE
backporting: Update instructions for backporting workflow

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -65,8 +65,15 @@ One-time Setup
       $ git config --global user.name "John Doe"
       $ git config --global user.email johndoe@example.com
 
+#. Add remotes for the Cilium upstream repository and your Cilium repository fork.
+
+   .. code-block:: bash
+
+      $ git remote add johndoe git@github.com:johndoe/cilium.git
+      $ git remote add upstream https://github.com/cilium/cilium.git
+
 #. Make sure you have a GitHub developer access token with the ``public_repos``
-   scope available. You can do this directly from
+   ``workflow`` scopes available. You can do this directly from
    https://github.com/settings/tokens or by opening GitHub and then navigating
    to: User Profile -> Settings -> Developer Settings -> Personal access token
    -> Generate new token.


### PR DESCRIPTION
Commit [02320e](https://github.com/cilium/cilium/pull/15008/commits/02320e347604128e76673dcbbbc05411721d522e) added support for using backporting scripts with Cilium forks. Document the
additional steps that are required with this new workflow.

Additionally, workflow scope might be needed with the GitHub token in
some cases that update the corresponding yamls -

``(refusing to allow a Personal Access Token to create or update workflow `.github/workflows/go-check.yaml` without `workflow` scope``
