### PR TITLE
nat: Create SNAT maps only if BPF NodePort is enabled

### DIFF
--- a/cilium/cmd/bpf_nat_flush.go
+++ b/cilium/cmd/bpf_nat_flush.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func flushNat() {
-	ipv4, ipv6 := nat.GlobalMaps(true, true)
+	ipv4, ipv6 := nat.GlobalMaps(true, true, true)
 
 	for _, m := range []*nat.Map{ipv4, ipv6} {
 		if m == nil {

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -33,7 +33,7 @@ var bpfNatListCmd = &cobra.Command{
 	Short:   "List all NAT mapping entries",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf nat list")
-		ipv4, ipv6 := nat.GlobalMaps(true, true)
+		ipv4, ipv6 := nat.GlobalMaps(true, true, true)
 		globalMaps := make([]interface{}, 2)
 		globalMaps[0] = ipv4
 		globalMaps[1] = ipv6

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -298,7 +298,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	isKubeProxyReplacementStrict := initKubeProxyReplacementOptions()
 
 	ctmap.InitMapInfo(option.Config.CTMapEntriesGlobalTCP, option.Config.CTMapEntriesGlobalAny,
-		option.Config.EnableIPv4, option.Config.EnableIPv6)
+		option.Config.EnableIPv4, option.Config.EnableIPv6, option.Config.EnableNodePort)
 	policymap.InitMapInfo(option.Config.PolicyMapEntries)
 	lbmap.Init(lbmap.InitParams{
 		IPv4: option.Config.EnableIPv4,

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -400,13 +400,13 @@ func (d *Daemon) initMaps() error {
 	}
 
 	ipv4Nat, ipv6Nat := nat.GlobalMaps(option.Config.EnableIPv4,
-		option.Config.EnableIPv6)
-	if option.Config.EnableIPv4 {
+		option.Config.EnableIPv6, option.Config.EnableNodePort)
+	if ipv4Nat != nil {
 		if _, err := ipv4Nat.Create(); err != nil {
 			return err
 		}
 	}
-	if option.Config.EnableIPv6 {
+	if ipv6Nat != nil {
 		if _, err := ipv6Nat.Create(); err != nil {
 			return err
 		}

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -152,10 +152,10 @@ func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxE
 // InitMapInfo builds the information about different CT maps for the
 // combination of L3/L4 protocols, using the specified limits on TCP vs non-TCP
 // maps.
-func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6 bool) {
+func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6, nodeport bool) {
 	mapInfo = make(map[mapType]mapAttributes, mapTypeMax)
 
-	global4Map, global6Map := nat.GlobalMaps(v4, v6)
+	global4Map, global6Map := nat.GlobalMaps(v4, v6, nodeport)
 
 	// SNAT also only works if the CT map is global so all local maps will be nil
 	natMaps := map[mapType]*nat.Map{
@@ -203,7 +203,7 @@ func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6 bool) {
 }
 
 func init() {
-	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true)
+	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 }
 
 // CtEndpoint represents an endpoint for the functions required to manage

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -106,16 +106,6 @@ const (
 
 var globalDeleteLock [mapTypeMax]lock.Mutex
 
-type NatMap interface {
-	Open() error
-	Close() error
-	DeleteMapping(key tuple.TupleKey) error
-	DumpWithCallback(bpf.DumpCallback) error
-	DumpReliablyWithCallback(bpf.DumpCallback, *bpf.DumpStats) error
-	Delete(bpf.MapKey) error
-	DumpStats() *bpf.DumpStats
-}
-
 type mapAttributes struct {
 	mapKey     bpf.MapKey
 	keySize    int
@@ -124,7 +114,7 @@ type mapAttributes struct {
 	maxEntries int
 	parser     bpf.DumpParser
 	bpfDefine  string
-	natMap     NatMap
+	natMap     *nat.Map
 }
 
 // CtMap interface represents a CT map, and can be reused to implement mock
@@ -145,7 +135,7 @@ type CtMapRecord struct {
 	Value CtEntry
 }
 
-func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxEntries int, nat NatMap) {
+func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxEntries int, nat *nat.Map) {
 	mapInfo[m] = mapAttributes{
 		bpfDefine: define,
 		mapKey:    mapKey,
@@ -168,7 +158,7 @@ func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6 bool) {
 	global4Map, global6Map := nat.GlobalMaps(v4, v6)
 
 	// SNAT also only works if the CT map is global so all local maps will be nil
-	natMaps := map[mapType]NatMap{
+	natMaps := map[mapType]*nat.Map{
 		mapTypeIPv4TCPLocal:  nil,
 		mapTypeIPv6TCPLocal:  nil,
 		mapTypeIPv4TCPGlobal: global4Map,
@@ -347,7 +337,7 @@ func newMap(mapName string, m mapType) *Map {
 	return result
 }
 
-func purgeCtEntry6(m *Map, key CtKey, natMap NatMap) error {
+func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
 	err := m.Delete(key)
 	if err == nil && natMap != nil {
 		natMap.DeleteMapping(key.GetTupleKey())
@@ -427,7 +417,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 	return stats
 }
 
-func purgeCtEntry4(m *Map, key CtKey, natMap NatMap) error {
+func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
 	err := m.Delete(key)
 	if err == nil && natMap != nil {
 		natMap.DeleteMapping(key.GetTupleKey())

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -40,7 +40,7 @@ func Test(t *testing.T) {
 }
 
 func (t *CTMapTestSuite) TestInit(c *C) {
-	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true)
+	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
 		info := mapInfo[mapType]
 		if mapType.isIPv6() {

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -136,7 +137,7 @@ type NatGCStats struct {
 	// to correctly count EgressAlive, so skip it
 }
 
-func newNatGCStats(m NatMap, family gcFamily) NatGCStats {
+func newNatGCStats(m *nat.Map, family gcFamily) NatGCStats {
 	return NatGCStats{
 		DumpStats: m.DumpStats(),
 		Family:    family,

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -298,7 +298,10 @@ func (m *Map) DeleteMapping(key tuple.TupleKey) error {
 }
 
 // GlobalMaps returns all global NAT maps.
-func GlobalMaps(ipv4, ipv6 bool) (ipv4Map, ipv6Map *Map) {
+func GlobalMaps(ipv4, ipv6, nodeport bool) (ipv4Map, ipv6Map *Map) {
+	if !nodeport {
+		return
+	}
 	entries := option.Config.NATMapEntriesGlobal
 	if entries == 0 {
 		entries = option.LimitTableMax


### PR DESCRIPTION
The IPv4 and IPv6 SNAT maps are only used if BPF NodePort is enabled. https://github.com/cilium/cilium/pull/14721 removed the maps on startup if BPF NodePort is disabled.

We were however still creating them regardless of the BPF NodePort status. The creation started a controller which then fails once the actual map is removed. This commit fixes the issue by not creating the userspace object, including the controller, for the SNAT maps when BPF NodePort is disabled.

See commits for details.

Fixes: https://github.com/cilium/cilium/pull/14721
Fixes: https://github.com/cilium/cilium/issues/15141

```release-note
Fix failing `bpf-map-sync-cilium_snat_v{4,6}_external` controllers when BPF NodePort is disabled
```
