### PR TITLE
test/gke: use correct cluster IPv4 CIDR

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -505,7 +505,15 @@ cluster.
           causing Ginkgo tests to fail. If so, you'll see them in ``kubectl get ns``,
           and can get rid of them by running ``cilium/test/gke/clean-cluster.sh``.
 
+.. note:: The tests require the ``NATIVE_CIDR`` environment variable to be set to
+          the value of the cluster IPv4 CIDR returned by the ``gcloud container
+          clusters describe`` command.
+
 ::
+
+  export CLUSTER_NAME=cluster1
+  export CLUSTER_ZONE=us-west2-a
+  export NATIVE_CIDR="$(gcloud container clusters describe $CLUSTER_NAME --zone $CLUSTER_ZONE --format 'value(clusterIpv4Cidr)')"
 
   CNI_INTEGRATION=gke K8S_VERSION=1.17 ginkgo --focus="K8sDemo" -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.hubble-relay-image="quay.io/cilium/hubble-relay-ci" -cilium.passCLIEnvironment=true
 

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -145,6 +145,10 @@ pipeline {
                         script: 'echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s*/" | tr -d \'\n\''
                         )}"""
                 KERNEL="419"
+                NATIVE_CIDR= """${sh(
+                        returnStdout: true,
+                        script: 'cat ${TESTDIR}/gke/cluster-cidr | tr -d \'\n\''
+                        )}"""
             }
             steps {
                 dir("${TESTDIR}"){

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -75,6 +75,7 @@ echo "${cluster_uri}" > "${script_dir}/cluster-uri"
 gcloud container clusters describe --project "${project}" --region "${region}" --format='value(name)' "${cluster_uri}" > "${script_dir}/cluster-name"
 gcloud container clusters describe --project "${project}" --region "${region}" --format='value(currentMasterVersion)' "${cluster_uri}" \
   | sed -E 's/([0-9]+\.[0-9]+)\..*/\1/' | tr -d '\n' > "${script_dir}/cluster-version"
+gcloud container clusters describe --project "${project}" --region "${region}" --format='value(clusterIpv4Cidr)' "${cluster_uri}" > "${script_dir}/cluster-cidr"
 
 echo "cleaning cluster before tests"
 "${script_dir}"/clean-cluster.sh

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -156,7 +156,7 @@ var (
 		"cni.binPath":                 "/home/kubernetes/bin",
 		"gke.enabled":                 "true",
 		"loadBalancer.mode":           "snat",
-		"nativeRoutingCIDR":           "10.0.0.0/8",
+		"nativeRoutingCIDR":           GKENativeRoutingCIDR(),
 		"hostFirewall":                "false",
 		"ipam.mode":                   "kubernetes",
 		"devices":                     "", // Override "eth0 eth0\neth0"

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -511,6 +511,10 @@ func RunsOn419Kernel() bool {
 	return os.Getenv("KERNEL") == "419"
 }
 
+func GKENativeRoutingCIDR() string {
+	return os.Getenv("NATIVE_CIDR")
+}
+
 // DoesNotRunOn419Kernel is the complement function of RunsOn419Kernel.
 func DoesNotRunOn419Kernel() bool {
 	return !RunsOn419Kernel()


### PR DESCRIPTION
Instead of hardcoding 10.0.0.0/8 as cluster IPv4 CIDR, which includes
also node IPs and may cause some tests to fail, use the correct one
obtained from the `gcloud container clusters describe` command.

Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>