### PR TITLE
k8s: Consolidate check for EndpointSlice support

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -363,7 +363,7 @@ func SupportsEndpointSlice() bool {
 // SupportsEndpointSliceV1 returns true if cilium-operator or cilium-agent should
 // watch and process endpoint slices V1.
 func SupportsEndpointSliceV1() bool {
-	return version.Capabilities().EndpointSliceV1 && option.Config.K8sEnableK8sEndpointSlice
+	return SupportsEndpointSlice() && version.Capabilities().EndpointSliceV1
 }
 
 // HasEndpointSlice returns true if the hasEndpointSlices is closed before the


### PR DESCRIPTION
When v1 support for EndpointSlice is checked, the capability for the
base EndpointSlice support is also toggled, therefore we can consolidate
the logic inside the support helpers. It's not possible for one variant
to return true and the other false, and vice versa.

Fixes: 5ee4c6f4d1 ("add support for EndpointSlice V1")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
