### PR TITLE
build: Skip custom vet check by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ LOGLEVEL ?= "error"
 SKIP_VET ?= "false"
 SKIP_KVSTORES ?= "false"
 SKIP_K8S_CODE_GEN_CHECK ?= "true"
-SKIP_CUSTOMVET_CHECK ?= "false"
+SKIP_CUSTOMVET_CHECK ?= "true"
 
 JOB_BASE_NAME ?= cilium_test
 


### PR DESCRIPTION
Change the custom vet check flag (SKIP_CUSTOMVET_CHECK) default value from `false` to `true`. This allows Dev VM to start up. Without this change the Dev VM startup fails like this:

```
    runtime1: contrib/scripts/custom-vet-check.sh
    runtime1: main: ./... matched no packages
    runtime1: exit status 1
    runtime1: Makefile:511: recipe for target 'precheck' failed
    runtime1: make: *** [precheck] Error 1
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```
Custom vet check was already disabled for CI builds:
```
test/provision/compile.sh:    sudo -u vagrant -H -E make SKIP_CUSTOMVET_CHECK=true LOCKDEBUG=1 SKIP_K8S_CODE_GEN_CHECK=false SKIP_DOCS=true
```
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
