### PR TITLE
Simplify runtime/builder image update

### DIFF
--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -237,11 +237,6 @@ Update cilium-builder and cilium-runtime images
 
        $ git commit --amend -s images/
 
-#. Run ``git grep -E 'quay.io/cilium/cilium-(runtime|builder)'`` and replace
-   all other places where the images are used. (This step will be removed once
-   it is part of the make targets ``update-runtime-image`` and
-   ``update-builder-image``).
-
 #. Update the versions of the images that are pulled into the CI VMs.
 
 * Open a PR against the :ref:`packer_ci` with an update to said image versions. Once your PR is merged, a new version of the VM will be ready for consumption in the CI.

--- a/images/README.md
+++ b/images/README.md
@@ -25,7 +25,7 @@ debugging as well as Ubuntu user-space for troubleshooting.
 
 ### [`cilium`](cilium/Dockerfile)
 
-It includes `cilium-agent` and other binaries, including `cilium`, `envoy`, 
+It includes `cilium-agent` and other binaries, including `cilium`, `envoy`,
 `cilium-health` and `hubble-cli`.
 
 This image is based on `runtime` image, and it contains Ubuntu user-space for
@@ -60,7 +60,7 @@ If you are making a routine update to the build and runtime images, you can
 update all dependent images in the same PR, as long as overall scope of the PR
 is just an update to some dependencies and not an implementation of a feature.
 
-The process is described in the [official documentation](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images) 
+The process is described in the [official documentation](https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images)
 
 ### Building Locally
 

--- a/images/scripts/update-cilium-builder-image.sh
+++ b/images/scripts/update-cilium-builder-image.sh
@@ -25,10 +25,10 @@ if [ -n "${sha256}" ]; then
 fi
 
 # shellcheck disable=SC2207
-used_by=($(git grep -l CILIUM_BUILDER_IMAGE= images/*/Dockerfile))
+used_by=($(git grep -l CILIUM_BUILDER_IMAGE= images/*/Dockerfile) "test/k8sT/manifests/test-verifier.yaml")
 
 for i in "${used_by[@]}" ; do
-  sed "s|\(CILIUM_BUILDER_IMAGE=\)${image}:.*\$|\1${image_full}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+  sed -E "s#(CILIUM_BUILDER_IMAGE=|image: )${image}:.*\$#\1${image_full}#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
 done
 
 do_check="${CHECK:-false}"

--- a/images/scripts/update-cilium-builder-image.sh
+++ b/images/scripts/update-cilium-builder-image.sh
@@ -18,19 +18,16 @@ image="quay.io/cilium/cilium-builder"
 
 image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" images/builder)"
 
+image_full="${image}:${image_tag}"
+sha256=$("${script_dir}/get-image-digest.sh" "${image_full}" || echo "")
+if [ -n "${sha256}" ]; then
+  image_full="${image_full}@${sha256}"
+fi
+
 # shellcheck disable=SC2207
 used_by=($(git grep -l CILIUM_BUILDER_IMAGE= images/*/Dockerfile))
 
 for i in "${used_by[@]}" ; do
-  image_full="${image}:${image_tag}"
-  # Detect if the image_tag already exists, if it does then we can assume the
-  # image was created and a sha256 is available for it.
-  if grep "CILIUM_BUILDER_IMAGE=${image}:${image_tag}" "${i}" ; then
-    sha256=$("${script_dir}/get-image-digest.sh" "${image_full}")
-    if [ -n "${sha256}" ]; then
-      image_full="${image_full}@${sha256}"
-    fi
-  fi
   sed "s|\(CILIUM_BUILDER_IMAGE=\)${image}:.*\$|\1${image_full}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
 done
 

--- a/images/scripts/update-cilium-runtime-image.sh
+++ b/images/scripts/update-cilium-runtime-image.sh
@@ -25,10 +25,17 @@ if [ -n "${sha256}" ]; then
 fi
 
 # shellcheck disable=SC2207
-used_by=($(git grep -l CILIUM_RUNTIME_IMAGE= images/*/Dockerfile))
+used_by=($(git grep -l CILIUM_RUNTIME_IMAGE= images/*/Dockerfile) $(git grep -l BASE_IMAGE= .github/workflows/) ".travis.yml")
 
 for i in "${used_by[@]}" ; do
-  sed "s|\(CILIUM_RUNTIME_IMAGE=\)${image}:.*\$|\1${image_full}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+  sed -E "s#((CILIUM_RUNTIME|BASE)_IMAGE=)${image}:.*\$#\1${image_full}#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+done
+
+# shellcheck disable=SC2207
+jenkins_used_by=($(git grep -l "${image}:" jenkinsfiles/))
+
+for i in "${jenkins_used_by[@]}" ; do
+  sed -E "s#\"${image}:.*\"#\"${image_full}\"#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
 done
 
 do_check="${CHECK:-false}"

--- a/images/scripts/update-cilium-runtime-image.sh
+++ b/images/scripts/update-cilium-runtime-image.sh
@@ -18,19 +18,16 @@ image="quay.io/cilium/cilium-runtime"
 
 image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" images/runtime)"
 
+image_full="${image}:${image_tag}"
+sha256=$("${script_dir}/get-image-digest.sh" "${image_full}" || echo "")
+if [ -n "${sha256}" ]; then
+  image_full="${image_full}@${sha256}"
+fi
+
 # shellcheck disable=SC2207
 used_by=($(git grep -l CILIUM_RUNTIME_IMAGE= images/*/Dockerfile))
 
 for i in "${used_by[@]}" ; do
-  image_full="${image}:${image_tag}"
-  # Detect if the image_tag already exists, if it does then we can assume the
-  # image was created and a sha256 is available for it.
-  if grep "CILIUM_RUNTIME_IMAGE=${image}:${image_tag}" "${i}" ; then
-    sha256=$("${script_dir}/get-image-digest.sh" "${image_full}")
-    if [ -n "${sha256}" ]; then
-      image_full="${image_full}@${sha256}"
-    fi
-  fi
   sed "s|\(CILIUM_RUNTIME_IMAGE=\)${image}:.*\$|\1${image_full}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
 done
 


### PR DESCRIPTION
Currently, some uses of the `cilium-runtime` and `cilium-builder` still need to be updated manually after updating the images (see https://docs.cilium.io/en/latest/contributing/development/images/#update-cilium-builder-and-cilium-runtime-images, step 9). This PR simplifies this process by changing the respective scripts in `images/scripts/` to update these users as well. This way the manual update step is no longer necessary.

See individual commits for details.