### PR TITLE
[1.8] contrib: Skip image digests during release prep

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -63,7 +63,7 @@ main() {
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
-    logrun make -C install/kubernetes all
+    logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
     sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -26,25 +26,26 @@ EXPERIMENTAL_OPTIONS := \
     --set global.hubble.relay.enabled=true \
     --set global.hubble.ui.enabled=true
 
+USE_DIGESTS ?= true
+ifeq ($(USE_DIGESTS),false)
+DIGEST_OPTS :=
+else
+# FIXME change the useDigest to 'true' once images were released by GH actions
+DIGEST_OPTS := --set agent.useDigest=false	\
+	--set hubble-relay.useDigest=false	\
+	--set operator.useDigest=false		\
+	--set preflight.useDigest=false
+endif
+
 all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL)
 
-# FIXME change the useDigest to 'true' once images were released by GH actions
 $(QUICK_INSTALL): $(shell find cilium/ -type f)
 	$(QUIET)helm template cilium --namespace=kube-system \
-     --set agent.useDigest=false \
-     --set hubble-relay.useDigest=false \
-     --set operator.useDigest=false \
-     --set preflight.useDigest=false \
-     $(OPTS) > $(QUICK_INSTALL)
+	$(DIGEST_OPTS) $(OPTS) > $(QUICK_INSTALL)
 
-# FIXME change the useDigest to 'true' once images were released by GH actions
 $(EXPERIMENTAL_INSTALL): $(shell find cilium/ -type f)
 	$(QUIET)helm template cilium --namespace=kube-system \
-     --set agent.useDigest=false \
-     --set hubble-relay.useDigest=false \
-     --set operator.useDigest=false \
-     --set preflight.useDigest=false \
-     $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
+	$(DIGEST_OPTS) $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
 
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"


### PR DESCRIPTION
In the initial PR, the image digest should be omitted, otherwise we
point to an image tag with the upcoming release and a digest from the
previous release. Skip it in that case.
