### PR TITLE
Use vishvananda/netlink instead of net.Interface*

### DIFF
--- a/pkg/mcastmanager/mcastmanager_test.go
+++ b/pkg/mcastmanager/mcastmanager_test.go
@@ -17,10 +17,10 @@
 package mcastmanager
 
 import (
-	"net"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/vishvananda/netlink"
 	. "gopkg.in/check.v1"
 )
 
@@ -32,7 +32,7 @@ type McastManagerSuite struct {
 var _ = Suite(&McastManagerSuite{})
 
 func (m *McastManagerSuite) TestAddRemoveEndpoint(c *C) {
-	ifaces, err := net.Interfaces()
+	ifaces, err := netlink.LinkList()
 	c.Assert(err, IsNil)
 
 	if len(ifaces) == 0 {
@@ -43,7 +43,7 @@ func (m *McastManagerSuite) TestAddRemoveEndpoint(c *C) {
 		ok bool
 
 		iface = ifaces[0]
-		mgr   = New(iface.Name)
+		mgr   = New(iface.Attrs().Name)
 	)
 
 	// Add first endpoint
@@ -74,7 +74,7 @@ func (m *McastManagerSuite) TestAddRemoveEndpoint(c *C) {
 }
 
 func (m *McastManagerSuite) TestAddRemoveNil(c *C) {
-	ifaces, err := net.Interfaces()
+	ifaces, err := netlink.LinkList()
 	c.Assert(err, IsNil)
 
 	if len(ifaces) == 0 {
@@ -83,7 +83,7 @@ func (m *McastManagerSuite) TestAddRemoveNil(c *C) {
 
 	var (
 		iface = ifaces[0]
-		mgr   = New(iface.Name)
+		mgr   = New(iface.Attrs().Name)
 	)
 
 	mgr.AddAddress(nil)

--- a/pkg/multicast/multicast_test.go
+++ b/pkg/multicast/multicast_test.go
@@ -18,11 +18,11 @@ package multicast
 
 import (
 	"math/rand"
-	"net"
 	"testing"
 	"time"
 
 	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/vishvananda/netlink"
 	. "gopkg.in/check.v1"
 )
 
@@ -37,7 +37,7 @@ var _ = Suite(&MulticastSuite{
 })
 
 func (m *MulticastSuite) TestGroupOps(c *C) {
-	ifs, err := net.Interfaces()
+	ifs, err := netlink.LinkList()
 	c.Assert(err, IsNil)
 
 	if len(ifs) == 0 {
@@ -48,20 +48,20 @@ func (m *MulticastSuite) TestGroupOps(c *C) {
 	maddr := m.randMaddr()
 
 	// Join Group
-	err = JoinGroup(ifc.Name, maddr.String())
+	err = JoinGroup(ifc.Attrs().Name, maddr.String())
 	c.Assert(err, IsNil)
 
 	// maddr in group
-	inGroup, err := IsInGroup(ifc.Name, maddr.String())
+	inGroup, err := IsInGroup(ifc.Attrs().Name, maddr.String())
 	c.Assert(err, IsNil)
 	c.Assert(inGroup, Equals, true)
 
 	// LeaveGroup
-	err = LeaveGroup(ifc.Name, maddr.String())
+	err = LeaveGroup(ifc.Attrs().Name, maddr.String())
 	c.Assert(err, IsNil)
 
 	// maddr not in group
-	inGroup, err = IsInGroup(ifc.Name, maddr.String())
+	inGroup, err = IsInGroup(ifc.Attrs().Name, maddr.String())
 	c.Assert(err, IsNil)
 	c.Assert(inGroup, Equals, false)
 }


### PR DESCRIPTION
This will allow us to avoid deadlocks when retrieving iface by name
described in cilium/cilium#15051.

