### PR TITLE
add support for EndpointSlice V1

### DIFF
--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	slim_discovery_v1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -775,12 +776,12 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		_, got := ParseEndpointSlice(args.eps)
+		_, got := ParseEndpointSliceV1Beta1(args.eps)
 		c.Assert(got, checker.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
 	}
 }
 
-func Test_parseEndpointPort(t *testing.T) {
+func Test_parseEndpointPortV1Beta1(t *testing.T) {
 	type args struct {
 		port slim_discovery_v1beta1.EndpointPort
 	}
@@ -845,12 +846,397 @@ func Test_parseEndpointPort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPortName, gotL4Addr := parseEndpointPort(tt.args.port)
+			gotPortName, gotL4Addr := parseEndpointPortV1Beta1(tt.args.port)
 			if gotPortName != tt.portName {
-				t.Errorf("parseEndpointPort() got = %v, want %v", gotPortName, tt.portName)
+				t.Errorf("parseEndpointPortV1Beta1() got = %v, want %v", gotPortName, tt.portName)
 			}
 			if !reflect.DeepEqual(gotL4Addr, tt.l4Addr) {
-				t.Errorf("parseEndpointPort() got1 = %v, want %v", gotL4Addr, tt.l4Addr)
+				t.Errorf("parseEndpointPortV1Beta1() got1 = %v, want %v", gotL4Addr, tt.l4Addr)
+			}
+		})
+	}
+}
+
+func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
+	nodeName := "k8s1"
+
+	type args struct {
+		eps *slim_discovery_v1.EndpointSlice
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() *Endpoints
+	}{
+		{
+			name: "empty endpoint",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				return newEndpoints()
+			},
+		},
+		{
+			name: "endpoint with an address and port",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{
+									"172.0.0.1",
+								},
+								DeprecatedTopology: map[string]string{
+									"kubernetes.io/hostname": nodeName,
+								},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc": loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					},
+					NodeName: nodeName,
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "endpoint with an address and 2 ports",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{
+									"172.0.0.1",
+								},
+								DeprecatedTopology: map[string]string{
+									"kubernetes.io/hostname": nodeName,
+								},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+							{
+								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8081); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+					},
+					NodeName: nodeName,
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "endpoint with 2 addresses and 2 ports",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{
+									"172.0.0.1",
+								},
+								DeprecatedTopology: map[string]string{
+									"kubernetes.io/hostname": nodeName,
+								},
+							},
+							{
+								Addresses: []string{
+									"172.0.0.2",
+								},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+							{
+								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8081); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+					},
+					NodeName: nodeName,
+				}
+				svcEP.Backends["172.0.0.2"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+					},
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "endpoint with 2 addresses, 1 address not ready and 2 ports",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{
+									"172.0.0.1",
+								},
+								DeprecatedTopology: map[string]string{
+									"kubernetes.io/hostname": nodeName,
+								},
+							},
+							{
+								Addresses: []string{
+									"172.0.0.2",
+								},
+							},
+							{
+								Conditions: slim_discovery_v1.EndpointConditions{
+									Ready: func() *bool { a := false; return &a }(),
+								},
+								Addresses: []string{
+									"172.0.0.3",
+								},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+							{
+								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8081); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+					},
+					NodeName: nodeName,
+				}
+				svcEP.Backends["172.0.0.2"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+					},
+				}
+				return svcEP
+			},
+		}, {
+			name: "endpoint with 2 addresses, 1 address not ready and 2 ports",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{
+									"172.0.0.1",
+								},
+								NodeName: func() *string { return &nodeName }(),
+							},
+							{
+								Addresses: []string{
+									"172.0.0.2",
+								},
+							},
+							{
+								Conditions: slim_discovery_v1.EndpointConditions{
+									Ready: func() *bool { a := false; return &a }(),
+								},
+								Addresses: []string{
+									"172.0.0.3",
+								},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+							{
+								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8081); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+					},
+					NodeName: nodeName,
+				}
+				svcEP.Backends["172.0.0.2"] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+					},
+				}
+				return svcEP
+			},
+		},
+	}
+	for _, tt := range tests {
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		_, got := ParseEndpointSliceV1(args.eps)
+		c.Assert(got, checker.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
+	}
+}
+
+func Test_parseEndpointPortV1(t *testing.T) {
+	type args struct {
+		port slim_discovery_v1.EndpointPort
+	}
+	tests := []struct {
+		name     string
+		args     args
+		portName string
+		l4Addr   *loadbalancer.L4Addr
+	}{
+		{
+			name: "tcp-port",
+			args: args{
+				port: slim_discovery_v1.EndpointPort{
+					Name:     func() *string { a := "http-test-svc"; return &a }(),
+					Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+					Port:     func() *int32 { a := int32(8080); return &a }(),
+				},
+			},
+			portName: "http-test-svc",
+			l4Addr: &loadbalancer.L4Addr{
+				Protocol: loadbalancer.TCP,
+				Port:     8080,
+			},
+		},
+		{
+			name: "udp-port",
+			args: args{
+				port: slim_discovery_v1.EndpointPort{
+					Name:     func() *string { a := "http-test-svc"; return &a }(),
+					Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolUDP; return &a }(),
+					Port:     func() *int32 { a := int32(8080); return &a }(),
+				},
+			},
+			portName: "http-test-svc",
+			l4Addr: &loadbalancer.L4Addr{
+				Protocol: loadbalancer.UDP,
+				Port:     8080,
+			},
+		},
+		{
+			name: "unset-protocol-should-have-tcp-port",
+			args: args{
+				port: slim_discovery_v1.EndpointPort{
+					Name: func() *string { a := "http-test-svc"; return &a }(),
+					Port: func() *int32 { a := int32(8080); return &a }(),
+				},
+			},
+			portName: "http-test-svc",
+			l4Addr: &loadbalancer.L4Addr{
+				Protocol: loadbalancer.TCP,
+				Port:     8080,
+			},
+		},
+		{
+			name: "unset-port-number-should-fail",
+			args: args{
+				port: slim_discovery_v1.EndpointPort{
+					Name: func() *string { a := "http-test-svc"; return &a }(),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPortName, gotL4Addr := parseEndpointPortV1(tt.args.port)
+			if gotPortName != tt.portName {
+				t.Errorf("parseEndpointPortV1() got = %v, want %v", gotPortName, tt.portName)
+			}
+			if !reflect.DeepEqual(gotL4Addr, tt.l4Addr) {
+				t.Errorf("parseEndpointPortV1() got1 = %v, want %v", gotL4Addr, tt.l4Addr)
 			}
 		})
 	}

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/ip"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	slim_discovery_v1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -304,8 +305,14 @@ func (s *ServiceCache) UpdateEndpoints(k8sEndpoints *slim_corev1.Endpoints, swg 
 	return s.updateEndpoints(epSliceID, newEndpoints, swg)
 }
 
-func (s *ServiceCache) UpdateEndpointSlices(epSlice *slim_discovery_v1beta1.EndpointSlice, swg *lock.StoppableWaitGroup) (ServiceID, *Endpoints) {
-	svcID, newEndpoints := ParseEndpointSlice(epSlice)
+func (s *ServiceCache) UpdateEndpointSlicesV1(epSlice *slim_discovery_v1.EndpointSlice, swg *lock.StoppableWaitGroup) (ServiceID, *Endpoints) {
+	svcID, newEndpoints := ParseEndpointSliceV1(epSlice)
+
+	return s.updateEndpoints(svcID, newEndpoints, swg)
+}
+
+func (s *ServiceCache) UpdateEndpointSlicesV1Beta1(epSlice *slim_discovery_v1beta1.EndpointSlice, swg *lock.StoppableWaitGroup) (ServiceID, *Endpoints) {
+	svcID, newEndpoints := ParseEndpointSliceV1Beta1(epSlice)
 
 	return s.updateEndpoints(svcID, newEndpoints, swg)
 }
@@ -348,7 +355,7 @@ func (s *ServiceCache) DeleteEndpoints(k8sEndpoints *slim_corev1.Endpoints, swg 
 	return s.deleteEndpoints(epSliceID, swg)
 }
 
-func (s *ServiceCache) DeleteEndpointSlices(epSlice *slim_discovery_v1beta1.EndpointSlice, swg *lock.StoppableWaitGroup) ServiceID {
+func (s *ServiceCache) DeleteEndpointSlices(epSlice endpointSlice, swg *lock.StoppableWaitGroup) ServiceID {
 	svcID := ParseEndpointSliceID(epSlice)
 
 	return s.deleteEndpoints(svcID, swg)

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	slim_discovery_v1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
+	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -155,23 +155,23 @@ func (s *K8sSuite) TestServiceCacheEndpoints(c *check.C) {
 }
 
 func (s *K8sSuite) TestServiceCacheEndpointSlice(c *check.C) {
-	k8sEndpointSlice := &slim_discovery_v1beta1.EndpointSlice{
-		AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
+	k8sEndpointSlice := &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "foo-afbh9",
 			Namespace: "bar",
 			Labels: map[string]string{
-				slim_discovery_v1beta1.LabelServiceName: "foo",
+				slim_discovery_v1.LabelServiceName: "foo",
 			},
 		},
-		Endpoints: []slim_discovery_v1beta1.Endpoint{
+		Endpoints: []slim_discovery_v1.Endpoint{
 			{
 				Addresses: []string{
 					"2.2.2.2",
 				},
 			},
 		},
-		Ports: []slim_discovery_v1beta1.EndpointPort{
+		Ports: []slim_discovery_v1.EndpointPort{
 			{
 				Name:     func() *string { a := "http-test-svc"; return &a }(),
 				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
@@ -181,7 +181,7 @@ func (s *K8sSuite) TestServiceCacheEndpointSlice(c *check.C) {
 	}
 
 	updateEndpoints := func(svcCache *ServiceCache, swgEps *lock.StoppableWaitGroup) {
-		svcCache.UpdateEndpointSlices(k8sEndpointSlice, swgEps)
+		svcCache.UpdateEndpointSlicesV1(k8sEndpointSlice, swgEps)
 	}
 	deleteEndpoints := func(svcCache *ServiceCache, swgEps *lock.StoppableWaitGroup) {
 		svcCache.DeleteEndpointSlices(k8sEndpointSlice, swgEps)
@@ -645,23 +645,23 @@ func (s *K8sSuite) TestNonSharedServie(c *check.C) {
 }
 
 func (s *K8sSuite) TestServiceCacheWith2EndpointSlice(c *check.C) {
-	k8sEndpointSlice1 := &slim_discovery_v1beta1.EndpointSlice{
-		AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
+	k8sEndpointSlice1 := &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "foo-yyyyy",
 			Namespace: "bar",
 			Labels: map[string]string{
-				slim_discovery_v1beta1.LabelServiceName: "foo",
+				slim_discovery_v1.LabelServiceName: "foo",
 			},
 		},
-		Endpoints: []slim_discovery_v1beta1.Endpoint{
+		Endpoints: []slim_discovery_v1.Endpoint{
 			{
 				Addresses: []string{
 					"2.2.2.2",
 				},
 			},
 		},
-		Ports: []slim_discovery_v1beta1.EndpointPort{
+		Ports: []slim_discovery_v1.EndpointPort{
 			{
 				Name:     func() *string { a := "http-test-svc"; return &a }(),
 				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
@@ -670,23 +670,23 @@ func (s *K8sSuite) TestServiceCacheWith2EndpointSlice(c *check.C) {
 		},
 	}
 
-	k8sEndpointSlice2 := &slim_discovery_v1beta1.EndpointSlice{
-		AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
+	k8sEndpointSlice2 := &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "foo-xxxxx",
 			Namespace: "bar",
 			Labels: map[string]string{
-				slim_discovery_v1beta1.LabelServiceName: "foo",
+				slim_discovery_v1.LabelServiceName: "foo",
 			},
 		},
-		Endpoints: []slim_discovery_v1beta1.Endpoint{
+		Endpoints: []slim_discovery_v1.Endpoint{
 			{
 				Addresses: []string{
 					"2.2.2.3",
 				},
 			},
 		},
-		Ports: []slim_discovery_v1beta1.EndpointPort{
+		Ports: []slim_discovery_v1.EndpointPort{
 			{
 				Name:     func() *string { a := "http-test-svc"; return &a }(),
 				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
@@ -695,23 +695,23 @@ func (s *K8sSuite) TestServiceCacheWith2EndpointSlice(c *check.C) {
 		},
 	}
 
-	k8sEndpointSlice3 := &slim_discovery_v1beta1.EndpointSlice{
-		AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
+	k8sEndpointSlice3 := &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "foo-xxxxx",
 			Namespace: "baz",
 			Labels: map[string]string{
-				slim_discovery_v1beta1.LabelServiceName: "foo",
+				slim_discovery_v1.LabelServiceName: "foo",
 			},
 		},
-		Endpoints: []slim_discovery_v1beta1.Endpoint{
+		Endpoints: []slim_discovery_v1.Endpoint{
 			{
 				Addresses: []string{
 					"2.2.2.4",
 				},
 			},
 		},
-		Ports: []slim_discovery_v1beta1.EndpointPort{
+		Ports: []slim_discovery_v1.EndpointPort{
 			{
 				Name:     func() *string { a := "http-test-svc"; return &a }(),
 				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
@@ -751,9 +751,9 @@ func (s *K8sSuite) TestServiceCacheWith2EndpointSlice(c *check.C) {
 	}
 
 	swgEps := lock.NewStoppableWaitGroup()
-	svcCache.UpdateEndpointSlices(k8sEndpointSlice1, swgEps)
-	svcCache.UpdateEndpointSlices(k8sEndpointSlice2, swgEps)
-	svcCache.UpdateEndpointSlices(k8sEndpointSlice3, swgEps)
+	svcCache.UpdateEndpointSlicesV1(k8sEndpointSlice1, swgEps)
+	svcCache.UpdateEndpointSlicesV1(k8sEndpointSlice2, swgEps)
+	svcCache.UpdateEndpointSlicesV1(k8sEndpointSlice3, swgEps)
 
 	// The service should be ready as both service and endpoints have been
 	// imported for k8sEndpointSlice1
@@ -841,7 +841,7 @@ func (s *K8sSuite) TestServiceCacheWith2EndpointSlice(c *check.C) {
 	c.Assert(endpoints.String(), check.Equals, "")
 
 	// Reinserting the endpoints should re-match with the still existing service
-	svcCache.UpdateEndpointSlices(k8sEndpointSlice1, swgEps)
+	svcCache.UpdateEndpointSlicesV1(k8sEndpointSlice1, swgEps)
 	c.Assert(testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
 		defer event.SWG.Done()

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,10 @@ type ServerCapabilities struct {
 	// EndpointSlice is the ability of k8s server to support endpoint slices
 	EndpointSlice bool
 
+	// EndpointSliceV1 is the ability of k8s server to support endpoint slices
+	// v1. This version was introduced in K8s v1.21.0.
+	EndpointSliceV1 bool
+
 	// LeasesResourceLock is the ability of K8s server to support Lease type
 	// from coordination.k8s.io/v1 API for leader election purposes(currently only in operator).
 	// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lease-v1-coordination-k8s-io
@@ -76,10 +80,11 @@ const (
 var (
 	cached = cachedVersion{}
 
-	discoveryAPIGroup      = "discovery.k8s.io/v1beta1"
-	coordinationV1APIGroup = "coordination.k8s.io/v1"
-	endpointSliceKind      = "EndpointSlice"
-	leaseKind              = "Lease"
+	discoveryAPIGroupV1beta1 = "discovery.k8s.io/v1beta1"
+	discoveryAPIGroupV1      = "discovery.k8s.io/v1"
+	coordinationV1APIGroup   = "coordination.k8s.io/v1"
+	endpointSliceKind        = "EndpointSlice"
+	leaseKind                = "Lease"
 
 	// Constraint to check support for Lease type from coordination.k8s.io/v1.
 	// Support for Lease resource was introduced in K8s version 1.14.
@@ -88,6 +93,10 @@ var (
 	// Constraint to check support for apiextensions/v1 CRD types. Support for
 	// v1 CRDs was introduced in K8s version 1.16.
 	isGEThanAPIExtensionsV1CRD = versioncheck.MustCompile(">=1.16.0")
+
+	// Constraint to check support for discovery/v1 types. Support for v1
+	// discovery was introduced in K8s version 1.21.
+	isGEThanAPIDiscoveryV1 = versioncheck.MustCompile(">=1.21.0")
 
 	// isGEThanMinimalVersionConstraint is the minimal version required to run
 	// Cilium
@@ -118,6 +127,7 @@ func updateVersion(version semver.Version) {
 
 	cached.capabilities.MinimalVersionMet = isGEThanMinimalVersionConstraint(version)
 	cached.capabilities.APIExtensionsV1CRD = isGEThanAPIExtensionsV1CRD(version)
+	cached.capabilities.EndpointSliceV1 = isGEThanAPIDiscoveryV1(version)
 }
 
 func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) {
@@ -125,12 +135,22 @@ func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) 
 	defer cached.mutex.Unlock()
 
 	cached.capabilities.EndpointSlice = false
+	cached.capabilities.EndpointSliceV1 = false
 	cached.capabilities.LeasesResourceLock = false
 	for _, rscList := range apiResourceLists {
-		if rscList.GroupVersion == discoveryAPIGroup {
+		if rscList.GroupVersion == discoveryAPIGroupV1beta1 {
 			for _, rsc := range rscList.APIResources {
 				if rsc.Kind == endpointSliceKind {
 					cached.capabilities.EndpointSlice = true
+					break
+				}
+			}
+		}
+		if rscList.GroupVersion == discoveryAPIGroupV1 {
+			for _, rsc := range rscList.APIResources {
+				if rsc.Kind == endpointSliceKind {
+					cached.capabilities.EndpointSlice = true
+					cached.capabilities.EndpointSliceV1 = true
 					break
 				}
 			}
@@ -158,6 +178,16 @@ func Force(version string) error {
 }
 
 func endpointSlicesFallbackDiscovery(client kubernetes.Interface) error {
+	// If a k8s version with discovery v1 is used, then do not even bother
+	// checking for v1beta1
+	cached.mutex.Lock()
+	if cached.capabilities.EndpointSliceV1 {
+		cached.capabilities.EndpointSlice = true
+		cached.mutex.Unlock()
+		return nil
+	}
+	cached.mutex.Unlock()
+
 	// Discovery of API groups requires the API services of the apiserver to be
 	// healthy. Such API services can depend on the readiness of regular pods
 	// which require Cilium to function correctly. By treating failure to

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,12 +19,15 @@ import (
 
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
+	slim_discover_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	slim_discover_v1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
 	"github.com/cilium/cilium/pkg/lock"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -33,55 +36,111 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 	var (
 		hasEndpointSlices = make(chan struct{})
 		once              sync.Once
+		esClient          rest.Interface
+		objType           runtime.Object
+		addFunc, delFunc  func(obj interface{})
+		updateFunc        func(oldObj, newObj interface{})
 	)
 
+	if k8s.SupportsEndpointSliceV1() {
+		esClient = k8sClient.DiscoveryV1().RESTClient()
+		objType = &slim_discover_v1.EndpointSlice{}
+		addFunc = func(obj interface{}) {
+			once.Do(func() {
+				// signalize that we have received an endpoint slice
+				// so it means the cluster has endpoint slices enabled.
+				close(hasEndpointSlices)
+			})
+			var valid, equal bool
+			defer func() { k.K8sEventReceived(metricEndpointSlice, metricCreate, valid, equal) }()
+			if k8sEP := k8s.ObjToV1EndpointSlice(obj); k8sEP != nil {
+				valid = true
+				k.K8sSvcCache.UpdateEndpointSlicesV1(k8sEP, swgEps)
+				k.K8sEventProcessed(metricEndpointSlice, metricCreate, true)
+			}
+		}
+		updateFunc = func(oldObj, newObj interface{}) {
+			var valid, equal bool
+			defer func() { k.K8sEventReceived(metricEndpointSlice, metricUpdate, valid, equal) }()
+			if oldk8sEP := k8s.ObjToV1EndpointSlice(oldObj); oldk8sEP != nil {
+				if newk8sEP := k8s.ObjToV1EndpointSlice(newObj); newk8sEP != nil {
+					valid = true
+					if oldk8sEP.DeepEqual(newk8sEP) {
+						equal = true
+						return
+					}
+
+					k.K8sSvcCache.UpdateEndpointSlicesV1(newk8sEP, swgEps)
+					k.K8sEventProcessed(metricEndpointSlice, metricUpdate, true)
+				}
+			}
+		}
+		delFunc = func(obj interface{}) {
+			var valid, equal bool
+			defer func() { k.K8sEventReceived(metricEndpointSlice, metricDelete, valid, equal) }()
+			k8sEP := k8s.ObjToV1EndpointSlice(obj)
+			if k8sEP == nil {
+				return
+			}
+			valid = true
+			k.K8sSvcCache.DeleteEndpointSlices(k8sEP, swgEps)
+			k.K8sEventProcessed(metricEndpointSlice, metricDelete, true)
+		}
+	} else {
+		esClient = k8sClient.DiscoveryV1beta1().RESTClient()
+		objType = &slim_discover_v1beta1.EndpointSlice{}
+		addFunc = func(obj interface{}) {
+			once.Do(func() {
+				// signalize that we have received an endpoint slice
+				// so it means the cluster has endpoint slices enabled.
+				close(hasEndpointSlices)
+			})
+			var valid, equal bool
+			defer func() { k.K8sEventReceived(metricEndpointSlice, metricCreate, valid, equal) }()
+			if k8sEP := k8s.ObjToV1Beta1EndpointSlice(obj); k8sEP != nil {
+				valid = true
+				k.K8sSvcCache.UpdateEndpointSlicesV1Beta1(k8sEP, swgEps)
+				k.K8sEventProcessed(metricEndpointSlice, metricCreate, true)
+			}
+		}
+		updateFunc = func(oldObj, newObj interface{}) {
+			var valid, equal bool
+			defer func() { k.K8sEventReceived(metricEndpointSlice, metricUpdate, valid, equal) }()
+			if oldk8sEP := k8s.ObjToV1Beta1EndpointSlice(oldObj); oldk8sEP != nil {
+				if newk8sEP := k8s.ObjToV1Beta1EndpointSlice(newObj); newk8sEP != nil {
+					valid = true
+					if oldk8sEP.DeepEqual(newk8sEP) {
+						equal = true
+						return
+					}
+
+					k.K8sSvcCache.UpdateEndpointSlicesV1Beta1(newk8sEP, swgEps)
+					k.K8sEventProcessed(metricEndpointSlice, metricUpdate, true)
+				}
+			}
+		}
+		delFunc = func(obj interface{}) {
+			var valid, equal bool
+			defer func() { k.K8sEventReceived(metricEndpointSlice, metricDelete, valid, equal) }()
+			k8sEP := k8s.ObjToV1Beta1EndpointSlice(obj)
+			if k8sEP == nil {
+				return
+			}
+			valid = true
+			k.K8sSvcCache.DeleteEndpointSlices(k8sEP, swgEps)
+			k.K8sEventProcessed(metricEndpointSlice, metricDelete, true)
+		}
+	}
+
 	_, endpointController := informer.NewInformer(
-		cache.NewListWatchFromClient(k8sClient.DiscoveryV1beta1().RESTClient(),
+		cache.NewListWatchFromClient(esClient,
 			"endpointslices", v1.NamespaceAll, fields.Everything()),
-		&slim_discover_v1beta1.EndpointSlice{},
+		objType,
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				once.Do(func() {
-					// signalize that we have received an endpoint slice
-					// so it means the cluster has endpoint slices enabled.
-					close(hasEndpointSlices)
-				})
-				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricEndpointSlice, metricCreate, valid, equal) }()
-				if k8sEP := k8s.ObjToV1EndpointSlice(obj); k8sEP != nil {
-					valid = true
-					k.K8sSvcCache.UpdateEndpointSlices(k8sEP, swgEps)
-					k.K8sEventProcessed(metricEndpointSlice, metricCreate, true)
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricEndpointSlice, metricUpdate, valid, equal) }()
-				if oldk8sEP := k8s.ObjToV1EndpointSlice(oldObj); oldk8sEP != nil {
-					if newk8sEP := k8s.ObjToV1EndpointSlice(newObj); newk8sEP != nil {
-						valid = true
-						if oldk8sEP.DeepEqual(newk8sEP) {
-							equal = true
-							return
-						}
-
-						k.K8sSvcCache.UpdateEndpointSlices(newk8sEP, swgEps)
-						k.K8sEventProcessed(metricEndpointSlice, metricUpdate, true)
-					}
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricEndpointSlice, metricDelete, valid, equal) }()
-				k8sEP := k8s.ObjToV1EndpointSlice(obj)
-				if k8sEP == nil {
-					return
-				}
-				valid = true
-				k.K8sSvcCache.DeleteEndpointSlices(k8sEP, swgEps)
-				k.K8sEventProcessed(metricEndpointSlice, metricDelete, true)
-			},
+			AddFunc:    addFunc,
+			UpdateFunc: updateFunc,
+			DeleteFunc: delFunc,
 		},
 		nil,
 	)


### PR DESCRIPTION
With this commit Cilium will have support for EndpointSlice v1 which is
being enabled by default in Kubernetes Clusters running with v1.21.

To have backward compatibility, Cilium will still continue to support
EndpointSlice v1beta1 for clusters below v1.21.

Signed-off-by: André Martins <andre@cilium.io>


Fixes https://github.com/cilium/cilium/issues/15501