### PR TITLE
test: Reenable debug mode for monitor tests

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -95,7 +95,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"bpf.monitorAggregation": "medium",
 				"bpf.monitorInterval":    "60s",
 				"bpf.monitorFlags":       "syn",
-				"debug.enabled":          "false",
 			}, DeployCiliumOptionsAndDNS)
 
 			monitorRes, monitorCancel, targetIP := monitorConnectivityAcrossNodes(kubectl)
@@ -149,7 +148,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"bpf.monitorAggregation": "medium",
 				"bpf.monitorInterval":    "60s",
 				"bpf.monitorFlags":       "psh",
-				"debug.enabled":          "false",
 			}, DeployCiliumOptionsAndDNS)
 			monitorRes, monitorCancel, _ := monitorConnectivityAcrossNodes(kubectl)
 			defer monitorCancel()


### PR DESCRIPTION
Debug mode was explicitly disabled in monitor tests, presumably to disable the datapath's debug mode which would change the traces collected by cilium monitor. Datapath debug mode is now disabled by default in all tests independently of the agent's debug mode. We can therefore reenable the later.