### PR TITLE
Assign specific, unique ports for pprof (Agent, Operator, Hubble Relay)

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -193,6 +193,7 @@ cilium-agent [flags]
       --policy-audit-mode                                    Enable policy audit (non-drop) mode
       --policy-queue-size int                                size of queues for policy-related events (default 100)
       --pprof                                                Enable serving the pprof debugging API
+      --pprof-port int                                       Port that the pprof listens on (default 6060)
       --preallocate-bpf-maps                                 Enable BPF map pre-allocation (default true)
       --prefilter-device string                              Device facing external network for XDP prefiltering (default "undefined")
       --prefilter-mode string                                Prefilter mode via XDP ("native", "generic") (default "native")

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -62,6 +62,7 @@ cilium-operator-aws [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -63,6 +63,7 @@ cilium-operator-azure [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -58,6 +58,7 @@ cilium-operator-generic [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -67,6 +67,7 @@ cilium-operator [flags]
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
+      --pprof-port int                            Port that the pprof listens on (default 6061)
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter stringToString         Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag (default [])
       --synchronize-k8s-nodes                     Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -318,6 +318,9 @@ Port Range / Protocol    Description
 4240/tcp                 cluster health checks (``cilium-health``)
 4244/tcp                 Hubble server
 4245/tcp                 Hubble Relay
+6060/tcp                 cilium-agent pprof server (listening on 127.0.0.1)
+6061/tcp                 cilium-operator pprof server (listening on 127.0.0.1)
+6062/tcp                 Hubble Relay pprof server (listening on 127.0.0.1)
 6942/tcp                 operator Prometheus metrics
 9090/tcp                 cilium-agent Prometheus metrics
 9876/tcp                 cilium-agent health status API

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -728,6 +728,9 @@ func init() {
 	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
 	option.BindEnv(option.PProf)
 
+	flags.Int(option.PProfPort, 6060, "Port that the pprof listens on")
+	option.BindEnv(option.PProfPort)
+
 	flags.String(option.PrefilterDevice, "undefined", "Device facing external network for XDP prefiltering")
 	option.BindEnv(option.PrefilterDevice)
 
@@ -1056,7 +1059,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.PProf {
-		pprof.Enable()
+		pprof.Enable(option.Config.PProfPort)
 	}
 
 	if option.Config.PreAllocateMaps {

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	keyPprof                  = "pprof"
+	keyPprofPort              = "pprof-port"
 	keyGops                   = "gops"
 	keyGopsPort               = "gops-port"
 	keyDialTimeout            = "dial-timeout"
@@ -64,6 +65,9 @@ func New(vp *viper.Viper) *cobra.Command {
 	flags := cmd.Flags()
 	flags.Bool(
 		keyPprof, false, "Enable serving the pprof debugging API",
+	)
+	flags.Int(
+		keyPprofPort, defaults.PprofPort, "Port that the pprof listens on",
 	)
 	flags.Bool(
 		keyGops, true, "Run gops agent",
@@ -185,7 +189,7 @@ func runServe(vp *viper.Viper) error {
 	}
 
 	if vp.GetBool(keyPprof) {
-		pprof.Enable()
+		pprof.Enable(vp.GetInt(keyPprofPort))
 	}
 	gopsEnabled := vp.GetBool(keyGops)
 	if gopsEnabled {

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -251,6 +251,9 @@ func init() {
 	flags.Bool(operatorOption.PProf, false, "Enable pprof debugging endpoint")
 	option.BindEnv(operatorOption.PProf)
 
+	flags.Int(operatorOption.PProfPort, 6061, "Port that the pprof listens on")
+	option.BindEnv(operatorOption.PProfPort)
+
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(operatorOption.SyncK8sServices)
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -258,7 +258,7 @@ func runOperator() {
 	}
 
 	if operatorOption.Config.PProf {
-		pprof.Enable()
+		pprof.Enable(operatorOption.Config.PProfPort)
 	}
 
 	initK8s(k8sInitDone)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -76,6 +76,9 @@ const (
 	// PProf enabled pprof debugging endpoint
 	PProf = "pprof"
 
+	// PProfPort is the port that the pprof listens on
+	PProfPort = "pprof-port"
+
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
 
@@ -222,6 +225,9 @@ type OperatorConfig struct {
 	// PProf enables pprof debugging endpoint
 	PProf bool
 
+	// PProfPort is the port that the pprof listens on
+	PProfPort int
+
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices bool
 
@@ -335,6 +341,7 @@ func (c *OperatorConfig) Populate() {
 	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)
 	c.OperatorPrometheusServeAddr = viper.GetString(OperatorPrometheusServeAddr)
 	c.PProf = viper.GetBool(PProf)
+	c.PProfPort = viper.GetInt(PProfPort)
 	c.SyncK8sServices = viper.GetBool(SyncK8sServices)
 	c.SyncK8sNodes = viper.GetBool(SyncK8sNodes)
 	c.UnmanagedPodWatcherInterval = viper.GetInt(UnmanagedPodWatcherInterval)

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -28,6 +28,8 @@ const (
 	DialTimeout = 5 * time.Second
 	// GopsPort is the default port for gops to listen on.
 	GopsPort = 9893
+	// PprofPort is the default port for pprof to listen on.
+	PprofPort = 6062
 	// RetryTimeout is the duration to wait between reconnection attempts.
 	RetryTimeout = 30 * time.Second
 	// HubbleTarget is the address of the local Hubble instance.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -394,6 +394,9 @@ const (
 	// PProf enables serving the pprof debugging API
 	PProf = "pprof"
 
+	// PProfPort is the port that the pprof listens on
+	PProfPort = "pprof-port"
+
 	// PrefilterDevice is the device facing external network for XDP prefiltering
 	PrefilterDevice = "prefilter-device"
 
@@ -1036,6 +1039,7 @@ var HelpFlagSections = []FlagsSection{
 			EnableHealthChecking,
 			TracePayloadlen,
 			PProf,
+			PProfPort,
 		},
 	},
 	{
@@ -1677,6 +1681,7 @@ type DaemonConfig struct {
 	TracePayloadlen        int
 	Version                string
 	PProf                  bool
+	PProfPort              int
 	PrometheusServeAddr    string
 	ToFQDNsMinTTL          int
 
@@ -2649,6 +2654,7 @@ func (c *DaemonConfig) Populate() {
 	c.FlannelMasterDevice = viper.GetString(FlannelMasterDevice)
 	c.FlannelUninstallOnExit = viper.GetBool(FlannelUninstallOnExit)
 	c.PProf = viper.GetBool(PProf)
+	c.PProfPort = viper.GetInt(PProfPort)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -16,8 +16,10 @@
 package pprof
 
 import (
+	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -25,10 +27,9 @@ import (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "pprof")
 
-const apiAddress = "localhost:6060"
-
 // Enable runs an HTTP server to serve the pprof API
-func Enable() {
+func Enable(port int) {
+	var apiAddress = net.JoinHostPort("localhost", strconv.Itoa(port))
 	go func() {
 		if err := http.ListenAndServe(apiAddress, nil); err != nil {
 			log.WithError(err).Warn("Unable to serve pprof API")


### PR DESCRIPTION
This allows users to enable pprof for both cilium-agent and
cilium-operator on the same machine without running into:

```
level=warning msg="Unable to serve pprof API" error="listen tcp
127.0.0.1:6060: bind: address already in use" subsys=pprof
```

It also provides users with the ability to specify the port via a flag.
Note that this flag is not exposed via Helm because it is a flag mainly
used for debugging, and shouldn't need to be exposed fully to the user.
A developer / advanced user can just as easily edit the daemonset or the
deployment object to append an extra arg. Also, given the fact that the
ports are unique across the components, that reduces the need to
provide a knob via Helm.

To avoid port collisions, the Agent, Operator, and Hubble Relay are all
assigned the following specific ports respectively: 6060, 6061, 6062.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
