### PR TITLE
endpoint: Fix the initialization of endpoints' datapath configs

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -266,15 +266,8 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		ip4Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv4Mask}
 	}
 
-	if option.Config.EnableEndpointRoutes {
-		disabled := false
-		dpConfig := &models.EndpointDatapathConfiguration{
-			InstallEndpointRoute: true,
-			RequireEgressProg:    true,
-			RequireRouting:       &disabled,
-		}
-		info.DatapathConfiguration = dpConfig
-	}
+	dpConfig := endpoint.NewDatapathConfiguration()
+	info.DatapathConfiguration = &dpConfig
 
 	netNS, err := netns.ReplaceNetNSWithName(netNSName)
 	if err != nil {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -306,24 +306,20 @@ func (m *endpointCreationManager) DebugStatus() (output string) {
 // createEndpoint attempts to create the endpoint corresponding to the change
 // request that was specified.
 func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, epTemplate *models.EndpointChangeRequest) (*endpoint.Endpoint, int, error) {
-	if option.Config.EnableEndpointRoutes {
-		if epTemplate.DatapathConfiguration == nil {
-			epTemplate.DatapathConfiguration = &models.EndpointDatapathConfiguration{}
+	if epTemplate.DatapathConfiguration == nil {
+		dpConfig := endpoint.NewDatapathConfiguration()
+		epTemplate.DatapathConfiguration = &dpConfig
+	} else {
+		if option.Config.EnableEndpointRoutes {
+			epTemplate.DatapathConfiguration.InstallEndpointRoute = true
+			epTemplate.DatapathConfiguration.RequireEgressProg = true
+			disabled := false
+			epTemplate.DatapathConfiguration.RequireRouting = &disabled
+		} else {
+			epTemplate.DatapathConfiguration.InstallEndpointRoute = false
+			epTemplate.DatapathConfiguration.RequireEgressProg = false
+			epTemplate.DatapathConfiguration.RequireRouting = nil
 		}
-
-		// Indicate to insert a per endpoint route instead of routing
-		// via cilium_host interface
-		epTemplate.DatapathConfiguration.InstallEndpointRoute = true
-
-		// Since routing occurs via endpoint interface directly, BPF
-		// program is needed on that device at egress as BPF program on
-		// cilium_host interface is bypassed
-		epTemplate.DatapathConfiguration.RequireEgressProg = true
-
-		// Delegate routing to the Linux stack rather than tail-calling
-		// between BPF programs.
-		disabled := false
-		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	}
 
 	log.WithFields(logrus.Fields{

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -342,16 +342,27 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 				}
 				return err
 			}
+		} else {
+			err := RemoveTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS)
+			if err != nil {
+				log.WithField("device", ep.InterfaceName()).Error(err)
+			}
 		}
 	}
 
-	if ep.RequireEndpointRoute() {
-		if ip := ep.IPv4Address(); ip.IsSet() {
+	if ip := ep.IPv4Address(); ip.IsSet() {
+		if ep.RequireEndpointRoute() {
 			upsertEndpointRoute(ep, *ip.IPNet(32))
+		} else {
+			removeEndpointRoute(ep, *ip.IPNet(32))
 		}
+	}
 
-		if ip := ep.IPv6Address(); ip.IsSet() {
+	if ip := ep.IPv6Address(); ip.IsSet() {
+		if ep.RequireEndpointRoute() {
 			upsertEndpointRoute(ep, *ip.IPNet(128))
+		} else {
+			removeEndpointRoute(ep, *ip.IPNet(128))
 		}
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -489,9 +489,7 @@ func CreateHostEndpoint(owner regeneration.Owner, proxy EndpointProxy, allocator
 	ep := createEndpoint(owner, proxy, allocator, 0, ifName)
 	ep.isHost = true
 	ep.nodeMAC = mac
-	ep.DatapathConfiguration = models.EndpointDatapathConfiguration{
-		RequireEgressProg: true,
-	}
+	ep.DatapathConfiguration = NewDatapathConfiguration()
 
 	ep.setState(StateWaitingForIdentity, "Endpoint creation")
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -847,6 +847,9 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, bEp []byte) (*
 	// If host label is present, it's the host endpoint.
 	ep.isHost = ep.HasLabels(labels.LabelHost)
 
+	// Overwrite datapath configuration with the current agent configuration.
+	ep.DatapathConfiguration = NewDatapathConfiguration()
+
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually
 	// error/panic if CurrentStatus or Log are not initialized correctly.


### PR DESCRIPTION
See commits for details.

Fixes: https://github.com/cilium/cilium/issues/13773.

```release-note
Fix bug where `enable-endpoint-routes` change required all pods to restart to take effect
```