### PR TITLE
Stub out some functionality on non-Linux platforms

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -26,10 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/mountinfo"
 	"github.com/cilium/cilium/pkg/option"
-
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -115,52 +112,6 @@ func getCgroupRootForKind() (string, error) {
 	}
 
 	return cgroupPath, nil
-}
-
-// mountCgroup mounts the Cgroup v2 filesystem into the desired cgroupRoot directory.
-func mountCgroup() error {
-	cgroupRootStat, err := os.Stat(cgroupRoot)
-	if err != nil {
-		if os.IsNotExist(err) {
-			if err := os.MkdirAll(cgroupRoot, 0755); err != nil {
-				return fmt.Errorf("Unable to create cgroup mount directory: %s", err)
-			}
-		} else {
-			return fmt.Errorf("Failed to stat the mount path %s: %s", cgroupRoot, err)
-		}
-	} else if !cgroupRootStat.IsDir() {
-		return fmt.Errorf("%s is a file which is not a directory", cgroupRoot)
-	}
-
-	if err := unix.Mount("none", cgroupRoot, "cgroup2", 0, ""); err != nil {
-		return fmt.Errorf("failed to mount %s: %s", cgroupRoot, err)
-	}
-
-	return nil
-}
-
-// checkOrMountCustomLocation tries to check or mount the BPF filesystem in the
-// given path.
-func cgrpCheckOrMountLocation(cgroupRoot string) error {
-	setCgroupRoot(cgroupRoot)
-
-	// Check whether the custom location has a mount.
-	mounted, cgroupInstance, err := mountinfo.IsMountFS(mountinfo.FilesystemTypeCgroup2, cgroupRoot)
-	if err != nil {
-		return err
-	}
-
-	// If the custom location has no mount, let's mount there.
-	if !mounted {
-		if err := mountCgroup(); err != nil {
-			return err
-		}
-	}
-
-	if !cgroupInstance {
-		return fmt.Errorf("Mount in the custom directory %s has a different filesystem than cgroup2", cgroupRoot)
-	}
-	return nil
 }
 
 // CheckOrMountCgrpFS this checks if the cilium cgroup2 root mount point is

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -1,0 +1,70 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cilium/cilium/pkg/mountinfo"
+
+	"golang.org/x/sys/unix"
+)
+
+// mountCgroup mounts the Cgroup v2 filesystem into the desired cgroupRoot directory.
+func mountCgroup() error {
+	cgroupRootStat, err := os.Stat(cgroupRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(cgroupRoot, 0755); err != nil {
+				return fmt.Errorf("Unable to create cgroup mount directory: %s", err)
+			}
+		} else {
+			return fmt.Errorf("Failed to stat the mount path %s: %s", cgroupRoot, err)
+		}
+	} else if !cgroupRootStat.IsDir() {
+		return fmt.Errorf("%s is a file which is not a directory", cgroupRoot)
+	}
+
+	if err := unix.Mount("none", cgroupRoot, "cgroup2", 0, ""); err != nil {
+		return fmt.Errorf("failed to mount %s: %s", cgroupRoot, err)
+	}
+
+	return nil
+}
+
+// checkOrMountCustomLocation tries to check or mount the BPF filesystem in the
+// given path.
+func cgrpCheckOrMountLocation(cgroupRoot string) error {
+	setCgroupRoot(cgroupRoot)
+
+	// Check whether the custom location has a mount.
+	mounted, cgroupInstance, err := mountinfo.IsMountFS(mountinfo.FilesystemTypeCgroup2, cgroupRoot)
+	if err != nil {
+		return err
+	}
+
+	// If the custom location has no mount, let's mount there.
+	if !mounted {
+		if err := mountCgroup(); err != nil {
+			return err
+		}
+	}
+
+	if !cgroupInstance {
+		return fmt.Errorf("Mount in the custom directory %s has a different filesystem than cgroup2", cgroupRoot)
+	}
+	return nil
+}

--- a/pkg/cgroups/cgroups_unspecified.go
+++ b/pkg/cgroups/cgroups_unspecified.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package cgroups
+
+import "errors"
+
+var ErrNotImplemented = errors.New("not implemented")
+
+func mountCgroup() error {
+	return ErrNotImplemented
+}
+
+func cgrpCheckOrMountLocation(cgroupRoot string) error {
+	return ErrNotImplemented
+}

--- a/pkg/health/server/health.go
+++ b/pkg/health/server/health.go
@@ -15,32 +15,14 @@
 package server
 
 import (
-	"strconv"
-
 	healthModels "github.com/cilium/cilium/api/v1/health/models"
 	. "github.com/cilium/cilium/api/v1/health/server/restapi"
 	ciliumModels "github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/client"
-	"golang.org/x/sys/unix"
 
 	"github.com/go-openapi/runtime/middleware"
 )
-
-func dumpLoad() (*healthModels.LoadResponse, error) {
-	var info unix.Sysinfo_t
-	err := unix.Sysinfo(&info)
-	if err != nil {
-		return nil, err
-	}
-
-	scale := float64(1 << unix.SI_LOAD_SHIFT)
-	return &healthModels.LoadResponse{
-		Last1min:  strconv.FormatFloat(float64(info.Loads[0])/scale, 'f', 2, 64),
-		Last5min:  strconv.FormatFloat(float64(info.Loads[1])/scale, 'f', 2, 64),
-		Last15min: strconv.FormatFloat(float64(info.Loads[2])/scale, 'f', 2, 64),
-	}, nil
-}
 
 type getHealthz struct {
 	*Server

--- a/pkg/health/server/health_linux.go
+++ b/pkg/health/server/health_linux.go
@@ -1,0 +1,38 @@
+// Copyright 2017-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"strconv"
+
+	healthModels "github.com/cilium/cilium/api/v1/health/models"
+
+	"golang.org/x/sys/unix"
+)
+
+func dumpLoad() (*healthModels.LoadResponse, error) {
+	var info unix.Sysinfo_t
+	err := unix.Sysinfo(&info)
+	if err != nil {
+		return nil, err
+	}
+
+	scale := float64(1 << unix.SI_LOAD_SHIFT)
+	return &healthModels.LoadResponse{
+		Last1min:  strconv.FormatFloat(float64(info.Loads[0])/scale, 'f', 2, 64),
+		Last5min:  strconv.FormatFloat(float64(info.Loads[1])/scale, 'f', 2, 64),
+		Last15min: strconv.FormatFloat(float64(info.Loads[2])/scale, 'f', 2, 64),
+	}, nil
+}

--- a/pkg/health/server/health_unspecified.go
+++ b/pkg/health/server/health_unspecified.go
@@ -1,0 +1,27 @@
+// Copyright 2017-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package server
+
+import (
+	"errors"
+
+	healthModels "github.com/cilium/cilium/api/v1/health/models"
+)
+
+func dumpLoad() (*healthModels.LoadResponse, error) {
+	return nil, errors.New("not implemented")
+}

--- a/pkg/modules/modules_unspecified.go
+++ b/pkg/modules/modules_unspecified.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package modules
+
+import (
+	"errors"
+	"io"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+func listModules() ([]string, error) {
+	return nil, ErrNotImplemented
+}
+
+func moduleLoader() string {
+	return "unknown-module-loader"
+}
+
+func parseModulesFile(r io.Reader) ([]string, error) {
+	return nil, ErrNotImplemented
+}

--- a/pkg/mountinfo/mountinfo.go
+++ b/pkg/mountinfo/mountinfo.go
@@ -16,23 +16,14 @@ package mountinfo
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
-	// FilesystemType superblock magic numbers for filesystems,
-	// to be used for IsMountFS.
-	FilesystemTypeBPFFS   = unix.BPF_FS_MAGIC
-	FilesystemTypeCgroup2 = unix.CGROUP2_SUPER_MAGIC
-
 	mountInfoFilepath = "/proc/self/mountinfo"
 )
 
@@ -132,43 +123,4 @@ func GetMountInfo() ([]*MountInfo, error) {
 	defer fMounts.Close()
 
 	return parseMountInfoFile(fMounts)
-}
-
-// IsMountFS returns two boolean values, checking
-//  - whether the path is a mount point;
-//  - if yes, whether its filesystem type is mntType.
-//
-// Note that this function can not detect bind mounts,
-// and is not working properly when path="/".
-func IsMountFS(mntType int64, path string) (bool, bool, error) {
-	var st, pst unix.Stat_t
-
-	err := unix.Lstat(path, &st)
-	if err != nil {
-		if errors.Is(err, unix.ENOENT) {
-			// non-existent path can't be a mount point
-			return false, false, nil
-		}
-		return false, false, &os.PathError{Op: "lstat", Path: path, Err: err}
-	}
-
-	parent := filepath.Dir(path)
-	err = unix.Lstat(parent, &pst)
-	if err != nil {
-		return false, false, &os.PathError{Op: "lstat", Path: parent, Err: err}
-	}
-	if st.Dev == pst.Dev {
-		// parent has the same dev -- not a mount point
-		return false, false, nil
-	}
-
-	// Check the fstype
-	fst := unix.Statfs_t{}
-	err = unix.Statfs(path, &fst)
-	if err != nil {
-		return true, false, &os.PathError{Op: "statfs", Path: path, Err: err}
-	}
-
-	return true, fst.Type == mntType, nil
-
 }

--- a/pkg/mountinfo/mountinfo_linux.go
+++ b/pkg/mountinfo/mountinfo_linux.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mountinfo
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// FilesystemType superblock magic numbers for filesystems,
+	// to be used for IsMountFS.
+	FilesystemTypeBPFFS   = unix.BPF_FS_MAGIC
+	FilesystemTypeCgroup2 = unix.CGROUP2_SUPER_MAGIC
+)
+
+// IsMountFS returns two boolean values, checking
+//  - whether the path is a mount point;
+//  - if yes, whether its filesystem type is mntType.
+//
+// Note that this function can not detect bind mounts,
+// and is not working properly when path="/".
+func IsMountFS(mntType int64, path string) (bool, bool, error) {
+	var st, pst unix.Stat_t
+
+	err := unix.Lstat(path, &st)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			// non-existent path can't be a mount point
+			return false, false, nil
+		}
+		return false, false, &os.PathError{Op: "lstat", Path: path, Err: err}
+	}
+
+	parent := filepath.Dir(path)
+	err = unix.Lstat(parent, &pst)
+	if err != nil {
+		return false, false, &os.PathError{Op: "lstat", Path: parent, Err: err}
+	}
+	if st.Dev == pst.Dev {
+		// parent has the same dev -- not a mount point
+		return false, false, nil
+	}
+
+	// Check the fstype
+	fst := unix.Statfs_t{}
+	err = unix.Statfs(path, &fst)
+	if err != nil {
+		return true, false, &os.PathError{Op: "statfs", Path: path, Err: err}
+	}
+
+	return true, fst.Type == mntType, nil
+
+}

--- a/pkg/mountinfo/mountinfo_privileged_test.go
+++ b/pkg/mountinfo/mountinfo_privileged_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build privileged_tests
+// +build linux,privileged_tests
 
 package mountinfo
 

--- a/pkg/mountinfo/mountinfo_test.go
+++ b/pkg/mountinfo/mountinfo_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !privileged_tests
+// +build linux,!privileged_tests
 
 package mountinfo
 
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"golang.org/x/sys/unix"
 
+	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/mountinfo/mountinfo_unspecified.go
+++ b/pkg/mountinfo/mountinfo_unspecified.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package mountinfo
+
+import "errors"
+
+const (
+	// Dummy FilesystemType superblock magic numbers for filesystems,
+	// to be used for IsMountFS.
+	FilesystemTypeBPFFS = 0
+)
+
+// IsMountFS returns two boolean values, checking
+//  - whether the path is a mount point;
+//  - if yes, whether its filesystem type is mntType.
+//
+// Note that this function can not detect bind mounts,
+// and is not working properly when path="/".
+func IsMountFS(mntType int64, path string) (bool, bool, error) {
+	return false, false, errors.New("not implemented")
+}


### PR DESCRIPTION
This is a drive-by attempt to improve the compilability of the Cilium codebase
on non-Linux platforms, taking steps in the direction of simplifying the build
and test process for developers on those platforms. There's still some fairly
significant Linux-only dependencies in the BPF and datapath sections of the
code which this PR does not attempt to resolve, but these are some steps
forward.

- mountinfo: Add stubs for non-Linux platforms
- cgroups: Add stubs for non-Linux platforms
- health: Add stubs for non-Linux platforms
- modules: Add stubs for non-Linux platforms

Tested via:

    $ GOOS=darwin go build ./pkg/$foo
