### PR TITLE
Route traffic from pod to node through tunnel

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1461,7 +1461,7 @@ skip_policy_enforcement:
 	ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	if (ifindex)
 		return redirect_ep(ctx, ifindex, from_host);
-#endif /* ENABLE_ROUTING && ENCAP_IFINDEX && !ENABLE_NODEPORT */
+#endif /* !ENABLE_ROUTING && ENCAP_IFINDEX && !ENABLE_NODEPORT */
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -193,7 +193,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 			return encap_and_redirect_ipsec(ctx, tunnel_endpoint,
 							encrypt_key, seclabel);
 #endif
-#if !defined(ENABLE_NODEPORT) && (defined(ENABLE_IPSEC) || defined(ENABLE_HOST_FIREWALL))
+#if !defined(ENABLE_NODEPORT)
 		/* For IPSec and the host firewall, traffic from a pod to a remote node
 		 * is sent through the tunnel. In the case of node --> VIP@remote pod,
 		 * packets may be DNATed when they enter the remote node. If kube-proxy
@@ -204,7 +204,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 		return __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
 #else
 		return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
-#endif /* !ENABLE_NODEPORT && (ENABLE_IPSEC || ENABLE_HOST_FIREWALL) */
+#endif /* !ENABLE_NODEPORT */
 	}
 
 	tunnel = map_lookup_elem(&TUNNEL_MAP, key);

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -589,8 +589,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// be fully enabled in the tunneling mode, so the following checks should
 	// happen after invoking initKubeProxyReplacementOptions().
 	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade &&
-		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "" || !option.Config.EnableRemoteNodeIdentity ||
-			(option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices())) {
+		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "" || !option.Config.EnableRemoteNodeIdentity) {
 
 		var msg string
 		switch {
@@ -600,10 +599,6 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		case !option.Config.EnableRemoteNodeIdentity:
 			msg = fmt.Sprintf("BPF masquerade requires remote node identities (--%s=\"true\").",
 				option.EnableRemoteNodeIdentity)
-		// Remove the check after https://github.com/cilium/cilium/issues/12544 is fixed
-		case option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices():
-			msg = fmt.Sprintf("BPF masquerade requires --%s to be fully enabled (TCP and UDP).",
-				option.EnableHostReachableServices)
 		case option.Config.EgressMasqueradeInterfaces != "":
 			msg = fmt.Sprintf("BPF masquerade does not allow to specify devices via --%s (use --%s instead).",
 				option.EgressMasqueradeInterfaces, option.Devices)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -809,9 +809,3 @@ func checkNodePortAndEphemeralPortRanges() error {
 
 	return nil
 }
-
-func hasFullHostReachableServices() bool {
-	return option.Config.EnableHostReachableServices &&
-		option.Config.EnableHostServicesTCP &&
-		option.Config.EnableHostServicesUDP
-}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -367,7 +367,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// encapsulation. In encryption case we also want to use vxlan device
 		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
 		if address.Type == addressing.NodeCiliumInternalIP || m.conf.EncryptionEnabled() ||
-			option.Config.EnableHostFirewall || option.Config.JoinCluster {
+			option.Config.EnableHostFirewall || option.Config.JoinCluster || option.Config.Tunnel != option.TunnelDisabled {
 			tunnelIP = nodeIP
 		}
 


### PR DESCRIPTION
Accroding to #15437, to stop requiring host reachable service for ebpf masq, pod to node traffic should go through tunnel.

Signed-off-by: Yuan Liu <liuyuan@google.com>

Fixes: #15437

```release-note
Route traffic from pod to node through tunnel
```
