### PR TITLE
azure: populate ApplicationSecurityGroups field in the new IPConfigurations

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -406,14 +406,23 @@ func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, v
 		return fmt.Errorf("interface %s does not exist in VM %s", interfaceName, instanceID)
 	}
 
+	// All IPConfigurations on the NIC should reference the same set of Application Security Groups (ASGs).
+	// So we should first fetch the set of ASGs referenced by other IPConfigurations so that it can be
+	// added to the new IPConfigurations.
+	var appSecurityGroups *[]compute.SubResource
+	if ipConfigs := *netIfConfig.IPConfigurations; len(ipConfigs) > 0 {
+		appSecurityGroups = ipConfigs[0].ApplicationSecurityGroups
+	}
+
 	ipConfigurations := make([]compute.VirtualMachineScaleSetIPConfiguration, 0, addresses)
 	for i := 0; i < addresses; i++ {
 		ipConfigurations = append(ipConfigurations,
 			compute.VirtualMachineScaleSetIPConfiguration{
 				Name: to.StringPtr(generateIpConfigName()),
 				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-					PrivateIPAddressVersion: compute.IPv4,
-					Subnet:                  &compute.APIEntityReference{ID: to.StringPtr(subnetID)},
+					ApplicationSecurityGroups: appSecurityGroups,
+					PrivateIPAddressVersion:   compute.IPv4,
+					Subnet:                    &compute.APIEntityReference{ID: to.StringPtr(subnetID)},
 				},
 			},
 		)
@@ -441,11 +450,20 @@ func (c *Client) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, inter
 		return fmt.Errorf("failed to get standalone instance's interface %s: %s", interfaceName, err)
 	}
 
+	// All IPConfigurations on the NIC should reference the same set of Application Security Groups (ASGs).
+	// So we should first fetch the set of ASGs referenced by other IPConfigurations so that it can be
+	// added to the new IPConfigurations.
+	var appSecurityGroups *[]network.ApplicationSecurityGroup
+	if ipConfigs := *iface.IPConfigurations; len(ipConfigs) > 0 {
+		appSecurityGroups = ipConfigs[0].ApplicationSecurityGroups
+	}
+
 	ipConfigurations := make([]network.InterfaceIPConfiguration, 0, addresses)
 	for i := 0; i < addresses; i++ {
 		ipConfigurations = append(ipConfigurations, network.InterfaceIPConfiguration{
 			Name: to.StringPtr(generateIpConfigName()),
 			InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+				ApplicationSecurityGroups: appSecurityGroups,
 				PrivateIPAllocationMethod: network.Dynamic,
 				Subnet: &network.Subnet{
 					ID: to.StringPtr(subnetID),


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Azure wants all IPConfigurations to have the same
ApplicationSecurityGroups. So if the primary IPConfiguration is already
assigned an ApplicationSecurityGroup, adding a new IPConfiguration
without any ApplicationSecurityGroup fails. So we should populate
ApplicationSecurityGroups field that is the same as ASG of other
IPConfiguration.

```release-note
Fix a bug that was causing Azure IPAM to not work when ApplicationSecurityGroups were attached to IPConfigurations of a NIC.
```
