### PR TITLE
Improve release scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -48,7 +48,7 @@ assignees: ''
   - [ ] Create a commit and push as a new PR.
   - [ ] Merge PR
 - [ ] Update helm charts
-  - [ ] Pull latest branch locally
+  - [ ] Pull latest branch locally into the cilium repository.
   - [ ] Create helm charts artifacts in [Cilium charts] repository using
         [cilium helm release tool] for both the `vX.Y.Z` release and `vX.Y`
         branch and push these changes into the helm repository. Make sure the

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -69,10 +69,16 @@ main() {
     version="v${ersion}"
     run_url_id="$(basename "${3}")"
 
+    if [ ! -e "${PWD}/install/kubernetes/Makefile.digests" ]; then
+        >&2 echo "Cannot find install/kubernetes/Makefile.digests"
+        >&2 echo "Are you in the Cilium root directory?"
+        return 1
+    fi
+
     makefile_digest=$(get_digest_output "${username}" "${run_url_id}" "${version}" Makefile.digests)
     >&2 echo "Adding image SHAs to install/kubernetes/Makefile.digests"
     >&2 echo ""
-    cp "${makefile_digest}" "${DIR}/../../install/kubernetes/Makefile.digests"
+    cp "${makefile_digest}" "${PWD}/install/kubernetes/Makefile.digests"
     make -C install/kubernetes/
 
     >&2 echo "Generating manifest text for release notes"
@@ -80,8 +86,8 @@ main() {
     echo "Docker Manifests" > "${DIR}/../../digest-${version}.txt"
     echo "----------------" >> "${DIR}/../../digest-${version}.txt"
     image_digest_output=$(get_digest_output "${username}" "${run_url_id}" "${version}" image-digest-output.txt)
-    cat "${image_digest_output}" >> "${DIR}/../../digest-${version}.txt"
-    >&2 echo "Image digests available at ${DIR}/../../digest-${version}.txt"
+    cat "${image_digest_output}" >> "${PWD}/digest-${version}.txt"
+    >&2 echo "Image digests available at ${PWD}/digest-${version}.txt"
 }
 
 main "$@"

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -12,7 +12,7 @@ repo="cilium/cilium"
 usage() {
     logecho "usage: $0 <GH-USERNAME> <VERSION> <RUN-URL>"
     logecho "GH-USERNAME  GitHub username"
-    logecho "VERSION      Target version"
+    logecho "VERSION      Target version (X.Y.Z)"
     logecho "RUN-URL      GitHub URL with the RUN for the release images"
     logecho "             example: https://github.com/cilium/cilium/actions/runs/600920964"
     logecho "GITHUB_TOKEN environment variable set with the scope public:repo"
@@ -63,9 +63,10 @@ get_digest_output() {
 
 main() {
     handle_args "$@"
-    local username version run_url_id
+    local username ersion version run_url_id
     username="${1}"
-    version="${2}"
+    ersion="$(echo ${2} | sed 's/^v//')"
+    version="v${ersion}"
     run_url_id="$(basename "${3}")"
 
     makefile_digest=$(get_digest_output "${username}" "${run_url_id}" "${version}" Makefile.digests)

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -83,8 +83,6 @@ main() {
 
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""
-    echo "Docker Manifests" > "${DIR}/../../digest-${version}.txt"
-    echo "----------------" >> "${DIR}/../../digest-${version}.txt"
     image_digest_output=$(get_digest_output "${username}" "${run_url_id}" "${version}" image-digest-output.txt)
     cat "${image_digest_output}" >> "${PWD}/digest-${version}.txt"
     >&2 echo "Image digests available at ${PWD}/digest-${version}.txt"

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -73,6 +73,7 @@ main() {
     >&2 echo "Adding image SHAs to install/kubernetes/Makefile.digests"
     >&2 echo ""
     cp "${makefile_digest}" "${DIR}/../../install/kubernetes/Makefile.digests"
+    make -C install/kubernetes/
 
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -63,6 +63,7 @@ main() {
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
+    sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -52,7 +52,6 @@ handle_args() {
 main() {
     handle_args "$@"
 
-    local old_version="$(cat VERSION)"
     local ersion="$(echo $1 | sed 's/^v//')"
     local version="v$ersion"
     local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
@@ -60,6 +59,7 @@ main() {
 
     git fetch $REMOTE
     git checkout -b pr/prepare-$version $REMOTE/$branch
+    local old_version="$(cat VERSION)"
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION


### PR DESCRIPTION
- contrib: Simplify docker manifest pull script
- contrib: Fix start-release "old release" detection
- .github: Clarify release step for generating helm charts
- contrib: Zero image digests when starting release
- contrib: Remove duplicate docker manifest title
- contrib: Allow pull-docker-manifests to run out of tree
- contrib: Update helm manifests during digest pull
- contrib: Make version parsing more lenient in digest pull