### PR TITLE
daemon: Add command line option --tofqdns-idle-connection-grace-period

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -211,6 +211,7 @@ cilium-agent [flags]
       --tofqdns-dns-reject-response-code string              DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
       --tofqdns-enable-dns-compression                       Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-endpoint-max-ip-per-hostname int             Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-idle-connection-grace-period duration        Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
       --tofqdns-max-deferred-connection-deletes int          Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
       --tofqdns-min-ttl int                                  The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
       --tofqdns-pre-cache string                             DNS cache data at this path is preloaded on agent startup

--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -271,6 +271,29 @@ corresponds to the ``toFQDNS: matchName: "*"`` rule would list all identities
 for IPs that came from the DNS Proxy. Other CIDR identities would not be
 included.
 
+Unintended DNS Policy Drops
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``toFQDNSs`` policy enforcement relies on the source POD performing a DNS query
+before using an IP address returned in the DNS response. Sometimes PODs may hold
+on to a DNS response and start new connections to the same IP address at a later
+time. This may trigger policy drops if the DNS response has expired as
+requested by the DNS server in the time-to-live (TTL) value in the
+response. When DNS is used for service load balancing the advertised TTL value
+may be short (e.g., 60 seconds). To allow for reasonable POD behavior without
+unintended policy drops Cilium employs a configurable minimum DNS TTL value via
+``--tofqdns-min-ttl`` which defaults to 3600 seconds. This setting overrides
+short TTLs and allows the POD to use the IP address in the DNS response for one
+hour. Existing connections also keep the IP address as allowed in the
+policy. Any new connections opened by the POD using the same IP address without
+performing a new DNS query after the (possibly extended) DNS TTL has expired
+can be dropped by Cilium policy enforcement. To allow PODs to use the DNS
+response after TTL expiry for new connections a command line option
+``--tofqdns-idle-connection-grace-period`` may be used to keep the
+IP-address/name mapping valid in the policy for an extended time after DNS TTL
+expiry. This option takes effect only if the POD has opened at least one
+connection during the DNS TTL period.
+
 Datapath Plumbing
 ~~~~~~~~~~~~~~~~~
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -818,6 +818,9 @@ func init() {
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)
 
+	flags.DurationVar(&option.Config.ToFQDNsIdleConnectionGracePeriod, option.ToFQDNsIdleConnectionGracePeriod, defaults.ToFQDNsIdleConnectionGracePeriod, "Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)")
+	option.BindEnv(option.ToFQDNsIdleConnectionGracePeriod)
+
 	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 100*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(option.FQDNProxyResponseMaxDelay)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -230,9 +230,15 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 			cfg.Cache.ReplaceFromCacheByNames(namesToClean, caches...)
 
 			metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToClean)))
-			log.WithField(logfields.Controller, dnsGCJobName).Infof(
-				"FQDN garbage collector work deleted %d name entries", len(namesToClean))
 			_, err := d.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToClean)
+			namesCount := len(namesToClean)
+			// Limit the amount of info level logging to some sane amount
+			if namesCount > 20 {
+				// namedsToClean is only used for logging after this so we can reslice it in place
+				namesToClean = namesToClean[:20]
+			}
+			log.WithField(logfields.Controller, dnsGCJobName).Infof(
+				"FQDN garbage collector work deleted %d name entries: %s", namesCount, strings.Join(namesToClean, ","))
 			return err
 		},
 		Context: d.ctx,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -119,6 +119,11 @@ const (
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes = 10000
 
+	// ToFQDNsIdleConnectionGracePeriod Time during which idle but
+	// previously active connections with expired DNS lookups are
+	// still considered alive
+	ToFQDNsIdleConnectionGracePeriod = 0 * time.Second
+
 	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
 	// global cache on startup.
 	// The file is not re-read after agent start.

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -40,9 +40,9 @@ func (e *Endpoint) MarkDNSCTEntry(dstIP net.IP, now time.Time) {
 
 // MarkCTGCTime is the START time of a GC run. It is used by the DNS garbage
 // collector to determine whether a DNS zombie can be deleted. This is done by
-// comparing the timestamp of the start CT GC run with the ailve timestamps of
+// comparing the timestamp of the start CT GC run with the alive timestamps of
 // specific DNS zombies IPs marked with MarkDNSCTEntry.
-// NOTE: While the timestamp is ths start of the run, it should be set AFTER
+// NOTE: While the timestamp is the start of the run, it should be set AFTER
 // the run completes. This avoids a race between the DNS garbage collector and
 // the CT GC. This would occur when a DNS zombie that has not been visited by
 // the CT GC run is seen by a concurrent DNS garbage collector run, and then

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -424,6 +424,10 @@ const (
 	// retain for expired DNS lookups with still-active connections"
 	ToFQDNsMaxDeferredConnectionDeletes = "tofqdns-max-deferred-connection-deletes"
 
+	// ToFQDNsIdleConnectionGracePeriod defines the connection idle time during which
+	// previously active connections with expired DNS lookups are still considered alive
+	ToFQDNsIdleConnectionGracePeriod = "tofqdns-idle-connection-grace-period"
+
 	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
 	// global cache on startup.
 	// The file is not re-read after agent start.
@@ -958,6 +962,7 @@ var HelpFlagSections = []FlagsSection{
 			FQDNProxyResponseMaxDelay,
 			ToFQDNsEnableDNSCompression,
 			ToFQDNsMaxDeferredConnectionDeletes,
+			ToFQDNsIdleConnectionGracePeriod,
 		},
 	},
 	{
@@ -1697,6 +1702,11 @@ type DaemonConfig struct {
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes int
+
+	// ToFQDNsIdleConnectionGracePeriod Time during which idle but
+	// previously active connections with expired DNS lookups are
+	// still considered alive
+	ToFQDNsIdleConnectionGracePeriod time.Duration
 
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string


### PR DESCRIPTION
Add Cilium daemon option `--tofqdns-idle-connection-grace-period` to allow previously active connections to keep a DNS name/IP mapping alive for future connections for a user-defined duration (default 0s).

Keep latest expiry time for DNS Zombie entries that result from multiple DNS results.

Add the domain names to the DNS GC info-level log message.

```release-note
Added a new daemon option `--tofqdns-idle-connection-grace-period`.
```
