### PR TITLE
Helm: adjust comment in values.yaml to accomodate Vim users

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1,8 +1,7 @@
 # upgradeCompatibility helps users upgrading to ensure that the configMap for
-#
 # Cilium will not change critical values to ensure continued operation
 # This is flag is not required for new installations.
-# ex: 1.7, 1.8, 1.9
+# For example: 1.7, 1.8, 1.9
 # upgradeCompatibility: '1.8'
 
 debug:


### PR DESCRIPTION
Vim, like some other editors, has a "modeline" function where one line, generally near the top of a source file, can be used to set some editing options for the file. Vim accepts several forms of [modeline][modeline], one of which is `[text{white}]ex:[white]{options}`.

It turns out that one of the commented lines at the top of the values.yaml file follows this syntax: `# ex: 1.7, 1.8, 1.9`. The version numbers on that line are of course not valid options for Vim, but it makes the editor complain and require an additional key stroke to edit the file. Let's expand the abbreviation to save Vim users the trouble, and let's remove a blank comment seemingly inserted by error in the middle of a sentence.

[modeline]: https://github.com/vim/vim/blob/008bff967f7fcaa6af066f71d65bfbba5ef5c7d3/runtime/doc/options.txt#L484
