### PR TITLE
test: Unquarantine tunneling + endpoint routes test

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -248,10 +248,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 
-		SkipItIf(func() bool {
-			// Skip K8s versions for which the test is currently flaky.
-			return helpers.SkipK8sVersions(">=1.13.0 <1.18.0") && helpers.SkipQuarantined()
-		}, "Check vxlan connectivity with per-endpoint routes", func() {
+		It("Check vxlan connectivity with per-endpoint routes", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                 "vxlan",
 				"endpointRoutes.enabled": "true",


### PR DESCRIPTION
Our tunneling + per-endpoint routes test was fixed by https://github.com/cilium/cilium/pull/14913. We can unquarantine it.