### PR TITLE
test/helpers: Support non-standard nodes names with NO_CILIUM_ON_NODE

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -635,9 +635,19 @@ func (kub *Kubectl) labelNodes() error {
 		return fmt.Errorf("unable to unmarshal string slice '%#v': %s", nodesList, err)
 	}
 
-	index := 1
+	var (
+		index int = 1
+
+		noCiliumNode     = GetNodeWithoutCilium()
+		noCiliumNodeName string
+	)
 	for _, nodeName := range nodesList {
-		cmd := fmt.Sprintf("%s label --overwrite node %s cilium.io/ci-node=k8s%d", KubectlCmd, nodeName, index)
+		ciNodeName := fmt.Sprintf("k8s%d", index)
+		if GetNodeWithoutCilium() == ciNodeName {
+			noCiliumNodeName = nodeName
+		}
+
+		cmd := fmt.Sprintf("%s label --overwrite node %s cilium.io/ci-node=%s", KubectlCmd, nodeName, ciNodeName)
 		res := kub.ExecShort(cmd)
 		if !res.WasSuccessful() {
 			return fmt.Errorf("unable to label node with '%s': %s", cmd, res.OutputPrettyPrint())
@@ -645,11 +655,10 @@ func (kub *Kubectl) labelNodes() error {
 		index++
 	}
 
-	node := GetNodeWithoutCilium()
-	if node != "" {
+	if noCiliumNode != "" {
 		// Prevent scheduling any pods on the node, as it will be used as an external client
 		// to send requests to k8s{1,2}
-		cmd := fmt.Sprintf("%s taint --overwrite nodes %s key=value:NoSchedule", KubectlCmd, node)
+		cmd := fmt.Sprintf("%s taint --overwrite nodes %s key=value:NoSchedule", KubectlCmd, noCiliumNodeName)
 		res := kub.ExecMiddle(cmd)
 		if !res.WasSuccessful() {
 			return fmt.Errorf("unable to taint node with '%s': %s", cmd, res.OutputPrettyPrint())


### PR DESCRIPTION
This commit allows users to now run setups such as kind. Specifically,
this commit supports the `NO_CILIUM_ON_NODE` use case used in the
Services test suite extensively in kind-like setups.

In kind, the user has no control over the nodes names, so if the user
has a three node cluster, the naming scheme is as follows:

kind-control-plane -> "k8s1"
kind-worker        -> "k8s2"
kind-worker2       -> "k8s3"

Setting `NO_CILIUM_ON_NODE=kind-worker2` doesn't work as the CI code
assumes that the third node in this case is called "k8s3". Specifically,
setting the taints to declare the node as unschedulable fails because
the code uses the "k8s3" as the node name.

Instead of changing how the CI handles node naming all over the code,
the user should still pass "k8s3" as the "outside" node, because of the
existing naming scheme (see above). Now, the code will detect the real
node name ("kind-worker2") when setting the taints.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
