### PR TITLE
Improve release scripts

### DIFF
--- a/.github/workflows/images-legacy-releases.yaml
+++ b/.github/workflows/images-legacy-releases.yaml
@@ -85,7 +85,7 @@ jobs:
           job_name_underscored=${job_name_capital//-/_}
           echo "${job_name_underscored}_DIGEST := \"${{ steps.docker_build_release.outputs.digest }}\"" > image-digest/makefile-digest.txt
 
-          echo "## ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
+          echo "### ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
           echo "\`docker.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
@@ -123,7 +123,9 @@ jobs:
         shell: bash
         run: |
           cd image-digest/
-          find -type f -not -name "makefile-digest.txt" | sort | xargs -d '\n' cat > ../image-digest-output.txt
+          echo "## Docker Manifests" > ../image-digest-output.txt
+          echo "" >> ../image-digest-output.txt
+          find -type f -not -name "makefile-digest.txt" | sort | xargs -d '\n' cat >> ../image-digest-output.txt
 
       - name: Image Makefile Digests
         shell: bash

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -29,6 +29,21 @@ get_remote () {
   echo "$remote"
 }
 
+# $1 - override
+get_user_remote() {
+  USER_REMOTE=${1:-}
+  if [ "$RESULT" = "" ]; then
+      gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
+      if [ "$gh_username" = "" ]; then
+          echo "Error: could not get user info from hub" 1>&2
+          exit 1
+      fi
+      USER_REMOTE=$(get_remote "$gh_username")
+      echo "Using GitHub repository ${gh_username}/cilium (git remote: ${USER_REMOTE})" 1>&2
+  fi
+  echo $USER_REMOTE
+}
+
 require_linux() {
   if [ "$(uname)" != "Linux" ]; then
       echo "$0: Linux required"

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -37,16 +37,7 @@ if [ "$SUMMARY" = "" ]; then
     SUMMARY="v$BRANCH-backport-$(date --rfc-3339=date).txt"
 fi
 
-USER_REMOTE=${3:-}
-if [ "$USER_REMOTE" = "" ]; then
-    gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
-    if [ "$gh_username" = "" ]; then
-        echo "Error: could not get user info from hub" 1>&2
-        exit 1
-    fi
-    USER_REMOTE=$(get_remote "$gh_username")
-    echo "Using GitHub repository ${gh_username}/cilium (git remote: ${USER_REMOTE})"
-fi
+USER_REMOTE=$(get_user_remote ${3:-})
 
 UPSTREAM_REMOTE=$(get_remote)
 if ! git branch -a | grep -q "${UPSTREAM_REMOTE}/v${BRANCH}$" || [ ! -e "$SUMMARY" ]; then

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -8,6 +8,7 @@ source $DIR/../backporting/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
 ACTS_YAML=".github/cilium-actions.yml"
+REMOTE="$(get_remote)"
 
 usage() {
     logecho "usage: $0 <VERSION> <GH-PROJECT>"
@@ -55,11 +56,10 @@ main() {
     local ersion="$(echo $1 | sed 's/^v//')"
     local version="v$ersion"
     local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
-    local remote="origin"
     local new_proj="$2"
 
-    git fetch $remote
-    git checkout -b pr/prepare-$version $remote/$branch
+    git fetch $REMOTE
+    git checkout -b pr/prepare-$version $REMOTE/$branch
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -21,8 +21,10 @@ if [ "$SUMMARY" = "" ]; then
     GENERATE_SUMMARY=true
 fi
 
+USER_REMOTE=$(get_user_remote ${3:-})
+
 if ! git branch -a | grep -q "$REMOTE/v$BRANCH$" || [ ! -e $SUMMARY ]; then
-    echo "usage: $0 [branch version] [release-summary]" 1>&2
+    echo "usage: $0 [branch version] [release-summary] [your remote]" 1>&2
     echo 1>&2
     echo "Ensure 'branch version' is available in '$REMOTE' and the summary file exists" 1>&2
     exit 1
@@ -56,5 +58,5 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-git push origin "$PR_BRANCH"
+git push $USER_REMOTE "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/release,backport/$BRANCH -F $SUMMARY

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -6,6 +6,7 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
+REMOTE="$(get_remote)"
 BRANCH="${1:-""}"
 if [ "$BRANCH" = "" ]; then
     BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
@@ -20,10 +21,10 @@ if [ "$SUMMARY" = "" ]; then
     GENERATE_SUMMARY=true
 fi
 
-if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+if ! git branch -a | grep -q "$REMOTE/v$BRANCH$" || [ ! -e $SUMMARY ]; then
     echo "usage: $0 [branch version] [release-summary]" 1>&2
     echo 1>&2
-    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
+    echo "Ensure 'branch version' is available in '$REMOTE' and the summary file exists" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
I collected these minor fixups while preparing the v1.7.14 release.

- contrib: Use 'get_remote' shell fn to fetch remote
- contrib: Move contributor remote detection to lib
- contrib: Submit release PRs via user repo
- .github: Improve digest formatting in workflow

