### PR TITLE
v1.9 backports 2021-03-10

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -325,6 +325,11 @@ func newEnvoyLogPiper() io.WriteCloser {
 			case "off", "critical", "error":
 				scopedLog.Error(msg)
 			case "warning":
+				// Silently drop expected warnings if flowdebug is not enabled
+				// TODO: Remove this special case when https://github.com/envoyproxy/envoy/issues/13504 is fixed.
+				if !flowdebug.Enabled() && strings.Contains(msg, "Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size") {
+					continue
+				}
 				scopedLog.Warn(msg)
 			case "info":
 				scopedLog.Info(msg)


### PR DESCRIPTION
 * #15284 -- envoy: Silently discard expected warnings if flowdebug is not enabled (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15284; do contrib/backporting/set-labels.py $pr done 1.9; done
```
