### PR TITLE
v1.7 backports 2021-03-03

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(SUBDIRS): force
 	@ $(MAKE) -C $@ all
 
 jenkins-precheck:
-	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER run --rm precheck
+	COMPOSE_INTERACTIVE_NO_CLI=1 docker-compose --verbose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER run --rm precheck
 
 clean-jenkins-precheck:
 	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER rm


### PR DESCRIPTION
* #15171 -- test: Fix docker compose in precheck (@nebril)

Skipped:

 * #15118 -- backporting: Update instructions for backporting workflow (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15118; do contrib/backporting/set-labels.py $pr done 1.7; done
```