### PR TITLE
ci: Fix local files chmod in test vagrantfile

### DIFF
--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
             }
 
             steps {
-                sh 'cd ${TESTDIR}; vagrant ssh k8s1-${K8S_VERSION} -c "cd /home/vagrant/go/${PROJ_PATH}; ./test/kubernetes-test.sh ${DOCKER_TAG}"'
+                sh 'cd ${TESTDIR}; vagrant ssh k8s1-${K8S_VERSION} -c "cd /home/vagrant/go/${PROJ_PATH}; sudo ./test/kubernetes-test.sh ${DOCKER_TAG}"'
             }
         }
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -221,8 +221,6 @@ Vagrant.configure("2") do |config|
                           "CILIUM_REGISTRY" => "#{$CILIUM_REGISTRY}"
                 }
             end
-            server.vm.provision :shell,
-                :inline => "sudo chmod -R 777 /home/vagrant/go/src"
         end
     end
 end


### PR DESCRIPTION
0ac54f42ba2371f1e183e41e2d986f8aab4ff619 causes local dev env to be
broken because of NFS mounted files being chmodded in the test vm.

This change uses sudo on previously failing test instead so that chmod
is not needed.