### PR TITLE
.travis: Remove race builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,6 @@ jobs:
     - arch: arm64-graviton2
       virt: vm
       group: edge
-    - arch: amd64
-      name: "amd64-race"
-      if: type != pull_request
-      env:
-        - RACE=1
-        - BASE_IMAGE=quay.io/cilium/cilium-runtime:7f84e5f2c9027e75b271a460d83c086f29127d3a@sha256:a1d73d2840b4b075ade33bd8f968ca6db3d9bca9f3ed14f168d14526b3208cc0
-        - LOCKDEBUG=1
-    - arch: arm64-graviton2
-      name: "arm64-graviton2-race"
-      if: type != pull_request
-      env:
-        - RACE=1
-        - BASE_IMAGE=quay.io/cilium/cilium-runtime:7f84e5f2c9027e75b271a460d83c086f29127d3a@sha256:a1d73d2840b4b075ade33bd8f968ca6db3d9bca9f3ed14f168d14526b3208cc0
-        - LOCKDEBUG=1
-      virt: vm
-      group: edge
-  allow_failures:
-    - name: "amd64-race"
-    - name: "arm64-graviton2-race"
 
 if: branch = master OR type = pull_request
 


### PR DESCRIPTION
The race builds have been failing for a long time and the failures are not being investigated by lack of resources. Since we are strongly limited by the number of concurrent Travis CI runs, let's remove those builds for now.