### PR TITLE
helm: global.registry support for hubble UI

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -33,7 +33,11 @@ spec:
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui
+{{- if contains "/" .Values.image.repository }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+{{- else }}
+          image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: NODE_ENV

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -1,7 +1,7 @@
 # Configuration for hubble ui
 image:
   # repository of the docker image
-  repository: quay.io/cilium/hubble-ui
+  repository: hubble-ui
   # tag is the container image tag to use.
   # Ref: https://github.com/cilium/hubble-ui/releases
   # Ref: https://quay.io/repository/cilium/hubble-ui?tab=tags


### PR DESCRIPTION
_**NOTE**: this PR is against the v1.8 branch._

Before this patch, hubble-ui was the only subchart not honoring `global.registry`.

```release-note
helm: the hubble-ui image now honor global.registry by default. If you were previously using global.registry without overriding global.hubble.ui.image.repository, you should either override hubble.ui.image.repository or expect the hubble-ui image to be pulled from global.registry.
```