### PR TITLE
ipam: Fix empty interface number in Azure

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -509,6 +509,18 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 			if iface.ID == ipInfo.Resource {
 				result.PrimaryMAC = iface.MAC
 				result.GatewayIP = iface.Gateway
+				// For now, we can hardcode the interface number to a valid
+				// integer because it will not be used in the allocation result
+				// anyway. To elaborate, Azure IPAM mode automatically sets
+				// option.Config.EgressMultiHomeIPRuleCompat to true, meaning
+				// that the CNI will not use the interface number when creating
+				// the pod rules and routes. We are hardcoding simply to bypass
+				// the parsing errors when InterfaceNumber is empty. See
+				// https://github.com/cilium/cilium/issues/15496.
+				//
+				// TODO: Once https://github.com/cilium/cilium/issues/14705 is
+				// resolved, then we don't need to hardcode this anymore.
+				result.InterfaceNumber = "0"
 				return
 			}
 		}


### PR DESCRIPTION
Since commit 4d50ae70f ("cni, routing: Plumb interface number") added
the interface number to the IPAM allocation result to fix a bug in ENI
mode (https://github.com/cilium/cilium/issues/14336), Azure has been
broken. However, we were able to avoid issues like pod connectivity
because there was a separate bug with Azure that hid it, which commit
ba069702c ("azure: Add the correct JSON tag to GatewayIP field in
CiliumNode CRD") fixed. Once that was fixed, then we began to see pod
failing to be set up by the CNI (see linked issue below).

The reason this didn't manifest in v1.9.5 even though the ENI fixes were
backported there is because the ba069702c ("azure: Add the correct JSON
tag to GatewayIP field in CiliumNode CRD") is not part of any release
yet. In any case, this commit will need to be backported as the latter
commit (ba069702c) is now part of the v1.9 tree.

Fixes: https://github.com/cilium/cilium/issues/15496

Signed-off-by: Chris Tarazi <chris@isovalent.com>
