### PR TITLE
Revert "loader : Log upsert and remove route errors"

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -351,32 +351,18 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 	}
 
 	if ip := ep.IPv4Address(); ip.IsSet() {
-		scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
-			logfields.Veth: ep.InterfaceName(),
-		})
 		if ep.RequireEndpointRoute() {
-			if err := upsertEndpointRoute(ep, *ip.IPNet(32)); err != nil {
-				scopedLog.WithError(err).Warn("Failed to upsert route")
-			}
+			upsertEndpointRoute(ep, *ip.IPNet(32))
 		} else {
-			if err := removeEndpointRoute(ep, *ip.IPNet(32)); err != nil {
-				scopedLog.WithError(err).Warn("Failed to remove route")
-			}
+			removeEndpointRoute(ep, *ip.IPNet(32))
 		}
 	}
 
 	if ip := ep.IPv6Address(); ip.IsSet() {
-		scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
-			logfields.Veth: ep.InterfaceName(),
-		})
 		if ep.RequireEndpointRoute() {
-			if err := upsertEndpointRoute(ep, *ip.IPNet(128)); err != nil {
-				scopedLog.WithError(err).Warn("Failed to upsert route")
-			} else {
-				if err := removeEndpointRoute(ep, *ip.IPNet(128)); err != nil {
-					scopedLog.WithError(err).Warn("Failed to remove route")
-				}
-			}
+			upsertEndpointRoute(ep, *ip.IPNet(128))
+		} else {
+			removeEndpointRoute(ep, *ip.IPNet(128))
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 32284cd7d600c111446222a715af4b33ad57914a.

It seems like PR #15339 introduced a regression on Kernel 4.9 with the two following tests failing consistently (not flakes):

- K8sDatapathConfig Encapsulation Check vxlan connectivity with per-endpoint routes
- K8sDatapathConfig Host firewall With VXLAN and endpoint routes


Fixes https://github.com/cilium/cilium/issues/15499