### PR TITLE
[1.9] doc: Fix masquerade option in AKS/Azure guides

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -93,7 +93,7 @@ Deploy Cilium release via Helm:
      --set nodeinit.enabled=true \\
      --set cni.configMap=cni-configuration \\
      --set tunnel=disabled \\
-     --set enableIPv4Masquerade=false
+     --set masquerade=false
 
 This will create both the main cilium daemonset, as well as the cilium-node-init daemonset, which handles tasks like mounting the eBPF filesystem and updating the
 existing Azure CNI plugin to run in 'transparent' mode.

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -119,7 +119,7 @@ Deploy Cilium release via Helm:
      --set azure.clientSecret=$AZURE_CLIENT_SECRET \\
      --set tunnel=disabled \\
      --set ipam.mode=azure \\
-     --set enableIPv4Masquerade=false \\
+     --set masquerade=false \\
      --set nodeinit.enabled=true
 
 .. include:: k8s-install-restart-pods.rst


### PR DESCRIPTION
The option enableIPv4Masquerade is only known in 1.10+. 1.9 must use the
masquerade option.

Fixes: 07f15bf1327 ("doc: Move Azure IPAM out of beta")

Reported-by: Andor Nemeth <andor_nemeth@swissre.com>
Signed-off-by: Thomas Graf <thomas@cilium.io>