### PR TITLE
docs: update k3s installation instructions

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -27,7 +27,7 @@ for the default CNI plugin:
 
 .. parsed-literal::
 
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none --no-flannel' sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none' sh -
 
 Install Agent Nodes (Optional)
 ==============================
@@ -42,7 +42,7 @@ replace the variables with values from your environment:
 
 .. parsed-literal::
 
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--disable-network-policy --no-flannel' K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
+    curl -sfL https://get.k3s.io | K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
 
 Should you encounter any issues during the installation, please refer to the
 :ref:`troubleshooting_k8s` section and / or seek help on the `Slack channel`.


### PR DESCRIPTION
This commit fixes the K3s installation instructions, removing
the deprecated `--no-flannel` option and removing the
unrecognized flags being passed to the agent. The installation
instructions will now result in a successful installation.

Co-authored-by: Adrian Goins <adrian.goins@suse.com>
Signed-off-by: André Martins <andre@cilium.io>