### PR TITLE
ci: Increase time limit from 15m to 30m

### DIFF
--- a/.github/workflows/kind-1.19.yaml
+++ b/.github/workflows/kind-1.19.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   installation-and-connectivitiy:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
A few test runs have failed when waiting on images takes a bit longer.
Increase the limit to 30m.

*Note: This only affects the GItHub workflow. No reason to run the full CI.*