### PR TITLE
Revert exported NoTrack rule function names.

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -741,7 +741,12 @@ func endpointNoTrackRules(prog string, cmd string, IP string, port *lb.L4Addr, i
 	return nil
 }
 
-func InstallEndpointNoTrackRules(IP string, port uint16, ipv6 bool) error {
+// InstallNoTrackRules is explicitly called when a pod has valid "io.cilium.no-track-port" annotation.
+// When InstallNoConntrackIptRules flag is set, a super set of v4 NOTRACK rules will be automatically
+// installed upon agent bootstrap (via function addNoTrackPodTrafficRules) and this function will be skipped.
+// When InstallNoConntrackIptRules is not set, this function will be executed to install NOTRACK rules.
+// The rules installed by this function is very specific, for now, the only user is node-local-dns pods.
+func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	// Do not install per endpoint NOTRACK rules if we are already skipping
 	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
@@ -776,9 +781,10 @@ func InstallEndpointNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	return nil
 }
 
-func RemoveEndpointNoTrackRules(IP string, port uint16, ipv6 bool) error {
-	// Do not attempt removing per endpoint NOTRACK rules if we are already
-	// skipping conntrack for all pod traffic.
+// See comments for InstallNoTrackRules.
+func RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	// Do not install per endpoint NOTRACK rules if we are already skipping
+	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
 		return nil
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2180,12 +2180,12 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		}).Debug("Deleting endpoint NOTRACK rules")
 
 		if e.IPv4.IsSet() {
-			if err := iptables.RemoveEndpointNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
+			if err := iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv4 rules: %s", err))
 			}
 		}
 		if e.IPv6.IsSet() {
-			if err := iptables.RemoveEndpointNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
+			if err := iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv6 rules: %s", err))
 			}
 		}

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -170,21 +170,21 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 		log.Debug("Updating NOTRACK rules")
 		if e.IPv4.IsSet() {
 			if port > 0 {
-				err = iptables.InstallEndpointNoTrackRules(e.IPv4.String(), port, false)
+				err = iptables.InstallNoTrackRules(e.IPv4.String(), port, false)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveEndpointNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
+				err = iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}
 		if e.IPv6.IsSet() {
 			if port > 0 {
-				iptables.InstallEndpointNoTrackRules(e.IPv6.String(), port, true)
+				iptables.InstallNoTrackRules(e.IPv6.String(), port, true)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveEndpointNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
+				err = iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}


### PR DESCRIPTION
Revert exported NoTrack rule function names.

Google's node-local-dns feature with Cilium depends on these names, revert to unbreak it. Also added comments to explain how these functions interact with flag `InstallNoConntrackIptRules`.
