### PR TITLE
all: don't use the deprecated io/ioutil package

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -29,6 +29,10 @@ jobs:
     name: build datapath
     runs-on: ubuntu-latest
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.16.0
       - name: Cache LLVM and Clang
         id: cache-llvm
         uses: actions/cache@v2.1.4

--- a/api/v1/health/server/server.go
+++ b/api/v1/health/server/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -282,7 +281,7 @@ func (s *Server) Serve() (err error) {
 
 		if s.TLSCACertificate != "" {
 			// include specified CA certificate
-			caCert, caCertErr := ioutil.ReadFile(s.TLSCACertificate)
+			caCert, caCertErr := os.ReadFile(s.TLSCACertificate)
 			if caCertErr != nil {
 				return caCertErr
 			}

--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -283,7 +282,7 @@ func (s *Server) Serve() (err error) {
 
 		if s.TLSCACertificate != "" {
 			// include specified CA certificate
-			caCert, caCertErr := ioutil.ReadFile(s.TLSCACertificate)
+			caCert, caCertErr := os.ReadFile(s.TLSCACertificate)
 			if caCertErr != nil {
 				return caCertErr
 			}

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -426,7 +426,7 @@ func (s *Server) Serve() (err error) {
 
 		if s.TLSCACertificate != "" {
 			// include specified CA certificate
-			caCert, caCertErr := ioutil.ReadFile(s.TLSCACertificate)
+			caCert, caCertErr := os.ReadFile(s.TLSCACertificate)
 			if caCertErr != nil {
 				return caCertErr
 			}

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -282,7 +281,7 @@ func (s *Server) Serve() (err error) {
 
 		if s.TLSCACertificate != "" {
 			// include specified CA certificate
-			caCert, caCertErr := ioutil.ReadFile(s.TLSCACertificate)
+			caCert, caCertErr := os.ReadFile(s.TLSCACertificate)
 			if caCertErr != nil {
 				return caCertErr
 			}

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -267,7 +267,7 @@ tests/bpf_ct_tests.o: tests/bpf_ct_tests.ll
 
 .PHONY: go_prog_test
 go_prog_test: $(BPF_TEST)
-	sudo go test -tags privileged_tests ./tests/prog_test
+	$(GO) test -tags privileged_tests -exec sudo ./tests/prog_test
 
 subdirs: $(SUBDIRS)
 	$(QUIET) $(foreach TARGET,$(SUBDIRS), \

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -156,7 +155,7 @@ func save(c *BugtoolConfiguration, path string) error {
 	if err != nil {
 		return fmt.Errorf("Cannot marshal config %s", err)
 	}
-	err = ioutil.WriteFile(path, data, 0644)
+	err = os.WriteFile(path, data, 0644)
 	if err != nil {
 		return fmt.Errorf("Cannot write config %s", err)
 	}
@@ -166,7 +165,7 @@ func save(c *BugtoolConfiguration, path string) error {
 func loadConfigFile(path string) (*BugtoolConfiguration, error) {
 	var content []byte
 	var err error
-	content, err = ioutil.ReadFile(path)
+	content, err = os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/bugtool/cmd/helper_test.go
+++ b/bugtool/cmd/helper_test.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"archive/tar"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,9 +61,9 @@ func (l *logWrapper) Write(p []byte) (n int, err error) {
 
 func (b *BugtoolSuite) SetUpSuite(c *C) {
 	var err error
-	baseDir, err = ioutil.TempDir("", "cilium_test_bugtool_base")
+	baseDir, err = os.MkdirTemp("", "cilium_test_bugtool_base")
 	c.Assert(err, IsNil)
-	tmpDir, err = ioutil.TempDir("", "cilium_test_bugtool_tmp")
+	tmpDir, err = os.MkdirTemp("", "cilium_test_bugtool_tmp")
 	c.Assert(err, IsNil)
 }
 
@@ -99,7 +98,7 @@ func (b *BugtoolSuite) TestWalkPath(c *C) {
 	c.Assert(err, IsNil)
 
 	// With real file
-	realFile, err := ioutil.TempFile(baseDir, "test")
+	realFile, err := os.CreateTemp(baseDir, "test")
 	c.Assert(err, IsNil)
 	info, err = os.Stat(realFile.Name())
 	c.Assert(err, IsNil)
@@ -116,7 +115,7 @@ func (b *BugtoolSuite) TestWalkPath(c *C) {
 	c.Assert(err, IsNil)
 
 	// With directory
-	nestedDir, err := ioutil.TempDir(baseDir, "nested")
+	nestedDir, err := os.MkdirTemp(baseDir, "nested")
 	c.Assert(err, IsNil)
 	info, err = os.Stat(nestedDir)
 	c.Assert(err, IsNil)

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -178,7 +177,7 @@ func runTool() {
 		sendArchiveToStdout = true
 		dumpPath = defaultDumpPath
 	}
-	dbgDir, err := ioutil.TempDir(dumpPath, prefix)
+	dbgDir, err := os.MkdirTemp(dumpPath, prefix)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create debug directory %s\n", err)
 		os.Exit(1)

--- a/cilium/cmd/bpf_sha_get.go
+++ b/cilium/cmd/bpf_sha_get.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -49,7 +49,7 @@ func init() {
 
 func dumpSha(sha string) {
 	headerPath := filepath.Join(templatesDir, sha, common.CHeaderFileName)
-	text, err := ioutil.ReadFile(headerPath)
+	text, err := os.ReadFile(headerPath)
 	if err != nil {
 		Fatalf("Failed to describe SHA: %s", err)
 	}

--- a/cilium/cmd/bpf_sha_list.go
+++ b/cilium/cmd/bpf_sha_list.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -88,7 +87,7 @@ func dumpShaList() {
 	bpfTemplateList := make(map[string][]string)
 
 	// Find all templates
-	templateDirs, err := ioutil.ReadDir(templatesDir)
+	templateDirs, err := os.ReadDir(templatesDir)
 	if err != nil {
 		Fatalf("failed to list template directory: %s\n", err)
 	}
@@ -97,7 +96,7 @@ func dumpShaList() {
 	}
 
 	// Find all endpoint usage of the templates
-	stateDirs, err := ioutil.ReadDir(stateDir)
+	stateDirs, err := os.ReadDir(stateDir)
 	if err != nil {
 		Fatalf("failed to list state directory: %s\n", err)
 	}

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -391,7 +390,7 @@ func removeDirs() error {
 
 func removeAllMaps() error {
 	mapDir := bpf.MapPrefixPath()
-	maps, err := ioutil.ReadDir(mapDir)
+	maps, err := os.ReadDir(mapDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -434,7 +433,7 @@ func printTicks(w io.Writer) {
 
 func writeHTML(data []byte, path string) {
 	output := blackfriday.Run(data)
-	if err := ioutil.WriteFile(path, output, 0644); err != nil {
+	if err := os.WriteFile(path, output, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Error while writing HTML file %s", err)
 		return
 	}

--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -119,9 +119,9 @@ func loadPolicyFile(path string) (api.Rules, error) {
 	logrus.WithField(logfields.Path, path).Debug("Loading file")
 
 	if path == "-" {
-		content, err = ioutil.ReadAll(bufio.NewReader(os.Stdin))
+		content, err = io.ReadAll(bufio.NewReader(os.Stdin))
 	} else {
-		content, err = ioutil.ReadFile(path)
+		content, err = os.ReadFile(path)
 	}
 
 	if err != nil {
@@ -152,7 +152,7 @@ func loadPolicy(name string) (api.Rules, error) {
 		return nil, fmt.Errorf("Error: %s is not a file or a directory", name)
 	}
 
-	files, err := ioutil.ReadDir(name)
+	files, err := os.ReadDir(name)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func loadPolicy(name string) (api.Rules, error) {
 	return result, nil
 }
 
-func processAllFilesFirst(name string, files []os.FileInfo) (api.Rules, error) {
+func processAllFilesFirst(name string, files []os.DirEntry) (api.Rules, error) {
 	result := api.Rules{}
 
 	for _, f := range files {
@@ -194,7 +194,7 @@ func processAllFilesFirst(name string, files []os.FileInfo) (api.Rules, error) {
 	return result, nil
 }
 
-func recursiveSearch(name string, files []os.FileInfo) (api.Rules, error) {
+func recursiveSearch(name string, files []os.DirEntry) (api.Rules, error) {
 	result := api.Rules{}
 	for _, f := range files {
 		if f.IsDir() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -1597,12 +1596,12 @@ func runDaemon() {
 		Info("Daemon initialization completed")
 
 	if option.Config.WriteCNIConfigurationWhenReady != "" {
-		input, err := ioutil.ReadFile(option.Config.ReadCNIConfiguration)
+		input, err := os.ReadFile(option.Config.ReadCNIConfiguration)
 		if err != nil {
 			log.WithError(err).Fatal("Unable to read CNI configuration file")
 		}
 
-		if err = ioutil.WriteFile(option.Config.WriteCNIConfigurationWhenReady, input, 0644); err != nil {
+		if err = os.WriteFile(option.Config.WriteCNIConfigurationWhenReady, input, 0644); err != nil {
 			log.WithError(err).Fatalf("Unable to write CNI configuration file to %s", option.Config.WriteCNIConfigurationWhenReady)
 		} else {
 			log.Infof("Wrote CNI configuration file to %s", option.Config.WriteCNIConfigurationWhenReady)

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -69,7 +68,7 @@ type DaemonSuite struct {
 }
 
 func setupTestDirectories() {
-	tempRunDir, err := ioutil.TempDir("", "cilium-test-run")
+	tempRunDir, err := os.MkdirTemp("", "cilium-test-run")
 	if err != nil {
 		panic("TempDir() failed.")
 	}
@@ -134,7 +133,6 @@ func (ds *DaemonSuite) TearDownSuite(c *C) {
 }
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
-
 	setupTestDirectories()
 
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()

--- a/daemon/cmd/debuginfo.go
+++ b/daemon/cmd/debuginfo.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -72,7 +71,7 @@ func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Resp
 }
 
 func memoryMap(pid int) string {
-	m, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
+	m, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
 	if err != nil {
 		return ""
 	}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -797,7 +797,7 @@ func deleteDNSLookups(globalCache *fqdn.DNSCache, endpoints []*endpoint.Endpoint
 // readPreCache returns a fqdn.DNSCache object created from the json data at
 // preCachePath
 func readPreCache(preCachePath string) (cache *fqdn.DNSCache, err error) {
-	data, err := ioutil.ReadFile(preCachePath)
+	data, err := os.ReadFile(preCachePath)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"sync"
@@ -131,7 +130,7 @@ func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
 
 	log.Info("Reading old endpoints...")
 
-	dirFiles, err := ioutil.ReadDir(dir)
+	dirFiles, err := os.ReadDir(dir)
 	if err != nil {
 		return state, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.15
+go 1.16
 
 // direct dependencies
 require (

--- a/pkg/aws/metadata/metadata.go
+++ b/pkg/aws/metadata/metadata.go
@@ -16,7 +16,7 @@ package metadata
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -27,7 +27,7 @@ func getMetadata(name string) (string, error) {
 	}
 
 	defer resp.Body.Close()
-	instanceID, err := ioutil.ReadAll(resp.Body)
+	instanceID, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("unable to read response body: %s", err)
 	}

--- a/pkg/azure/api/metadata.go
+++ b/pkg/azure/api/metadata.go
@@ -17,7 +17,7 @@ package api
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -68,7 +68,7 @@ func getMetadataString(ctx context.Context, path string) (string, error) {
 		}
 	}()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -109,18 +108,18 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 
-	dir, err := ioutil.TempDir("", "multicluster")
+	dir, err := os.MkdirTemp("", "multicluster")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
 	etcdConfig := []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
 
 	config1 := path.Join(dir, "cluster1")
-	err = ioutil.WriteFile(config1, etcdConfig, 0644)
+	err = os.WriteFile(config1, etcdConfig, 0644)
 	c.Assert(err, IsNil)
 
 	config2 := path.Join(dir, "cluster2")
-	err = ioutil.WriteFile(config2, etcdConfig, 0644)
+	err = os.WriteFile(config2, etcdConfig, 0644)
 	c.Assert(err, IsNil)
 
 	cm, err := NewClusterMesh(Configuration{

--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -15,7 +15,7 @@
 package clustermesh
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -57,7 +57,7 @@ func createConfigDirectoryWatcher(path string, lifecycle clusterLifecycle) (*con
 }
 
 func isEtcdConfigFile(path string) bool {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
@@ -86,7 +86,7 @@ func (cdw *configDirectoryWatcher) handleAddedFile(name, absolutePath string) {
 func (cdw *configDirectoryWatcher) watch() error {
 	log.WithField(fieldConfig, cdw.path).Debug("Starting config directory watcher")
 
-	files, err := ioutil.ReadDir(cdw.path)
+	files, err := os.ReadDir(cdw.path)
 	if err != nil {
 		return err
 	}

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -17,7 +17,6 @@
 package clustermesh
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -30,7 +29,7 @@ import (
 )
 
 func createFile(c *C, name string) {
-	err := ioutil.WriteFile(name, []byte("endpoints:\n- https://cluster1.cilium-etcd.cilium.svc:2379\n"), 0644)
+	err := os.WriteFile(name, []byte("endpoints:\n- https://cluster1.cilium-etcd.cilium.svc:2379\n"), 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -65,7 +64,7 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 		skipKvstoreConnection = false
 	}()
 
-	dir, err := ioutil.TempDir("", "multicluster")
+	dir, err := os.MkdirTemp("", "multicluster")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
@@ -161,17 +160,17 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 }
 
 func (s *ClusterMeshTestSuite) TestIsEtcdConfigFile(c *C) {
-	dir, err := ioutil.TempDir("", "etcdconfig")
+	dir, err := os.MkdirTemp("", "etcdconfig")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
 	validPath := path.Join(dir, "valid")
-	err = ioutil.WriteFile(validPath, []byte("endpoints:\n- https://cluster1.cilium-etcd.cilium.svc:2379\n"), 0644)
+	err = os.WriteFile(validPath, []byte("endpoints:\n- https://cluster1.cilium-etcd.cilium.svc:2379\n"), 0644)
 	c.Assert(err, IsNil)
 	c.Assert(isEtcdConfigFile(validPath), Equals, true)
 
 	invalidPath := path.Join(dir, "valid")
-	err = ioutil.WriteFile(invalidPath, []byte("sf324kj234lkjsdvl\nwl34kj23l4k\nendpoints"), 0644)
+	err = os.WriteFile(invalidPath, []byte("sf324kj234lkjsdvl\nwl34kj23l4k\nendpoints"), 0644)
 	c.Assert(err, IsNil)
 	c.Assert(isEtcdConfigFile(invalidPath), Equals, false)
 }

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -19,7 +19,6 @@ package clustermesh
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -73,16 +72,16 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-mgr.InitIdentityAllocator(nil, nil)
-	dir, err := ioutil.TempDir("", "multicluster")
+	dir, err := os.MkdirTemp("", "multicluster")
 	s.testDir = dir
 	c.Assert(err, IsNil)
 
 	config1 := path.Join(dir, s.randomName+"1")
-	err = ioutil.WriteFile(config1, etcdConfig, 0644)
+	err = os.WriteFile(config1, etcdConfig, 0644)
 	c.Assert(err, IsNil)
 
 	config2 := path.Join(dir, s.randomName+"2")
-	err = ioutil.WriteFile(config2, etcdConfig, 0644)
+	err = os.WriteFile(config2, etcdConfig, 0644)
 	c.Assert(err, IsNil)
 
 	cm, err := NewClusterMesh(Configuration{

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -17,7 +17,6 @@ package common
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -118,7 +117,7 @@ func GetNumPossibleCPUs(log *logrus.Entry) int {
 }
 
 func getNumPossibleCPUsFromReader(log *logrus.Entry, r io.Reader) int {
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	if err != nil {
 		log.WithError(err).Errorf("unable to read %q to get CPU count", PossibleCPUSysfsPath)
 		return 0

--- a/pkg/crypto/certificatemanager/certificate_manager.go
+++ b/pkg/crypto/certificatemanager/certificate_manager.go
@@ -17,7 +17,7 @@ package certificatemanager
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -67,14 +67,14 @@ func (m *Manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string)
 	// Give priority to local secrets.
 	// K8s API request is only done if the local secret directory can't be read!
 	certPath := filepath.Join(m.rootPath, nsName)
-	files, ioErr := ioutil.ReadDir(certPath)
+	files, ioErr := os.ReadDir(certPath)
 	if ioErr == nil {
 		secrets := make(map[string][]byte, len(files))
 		for _, file := range files {
 			var bytes []byte
 
 			path := filepath.Join(certPath, file.Name())
-			bytes, ioErr = ioutil.ReadFile(path)
+			bytes, ioErr = os.ReadFile(path)
 			if ioErr == nil {
 				secrets[file.Name()] = bytes
 			}

--- a/pkg/crypto/certloader/certloader_test.go
+++ b/pkg/crypto/certloader/certloader_test.go
@@ -17,7 +17,6 @@
 package certloader
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -301,18 +300,14 @@ type tlsConfigFiles struct {
 // directories create the TLS directories and return the TLS configuration file
 // paths.
 func directories(t *testing.T) (dir string, hubble, relay tlsConfigFiles) {
-	var err error
-	dir, err = ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal("ioutil.TempDir", err)
-	}
+	dir = t.TempDir()
 
 	// hubble tls config files
 	hubbleDir := filepath.Join(dir, "hubble")
 	hubble.caFiles = []string{filepath.Join(hubbleDir, "ca.crt")}
 	hubble.certFile = filepath.Join(hubbleDir, "server.crt")
 	hubble.privkeyFile = filepath.Join(hubbleDir, "server.key")
-	if err = os.MkdirAll(hubbleDir, 0755); err != nil {
+	if err := os.MkdirAll(hubbleDir, 0755); err != nil {
 		t.Fatal("os.MkdirAll", err)
 	}
 	// relay tls config files
@@ -320,7 +315,7 @@ func directories(t *testing.T) (dir string, hubble, relay tlsConfigFiles) {
 	relay.caFiles = []string{filepath.Join(relayDir, "ca.crt")}
 	relay.certFile = filepath.Join(relayDir, "server.crt")
 	relay.privkeyFile = filepath.Join(relayDir, "server.key")
-	if err = os.MkdirAll(relayDir, 0755); err != nil {
+	if err := os.MkdirAll(relayDir, 0755); err != nil {
 		t.Fatal("os.MkdirAll", err)
 	}
 
@@ -330,48 +325,48 @@ func directories(t *testing.T) (dir string, hubble, relay tlsConfigFiles) {
 // setup create the TLS files with the initial TLS configurations.
 func setup(t *testing.T, hubble, relay tlsConfigFiles) {
 	// hubble tls config files
-	if err := ioutil.WriteFile(hubble.caFiles[0], initialHubbleServerCA, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(hubble.caFiles[0], initialHubbleServerCA, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(hubble.certFile, initialHubbleServerCertificate, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(hubble.certFile, initialHubbleServerCertificate, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(hubble.privkeyFile, initialHubbleServerPrivkey, 0600); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(hubble.privkeyFile, initialHubbleServerPrivkey, 0600); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
 	// relay tls config files
-	if err := ioutil.WriteFile(relay.caFiles[0], initialRelayClientCA, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(relay.caFiles[0], initialRelayClientCA, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(relay.certFile, initialRelayClientCertificate, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(relay.certFile, initialRelayClientCertificate, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(relay.privkeyFile, initialRelayClientPrivkey, 0600); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(relay.privkeyFile, initialRelayClientPrivkey, 0600); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
 }
 
 // rotate replace the TLS files with the rotated TLS configurations.
 func rotate(t *testing.T, hubble, relay tlsConfigFiles) {
 	// hubble tls config files
-	if err := ioutil.WriteFile(hubble.caFiles[0], rotatedHubbleServerCA, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(hubble.caFiles[0], rotatedHubbleServerCA, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(hubble.certFile, rotatedHubbleServerCertificate, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(hubble.certFile, rotatedHubbleServerCertificate, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(hubble.privkeyFile, rotatedHubbleServerPrivkey, 0600); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(hubble.privkeyFile, rotatedHubbleServerPrivkey, 0600); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
 	// relay tls config files
-	if err := ioutil.WriteFile(relay.caFiles[0], rotatedRelayClientCA, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(relay.caFiles[0], rotatedRelayClientCA, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(relay.certFile, rotatedRelayClientCertificate, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(relay.certFile, rotatedRelayClientCertificate, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err := ioutil.WriteFile(relay.privkeyFile, rotatedRelayClientPrivkey, 0600); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(relay.privkeyFile, rotatedRelayClientPrivkey, 0600); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
 }
 
@@ -400,11 +395,7 @@ func k8sDataDirName() string {
 //          name: hubble-ca-cert
 //          optional: true
 func k8sDirectories(t *testing.T) (dir string, hubble tlsConfigFiles) {
-	var err error
-	dir, err = ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal("ioutil.TempDir", err)
-	}
+	dir = t.TempDir()
 
 	hubble.caFiles = []string{filepath.Join(dir, "client-ca.crt")}
 	hubbleDir := filepath.Join(dir, "hubble")
@@ -413,10 +404,10 @@ func k8sDirectories(t *testing.T) (dir string, hubble tlsConfigFiles) {
 
 	emptyDataDir := k8sDataDirName()
 	dataDir := filepath.Join(dir, emptyDataDir)
-	if err = os.MkdirAll(dataDir, 0755); err != nil {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		t.Fatal("os.MkdirAll", err)
 	}
-	if err = os.Symlink(emptyDataDir, filepath.Join(dir, "..data")); err != nil {
+	if err := os.Symlink(emptyDataDir, filepath.Join(dir, "..data")); err != nil {
 		t.Fatal("os.Symlink", err)
 	}
 
@@ -442,26 +433,26 @@ func k8sUpdate(t *testing.T, dir string, hubbleServerCert, hubbleServerKey, hubb
 	}
 
 	// write initial TLS certificates into dataDir
-	if err = ioutil.WriteFile(filepath.Join(dataDir, "hubble", "server.crt"), hubbleServerCert, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(filepath.Join(dataDir, "hubble", "server.crt"), hubbleServerCert, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err = ioutil.WriteFile(filepath.Join(dataDir, "hubble", "server.key"), hubbleServerKey, 0600); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(filepath.Join(dataDir, "hubble", "server.key"), hubbleServerKey, 0600); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
-	if err = ioutil.WriteFile(filepath.Join(dataDir, "client-ca.crt"), hubbleCA, 0644); err != nil {
-		t.Fatal("ioutil.WriteFile", err)
+	if err := os.WriteFile(filepath.Join(dataDir, "client-ca.crt"), hubbleCA, 0644); err != nil {
+		t.Fatal("os.WriteFile", err)
 	}
 
 	// create new '..data_tmp' symlink to point to newDataDir
-	if err = os.Symlink(newDataDir, filepath.Join(dir, "..data_tmp")); err != nil {
+	if err := os.Symlink(newDataDir, filepath.Join(dir, "..data_tmp")); err != nil {
 		t.Fatal("os.Symlink", err)
 	}
 	// overwrite '..data' with '..data_tmp'
-	if err = os.Rename(filepath.Join(dir, "..data_tmp"), filepath.Join(dir, "..data")); err != nil {
+	if err := os.Rename(filepath.Join(dir, "..data_tmp"), filepath.Join(dir, "..data")); err != nil {
 		t.Fatal("os.Rename", err)
 	}
 	// remove old setup data dir
-	if err = os.RemoveAll(filepath.Join(dir, oldDataDir)); err != nil {
+	if err := os.RemoveAll(filepath.Join(dir, oldDataDir)); err != nil {
 		t.Fatal("os.RemoveAll", err)
 	}
 }

--- a/pkg/crypto/certloader/fswatcher/fswatcher_test.go
+++ b/pkg/crypto/certloader/fswatcher/fswatcher_test.go
@@ -17,7 +17,6 @@
 package fswatcher
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,9 +33,7 @@ func Test(t *testing.T) {
 }
 
 func (s *FsWatcherTestSuite) TestWatcher(c *C) {
-	tmp, err := ioutil.TempDir("", "")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(tmp)
+	tmp := c.MkDir()
 
 	regularFile := filepath.Join(tmp, "file")
 	regularSymlink := filepath.Join(tmp, "symlink")
@@ -46,8 +43,7 @@ func (s *FsWatcherTestSuite) TestWatcher(c *C) {
 	indirectSymlink := filepath.Join(tmp, "foo", "symlink", "nested")
 	targetFile := filepath.Join(tmp, "target")
 
-	var w *Watcher
-	w, err = New([]string{
+	w, err := New([]string{
 		regularFile,
 		regularSymlink,
 		nestedFile,
@@ -87,12 +83,12 @@ func (s *FsWatcherTestSuite) TestWatcher(c *C) {
 
 	// create $tmp/file
 	var data = []byte("data")
-	err = ioutil.WriteFile(regularFile, data, 0777)
+	err = os.WriteFile(regularFile, data, 0777)
 	c.Assert(err, IsNil)
 	c.Assert(<-eventName, Equals, regularFile)
 
 	// symlink $tmp/symlink -> $tmp/target
-	err = ioutil.WriteFile(targetFile, data, 0777)
+	err = os.WriteFile(targetFile, data, 0777)
 	c.Assert(err, IsNil)
 	err = os.Symlink(targetFile, regularSymlink)
 	c.Assert(err, IsNil)
@@ -101,7 +97,7 @@ func (s *FsWatcherTestSuite) TestWatcher(c *C) {
 	// create $tmp/foo/bar/nested
 	err = os.MkdirAll(filepath.Dir(nestedFile), 0777)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(nestedFile, data, 0777)
+	err = os.WriteFile(nestedFile, data, 0777)
 	c.Assert(err, IsNil)
 	c.Assert(<-eventName, Equals, nestedFile)
 

--- a/pkg/crypto/certloader/reloader.go
+++ b/pkg/crypto/certloader/reloader.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -186,7 +186,7 @@ func (r *FileReloader) readKeypair() (*tls.Certificate, error) {
 func (r *FileReloader) readCertificateAuthority() (*x509.CertPool, error) {
 	caCertPool := x509.NewCertPool()
 	for _, path := range r.caFiles {
-		pem, err := ioutil.ReadFile(path)
+		pem, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load cert %q: %s", path, err)
 		}

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -373,7 +372,7 @@ func (p *ProbeManager) writeHeaders(featuresFile io.Writer) error {
 
 	io.Copy(writer, stdoutPipe)
 	if err := cmd.Wait(); err != nil {
-		stderr, err := ioutil.ReadAll(stderrPipe)
+		stderr, err := io.ReadAll(stderrPipe)
 		if err != nil {
 			return fmt.Errorf(
 				"reading from bpftool feature probe stderr pipe failed: %w", err)

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -19,7 +19,6 @@ package loader
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -30,7 +29,7 @@ import (
 )
 
 func (s *LoaderTestSuite) TestobjectCache(c *C) {
-	tmpDir, err := ioutil.TempDir("", "cilium_test")
+	tmpDir, err := os.MkdirTemp("", "cilium_test")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpDir)
 
@@ -83,7 +82,7 @@ func receiveResult(c *C, results chan buildResult) (*buildResult, error) {
 }
 
 func (s *LoaderTestSuite) TestobjectCacheParallel(c *C) {
-	tmpDir, err := ioutil.TempDir("", "cilium_test")
+	tmpDir, err := os.MkdirTemp("", "cilium_test")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpDir)
 

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -227,7 +226,7 @@ func compileAndLink(ctx context.Context, prog *progInfo, dir *directoryInfo, deb
 	/* Ignoring the output here because pkg/command/exec will log it. */
 	_, err = linkCmd.CombinedOutput(log, true)
 	if err == nil {
-		compileOut, _ = ioutil.ReadAll(compilerStderr)
+		compileOut, _ = io.ReadAll(compilerStderr)
 		err = compileCmd.Wait()
 	} else {
 		cancelCompile()

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -19,7 +19,6 @@ package loader
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,7 +110,7 @@ func runTests(m *testing.M) (int, error) {
 	SetTestIncludes([]string{"-I/usr/include/x86_64-linux-gnu/"})
 	defer SetTestIncludes(nil)
 
-	tmpDir, err := ioutil.TempDir("/tmp/", "cilium_")
+	tmpDir, err := os.MkdirTemp("/tmp/", "cilium_")
 	if err != nil {
 		return 1, fmt.Errorf("Failed to create temporary directory: %s", err)
 	}
@@ -324,7 +323,7 @@ func BenchmarkCompileOrLoad(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), benchTimeout)
 	defer cancel()
 
-	tmpDir, err := ioutil.TempDir("", "cilium_test")
+	tmpDir, err := os.MkdirTemp("", "cilium_test")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/elf/elf_test.go
+++ b/pkg/elf/elf_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -80,7 +79,7 @@ func compareFiles(path1, path2 string) error {
 }
 
 func (s *ELFTestSuite) TestWrite(c *C) {
-	tmpDir, err := ioutil.TempDir("", "cilium_")
+	tmpDir, err := os.MkdirTemp("", "cilium_")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpDir)
 
@@ -203,7 +202,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 
 // BenchmarkWriteELF benchmarks writing a very simple elf demo program.
 func BenchmarkWriteELF(b *testing.B) {
-	tmpDir, err := ioutil.TempDir("", "cilium_")
+	tmpDir, err := os.MkdirTemp("", "cilium_")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -19,7 +19,7 @@ package endpoint
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
@@ -49,7 +49,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 	}
 
 	var buf bytes.Buffer
-	file, err := ioutil.TempFile("", "cilium_ep_bench_")
+	file, err := os.CreateTemp("", "cilium_ep_bench_")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -16,7 +16,6 @@ package endpoint
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -60,11 +59,11 @@ func (e *Endpoint) backupDirectoryPath() string {
 
 // moveNewFilesTo copies all files, that do not exist in newDir, from oldDir.
 func moveNewFilesTo(oldDir, newDir string) error {
-	oldFiles, err := ioutil.ReadDir(oldDir)
+	oldFiles, err := os.ReadDir(oldDir)
 	if err != nil {
 		return err
 	}
-	newFiles, err := ioutil.ReadDir(newDir)
+	newFiles, err := os.ReadDir(newDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -17,7 +17,6 @@
 package endpoint
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -28,22 +27,22 @@ import (
 func (s *EndpointSuite) TestMoveNewFilesTo(c *check.C) {
 	oldDir := c.MkDir()
 	newDir := c.MkDir()
-	f1, err := ioutil.TempFile(oldDir, "")
+	f1, err := os.CreateTemp(oldDir, "")
 	c.Assert(err, check.IsNil)
-	f2, err := ioutil.TempFile(oldDir, "")
+	f2, err := os.CreateTemp(oldDir, "")
 	c.Assert(err, check.IsNil)
-	f3, err := ioutil.TempFile(newDir, "")
+	f3, err := os.CreateTemp(newDir, "")
 	c.Assert(err, check.IsNil)
 
 	// Copy the same file in both directories to make sure the same files
 	// are not moved from the old directory into the new directory.
-	err = ioutil.WriteFile(filepath.Join(oldDir, "foo"), []byte(""), os.FileMode(0644))
+	err = os.WriteFile(filepath.Join(oldDir, "foo"), []byte(""), os.FileMode(0644))
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(newDir, "foo"), []byte(""), os.FileMode(0644))
+	err = os.WriteFile(filepath.Join(newDir, "foo"), []byte(""), os.FileMode(0644))
 	c.Assert(err, check.IsNil)
 
 	compareDir := func(dir string, wantedFiles []string) {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		c.Assert(err, check.IsNil)
 		filesNames := make([]string, 0, len(wantedFiles))
 		for _, file := range files {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -798,7 +798,7 @@ func parseBase64ToEndpoint(b []byte, ep *Endpoint) error {
 }
 
 // FilterEPDir returns a list of directories' names that possible belong to an endpoint.
-func FilterEPDir(dirFiles []os.FileInfo) []string {
+func FilterEPDir(dirFiles []os.DirEntry) []string {
 	eptsID := []string{}
 	for _, file := range dirFiles {
 		if file.IsDir() {

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -18,7 +18,6 @@ package endpoint
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -64,7 +63,7 @@ func (s *EndpointSuite) TestPolicyLog(c *C) {
 	c.Assert(policyLogger, IsNil)
 
 	// Verify file exists and contains the logged message
-	buf, err := ioutil.ReadFile(filepath.Join(option.Config.StateDir, "endpoint-policy.log"))
+	buf, err := os.ReadFile(filepath.Join(option.Config.StateDir, "endpoint-policy.log"))
 	c.Assert(err, IsNil)
 	c.Assert(bytes.Contains(buf, []byte("testing policy logging")), Equals, true)
 	c.Assert(bytes.Contains(buf, []byte("testing policyDebug")), Equals, true)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -105,7 +104,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil)
 
 	epsWanted, _ := ds.createEndpoints()
-	tmpDir, err := ioutil.TempDir("", "cilium-tests")
+	tmpDir, err := os.MkdirTemp("", "cilium-tests")
 	defer func() {
 		os.RemoveAll(tmpDir)
 	}()
@@ -177,7 +176,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNamesWithRestoreFailure(c *C) {
 	eps, _ := ds.createEndpoints()
 	ep := eps[0]
 	c.Assert(ep, NotNil)
-	tmpDir, err := ioutil.TempDir("", "cilium-tests")
+	tmpDir, err := os.MkdirTemp("", "cilium-tests")
 	defer func() {
 		os.RemoveAll(tmpDir)
 	}()
@@ -241,7 +240,7 @@ func (ds *EndpointSuite) BenchmarkReadEPsFromDirNames(c *C) {
 	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil)
 
 	epsWanted, _ := ds.createEndpoints()
-	tmpDir, err := ioutil.TempDir("", "cilium-tests")
+	tmpDir, err := os.MkdirTemp("", "cilium-tests")
 	defer func() {
 		os.RemoveAll(tmpDir)
 	}()

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os/exec"
@@ -99,7 +98,7 @@ func (a *admin) transact(query string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -18,7 +18,6 @@ package envoy
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -81,7 +80,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	logging.ConfigureLogLevel(true) // Use 'true' for debugging
 	flowdebug.Enable()
 
-	stateLogDir, err := ioutil.TempDir("", "envoy_go_test")
+	stateLogDir, err := os.MkdirTemp("", "envoy_go_test")
 	c.Assert(err, IsNil)
 
 	log.Debugf("state log directory: %s", stateLogDir)
@@ -161,7 +160,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	flowdebug.Enable()
 
-	stateLogDir, err := ioutil.TempDir("", "envoy_go_test")
+	stateLogDir, err := os.MkdirTemp("", "envoy_go_test")
 	c.Assert(err, IsNil)
 
 	log.Debugf("state log directory: %s", stateLogDir)

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -17,7 +17,6 @@ package envoy
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -1025,7 +1024,7 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 	if err != nil {
 		log.WithError(err).Fatal("Envoy: Error marshaling Envoy bootstrap")
 	}
-	err = ioutil.WriteFile(filePath, data, 0644)
+	err = os.WriteFile(filePath, data, 0644)
 	if err != nil {
 		log.WithError(err).Fatal("Envoy: Error writing Envoy bootstrap file")
 	}

--- a/pkg/health/client/client_test.go
+++ b/pkg/health/client/client_test.go
@@ -17,7 +17,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/cilium/cilium/api/v1/health/models"
@@ -165,7 +165,7 @@ func (s *ClientTestSuite) TestFormatNodeStatus(c *C) {
 
 	// not testing output, just that permutations of NodeStatus don't cause
 	// panics.
-	w := ioutil.Discard
+	w := io.Discard
 
 	connectivityStatusGood := &models.ConnectivityStatus{
 		Latency: 1,

--- a/pkg/hubble/metrics/api/registry_test.go
+++ b/pkg/hubble/metrics/api/registry_test.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
@@ -58,7 +58,7 @@ func (t *testHandler) ProcessFlow(ctx context.Context, p *pb.Flow) {
 
 func TestRegister(t *testing.T) {
 	log := logrus.New()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	r := NewRegistry(log)
 
 	r.Register("test", &testPlugin{})

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -46,7 +45,7 @@ var log *logrus.Logger
 
 func init() {
 	log = logrus.New()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func noopParser(t *testing.T) *parser.Parser {

--- a/pkg/hubble/parser/debug/parser_test.go
+++ b/pkg/hubble/parser/debug/parser_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -39,7 +39,7 @@ var log *logrus.Logger
 
 func init() {
 	log = logrus.New()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func encodeDebugEvent(msg *monitor.DebugMsg) []byte {

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -17,7 +17,7 @@
 package parser
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -40,7 +40,7 @@ var log *logrus.Logger
 
 func init() {
 	log = logrus.New()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func Test_InvalidPayloads(t *testing.T) {

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -17,7 +17,7 @@
 package seven
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -63,7 +63,7 @@ var (
 
 func init() {
 	log = logrus.New()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func TestDecodeL7HTTPRecord(t *testing.T) {

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 
@@ -51,7 +51,7 @@ var log *logrus.Logger
 
 func init() {
 	log = logrus.New()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func TestL34Decode(t *testing.T) {

--- a/pkg/ipmasq/ipmasq.go
+++ b/pkg/ipmasq/ipmasq.go
@@ -17,7 +17,6 @@ package ipmasq
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -228,7 +227,7 @@ func (a *IPMasqAgent) Update() error {
 func (a *IPMasqAgent) readConfig() (bool, error) {
 	var cfg config
 
-	raw, err := ioutil.ReadFile(a.configPath)
+	raw, err := os.ReadFile(a.configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.WithField(logfields.Path, a.configPath).Info("Config file not found")

--- a/pkg/ipmasq/ipmasq_test.go
+++ b/pkg/ipmasq/ipmasq_test.go
@@ -18,7 +18,6 @@ package ipmasq
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -99,7 +98,7 @@ var _ = check.Suite(&IPMasqTestSuite{})
 func (i *IPMasqTestSuite) SetUpTest(c *check.C) {
 	i.ipMasqMap = &ipMasqMapMock{cidrs: map[string]net.IPNet{}}
 
-	configFile, err := ioutil.TempFile("", "ipmasq-test")
+	configFile, err := os.CreateTemp("", "ipmasq-test")
 	c.Assert(err, check.IsNil)
 	i.configFilePath = configFile.Name()
 
@@ -115,7 +114,7 @@ func (i *IPMasqTestSuite) TearDownTest(c *check.C) {
 }
 
 func (i *IPMasqTestSuite) writeConfig(cfg string, c *check.C) {
-	err := ioutil.WriteFile(i.configFilePath, []byte(cfg), 0644)
+	err := os.WriteFile(i.configFilePath, []byte(cfg), 0644)
 	c.Assert(err, check.IsNil)
 }
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/cilium/cilium/pkg/backoff"
@@ -100,7 +100,7 @@ func (c *consulModule) setConfigDummy() {
 	c.config = consulAPI.DefaultConfig()
 	c.config.Address = consulDummyAddress
 	yc := consulAPI.TLSConfig{}
-	b, err := ioutil.ReadFile(consulDummyConfigFile)
+	b, err := os.ReadFile(consulDummyConfigFile)
 	if err != nil {
 		log.WithError(err).Warnf("unable to read consul tls configuration file %s", consulDummyConfigFile)
 	}
@@ -150,7 +150,7 @@ func (c *consulModule) connectConsulClient(ctx context.Context, opts *ExtraOptio
 		addr := consulAddr.value
 		c.config = consulAPI.DefaultConfig()
 		if configPathOptSet && configPathOpt.value != "" {
-			b, err := ioutil.ReadFile(configPathOpt.value)
+			b, err := os.ReadFile(configPathOpt.value)
 			if err != nil {
 				return nil, fmt.Errorf("unable to read consul tls configuration file %s: %s", configPathOpt.value, err)
 			}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strconv"
@@ -1786,7 +1785,7 @@ func newConfig(fpath string) (*client.Config, error) {
 	}
 
 	yc := &yamlConfig{}
-	b, err := ioutil.ReadFile(fpath)
+	b, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}
@@ -1811,7 +1810,7 @@ func newConfig(fpath string) (*client.Config, error) {
 // reload on-disk certificate and key when needed
 func getClientCertificateReloader(fpath string) (func(*tls.CertificateRequestInfo) (*tls.Certificate, error), error) {
 	yc := &yamlKeyPairConfig{}
-	b, err := ioutil.ReadFile(fpath)
+	b, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"sync"
 	"testing"
@@ -194,7 +194,7 @@ endpoints:
 - https://cilium-etcd-client.kube-system.svc:2379
 `)
 	etcdTempFile := path.Join(temp, "etcd-config.yaml")
-	err := ioutil.WriteFile(etcdTempFile, etcdConfigByte, 0600)
+	err := os.WriteFile(etcdTempFile, etcdConfigByte, 0600)
 	c.Assert(err, IsNil)
 	type args struct {
 		backend      string

--- a/pkg/logging/debugdetection.go
+++ b/pkg/logging/debugdetection.go
@@ -15,7 +15,7 @@
 package logging
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -26,7 +26,7 @@ import (
 func init() {
 	flags := flag.NewFlagSet("init-debug", flag.ContinueOnError)
 	flags.Usage = func() {}
-	flags.SetOutput(ioutil.Discard)
+	flags.SetOutput(io.Discard)
 
 	debug := flags.Bool("debug", false, "")
 	flags.Parse(os.Args)

--- a/pkg/mountinfo/mountinfo_privileged_test.go
+++ b/pkg/mountinfo/mountinfo_privileged_test.go
@@ -17,7 +17,6 @@
 package mountinfo
 
 import (
-	"io/ioutil"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -32,7 +31,7 @@ var _ = Suite(&MountInfoPrivilegedTestSuite{})
 // TestIsMountFSbyMount tests the public function IsMountFS by performing
 // an actual mount.
 func (s *MountInfoPrivilegedTestSuite) TestIsMountFSbyMount(c *C) {
-	tmpDir, err := ioutil.TempDir("", "IsMountFS_")
+	tmpDir, err := os.MkdirTemp("", "IsMountFS_")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpDir)
 

--- a/pkg/netns/netns.go
+++ b/pkg/netns/netns.go
@@ -16,7 +16,7 @@ package netns
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -98,7 +98,7 @@ func RemoveNetNSWithName(netNSName string) error {
 // ListNamedNetNSWithPrefix returns list of named network namespaces which name
 // starts with the given prefix.
 func ListNamedNetNSWithPrefix(prefix string) ([]string, error) {
-	entries, err := ioutil.ReadDir(netNSRootDir())
+	entries, err := os.ReadDir(netNSRootDir())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -18,7 +18,6 @@ package option
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -166,7 +165,7 @@ func (s *OptionSuite) TestReadDirConfig(c *C) {
 				dirName = c.MkDir()
 
 				fullPath := filepath.Join(dirName, "test")
-				err := ioutil.WriteFile(fullPath, []byte(`"1"
+				err := os.WriteFile(fullPath, []byte(`"1"
 `), os.FileMode(0644))
 				c.Assert(err, IsNil)
 				fs := flag.NewFlagSet("single file configuration", flag.ContinueOnError)

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -16,7 +16,6 @@ package pidfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -43,7 +42,7 @@ func Remove(path string) error {
 
 func write(path string, pid int) error {
 	pidBytes := []byte(strconv.Itoa(pid) + "\n")
-	if err := ioutil.WriteFile(path, pidBytes, 0660); err != nil {
+	if err := os.WriteFile(path, pidBytes, 0660); err != nil {
 		return err
 	}
 
@@ -110,7 +109,7 @@ func Kill(pidfilePath string) (int, error) {
 		return 0, nil
 	}
 
-	pidfile, err := ioutil.ReadFile(pidfilePath)
+	pidfile, err := os.ReadFile(pidfilePath)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -18,7 +18,6 @@ package pidfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -46,7 +45,7 @@ func (s *PidfileTestSuite) TestWrite(c *C) {
 	c.Assert(err, IsNil)
 	defer Remove(path)
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	c.Assert(err, IsNil)
 	c.Assert(content, checker.DeepEquals, []byte(fmt.Sprintf("%d\n", os.Getpid())))
 }
@@ -91,7 +90,7 @@ func (s *PidfileTestSuite) TestKillPidfileNotExist(c *C) {
 }
 
 func (s *PidfileTestSuite) TestKillPidfilePermissionDenied(c *C) {
-	err := ioutil.WriteFile(path, []byte("foobar\n"), 0000)
+	err := os.WriteFile(path, []byte("foobar\n"), 0000)
 	c.Assert(err, IsNil)
 	defer Remove(path)
 
@@ -100,7 +99,7 @@ func (s *PidfileTestSuite) TestKillPidfilePermissionDenied(c *C) {
 }
 
 func (s *PidfileTestSuite) TestKillFailedParsePid(c *C) {
-	err := ioutil.WriteFile(path, []byte("foobar\n"), 0644)
+	err := os.WriteFile(path, []byte("foobar\n"), 0644)
 	c.Assert(err, IsNil)
 	defer Remove(path)
 

--- a/pkg/policy/trace/yaml.go
+++ b/pkg/policy/trace/yaml.go
@@ -17,7 +17,7 @@ package trace
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -47,7 +47,7 @@ func GetLabelsFromYaml(file string) ([][]string, error) {
 	}
 	defer reader.Close()
 
-	byteArr, err := ioutil.ReadAll(reader)
+	byteArr, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/netstat.go
+++ b/pkg/proxy/netstat.go
@@ -16,7 +16,7 @@ package proxy
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -49,7 +49,7 @@ func readOpenLocalPorts(procNetFiles []string) map[uint16]struct{} {
 	openLocalPorts := make(map[uint16]struct{}, 128)
 
 	for _, file := range procNetFiles {
-		b, err := ioutil.ReadFile(file)
+		b, err := os.ReadFile(file)
 		if err != nil {
 			log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
 			continue

--- a/pkg/sockops/sockops.go
+++ b/pkg/sockops/sockops.go
@@ -17,7 +17,6 @@ package sockops
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -128,7 +127,7 @@ func bpftoolLoad(bpfObject string, bpfFsFile string) error {
 	var mapArgList []string
 	bpffs := filepath.Join(bpf.GetMapRoot(), bpfFsFile)
 
-	maps, err := ioutil.ReadDir(filepath.Join(bpf.GetMapRoot(), "/tc/globals/"))
+	maps, err := os.ReadDir(filepath.Join(bpf.GetMapRoot(), "/tc/globals/"))
 	if err != nil {
 		return err
 	}

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -17,7 +17,6 @@ package sysctl
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,7 +82,7 @@ func Write(name string, val string) error {
 // Read reads the given sysctl parameter.
 func Read(name string) (string, error) {
 	fPath := fullPath(name)
-	val, err := ioutil.ReadFile(fPath)
+	val, err := os.ReadFile(fPath)
 	if err != nil {
 		return "", fmt.Errorf("Failed to read %s: %s", fPath, val)
 	}

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -17,8 +17,8 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
@@ -68,7 +68,7 @@ func parsePrevResult(n *NetConf) (*NetConf, error) {
 // ReadNetConf reads a CNI configuration file and returns the corresponding
 // NetConf structure
 func ReadNetConf(path string) (*NetConf, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to read CNI configuration '%s': %s", path, err)
 	}

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -17,7 +17,6 @@
 package types
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -40,12 +39,12 @@ type CNITypesSuite struct{}
 var _ = check.Suite(&CNITypesSuite{})
 
 func testConfRead(c *check.C, confContent string, netconf *NetConf) {
-	dir, err := ioutil.TempDir("", "cilium-cnitype-testsuite")
+	dir, err := os.MkdirTemp("", "cilium-cnitype-testsuite")
 	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(dir)
 
 	p := path.Join(dir, "conf1")
-	err = ioutil.WriteFile(p, []byte(confContent), 0644)
+	err = os.WriteFile(p, []byte(confContent), 0644)
 	c.Assert(err, check.IsNil)
 
 	netConf, err := ReadNetConf(p)
@@ -260,12 +259,12 @@ func (t *CNITypesSuite) TestReadCNIConfError(c *check.C) {
 }
 `
 
-	dir, err := ioutil.TempDir("", "cilium-cnitype-testsuite")
+	dir, err := os.MkdirTemp("", "cilium-cnitype-testsuite")
 	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(dir)
 
 	p := path.Join(dir, "errorconf")
-	err = ioutil.WriteFile(p, []byte(errorConf), 0644)
+	err = os.WriteFile(p, []byte(errorConf), 0644)
 	c.Assert(err, check.IsNil)
 
 	_, err = ReadNetConf(p)

--- a/proxylib/test/tmpdir.go
+++ b/proxylib/test/tmpdir.go
@@ -15,7 +15,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -24,7 +24,7 @@ var Tmpdir string
 
 func init() {
 	var err error
-	Tmpdir, err = ioutil.TempDir("", "cilium_envoy_go_test")
+	Tmpdir, err = os.MkdirTemp("", "cilium_envoy_go_test")
 	if err != nil {
 		log.Fatal("Failed to create a temporaty directory for testing")
 	}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -380,7 +379,7 @@ func (s *SSHMeta) MonitorStart(opts ...string) (*CmdRes, func() error) {
 			return err
 		}
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(testPath, MonitorLogFileName),
 			res.CombineOutput().Bytes(),
 			LogPerm)
@@ -660,7 +659,7 @@ func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 			s.logger.WithError(err).Error("Cannot create report directory")
 			return
 		}
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			fmt.Sprintf("%s/%s", testPath, CiliumTestLog),
 			[]byte(logs), LogPerm)
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -3362,7 +3361,7 @@ func (kub *Kubectl) ValidateListOfErrorsInLogs(duration time.Duration, blacklist
 					kub.Logger().WithError(err).Error("Cannot create report directory")
 					return
 				}
-				err = ioutil.WriteFile(
+				err = os.WriteFile(
 					fmt.Sprintf("%s/%s", testPath, file),
 					[]byte(logs), LogPerm)
 
@@ -4097,7 +4096,7 @@ func (kub *Kubectl) reportMapContext(ctx context.Context, path string, reportCmd
 		}
 
 		for name, res := range results {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				fmt.Sprintf("%s/%s-%s", path, name, logfile),
 				res.CombineOutput().Bytes(),
 				LogPerm)
@@ -4121,7 +4120,7 @@ func (kub *Kubectl) reportMapHost(ctx context.Context, path string, reportCmds m
 				log.WithError(res.GetErr("reportMapHost")).Errorf("command %s failed", cmd)
 			}
 
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				fmt.Sprintf("%s/%s", path, logfile),
 				res.CombineOutput().Bytes(),
 				LogPerm)

--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -268,9 +267,5 @@ func (s *LocalExecutor) RenderTemplateToFile(filename string, tmplt string, perm
 		return err
 	}
 
-	err = ioutil.WriteFile(filename, content.Bytes(), perm)
-	if err != nil {
-		return err
-	}
-	return nil
+	return os.WriteFile(filename, content.Bytes(), perm)
 }

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -669,7 +668,7 @@ func (t *TestSpec) NetworkPolicyApply(base string) error {
 		return nil
 	}
 
-	err = ioutil.WriteFile(t.NetworkPolicyName(), []byte(policy), os.ModePerm)
+	err = os.WriteFile(t.NetworkPolicyName(), []byte(policy), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("Network policy cannot be written prefix=%s: %s", t.Prefix, err)
 	}
@@ -696,7 +695,7 @@ func (t *TestSpec) InvalidNetworkPolicyApply(base string) (*cnpv2.CiliumNetworkP
 		return nil, fmt.Errorf("Network policy cannot be created prefix=%s: %s", t.Prefix, err)
 	}
 
-	err = ioutil.WriteFile(t.NetworkPolicyName(), []byte(policy), os.ModePerm)
+	err = os.WriteFile(t.NetworkPolicyName(), []byte(policy), os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("Network policy cannot be written prefix=%s: %s", t.Prefix, err)
 	}

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -98,7 +97,7 @@ func (cfg *SSHConfig) String() string {
 
 // GetSSHAgent returns the ssh.AuthMethod corresponding to SSHConfig cfg.
 func (cfg *SSHConfig) GetSSHAgent() ssh.AuthMethod {
-	key, err := ioutil.ReadFile(cfg.identityFile)
+	key, err := os.ReadFile(cfg.identityFile)
 	if err != nil {
 		log.Fatalf("unable to retrieve ssh-key on target '%s': %s", cfg.target, err)
 	}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -289,8 +288,7 @@ func CreateLogFile(filename string, data []byte) error {
 	}
 
 	finalPath := filepath.Join(path, filename)
-	err = ioutil.WriteFile(finalPath, data, LogPerm)
-	return err
+	return os.WriteFile(finalPath, data, LogPerm)
 }
 
 // WriteToReportFile writes data to filename. It appends to existing files.
@@ -332,7 +330,7 @@ func reportMapContext(ctx context.Context, path string, reportCmds map[string]st
 
 	for cmd, logfile := range reportCmds {
 		res := node.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
-		err := ioutil.WriteFile(
+		err := os.WriteFile(
 			fmt.Sprintf("%s/%s", path, logfile),
 			res.CombineOutput().Bytes(),
 			LogPerm)

--- a/tools/dev-doctor/etcnfsconfcheck.go
+++ b/tools/dev-doctor/etcnfsconfcheck.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/ini.v1"
@@ -30,7 +29,7 @@ func (etcNFSConfCheck) Name() string {
 }
 
 func (etcNFSConfCheck) Run() (checkResult, string) {
-	data, err := ioutil.ReadFile("/etc/nfs.conf")
+	data, err := os.ReadFile("/etc/nfs.conf")
 	switch {
 	case os.IsNotExist(err):
 		return checkError, "/etc/nfs.conf does not exist"

--- a/tools/licensegen/licensegen.go
+++ b/tools/licensegen/licensegen.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -17,7 +16,7 @@ func main() {
 			switch strings.TrimPrefix(strings.ToLower(ext), ".") {
 			case "", "code", "docs", "libyaml", "md", "txt":
 				fmt.Println("Name:", path)
-				lb, err := ioutil.ReadFile(path)
+				lb, err := os.ReadFile(path)
 				if err != nil {
 					log.Fatal(err)
 				}


### PR DESCRIPTION
With the release of Go 1.16, the `io/ioutil` has been deprecated (see
https://golang.org/doc/go1.16#ioutil). Thus, use the corresponding
symbols from the `io` and `os` packages.

Note: pushed two more commits to make sure the correct Go version is used for the BPF prog tests and in the GitHub actions.