### PR TITLE
v1.9 backports 2021-03-10

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -126,9 +126,9 @@ update-versions:
 		# image digests;													\
 		sed -i '/# cilium-digest.*/{!b;n;s/digest.*/digest: "'$(CILIUM_DIGEST)'"/}' $(CILIUM_VALUES); 				\
 		sed -i '/# hubble-relay-digest.*/{!b;n;s/digest.*/digest: "'$(HUBBLE_RELAY_DIGEST)'"/}' $(CILIUM_VALUES);			\
-		sed -i '/# operator-aws-digest.*/{!b;n;s/aws-digest.*/aws-digest: "'$(OPERATOR_AWS_DIGEST)'"/}' $(CILIUM_VALUES); 		\
-		sed -i '/# operator-azure-digest.*/{!b;n;s/azure-digest.*/azure-digest: "'$(OPERATOR_AZURE_DIGEST)'"/}' $(CILIUM_VALUES); 	\
-		sed -i '/# operator-generic-digest.*/{!b;n;s/generic-digest.*/generic-digest: "'$(OPERATOR_GENERIC_DIGEST)'"/}' $(CILIUM_VALUES); \
+		sed -i '/# operator-aws-digest.*/{!b;n;s/awsDigest.*/awsDigest: "'$(OPERATOR_AWS_DIGEST)'"/}' $(CILIUM_VALUES);                 \
+		sed -i '/# operator-azure-digest.*/{!b;n;s/azureDigest.*/azureDigest: "'$(OPERATOR_AZURE_DIGEST)'"/}' $(CILIUM_VALUES);         \
+		sed -i '/# operator-generic-digest.*/{!b;n;s/genericDigest.*/genericDigest: "'$(OPERATOR_GENERIC_DIGEST)'"/}' $(CILIUM_VALUES); \
 		sed -i '/# clustermesh-apiserver-digest.*/{!b;n;s/digest.*/digest: "'$(CLUSTERMESH_APISERVER_DIGEST)'"/}' $(CILIUM_VALUES)
 
 lint:


### PR DESCRIPTION
* #15311 -- install/kubernetes: Fix incorrect commands for digest generation (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15311; do contrib/backporting/set-labels.py $pr done 1.9; done
```