### PR TITLE
envoy: Silently discard expected warnings if flowdebug is not enabled

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -325,6 +325,11 @@ func newEnvoyLogPiper() io.WriteCloser {
 			case "off", "critical", "error":
 				scopedLog.Error(msg)
 			case "warning":
+				// Silently drop expected warnings if flowdebug is not enabled
+				// TODO: Remove this special case when https://github.com/envoyproxy/envoy/issues/13504 is fixed.
+				if !flowdebug.Enabled() && strings.Contains(msg, "Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size") {
+					continue
+				}
 				scopedLog.Warn(msg)
 			case "info":
 				scopedLog.Info(msg)


### PR DESCRIPTION
Filter out one Envoy warning repeating multiple times (~ once per core available to Envoy):

> "Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size"

There is an upstream issue tracking it's resolution: envoyproxy/envoy#13504. Apparently this will be fixed for the next Envoy release (1.18). Left a TODO in the source to remind removing this special treatment once upstream has been fixed.

Fixes: #14919
Signed-off-by: Jarno Rajahalme jarno@covalent.io
