### PR TITLE
.github: add dependabot for v1.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    ignore:
+        # cannot be updated until the etcd library is updated
+      - dependency-name: "google.golang.org/grpc"
+        # using a cilium-specific fork
+      - dependency-name: "github.com/miekg/dns"
+        # newer versions break our CI
+      - dependency-name: "github.com/onsi/ginkgo"
+    labels:
+    - kind/enhancement
+    - release-note/misc
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    labels:
+    - kind/enhancement
+    - release-note/misc


### PR DESCRIPTION
The dependabot can be useful for stable branches as
it will keep updating dependencies on these stable
branches automatically.

Signed-off-by: André Martins <andre@cilium.io>