### PR TITLE
policy: improve CNP initial sync

### DIFF
--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -244,6 +244,10 @@ func PreprocessRules(r api.Rules, cache *ServiceCache) error {
 	defer cache.mutex.Unlock()
 
 	for _, rule := range r {
+		// Translate only handles egress rules
+		if rule.Egress == nil {
+			continue
+		}
 		for ns, ep := range cache.endpoints {
 			svc, ok := cache.services[ns]
 			if ok && svc.IsExternal() {


### PR DESCRIPTION
Check for the existence of CNP egress rules before translating
since we only do translation for egress rules.
This reduces the time cost of an add event of CNP without egress rules
and makes cilium agent start faster in a cluster with large amount of
CNPs and services.

Time cost comparison in a cluster with 10k CCNPs (all without egress rule), 44k services/endpoints:

Before:

    per CNP add event time cost              20 ~ 30 ms
    overall time cost of initial CNP sync    255 s

After:

    per CNP add event time cost              0.5 ~ 1 ms
    overall time cost of initial CNP sync    15 s

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>
