### PR TITLE
daemon: add new option --allocator-list-timeout

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -13,6 +13,7 @@ cilium-agent [flags]
 ```
       --agent-health-port int                                TCP port for agent health status API (default 9876)
       --agent-labels strings                                 Additional labels to identify this agent
+      --allocator-list-timeout duration                      Timeout for listing allocator state before exiting (default 3m0s)
       --allow-icmp-frag-needed                               Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                               Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --annotate-k8s-node                                    Annotate Kubernetes node (default true)

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -379,6 +379,8 @@ New Options
   running in direct routing mode and is using the kube-proxy replacement.
   Moreover, this option cannot be enabled when Cilium is running in a managed
   Kubernetes environment or in a chained CNI setup.
+* ``allocator-list-timeout``: This option configures the timeout value for listing
+  allocator state before exiting (default 3m0s).
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -223,6 +223,9 @@ func runApiserver() error {
 	flags.StringVar(&cfg.serviceProxyName, option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
 	option.BindEnv(option.K8sServiceProxyName)
 
+	flags.Duration(option.AllocatorListTimeoutName, defaults.AllocatorListTimeout, "Timeout for listing allocator state before exiting")
+	option.BindEnv(option.AllocatorListTimeoutName)
+
 	viper.BindPFlags(flags)
 	option.Config.Populate()
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -526,6 +526,9 @@ func init() {
 	flags.MarkHidden(option.K8sSyncTimeoutName)
 	option.BindEnv(option.K8sSyncTimeoutName)
 
+	flags.Duration(option.AllocatorListTimeoutName, defaults.AllocatorListTimeout, "Timeout for listing allocator state before exiting")
+	option.BindEnv(option.AllocatorListTimeoutName)
+
 	flags.String(option.LabelPrefixFile, "", "Valid label prefixes file path")
 	option.BindEnv(option.LabelPrefixFile)
 

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -42,10 +42,6 @@ const (
 	// maxAllocAttempts is the number of attempted allocation requests
 	// performed before failing.
 	maxAllocAttempts = 16
-
-	// listTimeout is the time to wait for the initial list operation to
-	// succeed when creating a new allocator
-	listTimeout = 3 * time.Minute
 )
 
 // Allocator is a distributed ID allocator backed by a KVstore. It maps
@@ -320,7 +316,7 @@ func NewAllocator(typ AllocatorKey, backend Backend, opts ...AllocatorOption) (*
 		go func() {
 			select {
 			case <-a.initialListDone:
-			case <-time.After(listTimeout):
+			case <-time.After(option.Config.AllocatorListTimeout):
 				log.Fatalf("Timeout while waiting for initial allocator state")
 			}
 			a.startLocalKeySync()

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -257,6 +257,10 @@ const (
 	// local caches with Kubernetes state before exiting.
 	K8sSyncTimeout = 3 * time.Minute
 
+	// AllocatorListTimeout specifies the standard time to allow for listing
+	// initial allocator state from kvstore before exiting.
+	AllocatorListTimeout = 3 * time.Minute
+
 	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
 	// should watch for.
 	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -214,6 +214,9 @@ const (
 	// K8sSyncTimeout is the timeout to synchronize all resources with k8s.
 	K8sSyncTimeoutName = "k8s-sync-timeout"
 
+	// AllocatorListTimeout is the timeout to list initial allocator state.
+	AllocatorListTimeoutName = "allocator-list-timeout"
+
 	// KeepConfig when restoring state, keeps containers' configuration in place
 	KeepConfig = "keep-config"
 
@@ -1685,6 +1688,7 @@ type DaemonConfig struct {
 	K8sClientBurst                int
 	K8sClientQPSLimit             float64
 	K8sSyncTimeout                time.Duration
+	AllocatorListTimeout          time.Duration
 	K8sWatcherEndpointSelector    string
 	KVStore                       string
 	KVStoreOpt                    map[string]string
@@ -2221,6 +2225,7 @@ var (
 		EnableWellKnownIdentities:    defaults.EnableEndpointRoutes,
 		K8sEnableK8sEndpointSlice:    defaults.K8sEnableEndpointSlice,
 		k8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
+		AllocatorListTimeout:         defaults.AllocatorListTimeout,
 
 		k8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 		APIRateLimit:                     make(map[string]string),
@@ -2664,6 +2669,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
 	c.K8sSyncTimeout = viper.GetDuration(K8sSyncTimeoutName)
+	c.AllocatorListTimeout = viper.GetDuration(AllocatorListTimeoutName)
 	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepConfig = viper.GetBool(KeepConfig)
 	c.KVStore = viper.GetString(KVStore)


### PR DESCRIPTION
This enables user to configure how long they would like to wait before
successfully listed objects from kvstore. Especially, this determines the
agent restart frequency when clustermesh is enabled and remote kvstore
has connection problems: too many restarts in really large clusters pose
significant pressures on both k8s apiserver, local and remote kvstores.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>