### PR TITLE
install: Disable kube-proxy-replacement by default

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -339,6 +339,9 @@ Annotations:
   current behavior, set the value to ``1`` in the ``CiliumNode`` resource.
 * The legacy flannel integration has been deprecated. If you want to chain on
   top of flannel, use the standard chaining method.
+* The default setting for ``kubeProxyReplacement`` has been changed from
+  ``probe`` to ``disabled``. For any new installation, if you want to use
+  kube-proxy replacement, set  ``kubeProxyReplacement`` to ``strict``.
 
 Removed Metrics/Labels
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -251,8 +251,7 @@ contributors across the globe, there is almost always someone available to help.
 | k8s | object | `{}` | Configure Kubernetes specific configuration |
 | keepDeprecatedLabels | bool | `false` | requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR range via the Kubernetes node resource requireIPv6PodCIDR: false -- Keep the deprecated selector labels when deploying Cilium DaemonSet |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
-| kubeProxyReplacement | string | `"probe"` | Configure the kube-proxy replacement in Cilium BPF datapath Valid options are "disabled", "probe", "partial", "strict". ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/ |
-| kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
+| kubeProxyReplacementHealthzBindAddr | string | `""` | Configure the kube-proxy replacement in Cilium BPF datapath Valid options are "disabled", "probe", "partial", "strict". ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/ -- healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | localRedirectPolicy | bool | `false` |  |
 | logSystemLoad | bool | `false` |  |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -13,6 +13,7 @@
 {{- $enableIdentityMark := "true" -}}
 {{- $fragmentTracking := "true" -}}
 {{- $crdWaitTimeout := "5m" -}}
+{{- $defaultKubeProxyReplacement := "probe" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -31,9 +32,15 @@
 {{- $defaultBpfCtAnyMax = 0 -}}
 {{- end -}}
 
+{{- /* Default values when 1.10 was initially deployed */ -}}
+{{- if semverCompare ">=1.10" (default "1.10" .Values.upgradeCompatibility) -}}
+{{- $defaultKubeProxyReplacement = "disabled" -}}
+{{- end -}}
+
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
+{{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement $defaultKubeProxyReplacement) -}}
 
 apiVersion: v1
 kind: ConfigMap
@@ -486,12 +493,11 @@ data:
   devices: {{ join " " .Values.devices | quote }}
 {{- end }}
 
-{{- if hasKey .Values "kubeProxyReplacement" }}
-  kube-proxy-replacement:  {{ .Values.kubeProxyReplacement | quote }}
-{{- if ne .Values.kubeProxyReplacement "disabled" }}
+  kube-proxy-replacement:  {{ $kubeProxyReplacement | quote }}
+{{- if ne $kubeProxyReplacement "disabled" }}
   kube-proxy-replacement-healthz-bind-address: {{ default "" .Values.kubeProxyReplacementHealthzBindAddr | quote}}
 {{- end }}
-{{- end }}
+
 {{- if hasKey .Values "hostServices" }}
 {{- if .Values.hostServices.enabled }}
   enable-host-reachable-services: {{ .Values.hostServices.enabled | quote }}
@@ -501,17 +507,17 @@ data:
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "hostPort" }}
-{{- if eq .Values.kubeProxyReplacement "partial" }}
+{{- if eq $kubeProxyReplacement "partial" }}
   enable-host-port: {{ .Values.hostPort.enabled | quote }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "externalIPs" }}
-{{- if eq .Values.kubeProxyReplacement "partial" }}
+{{- if eq $kubeProxyReplacement "partial" }}
   enable-external-ips: {{ .Values.externalIPs.enabled | quote }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "nodePort" }}
-{{- if eq .Values.kubeProxyReplacement "partial" }}
+{{- if eq $kubeProxyReplacement "partial" }}
   enable-node-port: {{ .Values.nodePort.enabled | quote }}
 {{- end }}
 {{- if hasKey .Values.nodePort "range" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -898,7 +898,7 @@ keepDeprecatedProbes: false
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
 # Valid options are "disabled", "probe", "partial", "strict".
 # ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/
-kubeProxyReplacement: "probe"
+#kubeProxyReplacement: "disabled"
 
 # -- healthz server bind address for the kube-proxy replacement.
 # To enable set the value to '0.0.0.0:10256' for all ipv4


### PR DESCRIPTION
The default value of "probe" is not ideal. It leads to a situation where
users are unaware who is performing the load-balancing. This can be
desirable for some and undesirable for others. A couple of
examples:

 * It typically leads to users continuing to run kube-proxy
 * It can lead to a situation where users believe they are running
   in kube-proxy replacement mode but the kernel requirement disables
   the feature automatically.
 * Automatic enabling of host-services can lead to incompatibility with
   Istio. Because of a the probe nature, a kernel upgrade in a cluster
   can lead to sudden issues with Istio without any additional action by
   the user.

It is generally preferred for users to take an explicit action to enable
kube-proxy and set it to strict so the cilium-agent fails if the mode is
not available.