### PR TITLE
config: remove POLICY_AUDIT_MODE from node_config.h

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -457,13 +457,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		ctmap.WriteBPFMacros(fw, nil)
 	}
 
-	// option.Config.Opts.Opts stores agent mutable config options. We check PolicyAuditMode
-	// by its value instead of option.Config.PolicyAuditMode since PolicyAuditMode can be changed
-	// by cilium CLI/API at runtime and need to be written to bpf header files.
-	if val, ok := option.Config.Opts.Opts[option.PolicyAuditMode]; ok && val != option.OptionDisabled {
-		cDefinesMap["POLICY_AUDIT_MODE"] = "1"
-	}
-
 	if option.Config.AllowICMPFragNeeded {
 		cDefinesMap["ALLOW_ICMP_FRAG_NEEDED"] = "1"
 	}


### PR DESCRIPTION
Fix: #15197

If audit mode is enabled at agent startup, the POLICY_AUDIT_MODE macro in
node_config.h will override the corresponding settings in each endpoint's
header file, which leads to runtime changes (via CLI/API) don't work.

Looking at the code, the macro in node_config.h seems to be unnecessary
and can be removed. And this can solve the problem described above.

```release-note
Fix bug where PolicyAuditMode could not be changed at runtime if it was enabled at startup
```

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>