### PR TITLE
azure: Fix API rate limit test

### DIFF
--- a/pkg/azure/api/api_test.go
+++ b/pkg/azure/api/api_test.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -35,6 +36,19 @@ type ApiSuite struct{}
 var _ = check.Suite(&ApiSuite{})
 
 func (a *ApiSuite) TestRateLimit(c *check.C) {
+	// Since github.com/Azure/go-autorest/autorest/azure/auth v0.5.6, the
+	// MSI_ENDPOINT environment variable must be set, otherwise this test will
+	// fail with the error "failed to get oauth token from MSI: MSI not
+	// available".
+	//
+	// Temporarily set the environment variable for the duration of the test,
+	// using the same workaround as used in
+	// github.com/Azure/go-autorest/autorest/azure/auth's tests.
+	os.Setenv("MSI_ENDPOINT", "http://localhost")
+	defer func() {
+		os.Unsetenv("MSI_ENDPOINT")
+	}()
+
 	metricsAPI := mock.NewMockMetrics()
 	client, err := NewClient("", "dummy-subscription", "dummy-resource-group", "", metricsAPI, 10.0, 4, true)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
As [discussed on Slack](https://cilium.slack.com/archives/C7PE7V806/p1615560463020300), this PR fixes a regression introduced in #14771 where unit tests fail locally due to `github.com/Azure/go-autorest/autorest/azure/auth` now requiring the `MSI_ENDPOINT` environment variable to be set.