### PR TITLE
tools/licensegen: consider COPYING files

### DIFF
--- a/tools/licensegen/licensegen.go
+++ b/tools/licensegen/licensegen.go
@@ -13,7 +13,7 @@ func main() {
 	err := filepath.Walk("./vendor", func(path string, _ os.FileInfo, _ error) error {
 		base := filepath.Base(path)
 		ext := filepath.Ext(base)
-		if strings.TrimSuffix(base, ext) == "LICENSE" {
+		if stem := strings.TrimSuffix(base, ext); stem == "LICENSE" || stem == "COPYING" {
 			switch strings.TrimPrefix(strings.ToLower(ext), ".") {
 			case "", "code", "docs", "libyaml", "md", "txt":
 				fmt.Println("Name:", path)


### PR DESCRIPTION
Some projects use a `COPYING` file for their license. Consider these as
well. Currently, the only vendored dependency using such a file is
`github.com/BurntSushi/toml`:

```
$ diff -u LICENSE.all LICENSE.all.new
--- LICENSE.all	2021-03-08 11:12:05.281088204 +0100
+++ LICENSE.all.new	2021-03-08 11:11:38.757023948 +0100
@@ -2132,6 +2132,29 @@
    See the License for the specific language governing permissions and
    limitations under the License.

+Name: vendor/github.com/BurntSushi/toml/COPYING
+License: The MIT License (MIT)
+
+Copyright (c) 2013 TOML authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 Name: vendor/github.com/Microsoft/go-winio/LICENSE
 License: The MIT License (MIT)
```