### PR TITLE
iptables: relax no CT rules to match all pod traffic

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -138,7 +138,7 @@ cilium-agent [flags]
       --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
       --identity-change-grace-period duration                Time to wait before using new identity on endpoint identity change (default 5s)
       --install-iptables-rules                               Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --install-no-conntrack-iptables-rules                  Install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode.
+      --install-no-conntrack-iptables-rules                  Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
       --ip-allocation-timeout duration                       Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
       --ip-masq-agent-config-path string                     ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -368,8 +368,10 @@ New Options
   plugin on all nodes.
 * ``install-no-conntrack-iptables-rules``: This option, by default set to false,
   installs some extra Iptables rules to skip netfilter connection tracking on all
-  pod-to-pod traffic. Disabling connection tracking is only possible when Cilium
-  is running in direct routing mode and is using the kube-proxy replacement.
+  pod traffic. Disabling connection tracking is only possible when Cilium is
+  running in direct routing mode and is using the kube-proxy replacement.
+  Moreover, this option cannot be enabled when Cilium is running in a managed
+  Kubernetes environment or in a chained CNI setup.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -928,7 +928,7 @@ func init() {
 	flags.Bool(option.EnableBPFBypassFIBLookup, defaults.EnableBPFBypassFIBLookup, "Enable FIB lookup bypass optimization for nodeport reverse NAT handling")
 	option.BindEnv(option.EnableBPFBypassFIBLookup)
 
-	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode.")
+	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.")
 	option.BindEnv(option.InstallNoConntrackIptRules)
 
 	flags.Bool(option.EnableCustomCallsName, false, "Enable tail call hooks for custom eBPF programs")
@@ -1386,8 +1386,8 @@ func initEnv(cmd *cobra.Command) {
 		}
 
 		// Moreover InstallNoConntrackIptRules requires IPv4 support as
-		// the native routing CIDR, used to select all pod-to-pod
-		// traffic, can only be an IPv4 CIDR at the moment.
+		// the native routing CIDR, used to select all pod traffic, can
+		// only be an IPv4 CIDR at the moment.
 		if !option.Config.EnableIPv4 {
 			log.Fatalf("%s requires IPv4 support.", option.InstallNoConntrackIptRules)
 		}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -230,7 +230,7 @@ contributors across the globe, there is almost always someone available to help.
 | image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Agent container image. |
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
 | installIptablesRules | bool | `true` |  |
-| installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. |
+| installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
 | ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/ |
 | ipam.operator.clusterPoolIPv4MaskSize | int | `24` | IPv4 CIDR mask size to delegate to individual nodes for IPAM. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -801,9 +801,10 @@ identityAllocationMode: "crd"
 # with kube-proxy.
 installIptablesRules: true
 
-# -- Install Iptables rules to skip netfilter connection tracking on all
-# pod-to-pod traffic. This option is only effective when Cilium is running in
-# direct routing and full KPR mode.
+# -- Install Iptables rules to skip netfilter connection tracking on all pod
+# traffic. This option is only effective when Cilium is running in direct
+# routing and full KPR mode. Moreover, this option cannot be enabled when Cilium
+# is running in a managed Kubernetes environment or in a chained CNI setup.
 installNoConntrackIptablesRules: false
 
 ipam:

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -409,6 +409,6 @@ const (
 	// EnableBPFBypassFIBLookup instructs Cilium to enable the FIB lookup bypass optimization for nodeport reverse NAT handling.
 	EnableBPFBypassFIBLookup = true
 
-	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic.
+	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = false
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -349,7 +349,7 @@ const (
 	InstallIptRules = "install-iptables-rules"
 
 	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules
-	// to skip netfilter connection tracking on all pod-to-pod traffic.
+	// to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = "install-no-conntrack-iptables-rules"
 
 	IPTablesLockTimeout = "iptables-lock-timeout"
@@ -2127,7 +2127,7 @@ type DaemonConfig struct {
 	// EnableBPFBypassFIBLookup instructs Cilium to enable the FIB lookup bypass optimization for nodeport reverse NAT handling.
 	EnableBPFBypassFIBLookup bool
 
-	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod-to-pod traffic.
+	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules bool
 
 	// EnableCustomCalls enables tail call hooks for user-defined custom

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -677,7 +677,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	Context("Iptables", func() {
 		SkipItIf(func() bool {
 			return helpers.IsIntegration(helpers.CIIntegrationGKE) || helpers.RunsWithKubeProxy()
-		}, "Skip conntrack for pod-to-pod traffic", func() {
+		}, "Skip conntrack for pod traffic", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                          "disabled",
 				"autoDirectNodeRoutes":            "true",
@@ -692,11 +692,19 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 
-			cmd := fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -s %s -d %s -m comment --comment 'cilium: NOTRACK for pod-to-pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR, helpers.NativeRoutingCIDR)
+			cmd := fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -s %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR)
 			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
 			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing -j NOTRACK iptables rule")
 
-			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -s %s -d %s -m comment --comment 'cilium: NOTRACK for pod-to-pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR, helpers.NativeRoutingCIDR)
+			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -d %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR)
+			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
+			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing -j NOTRACK iptables rule")
+
+			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -s %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR)
+			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
+			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing -j NOTRACK iptables rule")
+
+			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -d %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j NOTRACK", helpers.NativeRoutingCIDR)
 			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
 			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing -j NOTRACK iptables rule")
 


### PR DESCRIPTION
The --install-no-conntrack-iptables-rules option was originally intended
to be enabled by default. Because of this, it was targeting only
pod-to-pod traffic to avoid any unpredictable interaction with traffic
to/from the hostns.

Since the original decision of making this option enabled by default has
been revised (now the user has to explicitly enable it) we can relax the
rules to match also pod <-> hostns traffic.

With this commit, the set of Iptables rules installed on all nodes
when the option is enabled changes from:

    iptables -t raw -I CILIUM_PRE_raw    -s $POD_CIDR -d $POD_CIDR -j NOTRACK
    iptables -t raw -I CILIUM_OUTPUT_raw -s $POD_CIDR -d $POD_CIDR -j NOTRACK

(i.e. all traffic which is at the same time originating from and
destined to a pod)

to:

    iptables -t raw -I CILIUM_PRE_raw    -s $POD_CIDR -j NOTRACK
    iptables -t raw -I CILIUM_PRE_raw    -d $POD_CIDR -j NOTRACK
    iptables -t raw -I CILIUM_OUTPUT_raw -s $POD_CIDR -j NOTRACK
    iptables -t raw -I CILIUM_OUTPUT_raw -d $POD_CIDR -j NOTRACK

(i.e. all traffic which is either originating from a pod or destined to
a pod).