### PR TITLE
contrib: Skip image digests during release prep

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -63,7 +63,7 @@ main() {
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
-    logrun make -C install/kubernetes all
+    logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
     sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML


### PR DESCRIPTION
In the initial release PR, the image digest should be omitted, otherwise
we point to an image tag with the upcoming release and a digest from the
previous release. Skip it in that case.

This variable will trigger logic embedded into the Makefiles on older
branches.
