### PR TITLE
backport v1.9: node-neigh: Query once netlink for neigh discovery device

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -53,6 +53,7 @@ type linuxNodeHandler struct {
 	datapathConfig       DatapathConfiguration
 	nodes                map[nodeTypes.Identity]*nodeTypes.Node
 	enableNeighDiscovery bool
+	neighDiscoveryLink   netlink.Link
 	neighNextHopByNode   map[nodeTypes.Identity]string // val = string(net.IP)
 	neighNextHopRefCount counter.StringCounter
 	neighByNextHop       map[string]*netlink.Neigh // key = string(net.IP)
@@ -621,7 +622,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 }
 
-func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP, ifaceName string) (srcIPv4, nextHopIPv4 net.IP, err error) {
+func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextHopIPv4 net.IP, err error) {
 	// Figure out whether nodeIPv4 is directly reachable (i.e. in the same L2)
 	routes, err := netlink.RouteGet(nodeIPv4)
 	if err != nil {
@@ -653,7 +654,7 @@ func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP, ifaceName strin
 // insertNeighbor inserts a permanent ARP entry for a nexthop to the given
 // "newNode" (ip route get newNodeIP.GetNodeIP()). The L2 addr of the nexthop
 // is determined by sending ARP request for the nexthop from an iface specified
-// by the given "ifaceName".
+// by n.neighDiscoveryLink.
 //
 // The given "refresh" param denotes whether the method is called by a controller
 // which tries to update ARP entries previously inserted by insertNeighbor(). In
@@ -661,7 +662,7 @@ func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP, ifaceName strin
 // sends the ARP request anyway.
 //
 // The method must be called with linuxNodeHandler.mutex held.
-func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, ifaceName string, refresh bool) {
+func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, refresh bool) {
 	if newNode.IsLocal() {
 		return
 	}
@@ -672,11 +673,11 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.LogSubsys: "node-neigh",
-		logfields.Interface: ifaceName,
+		logfields.Interface: n.neighDiscoveryLink.Attrs().Name,
 		logfields.IPAddr:    newNodeIP,
 	})
 
-	srcIPv4, nextHopIPv4, err := n.getSrcAndNextHopIPv4(nextHopIPv4, ifaceName)
+	srcIPv4, nextHopIPv4, err := n.getSrcAndNextHopIPv4(nextHopIPv4)
 	if err != nil {
 		scopedLog.WithError(err).Error("Failed to determine source and nexthop IP addr")
 		return
@@ -724,14 +725,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 
 	// nextHop hasn't been arpinged before OR we are refreshing neigh entry
 	if nextHopIsNew || refresh {
-		linkAttr, err := netlink.LinkByName(ifaceName)
-		if err != nil {
-			scopedLog.WithError(err).Error("Failed to retrieve iface by name (netlink)")
-			return
-		}
-		link := linkAttr.Attrs().Index
-
-		hwAddr, _, err := arping.PingOverIface(nextHopIPv4, linkAttr, srcIPv4)
+		hwAddr, _, err := arping.PingOverIface(nextHopIPv4, n.neighDiscoveryLink, srcIPv4)
 		if err != nil {
 			scopedLog.WithError(err).Error("arping failed")
 			return
@@ -756,7 +750,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		scopedLog = scopedLog.WithField(logfields.HardwareAddr, hwAddr)
 
 		neigh := netlink.Neigh{
-			LinkIndex:    link,
+			LinkIndex:    n.neighDiscoveryLink.Attrs().Index,
 			IP:           nextHopIPv4,
 			HardwareAddr: hwAddr,
 			State:        netlink.NUD_PERMANENT,
@@ -775,13 +769,13 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	}
 }
 
-func (n *linuxNodeHandler) refreshNeighbor(ctx context.Context, nodeToRefresh *nodeTypes.Node, ifaceName string, completed chan struct{}) {
+func (n *linuxNodeHandler) refreshNeighbor(ctx context.Context, nodeToRefresh *nodeTypes.Node, completed chan struct{}) {
 	defer close(completed)
 
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	n.insertNeighbor(ctx, nodeToRefresh, ifaceName, true)
+	n.insertNeighbor(ctx, nodeToRefresh, true)
 }
 
 // Must be called with linuxNodeHandler.mutex held.
@@ -902,13 +896,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 	}
 
 	if n.enableNeighDiscovery {
-		var ifaceName string
-		if option.Config.EnableNodePort {
-			ifaceName = option.Config.DirectRoutingDevice
-		} else {
-			ifaceName = option.Config.EncryptInterface[0]
-		}
-		n.insertNeighbor(context.Background(), newNode, ifaceName, false)
+		n.insertNeighbor(context.Background(), newNode, false)
 	}
 
 	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
@@ -1312,10 +1300,26 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 	prevConfig := n.nodeConfig
 	n.nodeConfig = newConfig
 
-	// tbd track down where ifaceName goes
-	n.enableNeighDiscovery = n.nodeConfig.EnableIPv4 &&
-		(option.Config.EnableNodePort ||
-			(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled))
+	if n.nodeConfig.EnableIPv4 {
+		ifaceName := ""
+		switch {
+		case option.Config.EnableNodePort:
+			ifaceName = option.Config.DirectRoutingDevice
+			n.enableNeighDiscovery = true
+		case n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled:
+			ifaceName = option.Config.EncryptInterface[0]
+			n.enableNeighDiscovery = true
+		}
+
+		if n.enableNeighDiscovery {
+			link, err := netlink.LinkByName(ifaceName)
+			if err != nil {
+				return fmt.Errorf("cannot find link by name %s for neigh discovery: %w",
+					ifaceName, err)
+			}
+			n.neighDiscoveryLink = link
+		}
+	}
 
 	n.updateOrRemoveNodeRoutes(prevConfig.AuxiliaryPrefixes, newConfig.AuxiliaryPrefixes, true)
 
@@ -1378,14 +1382,8 @@ func (n *linuxNodeHandler) NodeNeighborRefresh(ctx context.Context, nodeToRefres
 		return
 	}
 
-	var ifaceName string
-	if option.Config.EnableNodePort {
-		ifaceName = option.Config.DirectRoutingDevice
-	} else if option.Config.EnableIPSec {
-		ifaceName = option.Config.EncryptInterface[0]
-	}
 	refreshComplete := make(chan struct{})
-	go n.refreshNeighbor(ctx, &nodeToRefresh, ifaceName, refreshComplete)
+	go n.refreshNeighbor(ctx, &nodeToRefresh, refreshComplete)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
* #15431 -- node-neigh: Query once netlink for neigh discovery device (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15431; do contrib/backporting/set-labels.py $pr done 1.9; done
```