### PR TITLE
docs: Add L7 not working warning to AWS CNI Chaining page

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -15,6 +15,11 @@ networking is setup, the Cilium CNI plugin is called to attach eBPF programs to
 the network devices set up by aws-cni to enforce network policies, perform
 load-balancing, and encryption.
 
+.. note::
+
+   When running Cilium in chaining configuration on top of AWS VPC CNI, the L7 policies may not work. 
+   This limitation is currently tracked at `#12454 <https://github.com/cilium/cilium/issues/12454>`_.
+
 .. image:: aws-cni-architecture.png
 
 


### PR DESCRIPTION
This PR adds a warning to the AWS CNI chaining page about L7 policy's not working, just like it says on the Calico page.

AWS CNI chaining page: https://docs.cilium.io/en/v1.9/gettingstarted/cni-chaining-aws-cni/
Calico CNI chaining page: https://docs.cilium.io/en/v1.9/gettingstarted/cni-chaining-calico/
