### PR TITLE
Documentation: fix key rotation command in encryption guide

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -184,7 +184,7 @@ To replace cilium-ipsec-keys secret with a new keys,
 
 .. code-block:: shell-session
 
-    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml|grep keys: | awk '{print $2}' | base64 -d | awk '{print $1}')
+    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | awk '/^keys:/ {print $2}' | base64 -d | awk '{print $1}')
     if [[ $KEYID -gt 15 ]]; then KEYID=0; fi
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1


### PR DESCRIPTION
"kubectl get secret -n kube-system cilium-ipsec-keys" outputs two lines
with "keys:", one is the real key data and other is a "managedField":

$ kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | grep keys:
  keys: MyByZmM0MTA2KGdjbShhZXMpKSA3ZTE1YmZlNmQyZjczNGUzZmQ0YTEzM2FlZDU2MGQwMjEzZjBjNmRmIDEyOA==
        f:keys: {}

It makes the whole command to get the key id to fail:

$ KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml|grep keys: | awk '{print $2}' | base64 -d | awk '{print $1}')
base64: invalid input

This will be fixed in next Kubernetes release
(https://github.com/kubernetes/kubernetes/pull/96878), in the meanwhile
we can just use "-m 1" for grep to make it only return the first result.

Fixes: 4ea52ae1394b ("cilium: encryption, docs key updates")

Signed-off-by: Mauricio Vásquez <mauricio@accuknox.com>
Signed-off-by: Mauricio Vásquez <mauricio@kinvolk.io>