### PR TITLE
v1.8 backports 2021-03-02

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -65,9 +65,18 @@ One-time setup
       $ git config --global user.name "John Doe"
       $ git config --global user.email johndoe@example.com
 
+#. Add remotes for the Cilium upstream repository and your Cilium repository fork.
+
+   .. code-block:: bash
+
+      $ git remote add johndoe git@github.com:johndoe/cilium.git
+      $ git remote add upstream https://github.com/cilium/cilium.git
+
 #. Make sure you have a GitHub developer access token with the ``public_repos``
-   scope available. For details, see `contrib/backporting/README.md
-   <https://github.com/cilium/cilium/blob/master/contrib/backporting/README.md>`_
+   ``workflow`` scopes available. You can do this directly from
+   https://github.com/settings/tokens or by opening GitHub and then navigating
+   to: User Profile -> Settings -> Developer Settings -> Personal access token
+   -> Generate new token.
 
 #. This guide makes use of several tools to automate the backporting process.
    The basics require ``bash`` and ``git``, but to automate interactions with

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1643,18 +1643,20 @@ func (e *etcdClient) ListPrefix(ctx context.Context, prefix string) (v KeyValueP
 // Close closes the etcd session
 func (e *etcdClient) Close() {
 	close(e.stopStatusChecker)
-	<-e.firstSession
+	sessionErr := e.waitForInitialSession(context.Background())
 	if e.controllers != nil {
 		e.controllers.RemoveAll()
 	}
 	e.RLock()
 	defer e.RUnlock()
-	if e.lockSession != nil {
+	// Only close e.lockSession if the initial session was successful
+	if sessionErr == nil {
 		if err := e.lockSession.Close(); err != nil {
 			e.getLogger().WithError(err).Warning("Failed to revoke lock session while closing etcd client")
 		}
 	}
-	if e.session != nil {
+	// Only close e.session if the initial session was successful
+	if sessionErr == nil {
 		if err := e.session.Close(); err != nil {
 			e.getLogger().WithError(err).Warning("Failed to revoke main session while closing etcd client")
 		}


### PR DESCRIPTION
* #15107 -- pkg/kvstore: fix etcd segmentation violation (@aanm)
 * #15118 -- backporting: Update instructions for backporting workflow (@aditighag)

Skipped due to non-trivial conflicts:
  * #15048 -- cilium: encryption, fixes for ENI & Azure mode with shared podIPs and networkIPs (@jrfastab)
    * Mostly `bpf/lib/encrypt.h` not existing in v1.8 tree

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15107 15118; do contrib/backporting/set-labels.py $pr done 1.8; done
```