### PR TITLE
test: Fix local tests

### DIFF
--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 set -e
 
-CILIUM_DS_TAG="k8s-app=cilium"
-KUBE_SYSTEM_NAMESPACE="kube-system"
-KUBECTL="/usr/bin/kubectl"
-PROVISIONSRC="/tmp/provision"
-GOPATH="/home/vagrant/go"
-REGISTRY="k8s1:5000"
-CILIUM_TAG="cilium/cilium-dev"
-CILIUM_OPERATOR_TAG="cilium/operator"
-CILIUM_OPERATOR_GENERIC_TAG="cilium/operator-generic"
-CILIUM_OPERATOR_AWS_TAG="cilium/operator-aws"
-CILIUM_OPERATOR_AZURE_TAG="cilium/operator-azure"
-HUBBLE_RELAY_TAG="cilium/hubble-relay"
+export CILIUM_DS_TAG="k8s-app=cilium"
+export KUBE_SYSTEM_NAMESPACE="kube-system"
+export KUBECTL="/usr/bin/kubectl"
+export PROVISIONSRC="/tmp/provision"
+export GOPATH="/home/vagrant/go"
+export REGISTRY="k8s1:5000"
+export DOCKER_REGISTRY="docker.io"
+export CILIUM_TAG="cilium/cilium-dev"
+export CILIUM_OPERATOR_TAG="cilium/operator"
+export CILIUM_OPERATOR_GENERIC_TAG="cilium/operator-generic"
+export CILIUM_OPERATOR_AWS_TAG="cilium/operator-aws"
+export CILIUM_OPERATOR_AZURE_TAG="cilium/operator-azure"
+export HUBBLE_RELAY_TAG="cilium/hubble-relay"
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 


### PR DESCRIPTION
Local ginkgo execution is failing with:

        k8s1-1.20: building cilium container image...
        k8s1-1.20: Using Docker Buildx builder "default" with build flags " --load".
        k8s1-1.20: docker buildx build -f images/cilium/Dockerfile  --load --build-arg BASE_IMAGE=scratch --build-arg NOSTRIP= --build-arg LOCKDEBUG=1 --build-arg RACE= --build-arg V= --build-arg LIBNETWORK_PLUGIN= --build-arg CILIUM_SHA=0df8078e9 -t quay.io/cilium/cilium:latest .
        k8s1-1.20: #1 [internal] load build definition from Dockerfile
        [...]
        k8s1-1.20: #26 writing image sha256:1ec75dbc4cc595cc0700cf3070f2ba18c7c06cef5542c763fc4da4acd23aa275 done
        k8s1-1.20: #26 naming to quay.io/cilium/cilium:latest done
        k8s1-1.20: #26 DONE 2.1s
        k8s1-1.20: Define "DOCKER_FLAGS=--push" to push the build results.
        k8s1-1.20: tagging cilium image...
        k8s1-1.20: Error response from daemon: No such image: cilium/cilium:latest
    The SSH command responded with a non-zero exit status. Vagrant
    assumes that this means the command failed. The output for this command
    should be in the log above. Please read the output to determine what
    went wrong.

André suggested to define `DOCKER_REGISTRY` and export the environment variables.

Co-authored-by: André Martins <andre@cilium.io>
Signed-off-by: Paul Chaignon <paul@cilium.io>