### PR TITLE
bpf: ignore errno 2 when deleting non-existing entry

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -981,7 +981,12 @@ func (m *Map) Delete(key MapKey) error {
 		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Errno2Outcome(errno)).Inc()
 	}
 	if errno != 0 {
-		err = fmt.Errorf("unable to delete element %s from map %s: %w", key, m.name, errno)
+		if errno == 2 {
+			// ignore errno 2 "no such file or directory"
+			m.scopedLogger().WithField("element", key).WithField("map", m.name).Warn("element not found")
+		} else {
+			err = fmt.Errorf("unable to delete element %s from map %s: %w", key, m.name, errno)
+		}
 	}
 	return err
 }

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -300,6 +300,9 @@ func (s *BPFPrivilegedTestSuite) TestBasicManipulation(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(value, checker.DeepEquals, value2)
 
+	// delete non-existing key
+	err = existingMap.Delete("404")
+	c.Assert(err, IsNil)
 	err = existingMap.Delete(key1)
 	c.Assert(err, IsNil)
 	// key    val


### PR DESCRIPTION
```release-note
Fix bug when deleting an non-existing entry
```

Note: errno 2 is "no such file or directory".

Previously if an entry doesn't exist in underlying map, an error will be returned
directly and the cache entry will be left there. This fix logs such event and
ignores the error so that cache deletion will go through.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

