### PR TITLE
Partial revert "vendor: Bump netlink to include timeouts"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ replace (
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 
 	// Using cilium/netlink until XFRM patches merged upstream
-	github.com/vishvananda/netlink => github.com/cilium/netlink v1.0.1-0.20210305225027-66e1713b4f2e
+	github.com/vishvananda/netlink => github.com/cilium/netlink v1.0.1-0.20210223023818-d826f2a4c934
 	gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8 // To avoid https://github.com/go-yaml/yaml/pull/571.
 	k8s.io/client-go => github.com/cilium/client-go v0.0.0-20210218151335-3861ecd89595
 

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2 h1:RHNYGjc9Rkdr75ZgFOb
 github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
-github.com/cilium/netlink v1.0.1-0.20210305225027-66e1713b4f2e h1:qBdK+HupNgmfj/P5caacBQ5S6opj1C9Wo6SlHaI2I+I=
-github.com/cilium/netlink v1.0.1-0.20210305225027-66e1713b4f2e/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/cilium/netlink v1.0.1-0.20210223023818-d826f2a4c934 h1:facUillFWlSkMJiaLPRtgharophG/rOlWpsUCcwhVi4=
+github.com/cilium/netlink v1.0.1-0.20210223023818-d826f2a4c934/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/cilium/proxy v0.0.0-20210304222512-e7430b113e09 h1:tumqMHANCuRoQX93Ph94xdhEpUlP/KhPEDznJIokH/4=
 github.com/cilium/proxy v0.0.0-20210304222512-e7430b113e09/go.mod h1:mvauc94lqkyJunRsU9Ef5FIsixi8vBeDoxuMYoGBemk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -52,7 +52,7 @@ func (r *Route) getNetlinkRoute() netlink.Route {
 		Dst:      &r.Prefix,
 		Src:      r.Local,
 		MTU:      r.MTU,
-		Protocol: netlink.RouteProtocol(r.Proto),
+		Protocol: r.Proto,
 		Table:    r.Table,
 		Type:     r.Type,
 	}

--- a/vendor/github.com/vishvananda/netlink/filter_linux.go
+++ b/vendor/github.com/vishvananda/netlink/filter_linux.go
@@ -36,7 +36,6 @@ type U32 struct {
 	ClassId    uint32
 	Divisor    uint32 // Divisor MUST be power of 2.
 	Hash       uint32
-	Link       uint32
 	RedirIndex int
 	Sel        *TcU32Sel
 	Actions    []Action
@@ -225,9 +224,6 @@ func (h *Handle) filterModify(filter Filter, flags int) error {
 		}
 		if filter.Hash != 0 {
 			options.AddRtAttr(nl.TCA_U32_HASH, nl.Uint32Attr(filter.Hash))
-		}
-		if filter.Link != 0 {
-			options.AddRtAttr(nl.TCA_U32_LINK, nl.Uint32Attr(filter.Link))
 		}
 		actionsAttr := options.AddRtAttr(nl.TCA_U32_ACT, nil)
 		// backwards compatibility
@@ -670,8 +666,6 @@ func parseU32Data(filter Filter, data []syscall.NetlinkRouteAttr) (bool, error) 
 			u32.Divisor = native.Uint32(datum.Value)
 		case nl.TCA_U32_HASH:
 			u32.Hash = native.Uint32(datum.Value)
-		case nl.TCA_U32_LINK:
-			u32.Link = native.Uint32(datum.Value)
 		}
 	}
 	return detailed, nil

--- a/vendor/github.com/vishvananda/netlink/link.go
+++ b/vendor/github.com/vishvananda/netlink/link.go
@@ -555,27 +555,6 @@ const (
 	BOND_ARP_VALIDATE_ALL
 )
 
-var bondArpValidateToString = map[BondArpValidate]string{
-	BOND_ARP_VALIDATE_NONE:   "none",
-	BOND_ARP_VALIDATE_ACTIVE: "active",
-	BOND_ARP_VALIDATE_BACKUP: "backup",
-	BOND_ARP_VALIDATE_ALL:    "none",
-}
-var StringToBondArpValidateMap = map[string]BondArpValidate{
-	"none":   BOND_ARP_VALIDATE_NONE,
-	"active": BOND_ARP_VALIDATE_ACTIVE,
-	"backup": BOND_ARP_VALIDATE_BACKUP,
-	"all":    BOND_ARP_VALIDATE_ALL,
-}
-
-func (b BondArpValidate) String() string {
-	s, ok := bondArpValidateToString[b]
-	if !ok {
-		return fmt.Sprintf("BondArpValidate(%d)", b)
-	}
-	return s
-}
-
 // BondPrimaryReselect type
 type BondPrimaryReselect int
 
@@ -586,25 +565,6 @@ const (
 	BOND_PRIMARY_RESELECT_FAILURE
 )
 
-var bondPrimaryReselectToString = map[BondPrimaryReselect]string{
-	BOND_PRIMARY_RESELECT_ALWAYS:  "always",
-	BOND_PRIMARY_RESELECT_BETTER:  "better",
-	BOND_PRIMARY_RESELECT_FAILURE: "failure",
-}
-var StringToBondPrimaryReselectMap = map[string]BondPrimaryReselect{
-	"always":  BOND_PRIMARY_RESELECT_ALWAYS,
-	"better":  BOND_PRIMARY_RESELECT_BETTER,
-	"failure": BOND_PRIMARY_RESELECT_FAILURE,
-}
-
-func (b BondPrimaryReselect) String() string {
-	s, ok := bondPrimaryReselectToString[b]
-	if !ok {
-		return fmt.Sprintf("BondPrimaryReselect(%d)", b)
-	}
-	return s
-}
-
 // BondArpAllTargets type
 type BondArpAllTargets int
 
@@ -613,23 +573,6 @@ const (
 	BOND_ARP_ALL_TARGETS_ANY BondArpAllTargets = iota
 	BOND_ARP_ALL_TARGETS_ALL
 )
-
-var bondArpAllTargetsToString = map[BondArpAllTargets]string{
-	BOND_ARP_ALL_TARGETS_ANY: "any",
-	BOND_ARP_ALL_TARGETS_ALL: "all",
-}
-var StringToBondArpAllTargetsMap = map[string]BondArpAllTargets{
-	"any": BOND_ARP_ALL_TARGETS_ANY,
-	"all": BOND_ARP_ALL_TARGETS_ALL,
-}
-
-func (b BondArpAllTargets) String() string {
-	s, ok := bondArpAllTargetsToString[b]
-	if !ok {
-		return fmt.Sprintf("BondArpAllTargets(%d)", b)
-	}
-	return s
-}
 
 // BondFailOverMac type
 type BondFailOverMac int
@@ -640,25 +583,6 @@ const (
 	BOND_FAIL_OVER_MAC_ACTIVE
 	BOND_FAIL_OVER_MAC_FOLLOW
 )
-
-var bondFailOverMacToString = map[BondFailOverMac]string{
-	BOND_FAIL_OVER_MAC_NONE:   "none",
-	BOND_FAIL_OVER_MAC_ACTIVE: "active",
-	BOND_FAIL_OVER_MAC_FOLLOW: "follow",
-}
-var StringToBondFailOverMacMap = map[string]BondFailOverMac{
-	"none":   BOND_FAIL_OVER_MAC_NONE,
-	"active": BOND_FAIL_OVER_MAC_ACTIVE,
-	"follow": BOND_FAIL_OVER_MAC_FOLLOW,
-}
-
-func (b BondFailOverMac) String() string {
-	s, ok := bondFailOverMacToString[b]
-	if !ok {
-		return fmt.Sprintf("BondFailOverMac(%d)", b)
-	}
-	return s
-}
 
 // BondXmitHashPolicy type
 type BondXmitHashPolicy int
@@ -751,25 +675,6 @@ const (
 	BOND_AD_SELECT_COUNT
 )
 
-var bondAdSelectToString = map[BondAdSelect]string{
-	BOND_AD_SELECT_STABLE:    "stable",
-	BOND_AD_SELECT_BANDWIDTH: "bandwidth",
-	BOND_AD_SELECT_COUNT:     "count",
-}
-var StringToBondAdSelectMap = map[string]BondAdSelect{
-	"stable":    BOND_AD_SELECT_STABLE,
-	"bandwidth": BOND_AD_SELECT_BANDWIDTH,
-	"count":     BOND_AD_SELECT_COUNT,
-}
-
-func (b BondAdSelect) String() string {
-	s, ok := bondAdSelectToString[b]
-	if !ok {
-		return fmt.Sprintf("BondAdSelect(%d)", b)
-	}
-	return s
-}
-
 // BondAdInfo represents ad info for bond
 type BondAdInfo struct {
 	AggregatorId int
@@ -801,7 +706,7 @@ type Bond struct {
 	AllSlavesActive int
 	MinLinks        int
 	LpInterval      int
-	PacketsPerSlave int
+	PackersPerSlave int
 	LacpRate        BondLacpRate
 	AdSelect        BondAdSelect
 	// looking at iproute tool AdInfo can only be retrived. It can't be set.
@@ -834,7 +739,7 @@ func NewLinkBond(atr LinkAttrs) *Bond {
 		AllSlavesActive: -1,
 		MinLinks:        -1,
 		LpInterval:      -1,
-		PacketsPerSlave: -1,
+		PackersPerSlave: -1,
 		LacpRate:        -1,
 		AdSelect:        -1,
 		AdActorSysPrio:  -1,

--- a/vendor/github.com/vishvananda/netlink/link_linux.go
+++ b/vendor/github.com/vishvananda/netlink/link_linux.go
@@ -34,21 +34,6 @@ const (
 	TUNTAP_MULTI_QUEUE_DEFAULTS TuntapFlag = TUNTAP_MULTI_QUEUE | TUNTAP_NO_PI
 )
 
-var StringToTuntapModeMap = map[string]TuntapMode{
-	"tun": TUNTAP_MODE_TUN,
-	"tap": TUNTAP_MODE_TAP,
-}
-
-func (ttm TuntapMode) String() string {
-	switch ttm {
-	case TUNTAP_MODE_TUN:
-		return "tun"
-	case TUNTAP_MODE_TAP:
-		return "tap"
-	}
-	return "unknown"
-}
-
 const (
 	VF_LINK_STATE_AUTO    uint32 = 0
 	VF_LINK_STATE_ENABLE  uint32 = 1
@@ -1061,8 +1046,8 @@ func addBondAttrs(bond *Bond, linkInfo *nl.RtAttr) {
 	if bond.LpInterval >= 0 {
 		data.AddRtAttr(nl.IFLA_BOND_LP_INTERVAL, nl.Uint32Attr(uint32(bond.LpInterval)))
 	}
-	if bond.PacketsPerSlave >= 0 {
-		data.AddRtAttr(nl.IFLA_BOND_PACKETS_PER_SLAVE, nl.Uint32Attr(uint32(bond.PacketsPerSlave)))
+	if bond.PackersPerSlave >= 0 {
+		data.AddRtAttr(nl.IFLA_BOND_PACKETS_PER_SLAVE, nl.Uint32Attr(uint32(bond.PackersPerSlave)))
 	}
 	if bond.LacpRate >= 0 {
 		data.AddRtAttr(nl.IFLA_BOND_AD_LACP_RATE, nl.Uint8Attr(uint8(bond.LacpRate)))
@@ -2324,7 +2309,7 @@ func parseBondData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_BOND_LP_INTERVAL:
 			bond.LpInterval = int(native.Uint32(data[i].Value[0:4]))
 		case nl.IFLA_BOND_PACKETS_PER_SLAVE:
-			bond.PacketsPerSlave = int(native.Uint32(data[i].Value[0:4]))
+			bond.PackersPerSlave = int(native.Uint32(data[i].Value[0:4]))
 		case nl.IFLA_BOND_AD_LACP_RATE:
 			bond.LacpRate = BondLacpRate(data[i].Value[0])
 		case nl.IFLA_BOND_AD_SELECT:

--- a/vendor/github.com/vishvananda/netlink/route.go
+++ b/vendor/github.com/vishvananda/netlink/route.go
@@ -3,31 +3,11 @@ package netlink
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 // Scope is an enum representing a route scope.
 type Scope uint8
-
-func (s Scope) String() string {
-	switch s {
-	case SCOPE_UNIVERSE:
-		return "universe"
-	case SCOPE_SITE:
-		return "site"
-	case SCOPE_LINK:
-		return "link"
-	case SCOPE_HOST:
-		return "host"
-	case SCOPE_NOWHERE:
-		return "nowhere"
-	default:
-		return "unknown"
-	}
-}
 
 type NextHopFlag int
 
@@ -47,60 +27,6 @@ type Encap interface {
 	Equal(Encap) bool
 }
 
-//Protocol describe what was the originator of the route
-type RouteProtocol int
-
-func (p RouteProtocol) String() string {
-	switch int(p) {
-	case unix.RTPROT_BABEL:
-		return "babel"
-	case unix.RTPROT_BGP:
-		return "bgp"
-	case unix.RTPROT_BIRD:
-		return "bird"
-	case unix.RTPROT_BOOT:
-		return "boot"
-	case unix.RTPROT_DHCP:
-		return "dhcp"
-	case unix.RTPROT_DNROUTED:
-		return "dnrouted"
-	case unix.RTPROT_EIGRP:
-		return "eigrp"
-	case unix.RTPROT_GATED:
-		return "gated"
-	case unix.RTPROT_ISIS:
-		return "isis"
-	//case unix.RTPROT_KEEPALIVED:
-	//	return "keepalived"
-	case unix.RTPROT_KERNEL:
-		return "kernel"
-	case unix.RTPROT_MROUTED:
-		return "mrouted"
-	case unix.RTPROT_MRT:
-		return "mrt"
-	case unix.RTPROT_NTK:
-		return "ntk"
-	case unix.RTPROT_OSPF:
-		return "ospf"
-	case unix.RTPROT_RA:
-		return "ra"
-	case unix.RTPROT_REDIRECT:
-		return "redirect"
-	case unix.RTPROT_RIP:
-		return "rip"
-	case unix.RTPROT_STATIC:
-		return "static"
-	case unix.RTPROT_UNSPEC:
-		return "unspec"
-	case unix.RTPROT_XORP:
-		return "xorp"
-	case unix.RTPROT_ZEBRA:
-		return "zebra"
-	default:
-		return strconv.Itoa(int(p))
-	}
-}
-
 // Route represents a netlink route.
 type Route struct {
 	LinkIndex        int
@@ -110,7 +36,7 @@ type Route struct {
 	Src              net.IP
 	Gw               net.IP
 	MultiPath        []*NexthopInfo
-	Protocol         RouteProtocol
+	Protocol         int
 	Priority         int
 	Table            int
 	Type             int

--- a/vendor/github.com/vishvananda/netlink/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux.go
@@ -907,7 +907,7 @@ func deserializeRoute(m []byte) (Route, error) {
 	}
 	route := Route{
 		Scope:    Scope(msg.Scope),
-		Protocol: RouteProtocol(int(msg.Protocol)),
+		Protocol: int(msg.Protocol),
 		Table:    int(msg.Table),
 		Type:     int(msg.Type),
 		Tos:      int(msg.Tos),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -550,7 +550,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
-# github.com/vishvananda/netlink v1.1.1-0.20210304225204-ec93726159ae => github.com/cilium/netlink v1.0.1-0.20210305225027-66e1713b4f2e
+# github.com/vishvananda/netlink v1.1.1-0.20210304225204-ec93726159ae => github.com/cilium/netlink v1.0.1-0.20210223023818-d826f2a4c934
 ## explicit
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl
@@ -1128,7 +1128,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 # github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
-# github.com/vishvananda/netlink => github.com/cilium/netlink v1.0.1-0.20210305225027-66e1713b4f2e
+# github.com/vishvananda/netlink => github.com/cilium/netlink v1.0.1-0.20210223023818-d826f2a4c934
 # gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
 # k8s.io/client-go => github.com/cilium/client-go v0.0.0-20210218151335-3861ecd89595
 # sigs.k8s.io/controller-tools => github.com/christarazi/controller-tools v0.3.1-0.20200911184030-7e668c1fb4c2


### PR DESCRIPTION
This is a partial revert of commit 3ee6824ef14b (" vendor: Bump netlink
to include timeouts") to roll back to an earlier version of the forked
upstream library which includes only upstream commit 9de6d08565b3
("Allow to set/get netlink socket timeout for default handle"), which
was the original target of the backport, plus the forked commit
d826f2a4c934 ("netlink: xfrm, add optional field to XfrmPolicyTmpl")
which resolves a known issue with encryption.

Mitigates issues with newer versions of the upstream library which
break the build by changing the public route structure definition and
introducing dependencies on unix libraries that are not exported on all
platforms (see the deleted lines for more details).

These changes were only present on the v1.9 branch as they were
performed as part of the backporting duties on that PR only, not on
master or the v1.8 branch backport.

Implemented via:

    $ go mod edit -replace github.com/vishvananda/netlink=github.com/cilium/netlink@d826f2a4c934c4404b5da0f2b974ec253d8002d5
    $ go mod tidy
    go mod vendorgo: downloading github.com/cilium/netlink v1.0.1-0.20210223023818-d826f2a4c934
    $ go mod vendor

There should be no impact on fixed bugs in existing releases, in effect this reverts the following upstream commits:
https://github.com/vishvananda/netlink/commit/3bf47faadc7f87746ce454fb8f7ff2bb68d9f917
https://github.com/vishvananda/netlink/commit/ec93726159aeeb86e36a0e4b6d120089434fe02e

Fixes: 3ee6824ef14b (" vendor: Bump netlink to include timeouts")
