### PR TITLE
install: Update generated helm YAMLs to use digests

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -30,11 +30,10 @@ USE_DIGESTS ?= true
 ifeq ($(USE_DIGESTS),false)
 DIGEST_OPTS :=
 else
-# FIXME change the useDigest to 'true' once images were released by GH actions
-DIGEST_OPTS := --set agent.useDigest=false	\
-	--set hubble-relay.useDigest=false	\
-	--set operator.useDigest=false		\
-	--set preflight.useDigest=false
+DIGEST_OPTS := --set agent.useDigest=true	\
+	--set hubble-relay.useDigest=true	\
+	--set operator.useDigest=true		\
+	--set preflight.useDigest=true
 endif
 
 all: update-versions $(QUICK_INSTALL) $(EXPERIMENTAL_INSTALL)

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -577,7 +577,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/cilium:v1.8.8"
+        image: "quay.io/cilium/cilium:v1.8.8@sha256:a3700a673e148356ee538e22bc87b6d4ddcde76b43e6712c7a225918549d7b2b"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -645,7 +645,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/cilium:v1.8.8"
+        image: "quay.io/cilium/cilium:v1.8.8@sha256:a3700a673e148356ee538e22bc87b6d4ddcde76b43e6712c7a225918549d7b2b"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -900,7 +900,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "quay.io/cilium/operator-generic:v1.8.8"
+        image: "quay.io/cilium/operator-generic:v1.8.8@sha256:453393fbb80fe894dd6e5999142cf97e96694c2715bf06df5f24365c9366203e"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -432,7 +432,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/cilium:v1.8.8"
+        image: "quay.io/cilium/cilium:v1.8.8@sha256:a3700a673e148356ee538e22bc87b6d4ddcde76b43e6712c7a225918549d7b2b"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -495,7 +495,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/cilium:v1.8.8"
+        image: "quay.io/cilium/cilium:v1.8.8@sha256:a3700a673e148356ee538e22bc87b6d4ddcde76b43e6712c7a225918549d7b2b"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -648,7 +648,7 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: "quay.io/cilium/operator-generic:v1.8.8"
+        image: "quay.io/cilium/operator-generic:v1.8.8@sha256:453393fbb80fe894dd6e5999142cf97e96694c2715bf06df5f24365c9366203e"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:


### PR DESCRIPTION
Now that we have digests in the tree for the target image tags, use them
when generating the quick-install/experimental-install YAMLs.
