### PR TITLE
v1.8: Fix test verifier scheduling on k8s1.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ $(SUBDIRS): force
 	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
 
 jenkins-precheck:
-	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER run --rm precheck
+	COMPOSE_INTERACTIVE_NO_CLI=1 docker-compose --verbose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER run --rm precheck
 
 clean-jenkins-precheck:
 	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER rm

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -37,5 +37,4 @@ spec:
   - key: "node.kubernetes.io/unreachable"
     operator: "Exists"
   hostNetwork: true
-  nodeSelector:
-    "cilium.io/ci-node": k8s1
+  nodeName: k8s1


### PR DESCRIPTION
Upstream commit 0fbd74c intended to fix a weird scheduling issue on K8s 1.11 by explicitly specifying the node on which the pod should be scheduled. During the review, [it was suggested](https://github.com/cilium/cilium/pull/14803#discussion_r567264072) to match the node by label instead of name.

Unfortunately that last change broke the fix: specifying explicitly the node to schedule on by label isn't enough. The node name must be used. I've confirmed it locally this time.

I'm sending this directly to v1.8 as it's the only branch where we run test on K8s 1.11. Other branches don't require this fix.

Also picked up:

  * https://github.com/cilium/cilium/pull/15171 -- test: Fix docker compose in precheck (@nebril)

Fixes: https://github.com/cilium/cilium/commit/0fbd74ce9e3602cd4cb5e06a67ac991b98043999
Fixes: https://github.com/cilium/cilium/issues/14791

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15171; do contrib/backporting/set-labels.py $pr done 1.8; done
```