### PR TITLE
Revert "ci: push cilium-test image to quay.io, use it in nightly"

### DIFF
--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -44,9 +44,6 @@ jobs:
           - name: docker-plugin
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
 
-          - name: cilium-test
-            dockerfile: ./images/cilium-test/Dockerfile
-
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,13 +8,16 @@ jobs:
     if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-18.04
     steps:
+      - name: Trim git sha
+        id: vars
+        run: echo "::set-output name=sha_short::$(echo ${GITHUB_SHA:0:9})"
       - name: Request GKE test cluster
         uses: docker://quay.io/isovalent/gke-test-cluster-requester:fe34abda190c31680968ba62634c788428d91706
         env:
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --namespace=test-clusters --image=quay.io/cilium/cilium-test-ci:${{ env.GITHUB_SHA }} "/usr/local/bin/cilium-test-gke.sh" "quay.io/cilium/cilium-ci:${{ env.GITHUB_SHA }}" "quay.io/cilium/operator-generic-ci:${{ env.GITHUB_SHA }}" "quay.io/cilium/hubble-relay-ci:${{ env.GITHUB_SHA }}" "NightlyPolicyStress"
+          args: --namespace=test-clusters --image=cilium/cilium-test-dev:${{ steps.vars.outputs.sha_short }} "/usr/local/bin/cilium-test-gke.sh" "quay.io/cilium/cilium:latest" "quay.io/cilium/operator-generic:latest" "quay.io/cilium/hubble-relay:latest" "NightlyPolicyStress"
   baseline-test:
     name: Start performance test
     if: github.repository == 'cilium/cilium'


### PR DESCRIPTION
This reverts pull request https://github.com/cilium/cilium/pull/15569.

All image CI builds started failing in pull requests after we merged this pull request. Reverting while we investigate and find a fix.

Reported-by: @aanm 
/cc @nebril 