### PR TITLE
test: change accees of go dir in test vm

### DIFF
--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -36,9 +36,9 @@ pipeline {
             steps {
                 sh 'env'
                 Status("PENDING", "${env.JOB_NAME}")
-                sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
                 checkout scm
+                sh 'mkdir -p ${PROJ_PATH}'
+                sh 'ls -A | grep -v src | xargs mv -t ${PROJ_PATH}'
                 sh '/usr/local/bin/cleanup || true'
             }
         }

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -221,6 +221,8 @@ Vagrant.configure("2") do |config|
                           "CILIUM_REGISTRY" => "#{$CILIUM_REGISTRY}"
                 }
             end
+            server.vm.provision :shell,
+                :inline => "sudo chmod -R 777 /home/vagrant/go/src"
         end
     end
 end


### PR DESCRIPTION
This directory had some subdirs that belonged to root, which caused upstream tests to fail