### PR TITLE
Recognize node address changes and reflect in ciliumnode

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -382,7 +382,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	d.k8sWatcher = watchers.NewK8sWatcher(
 		d.endpointManager,
-		d.nodeDiscovery.Manager,
+		d.nodeDiscovery,
 		&d,
 		d.policy,
 		d.svc,

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -203,7 +203,7 @@ func (k *K8sWatcher) addCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface
 		updateContext := &k8s.CNPStatusUpdateContext{
 			CiliumNPClient:              ciliumNPClient,
 			NodeName:                    nodeTypes.GetName(),
-			NodeManager:                 k.nodeDiscoverManager,
+			NodeManager:                 k.nodeDiscovery.Manager,
 			UpdateDuration:              spanstat.Start(),
 			WaitForEndpointsAtPolicyRev: k.endpointManager.WaitForEndpointsAtPolicyRev,
 		}
@@ -333,7 +333,7 @@ func (k *K8sWatcher) updateCiliumNetworkPolicyV2AnnotationsOnly(ciliumNPClient c
 	updateContext := &k8s.CNPStatusUpdateContext{
 		CiliumNPClient:              ciliumNPClient,
 		NodeName:                    nodeTypes.GetName(),
-		NodeManager:                 k.nodeDiscoverManager,
+		NodeManager:                 k.nodeDiscovery.Manager,
 		UpdateDuration:              spanstat.Start(),
 		WaitForEndpointsAtPolicyRev: k.endpointManager.WaitForEndpointsAtPolicyRev,
 	}

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -50,7 +50,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 						if n.IsLocal() {
 							return
 						}
-						k.nodeDiscoverManager.NodeUpdated(n)
+						k.nodeDiscovery.Manager.NodeUpdated(n)
 						k.K8sEventProcessed(metricCiliumNode, metricCreate, true)
 					}
 				},
@@ -68,7 +68,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 							if n.IsLocal() {
 								return
 							}
-							k.nodeDiscoverManager.NodeUpdated(n)
+							k.nodeDiscovery.Manager.NodeUpdated(n)
 							k.K8sEventProcessed(metricCiliumNode, metricUpdate, true)
 						}
 					}
@@ -82,7 +82,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 					}
 					valid = true
 					n := nodeTypes.ParseCiliumNode(ciliumNode)
-					k.nodeDiscoverManager.NodeDeleted(n)
+					k.nodeDiscovery.Manager.NodeDeleted(n)
 				},
 			},
 			k8s.ConvertToCiliumNode,


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!


Addresses of node objects may change, especially during startup.
Depending on the cloud provider implementation CCM may add to or change
the node status.addresses field.
Cilium needs to watch for certain changes and sync them to the
ciliumnode object in order to have networking configured how it's
intended by the cloud provider.

Fixes: #15406

Signed-off-by: Ingo Gottwald <igottwald@digitalocean.com>

```release-note
Recognize node address changes and reflect them in ciliumnode objects.
```
