### PR TITLE
wireguard: Fix rp_filter setting

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -104,7 +104,7 @@ func (a *Agent) Init() error {
 		return err
 	}
 
-	if !option.Config.EnableIPv4 {
+	if option.Config.EnableIPv4 {
 		if err := sysctl.Write(fmt.Sprintf("net.ipv4.conf.%s.rp_filter", types.IfaceName), "2"); err != nil {
 			return nil
 		}


### PR DESCRIPTION
We need it only when IPv4 is enabled.

Fixes: 3bb90864fa5 ("wireguard: Add agent code")