### PR TITLE
v1.8 backports 2021-03-31

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,189 +15,190 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --agent-health-port int                         TCP port for agent health status API (default 9876)
-      --agent-labels strings                          Additional labels to identify this agent
-      --allow-icmp-frag-needed                        Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
-      --allow-localhost string                        Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --annotate-k8s-node                             Annotate Kubernetes node (default true)
-      --api-rate-limit map                            API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
-      --auto-create-cilium-node-resource              Automatically create CiliumNode resource for own node on startup (default true)
-      --auto-direct-node-routes                       Enable automatic L2 routing between nodes
-      --blacklist-conflicting-routes                  Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
-      --bpf-compile-debug                             Enable debugging of the BPF compilation process
-      --bpf-ct-global-any-max int                     Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                     Maximum number of entries in TCP CT table (default 524288)
-      --bpf-ct-timeout-regular-any duration           Timeout for entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-regular-tcp duration           Timeout for established entries in TCP CT table (default 6h0m0s)
-      --bpf-ct-timeout-regular-tcp-fin duration       Teardown timeout for entries in TCP CT table (default 10s)
-      --bpf-ct-timeout-regular-tcp-syn duration       Establishment timeout for entries in TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-any duration           Timeout for service entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-tcp duration           Timeout for established service entries in TCP CT table (default 6h0m0s)
-      --bpf-fragments-map-max int                     Maximum number of entries in fragments tracking map (default 8192)
-      --bpf-map-dynamic-size-ratio float              Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
-      --bpf-nat-global-max int                        Maximum number of entries for the global BPF NAT table (default 524288)
-      --bpf-neigh-global-max int                      Maximum number of entries for the global BPF neighbor table (default 524288)
-      --bpf-policy-map-max int                        Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
-      --bpf-root string                               Path to BPF filesystem
-      --bpf-sock-rev-map-max int                      Maximum number of entries for the SockRevNAT BPF map (default 262144)
-      --certificates-directory string                 Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cgroup-root string                            Path to Cgroup2 filesystem
-      --cluster-id int                                Unique identifier of the cluster
-      --cluster-name string                           Name of the cluster (default "default")
-      --clustermesh-config string                     Path to the ClusterMesh configuration directory
-      --config string                                 Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                             Configuration directory that contains a file for each option
-      --conntrack-gc-interval duration                Overwrite the connection-tracking garbage collection interval
-      --datapath-mode string                          Datapath mode name (default "veth")
-  -D, --debug                                         Enable debugging mode
-      --debug-verbose strings                         List of enabled verbose debug groups
-      --devices strings                               List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
-      --direct-routing-device string                  Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
-      --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
-      --disable-conntrack                             Disable connection tracking
-      --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
-      --disable-iptables-feeder-rules strings         Chains to ignore when installing feeder rules.
-      --dns-max-ips-per-restored-rule int             Maximum number of IPs to maintain for each restored DNS rule (default 1000)
-      --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
-      --egress-multi-home-ip-rule-compat              Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.
-      --enable-api-rate-limit                         Enables the use of the API rate limiting configuration
-      --enable-auto-protect-node-port-range           Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
-      --enable-bpf-clock-probe                        Enable BPF clock source probing for more efficient tick retrieval
-      --enable-bpf-masquerade                         Masquerade packets from endpoints leaving the host with BPF instead of iptables
-      --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
-      --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host
-      --enable-external-ips                           Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
-      --enable-health-check-nodeport                  Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
-      --enable-health-checking                        Enable connectivity health checking (default true)
-      --enable-host-firewall                          Enable host network policies (beta)
-      --enable-host-port                              Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
-      --enable-host-reachable-services                Enable reachability of services for host applications (beta)
-      --enable-hubble                                 Enable hubble server
-      --enable-identity-mark                          Enable setting identity mark for local traffic (default true)
-      --enable-ip-masq-agent                          Enable BPF ip-masq-agent
-      --enable-ipsec                                  Enable IPSec support
-      --enable-ipv4                                   Enable IPv4 support (default true)
-      --enable-ipv4-fragment-tracking                 Enable IPv4 fragments tracking for L4-based lookups (default true)
-      --enable-ipv6                                   Enable IPv6 support (default true)
-      --enable-k8s-api-discovery                      Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                     Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                     Enable k8s event handover to kvstore for improved scalability
-      --enable-l7-proxy                               Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-local-node-route                       Enable installation of the route which points the allocation prefix of the local node (default true)
-      --enable-node-port                              Enable NodePort type services by Cilium (beta)
-      --enable-policy string                          Enable policy enforcement (default "default")
-      --enable-remote-node-identity                   Enable use of remote node identity
-      --enable-session-affinity                       Enable support for service session affinity
-      --enable-svc-source-range-check                 Enable check of service source ranges (currently, only for LoadBalancer) (default true)
-      --enable-tracing                                Enable tracing while determining policy (debugging)
-      --enable-well-known-identities                  Enable well-known identities for known Kubernetes components (default true)
-      --enable-xt-socket-fallback                     Enable fallback for missing xt_socket module (default true)
-      --encrypt-interface string                      Transparent encryption interface
-      --encrypt-node                                  Enables encrypting traffic from non-Cilium pods and host networking
-      --endpoint-interface-name-prefix string         Prefix of interface name shared by all endpoints (default "lxc+")
-      --endpoint-queue-size int                       size of EventQueue per-endpoint (default 25)
-      --endpoint-status strings                       Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
-      --envoy-log string                              Path to a separate Envoy log file, if any
-      --exclude-local-address strings                 Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                    Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --flannel-master-device string                  Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
-      --flannel-uninstall-on-exit                     When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
-      --force-local-policy-eval-at-source             Force policy evaluation of all local communication at the source endpoint (default true)
-  -h, --help                                          help for cilium-agent
-      --host-reachable-services-protos strings        Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
-      --http-idle-timeout uint                        Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                    Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-request-timeout uint                     Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                         Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                       Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --hubble-event-queue-size int                   Buffer size of the channel to receive monitor events.
-      --hubble-flow-buffer-size int                   Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
-      --hubble-listen-address string                  An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                        List of Hubble metrics to enable.
-      --hubble-metrics-server string                  Address to serve Hubble metrics on.
-      --hubble-socket-path string                     Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
-      --identity-allocation-mode string               Method to use for identity allocation (default "kvstore")
-      --identity-change-grace-period duration         Time to wait before using new identity on endpoint identity change (default 5s)
-      --install-iptables-rules                        Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --ip-allocation-timeout duration                Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
-      --ip-masq-agent-config-path string              ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
-      --ipam string                                   Backend to use for IPAM (default "hostscope-legacy")
-      --ipsec-key-file string                         Path to IPSec key file
-      --iptables-lock-timeout duration                Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
-      --iptables-random-fully                         Set iptables flag random-fully on masquerading rules
-      --ipv4-node string                              IPv4 address of node (default "auto")
-      --ipv4-pod-subnets strings                      List of IPv4 pod subnets to preconfigure for encryption
-      --ipv4-range string                             Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-loopback-address string          IPv4 address for service loopback SNAT (default "169.254.42.1")
-      --ipv4-service-range string                     Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string                IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-node string                              IPv6 address of node (default "auto")
-      --ipv6-pod-subnets strings                      List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                             Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                     Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --ipvlan-master-device string                   Device facing external network acting as ipvlan master (default "undefined")
-      --k8s-api-server string                         Kubernetes API server URL
-      --k8s-heartbeat-timeout duration                Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                    Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in
-      --k8s-require-ipv4-pod-cidr                     Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                     Require IPv6 PodCIDR to be specified in node resource
-      --k8s-service-proxy-name string                 Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --k8s-watcher-endpoint-selector string          K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --k8s-watcher-queue-size uint                   Queue size used to serialize each k8s event type (default 1024)
-      --keep-config                                   When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                 auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
-      --kvstore string                                Key-value store type
-      --kvstore-connectivity-timeout duration         Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-opt map                               Key-value store options (default map[])
-      --kvstore-periodic-sync duration                Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                      Valid label prefixes file path
-      --labels strings                                List of label prefixes used to determine identity of an endpoint
-      --lib-dir string                                Directory path to store runtime build environment (default "/var/lib/cilium")
-      --log-driver strings                            Logging endpoints to use for example syslog
-      --log-opt map                                   Log driver options for cilium (default map[])
-      --log-system-load                               Enable periodic logging of system load
-      --masquerade                                    Masquerade packets from endpoints leaving the host (default true)
-      --metrics strings                               Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
-      --monitor-aggregation string                    Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-aggregation-flags strings             TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
-      --monitor-aggregation-interval duration         Monitor report interval when monitor aggregation is enabled (default 5s)
-      --monitor-queue-size int                        Size of the event queue when reading monitor events
-      --mtu int                                       Overwrite auto-detected MTU of underlying network
-      --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --native-routing-cidr string                    Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
-      --node-port-acceleration string                 BPF NodePort acceleration via XDP ("native", "disabled") (default "disabled")
-      --node-port-bind-protection                     Reject application bind(2) requests to service ports in the NodePort range (default true)
-      --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")
-      --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])
-      --policy-audit-mode                             Enable policy audit (non-drop) mode
-      --policy-queue-size int                         size of queues for policy-related events (default 100)
-      --pprof                                         Enable serving the pprof debugging API
-      --preallocate-bpf-maps                          Enable BPF map pre-allocation (default true)
-      --prefilter-device string                       Device facing external network for XDP prefiltering (default "undefined")
-      --prefilter-mode string                         Prefilter mode via XDP ("native", "generic") (default "native")
-      --prepend-iptables-chains                       Prepend custom iptables chains instead of appending (default true)
-      --prometheus-serve-addr string                  IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                    Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --read-cni-conf string                          Read to the CNI configuration at specified path to extract per node configuration
-      --restore                                       Restores state, if possible, from previous daemon (default true)
-      --sidecar-istio-proxy-image string              Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                          Use a single cluster route instead of per node routes
-      --skip-crd-creation                             Skip Kubernetes Custom Resource Definitions creations
-      --socket-path string                            Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                                Enable sockops when kernel supported
-      --state-dir string                              Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string       DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-dns-compression                Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int      Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-max-deferred-connection-deletes int   Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-min-ttl int                           The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
-      --tofqdns-pre-cache string                      DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                        Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --tofqdns-proxy-response-max-delay duration     The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
-      --trace-payloadlen int                          Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                                 Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --version                                       Print version information
-      --write-cni-conf-when-ready string              Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
+      --agent-health-port int                           TCP port for agent health status API (default 9876)
+      --agent-labels strings                            Additional labels to identify this agent
+      --allow-icmp-frag-needed                          Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
+      --allow-localhost string                          Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                               Annotate Kubernetes node (default true)
+      --api-rate-limit map                              API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
+      --auto-create-cilium-node-resource                Automatically create CiliumNode resource for own node on startup (default true)
+      --auto-direct-node-routes                         Enable automatic L2 routing between nodes
+      --blacklist-conflicting-routes                    Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
+      --bpf-compile-debug                               Enable debugging of the BPF compilation process
+      --bpf-ct-global-any-max int                       Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                       Maximum number of entries in TCP CT table (default 524288)
+      --bpf-ct-timeout-regular-any duration             Timeout for entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-regular-tcp duration             Timeout for established entries in TCP CT table (default 6h0m0s)
+      --bpf-ct-timeout-regular-tcp-fin duration         Teardown timeout for entries in TCP CT table (default 10s)
+      --bpf-ct-timeout-regular-tcp-syn duration         Establishment timeout for entries in TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-any duration             Timeout for service entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-tcp duration             Timeout for established service entries in TCP CT table (default 6h0m0s)
+      --bpf-fragments-map-max int                       Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-map-dynamic-size-ratio float                Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
+      --bpf-nat-global-max int                          Maximum number of entries for the global BPF NAT table (default 524288)
+      --bpf-neigh-global-max int                        Maximum number of entries for the global BPF neighbor table (default 524288)
+      --bpf-policy-map-max int                          Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-root string                                 Path to BPF filesystem
+      --bpf-sock-rev-map-max int                        Maximum number of entries for the SockRevNAT BPF map (default 262144)
+      --certificates-directory string                   Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cgroup-root string                              Path to Cgroup2 filesystem
+      --cluster-id int                                  Unique identifier of the cluster
+      --cluster-name string                             Name of the cluster (default "default")
+      --clustermesh-config string                       Path to the ClusterMesh configuration directory
+      --config string                                   Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                               Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration                  Overwrite the connection-tracking garbage collection interval
+      --datapath-mode string                            Datapath mode name (default "veth")
+  -D, --debug                                           Enable debugging mode
+      --debug-verbose strings                           List of enabled verbose debug groups
+      --devices strings                                 List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
+      --direct-routing-device string                    Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
+      --disable-cnp-status-updates                      Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
+      --disable-conntrack                               Disable connection tracking
+      --disable-endpoint-crd                            Disable use of CiliumEndpoint CRD
+      --disable-iptables-feeder-rules strings           Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int               Maximum number of IPs to maintain for each restored DNS rule (default 1000)
+      --egress-masquerade-interfaces string             Limit egress masquerading to interface selector
+      --egress-multi-home-ip-rule-compat                Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.
+      --enable-api-rate-limit                           Enables the use of the API rate limiting configuration
+      --enable-auto-protect-node-port-range             Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
+      --enable-bpf-clock-probe                          Enable BPF clock source probing for more efficient tick retrieval
+      --enable-bpf-masquerade                           Masquerade packets from endpoints leaving the host with BPF instead of iptables
+      --enable-endpoint-health-checking                 Enable connectivity health checking between virtual endpoints (default true)
+      --enable-endpoint-routes                          Use per endpoint routes instead of routing via cilium_host
+      --enable-external-ips                             Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
+      --enable-health-check-nodeport                    Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                          Enable connectivity health checking (default true)
+      --enable-host-firewall                            Enable host network policies (beta)
+      --enable-host-port                                Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
+      --enable-host-reachable-services                  Enable reachability of services for host applications (beta)
+      --enable-hubble                                   Enable hubble server
+      --enable-identity-mark                            Enable setting identity mark for local traffic (default true)
+      --enable-ip-masq-agent                            Enable BPF ip-masq-agent
+      --enable-ipsec                                    Enable IPSec support
+      --enable-ipv4                                     Enable IPv4 support (default true)
+      --enable-ipv4-fragment-tracking                   Enable IPv4 fragments tracking for L4-based lookups (default true)
+      --enable-ipv6                                     Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                        Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                       Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                       Enable k8s event handover to kvstore for improved scalability
+      --enable-l7-proxy                                 Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-local-node-route                         Enable installation of the route which points the allocation prefix of the local node (default true)
+      --enable-node-port                                Enable NodePort type services by Cilium (beta)
+      --enable-policy string                            Enable policy enforcement (default "default")
+      --enable-remote-node-identity                     Enable use of remote node identity
+      --enable-session-affinity                         Enable support for service session affinity
+      --enable-svc-source-range-check                   Enable check of service source ranges (currently, only for LoadBalancer) (default true)
+      --enable-tracing                                  Enable tracing while determining policy (debugging)
+      --enable-well-known-identities                    Enable well-known identities for known Kubernetes components (default true)
+      --enable-xt-socket-fallback                       Enable fallback for missing xt_socket module (default true)
+      --encrypt-interface string                        Transparent encryption interface
+      --encrypt-node                                    Enables encrypting traffic from non-Cilium pods and host networking
+      --endpoint-interface-name-prefix string           Prefix of interface name shared by all endpoints (default "lxc+")
+      --endpoint-queue-size int                         size of EventQueue per-endpoint (default 25)
+      --endpoint-status strings                         Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
+      --envoy-log string                                Path to a separate Envoy log file, if any
+      --exclude-local-address strings                   Exclude CIDR from being recognized as local address
+      --fixed-identity-mapping map                      Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
+      --flannel-master-device string                    Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
+      --flannel-uninstall-on-exit                       When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
+      --force-local-policy-eval-at-source               Force policy evaluation of all local communication at the source endpoint (default true)
+  -h, --help                                            help for cilium-agent
+      --host-reachable-services-protos strings          Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
+      --http-idle-timeout uint                          Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                      Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-request-timeout uint                       Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                           Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                         Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --hubble-event-queue-size int                     Buffer size of the channel to receive monitor events.
+      --hubble-flow-buffer-size int                     Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
+      --hubble-listen-address string                    An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-metrics strings                          List of Hubble metrics to enable.
+      --hubble-metrics-server string                    Address to serve Hubble metrics on.
+      --hubble-socket-path string                       Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
+      --identity-allocation-mode string                 Method to use for identity allocation (default "kvstore")
+      --identity-change-grace-period duration           Time to wait before using new identity on endpoint identity change (default 5s)
+      --install-iptables-rules                          Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --ip-allocation-timeout duration                  Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
+      --ip-masq-agent-config-path string                ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ipam string                                     Backend to use for IPAM (default "hostscope-legacy")
+      --ipsec-key-file string                           Path to IPSec key file
+      --iptables-lock-timeout duration                  Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                           Set iptables flag random-fully on masquerading rules
+      --ipv4-node string                                IPv4 address of node (default "auto")
+      --ipv4-pod-subnets strings                        List of IPv4 pod subnets to preconfigure for encryption
+      --ipv4-range string                               Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string            IPv4 address for service loopback SNAT (default "169.254.42.1")
+      --ipv4-service-range string                       Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string                  IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-node string                                IPv6 address of node (default "auto")
+      --ipv6-pod-subnets strings                        List of IPv6 pod subnets to preconfigure for encryption
+      --ipv6-range string                               Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                       Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --ipvlan-master-device string                     Device facing external network acting as ipvlan master (default "undefined")
+      --k8s-api-server string                           Kubernetes API server URL
+      --k8s-heartbeat-timeout duration                  Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                      Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                            Name of the Kubernetes namespace in which Cilium is deployed in
+      --k8s-require-ipv4-pod-cidr                       Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                       Require IPv6 PodCIDR to be specified in node resource
+      --k8s-service-proxy-name string                   Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --k8s-watcher-endpoint-selector string            K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --k8s-watcher-queue-size uint                     Queue size used to serialize each k8s event type (default 1024)
+      --keep-config                                     When restoring state, keeps containers' configuration in place
+      --kube-proxy-replacement string                   auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
+      --kvstore string                                  Key-value store type
+      --kvstore-connectivity-timeout duration           Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-opt map                                 Key-value store options (default map[])
+      --kvstore-periodic-sync duration                  Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                        Valid label prefixes file path
+      --labels strings                                  List of label prefixes used to determine identity of an endpoint
+      --lib-dir string                                  Directory path to store runtime build environment (default "/var/lib/cilium")
+      --log-driver strings                              Logging endpoints to use for example syslog
+      --log-opt map                                     Log driver options for cilium (default map[])
+      --log-system-load                                 Enable periodic logging of system load
+      --masquerade                                      Masquerade packets from endpoints leaving the host (default true)
+      --metrics strings                                 Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
+      --monitor-aggregation string                      Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-aggregation-flags strings               TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
+      --monitor-aggregation-interval duration           Monitor report interval when monitor aggregation is enabled (default 5s)
+      --monitor-queue-size int                          Size of the event queue when reading monitor events
+      --mtu int                                         Overwrite auto-detected MTU of underlying network
+      --nat46-range string                              IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --native-routing-cidr string                      Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
+      --node-port-acceleration string                   BPF NodePort acceleration via XDP ("native", "disabled") (default "disabled")
+      --node-port-bind-protection                       Reject application bind(2) requests to service ports in the NodePort range (default true)
+      --node-port-mode string                           BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")
+      --node-port-range strings                         Set the min/max NodePort port range (default [30000,32767])
+      --policy-audit-mode                               Enable policy audit (non-drop) mode
+      --policy-queue-size int                           size of queues for policy-related events (default 100)
+      --pprof                                           Enable serving the pprof debugging API
+      --preallocate-bpf-maps                            Enable BPF map pre-allocation (default true)
+      --prefilter-device string                         Device facing external network for XDP prefiltering (default "undefined")
+      --prefilter-mode string                           Prefilter mode via XDP ("native", "generic") (default "native")
+      --prepend-iptables-chains                         Prepend custom iptables chains instead of appending (default true)
+      --prometheus-serve-addr string                    IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                      Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --read-cni-conf string                            Read to the CNI configuration at specified path to extract per node configuration
+      --restore                                         Restores state, if possible, from previous daemon (default true)
+      --sidecar-istio-proxy-image string                Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                            Use a single cluster route instead of per node routes
+      --skip-crd-creation                               Skip Kubernetes Custom Resource Definitions creations
+      --socket-path string                              Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                                  Enable sockops when kernel supported
+      --state-dir string                                Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string         DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-dns-compression                  Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int        Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-idle-connection-grace-period duration   Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
+      --tofqdns-max-deferred-connection-deletes int     Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-min-ttl int                             The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
+      --tofqdns-pre-cache string                        DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                          Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-max-delay duration       The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --trace-payloadlen int                            Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                                   Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --version                                         Print version information
+      --write-cni-conf-when-ready string                Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -271,6 +271,29 @@ corresponds to the ``toFQDNS: matchName: "*"`` rule would list all identities
 for IPs that came from the DNS Proxy. Other CIDR identities would not be
 included.
 
+Unintended DNS Policy Drops
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``toFQDNSs`` policy enforcement relies on the source POD performing a DNS query
+before using an IP address returned in the DNS response. Sometimes PODs may hold
+on to a DNS response and start new connections to the same IP address at a later
+time. This may trigger policy drops if the DNS response has expired as
+requested by the DNS server in the time-to-live (TTL) value in the
+response. When DNS is used for service load balancing the advertised TTL value
+may be short (e.g., 60 seconds). To allow for reasonable POD behavior without
+unintended policy drops Cilium employs a configurable minimum DNS TTL value via
+``--tofqdns-min-ttl`` which defaults to 3600 seconds. This setting overrides
+short TTLs and allows the POD to use the IP address in the DNS response for one
+hour. Existing connections also keep the IP address as allowed in the
+policy. Any new connections opened by the POD using the same IP address without
+performing a new DNS query after the (possibly extended) DNS TTL has expired
+can be dropped by Cilium policy enforcement. To allow PODs to use the DNS
+response after TTL expiry for new connections a command line option
+``--tofqdns-idle-connection-grace-period`` may be used to keep the
+IP-address/name mapping valid in the policy for an extended time after DNS TTL
+expiry. This option takes effect only if the POD has opened at least one
+connection during the DNS TTL period.
+
 Datapath Plumbing
 ~~~~~~~~~~~~~~~~~
 

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -150,7 +150,7 @@ To replace cilium-ipsec-keys secret with a new keys,
 
 .. code-block:: shell-session
 
-    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | awk '/^keys:/ {print $2}' | base64 -d | awk '{print $1}')
+    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | awk '/^\s*keys:/ {print $2}' | base64 -d | awk '{print $1}')
     if [[ $KEYID -gt 15 ]]; then KEYID=0; fi
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -9,7 +9,7 @@ Jinja2==2.10.1
 jsonschema==2.6.0
 MarkupSafe==1.1.1
 pyenchant==2.0.0
-Pygments==2.4.2
+Pygments==2.7.4
 pytz==2018.7
 PyYAML==5.3.1
 recommonmark==0.4.0

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -69,10 +69,16 @@ main() {
     version="v${ersion}"
     run_url_id="$(basename "${3}")"
 
+    if [ ! -e "${PWD}/install/kubernetes/Makefile.digests" ]; then
+        >&2 echo "Cannot find install/kubernetes/Makefile.digests"
+        >&2 echo "Are you in the Cilium root directory?"
+        return 1
+    fi
+
     makefile_digest=$(get_digest_output "${username}" "${run_url_id}" "${version}" Makefile.digests)
     >&2 echo "Adding image SHAs to install/kubernetes/Makefile.digests"
     >&2 echo ""
-    cp "${makefile_digest}" "${DIR}/../../install/kubernetes/Makefile.digests"
+    cp "${makefile_digest}" "${PWD}/install/kubernetes/Makefile.digests"
     make -C install/kubernetes/
 
     >&2 echo "Generating manifest text for release notes"
@@ -80,8 +86,8 @@ main() {
     echo "Docker Manifests" > "${DIR}/../../digest-${version}.txt"
     echo "----------------" >> "${DIR}/../../digest-${version}.txt"
     image_digest_output=$(get_digest_output "${username}" "${run_url_id}" "${version}" image-digest-output.txt)
-    cat "${image_digest_output}" >> "${DIR}/../../digest-${version}.txt"
-    >&2 echo "Image digests available at ${DIR}/../../digest-${version}.txt"
+    cat "${image_digest_output}" >> "${PWD}/digest-${version}.txt"
+    >&2 echo "Image digests available at ${PWD}/digest-${version}.txt"
 }
 
 main "$@"

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -12,7 +12,7 @@ repo="cilium/cilium"
 usage() {
     logecho "usage: $0 <GH-USERNAME> <VERSION> <RUN-URL>"
     logecho "GH-USERNAME  GitHub username"
-    logecho "VERSION      Target version"
+    logecho "VERSION      Target version (X.Y.Z)"
     logecho "RUN-URL      GitHub URL with the RUN for the release images"
     logecho "             example: https://github.com/cilium/cilium/actions/runs/600920964"
     logecho "GITHUB_TOKEN environment variable set with the scope public:repo"
@@ -63,9 +63,10 @@ get_digest_output() {
 
 main() {
     handle_args "$@"
-    local username version run_url_id
+    local username ersion version run_url_id
     username="${1}"
-    version="${2}"
+    ersion="$(echo ${2} | sed 's/^v//')"
+    version="v${ersion}"
     run_url_id="$(basename "${3}")"
 
     makefile_digest=$(get_digest_output "${username}" "${run_url_id}" "${version}" Makefile.digests)

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -83,8 +83,6 @@ main() {
 
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""
-    echo "Docker Manifests" > "${DIR}/../../digest-${version}.txt"
-    echo "----------------" >> "${DIR}/../../digest-${version}.txt"
     image_digest_output=$(get_digest_output "${username}" "${run_url_id}" "${version}" image-digest-output.txt)
     cat "${image_digest_output}" >> "${PWD}/digest-${version}.txt"
     >&2 echo "Image digests available at ${PWD}/digest-${version}.txt"

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -73,6 +73,7 @@ main() {
     >&2 echo "Adding image SHAs to install/kubernetes/Makefile.digests"
     >&2 echo ""
     cp "${makefile_digest}" "${DIR}/../../install/kubernetes/Makefile.digests"
+    make -C install/kubernetes/
 
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -63,6 +63,7 @@ main() {
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
+    sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -52,7 +52,6 @@ handle_args() {
 main() {
     handle_args "$@"
 
-    local old_version="$(cat VERSION)"
     local ersion="$(echo $1 | sed 's/^v//')"
     local version="v$ersion"
     local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
@@ -60,6 +59,7 @@ main() {
 
     git fetch $REMOTE
     git checkout -b pr/prepare-$version $REMOTE/$branch
+    local old_version="$(cat VERSION)"
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -765,6 +765,9 @@ func init() {
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)
 
+	flags.DurationVar(&option.Config.ToFQDNsIdleConnectionGracePeriod, option.ToFQDNsIdleConnectionGracePeriod, defaults.ToFQDNsIdleConnectionGracePeriod, "Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)")
+	option.BindEnv(option.ToFQDNsIdleConnectionGracePeriod)
+
 	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 100*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(option.FQDNProxyResponseMaxDelay)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -242,9 +242,15 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 			cfg.Cache.ReplaceFromCacheByNames(namesToClean, caches...)
 
 			metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToClean)))
-			log.WithField(logfields.Controller, dnsGCJobName).Infof(
-				"FQDN garbage collector work deleted %d name entries", len(namesToClean))
 			_, err := d.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToClean)
+			namesCount := len(namesToClean)
+			// Limit the amount of info level logging to some sane amount
+			if namesCount > 20 {
+				// namedsToClean is only used for logging after this so we can reslice it in place
+				namesToClean = namesToClean[:20]
+			}
+			log.WithField(logfields.Controller, dnsGCJobName).Infof(
+				"FQDN garbage collector work deleted %d name entries: %s", namesCount, strings.Join(namesToClean, ","))
 			return err
 		},
 		Context: d.ctx,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -115,6 +115,11 @@ const (
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes = 10000
 
+	// ToFQDNsIdleConnectionGracePeriod Time during which idle but
+	// previously active connections with expired DNS lookups are
+	// still considered alive
+	ToFQDNsIdleConnectionGracePeriod = 0 * time.Second
+
 	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
 	// global cache on startup.
 	// The file is not re-read after agent start.

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -40,9 +40,9 @@ func (e *Endpoint) MarkDNSCTEntry(dstIP net.IP, now time.Time) {
 
 // MarkCTGCTime is the START time of a GC run. It is used by the DNS garbage
 // collector to determine whether a DNS zombie can be deleted. This is done by
-// comparing the timestamp of the start CT GC run with the ailve timestamps of
+// comparing the timestamp of the start CT GC run with the alive timestamps of
 // specific DNS zombies IPs marked with MarkDNSCTEntry.
-// NOTE: While the timestamp is ths start of the run, it should be set AFTER
+// NOTE: While the timestamp is the start of the run, it should be set AFTER
 // the run completes. This avoids a race between the DNS garbage collector and
 // the CT GC. This would occur when a DNS zombie that has not been visited by
 // the CT GC run is seen by a concurrent DNS garbage collector run, and then

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -737,20 +737,26 @@ func NewDNSZombieMappings(max int) *DNSZombieMappings {
 
 // Upsert enqueues the ip -> qname as a possible deletion
 // updatedExisting is true when an earlier enqueue existed and was updated
+// If an existing entry is updated, the later expiryTime is applied to the existing entry.
 func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, ipStr string, qname ...string) (updatedExisting bool) {
 	zombies.Lock()
 	defer zombies.Unlock()
 
 	zombie, updatedExisting := zombies.deletes[ipStr]
 	if !updatedExisting {
-		zombie = &DNSZombieMapping{}
+		zombie = &DNSZombieMapping{
+			Names:           KeepUniqueNames(qname),
+			IP:              net.ParseIP(ipStr),
+			DeletePendingAt: expiryTime,
+		}
 		zombies.deletes[ipStr] = zombie
+	} else {
+		zombie.Names = KeepUniqueNames(append(zombie.Names, qname...))
+		// Keep the latest expiry time
+		if expiryTime.After(zombie.DeletePendingAt) {
+			zombie.DeletePendingAt = expiryTime
+		}
 	}
-
-	zombie.Names = KeepUniqueNames(append(zombie.Names, qname...))
-	zombie.IP = net.ParseIP(ipStr)
-	zombie.DeletePendingAt = expiryTime
-
 	return updatedExisting
 }
 

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -737,7 +737,7 @@ func NewDNSZombieMappings(max int) *DNSZombieMappings {
 
 // Upsert enqueues the ip -> qname as a possible deletion
 // updatedExisting is true when an earlier enqueue existed and was updated
-func (zombies *DNSZombieMappings) Upsert(now time.Time, ipStr string, qname ...string) (updatedExisting bool) {
+func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, ipStr string, qname ...string) (updatedExisting bool) {
 	zombies.Lock()
 	defer zombies.Unlock()
 
@@ -749,17 +749,17 @@ func (zombies *DNSZombieMappings) Upsert(now time.Time, ipStr string, qname ...s
 
 	zombie.Names = KeepUniqueNames(append(zombie.Names, qname...))
 	zombie.IP = net.ParseIP(ipStr)
-	zombie.DeletePendingAt = now
+	zombie.DeletePendingAt = expiryTime
 
 	return updatedExisting
 }
 
-// isAlive returns true when a CT GC has completed without marking this zombie
-// alive. This occurs when:
-//  DeletePendingAt <= lastCTGCUpdate (i.e. CT GC has not happened yet), or
-//  AliveAt is not 0 and AliveAt >= lastCTGCUpdate (i.e it is marked by the CT GC run)
+// isConnectionAlive returns true if 'zombie' is considered alive.
+// Zombie is considered dead if both of these conditions apply:
+// 1. CT GC has run after the DNS Expiry time and grace period (lastCTGCUpdate > DeletePendingAt + GracePeriod), and
+// 2. The CG GC run did not mark the Zombie alive (lastCTGCUpdate > AliveAt)
+// otherwise the Zombie is alive.
 func (zombies *DNSZombieMappings) isConnectionAlive(zombie *DNSZombieMapping) bool {
-	// These are opposite because there is no BeforeEquals with time.Time :/
 	return !(zombies.lastCTGCUpdate.After(zombie.DeletePendingAt) && zombies.lastCTGCUpdate.After(zombie.AliveAt))
 }
 
@@ -863,12 +863,12 @@ func (zombies *DNSZombieMappings) MarkAlive(now time.Time, ip net.IP) {
 // collector and the CT GC. This would occur when a DNS zombie that has not
 // been visited by the CT GC run is seen by a concurrent DNS garbage collector
 // run, and then deleted.
-// When now is later than an alive timestamp, set with MarkAlive, the zombie is
+// When 'ctGCStart' is later than an alive timestamp, set with MarkAlive, the zombie is
 // no longer alive. Thus, this call acts as a gating function for what data is
 // returned by GC.
-func (zombies *DNSZombieMappings) SetCTGCTime(now time.Time) {
+func (zombies *DNSZombieMappings) SetCTGCTime(ctGCStart time.Time) {
 	zombies.Lock()
-	zombies.lastCTGCUpdate = now
+	zombies.lastCTGCUpdate = ctGCStart
 	zombies.Unlock()
 }
 

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/sirupsen/logrus"
 )
@@ -70,13 +71,18 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 				// mean the next iteration has completed and it is not in-use.
 				gcStart = time.Now()
 
+				// aliveTime is offset to the future by ToFQDNsIdleConnectionGracePeriod
+				// (default 0), allowing previously active connections to be considerred
+				// alive during idle periods of upto ToFQDNsIdleConnectionGracePeriod.
+				aliveTime = gcStart.Add(option.Config.ToFQDNsIdleConnectionGracePeriod)
+
 				emitEntryCB = func(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHdr, flags uint8, entry *ctmap.CtEntry) {
 					// FQDN related connections can only be outbound
 					if flags != ctmap.TUPLE_F_OUT {
 						return
 					}
 					if ep, exists := epsMap[srcIP.String()]; exists {
-						ep.MarkDNSCTEntry(dstIP, gcStart)
+						ep.MarkDNSCTEntry(dstIP, aliveTime)
 					}
 				}
 			)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -388,6 +388,10 @@ const (
 	// retain for expired DNS lookups with still-active connections"
 	ToFQDNsMaxDeferredConnectionDeletes = "tofqdns-max-deferred-connection-deletes"
 
+	// ToFQDNsIdleConnectionGracePeriod defines the connection idle time during which
+	// previously active connections with expired DNS lookups are still considered alive
+	ToFQDNsIdleConnectionGracePeriod = "tofqdns-idle-connection-grace-period"
+
 	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
 	// global cache on startup.
 	// The file is not re-read after agent start.
@@ -879,6 +883,7 @@ var HelpFlagSections = []FlagsSection{
 			FQDNProxyResponseMaxDelay,
 			ToFQDNsEnableDNSCompression,
 			ToFQDNsMaxDeferredConnectionDeletes,
+			ToFQDNsIdleConnectionGracePeriod,
 		},
 	},
 	{
@@ -1589,6 +1594,11 @@ type DaemonConfig struct {
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to retain for
 	// expired DNS lookups with still-active connections
 	ToFQDNsMaxDeferredConnectionDeletes int
+
+	// ToFQDNsIdleConnectionGracePeriod Time during which idle but
+	// previously active connections with expired DNS lookups are
+	// still considered alive
+	ToFQDNsIdleConnectionGracePeriod time.Duration
 
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -489,7 +489,11 @@ func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 // or bpf-next.git tree).
 func RunsOnNetNextKernel() bool {
 	netNext := os.Getenv("NETNEXT")
-	return netNext == "true" || netNext == "1"
+	if netNext == "true" || netNext == "1" {
+		return true
+	}
+	netNext = os.Getenv("KERNEL")
+	return netNext == "net-next"
 }
 
 // DoesNotRunOnNetNextKernel is the complement function of RunsOnNetNextKernel.


### PR DESCRIPTION
* #15395 -- test: make RunsOnNetNextKernel() helper work with KERNEL="net-next" (@qmonnet)
 * #15481 -- docs: Fix commands for IPSec key rotations (@pchaigno)
 * #15294 -- Improve release scripts (@joestringer)
 * #15495 -- build(deps): bump pygments from 2.4.2 to 2.7.4 in /Documentation (@dependabot[bot])
 * #15458 -- daemon: Add command line option --tofqdns-idle-connection-grace-period (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15395 15481 15294 15495 15458; do contrib/backporting/set-labels.py $pr done 1.8; done
```

@brb the PR 15431 -- node-neigh: Query once netlink for neigh discovery device (@brb) was not backported due conflicts.