### PR TITLE
test: Make Wireguard tcpdump filter more fine grained

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3490,7 +3490,7 @@ func (kub *Kubectl) ExecInHostNetNSInBackground(ctx context.Context, node, cmd s
 	bgCmd := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, LogGathererNamespace, pod, cmd)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return kub.ExecInBackground(ctx, bgCmd, ExecOptions{SkipLog: true}), cancel, nil
+	return kub.ExecInBackground(ctx, bgCmd, ExecOptions{}), cancel, nil
 }
 
 // ExecInHostNetNSByLabel runs given command in a pod running in a host network namespace.

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2625,7 +2625,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 							// "-c 1" captures only one packet (it's enough, as we expect that no
 							// unencrypted packet is being forwarded).
 							_, dstPodIPK8s2 := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s2, testDS, 1)
-							cmd := fmt.Sprintf("tcpdump -i %s --immediate-mode -n 'host %s' -c 1", privateIface, dstPodIPK8s2)
+							podPort := data.Spec.Ports[0].TargetPort.String()
+							cmd := fmt.Sprintf("tcpdump -i %s --immediate-mode -n 'host %s and port %s' -c 1", privateIface, dstPodIPK8s2, podPort)
 							res, cancel, err := kubectl.ExecInHostNetNSInBackground(context.TODO(), k8s1NodeName, cmd)
 							Expect(err).Should(BeNil(), "Cannot exec tcpdump in bg")
 


### PR DESCRIPTION
It was reported that the native Wireguard CI test failed with the
tcpdump assertion. This means that the tcpdump was able to capture
a packet on the private iface (used for direct routing) targeting
the pod on any port.

Improve the filter by adding 'port $targetPort' filter to eliminate non
service traffic. Also, write tcpdump output into test-output.log, so
that next time we know whether a failure was a false positive.