### PR TITLE
.travis: fail Travis if race detection builds also fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ jobs:
         - LOCKDEBUG=1
       virt: vm
       group: edge
-  allow_failures:
-    - name: "amd64-race"
-    - name: "arm64-graviton2-race"
 
 if: branch = master OR type = pull_request
 


### PR DESCRIPTION
The race detection builds shouldn't be allowed to fail on master branch
to make it easier detect if race detection tests are failing.

Signed-off-by: André Martins <andre@cilium.io>