### PR TITLE
agent: Silence some useless warnings

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -555,7 +555,7 @@ func (e *Endpoint) setRegenerateStateLocked(regenMetadata *regeneration.External
 func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
 	regen, err := e.SetRegenerateStateIfAlive(regenMetadata)
 	if err != nil {
-		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
+		log.WithError(err).Debugf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
 	}
 	if regen {
 		// Regenerate logs status according to the build success/failure

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -66,7 +66,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 	)
 
 	if option.Config.DisableCiliumEndpointCRD {
-		scopedLog.Warn("Not running controller. CEP CRD synchronization is disabled")
+		scopedLog.Debug("Not running controller. CEP CRD synchronization is disabled")
 		return
 	}
 


### PR DESCRIPTION
These warnings describe situations that can happen regularly and are no
cause of concern. Convert them into debug log messages.
