### PR TITLE
[v1.8] helm: Remove duplicate `tolerations` value in hubble-relay

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -13,9 +13,6 @@ resources: {}
 # Number of replicas run for the hubble-relay deployment.
 numReplicas: 1
 
-# Specifies the tolerations of the hubble-relay deployment
-tolerations: {}
-
 # Host to listen to. Specify an empty string to bind to all the interfaces.
 listenHost: ""
 


### PR DESCRIPTION
It's already defined as an array object on the bottom of the `values.yaml`, which is consistent with the other subcharts in v1.8

Fixes: #15155
