### PR TITLE
test: Unquarantine the random-fully test

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -261,10 +261,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 		})
 
-		SkipItIf(func() bool {
-			// Skip K8s versions for which the test is currently flaky.
-			return helpers.SkipK8sVersions(">=1.14.0 <1.20.0") && helpers.SkipQuarantined()
-		}, "Check iptables masquerading with random-fully", func() {
+		It("Check iptables masquerading with random-fully", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"bpf.masquerade":      "false",
 				"iptablesRandomFully": "true",


### PR DESCRIPTION
It [doesn't seem to be flaky](https://datastudio.google.com/s/lDk0zKOzBO8) anymore. Could have been fixed by the split of k8s-all or by https://github.com/cilium/cilium/pull/14913.

Fixes: https://github.com/cilium/cilium/issues/13773