### PR TITLE
docs: document final steps for nomination of new committers

### DIFF
--- a/Documentation/contributing/governance/commit_access.rst
+++ b/Documentation/contributing/governance/commit_access.rst
@@ -44,7 +44,9 @@ sensitive to the nuance of specific situations. In the end the decision
 to grant or revoke committer privileges is a judgment call made by the
 existing set of committers.
 
-For the list of current committers, see `Maintainers <https://raw.githubusercontent.com/cilium/cilium/master/MAINTAINERS.md>`_.
+For the list of current committers, see MAINTAINERS.md_.
+
+.. _MAINTAINERS.md: https://raw.githubusercontent.com/cilium/cilium/master/MAINTAINERS.md
 
 Expectations for Developers with commit access
 ----------------------------------------------
@@ -176,7 +178,10 @@ The process to grant commit access to a candidate is simple:
    web site.
 
 -  If the candidate agrees access is granted by setting up commit access
-   to the repos.
+   to the repos. The new committer is invited to the #committers Slack channel,
+   *after* the nomination poll and related discussions have been deleted. The
+   name of the new committer is also added to the list in the MAINTAINERS.md_
+   file.
 
 Revoking Commit Access
 ----------------------
@@ -320,7 +325,7 @@ Company Block Vote Limit
 
 In the spirit of ensuring a diverse community, the number of votes a single
 company can receive is limited to 6 votes. The company affiliation of
-maintainers and committers is documented in the MAINTAINERS.md file.
+maintainers and committers is documented in the MAINTAINERS.md_ file.
 
 Votes are counted within the company association and then broken down
 proportionally. Example: 7 committers from a company vote, 6 votes yes,


### PR DESCRIPTION
New committers are granted commit access to the Cilium repository, as explained in the documentation. Additionally:

- They should be invited to the #committers Slack channel, to take part in future discussions involving committers. Before that, the nomination poll for those committers should be removed. This is to avoid that, in the absence of an unanimous vote, there were some misunderstanding and ongoing grief between the persons voting against nomination and the new committer.

- They should be added to the MAINTAINERS.md file, which is supposed to be the official list of Committers for all unprivileged users who cannot see the list of individuals on the (private) #committers channel.
