### PR TITLE
cilium: encryption, auto-discover interface and subnet

### DIFF
--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -8,8 +8,6 @@
 #include <netdev_config.h>
 
 #include "lib/common.h"
-#include "lib/eth.h"
-#include "lib/dbg.h"
 #include "lib/trace.h"
 #include "lib/encrypt.h"
 

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -27,19 +27,17 @@ HOST_DEV2=$9
 XDP_DEV=${10}
 XDP_MODE=${11}
 MTU=${12}
-IPSEC=${13}
-ENCRYPT_DEV=${14}
-HOSTLB=${15}
-HOSTLB_UDP=${16}
-HOSTLB_PEER=${17}
-CGROUP_ROOT=${18}
-BPFFS_ROOT=${19}
-NODE_PORT=${20}
-NODE_PORT_BIND=${21}
-MCPU=${22}
-NR_CPUS=${23}
-ENDPOINT_ROUTES=${24}
-PROXY_RULE=${25}
+HOSTLB=${13}
+HOSTLB_UDP=${14}
+HOSTLB_PEER=${15}
+CGROUP_ROOT=${16}
+BPFFS_ROOT=${17}
+NODE_PORT=${18}
+NODE_PORT_BIND=${19}
+MCPU=${20}
+NR_CPUS=${21}
+ENDPOINT_ROUTES=${22}
+PROXY_RULE=${23}
 
 ID_HOST=1
 ID_WORLD=2
@@ -608,12 +606,6 @@ else
 	bpf_clear_cgroups $CGROUP_ROOT getpeername6
 fi
 
-if [ "$IPSEC" == "true" ]; then
-	if [ "$ENCRYPT_DEV" != "<nil>" ]; then
-		CALLS_MAP="cilium_calls_netdev_ns_${ID_HOST}"
-		bpf_load $ENCRYPT_DEV "" "ingress" bpf_network.c bpf_network.o from-network $CALLS_MAP
-	fi
-fi
 if [ "$HOST_DEV1" != "$HOST_DEV2" ]; then
 	bpf_unload $HOST_DEV2 "egress"
 fi

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -6,11 +6,10 @@
 
 #include <bpf/ctx/skb.h>
 #include <bpf/api.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
 
 #include "lib/common.h"
-#include "lib/ipv6.h"
-#include "lib/l3.h"
-#include "lib/eth.h"
 
 #ifdef ENABLE_IPSEC
 static __always_inline int

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1287,7 +1287,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && len(option.Config.EncryptInterface) == 0 {
+	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
+	// that may be added or removed at runtime.
+	if option.Config.EnableIPSec &&
+		option.Config.Tunnel == option.TunnelDisabled &&
+		len(option.Config.EncryptInterface) == 0 &&
+		option.Config.IPAM != ipamOption.IPAMENI {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {
 			log.WithError(err).Fatal("Ipsec default interface lookup failed, consider \"encrypt-interface\" to manually configure interface.")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1287,12 +1287,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && option.Config.EncryptInterface == "" {
+	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && len(option.Config.EncryptInterface) == 0 {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {
 			log.WithError(err).Fatal("Ipsec default interface lookup failed, consider \"encrypt-interface\" to manually configure interface.")
 		}
-		option.Config.EncryptInterface = link
+		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
 
 	if option.Config.Tunnel != option.TunnelDisabled && option.Config.EnableAutoDirectRouting {
@@ -1459,8 +1459,8 @@ func (d *Daemon) initKVStore() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice:       option.Config.HostDevice,
-		EncryptInterface: option.Config.EncryptInterface,
+		HostDevice:        option.Config.HostDevice,
+		EncryptInterfaces: option.Config.EncryptInterface,
 	}
 
 	log.Info("Initializing daemon")

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -440,8 +440,13 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_HOST_FIREWALL"] = "1"
 	}
 
-	if iface := option.Config.EncryptInterface; iface != "" {
-		link, err := netlink.LinkByName(iface)
+	if iface := option.Config.EncryptInterface; len(iface) != 0 {
+		// When FIB lookup is not supported (older kernels)  we need to
+		// pick an interface so pick first interface in list. Then we pick
+		// an IPv4 address to use by selecting link IPAddr. In case with
+		// kernel support, the kernel datapath will use the FIB lookup helper
+		// and this define is ignored.
+		link, err := netlink.LinkByName(iface[0])
 		if err == nil {
 			cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -27,8 +27,8 @@ import (
 type DatapathConfiguration struct {
 	// HostDevice is the name of the device to be used to access the host.
 	HostDevice string
-	// EncryptInterface is the name of the device to be used for direct ruoting encryption
-	EncryptInterface string
+	// EncryptInterfaces is the list of devices used for direct ruoting encryption
+	EncryptInterfaces []string
 }
 
 type linuxDatapath struct {
@@ -54,9 +54,9 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 
 	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, wgAgent)
 
-	if cfg.EncryptInterface != "" {
-		if err := connector.DisableRpFilter(cfg.EncryptInterface); err != nil {
-			log.WithField(logfields.Interface, cfg.EncryptInterface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
+	for _, iface := range cfg.EncryptInterfaces {
+		if err := connector.DisableRpFilter(iface); err != nil {
+			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
 		}
 	}
 

--- a/pkg/datapath/linux/ethtool/ethtool.go
+++ b/pkg/datapath/linux/ethtool/ethtool.go
@@ -1,0 +1,97 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethtool
+
+import (
+	"bytes"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	SIOCETHTOOL      = 0x8946
+	ETHTOOL_GDRVINFO = 0x00000003 // Get driver info
+
+	IFNAMSIZ = 16
+)
+
+const (
+	veth = "veth"
+)
+
+type ifreq struct {
+	name [IFNAMSIZ]byte
+	data uintptr
+}
+
+type ethtoolDrvInfo struct {
+	cmd         uint32
+	driver      [32]byte
+	version     [32]byte
+	fwVersion   [32]byte
+	busInfo     [32]byte
+	eromVersion [32]byte
+	reserved2   [12]byte
+	nPrivFlags  uint32
+	nStats      uint32
+	testInfoLen uint32
+	eedumpLen   uint32
+	regdumpLen  uint32
+}
+
+func ethtoolIoctl(iface string, info *ethtoolDrvInfo) error {
+	var ifname [IFNAMSIZ]byte
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_IP)
+	if err != nil {
+		return err
+	}
+	copy(ifname[:], iface)
+	req := ifreq{
+		name: ifname,
+		data: uintptr(unsafe.Pointer(info)),
+	}
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), SIOCETHTOOL, uintptr(unsafe.Pointer(&req)))
+	if ep != 0 {
+		return ep
+	}
+	return nil
+}
+
+func GetDeviceName(iface string) (string, error) {
+	info := ethtoolDrvInfo{
+		cmd: ETHTOOL_GDRVINFO,
+	}
+
+	if err := ethtoolIoctl(iface, &info); err != nil {
+		return "", err
+	}
+	return string(bytes.Trim(info.driver[:], "\x00")), nil
+}
+
+func IsVirtualDriver(iface string) (bool, error) {
+	drvName, err := GetDeviceName(iface)
+	if err != nil {
+		return false, err
+	}
+
+	switch drvName {
+	case veth:
+		return true, nil
+	}
+
+	return true, nil
+}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -177,6 +177,7 @@ func _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst *net.IPNet, dir netlink
 	// policy because Cilium BPF programs do that.
 	if dir == netlink.XFRM_DIR_FWD {
 		optional = 1
+		policy.Priority = linux_defaults.IPsecFwdPriority
 	}
 	ipSecAttachPolicyTempl(policy, key, tmplSrc.IP, tmplDst.IP, false, optional)
 	return netlink.XfrmPolicyUpdate(policy)
@@ -186,7 +187,7 @@ func ipSecReplacePolicyIn(src, dst, tmplSrc, tmplDst *net.IPNet) error {
 	return _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst, netlink.XFRM_DIR_IN)
 }
 
-func ipSecReplacePolicyFwd(src, dst, tmplSrc, tmplDst *net.IPNet) error {
+func IpSecReplacePolicyFwd(src, dst, tmplSrc, tmplDst *net.IPNet) error {
 	return _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst, netlink.XFRM_DIR_FWD)
 }
 
@@ -342,7 +343,7 @@ func UpsertIPsecEndpoint(local, remote, fwd *net.IPNet, dir IPSecDir, outputMark
 					return 0, fmt.Errorf("unable to replace policy in: %s", err)
 				}
 			}
-			if err = ipSecReplacePolicyFwd(remote, fwd, remote, local); err != nil {
+			if err = IpSecReplacePolicyFwd(remote, fwd, remote, local); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace policy fwd: %s", err)
 				}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -66,10 +66,9 @@ func getIPSecKeys(ip net.IP) *ipSecKey {
 
 func ipSecNewState() *netlink.XfrmState {
 	state := netlink.XfrmState{
-		Mode:         netlink.XFRM_MODE_TUNNEL,
-		Proto:        netlink.XFRM_PROTO_ESP,
-		ESN:          true,
-		ReplayWindow: 1024,
+		Mode:  netlink.XFRM_MODE_TUNNEL,
+		Proto: netlink.XFRM_PROTO_ESP,
+		ESN:   false,
 	}
 	return &state
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -95,6 +95,9 @@ const (
 	// IPsecMarkMaskIn is the mask required for IPsec to lookup encrypt/decrypt bits
 	IPsecMarkMaskIn = 0x0F00
 
+	// IPsecFwdPriority is the priority of the fwd rules placed by IPsec
+	IPsecFwdPriority = 0x0B9F
+
 	// IPsecKeyDeleteDelay is the time to wait before removing old keys when
 	// the IPsec key is changing.
 	IPsecKeyDeleteDelay = 5 * time.Minute

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -463,8 +463,22 @@ func upsertIPsecLog(err error, spec string, loc, rem *net.IPNet, spi uint8) {
 	}
 }
 
+// getDefaultEncryptionInterface() is needed to find the interface used when
+// populating neighbor table and doing arpRequest. For most configurations
+// there is only a single interface so choosing [0] works by choosing the only
+// interface. However EKS, uses multiple interfaces, but fortunately for us
+// in EKS any interface would work so pick the [0] index here as well.
+func getDefaultEncryptionInterface() string {
+	iface := ""
+	if len(option.Config.EncryptInterface) > 0 {
+		iface = option.Config.EncryptInterface[0]
+	}
+	return iface
+}
+
 func getLinkLocalIp(family int) (*net.IPNet, error) {
-	link, err := netlink.LinkByName(option.Config.EncryptInterface)
+	iface := getDefaultEncryptionInterface()
+	link, err := netlink.LinkByName(iface)
 	if err != nil {
 		return nil, err
 	}
@@ -1105,7 +1119,7 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 	var device string
 
 	if option.Config.Tunnel == option.TunnelDisabled {
-		device = n.datapathConfig.EncryptInterface
+		device = n.datapathConfig.EncryptInterfaces[0]
 	} else {
 		device = linux_defaults.TunnelDeviceName
 	}
@@ -1320,8 +1334,14 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 			}
 			ifaceName = option.Config.DirectRoutingDevice
 			n.enableNeighDiscovery = mac != nil // No need to arping for L2-less devices
-		case n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled:
-			ifaceName = option.Config.EncryptInterface
+		case n.nodeConfig.EnableIPSec &&
+			option.Config.Tunnel == option.TunnelDisabled &&
+			len(option.Config.EncryptInterface) != 0:
+			// When FIB lookup is not supported we need to pick an
+			// interface so pick first interface in the list. On
+			// kernels with FIB lookup helpers we do a lookup from
+			// the datapath side and ignore this value.
+			ifaceName = option.Config.EncryptInterface[0]
 			n.enableNeighDiscovery = true
 		}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -843,6 +843,12 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 				n.replaceNodeIPSecOutRoute(new4Net)
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv4", ipsecLocal, ipsecRemote, spi)
+
+				/* Insert wildcard policy rules for traffic skipping back through host */
+				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecLocal, ipsecRemote); err != nil {
+					log.WithError(err).Warning("egress unable to replace policy fwd:")
+				}
 			}
 		}
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1099,6 +1099,10 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 		}
 	}
 
+	if err := route.DeleteRouteTable(linux_defaults.RouteTableIPSec, netlink.FAMILY_V4); err != nil {
+		log.WithError(err).Warn("Deletion of IPSec routes failed")
+	}
+
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
 		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -514,6 +514,24 @@ func lookupDefaultRoute(family int) (netlink.Route, error) {
 	return routes[0], nil
 }
 
+func DeleteRouteTable(table, family int) error {
+	var routeErr error
+
+	routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("Unable to list table %d routes: %s", table, err)
+	}
+
+	routeErr = nil
+	for _, route := range routes {
+		err := netlink.RouteDel(&route)
+		if err != nil {
+			routeErr = fmt.Errorf("%w: Failed to delete route: %s", routeErr, err)
+		}
+	}
+	return routeErr
+}
+
 // NodeDeviceWithDefaultRoute returns the node's device which handles the
 // default route in the current namespace
 func NodeDeviceWithDefaultRoute(enableIPv4, enableIPv6 bool) (netlink.Link, error) {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -57,8 +57,6 @@ const (
 	initArgXDPDevice
 	initArgXDPMode
 	initArgMTU
-	initArgIPSec
-	initArgEncryptInterface
 	initArgHostReachableServices
 	initArgHostReachableServicesUDP
 	initArgHostReachableServicesPeer
@@ -257,12 +255,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	args[initArgMTU] = fmt.Sprintf("%d", deviceMTU)
 
-	if option.Config.EnableIPSec {
-		args[initArgIPSec] = "true"
-	} else {
-		args[initArgIPSec] = "false"
-	}
-
 	if option.Config.EnableHostReachableServices {
 		args[initArgHostReachableServices] = "true"
 		if option.Config.EnableHostServicesUDP {
@@ -279,12 +271,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initArgHostReachableServices] = "false"
 		args[initArgHostReachableServicesUDP] = "false"
 		args[initArgHostReachableServicesPeer] = "false"
-	}
-
-	if option.Config.EncryptInterface != "" {
-		args[initArgEncryptInterface] = option.Config.EncryptInterface
-	} else {
-		args[initArgEncryptInterface] = "<nil>"
 	}
 
 	devices := make([]netlink.Link, 0, len(option.Config.Devices))
@@ -358,18 +344,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}).Info("Setting up BPF datapath")
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
-		// For the ENI ipam mode on EKS, this will be the interface that
-		// the router (cilium_host) IP is associated to.
-		if option.Config.EncryptInterface == "" {
-			if info := node.GetRouterInfo(); info != nil {
-				mac := info.GetMac()
-				iface, err := linuxrouting.RetrieveIfaceNameFromMAC(mac.String())
-				if err != nil {
-					log.WithError(err).WithField("mac", mac).Fatal("Failed to set encrypt interface in the ENI ipam mode")
-				}
-				args[initArgEncryptInterface] = iface
-			}
-		}
 		var err error
 		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
@@ -416,6 +390,27 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		}
 	} else {
 		log.Warning("Cannot check matching of C and Go common struct alignments due to old LLVM/clang version")
+	}
+
+	// Compile and load network programs, currently used for encryption.
+	if option.Config.EnableIPSec {
+		interfaces := option.Config.EncryptInterface
+
+		// For the ENI ipam mode on EKS, this will be the interface that
+		// the router (cilium_host) IP is associated to.
+		if len(interfaces) == 0 && option.Config.IPAM == ipamOption.IPAMENI {
+			if info := node.GetRouterInfo(); info != nil {
+				mac := info.GetMac()
+				iface, err := linuxrouting.RetrieveIfaceNameFromMAC(mac.String())
+				if err != nil {
+					log.WithError(err).WithField("mac", mac).Fatal("Failed to set encrypt interface in the ENI ipam mode")
+				}
+				interfaces = append(interfaces, iface)
+			}
+		}
+		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {
+			log.WithError(err).Fatal("failed to load encryption program")
+		}
 	}
 
 	if err := o.Datapath().Node().NodeConfigurationChanged(*o.LocalConfig()); err != nil {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/linux/ethtool"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
@@ -173,6 +174,49 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 	}
 
 	return retSettings, nil
+}
+
+// reinitializeIPSec is used to recompile and load encryption network programs.
+func (l *Loader) reinitializeIPSec(ctx context.Context) error {
+	if !option.Config.EnableIPSec {
+		return nil
+	}
+
+	interfaces := option.Config.EncryptInterface
+	if option.Config.IPAM == ipamOption.IPAMENI {
+		// IPAMENI mode supports multiple network facing interfaces that
+		// will all need Encrypt logic applied in order to decrypt any
+		// received encrypted packets. This logic will attach to all
+		// !veth devices. Only use if user has not configured interfaces.
+		if len(interfaces) == 0 {
+			if links, err := netlink.LinkList(); err == nil {
+				for _, link := range links {
+					isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
+					if err == nil && !isVirtual {
+						interfaces = append(interfaces, link.Attrs().Name)
+					}
+				}
+			}
+		}
+
+		// For the ENI ipam mode on EKS, this will be the interface that
+		// the router (cilium_host) IP is associated to.
+		if len(option.Config.IPv4PodSubnets) == 0 {
+			if info := node.GetRouterInfo(); info != nil {
+				for _, c := range info.GetIPv4CIDRs() {
+					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &c)
+				}
+			}
+		}
+	}
+
+	// No interfaces is valid in tunnel disabled case
+	if len(interfaces) != 0 {
+		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {
+			return fmt.Errorf("failed to load encryption program: %w", err)
+		}
+	}
+	return nil
 }
 
 // Reinitialize (re-)configures the base datapath configuration including global
@@ -392,35 +436,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		log.Warning("Cannot check matching of C and Go common struct alignments due to old LLVM/clang version")
 	}
 
-	// Compile and load network programs, currently used for encryption.
-	if option.Config.EnableIPSec {
-		interfaces := option.Config.EncryptInterface
-
-		// For the ENI ipam mode on EKS, this will be the interface that
-		// the router (cilium_host) IP is associated to.
-		if option.Config.IPAM == ipamOption.IPAMENI {
-			if len(interfaces) == 0 {
-				if info := node.GetRouterInfo(); info != nil {
-					mac := info.GetMac()
-					iface, err := linuxrouting.RetrieveIfaceNameFromMAC(mac.String())
-					if err != nil {
-						log.WithError(err).WithField("mac", mac).Fatal("Failed to set encrypt interface in the ENI ipam mode")
-					}
-					interfaces = append(interfaces, iface)
-				}
-			}
-			if len(option.Config.IPv4PodSubnets) == 0 {
-				if info := node.GetRouterInfo(); info != nil {
-					for _, c := range info.GetIPv4CIDRs() {
-						option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &c)
-					}
-				}
-				log.Info("Encryption IPv4PodSubnets in-use")
-			}
-		}
-		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {
-			log.WithError(err).Fatal("failed to load encryption program")
-		}
+	if err := l.reinitializeIPSec(ctx); err != nil {
+		return err
 	}
 
 	if err := o.Datapath().Node().NodeConfigurationChanged(*o.LocalConfig()); err != nil {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -47,6 +47,7 @@ const (
 
 	symbolFromEndpoint = "from-container"
 	symbolToEndpoint   = "to-container"
+	symbolFromNetwork  = "from-network"
 
 	symbolFromHostNetdevEp = "from-netdev"
 	symbolToHostNetdevEp   = "to-netdev"
@@ -366,6 +367,18 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 		}
 	}
 
+	return nil
+}
+
+func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string) error {
+	if err := compileNetwork(ctx); err != nil {
+		log.WithError(err).Fatal("failed to compile encryption programs")
+	}
+	for _, iface := range option.Config.EncryptInterface {
+		if err := l.replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress); err != nil {
+			log.WithField(logfields.Interface, iface).Fatal("Load encryption network failed")
+		}
+	}
 	return nil
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1419,7 +1419,7 @@ type DaemonConfig struct {
 	XDPMode             string     // XDP mode, values: { xdpdrv | xdpgeneric | none }
 	HostV4Addr          net.IP     // Host v4 address of the snooping device
 	HostV6Addr          net.IP     // Host v6 address of the snooping device
-	EncryptInterface    string     // Set with name of network facing interface to encrypt
+	EncryptInterface    []string   // Set of network facing interface to encrypt over
 	EncryptNode         bool       // Set to true for encrypting node IP traffic
 
 	Ipvlan IpvlanConfig // Ipvlan related configuration
@@ -2627,7 +2627,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableRecorder = viper.GetBool(EnableRecorder)
 	c.EnableHostFirewall = viper.GetBool(EnableHostFirewall)
 	c.EnableLocalRedirectPolicy = viper.GetBool(EnableLocalRedirectPolicy)
-	c.EncryptInterface = viper.GetString(EncryptInterface)
+	c.EncryptInterface = viper.GetStringSlice(EncryptInterface)
 	c.EncryptNode = viper.GetBool(EncryptNode)
 	c.EnvoyLogPath = viper.GetString(EnvoyLog)
 	c.ForceLocalPolicyEvalAtSource = viper.GetBool(ForceLocalPolicyEvalAtSource)


### PR DESCRIPTION
Resolve numerous issues that have crept into encryption side with EKS, AKS, and GKE environments.

* EKS requires editing config-map with a set of undocumented cilium-internal fields to get working. Instead of exposing these lets learn these from the environment. Patches 1,2, and 3 address this so that subnets and encryption interfaces are learned at init time.
* EKS interface auto-detection was not reliable, fix by patch 3 to add all network facing interfaces. The issue here is EKS uses source based routing and has multiple interfaces where encrypted traffic could arrive. If we don't load our BPF program bpf-network on these interfaces packets may not be marked for decryption and dropped by the stack.
* We attempted to enable Extended sequence support, but missed two bits of information here: (i) the seq# will need to be sync'd on node join and (ii) the encryption overhead is increased. Rather than deal with the somewhat more complicated solution for (i) lets revert for now to make backporting doable. Cilium-cli should make key rotations easy and painless so that ESN is not needed for most cases. Patch 4.
* Patches 5, 6 ensure IPSec configuration is cleaned up. Otherwise we risk having conflicting rules in the datapath when running install, uninstall, install and/or restarting cilium-agent if it comes up with new IP addresses, cidrs. Which in practice is unlikely, but can happen. In CI its commonplace because we reused the nodes across tests.

Tested on EKS using,
* ./cilium install --agent-image quay.io/isovalent/cilium-hubble-fgs --operator-image quay.io/cilium/operator-aws-ci --version latest --encryption
* ./cilium connectivity test
   ✅ 9/9 tests successful (0 warnings)
   
Tested on GKE using
*./cilium install --datapath-mode=tunnel --agent-image quay.io/isovalent/cilium-hubble-fgs --operator-image quay.io/cilium/operator-generic-ci --version latest --encryption
* ./cilium connectivity test

And
* ./cilium install --datapath-mode=tunnel --ipam=cluster-pool --agent-image quay.io/isovalent/cilium-hubble-fgs --operator-image quay.io/cilium/operator-generic-ci --version latest --encryption
* ./cilium connectivity test

All three pass 9/9/ tests successfully. To test transitions between encryption and non-encryption I cycled through above with `install --encryption`, `uninstall`, `install`, `uninstall`, `install --encryption`. This mostly works however with `--ipam=cluster-pool` case in GKE there is some flake where encryption does not come back online correctly in last case and tests fail. I am attempting to track that down now, but don't think it needs to block this series.