### PR TITLE
v1.8 backports 2021-03-23

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -61,7 +61,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 #ifdef ENABLE_ROUTING
 	union macaddr router_mac = NODE_MAC;
 #endif
-	int ret, verdict, l4_off, hdrlen;
+	int ret, verdict = 0, l4_off, hdrlen;
 	struct csum_offset csum_off = {};
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
@@ -171,12 +171,22 @@ skip_service_lookup:
 			   orig_dip.p4, *dstID);
 	}
 
+	/* When an endpoint connects to itself via service clusterIP, we need
+	 * to skip the policy enforcement. If we didn't, the user would have to
+	 * define policy rules to allow pods to talk to themselves. We still
+	 * want to execute the conntrack logic so that replies can be correctly
+	 * matched.
+	 */
+	if (hairpin_flow)
+		goto skip_policy_enforcement;
+
 	/* If the packet is in the establishing direction and it's destined
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check.
 	 */
 	verdict = policy_can_egress6(ctx, tuple, SECLABEL, *dstID,
 				     &policy_match_type, &audited);
+
 	if (ret != CT_REPLY && ret != CT_RELATED && verdict < 0) {
 		send_policy_verdict_notify(ctx, *dstID, tuple->dport,
 					   tuple->nexthdr, POLICY_EGRESS, 1,
@@ -184,11 +194,13 @@ skip_service_lookup:
 		return verdict;
 	}
 
+skip_policy_enforcement:
 	switch (ret) {
 	case CT_NEW:
-		send_policy_verdict_notify(ctx, *dstID, tuple->dport,
-					   tuple->nexthdr, POLICY_EGRESS, 1,
-					   verdict, policy_match_type, audited);
+		if (!hairpin_flow)
+			send_policy_verdict_notify(ctx, *dstID, tuple->dport,
+						   tuple->nexthdr, POLICY_EGRESS, 1,
+						   verdict, policy_match_type, audited);
 ct_recreate6:
 		/* New connection implies that rev_nat_index remains untouched
 		 * to the index provided by the loadbalancer (if it applied).
@@ -204,9 +216,10 @@ ct_recreate6:
 		break;
 
 	case CT_REOPENED:
-		send_policy_verdict_notify(ctx, *dstID, tuple->dport,
-					   tuple->nexthdr, POLICY_EGRESS, 1,
-					   verdict, policy_match_type, audited);
+		if (!hairpin_flow)
+			send_policy_verdict_notify(ctx, *dstID, tuple->dport,
+						   tuple->nexthdr, POLICY_EGRESS, 1,
+						   verdict, policy_match_type, audited);
 	case CT_ESTABLISHED:
 		/* Did we end up at a stale non-service entry? Recreate if so. */
 		if (unlikely(ct_state.rev_nat_index != ct_state_new.rev_nat_index))
@@ -446,7 +459,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 #endif
 	void *data, *data_end;
 	struct iphdr *ip4;
-	int ret, verdict, l3_off = ETH_HLEN, l4_off;
+	int ret, verdict = 0, l3_off = ETH_HLEN, l4_off;
 	struct csum_offset csum_off = {};
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
@@ -548,6 +561,15 @@ skip_service_lookup:
 			   orig_dip, *dstID);
 	}
 
+	/* When an endpoint connects to itself via service clusterIP, we need
+	 * to skip the policy enforcement. If we didn't, the user would have to
+	 * define policy rules to allow pods to talk to themselves. We still
+	 * want to execute the conntrack logic so that replies can be correctly
+	 * matched.
+	 */
+	if (hairpin_flow)
+		goto skip_policy_enforcement;
+
 	/* If the packet is in the establishing direction and it's destined
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check.
@@ -562,11 +584,13 @@ skip_service_lookup:
 		return verdict;
 	}
 
+skip_policy_enforcement:
 	switch (ret) {
 	case CT_NEW:
-		send_policy_verdict_notify(ctx, *dstID, tuple.dport,
-					   tuple.nexthdr, POLICY_EGRESS, 0,
-					   verdict, policy_match_type, audited);
+		if (!hairpin_flow)
+			send_policy_verdict_notify(ctx, *dstID, tuple.dport,
+						   tuple.nexthdr, POLICY_EGRESS, 0,
+						   verdict, policy_match_type, audited);
 ct_recreate4:
 		/* New connection implies that rev_nat_index remains untouched
 		 * to the index provided by the loadbalancer (if it applied).
@@ -584,9 +608,10 @@ ct_recreate4:
 		break;
 
 	case CT_REOPENED:
-		send_policy_verdict_notify(ctx, *dstID, tuple.dport,
-					   tuple.nexthdr, POLICY_EGRESS, 0,
-					   verdict, policy_match_type, audited);
+		if (!hairpin_flow)
+			send_policy_verdict_notify(ctx, *dstID, tuple.dport,
+						   tuple.nexthdr, POLICY_EGRESS, 0,
+						   verdict, policy_match_type, audited);
 	case CT_ESTABLISHED:
 		/* Did we end up at a stale non-service entry? Recreate if so. */
 		if (unlikely(ct_state.rev_nat_index != ct_state_new.rev_nat_index))
@@ -1094,7 +1119,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	void *data, *data_end;
 	struct iphdr *ip4;
 	struct csum_offset csum_off = {};
-	int ret, verdict, l3_off = ETH_HLEN, l4_off;
+	int ret, verdict = 0, l3_off = ETH_HLEN, l4_off;
 	struct ct_state ct_state = {};
 	struct ct_state ct_state_new = {};
 	bool skip_ingress_proxy = false;
@@ -1169,6 +1194,17 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 			return ret2;
 	}
 
+#if !defined(ENABLE_HOST_SERVICES_FULL) && !defined(DISABLE_LOOPBACK_LB)
+	/* When an endpoint connects to itself via service clusterIP, we need
+	 * to skip the policy enforcement. If we didn't, the user would have to
+	 * define policy rules to allow pods to talk to themselves. We still
+	 * want to execute the conntrack logic so that replies can be correctly
+	 * matched.
+	 */
+	if (unlikely(ct_state.loopback))
+		goto skip_policy_enforcement;
+#endif /* !ENABLE_HOST_SERVICES_FULL && !DISABLE_LOOPBACK_LB */
+
 	verdict = policy_can_access_ingress(ctx, src_label, SECLABEL,
 					    tuple.dport, tuple.nexthdr,
 					    is_untracked_fragment,
@@ -1192,6 +1228,10 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 					   tuple.nexthdr, POLICY_INGRESS, 0,
 					   verdict, policy_match_type, audited);
 	}
+
+#if !defined(ENABLE_HOST_SERVICES_FULL) && !defined(DISABLE_LOOPBACK_LB)
+skip_policy_enforcement:
+#endif /* !ENABLE_HOST_SERVICES_FULL && !DISABLE_LOOPBACK_LB */
 
 	if (ret == CT_NEW) {
 #ifdef ENABLE_DSR

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -7,6 +7,8 @@
 #include <ep_config.h>
 #include <node_config.h>
 
+#include <bpf/verifier.h>
+
 #include <linux/icmpv6.h>
 
 #define EVENT_SOURCE LXC_ID
@@ -1139,6 +1141,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	/* Check it this is return traffic to an egress proxy.
 	 * Do not redirect again if the packet is coming from the egress proxy.
 	 */
+	relax_verifier();
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect &&
 	    !tc_index_skip_egress_proxy(ctx)) {
 		/* This is a reply, the proxy port does not need to be embedded

--- a/bpf/include/bpf/verifier.h
+++ b/bpf/include/bpf/verifier.h
@@ -4,7 +4,7 @@
 #ifndef __BPF_VERIFIER__
 #define __BPF_VERIFIER__
 
-#include "csum.h"
+#include "compiler.h"
 
 /* relax_verifier is a dummy helper call to introduce a pruning checkpoint
  * to help relax the verifier to avoid reaching complexity limits on older
@@ -13,9 +13,7 @@
 static __always_inline void relax_verifier(void)
 {
 #ifdef NEEDS_RELAX_VERIFIER
-       int foo = 0;
-
-       csum_diff(0, 0, &foo, 1, 0);
+       volatile int __maybe_unused id = get_smp_processor_id();
 #endif
 }
 

--- a/bpf/include/bpf/verifier.h
+++ b/bpf/include/bpf/verifier.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2016-2020 Authors of Cilium */
+
+#ifndef __BPF_VERIFIER__
+#define __BPF_VERIFIER__
+
+#include "csum.h"
+
+/* relax_verifier is a dummy helper call to introduce a pruning checkpoint
+ * to help relax the verifier to avoid reaching complexity limits on older
+ * kernels.
+ */
+static __always_inline void relax_verifier(void)
+{
+#ifdef NEEDS_RELAX_VERIFIER
+       int foo = 0;
+
+       csum_diff(0, 0, &foo, 1, 0);
+#endif
+}
+
+#endif /* __BPF_VERIFIER__ */

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -7,6 +7,8 @@
 #include <linux/icmpv6.h>
 #include <linux/icmp.h>
 
+#include <bpf/verifier.h>
+
 #include "common.h"
 #include "utils.h"
 #include "ipv4.h"
@@ -206,6 +208,8 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 {
 	struct ct_entry *entry;
 	int reopen;
+
+	relax_verifier();
 
 	entry = map_lookup_elem(map, tuple);
 	if (entry) {
@@ -589,6 +593,8 @@ static __always_inline int ct_lookup4(const void *map,
 		}
 		goto out;
 	}
+
+	relax_verifier();
 
 	/* Lookup entry in forward direction */
 	if (dir != CT_SERVICE) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1236,6 +1236,10 @@ func initEnv(cmd *cobra.Command) {
 			option.EgressMultiHomeIPRuleCompat,
 		)
 	}
+
+	if !probes.NewProbeManager().GetMisc().HaveLargeInsnLimit {
+		option.Config.NeedsRelaxVerifier = true
+	}
 }
 
 func (d *Daemon) initKVStore() {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -187,6 +187,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if option.Config.NeedsRelaxVerifier {
+		cDefinesMap["NEEDS_RELAX_VERIFIER"] = "1"
+	}
+
 	cDefinesMap["TRACE_PAYLOAD_LEN"] = fmt.Sprintf("%dULL", option.Config.TracePayloadlen)
 	cDefinesMap["MTU"] = fmt.Sprintf("%d", cfg.MtuConfig.GetDeviceMTU())
 

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -129,11 +129,17 @@ type MapTypes struct {
 	HaveStackMapType               bool `json:"have_stack_map_type"`
 }
 
+// Misc contains bools exposing miscellaneous eBPF features.
+type Misc struct {
+	HaveLargeInsnLimit bool `json:"have_large_insn_limit"`
+}
+
 // Features contains BPF feature checks returned by bpftool.
 type Features struct {
 	SystemConfig `json:"system_config"`
 	MapTypes     `json:"map_types"`
 	Helpers      map[string][]string `json:"helpers"`
+	Misc         `json:"misc"`
 }
 
 // ProbeManager is a manager of BPF feature checks.
@@ -247,6 +253,11 @@ func (p *ProbeManager) SystemConfigProbes() error {
 // GetMapTypes returns information about supported BPF map types.
 func (p *ProbeManager) GetMapTypes() *MapTypes {
 	return &p.features.MapTypes
+}
+
+// GetMisc returns information about miscellaneous eBPF features.
+func (p *ProbeManager) GetMisc() *Misc {
+	return &p.features.Misc
 }
 
 // GetHelpers returns information about available BPF helpers for the given

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1937,6 +1937,11 @@ type DaemonConfig struct {
 	// store rules and routes under ENI and Azure IPAM modes, if false.
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat bool
+
+	// NeedsRelaxVerifier enables the relax_verifier() helper which is used
+	// to introduce state pruning points for the verifier in the datapath
+	// program.
+	NeedsRelaxVerifier bool
 }
 
 var (


### PR DESCRIPTION
 * #13347 -- bpf: add metrics for fragmented ipv4 packets (@jibi)
     - I backported only the commits that pertain to the complexity issue, those for `relax_verifier()`.
 * #15321 -- bpf: Skip policy enforcements for service loopback case (@aditighag)
     - No conflicts or changes to the upstream commit. The commits from #13347 were enough to fix the complexity issue it seems.

@joestringer I didn't set backport labels for #13347 because the "feature" introduced by that PR isn't backported here. Is it the right way to proceed?
 
Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15321; do contrib/backporting/set-labels.py $pr done 1.9; done
```
