### PR TITLE
Documentation: update iproute2 git URL in bpf.rst

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -935,14 +935,14 @@ be used:
 
 ::
 
-    $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/iproute2/iproute2.git
+    $ git clone https://git.kernel.org/pub/scm/network/iproute2/iproute2.git
 
 Similarly, to clone into mentioned ``net-next`` branch of iproute2, run the
 following:
 
 ::
 
-    $ git clone -b net-next git://git.kernel.org/pub/scm/linux/kernel/git/iproute2/iproute2.git
+    $ git clone -b net-next https://git.kernel.org/pub/scm/network/iproute2/iproute2.git
 
 After that, proceed with the build and installation:
 


### PR DESCRIPTION
<!-- Description of change -->
PR fixes the git URL for iproute2 on https://docs.cilium.io/en/latest/bpf/#compiling-iproute2 - the current one doesn't work:
```
$ git clone git://git.kernel.org/pub/scm/linux/kernel/git/iproute2/iproute2.git /tmp/iproute
Cloning into '/tmp/iproute'...
fatal: remote error: access denied or repository not exported: /pub/scm/linux/kernel/git/iproute2/iproute2.git
```
Changed it to the https:// URL from the bottom of https://git.kernel.org/pub/scm/network/iproute2/iproute2.git which works fine.
