### PR TITLE
policy: Fix typo in issue link

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -348,7 +348,7 @@ all
     world and whitelists all communication.
 
 .. versionadded:: future
-   Allowing users to `define custom identities <https://github.com/cilium/cilium/issues/3553>`_
+   Allowing users to `define custom entities <https://github.com/cilium/cilium/issues/3553>`_
    is on the roadmap but has not been implemented yet.
 
 Access to/from local host


### PR DESCRIPTION
The feature is to have user-defined policy *entities* that match a set
of identities, not to override the underlying identities for pods.
