### PR TITLE
docs: Fix commands for IPSec key rotations

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -191,7 +191,7 @@ To replace cilium-ipsec-keys secret with a new keys,
 
 .. code-block:: shell-session
 
-    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | awk '/^keys:/ {print $2}' | base64 -d | awk '{print $1}')
+    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | awk '/^\s*keys:/ {print $2}' | base64 -d | awk '{print $1}')
     if [[ $KEYID -gt 2 ]]; then KEYID=1; fi
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1


### PR DESCRIPTION
The commands to perform key rotations don't work because of YAML's indentations. The key keys can be indented:

    $ ks get secrets cilium-ipsec-keys -o yaml | grep -C1 keys:
    data:
      keys: MSByZmM0MTA2KGdjbShhZXMpKSA0NDQzNDI0MTM0MzMzMjMxMjQyMzIyMjExNDEzMTIxMWY0ZjNmMmYxIDEyOA==
    kind: Secret

This pull request fixes the regular expression.

Fixes: https://github.com/cilium/cilium/pull/15365