### PR TITLE
helm: allow setting blacklist-conflicting-routes

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -58,6 +58,7 @@ contributors across the globe, there is almost always someone available to help.
 | autoDirectNodeRoutes | bool | `false` |  |
 | azure.enabled | bool | `false` | Enable Azure integration |
 | bandwidthManager | bool | `true` | Optimize TCP and UDP workloads and enable rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
+| blacklistConflictingRoutes | bool | `true` | Configure if conflicting routes are blacklisted (true by default). |
 | bpf.clockProbe | bool | `false` |  |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of entries in the TCP connection tracking table. ctTcpMax: '524288' -- Configure the maximum number of entries for the non-TCP connection tracking table. ctAnyMax: '262144' -- Configure the maximum number of service entries in the load balancer maps. |
 | bpf.monitorAggregation | string | `"medium"` | Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/v1.9/concepts/ebpf/maps/#ebpf-maps -- Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -680,6 +680,10 @@ data:
   k8s-service-proxy-name: {{ .Values.k8s.serviceProxyName | quote }}
 {{- end }}
 
+{{- if hasKey .Values "blacklistConflictingRoutes" }}
+  blacklist-conflicting-routes: {{ .Values.blacklistConflictingRoutes | quote }}
+{{- end }}
+
 {{- if .Values.extraConfig }}
 {{ toYaml .Values.extraConfig | indent 2 }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1576,3 +1576,6 @@ clustermesh:
 externalWorkloads:
   # -- Enable support for external workloads, such as VMs (false by default).
   enabled: false
+
+# -- Configure if conflicting routes are blacklisted (true by default).
+blacklistConflictingRoutes: true


### PR DESCRIPTION
So far the Helm chart does not allow changing the blacklist-conflicting-routes
setting. This adds a blacklistConflictingRoutes setting to values.yaml which
by default is set to true and references its value in the created ConfigMap.

```release-note
helm: allow setting blacklist-conflicting-routes
```
