### PR TITLE
pkg/k8s: fix concurrent access in CNP field

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 package v2
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
 	k8sCiliumUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/policy/api"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -118,7 +118,7 @@ type CiliumClusterwideNetworkPolicyList struct {
 // policy rules.
 func (r *CiliumClusterwideNetworkPolicy) Parse() (api.Rules, error) {
 	if r.ObjectMeta.Name == "" {
-		return nil, fmt.Errorf("CiliumClusterwideNetworkPolicy must have name")
+		return nil, NewErrParse("CiliumClusterwideNetworkPolicy must have name")
 	}
 
 	name := r.ObjectMeta.Name
@@ -132,7 +132,7 @@ func (r *CiliumClusterwideNetworkPolicy) Parse() (api.Rules, error) {
 
 	if r.Spec != nil {
 		if err := r.Spec.Sanitize(); err != nil {
-			return nil, fmt.Errorf("Invalid CiliumClusterwideNetworkPolicy spec: %s", err)
+			return nil, NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy spec: %s", err))
 		}
 		cr := k8sCiliumUtils.ParseToCiliumRule("", name, uid, r.Spec)
 		retRules = append(retRules, cr)
@@ -140,7 +140,7 @@ func (r *CiliumClusterwideNetworkPolicy) Parse() (api.Rules, error) {
 	if r.Specs != nil {
 		for _, rule := range r.Specs {
 			if err := rule.Sanitize(); err != nil {
-				return nil, fmt.Errorf("Invalid CiliumClusterwideNetworkPolicy specs: %s", err)
+				return nil, NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy specs: %s", err))
 
 			}
 			cr := k8sCiliumUtils.ParseToCiliumRule("", name, uid, rule)
@@ -150,7 +150,3 @@ func (r *CiliumClusterwideNetworkPolicy) Parse() (api.Rules, error) {
 
 	return retRules, nil
 }
-
-// ErrEmptyCCNP is an error representing a CCNP that is empty, which means it is
-// missing both a `spec` and `specs` (both are nil).
-var ErrEmptyCCNP = errors.New("Invalid CiliumClusterwideNetworkPolicy spec(s): empty policy")

--- a/pkg/k8s/apis/cilium.io/v2/errors.go
+++ b/pkg/k8s/apis/cilium.io/v2/errors.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+var (
+	// ErrEmptyCNP is an error representing a CNP that is empty, which means it is
+	// missing both a `spec` and `specs` (both are nil).
+	ErrEmptyCNP = NewErrParse("Invalid CiliumNetworkPolicy spec(s): empty policy")
+
+	// ErrEmptyCCNP is an error representing a CCNP that is empty, which means it is
+	// missing both a `spec` and `specs` (both are nil).
+	ErrEmptyCCNP = NewErrParse("Invalid CiliumClusterwideNetworkPolicy spec(s): empty policy")
+
+	// ParsingErr is for comparison when checking error types.
+	ParsingErr = NewErrParse("")
+)
+
+// ErrParse is an error to describe where policy fails to parse due any invalid
+// rule.
+//
+// +k8s:deepcopy-gen=false
+// +deepequal-gen=false
+type ErrParse struct {
+	msg string
+}
+
+// NewErrParse returns a new ErrParse.
+func NewErrParse(msg string) ErrParse {
+	return ErrParse{
+		msg: msg,
+	}
+}
+
+// Error returns the error message for parsing
+func (e ErrParse) Error() string {
+	return e.msg
+}
+
+// Is returns true if the given error is the type of 'ErrParse'.
+func (_ ErrParse) Is(e error) bool {
+	_, ok := e.(ErrParse)
+	return ok
+}


### PR DESCRIPTION
When doing a StatusUpdate of a particular CNP, we are performing an
unnecessary sanitization of the CNP. This is unnecessary as we have
already performed it when the CNP event was received and we pass the
result of this sanitation down to the status updater. Removing this code
fixes some concurrent access in some of the fields in the CNP.

```
WARNING: DATA RACE
Write at 0x00c000d956b0 by goroutine 406:
github.com/cilium/cilium/pkg/policy/api.(*PortProtocol).Sanitize()
    /go/src/github.com/cilium/cilium/pkg/policy/api/rule_validation.go:393 +0x187
github.com/cilium/cilium/pkg/policy/api.(*PortRule).sanitize()
    /go/src/github.com/cilium/cilium/pkg/policy/api/rule_validation.go:345 +0xe9
github.com/cilium/cilium/pkg/policy/api.(*IngressRule).sanitize()
    /go/src/github.com/cilium/cilium/pkg/policy/api/rule_validation.go:151 +0xc24
github.com/cilium/cilium/pkg/policy/api.Rule.Sanitize()
    /go/src/github.com/cilium/cilium/pkg/policy/api/rule_validation.go:71 +0x1c6
github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2.(*CiliumNetworkPolicy).Parse()
    /go/src/github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/cnp_types.go:227 +0x6f7
github.com/cilium/cilium/pkg/k8s.(*CNPStatusUpdateContext).prepareUpdate()
    /go/src/github.com/cilium/cilium/pkg/k8s/cnp.go:87 +0x6b
github.com/cilium/cilium/pkg/k8s.(*CNPStatusUpdateContext).UpdateStatus()
    /go/src/github.com/cilium/cilium/pkg/k8s/cnp.go:180 +0x587
github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).addCiliumNetworkPolicyV2.func1()
    /go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_network_policy.go:215 +0x7d
github.com/cilium/cilium/pkg/controller.(*Controller).runController()
    /go/src/github.com/cilium/cilium/pkg/controller/controller.go:208 +0xda6

Previous read at 0x00c000d956b0 by goroutine 377:
reflect.Value.String()
    /usr/local/go/src/reflect/value.go:1876 +0x84
encoding/json.stringEncoder()
    /usr/local/go/src/encoding/json/encode.go:647 +0x210
[...]
encoding/json.(*encodeState).marshal()
    /usr/local/go/src/encoding/json/encode.go:332 +0xd2
encoding/json.Marshal()
    /usr/local/go/src/encoding/json/encode.go:161 +0x78
github.com/cilium/cilium/pkg/policy/api.(*Rule).MarshalJSON()
    /go/src/github.com/cilium/cilium/pkg/policy/api/rule.go:140 +0x2e7
[...]
encoding/json.Marshal()
    /usr/local/go/src/encoding/json/encode.go:161 +0x78
encoding/json.MarshalIndent()
    /usr/local/go/src/encoding/json/encode.go:176 +0x64
github.com/cilium/cilium/pkg/policy.JSONMarshalRules()
    /go/src/github.com/cilium/cilium/pkg/policy/repository.go:505 +0x8d
github.com/cilium/cilium/daemon/cmd.(*getPolicy).Handle()
    /go/src/github.com/cilium/cilium/daemon/cmd/policy.go:760 +0x1d3
github.com/cilium/cilium/api/v1/server/restapi/policy.(*GetPolicy).ServeHTTP()
    /go/src/github.com/cilium/cilium/api/v1/server/restapi/policy/get_policy.go:60 +0x2e7
github.com/go-openapi/runtime/middleware.NewOperationExecutor.func1()
    /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/operation.go:28 +0xb3
net/http.HandlerFunc.ServeHTTP()
    /usr/local/go/src/net/http/server.go:2069 +0x51
github.com/go-openapi/runtime/middleware.NewRouter.func1()
    /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/router.go:78 +0x486
net/http.HandlerFunc.ServeHTTP()
    /usr/local/go/src/net/http/server.go:2069 +0x51
github.com/go-openapi/runtime/middleware.Redoc.func1()
    /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/redoc.go:72 +0x35a
net/http.HandlerFunc.ServeHTTP()
    /usr/local/go/src/net/http/server.go:2069 +0x51
github.com/go-openapi/runtime/middleware.Spec.func1()
    /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/spec.go:46 +0x281
net/http.HandlerFunc.ServeHTTP()
    /usr/local/go/src/net/http/server.go:2069 +0x51
github.com/cilium/cilium/pkg/metrics.(*APIEventTSHelper).ServeHTTP()
    /go/src/github.com/cilium/cilium/pkg/metrics/middleware.go:69 +0x1ce
github.com/cilium/cilium/pkg/api.(*APIPanicHandler).ServeHTTP()
    /go/src/github.com/cilium/cilium/pkg/api/apipanic.go:53 +0xe4
net/http.serverHandler.ServeHTTP()
    /usr/local/go/src/net/http/server.go:2887 +0xca
net/http.(*conn).serve()
    /usr/local/go/src/net/http/server.go:1952 +0x87d
```

Fixes: 6ec0d0f8d00b ("k8s: add support for k8s 1.20 and drop support for k8s 1.12")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/15439