### PR TITLE
Revert "encryption: Limit encryption keys to 2 bits"

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -315,16 +315,6 @@ Annotations:
 1.10 Upgrade Notes
 ------------------
 
-.. important::
-
-   Please review the following changes before upgrading to 1.10 as some of the
-   changes may require an action in your cluster before upgrading.
-
-* The encryption key ID has been limited to 2 bits (stored in the skb mark) in
-  order to guarantee compatibility with kube-proxy in all environments. If you
-  are using an encryption key ID in the range 4-15 then you *must* rotate the
-  key ID to a value of 1-3 before upgrading. Values outside of the range 1-3
-  will be rejected in 1.10.
 * Cilium has bumped the minimal Kubernetes version supported to v1.13.0.
 * When using the ENI-based IPAM in conjunction with the ``--eni-tags``, failures
   to create tags are treated as errors which will result in ENIs not being

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -457,29 +457,6 @@ enum {
 
 /* Magic ctx->mark identifies packets origination and encryption status.
  *
- *  1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2
- * +-------------------------------+---+---+-------+---------------+
- * |L L L L L L L L L L L L L L L L|R R|E E|M M M M|U U U U U U U U|
- * +-------------------------------+---+---+-------+---------------+
- *  identity                        k8s     mark    identity
- *
- * Identity (24 bits):
- * +-----------------------------------------------+
- * |U U U U U U U U|L L L L L L L L L L L L L L L L|
- * +-----------------------------------------------+
- *  1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
- *
- * Kubernetes Mark (2 bits):
- * 0 1  Masquerade
- * 1 0  Drop
- *
- * Cilium Mark (4 bits):
- * M M M M
- * (see MARK_MAGIC_* below)
- *
- * Encryption ID (2 bits):
- * E E  Key ID
- *
  * The upper 16 bits plus lower 8 bits (e.g. mask 0XFFFF00FF) contain the
  * packets security identity. The lower/upper halves are swapped to recover
  * the identity.
@@ -489,14 +466,7 @@ enum {
  *    an ingress or egress proxy, a local process and its current encryption
  *    status.
  *
- * The 2 bits at 0x3000 provide
- *  - the key index to use for encryption when multiple keys are in-flight.
- *    In the IPsec case this becomes the SPI on the wire.
- *
- * The 1 bit at 0x2000 is used by portmap CNI in chaining mode. It is not used
- * by the eBPF implementation of portmap.
- *
- * The 2 bits at 0xC000 are reserved for Kubernetes (kube-proxy)
+ * The 4 bits at 0xF000 provide
  *  - the key index to use for encryption when multiple keys are in-flight.
  *    In the IPsec case this becomes the SPI on the wire.
  */
@@ -509,8 +479,8 @@ enum {
 #define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
 #define MARK_MAGIC_TO_PROXY		0x0200
 
-#define MARK_MAGIC_KEY_ID		0x3000
-#define MARK_MAGIC_KEY_MASK		0x3F00
+#define MARK_MAGIC_KEY_ID		0xF000
+#define MARK_MAGIC_KEY_MASK		0xFF00
 
 /* IPSec cannot be configured with NodePort BPF today, hence non-conflicting
  * overlap with MARK_MAGIC_KEY_ID.
@@ -555,8 +525,8 @@ enum {
 #define DSR_IPV6_OPT_LEN	0x14	/* to store ipv6 addr + port */
 #define DSR_IPV6_EXT_LEN	0x2	/* = (sizeof(dsr_opt_v6) - 8) / 8 */
 
-/* We cap key index at 2 bits because mark value is used to map ctx to key */
-#define MAX_KEY_INDEX 3
+/* We cap key index at 4 bits because mark value is used to map ctx to key */
+#define MAX_KEY_INDEX 15
 
 /* encrypt_key is the index into the encrypt map */
 struct encrypt_key {

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -38,7 +38,7 @@ var _ = Suite(&IPSecSuitePrivileged{})
 var (
 	path           = "ipsec_keys_test"
 	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n1 digest_null \"\" cipher_null \"\"\n")
-	keysAeadDat    = []byte("2 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
+	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
 )
 

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -87,10 +87,10 @@ const (
 	TunnelDeviceName = "cilium_vxlan"
 
 	// IPSec offset value for node rules
-	IPsecMaxKeyVersion = 3
+	IPsecMaxKeyVersion = 16
 
 	// IPsecMarkMask is the mask required for the IPsec SPI and encrypt/decrypt bits
-	IPsecMarkMask = 0xCF00
+	IPsecMarkMask = 0xFF00
 
 	// IPsecMarkMaskIn is the mask required for IPsec to lookup encrypt/decrypt bits
 	IPsecMarkMaskIn = 0x0F00

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package linux_defaults
 // following way:
 //
 //  1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2
-// +-------------------------------+---+---+-------+---------------+
-// |L L L L L L L L L L L L L L L L|R R|E E|M M M M|U U U U U U U U|
-// +-------------------------------+---+---+-------+---------------+
+// +-------------------------------+-------+-------+---------------+
+// |L L L L L L L L L L L L L L L L|R R R R|M M M M|U U U U U U U U|
+// +-------------------------------+-------+-------+---------------+
 //  identity                        k8s     mark    identity
 //
 // Identity (24 bits):
@@ -30,16 +30,14 @@ package linux_defaults
 // +-----------------------------------------------+
 //  1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
 //
-// Kubernetes Mark (2 bits):
-// 0 1  Masquerade
-// 1 0  Drop
+// Kubernetes Mark (4 bits):
+// R R R R
+// 0 1 0 0  Masquerade
+// 1 0 0 0  Drop
 //
 // Cilium Mark (4 bits):
 // M M M M
 // (see MARK_MAGIC_* in bpf/lib/common.h)
-//
-// Encryption ID (2 bits):
-// E E  Key ID
 const (
 	// MagicMarkHostMask can be used to fetch the host/proxy-relevant magic
 	// bits from a mark.
@@ -73,9 +71,6 @@ const (
 	// MagicMarkIdentity determines that the traffic carries a security
 	// identity in the skb->mark
 	MagicMarkIdentity int = 0x0F00
-
-	// MagicMarkPortmap is used by portmap (https://github.com/fwmark/registry/#bitwise-mark-registry)
-	MagicMarkPortmap int = 0x2000
 
 	// MagicMarkK8sMasq determines that the traffic should be masqueraded
 	// by kube-proxy in kubernetes environments.

--- a/test/k8sT/manifests/ipsec_secret.yaml
+++ b/test/k8sT/manifests/ipsec_secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: cilium-ipsec-keys
 type: Opaque
 stringData:
-  keys: "1 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128"
+  keys: "6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128"


### PR DESCRIPTION
This revert fixes the failing CI on 4.9 (`Transparent encryption DirectRouting Check connectivity with transparent encryption and direct routing*`). Let's revert until the PR has been fixed.