### PR TITLE
[1.9] contrib: Skip image digests during release prep

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -63,7 +63,7 @@ main() {
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
-    logrun make -C install/kubernetes all
+    logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
     sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -41,6 +41,18 @@ EXPERIMENTAL_OPTIONS := \
     --set bandwidthManager=true \
     --set operator.replicas=1
 
+USE_DIGESTS ?= true
+ifeq ($(USE_DIGESTS),false)
+DIGEST_OPTS :=
+else
+# FIXME change the useDigest to 'true' once images were released by GH actions
+DIGEST_OPTS := --set image.useDigest=false \
+	--set operator.image.useDigest=false \
+	--set preflight.image.useDigest=false \
+	--set hubble.relay.image.useDigest=false \
+	--set clustermesh.apiserver.image.useDigest=false
+endif
+
 DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 	--workdir /src/install/kubernetes \
 	--volume $(CURDIR)/../..:/src \
@@ -56,35 +68,17 @@ LOGO_PATH := Documentation/images/logo-solo.svg
 
 all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL) $(QUICK_HUBBLE_INSTALL) docs
 
-# FIXME change the useDigest to 'true' once images were released by GH actions
 $(QUICK_INSTALL) quick-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system \
-     --set image.useDigest=false \
-     --set operator.image.useDigest=false \
-     --set preflight.image.useDigest=false \
-     --set hubble.relay.image.useDigest=false \
-     --set clustermesh.apiserver.image.useDigest=false \
-     $(QUICK_OPTIONS) > $(QUICK_INSTALL)
+	$(DIGEST_OPTS) $(QUICK_OPTIONS) > $(QUICK_INSTALL)
 
-# FIXME change the useDigest to 'true' once images were released by GH actions
 $(QUICK_HUBBLE_INSTALL) quick-hubble-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system \
-     --set image.useDigest=false \
-     --set operator.image.useDigest=false \
-     --set preflight.image.useDigest=false \
-     --set hubble.relay.image.useDigest=false \
-     --set clustermesh.apiserver.image.useDigest=false \
-     $(QUICK_HUBBLE_OPTIONS) > $(QUICK_HUBBLE_INSTALL)
+	$(DIGEST_OPTS) $(QUICK_HUBBLE_OPTIONS) > $(QUICK_HUBBLE_INSTALL)
 
-# FIXME change the useDigest to 'true' once images were released by GH actions
 $(EXPERIMENTAL_INSTALL) experimental-install: $(shell find cilium/ -type f) update-versions
 	$(QUIET)helm template cilium cilium --namespace=kube-system \
-     --set image.useDigest=false \
-     --set operator.image.useDigest=false \
-     --set preflight.image.useDigest=false \
-     --set hubble.relay.image.useDigest=false \
-     --set clustermesh.apiserver.image.useDigest=false \
-     $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
+	$(DIGEST_OPTS) $(EXPERIMENTAL_OPTIONS) > $(EXPERIMENTAL_INSTALL)
 
 update-versions:
 	$(ECHO_GEN) " -> Updating version to $(VERSION)"


### PR DESCRIPTION
In the initial PR, the image digest should be omitted, otherwise we
point to an image tag with the upcoming release and a digest from the
previous release. Skip it in that case.
