### PR TITLE
Fix BPF_JMP_MAP_ID on tail call toy example.

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -1939,7 +1939,7 @@ describe some of the differences for the BPF model:
         .max_elem       = 1,
     };
 
-    __section_tail(JMP_MAP_ID, 0)
+    __section_tail(BPF_JMP_MAP_ID, 0)
     int looper(struct __sk_buff *skb)
     {
         printk("skb cb: %u\n", skb->cb[0]++);


### PR DESCRIPTION
Toy example for tail call defines BPF_JMP_MAP_ID for the tail call, but uses
JMP_MAP_ID at the __section_tail function. This would load the program and map
but __section_tail will not be loaded to JMP_MAP because the IDs don't match.
Small fix to address this and use BPF_JMP_MAP_ID everywhere.

Signed-off-by: Yiannis Yiakoumis <yiannis@selfienetworks.com>