### PR TITLE
docs: fix the Cilium namespace in GKE

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -101,6 +101,6 @@ to the cluster. The NodeInit DaemonSet will perform the following actions:
 
 .. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-gke-validate.rst
-.. include:: namespace-cilium.rst
+.. include:: namespace-kube-system.rst
 .. include:: hubble-enable.rst
 


### PR DESCRIPTION
Before this patch the documentation install Cilium in the `kube-system` namespace, but then configure Hubble assuming that Cilium is installed in the `cilium` namespace.

See https://github.com/cilium/cilium/pull/14899