### PR TITLE
ci: add gke workflow

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,0 +1,120 @@
+name: ConformanceGKE
+
+on:
+  pull_request_target:
+    types:
+      - "labeled"
+  #pull_request: #uncomment for testing
+  #  types:
+  #    - "labeled"
+  push:
+    branches:
+      - master
+
+env:
+  clusterName: cilium-cli-ci-${{ github.run_number }}
+  zone: us-west2-a
+
+jobs:
+  installation-and-connectivitiy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ github.event.label.name == 'ci-run/gke' || github.event_name == 'push' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set image tag
+        id: vars
+        run: |
+          if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
+            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+          else
+            echo ::set-output name=tag::${{ github.sha }}
+          fi
+
+      - name: Install Cilium CLI
+        run: |
+          curl -LO https://github.com/cilium/cilium-cli/releases/download/v0.4/cilium-linux-amd64.tar.gz
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_PR_SA_KEY }}
+          export_default_credentials: true
+
+      - name: gcloud info
+        run: |
+          gcloud info
+
+      - name: Create GKE cluster
+        run: |
+          gcloud container clusters create ${{ env.clusterName }} \
+            --preemptible \
+            --labels "usage=pr,owner=${{ github.event.pull_request.number }}" \
+            --image-type COS \
+            --num-nodes 2 \
+            --machine-type n1-standard-4 \
+            --zone ${{ env.zone }}
+
+      - name: Get Credentials
+        run: |
+          gcloud container clusters get-credentials ${{ env.clusterName }} --zone ${{ env.zone }}
+
+      - name: Wait for images to be available
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+
+      - name: Install cilium
+        run: |
+          cilium install \
+            --cluster-name=${{ env.clusterName }} \
+            --restart-unmanaged-pods=false \
+            --config monitor-aggregation=none \
+            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --version ${{ steps.vars.outputs.tag }}
+
+      - name: Enable Relay
+        run: |
+          cilium hubble enable
+
+      - name: Status
+        run: |
+          cilium status --wait
+
+      - name: Relay Port Forward
+        run: |
+          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          sleep 5s
+
+      - name: Connectivity Test
+        run: |
+          cilium connectivity test
+
+      - name: Uninstall cilium
+        run: |
+          cilium uninstall --wait
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          cilium status
+          kubectl get pods --all-namespaces -o wide
+          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
+          python cilium-sysdump.zip --output cilium-sysdump-out
+          gcloud container clusters delete --quiet ${{ env.clusterName }} --zone ${{ env.zone }}
+
+      - name: Upload Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip
+          retention-days: 5


### PR DESCRIPTION
This is an adapted workflow from cilium-cli repo

note - actual gke runs are running in https://github.com/cilium/cilium/pull/15421 to actually test these changes, but we want to use pull_request_target here so this PR is actually going to get merged after https://github.com/cilium/cilium/pull/15421 passes and reviews are in