### PR TITLE
Add warning log when host enable SELinux

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -37,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/sysctl"
 	wireguardTypes "github.com/cilium/cilium/pkg/wireguard/types"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func initKubeProxyReplacementOptions() (strict bool) {
@@ -355,6 +357,10 @@ func probeCgroupSupportTCP(strict, ipv4 bool) {
 	if err != nil {
 		scopedLog := log.WithError(err)
 		msg := "BPF host reachable services for TCP needs kernel 4.17.0 or newer."
+		if errors.Is(err, unix.EPERM) {
+			msg = "Cilium cannot load bpf programs. Security profiles like SELinux may be restricting permissions."
+		}
+
 		if strict {
 			scopedLog.Fatal(msg)
 		} else {
@@ -375,6 +381,10 @@ func probeCgroupSupportUDP(strict, ipv4 bool) {
 	if err != nil {
 		scopedLog := log.WithError(err)
 		msg := fmt.Sprintf("BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --%s=tcp and --%s=%s", option.HostReachableServicesProtos, option.KubeProxyReplacement, option.KubeProxyReplacementPartial)
+		if errors.Is(err, unix.EPERM) {
+			msg = "Cilium cannot load bpf programs. Security profiles like SELinux may be restricting permissions."
+		}
+
 		if strict {
 			scopedLog.Fatal(msg)
 		} else {


### PR DESCRIPTION
If host enable SELinux. Program running on the container doesn't  allow invoke bpf syscall with load option. The logs like this
```
type=AVC msg=audit(1616403520.545:155): avc:  denied  { prog_load } for  pid=3778 comm="bpftest" scontext=system_u:system_r:unconfined_service_t:s0 tcontext=system_u:system_r:unconfined_service_t:s0 tclass=bpf permissive=0
type=SYSCALL msg=audit(1616403520.545:155): arch=c000003e syscall=321 success=no exit=-13 a0=5 a1=c00005ee10 a2=48 a3=6 items=0 ppid=3622 pid=3778 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=4294967295 comm="bpftest" exe="/home/cilium/bpftest" subj=system_u:system_r:unconfined_service_t:s0 key=(null)
type=PROCTITLE msg=audit(1616403520.545:155): proctitle="./bpftest"
```

So if user running cilium with enable `host reachable service` on a host with correct kernel version(4.19.57, 5.1.16, 5.2.0 or newer) and SELinux enabled. It still display such error:
```
BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify
```
It makes user confuse about this log, because there kernel version was correct.

So I add the warning message tell user they need to disable SELinux when the cilium start faild due to  SELinux enabled.

