### PR TITLE
ci: disable fail-fast behavior in cleanup step

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -110,6 +110,7 @@ jobs:
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
           gcloud container clusters delete --quiet ${{ env.clusterName }} --zone ${{ env.zone }}
+        shell: bash {0}
 
       - name: Upload Artifacts
         if: ${{ always() }}


### PR DESCRIPTION
By default, shell scripts in GitHub actions `jobs.<job_id>.steps[*].run`
have fail-fast behavior. This can lead to commands in the cleanup
step not being executed in case a previous command fails. In the worst
case this could lead to cloud resources not being cleaned up, e.g. when
`cilium status` fails with non-zero exit status, the remaining commands
(i.e. `gcloud container clusters delete`) will not be run.

Fix this by specifying `shell: bash {0}` for the cleanup step, which
will opt out of the fail-fast behavior and will always run all commands
regardless for earlier command's exit status.

For details see:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

Also see cilium/cilium-cli#140