### PR TITLE
v1.9 backports 2021-03-02 amendment

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -267,7 +267,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod |
 | operator.identityGCInterval | string | `"15m0s"` |  |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` |  |
-| operator.image | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","tag":"v1.9.4"}` | cilium-operator image. |
+| operator.image | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.9.4"}` | cilium-operator image. |
 | operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -136,11 +136,11 @@ spec:
           value: {{ $value }}
 {{- end }}
 {{- if .Values.eni }}
-        image: {{ .Values.operator.image.repository }}-aws:{{ .Values.operator.image.tag }}
+        image: {{ .Values.operator.image.repository }}-aws{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}
 {{- else if .Values.azure.enabled }}
-        image: {{ .Values.operator.image.repository }}-azure:{{ .Values.operator.image.tag }}
+        image: {{ .Values.operator.image.repository }}-azure{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}
 {{- else }}
-        image: {{ .Values.operator.image.repository }}-generic:{{ .Values.operator.image.tag }}
+        image: {{ .Values.operator.image.repository }}-generic{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         name: cilium-operator

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1063,6 +1063,7 @@ operator:
     repository: quay.io/cilium/operator
     tag: v1.9.4
     pullPolicy: IfNotPresent
+    suffix: ""
 
   # -- Number of replicas to run for the cilium-operator deployment
   replicas: 2

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -34,22 +34,23 @@ type CiliumTestConfigType struct {
 	// PassCLIEnvironment passes through the environment invoking the gingko
 	// tests. When false all subcommands are executed with an empty environment,
 	// including PATH.
-	PassCLIEnvironment  bool
-	SSHConfig           string
-	ShowCommands        bool
-	TestScope           string
-	SkipLogGathering    bool
-	CiliumImage         string
-	CiliumTag           string
-	CiliumOperatorImage string
-	CiliumOperatorTag   string
-	HubbleRelayImage    string
-	HubbleRelayTag      string
-	ProvisionK8s        bool
-	Timeout             time.Duration
-	Kubeconfig          string
-	RegistryCredentials string
-	Benchmarks          bool
+	PassCLIEnvironment   bool
+	SSHConfig            string
+	ShowCommands         bool
+	TestScope            string
+	SkipLogGathering     bool
+	CiliumImage          string
+	CiliumTag            string
+	CiliumOperatorImage  string
+	CiliumOperatorTag    string
+	CiliumOperatorSuffix string
+	HubbleRelayImage     string
+	HubbleRelayTag       string
+	ProvisionK8s         bool
+	Timeout              time.Duration
+	Kubeconfig           string
+	RegistryCredentials  string
+	Benchmarks           bool
 	// Multinode enables the running of tests that involve more than one
 	// node. If false, some tests will silently skip multinode checks.
 	Multinode      bool
@@ -86,6 +87,8 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies which image of cilium-operator to use during tests")
 	flagset.StringVar(&c.CiliumOperatorTag, "cilium.operator-tag", "",
 		"Specifies which tag of cilium-operator to use during tests")
+	flagset.StringVar(&c.CiliumOperatorSuffix, "cilium.operator-suffix", "",
+		"Specifies a suffix to append to operator image after cloud-specific suffix")
 	flagset.StringVar(&c.HubbleRelayImage, "cilium.hubble-relay-image", "",
 		"Specifies which image of hubble-relay to use during tests")
 	flagset.StringVar(&c.HubbleRelayTag, "cilium.hubble-relay-tag", "",

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -95,6 +95,7 @@ var (
 		"preflight.image.tag":           "latest",
 		"operator.image.repository":     "k8s1:5000/cilium/operator",
 		"operator.image.tag":            "latest",
+		"operator.image.suffix":         "",
 		"hubble.relay.image.repository": "k8s1:5000/cilium/hubble-relay",
 		"hubble.relay.image.tag":        "latest",
 		"debug.enabled":                 "true",
@@ -239,6 +240,10 @@ func Init() {
 		os.Setenv("CILIUM_OPERATOR_TAG", config.CiliumTestConfig.CiliumOperatorTag)
 	}
 
+	if config.CiliumTestConfig.CiliumOperatorSuffix != "" {
+		os.Setenv("CILIUM_OPERATOR_SUFFIX", config.CiliumTestConfig.CiliumOperatorSuffix)
+	}
+
 	if config.CiliumTestConfig.HubbleRelayImage != "" {
 		os.Setenv("HUBBLE_RELAY_IMAGE", config.CiliumTestConfig.HubbleRelayImage)
 	}
@@ -253,12 +258,13 @@ func Init() {
 
 	// Copy over envronment variables that are passed in.
 	for envVar, helmVar := range map[string]string{
-		"CILIUM_TAG":            "image.tag",
-		"CILIUM_IMAGE":          "image.repository",
-		"CILIUM_OPERATOR_TAG":   "operator.image.tag",
-		"CILIUM_OPERATOR_IMAGE": "operator.image.repository",
-		"HUBBLE_RELAY_IMAGE":    "hubble.relay.image.repository",
-		"HUBBLE_RELAY_TAG":      "hubble.relay.image.tag",
+		"CILIUM_TAG":             "image.tag",
+		"CILIUM_IMAGE":           "image.repository",
+		"CILIUM_OPERATOR_TAG":    "operator.image.tag",
+		"CILIUM_OPERATOR_IMAGE":  "operator.image.repository",
+		"CILIUM_OPERATOR_SUFFIX": "operator.image.suffix",
+		"HUBBLE_RELAY_IMAGE":     "hubble.relay.image.repository",
+		"HUBBLE_RELAY_TAG":       "hubble.relay.image.tag",
 	} {
 		if v := os.Getenv(envVar); v != "" {
 			defaultHelmOptions[helmVar] = v


### PR DESCRIPTION
* #14952 -- Add configurable suffix for operator image repo in helm (@nebril)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14952; do contrib/backporting/set-labels.py $pr done 1.9; done
```