### PR TITLE
hubble: Add a flag to write Hubble events to a rotated file

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -131,6 +131,10 @@ cilium-agent [flags]
       --hubble-disable-tls                                   Allow Hubble server to run on the given listen address without TLS.
       --hubble-event-buffer-capacity int                     Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
       --hubble-event-queue-size int                          Buffer size of the channel to receive monitor events.
+      --hubble-export-file-compress                          Compress rotated Hubble export files.
+      --hubble-export-file-max-backups int                   Number of rotated Hubble export files to keep. (default 5)
+      --hubble-export-file-max-size-mb int                   Size in MB at which to rotate Hubble export file. (default 10)
+      --hubble-export-file-path string                       Filepath to write Hubble events to.
       --hubble-listen-address string                         An additional address for Hubble server to listen to, e.g. ":4244"
       --hubble-metrics strings                               List of Hubble metrics to enable.
       --hubble-metrics-server string                         Address to serve Hubble metrics on.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -930,6 +931,18 @@ func init() {
 
 	flags.StringSlice(option.HubbleMetrics, []string{}, "List of Hubble metrics to enable.")
 	option.BindEnv(option.HubbleMetrics)
+
+	flags.String(option.HubbleExportFilePath, exporteroption.Default.Path, "Filepath to write Hubble events to.")
+	option.BindEnv(option.HubbleExportFilePath)
+
+	flags.Int(option.HubbleExportFileMaxSizeMB, exporteroption.Default.MaxSizeMB, "Size in MB at which to rotate Hubble export file.")
+	option.BindEnv(option.HubbleExportFileMaxSizeMB)
+
+	flags.Int(option.HubbleExportFileMaxBackups, exporteroption.Default.MaxBackups, "Number of rotated Hubble export files to keep.")
+	option.BindEnv(option.HubbleExportFileMaxBackups)
+
+	flags.Bool(option.HubbleExportFileCompress, exporteroption.Default.Compress, "Compress rotated Hubble export files.")
+	option.BindEnv(option.HubbleExportFileCompress)
 
 	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
 	option.BindEnv(option.DisableIptablesFeederRules)

--- a/pkg/hubble/exporter/exporter.go
+++ b/pkg/hubble/exporter/exporter.go
@@ -1,0 +1,70 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
+	"github.com/cilium/cilium/pkg/hubble/observer"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// exporter is an implementation of OnDecodedEvent interface that writes Hubble events to a file.
+type exporter struct {
+	logger  logrus.FieldLogger
+	encoder *json.Encoder
+}
+
+// NewExporter initializes an exporter.
+func NewExporter(
+	logger logrus.FieldLogger,
+	options ...exporteroption.Option) (*exporter, error) {
+	opts := exporteroption.Default // start with defaults
+	for _, opt := range options {
+		if err := opt(&opts); err != nil {
+			return nil, fmt.Errorf("failed to apply option: %v", err)
+		}
+	}
+	logger.WithField("options", opts).Info("Configuring Hubble event exporter")
+	encoder := json.NewEncoder(&lumberjack.Logger{
+		Filename:   opts.Path,
+		MaxSize:    opts.MaxSizeMB,
+		MaxBackups: opts.MaxBackups,
+		Compress:   opts.Compress,
+	})
+	return newExporter(logger, encoder), nil
+}
+
+func newExporter(logger logrus.FieldLogger, encoder *json.Encoder) *exporter {
+	return &exporter{
+		logger:  logger,
+		encoder: encoder,
+	}
+}
+
+// Start calls GetFlows and writes responses to a file.
+func (e *exporter) OnDecodedEvent(_ context.Context, ev *v1.Event) (bool, error) {
+	res := observer.EventToGetFlowsResponse(ev)
+	if res == nil {
+		return false, nil
+	}
+	return false, e.encoder.Encode(res)
+}

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -1,0 +1,71 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package exporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	observerAPI "github.com/cilium/cilium/api/v1/observer"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/golang/protobuf/ptypes/timestamp"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExporter(t *testing.T) {
+	// override node name for unit test.
+	nodeName := nodeTypes.GetName()
+	newNodeName := "my-node"
+	nodeTypes.SetName(newNodeName)
+	defer func() {
+		nodeTypes.SetName(nodeName)
+	}()
+	events := []*v1.Event{
+		{
+			Event: &observerAPI.Flow{
+				NodeName: newNodeName,
+				Time:     &timestamp.Timestamp{Seconds: 1},
+			},
+		},
+		{Timestamp: &timestamp.Timestamp{Seconds: 2}, Event: &observerAPI.AgentEvent{}},
+		{Timestamp: &timestamp.Timestamp{Seconds: 3}, Event: &observerAPI.DebugEvent{}},
+		{Timestamp: &timestamp.Timestamp{Seconds: 4}, Event: &observerAPI.LostEvent{}},
+	}
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	exporter := newExporter(log, encoder)
+	ctx := context.Background()
+	for _, ev := range events {
+		stop, err := exporter.OnDecodedEvent(ctx, ev)
+		assert.False(t, stop)
+		assert.NoError(t, err)
+
+	}
+	assert.Equal(t, `{"flow":{"time":"1970-01-01T00:00:01Z","node_name":"my-node"},"node_name":"my-node","time":"1970-01-01T00:00:01Z"}
+{"agent_event":{},"node_name":"my-node","time":"1970-01-01T00:00:02Z"}
+{"debug_event":{},"node_name":"my-node","time":"1970-01-01T00:00:03Z"}
+{"lost_events":{},"node_name":"my-node","time":"1970-01-01T00:00:04Z"}
+`, buf.String())
+}

--- a/pkg/hubble/exporter/exporteroption/defaults.go
+++ b/pkg/hubble/exporter/exporteroption/defaults.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporteroption
+
+// Default specifies default values for Hubble exporter options.
+var Default = Options{
+	Path:       "", // An empty string disables Hubble export.
+	MaxSizeMB:  10,
+	MaxBackups: 5,
+	Compress:   false,
+}

--- a/pkg/hubble/exporter/exporteroption/option.go
+++ b/pkg/hubble/exporter/exporteroption/option.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporteroption
+
+// Options stores all the configurations values for Hubble exporter.
+type Options struct {
+	Path       string
+	MaxSizeMB  int
+	MaxBackups int
+	Compress   bool
+}
+
+// Option customizes the configuration of the hubble server.
+type Option func(o *Options) error
+
+// WithPath sets the Hubble export filepath. It's set to an empty string by default,
+// which disables Hubble export.
+func WithPath(path string) Option {
+	return func(o *Options) error {
+		o.Path = path
+		return nil
+	}
+}
+
+// WithMaxSizeMB sets the size in MB at which to rotate the Hubble export file.
+func WithMaxSizeMB(size int) Option {
+	return func(o *Options) error {
+		o.MaxSizeMB = size
+		return nil
+	}
+}
+
+// WithMaxSizeMB sets the number of rotated Hubble export files to keep.
+func WithMaxBackups(backups int) Option {
+	return func(o *Options) error {
+		o.MaxBackups = backups
+		return nil
+	}
+}
+
+// WithCompress specifies whether rotated files are compressed.
+func WithCompress() Option {
+	return func(o *Options) error {
+		o.Compress = true
+		return nil
+	}
+}

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -26,6 +26,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
@@ -33,6 +34,8 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/golang/protobuf/ptypes/timestamp"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -483,4 +486,68 @@ func TestLocalObserverServer_OnGetFlows(t *testing.T) {
 	// This should be assert.Equals(t, flowsReceived, numFlows)
 	// A bug in the ring buffer prevents this from succeeding
 	assert.Greater(t, flowsReceived, 0)
+}
+
+func TestEventToGetFlowsResponse(t *testing.T) {
+	// override node name for unit test.
+	nodeName := nodeTypes.GetName()
+	newNodeName := "my-node"
+	nodeTypes.SetName(newNodeName)
+	defer func() {
+		nodeTypes.SetName(nodeName)
+	}()
+
+	// flow
+	ev := v1.Event{
+		Event: &observerpb.Flow{
+			NodeName: newNodeName,
+			Time:     &timestamp.Timestamp{Seconds: 1},
+		},
+	}
+	res := EventToGetFlowsResponse(&ev)
+	expected := &observerpb.GetFlowsResponse{
+		ResponseTypes: &observerpb.GetFlowsResponse_Flow{Flow: ev.Event.(*flowpb.Flow)},
+		NodeName:      newNodeName,
+		Time:          ev.GetFlow().Time,
+	}
+	assert.Equal(t, res, expected)
+
+	// lost event
+	ev = v1.Event{
+		Timestamp: &timestamp.Timestamp{Seconds: 1},
+		Event:     &observerpb.LostEvent{},
+	}
+	res = EventToGetFlowsResponse(&ev)
+	expected = &observerpb.GetFlowsResponse{
+		ResponseTypes: &observerpb.GetFlowsResponse_LostEvents{LostEvents: ev.Event.(*flowpb.LostEvent)},
+		NodeName:      newNodeName,
+		Time:          ev.Timestamp,
+	}
+	assert.Equal(t, res, expected)
+
+	// agent event
+	ev = v1.Event{
+		Timestamp: &timestamp.Timestamp{Seconds: 1},
+		Event:     &observerpb.AgentEvent{},
+	}
+	res = EventToGetFlowsResponse(&ev)
+	expected = &observerpb.GetFlowsResponse{
+		ResponseTypes: &observerpb.GetFlowsResponse_AgentEvent{AgentEvent: ev.Event.(*flowpb.AgentEvent)},
+		NodeName:      newNodeName,
+		Time:          ev.Timestamp,
+	}
+	assert.Equal(t, res, expected)
+
+	// debug event
+	ev = v1.Event{
+		Timestamp: &timestamp.Timestamp{Seconds: 1},
+		Event:     &observerpb.DebugEvent{},
+	}
+	res = EventToGetFlowsResponse(&ev)
+	expected = &observerpb.GetFlowsResponse{
+		ResponseTypes: &observerpb.GetFlowsResponse_DebugEvent{DebugEvent: ev.Event.(*flowpb.DebugEvent)},
+		NodeName:      newNodeName,
+		Time:          ev.Timestamp,
+	}
+	assert.Equal(t, res, expected)
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -869,6 +869,20 @@ const (
 	// HubbleMetrics specifies enabled metrics and their configuration options.
 	HubbleMetrics = "hubble-metrics"
 
+	// HubbleExportFilePath specifies the filepath to write Hubble events to.
+	// e.g. "/var/run/cilium/hubble/events.log"
+	HubbleExportFilePath = "hubble-export-file-path"
+
+	// HubbleExportFileMaxSizeMB specifies the file size in MB at which to rotate
+	// the Hubble export file.
+	HubbleExportFileMaxSizeMB = "hubble-export-file-max-size-mb"
+
+	// HubbleExportFileMaxBacks specifies the number of rotated files to keep.
+	HubbleExportFileMaxBackups = "hubble-export-file-max-backups"
+
+	// HubbleExportFileCompress specifies whether rotated files are compressed.
+	HubbleExportFileCompress = "hubble-export-file-compress"
+
 	// DisableIptablesFeederRules specifies which chains will be excluded
 	// when installing the feeder rules
 	DisableIptablesFeederRules = "disable-iptables-feeder-rules"
@@ -1813,6 +1827,20 @@ type DaemonConfig struct {
 	// HubbleMetrics specifies enabled metrics and their configuration options.
 	HubbleMetrics []string
 
+	// HubbleExportFilePath specifies the filepath to write Hubble events to.
+	// e.g. "/var/run/cilium/hubble/events.log"
+	HubbleExportFilePath string
+
+	// HubbleExportFileMaxSizeMB specifies the file size in MB at which to rotate
+	// the Hubble export file.
+	HubbleExportFileMaxSizeMB int
+
+	// HubbleExportFileMaxBacks specifies the number of rotated files to keep.
+	HubbleExportFileMaxBackups int
+
+	// HubbleExportFileCompress specifies whether rotated files are compressed.
+	HubbleExportFileCompress bool
+
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout time.Duration
 
@@ -2650,6 +2678,10 @@ func (c *DaemonConfig) Populate() {
 	}
 	c.HubbleMetricsServer = viper.GetString(HubbleMetricsServer)
 	c.HubbleMetrics = viper.GetStringSlice(HubbleMetrics)
+	c.HubbleExportFilePath = viper.GetString(HubbleExportFilePath)
+	c.HubbleExportFileMaxSizeMB = viper.GetInt(HubbleExportFileMaxSizeMB)
+	c.HubbleExportFileMaxBackups = viper.GetInt(HubbleExportFileMaxBackups)
+	c.HubbleExportFileCompress = viper.GetBool(HubbleExportFileCompress)
 	c.DisableIptablesFeederRules = viper.GetStringSlice(DisableIptablesFeederRules)
 
 	// Hidden options


### PR DESCRIPTION
Add a flag to write Hubble events from OnDecodeEvent() to a rotated
file. It could be useful for troubleshooting to have access to recent
events beyond what's kept in memory. Use it with caution as it can
add significant overhead on busy nodes.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>