### PR TITLE
[1.7] contrib: Skip image digests during release prep

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -63,7 +63,7 @@ main() {
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
-    logrun make -C install/kubernetes all
+    logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
     sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -17,14 +17,20 @@ CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
 CILIUM_PULLPOLICY_REGEX := '\(pullPolicy:\) .*'
 
+USE_DIGESTS ?= true
+ifeq ($(USE_DIGESTS),false)
+DIGEST_OPTS :=
+else
+DIGEST_OPTS := --set agent.useDigest=true	\
+	--set operator.useDigest=true		\
+	--set preflight.useDigest=true
+endif
+
 all: update-versions $(QUICK_INSTALL)
 
 $(QUICK_INSTALL): $(shell find cilium/ -type f)
 	$(QUIET)helm template cilium --namespace=kube-system \
-     --set agent.useDigest=true \
-     --set operator.useDigest=true \
-     --set preflight.useDigest=true \
-     $(OPTS) > $(QUICK_INSTALL)
+	$(DIGEST_OPTS) $(OPTS) > $(QUICK_INSTALL)
 
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"


### PR DESCRIPTION
In the initial PR, the image digest should be omitted, otherwise we
point to an image tag with the upcoming release and a digest from the
previous release. Skip it in that case.
