### PR TITLE
vendor: Pin github.com/optiopay/kafka to commit before fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/onsi/gomega v1.10.5
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/optiopay/kafka v0.0.0-00010101000000-000000000000
+	github.com/optiopay/kafka v0.0.0-20171218140449-a1e0071f1ce8
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.1-0.20200623203004-60555c9708c7

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -504,7 +504,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
-# github.com/optiopay/kafka v0.0.0-00010101000000-000000000000 => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
+# github.com/optiopay/kafka v0.0.0-20171218140449-a1e0071f1ce8 => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 ## explicit
 github.com/optiopay/kafka/proto
 # github.com/pelletier/go-toml v1.7.0


### PR DESCRIPTION
This dependency has been causing a lot of issues for those who are
consuming the Cilium code as a module. It required consumers to
duplicate the `replace` directive for `optiopay/kafka` in their
respective go.mod file.

This commit fixes this by pinning the original `optiopay/kafka` to the
commit when it was forked by Cilium developers (and hence the `replace`
directive).

Suggested-by: Glib Smaga <code@gsmaga.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
