### PR TITLE
bpf: fix skb pacing for traffic from pods

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -344,6 +344,11 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (!udp_only && !sock_proto_enabled(ctx->protocol))
 		return -ENOTSUP;
 
+	if (!in_hostns) {
+		int val = 500000000;//250000000;
+		set_socket_opt(ctx_full, SOL_SOCKET, SO_MAX_PACING_RATE, &val, sizeof(val));
+	}
+
 	/* In case a direct match fails, we try to look-up surrogate
 	 * service entries via wildcarded lookup for NodePort and
 	 * HostPort services.

--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -99,5 +99,8 @@ static struct bpf_sock *BPF_FUNC(sk_lookup_udp, void *ctx,
 static int BPF_FUNC_REMAP(get_socket_opt, void *ctx, int level, int optname,
 			  void *optval, int optlen) =
 	(void *)BPF_FUNC_getsockopt;
+static int BPF_FUNC_REMAP(set_socket_opt, void *ctx, int level, int optname,
+			  void *optval, int optlen) =
+	(void *)BPF_FUNC_setsockopt;
 
 #endif /* __BPF_HELPERS__ */

--- a/bpf/include/linux/bpf.h
+++ b/bpf/include/linux/bpf.h
@@ -4032,6 +4032,7 @@ enum {
 /* BPF_FUNC_clone_redirect and BPF_FUNC_redirect flags. */
 enum {
 	BPF_F_INGRESS			= (1ULL << 0),
+	BPF_F_TSTAMP_RETAIN		= (1ULL << 1),
 };
 
 /* BPF_FUNC_skb_set_tunnel_key and BPF_FUNC_skb_get_tunnel_key flags. */

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -114,13 +114,14 @@ redirect_direct_v4(struct __ctx_buff *ctx __maybe_unused,
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 	if (no_neigh)
-		return redirect_neigh(oif, nh, nh ? sizeof(*nh) : 0, 0);
+		return redirect_neigh(oif, nh, nh ? sizeof(*nh) : 0,
+				      BPF_F_TSTAMP_RETAIN);
 # ifndef ENABLE_SKIP_FIB
 	if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 		return CTX_ACT_DROP;
 	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 		return CTX_ACT_DROP;
-	return redirect(oif, 0);
+	return redirect(oif, BPF_F_TSTAMP_RETAIN);
 # endif /* ENABLE_SKIP_FIB */
 	return CTX_ACT_DROP;
 }

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -101,6 +101,10 @@ func InitBandwidthManager() {
 		{"net.ipv4.tcp_congestion_control", "bbr"},
 		{"net.ipv4.tcp_max_syn_backlog", "4096"},
 	}
+	if !option.Config.EnableHostLegacyRouting {
+		baseSettings = append(baseSettings,
+			setting{"net.core.netdev_tstamp_retain", "1"})
+	}
 	for _, s := range baseSettings {
 		log.WithFields(logrus.Fields{
 			logfields.SysParamName:  s.name,


### PR DESCRIPTION
See commit msg.

TODOs till final release:

- [ ] edt map removal if feature not used
- [ ] adapt edt drop horizon for any proto to 2s in general (incl UDP)
- [ ] finalize l7 support
- [ ] Implement for NodePort backend Pods (double check if supported)

Related:
- https://github.com/cilium/cilium/issues/13371
- https://github.com/cilium/cilium/pull/12982
