### PR TITLE
v1.9 backports 2021-03-08

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -189,7 +189,7 @@ programs run inside the kernel, the verifier's job is to make sure that these ar
 safe to run, not affecting the system's stability. This means that from an instruction
 set point of view, loops can be implemented, but the verifier will restrict that.
 However, there is also a concept of tail calls that allows for one BPF program to
-jump into another one. This, too, comes with an upper nesting limit of 32 calls,
+jump into another one. This, too, comes with an upper nesting limit of 33 calls,
 and is usually used to decouple parts of the program logic, for example, into stages.
 
 The instruction format is modeled as two operand instructions, which helps mapping
@@ -581,7 +581,7 @@ bytes per subprogram (note that if the verifier detects the bpf2bpf call, then
 the main function is treated as a sub-function as well). In total, with this
 restriction, the BPF program's call chain can consume at most 8KB of stack
 space. This limit comes from the 256 bytes per stack frame multiplied by the
-tail call count limit(32). Without this, the BPF programs will operate on
+tail call count limit (33). Without this, the BPF programs will operate on
 512-byte stack size, yielding the 16KB size in total for the maximum count of
 tail calls that would overflow the stack on some architectures.
 
@@ -1866,7 +1866,8 @@ describe some of the differences for the BPF model:
   Another possibility is to use tail calls by calling into the same program
   again and using a ``BPF_MAP_TYPE_PERCPU_ARRAY`` map for having a local
   scratch space. While being dynamic, this form of looping however is limited
-  to a maximum of 32 iterations.
+  to a maximum of 34 iterations (the initial program, plus 33 iterations from
+  the tail calls).
 
   In the future, BPF may have some native, but limited form of implementing loops.
 

--- a/Documentation/concepts/security/proxy/envoy.rst
+++ b/Documentation/concepts/security/proxy/envoy.rst
@@ -529,7 +529,7 @@ and adding the ''--debug-verbose=flow'' flag.
 
   $ sudo service cilium stop 
   
-  $ sudo /usr/bin/cilium-agent --debug --auto-direct-node-routes --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow
+  $ sudo /usr/bin/cilium-agent --debug --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow
 
 
 Step 13: Add Runtime Tests

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -15,6 +15,11 @@ networking is setup, the Cilium CNI plugin is called to attach eBPF programs to
 the network devices set up by aws-cni to enforce network policies, perform
 load-balancing, and encryption.
 
+.. note::
+
+   When running Cilium in chaining configuration on top of AWS VPC CNI, the L7 policies may not work. 
+   This limitation is currently tracked at `#12454 <https://github.com/cilium/cilium/issues/12454>`_.
+
 .. image:: aws-cni-architecture.png
 
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -85,8 +85,8 @@ the label ``role=backend``.
         .. literalinclude:: ../../examples/policies/l3/simple/l3.json
 
 
-Ingress Allow All
-~~~~~~~~~~~~~~~~~
+Ingress Allow All Endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An empty `EndpointSelector` will select all endpoints, thus writing a rule that will allow
 all ingress traffic to an endpoint may be done as follows:
@@ -140,8 +140,8 @@ the label ``role=frontend``.
         .. literalinclude:: ../../examples/policies/l3/simple/l3_egress.json
 
 
-Egress Allow All
-~~~~~~~~~~~~~~~~~
+Egress Allow All Endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An empty `EndpointSelector` will select all endpoints, thus writing a rule that will allow
 all egress traffic from an endpoint may be done as follows:

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -307,7 +307,7 @@ function write_cilium_cfg() {
     ipv6_addr="${3}"
     filename="${4}"
 
-    cilium_options=" --debug --pprof --enable-hubble --hubble-listen-address :4244 --enable-k8s-event-handover --k8s-require-ipv4-pod-cidr --auto-direct-node-routes"
+    cilium_options=" --debug --pprof --enable-hubble --hubble-listen-address :4244 --enable-k8s-event-handover --k8s-require-ipv4-pod-cidr"
     cilium_operator_options=" --debug"
 
     if [[ "${IPV4}" -eq "1" ]]; then

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1221,6 +1221,10 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EncryptInterface = link
 	}
 
+	if option.Config.Tunnel != option.TunnelDisabled && option.Config.EnableAutoDirectRouting {
+		log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
+	}
+
 	initClockSourceOption()
 	initSockmapOption()
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -403,10 +403,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		ctmap.WriteBPFMacros(fw, nil)
 	}
 
-	if option.Config.PolicyAuditMode {
-		cDefinesMap["POLICY_AUDIT_MODE"] = "1"
-	}
-
 	if option.Config.AllowICMPFragNeeded {
 		cDefinesMap["ALLOW_ICMP_FRAG_NEEDED"] = "1"
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -262,6 +262,16 @@ func (s *Service) UpsertService(params *lb.SVC) (bool, lb.ID, error) {
 			option.EnableSVCSourceRangeCheck)
 	}
 
+	ipv6Svc := params.Frontend.IsIPv6()
+	if ipv6Svc && !option.Config.EnableIPv6 {
+		err := fmt.Errorf("Unable to upsert service %s as IPv6 is disabled", params.Frontend.L3n4Addr.String())
+		return false, lb.ID(0), err
+	}
+	if !ipv6Svc && !option.Config.EnableIPv4 {
+		err := fmt.Errorf("Unable to upsert service %s as IPv4 is disabled", params.Frontend.L3n4Addr.String())
+		return false, lb.ID(0), err
+	}
+
 	// If needed, create svcInfo and allocate service ID
 	svc, new, prevSessionAffinity, prevLoadBalancerSourceRanges, err :=
 		s.createSVCInfoIfNotExist(params)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -36,6 +36,7 @@ type ManagerTestSuite struct {
 	svcHealth                 *healthserver.MockHealthHTTPServerFactory
 	prevOptionSessionAffinity bool
 	prevOptionLBSourceRanges  bool
+	ipv6                      bool
 }
 
 var _ = Suite(&ManagerTestSuite{})
@@ -56,6 +57,8 @@ func (m *ManagerTestSuite) SetUpTest(c *C) {
 
 	m.prevOptionLBSourceRanges = option.Config.EnableSVCSourceRangeCheck
 	option.Config.EnableSVCSourceRangeCheck = true
+
+	m.ipv6 = option.Config.EnableIPv6
 }
 
 func (m *ManagerTestSuite) TearDownTest(c *C) {
@@ -63,11 +66,13 @@ func (m *ManagerTestSuite) TearDownTest(c *C) {
 	backendIDAlloc.resetLocalID()
 	option.Config.EnableSessionAffinity = m.prevOptionSessionAffinity
 	option.Config.EnableSVCSourceRangeCheck = m.prevOptionLBSourceRanges
+	option.Config.EnableIPv6 = m.ipv6
 }
 
 var (
 	frontend1 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.1"), 80, lb.ScopeExternal, 0)
 	frontend2 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.2"), 80, lb.ScopeExternal, 0)
+	frontend3 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("f00d::1"), 80, lb.ScopeExternal, 0)
 	backends1 = []lb.Backend{
 		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080),
 		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
@@ -76,9 +81,22 @@ var (
 		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
 		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080),
 	}
+	backends3 = []lb.Backend{
+		*lb.NewBackend(0, lb.TCP, net.ParseIP("fd00::2"), 8080),
+		*lb.NewBackend(0, lb.TCP, net.ParseIP("fd00::3"), 8080),
+	}
 )
 
 func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
+	m.testUpsertAndDeleteService(c)
+}
+
+func (m *ManagerTestSuite) TestUpsertAndDeleteServiceWithoutIPv6(c *C) {
+	option.Config.EnableIPv6 = false
+	m.testUpsertAndDeleteService(c)
+}
+
+func (m *ManagerTestSuite) testUpsertAndDeleteService(c *C) {
 	// Should create a new service with two backends and session affinity
 	p := &lb.SVC{
 		Frontend:                  frontend1,
@@ -169,6 +187,44 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(m.svc.svcByID[id2].svcNamespace, Equals, "ns2")
 	c.Assert(len(m.lbmap.AffinityMatch[uint16(id2)]), Equals, 2)
 	c.Assert(len(m.lbmap.SourceRanges[uint16(id2)]), Equals, 2)
+
+	// Should add IPv6 service only if IPv6 is enabled
+	c.Assert(err, IsNil)
+	cidr1, err = cidr.ParseCIDR("fd00::/8")
+	c.Assert(err, IsNil)
+	p3 := &lb.SVC{
+		Frontend:                  frontend3,
+		Backends:                  backends3,
+		Type:                      lb.SVCTypeLoadBalancer,
+		TrafficPolicy:             lb.SVCTrafficPolicyCluster,
+		SessionAffinity:           true,
+		SessionAffinityTimeoutSec: 300,
+		Name:                      "svc3",
+		Namespace:                 "ns3",
+		LoadBalancerSourceRanges:  []*cidr.CIDR{cidr1},
+	}
+	created, id3, err := m.svc.UpsertService(p3)
+	if option.Config.EnableIPv6 {
+		c.Assert(err, IsNil)
+		c.Assert(created, Equals, true)
+		c.Assert(id3, Equals, lb.ID(3))
+		c.Assert(len(m.lbmap.ServiceByID[uint16(id3)].Backends), Equals, 2)
+		c.Assert(len(m.lbmap.BackendByID), Equals, 4)
+		c.Assert(m.svc.svcByID[id3].svcName, Equals, "svc3")
+		c.Assert(m.svc.svcByID[id3].svcNamespace, Equals, "ns3")
+		c.Assert(len(m.lbmap.AffinityMatch[uint16(id3)]), Equals, 2)
+		c.Assert(len(m.lbmap.SourceRanges[uint16(id3)]), Equals, 1)
+
+		// Should remove the IPv6 service
+		found, err := m.svc.DeleteServiceByID(lb.ServiceID(id3))
+		c.Assert(err, IsNil)
+		c.Assert(found, Equals, true)
+	} else {
+		c.Assert(err, ErrorMatches, "Unable to upsert service .+ as IPv6 is disabled")
+		c.Assert(created, Equals, false)
+	}
+	c.Assert(len(m.lbmap.ServiceByID), Equals, 2)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
 
 	// Should remove the service and the backend, but keep another service and
 	// its backends. Also, should remove the affinity match.

--- a/tools/licensegen/licensegen.go
+++ b/tools/licensegen/licensegen.go
@@ -13,7 +13,7 @@ func main() {
 	err := filepath.Walk("./vendor", func(path string, _ os.FileInfo, _ error) error {
 		base := filepath.Base(path)
 		ext := filepath.Ext(base)
-		if strings.TrimSuffix(base, ext) == "LICENSE" {
+		if stem := strings.TrimSuffix(base, ext); stem == "LICENSE" || stem == "COPYING" {
 			switch strings.TrimPrefix(strings.ToLower(ext), ".") {
 			case "", "code", "docs", "libyaml", "md", "txt":
 				fmt.Println("Name:", path)


### PR DESCRIPTION
* #15145 -- docs: Clarify titles for allow-all-endpoints examples (@pchaigno)
 * #15163 -- docs: Add L7 not working warning to AWS CNI Chaining page (@stimmerman)
 * #15162 -- docs: Fix max. number of tail calls (@pchaigno)
 * #15026 -- service: Skip upsert of service for disabled IP family (@pchaigno)
   * Minor merge conflicts, please take a look whether I resolved them
     correctly.
 * #15206 -- bpf: Fix bpf masquerade issue when host connecting to remote pod (@borkmann)
   * Minor merge conflict due to rename of `option.Config.Masquerade` to
     `option.Config.EnableIPv4Masquerade` on `master`. Please take a look
     whether I resolved it correctly.
 * #15196 -- daemon: do not allow --auto-direct-node-routes when tunneling is enabled (@jibi)
 * #15218 -- config: remove POLICY_AUDIT_MODE from node_config.h (@ArthurChiao)
   * Merge conflict. It seems the condition for adding `POLICY_AUDIT_MODE`
     changed in `master` vs. `v1.9`. Please check whether this is still correct
     to be removed.
 * #15239 -- tools/licensegen: consider COPYING files (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15145 15163 15162 15026 15206 15196 15218 15239; do contrib/backporting/set-labels.py $pr done 1.9; done
```