### PR TITLE
iptables: add support for NOTRACK rules for pod to pod traffic

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -137,6 +137,7 @@ cilium-agent [flags]
       --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
       --identity-change-grace-period duration                Time to wait before using new identity on endpoint identity change (default 5s)
       --install-iptables-rules                               Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --install-no-conntrack-iptables-rules                  Install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode.
       --ip-allocation-timeout duration                       Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
       --ip-masq-agent-config-path string                     ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -366,6 +366,10 @@ New Options
   and has the same desired effect as ``masquerade`` option.
 * ``cni.exclusive``: Use to toggle Cilium installing itself as the only available CNI
   plugin on all nodes.
+* ``install-no-conntrack-iptables-rules``: This option, by default set to false,
+  installs some extra Iptables rules to skip netfilter connection tracking on all
+  pod-to-pod traffic. Disabling connection tracking is only possible when Cilium
+  is running in direct routing mode and is using the kube-proxy replacement.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -928,6 +928,9 @@ func init() {
 	flags.Bool(option.EnableBPFBypassFIBLookup, defaults.EnableBPFBypassFIBLookup, "Enable FIB lookup bypass optimization for nodeport reverse NAT handling")
 	option.BindEnv(option.EnableBPFBypassFIBLookup)
 
+	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode.")
+	option.BindEnv(option.InstallNoConntrackIptRules)
+
 	viper.BindPFlags(flags)
 
 	CustomCommandHelpFormat(RootCmd, option.HelpFlagSections)
@@ -1369,6 +1372,22 @@ func initEnv(cmd *cobra.Command) {
 				"Connectivity is not affected.",
 			option.EgressMultiHomeIPRuleCompat,
 		)
+	}
+
+	if option.Config.InstallNoConntrackIptRules {
+		// InstallNoConntrackIptRules can only be enabled in direct
+		// routing mode as in tunneling mode the encapsulated traffic is
+		// already skipping netfilter conntrack.
+		if option.Config.Tunnel != option.TunnelDisabled {
+			log.Fatalf("%s requires the agent to run in direct routing mode.", option.InstallNoConntrackIptRules)
+		}
+
+		// Moreover InstallNoConntrackIptRules requires IPv4 support as
+		// the native routing CIDR, used to select all pod-to-pod
+		// traffic, can only be an IPv4 CIDR at the moment.
+		if !option.Config.EnableIPv4 {
+			log.Fatalf("%s requires IPv4 support.", option.InstallNoConntrackIptRules)
+		}
 	}
 }
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -334,6 +334,16 @@ func initKubeProxyReplacementOptions() (strict bool) {
 		}
 	}
 
+	if option.Config.InstallNoConntrackIptRules {
+		// InstallNoConntrackIptRules can only be enabled when Cilium is
+		// running in full KPR mode as otherwise conntrack would be
+		// required for NAT operations
+		if !option.Config.KubeProxyReplacementFullyEnabled() {
+			log.Fatalf("%s requires the agent to run with %s=%s.",
+				option.InstallNoConntrackIptRules, option.KubeProxyReplacement, option.KubeProxyReplacementStrict)
+		}
+	}
+
 	return
 }
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -229,6 +229,7 @@ contributors across the globe, there is almost always someone available to help.
 | image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Agent container image. |
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
 | installIptablesRules | bool | `true` |  |
+| installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
 | ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/ |
 | ipam.operator.clusterPoolIPv4MaskSize | int | `24` | IPv4 CIDR mask size to delegate to individual nodes for IPAM. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -436,6 +436,11 @@ data:
 
   enable-xt-socket-fallback: {{ .Values.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.installIptablesRules | quote }}
+{{- if or (.Values.azure.enabled) (.Values.eni.enabled) (.Values.gke.enabled) (ne .Values.cni.chainingMode "none") }}
+  install-no-conntrack-iptables-rules: "false"
+{{- else }}
+  install-no-conntrack-iptables-rules: {{ .Values.installNoConntrackIptablesRules | quote }}
+{{- end}}
 
 {{- if hasKey .Values "iptablesRandomFully" }}
   iptables-random-fully: {{ .Values.iptablesRandomFully | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -796,6 +796,11 @@ identityAllocationMode: "crd"
 # with kube-proxy.
 installIptablesRules: true
 
+# -- Install Iptables rules to skip netfilter connection tracking on all
+# pod-to-pod traffic. This option is only effective when Cilium is running in
+# direct routing and full KPR mode.
+installNoConntrackIptablesRules: false
+
 ipam:
   # -- Configure IP Address Management mode.
   # ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -125,6 +125,12 @@ func getFeedRule(name, args string) []string {
 	return append(argsList, ruleTail...)
 }
 
+// skipPodToPodConntrack returns true if it's possible to install iptables
+// `-j NOTRACK` rules to skip tracking pod-to-pod traffic.
+func skipPodToPodConntrack(ipv6 bool) bool {
+	return !ipv6 && option.Config.InstallNoConntrackIptRules
+}
+
 // KernelHasNetfilter probes whether iptables related modules are present in
 // the kernel and returns true if indeed the case, else false.
 func KernelHasNetfilter() bool {
@@ -711,7 +717,7 @@ func (m *IptablesManager) iptProxyRules(cmd string, proxyPort uint16, ingress bo
 	return nil
 }
 
-func noTrackRules(prog string, cmd string, IP string, port *lb.L4Addr, ingress bool) error {
+func endpointNoTrackRules(prog string, cmd string, IP string, port *lb.L4Addr, ingress bool) error {
 	protocol := strings.ToLower(port.Protocol)
 	p := strconv.FormatUint(uint64(port.Port), 10)
 	if ingress {
@@ -735,7 +741,13 @@ func noTrackRules(prog string, cmd string, IP string, port *lb.L4Addr, ingress b
 	return nil
 }
 
-func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
+func InstallEndpointNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	// Do not install per endpoint NOTRACK rules if we are already skipping
+	// conntrack for all pod-to-pod traffic.
+	if skipPodToPodConntrack(ipv6) {
+		return nil
+	}
+
 	prog := "iptables"
 	ipField := logfields.IPv4
 	if ipv6 {
@@ -744,7 +756,7 @@ func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	}
 	ports := noTrackPorts(port)
 	for _, p := range ports {
-		if err := noTrackRules(prog, "-A", IP, p, true); err != nil {
+		if err := endpointNoTrackRules(prog, "-A", IP, p, true); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -752,7 +764,7 @@ func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 			}).WithError(err).Warn("Unable to install ingress NOTRACK rules")
 			return err
 		}
-		if err := noTrackRules(prog, "-A", IP, p, false); err != nil {
+		if err := endpointNoTrackRules(prog, "-A", IP, p, false); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -764,7 +776,13 @@ func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	return nil
 }
 
-func RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
+func RemoveEndpointNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	// Do not attempt removing per endpoint NOTRACK rules if we are already
+	// skipping conntrack for all pod-to-pod traffic.
+	if skipPodToPodConntrack(ipv6) {
+		return nil
+	}
+
 	prog := "iptables"
 	ipField := logfields.IPv4
 	if ipv6 {
@@ -773,7 +791,7 @@ func RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	}
 	ports := noTrackPorts(port)
 	for _, p := range ports {
-		if err := noTrackRules(prog, "-D", IP, p, true); err != nil {
+		if err := endpointNoTrackRules(prog, "-D", IP, p, true); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -781,7 +799,7 @@ func RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
 			}).WithError(err).Warn("Unable to remove ingress NOTRACK rules")
 			return err
 		}
-		if err := noTrackRules(prog, "-D", IP, p, false); err != nil {
+		if err := endpointNoTrackRules(prog, "-D", IP, p, false); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -1226,6 +1244,14 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		}
 	}
 
+	if skipPodToPodConntrack(false) {
+		podsCIDR := option.Config.IPv4NativeRoutingCIDR().String()
+
+		if err := m.addNoTrackPodToPodRules("iptables", podsCIDR); err != nil {
+			return fmt.Errorf("Cannot install rules to skip pod-to-pod CT: %w", err)
+		}
+	}
+
 	for _, c := range ciliumChains {
 		// do not install feeder for chains that are set to be disabled
 		skipFeeder := false
@@ -1322,6 +1348,33 @@ func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 	if option.Config.EnableIPv4 {
 		return m.ciliumNoTrackXfrmRules("iptables", "-I")
 	}
+	return nil
+}
+
+func (m *IptablesManager) addNoTrackPodToPodRules(prog, podsCIDR string) error {
+	if err := runProg(prog, append(
+		m.waitArgs,
+		"-t", "raw",
+		"-I", ciliumPreRawChain,
+		"-s", podsCIDR,
+		"-d", podsCIDR,
+		"-m", "comment", "--comment", "cilium: NOTRACK for pod-to-pod traffic",
+		"-j", "NOTRACK"),
+		false); err != nil {
+		return err
+	}
+	if err := runProg(prog, append(
+		m.waitArgs,
+		"-t", "raw",
+		"-I", ciliumOutputRawChain,
+		"-s", podsCIDR,
+		"-d", podsCIDR,
+		"-m", "comment", "--comment", "cilium: NOTRACK for pod-to-pod traffic",
+		"-j", "NOTRACK"),
+		false); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -408,4 +408,7 @@ const (
 
 	// EnableBPFBypassFIBLookup instructs Cilium to enable the FIB lookup bypass optimization for nodeport reverse NAT handling.
 	EnableBPFBypassFIBLookup = true
+
+	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic.
+	InstallNoConntrackIptRules = false
 )

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2179,12 +2179,12 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		}).Debug("Deleting endpoint NOTRACK rules")
 
 		if e.IPv4.IsSet() {
-			if err := iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
+			if err := iptables.RemoveEndpointNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv4 rules: %s", err))
 			}
 		}
 		if e.IPv6.IsSet() {
-			if err := iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
+			if err := iptables.RemoveEndpointNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv6 rules: %s", err))
 			}
 		}

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -170,21 +170,21 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 		log.Debug("Updating NOTRACK rules")
 		if e.IPv4.IsSet() {
 			if port > 0 {
-				err = iptables.InstallNoTrackRules(e.IPv4.String(), port, false)
+				err = iptables.InstallEndpointNoTrackRules(e.IPv4.String(), port, false)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
+				err = iptables.RemoveEndpointNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}
 		if e.IPv6.IsSet() {
 			if port > 0 {
-				iptables.InstallNoTrackRules(e.IPv6.String(), port, true)
+				iptables.InstallEndpointNoTrackRules(e.IPv6.String(), port, true)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
+				err = iptables.RemoveEndpointNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -81,6 +81,8 @@ const (
 
 	LogGathererSelector = "k8s-app=cilium-test-logs"
 	CiliumSelector      = "k8s-app=cilium"
+
+	NativeRoutingCIDR = "10.0.0.0/8"
 )
 
 var (
@@ -117,7 +119,7 @@ var (
 
 		// We need CNP node status to know when a policy is being enforced
 		"enableCnpStatusUpdates": "true",
-		"nativeRoutingCIDR":      "10.0.0.0/8",
+		"nativeRoutingCIDR":      NativeRoutingCIDR,
 
 		"ipam.operator.clusterPoolIPv6PodCIDR": "fd02::/112",
 	}

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -667,6 +667,39 @@ var _ = Describe("K8sDatapathConfig", func() {
 			testHostFirewall(kubectl)
 		})
 	})
+
+	Context("Iptables", func() {
+		SkipItIf(func() bool {
+			return helpers.IsIntegration(helpers.CIIntegrationGKE) || helpers.RunsWithKubeProxy()
+		}, "Skip conntrack for pod-to-pod traffic", func() {
+			deploymentManager.DeployCilium(map[string]string{
+				"tunnel":                          "disabled",
+				"autoDirectNodeRoutes":            "true",
+				"installNoConntrackIptablesRules": "true",
+			}, DeployCiliumOptionsAndDNS)
+
+			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
+			ExpectWithOffset(1, err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
+
+			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "sh -c 'apt update && apt install -y conntrack && conntrack -F'")
+			Expect(res.WasSuccessful()).Should(BeTrue(), "Cannot flush conntrack table")
+
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+
+			cmd := fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -s %s -d %s -m comment --comment 'cilium: NOTRACK for pod-to-pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR, helpers.NativeRoutingCIDR)
+			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
+			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing -j NOTRACK iptables rule")
+
+			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -s %s -d %s -m comment --comment 'cilium: NOTRACK for pod-to-pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR, helpers.NativeRoutingCIDR)
+			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
+			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing -j NOTRACK iptables rule")
+
+			cmd = fmt.Sprintf("conntrack -L -s %s -d %s | wc -l", helpers.NativeRoutingCIDR, helpers.NativeRoutingCIDR)
+			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
+			Expect(res.WasSuccessful()).Should(BeTrue(), "Cannot list conntrack entries")
+			Expect(strings.TrimSpace(res.Stdout())).To(Equal("0"), "Unexpected conntrack entries")
+		})
+	})
 })
 
 func testHostFirewall(kubectl *helpers.Kubectl) {


### PR DESCRIPTION
When running in KPR mode, all pod-to-pod traffic goes through connection
tracking twice: the first time traffic is tracked by netfilter and the
second one by the BPF datapath.

This is suboptimal as doing conntrack at the netfilter layer is not
strictly required for the operation of the CNI, but it has some
important performance implications.

This commit introduces a new agent option,
--install-no-conntrack-iptables-rules (enabled by default) which
installs `-j NOTRACK` Iptables rules that match all traffic from and to
the native-routing-cidr CIDR, to prevent netfilter from tracking all
pod-to-pod traffic.

This feature can be only enabled when Cilium is:

* running in direct routing
* running in full KPR mode
* not running its CNI chained on top of other CNI plugins
* not running in a managed Kubernetes environment such as AKS, EKS or GKE

There are a few reasons for these specific requirements:

* when running in tunneling mode (and with full KPR), the pod-to-pod
  traffic is encapsulated and decapsulated in the context of the BPF
  datapath program and so it is already skipping the netfilter raw table
  where connection tracking happens.
* when running in kube-proxy mode conntrack is required to perform NAT
* we cannot make assumptions on how a generic CNI is going to use
  netfilter conntrack

Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>