### PR TITLE
k8s: Retry CRD update upon conflict

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -385,7 +385,12 @@ func updateV1CRD(
 					context.TODO(),
 					clusterCRD,
 					metav1.UpdateOptions{})
-				if err == nil {
+				switch {
+				case errors.IsConflict(err): // Occurs as Operators race to update CRDs.
+					scopedLog.WithError(err).
+						Debug("The CRD update was based on an older version, retrying...")
+					return false, nil
+				case err == nil:
 					return true, nil
 				}
 


### PR DESCRIPTION
Previously, when the Operators started up and were updating the CRDs, it
was a race to who can update the CRDs first. Any Operator that wasn't
first would error out and fatal (see linked issue for the msg).

This commit fixes this by checking if the update operation ended in a
conflict. If it did, then we retry the operation which includes fetching
the latest version from the apiserver. We can detect this error because
the K8s client libraries expose a convenience function
(errors.IsConflict()) to check for these kinds of errors, as they are
quite common in K8s code.

Fixes: https://github.com/cilium/cilium/issues/14283

Signed-off-by: Chris Tarazi <chris@isovalent.com>

```release-note
Fix bug where any non-leader Operator in HA mode would crash updating CRDs
```

