### PR TITLE
.travis: Disable email notifications on master failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,6 @@ before_script:
   - export PATH=/usr/local/clang/bin:$PATH
 
 script: ./.travis/build.sh
+
+notifications:
+  email: false


### PR DESCRIPTION
Until we fix the race builds, master will always fail. So let's disable email notifications for master builds to avoid spamming everyone. Email notifications are sent only for master builds by default, so this commit just disables email notifications in general.