### PR TITLE
iptables: use CILIUM_* chains for per-endpoint no CT rules

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -715,20 +715,20 @@ func noTrackRules(prog string, cmd string, IP string, port *lb.L4Addr, ingress b
 	protocol := strings.ToLower(port.Protocol)
 	p := strconv.FormatUint(uint64(port.Port), 10)
 	if ingress {
-		if _, err := runProgCombinedOutput(prog, []string{"-t", "raw", cmd, "PREROUTING", "-p", protocol, "-d", IP, "--dport", p, "-j", "NOTRACK"}, false); err != nil {
+		if _, err := runProgCombinedOutput(prog, []string{"-t", "raw", cmd, ciliumPreRawChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "NOTRACK"}, false); err != nil {
 			return err
 		}
-		if _, err := runProgCombinedOutput(prog, []string{"-t", "filter", cmd, "INPUT", "-p", protocol, "-d", IP, "--dport", p, "-j", "ACCEPT"}, false); err != nil {
+		if _, err := runProgCombinedOutput(prog, []string{"-t", "filter", cmd, ciliumInputChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "ACCEPT"}, false); err != nil {
 			return err
 		}
-		if _, err := runProgCombinedOutput(prog, []string{"-t", "raw", cmd, "OUTPUT", "-p", protocol, "-d", IP, "--dport", p, "-j", "NOTRACK"}, false); err != nil {
+		if _, err := runProgCombinedOutput(prog, []string{"-t", "raw", cmd, ciliumOutputRawChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "NOTRACK"}, false); err != nil {
 			return err
 		}
 	} else {
-		if _, err := runProgCombinedOutput(prog, []string{"-t", "raw", cmd, "OUTPUT", "-p", protocol, "-s", IP, "--sport", p, "-j", "NOTRACK"}, false); err != nil {
+		if _, err := runProgCombinedOutput(prog, []string{"-t", "raw", cmd, ciliumOutputRawChain, "-p", protocol, "-s", IP, "--sport", p, "-j", "NOTRACK"}, false); err != nil {
 			return err
 		}
-		if _, err := runProgCombinedOutput(prog, []string{"-t", "filter", cmd, "OUTPUT", "-p", protocol, "-s", IP, "--sport", p, "-j", "ACCEPT"}, false); err != nil {
+		if _, err := runProgCombinedOutput(prog, []string{"-t", "filter", cmd, ciliumOutputChain, "-p", protocol, "-s", IP, "--sport", p, "-j", "ACCEPT"}, false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
These per-endpoint no CT rules should be added to the Cilium managed
chains rather than to the Iptables default ones as otherwise during
initialization the agent will keep readding them even if they are
already present.

Here's an example: a pod with the `io.cilium.no-track-port` annotation
is created and the rules are correctly added:

    vagrant@k8s1:~/go/src/github.com/cilium/cilium/mydev$ sudo iptables -t raw -L PREROUTING
    Chain PREROUTING (policy ACCEPT)
    target     prot opt source               destination
    CILIUM_PRE_raw  all  --  anywhere             anywhere             /* cilium-feeder: CILIUM_PRE_raw */
    CT         tcp  --  anywhere             10.11.0.14           tcp dpt:domain NOTRACK
    CT         udp  --  anywhere             10.11.0.14           udp dpt:domain NOTRACK
    vagrant@k8s1:~/go/src/github.com/cilium/cilium/mydev$ sudo iptables -t raw -L OUTPUT
    Chain OUTPUT (policy ACCEPT)
    target     prot opt source               destination
    CILIUM_OUTPUT_raw  all  --  anywhere             anywhere             /* cilium-feeder: CILIUM_OUTPUT_raw */
    CT         tcp  --  anywhere             10.11.0.14           tcp dpt:domain NOTRACK
    CT         tcp  --  10.11.0.14           anywhere             tcp spt:domain NOTRACK
    CT         udp  --  anywhere             10.11.0.14           udp dpt:domain NOTRACK
    CT         udp  --  10.11.0.14           anywhere             udp spt:domain NOTRACK

However when the agent is restarted the same rules are incorrectly
appended again:

    vagrant@k8s1:~/go/src/github.com/cilium/cilium/mydev$ sudo iptables -t raw -L PREROUTING
    Chain PREROUTING (policy ACCEPT)
    target     prot opt source               destination
    CILIUM_PRE_raw  all  --  anywhere             anywhere             /* cilium-feeder: CILIUM_PRE_raw */
    CT         tcp  --  anywhere             10.11.0.14           tcp dpt:domain NOTRACK
    CT         udp  --  anywhere             10.11.0.14           udp dpt:domain NOTRACK
    CT         tcp  --  anywhere             10.11.0.14           tcp dpt:domain NOTRACK
    CT         udp  --  anywhere             10.11.0.14           udp dpt:domain NOTRACK
    vagrant@k8s1:~/go/src/github.com/cilium/cilium/mydev$ sudo iptables -t raw -L OUTPUT
    Chain OUTPUT (policy ACCEPT)
    target     prot opt source               destination
    CILIUM_OUTPUT_raw  all  --  anywhere             anywhere             /* cilium-feeder: CILIUM_OUTPUT_raw */
    CT         tcp  --  anywhere             10.11.0.14           tcp dpt:domain NOTRACK
    CT         tcp  --  10.11.0.14           anywhere             tcp spt:domain NOTRACK
    CT         udp  --  anywhere             10.11.0.14           udp dpt:domain NOTRACK
    CT         udp  --  10.11.0.14           anywhere             udp spt:domain NOTRACK
    CT         tcp  --  anywhere             10.11.0.14           tcp dpt:domain NOTRACK
    CT         tcp  --  10.11.0.14           anywhere             tcp spt:domain NOTRACK
    CT         udp  --  anywhere             10.11.0.14           udp dpt:domain NOTRACK
    CT         udp  --  10.11.0.14           anywhere             udp spt:domain NOTRACK

Fixes: e463cfe ("Adds iptables managment for nodelocaldns")
Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>