### PR TITLE
test: make RunsOnNetNextKernel() helper work with KERNEL="net-next"

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -496,7 +496,11 @@ func failIfContainsBadLogMsg(logs, label string, blacklist map[string][]string) 
 // or bpf-next.git tree).
 func RunsOnNetNextKernel() bool {
 	netNext := os.Getenv("NETNEXT")
-	return netNext == "true" || netNext == "1"
+	if netNext == "true" || netNext == "1" {
+		return true
+	}
+	netNext = os.Getenv("KERNEL")
+	return netNext == "net-next"
 }
 
 // DoesNotRunOnNetNextKernel is the complement function of RunsOnNetNextKernel.


### PR DESCRIPTION
The NETNEXT environment variable, set to `1` or to `true`, has traditionally instructed the CI to use the net-next kernel for the Vagrant virtual machines. For some time, the KERNEL variable has also been assuming this role, if its value is set to `net-next` (see test/Vagrantfile). But the relevant helper in the CI is not aware of that, and when passing `KERNEL="net-next"` instead of `NETNEXT="true"`, ginkgo will skip tests that should run on the net-next kernel.

Let's update the relevant helper to fix this issue.

Fixes: #11061