### PR TITLE
Makefile: do not depend on TARGET for install-bash-completion

### DIFF
--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -18,13 +18,15 @@ clean:
 	-$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO_CLEAN)
 
-install: install-binary install-bash-completion
+install: install-binary install-bash-completion-only
 
 install-binary:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 
-install-bash-completion: $(TARGET)
+install-bash-completion: $(TARGET) install-bash-completion-only
+
+install-bash-completion-only:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CONFDIR)/bash_completion.d
 	./$(TARGET) completion bash > $(TARGET)_bash_completion
 	$(QUIET)$(INSTALL) -m 0644 -T $(TARGET)_bash_completion $(DESTDIR)$(CONFDIR)/bash_completion.d/$(TARGET)

--- a/clustermesh-apiserver/Makefile
+++ b/clustermesh-apiserver/Makefile
@@ -18,13 +18,15 @@ clean:
 	-$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO_CLEAN)
 
-install: install-binary install-bash-completion
+install: install-binary install-bash-completion-only
 
 install-binary:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 
-install-bash-completion: $(TARGET)
+install-bash-completion: $(TARGET) install-bash-completion-only
+
+install-bash-completion-only:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CONFDIR)/bash_completion.d
 	./$(TARGET) completion bash > $(TARGET)_bash_completion
 	$(QUIET)$(INSTALL) -m 0644 -T $(TARGET)_bash_completion $(DESTDIR)$(CONFDIR)/bash_completion.d/$(TARGET)

--- a/hubble-relay/Makefile
+++ b/hubble-relay/Makefile
@@ -18,13 +18,15 @@ clean:
 	-$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO_CLEAN)
 
-install: install-binary install-bash-completion
+install: install-binary install-bash-completion-only
 
 install-binary:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 
-install-bash-completion: $(TARGET)
+install-bash-completion: $(TARGET) install-bash-completion-only
+
+install-bash-completion-only:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CONFDIR)/bash_completion.d
 	./$(TARGET) completion bash > $(TARGET)_bash_completion
 	$(QUIET)$(INSTALL) -m 0644 -T $(TARGET)_bash_completion $(DESTDIR)$(CONFDIR)/bash_completion.d/$(TARGET)


### PR DESCRIPTION
As it was done before 6fb045dc3dac ("Makefile: add install-bash-completion target")
the install target did not depend on TARGET. This fixes up the change to
have the same behavior as before.

Fixes: 6fb045dc3dac ("Makefile: add install-bash-completion target")
Signed-off-by: André Martins <andre@cilium.io>