### PR TITLE
node: Fix CIDR comparison when updating routes

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -112,7 +112,7 @@ func updateTunnelMapping(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP, first
 	case newCIDR == nil && oldCIDR != nil:
 		fallthrough
 	// Node allocation CIDR has changed
-	case oldCIDR != nil && newCIDR != nil && !oldCIDR.IP.Equal(newCIDR.IP):
+	case oldCIDR != nil && newCIDR != nil && !oldCIDR.Equal(newCIDR):
 		deleteTunnelMapping(oldCIDR, false)
 	}
 }
@@ -140,7 +140,7 @@ func cidrNodeMappingUpdateRequired(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net
 	}
 
 	// CIDR changed
-	return !oldCIDR.IP.Equal(newCIDR.IP)
+	return !oldCIDR.Equal(newCIDR)
 }
 
 func deleteTunnelMapping(oldCIDR *cidr.CIDR, quietMode bool) {
@@ -264,7 +264,7 @@ func (n *linuxNodeHandler) updateDirectRoute(oldCIDR, newCIDR *cidr.CIDR, oldIP,
 	case !oldIP.Equal(newIP):
 		fallthrough
 	// Node allocation CIDR has changed
-	case oldCIDR != nil && newCIDR != nil && !oldCIDR.IP.Equal(newCIDR.IP):
+	case oldCIDR != nil && newCIDR != nil && !oldCIDR.Equal(newCIDR):
 		n.deleteDirectRoute(oldCIDR, oldIP)
 	}
 

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -644,7 +644,7 @@ func lookupDirectRoute(CIDR *cidr.CIDR, nodeIP net.IP) ([]netlink.Route, error) 
 
 func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
-	ip4Alloc2 := cidr.MustParseCIDR("6.6.6.0/24")
+	ip4Alloc2 := cidr.MustParseCIDR("5.5.5.0/26")
 
 	externalNode1IP4v1 := net.ParseIP("4.4.4.4")
 	externalNode1IP4v2 := net.ParseIP("4.4.4.5")
@@ -700,6 +700,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 		},
 		IPv4AllocCIDR: ip4Alloc1,
 	}
+
 	err = linuxNodeHandler.NodeUpdate(nodev1, nodev2)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
Previously, the CIDR comparison didn't take into account the CIDR mask.
So, if IP didn't change, but the mask did, the comparison would have not
detected the change. The result of it was that old routes could not be
removed.

Fixes: c7a83bf562 ("datapath/linux: New scalable routing layer via Linux datapath implementation")
Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
Signed-off-by: Martynas Pumputis <m@lambda.lt>