### PR TITLE
k8s: Introduce subscriber package to simplify & consolidate K8s watcher callbacks / event handling

### DIFF
--- a/operator/watchers/service_cache.go
+++ b/operator/watchers/service_cache.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchers
+
+import (
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func newServiceCacheSubscriber(swgSvcs, swgEps *lock.StoppableWaitGroup) *serviceCacheSubscriber {
+	return &serviceCacheSubscriber{
+		swgSvcs: swgSvcs,
+		swgEps:  swgEps,
+	}
+}
+
+// serviceCacheSubscriber represents an object that's subscribed to K8s service
+// events in order to keep the K8sSvcCache up-to-date. It implements
+// subscriber.ServiceHandler and is used in the watcher.
+type serviceCacheSubscriber struct {
+	swgSvcs, swgEps *lock.StoppableWaitGroup
+}
+
+func (c *serviceCacheSubscriber) OnAdd(obj *slim_corev1.Service) {
+	log.WithField(logfields.ServiceName, obj.Name).Debugf("Received service addition %+v", obj)
+	K8sSvcCache.UpdateService(obj, c.swgSvcs)
+}
+func (c *serviceCacheSubscriber) OnUpdate(oldObj, newObj *slim_corev1.Service) {
+	log.WithField(logfields.ServiceName, newObj.Name).Debugf("Received service update %+v", newObj)
+	K8sSvcCache.UpdateService(newObj, c.swgSvcs)
+}
+func (c *serviceCacheSubscriber) OnDelete(obj *slim_corev1.Service) {
+	log.WithField(logfields.ServiceName, obj.Name).Debugf("Received service deletion %+v", obj)
+	K8sSvcCache.DeleteService(obj, c.swgSvcs)
+}

--- a/pkg/k8s/watchers/subscriber/raw.go
+++ b/pkg/k8s/watchers/subscriber/raw.go
@@ -1,0 +1,70 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscriber
+
+import (
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewRaw creates a new raw subscriber list.
+func NewRaw() *RawList {
+	return &RawList{}
+}
+
+// Register registers the raw event handler as a subscriber.
+func (l *RawList) Register(cb cache.ResourceEventHandler) {
+	l.Lock()
+	l.subs = append(l.subs, cache.ResourceEventHandlerFuncs{
+		AddFunc:    cb.OnAdd,
+		UpdateFunc: cb.OnUpdate,
+		DeleteFunc: cb.OnDelete,
+	})
+	l.Unlock()
+}
+
+// NotifyAdd notifies all the subscribers of an add event to an object.
+func (l *RawList) NotifyAdd(obj interface{}) {
+	l.RLock()
+	defer l.RUnlock()
+	for _, s := range l.subs {
+		s.OnAdd(obj)
+	}
+}
+
+// NotifyUpdate notifies all the subscribers of an update event to an object.
+func (l *RawList) NotifyUpdate(oldObj, newObj interface{}) {
+	l.RLock()
+	defer l.RUnlock()
+	for _, s := range l.subs {
+		s.OnUpdate(oldObj, newObj)
+	}
+}
+
+// NotifyDelete notifies all the subscribers of an update event to an object.
+func (l *RawList) NotifyDelete(obj interface{}) {
+	l.RLock()
+	defer l.RUnlock()
+	for _, s := range l.subs {
+		s.OnDelete(obj)
+	}
+}
+
+// RawList holds the raw subscribers to any K8s resource / object changes in
+// the K8s watchers.
+type RawList struct {
+	list
+
+	subs []cache.ResourceEventHandlerFuncs
+}

--- a/pkg/k8s/watchers/subscriber/service.go
+++ b/pkg/k8s/watchers/subscriber/service.go
@@ -1,0 +1,75 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscriber
+
+import (
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+// ServiceHandler is implemented by event handlers responding to K8s Service
+// events.
+type ServiceHandler interface {
+	OnAdd(*slim_corev1.Service)
+	OnUpdate(oldObj, newObj *slim_corev1.Service)
+	OnDelete(*slim_corev1.Service)
+}
+
+// NewService creates a new subscriber list for ServiceHandlers.
+func NewService() *ServiceList {
+	return &ServiceList{}
+}
+
+// Register registers ServiceHandler as a subscriber for reacting to Service
+// objects into the list.
+func (l *ServiceList) Register(s ServiceHandler) {
+	l.Lock()
+	l.subs = append(l.subs, s)
+	l.Unlock()
+}
+
+// NotifyAdd notifies all the subscribers of an add event to a service.
+func (l *ServiceList) NotifyAdd(svc *slim_corev1.Service) {
+	l.RLock()
+	defer l.RUnlock()
+	for _, s := range l.subs {
+		s.OnAdd(svc)
+	}
+}
+
+// NotifyUpdate notifies all the subscribers of an update event to a service.
+func (l *ServiceList) NotifyUpdate(oldSvc, newSvc *slim_corev1.Service) {
+	l.RLock()
+	defer l.RUnlock()
+	for _, s := range l.subs {
+		s.OnUpdate(oldSvc, newSvc)
+	}
+}
+
+// NotifyDelete notifies all the subscribers of an update event to a service.
+func (l *ServiceList) NotifyDelete(svc *slim_corev1.Service) {
+	l.RLock()
+	defer l.RUnlock()
+	for _, s := range l.subs {
+		s.OnDelete(svc)
+	}
+}
+
+// ServiceList holds the ServiceHandler subscribers that are notified when
+// reacting to K8s Service resource / object changes in the K8s watchers.
+type ServiceList struct {
+	list
+
+	subs []ServiceHandler
+}

--- a/pkg/k8s/watchers/subscriber/subscriber.go
+++ b/pkg/k8s/watchers/subscriber/subscriber.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package subscriber implements a mechanism to represent K8s watcher
+// subscribers and allows K8s events to objects / resources to notify their
+// respective subscribers. The intent is to allow the K8s watchers to
+// consolidate all the event handling from various subsystems into one place.
+package subscriber
+
+import "github.com/cilium/cilium/pkg/lock"
+
+type list struct {
+	lock.RWMutex
+}


### PR DESCRIPTION
This PR implements a new package which represents a subscriber to K8s watcher
events. This package simplifies the logic of K8s watchers and removes all the
unnecessary logic of the consumer (subscriber) from them.

In order for a subscriber to add their event handling to the K8s watcher, it
must use register itself. Depending on what kind of object it's subscribed to,
it must use implement the ServiceHandler interface if it's handling Service
objects, or use the "Raw" API where no such constraint on the object type
exists.

With this implementation, future subscribers can easily add their own logic
without worrying about polluting K8s watcher code with specific, irrelevant
details only really meant for them. Meanwhile, the K8s watchers themselves
simply call `Notify*()` depending on the event type. This notifies all the
subscribers to run their logic on the event.

In an upcoming PR, a BGP subscriber will utilize this infrastructure, all the
while, the core service watcher code remains unchanged.

This PR does not convert the rest of the Operator's watchers, but instead
provides the groundwork for future PRs.

See commit msgs.

- watchers: Add subscriber package
- operator/watchers: Convert service watcher to use subscriber
