### PR TITLE
test: Respect cilium.holdEnvironment on Cilium status check

### DIFF
--- a/test/helpers/manifest.go
+++ b/test/helpers/manifest.go
@@ -322,7 +322,7 @@ func (m *DeploymentManager) DeployCilium(options map[string]string, deploy Ciliu
 
 	ginkgoext.By("Making sure all endpoints are in ready state")
 	if err = m.kubectl.CiliumEndpointWaitReady(); err != nil {
-		ginkgoext.Failf("Failure while waiting for all cilium endpoints to reach ready state: %s", err)
+		Fail(fmt.Sprintf("Failure while waiting for all cilium endpoints to reach ready state: %s", err))
 	}
 
 	m.ciliumDeployed = true


### PR DESCRIPTION
In local tests, when `-cilium.holdEnvironment=true`, the tests don't pause if Cilium pods fail to become ready. That is because we fail the test with `ginkgo.Fail` instead of our wrapper function `helpers.Fail`. This commit fixes it.