### PR TITLE
test: Uncouple KPR from presence of kube-proxy

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2349,7 +2349,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 	}
 
-	if !RunsWithKubeProxy() {
+	if RunsWithKubeProxyReplacement() {
 		opts := map[string]string{
 			"kubeProxyReplacement": "strict",
 		}
@@ -2387,7 +2387,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		addIfNotOverwritten(options, "hostFirewall", "true")
 	}
 
-	if !RunsWithKubeProxy() || options["hostFirewall"] == "true" {
+	if RunsWithKubeProxyReplacement() || options["hostFirewall"] == "true" {
 		// Set devices
 		privateIface, err := kub.GetPrivateIface()
 		if err != nil {

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -553,6 +553,19 @@ func RunsOnEKS() bool {
 // DoesNotRunOnEKS is the complement function of DoesNotRunOnEKS.
 func DoesNotRunOnEKS() bool {
 	return !RunsOnEKS()
+}
+
+// RunsWithKubeProxyReplacement returns true if the kernel supports our
+// kube-proxy replacement. Note that kube-proxy may still be running
+// alongside Cilium.
+func RunsWithKubeProxyReplacement() bool {
+	return RunsOnGKE() || RunsOnNetNextOr419Kernel()
+}
+
+// DoesNotRunWithKubeProxyReplacement is the complement function of
+// RunsWithKubeProxyReplacement.
+func DoesNotRunWithKubeProxyReplacement() bool {
+	return !RunsWithKubeProxyReplacement()
 }
 
 // DoesNotHaveHosts returns a function which returns true if a CI job

--- a/test/k8sT/Conformance.go
+++ b/test/k8sT/Conformance.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 
 var _ = Describe("K8sConformance", func() {
 	SkipContextIf(func() bool {
-		return !helpers.RunsWithKubeProxy() || helpers.GetCurrentIntegration() == helpers.CIIntegrationFlannel
+		return helpers.RunsWithKubeProxyReplacement() || helpers.GetCurrentIntegration() == helpers.CIIntegrationFlannel
 	}, "Portmap Chaining", func() {
 		var (
 			kubectl                         *helpers.Kubectl

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ var _ = Describe("K8sServicesTest", func() {
 		var err error
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		if helpers.DualStackSupported() && helpers.RunsWithKubeProxy() {
+		if helpers.DualStackSupported() && helpers.DoesNotRunWithKubeProxyReplacement() {
 			// This is a fix required for kube-proxy when running in dual-stack mode.
 			// Sometimes there is a condition where kube-proxy repeatedly fails as it is not able
 			// to find KUBE-MARK-DROP iptables chain for IPv6 which should be created by kubelet.
@@ -355,7 +355,7 @@ var _ = Describe("K8sServicesTest", func() {
 			}
 		})
 
-		SkipItIf(helpers.RunsWithoutKubeProxy, "Checks service on same node", func() {
+		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Checks service on same node", func() {
 			serviceNames := []string{serviceName}
 			if helpers.DualStackSupported() {
 				serviceNames = append(serviceNames, serviceNameIPv6)
@@ -460,7 +460,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 		}, 600)
 
-		SkipContextIf(manualIPv6TestingNotRequired(helpers.RunsWithKubeProxy), "IPv6 Connectivity", func() {
+		SkipContextIf(manualIPv6TestingNotRequired(helpers.DoesNotRunWithKubeProxyReplacement), "IPv6 Connectivity", func() {
 			// Because the deployed K8s does not have dual-stack mode enabled,
 			// we install the Cilium service rules manually via Cilium CLI.
 			demoClusterIPv6 := "fd03::100"
@@ -1808,7 +1808,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			)
 			// Destination address and port for fragmented datagram
 			// are not DNAT-ed with kube-proxy but without bpf_sock.
-			if helpers.RunsWithKubeProxy() {
+			if helpers.DoesNotRunWithKubeProxyReplacement() {
 				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 				hasDNAT = kubectl.HasHostReachableServices(ciliumPodK8s1, false, true)
@@ -1879,7 +1879,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			}
 		}
 
-		SkipItIf(helpers.RunsWithoutKubeProxy, "Checks ClusterIP Connectivity", func() {
+		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Checks ClusterIP Connectivity", func() {
 			services := []string{testDSServiceIPv4}
 			if helpers.DualStackSupported() {
 				services = append(services, testDSServiceIPv6)
@@ -1898,7 +1898,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			}
 		})
 
-		SkipContextIf(manualIPv6TestingNotRequired(helpers.RunsWithKubeProxy), "IPv6 Connectivity", func() {
+		SkipContextIf(manualIPv6TestingNotRequired(helpers.DoesNotRunWithKubeProxyReplacement), "IPv6 Connectivity", func() {
 			testDSIPv6 := "fd03::310"
 
 			BeforeAll(func() {
@@ -1924,7 +1924,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		})
 
 		SkipContextIf(func() bool {
-			return helpers.RunsWithoutKubeProxy() || helpers.GetCurrentIntegration() != ""
+			return helpers.RunsWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != ""
 		}, "IPv6 masquerading", func() {
 			var (
 				k8s2NodeIP      string
@@ -1973,7 +1973,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 		})
 
-		SkipContextIf(helpers.RunsWithoutKubeProxy, "Tests NodePort (kube-proxy)", func() {
+		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "Tests NodePort (kube-proxy)", func() {
 			SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "with IPSec and externalTrafficPolicy=Local", func() {
 				deploymentManager.SetKubectl(kubectl)
 				deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
@@ -2005,7 +2005,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		// IPv6 tests do not work on Integrations like GKE as we don't have IPv6
 		// addresses assigned to nodes in those environments.
 		SkipContextIf(manualIPv6TestingNotRequired(func() bool {
-			return helpers.RunsWithKubeProxy() || helpers.GetCurrentIntegration() != ""
+			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != ""
 		}), "Tests IPv6 NodePort Services", func() {
 			var (
 				testDSIPv6 string = "fd03::310"
@@ -2166,7 +2166,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 		})
 
-		SkipContextIf(helpers.RunsWithoutKubeProxy, "with L7 policy", func() {
+		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "with L7 policy", func() {
 			AfterAll(func() {
 				// Explicitly ignore result of deletion of resources to avoid incomplete
 				// teardown if any step fails.
@@ -2192,13 +2192,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 		})
 
-		SkipContextIf(
-			func() bool {
-				return helpers.DoesNotRunOnNetNextOr419Kernel() ||
-					helpers.RunsWithKubeProxy()
-			},
-			"Tests NodePort BPF", func() {
-
+		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Tests NodePort BPF",
+			func() {
 				BeforeAll(func() {
 					enableBackgroundReport = false
 				})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2233,7 +2233,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						testExternalIPs()
 					})
 
-					Context("With host policy", func() {
+					SkipContextIf(helpers.RunsOnGKE, "With host policy", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
@@ -2360,16 +2360,15 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						testExternalIPs()
 					})
 
-					Context("With host policy", func() {
+					SkipContextIf(helpers.RunsOnGKE, "With host policy", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
-							options := map[string]string{
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 								"tunnel":               "disabled",
 								"autoDirectNodeRoutes": "true",
 								"hostFirewall":         "true",
-							}
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
+							})
 
 							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
 							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -132,7 +132,9 @@ var _ = Describe("K8sServicesTest", func() {
 
 	manualIPv6TestingNotRequired := func(f func() bool) func() bool {
 		return func() bool {
-			return helpers.DualStackSupported() || f()
+			// IPv6 tests do not work on Integrations like GKE as we don't have IPv6
+			// addresses assigned to nodes in those environments.
+			return helpers.DualStackSupported() || helpers.GetCurrentIntegration() != "" || f()
 		}
 	}
 
@@ -2002,11 +2004,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 		})
 
-		// IPv6 tests do not work on Integrations like GKE as we don't have IPv6
-		// addresses assigned to nodes in those environments.
-		SkipContextIf(manualIPv6TestingNotRequired(func() bool {
-			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != ""
-		}), "Tests IPv6 NodePort Services", func() {
+		SkipContextIf(manualIPv6TestingNotRequired(helpers.DoesNotRunWithKubeProxyReplacement), "Tests IPv6 NodePort Services", func() {
 			var (
 				testDSIPv6 string = "fd03::310"
 				data       v1.Service

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -215,13 +215,5 @@ func SkipIfIntegration(integration string) {
 		Skip(fmt.Sprintf(
 			"This feature is not supported in Cilium %q mode. Skipping test.",
 			integration))
-	}
-}
-
-// SkipItIfNoKubeProxy will skip It if kube-proxy is disabled (= NodePort BPF is
-// enabled)
-func SkipItIfNoKubeProxy() {
-	if !helpers.RunsWithKubeProxy() {
-		Skip("kube-proxy is disabled (NodePort BPF is enabled). Skipping test.")
 	}
 }


### PR DESCRIPTION
This pull request is preparatory work to allow us to run both kube-proxy and our kube-proxy replacement on the 4.19 CI job. That would in turn allow us to test e.g. IPSec on newer kernels.

As a summary of commits:
1. Replace `RunsWithKubeProxy` with `RunsWithKubeProxyReplacement` to have two separate functions to indicate (1) whether kube-proxy is installed and (2) whether we can run our kube-proxy replacement. This commit also enables more tests in GKE (because `RunsWithKubeProxyReplacement` returns true for GKE).
2. Small code refactoring.
3. Skip NodePort + hostfw tests on GKE as the host policy used in the tests doesn't support that setup yet.

A follow up pull request will install kube-proxy in our 4.19 CI job and enable new tests to be executed there.