### PR TITLE
helm: Replaced object-based extraArgs with array-based

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -135,7 +135,7 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.clusterSize | int | `3` | Size of the managed etcd cluster. |
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |
 | etcd.endpoints | list | `["https://CHANGE-ME:2379"]` | List of etcd endpoints (not needed when using managed=true). |
-| etcd.extraArgs | object | `{}` | Additional cilium-etcd-operator container arguments |
+| etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments |
 | etcd.extraConfigmapMounts | list | `[]` | Additional cilium-etcd-operator ConfigMap mounts |
 | etcd.extraHostPathMounts | list | `[]` | Additional cilium-etcd-operator hostPath mounts |
 | etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod |
@@ -155,7 +155,7 @@ contributors across the globe, there is almost always someone available to help.
 | externalIPs.enabled | bool | `false` | Enable ExternalIPs service support. |
 | externalWorkloads | object | `{"enabled":false}` | Configure external workloads support |
 | externalWorkloads.enabled | bool | `false` | Enable support for external workloads, such as VMs (false by default). |
-| extraArgs | object | `{}` | Additional agent container arguments |
+| extraArgs | list | `[]` | Additional agent container arguments |
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
 | extraConfigmapMounts | list | `[]` | Additional agent ConfigMap mounts |
 | extraEnv | object | `{}` | Additional agent container environment variables |
@@ -256,7 +256,6 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
-| nodeinit.extraArgs | object | `{}` |  |
 | nodeinit.extraConfigmapMounts | list | `[]` |  |
 | nodeinit.extraEnv | object | `{}` |  |
 | nodeinit.extraHostPathMounts | list | `[]` |  |
@@ -274,7 +273,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"io.cilium/app","operator":"In","values":["operator"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | cilium-operator affinity |
 | operator.enabled | bool | `true` | Enable the cilium-operator component (required). |
 | operator.endpointGCInterval | string | `"5m0s"` |  |
-| operator.extraArgs | object | `{}` | Additional cilium-etcd-operator container arguments |
+| operator.extraArgs | list | `[]` | Additional cilium-operator container arguments |
 | operator.extraConfigmapMounts | list | `[]` |  |
 | operator.extraEnv | object | `{}` |  |
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts |
@@ -302,7 +301,6 @@ contributors across the globe, there is almost always someone available to help.
 | policyEnforcementMode | string | `"default"` |  |
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
-| preflight.extraArgs | object | `{}` |  |
 | preflight.extraConfigmapMounts | list | `[]` |  |
 | preflight.extraEnv | object | `{}` |  |
 | preflight.extraHostPathMounts | list | `[]` |  |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -102,12 +102,8 @@ spec:
 {{- else }}
       - args:
         - --config-dir=/tmp/cilium/config-map
-{{- range $key, $value := .Values.extraArgs }}
-{{- if $value }}
-        - --{{ $key }}={{ $value }}
-{{- else }}
-        - --{{ $key }}
-{{- end }}
+{{- with .Values.extraArgs }}
+        {{- toYaml . | trim | nindent 8 }}
 {{- end }}
         command:
         - cilium-agent

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
@@ -60,6 +60,9 @@ spec:
 {{- end }}
       containers:
       - args:
+{{- with .Values.etcd.extraArgs }}
+        {{- toYaml . | trim | nindent 8 }}
+{{- end }}
         #- --etcd-node-selector=disktype=ssd,cputype=high
         command:
         - /usr/bin/cilium-etcd-operator

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -81,6 +81,9 @@ spec:
       - args:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
+{{- with .Values.operator.extraArgs }}
+        {{- toYaml . | trim | nindent 8 }}
+{{- end }}
         command:
 {{- if .Values.eni.enabled }}
         - cilium-operator-aws

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -115,7 +115,7 @@ affinity:
 priorityClassName: ""
 
 # -- Additional agent container arguments
-extraArgs: {}
+extraArgs: []
 
 # -- Additional agent container environment variables
 extraEnv: {}
@@ -1026,7 +1026,7 @@ etcd:
 
   # -- Additional cilium-etcd-operator container arguments
   #
-  extraArgs: {}
+  extraArgs: []
 
   # -- Additional InitContainers to initialize the pod
   #
@@ -1165,9 +1165,9 @@ operator:
         topologyKey: kubernetes.io/hostname
 
 
-  # -- Additional cilium-etcd-operator container arguments
+  # -- Additional cilium-operator container arguments
   #
-  extraArgs: {}
+  extraArgs: []
 
   extraEnv: {}
 
@@ -1266,8 +1266,6 @@ nodeinit:
   updateStrategy:
     type: RollingUpdate
 
-  extraArgs: {}
-
   extraEnv: {}
 
   extraInitContainers: []
@@ -1345,8 +1343,6 @@ preflight:
   # -- preflight update strategy
   updateStrategy:
     type: RollingUpdate
-
-  extraArgs: {}
 
   extraEnv: {}
 


### PR DESCRIPTION
Signed-off-by: Sergey Monakhov <monakhov@puzl.ee>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

Hi, I refactored `extra-args`. 

Fixes: #15150

```release-noteaa
Replaced object-based extraArgs with array-based in Helm chart for all sub-components
```
