### PR TITLE
ci: remove params from upstream k8s job

### DIFF
--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -5,32 +5,6 @@ pipeline {
         label 'baremetal'
     }
 
-    parameters {
-        string(defaultValue: '${ghprbPullDescription}', name: 'ghprbPullDescription')
-        string(defaultValue: '${ghprbActualCommit}', name: 'ghprbActualCommit')
-        string(defaultValue: '${ghprbTriggerAuthorLoginMention}', name: 'ghprbTriggerAuthorLoginMention')
-        string(defaultValue: '${ghprbPullAuthorLoginMention}', name: 'ghprbPullAuthorLoginMention')
-        string(defaultValue: '${ghprbGhRepository}', name: 'ghprbGhRepository')
-        string(defaultValue: '${ghprbPullLongDescription}', name: 'ghprbPullLongDescription')
-        string(defaultValue: '${ghprbCredentialsId}', name: 'ghprbCredentialsId')
-        string(defaultValue: '${ghprbTriggerAuthorLogin}', name: 'ghprbTriggerAuthorLogin')
-        string(defaultValue: '${ghprbPullAuthorLogin}', name: 'ghprbPullAuthorLogin')
-        string(defaultValue: '${ghprbTriggerAuthor}', name: 'ghprbTriggerAuthor')
-        string(defaultValue: '${ghprbCommentBody}', name: 'ghprbCommentBody')
-        string(defaultValue: '${ghprbPullTitle}', name: 'ghprbPullTitle')
-        string(defaultValue: '${ghprbPullLink}', name: 'ghprbPullLink')
-        string(defaultValue: '${ghprbAuthorRepoGitUrl}', name: 'ghprbAuthorRepoGitUrl')
-        string(defaultValue: '${ghprbTargetBranch}', name: 'ghprbTargetBranch')
-        string(defaultValue: '${ghprbPullId}', name: 'ghprbPullId')
-        string(defaultValue: '${ghprbActualCommitAuthor}', name: 'ghprbActualCommitAuthor')
-        string(defaultValue: '${ghprbActualCommitAuthorEmail}', name: 'ghprbActualCommitAuthorEmail')
-        string(defaultValue: '${ghprbTriggerAuthorEmail}', name: 'ghprbTriggerAuthorEmail')
-        string(defaultValue: '${GIT_BRANCH}', name: 'GIT_BRANCH')
-        string(defaultValue: '${ghprbPullAuthorEmail}', name: 'ghprbPullAuthorEmail')
-        string(defaultValue: '${sha1}', name: 'sha1')
-        string(defaultValue: '${ghprbSourceBranch}', name: 'ghprbSourceBranch')
-    }
-
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"


### PR DESCRIPTION
These params are not compatible with our master job configuration, which
causes master builds to fail.

These params are stored in jenkins PR upstream k8s job config, so there
is no need for them to be in jenkinsfile.

Note: after this is merged, we need to manually delete parameters from https://jenkins.cilium.io/job/cilium-master-k8s-upstream/configure