### PR TITLE
vagrant: Follow cilium-agent options on development VM to Helm defaults

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -306,7 +306,10 @@ function write_cilium_cfg() {
     ipv6_addr="${3}"
     filename="${4}"
 
-    cilium_options=" --debug --pprof --enable-hubble --hubble-listen-address :4244 --enable-k8s-event-handover --k8s-require-ipv4-pod-cidr"
+    cilium_options="\
+      --debug --pprof --enable-hubble --hubble-listen-address :4244 --enable-k8s-event-handover \
+      --k8s-require-ipv4-pod-cidr --enable-bandwidth-manager --kube-proxy-replacement probe \
+      --enable-remote-node-identity"
     cilium_operator_options=" --debug"
 
     if [[ "${IPV4}" -eq "1" ]]; then


### PR DESCRIPTION
Signed-off-by: Rei Shimizu <Shikugawa@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #15364 

This PR fixes inconsistency between development VM and helm based one.
It adds following options to cilium-agent like helm file.

`--kube-proxy-replacement probe`: https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml#L855
`--enable-remote-node-identity`: https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml#L973
`--enable-bandwitdh-manager`: https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml#L213

I found that `pprof` and `k8s-event-handover` are disabled on helm config. I'm not sure whether it causes inconsistency but nice to discuss that is truly needed if it is required or not on the development VM.
