### PR TITLE
daemon: Fatal on XDP + egress gateway

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -303,6 +303,11 @@ func initKubeProxyReplacementOptions() (strict bool) {
 				log.Fatalf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
 					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
 			}
+
+			if option.Config.EnableEgressGateway {
+				log.Fatalf("Cannot use NodePort acceleration with the egress gateway. Run cilium-agent with either --%s=%s or %s=false",
+					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.EnableEgressGateway)
+			}
 		}
 
 		if option.Config.NodePortMode == option.NodePortModeDSR &&


### PR DESCRIPTION
That combination of options is not currently supported and results in the following datapath compilation error:

    In file included from bpf_xdp.c:38:
    /cilium/bpf/lib/nodeport.h:1108:20: error: no member named 'ifindex' in 'struct xdp_md'
                    if (info && ctx->ifindex != ENCAP_IFINDEX) {
                                ~~~  ^
    /cilium/bpf/lib/nodeport.h:1108:31: error: use of undeclared identifier 'ENCAP_IFINDEX'; did you mean 'CB_IFINDEX'?
                    if (info && ctx->ifindex != ENCAP_IFINDEX) {
                                                ^~~~~~~~~~~~~
                                                CB_IFINDEX
    /cilium/bpf/lib/common.h:599:2: note: 'CB_IFINDEX' declared here
            CB_IFINDEX,
            ^
    2 errors generated.
    make: *** [Makefile:188: bpf_xdp.ll] Error 1

/cc @anfernee @MasterZ40 