### PR TITLE
Adds a new IPAMNone option

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1408,7 +1408,9 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.LocalRouterIPv4 != "" || option.Config.LocalRouterIPv6 != "" {
-		// TODO(weil0ng): add a proper check for ipam in PR# 15429.
+		if option.Config.IPAM != ipamOption.IPAMNone {
+			log.Fatalf("%s and/or %s can only be specified with %s=%s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.IPAM, ipamOption.IPAMNone)
+		}
 		if option.Config.Tunnel != option.TunnelDisabled {
 			log.Fatalf("Cannot specify %s or %s in tunnel mode.", option.LocalRouterIPv4, option.LocalRouterIPv6)
 		}
@@ -1417,6 +1419,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 		if option.Config.EnableIPSec {
 			log.Fatalf("Cannot specify %s or %s with %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableIPSecName)
+		}
+	}
+
+	if option.Config.IPAM == ipamOption.IPAMNone {
+		if option.Config.LocalRouterIPv4 == "" && option.Config.LocalRouterIPv6 == "" {
+			log.Fatalf("%s and/or %s must be specified when %s=%s", option.LocalRouterIPv4, option.LocalRouterIPv6, option.IPAM, ipamOption.IPAMNone)
 		}
 	}
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -178,7 +178,7 @@ func (d *Daemon) allocateRouterIPv4(family datapath.NodeAddressingFamily) (net.I
 	if option.Config.LocalRouterIPv4 != "" {
 		routerIP := net.ParseIP(option.Config.LocalRouterIPv4)
 		if routerIP == nil {
-			return nil, fmt.Errorf("Invalid local-router-ip: %s", option.Config.LocalRouterIPv4)
+			return nil, fmt.Errorf("Invalid local-router-ipv4: %s", option.Config.LocalRouterIPv4)
 		}
 		if d.datapath.LocalNodeAddressing().IPv4().AllocationCIDR().Contains(routerIP) {
 			log.Warn("Specified router IP is within IPv4 podCIDR.")
@@ -193,7 +193,7 @@ func (d *Daemon) allocateRouterIPv6(family datapath.NodeAddressingFamily) (net.I
 	if option.Config.LocalRouterIPv6 != "" {
 		routerIP := net.ParseIP(option.Config.LocalRouterIPv6)
 		if routerIP == nil {
-			return nil, fmt.Errorf("Invalid local-router-ip: %s", option.Config.LocalRouterIPv6)
+			return nil, fmt.Errorf("Invalid local-router-ipv6: %s", option.Config.LocalRouterIPv6)
 		}
 		if d.datapath.LocalNodeAddressing().IPv6().AllocationCIDR().Contains(routerIP) {
 			log.Warn("Specified router IP is within IPv6 podCIDR.")

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -130,6 +130,8 @@ func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owne
 		if c.IPv4Enabled() {
 			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, k8sEventReg, mtuConfig)
 		}
+	case ipamOption.IPAMNone:
+		log.Info("Disabling Cilium's IP allocation")
 	default:
 		log.Fatalf("Unknown IPAM backend %s", c.IPAMMode())
 	}

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -36,4 +36,7 @@ const (
 
 	// IPAMAlibabaCloud is the value to select the AlibabaCloud ENI IPAM plugin for option.IPAM
 	IPAMAlibabaCloud = "alibabacloud"
+
+	// IPAMNone is the value to stop Cilium from handling IPAM
+	IPAMNone = "none"
 )


### PR DESCRIPTION
This is used to specify Cilium should not handle IPAM. When this option
is selected, we will spin up a dummy IPAM which does not do IP
allocation.
