### PR TITLE
custom calls: add new metrics to count skipped tail calls to custom programs

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -498,9 +498,12 @@ int tail_handle_ipv6(struct __ctx_buff *ctx)
 					CTX_ACT_DROP, METRIC_EGRESS);
 
 #ifdef ENABLE_CUSTOM_CALLS
-	if (!encode_custom_prog_meta(ctx, ret, dstID))
+	if (!encode_custom_prog_meta(ctx, ret, dstID)) {
 		tail_call_static(ctx, &CUSTOM_CALLS_MAP,
 				 CUSTOM_CALLS_IDX_IPV6_EGRESS);
+		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
+			       REASON_MISSED_CUSTOM_CALL);
+	}
 #endif
 
 	return ret;
@@ -906,9 +909,12 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 					CTX_ACT_DROP, METRIC_EGRESS);
 
 #ifdef ENABLE_CUSTOM_CALLS
-	if (!encode_custom_prog_meta(ctx, ret, dstID))
+	if (!encode_custom_prog_meta(ctx, ret, dstID)) {
 		tail_call_static(ctx, &CUSTOM_CALLS_MAP,
 				 CUSTOM_CALLS_IDX_IPV4_EGRESS);
+		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
+			       REASON_MISSED_CUSTOM_CALL);
+	}
 #endif
 
 	return ret;
@@ -1185,9 +1191,12 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	 * incoming packet (before redirecting, and on the way back from the
 	 * proxy).
 	 */
-	if (!proxy_redirect && !encode_custom_prog_meta(ctx, ret, src_label))
+	if (!proxy_redirect && !encode_custom_prog_meta(ctx, ret, src_label)) {
 		tail_call_static(ctx, &CUSTOM_CALLS_MAP,
 				 CUSTOM_CALLS_IDX_IPV6_INGRESS);
+		update_metrics(ctx_full_len(ctx), METRIC_INGRESS,
+			       REASON_MISSED_CUSTOM_CALL);
+	}
 #endif
 
 	return ret;
@@ -1260,9 +1269,13 @@ out:
 	 * incoming packet (before redirecting, and on the way back from the
 	 * proxy).
 	 */
-	if (!proxy_redirect && !encode_custom_prog_meta(ctx, ret, src_identity))
+	if (!proxy_redirect &&
+	    !encode_custom_prog_meta(ctx, ret, src_identity)) {
 		tail_call_static(ctx, &CUSTOM_CALLS_MAP,
 				 CUSTOM_CALLS_IDX_IPV6_INGRESS);
+		update_metrics(ctx_full_len(ctx), METRIC_INGRESS,
+			       REASON_MISSED_CUSTOM_CALL);
+	}
 #endif
 
 	return ret;
@@ -1487,9 +1500,12 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	 * incoming packet (before redirecting, and on the way back from the
 	 * proxy).
 	 */
-	if (!proxy_redirect && !encode_custom_prog_meta(ctx, ret, src_label))
+	if (!proxy_redirect && !encode_custom_prog_meta(ctx, ret, src_label)) {
 		tail_call_static(ctx, &CUSTOM_CALLS_MAP,
 				 CUSTOM_CALLS_IDX_IPV4_INGRESS);
+		update_metrics(ctx_full_len(ctx), METRIC_INGRESS,
+			       REASON_MISSED_CUSTOM_CALL);
+	}
 #endif
 
 	return ret;
@@ -1561,9 +1577,13 @@ out:
 	 * incoming packet (before redirecting, and on the way back from the
 	 * proxy).
 	 */
-	if (!proxy_redirect && !encode_custom_prog_meta(ctx, ret, src_identity))
+	if (!proxy_redirect &&
+	    !encode_custom_prog_meta(ctx, ret, src_identity)) {
 		tail_call_static(ctx, &CUSTOM_CALLS_MAP,
 				 CUSTOM_CALLS_IDX_IPV4_INGRESS);
+		update_metrics(ctx_full_len(ctx), METRIC_INGRESS,
+			       REASON_MISSED_CUSTOM_CALL);
+	}
 #endif
 
 	return ret;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -444,6 +444,7 @@ enum {
 #define REASON_LB_REVNAT_STALE		8
 #define REASON_FRAG_PACKET		9
 #define REASON_FRAG_PACKET_UPDATE	10
+#define REASON_MISSED_CUSTOM_CALL	11
 
 /* Lookup scope for externalTrafficPolicy=Local */
 #define LB_LOOKUP_SCOPE_EXT	0

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ var errors = map[uint8]string{
 	8:   "LB, sock cgroup: Reverse entry stale",
 	9:   "Fragmented packet",
 	10:  "Fragmented packet entry update failed",
+	11:  "Missed tail call to custom program",
 	130: "Invalid source mac",      // Unused
 	131: "Invalid destination mac", // Unused
 	132: "Invalid source ip",


### PR DESCRIPTION
Add a new metrics to count the number of skipped tail calls to custom programs in the datapath. This metrics provides an indicator of whether or not custom programs are effectively attached to the dedicated hooks.

However, note that when tail calls to custom programs are enabled, all endpoints attempt to use them, so the metrics will keep incrementing unless all hooks have a program attached (or if tail calls to custom programs are disabled).

Note that the CI test relies on the CLI command `cilium cleanup` to reset the values for the metrics. Given that the command must be run when the agent is not running, we cannot call it from the Cilium pods. Instead, we build it and call it from the pod we use to compile the custom program. Building the CLI takes time (maybe ~20 seconds on local runs), so this is not ideal. I plan to package the byte counter example as a dedicated image, and could include the CLI with it so it is part of the image, which would solve the problem. Before that, I wonder if there's an alternative solution to reset the metrics. Maybe just edit the eBPF map by running `bpftool map delete pinned /sys/fs/bpf/tc/globals/cilium_metrics/key <...>` directly on the node? But this looks less clean, maybe?
