### PR TITLE
daemon: do not allow --auto-direct-node-routes when tunneling is enabled

### DIFF
--- a/Documentation/concepts/security/proxy/envoy.rst
+++ b/Documentation/concepts/security/proxy/envoy.rst
@@ -529,7 +529,7 @@ and adding the ''--debug-verbose=flow'' flag.
 
   $ sudo service cilium stop 
   
-  $ sudo /usr/bin/cilium-agent --debug --auto-direct-node-routes --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow
+  $ sudo /usr/bin/cilium-agent --debug --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow
 
 
 Step 13: Add Runtime Tests

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -306,7 +306,7 @@ function write_cilium_cfg() {
     ipv6_addr="${3}"
     filename="${4}"
 
-    cilium_options=" --debug --pprof --enable-hubble --hubble-listen-address :4244 --enable-k8s-event-handover --k8s-require-ipv4-pod-cidr --auto-direct-node-routes"
+    cilium_options=" --debug --pprof --enable-hubble --hubble-listen-address :4244 --enable-k8s-event-handover --k8s-require-ipv4-pod-cidr"
     cilium_operator_options=" --debug"
 
     if [[ "${IPV4}" -eq "1" ]]; then

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1266,6 +1266,10 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EncryptInterface = link
 	}
 
+	if option.Config.Tunnel != option.TunnelDisabled && option.Config.EnableAutoDirectRouting {
+		log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
+	}
+
 	initClockSourceOption()
 	initSockmapOption()
 


### PR DESCRIPTION
Enabling --auto-direct-node-routes when tunneling is enabled can cause
traffic to leave the node through a physical interface (i.e. not
encapsulated) rather than via the tunnel.

Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>