### PR TITLE
Makefile: Remove microk8s.registry dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,8 +494,6 @@ check-microk8s:
 	@$(ECHO_CHECK) microk8s is ready...
 	$(QUIET)microk8s.status >/dev/null \
 		|| (echo "Error: Microk8s is not running" && exit 1)
-	$(QUIET)microk8s.status --yaml | grep -q "registry.*enabled" \
-		|| (echo "Error: Microk8s registry must be enabled" && exit 1)
 
 LOCAL_IMAGE_TAG=local
 LOCAL_IMAGE=localhost:32000/cilium/cilium:$(LOCAL_IMAGE_TAG)


### PR DESCRIPTION
The "make microk8s" target used to depend on deploying the registry
addon into the microk8s cluster, but since commit 1eedfb3af646e
("Makefile: Remove microk8s prepull script") we've just relied on
importing the image directly so the registry is no longer necessary.
