### PR TITLE
examples: Split host policies for dev. VMs

### DIFF
--- a/examples/policies/host/lock-down-dev-vms-cidr-node.yaml
+++ b/examples/policies/host/lock-down-dev-vms-cidr-node.yaml
@@ -1,0 +1,157 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "lock-down-dev-vms"
+spec:
+  description: "Lock down the development VMs when enable-remote-node-identity=false.
+    USE ELSEWHERE AT YOUR OWN RISK."
+  nodeSelector:
+    {}
+  ingress:
+  # Only ICMP echo/reply messages should be drop if this is commented.
+  - fromEntities:
+    - health
+  - fromCIDR:
+    - 192.168.33.0/24
+
+  # SSH access to the VMs
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "22"
+        protocol: TCP
+
+  - fromCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      # VXLAN tunnels between nodes
+      - port: "8472"
+        protocol: UDP
+      # etcd connections
+      - port: "2379"
+        protocol: TCP
+      - port: "2380"
+        protocol: TCP
+      # kube-api server
+      - port: "6443"
+        protocol: TCP
+
+  # kube-api server access for kube-dns
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
+    toPorts:
+    - ports:
+      - port: "6443"
+        protocol: TCP
+
+  # Health checks
+  - fromEntities:
+    - health
+    toPorts:
+    - ports:
+      - port: "4240"
+        protocol: TCP
+  - fromCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      - port: "4240"
+        protocol: TCP
+
+  # NodePort
+  # These two rules are only needed when kube-proxy is used.
+  # They should be removed when running in kube-proxy-free mode.
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-intra-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+  - fromEndpoints:
+    - matchLabels:
+        name: pod-to-b-multi-node-nodeport
+    toPorts:
+    - ports:
+      - port: "31313"
+        protocol: TCP
+
+
+  egress:
+  # Only ICMP echo/reply messages should be drop if this is commented.
+  - toEntities:
+    - health
+  - toCIDR:
+    - 192.168.33.0/24
+
+  # DNS traffic to kube-dns
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      - port: "8181"
+        protocol: TCP
+      - port: "53"
+        protocol: UDP
+
+  - toCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      # VXLAN tunnels between nodes
+      - port: "8472"
+        protocol: UDP
+      # etcd connections
+      - port: "2379"
+        protocol: TCP
+      - port: "2380"
+        protocol: TCP
+      # kube-api server
+      - port: "6443"
+        protocol: TCP
+
+  # Health checks
+  - toEntities:
+    - health
+    toPorts:
+    - ports:
+      - port: "4240"
+        protocol: TCP
+  - toCIDR:
+    - 192.168.33.0/24
+    toPorts:
+    - ports:
+      - port: "4240"
+        protocol: TCP
+
+  # NTP queries
+  - toEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "123"
+        protocol: UDP
+  - toCIDR:
+    - 8.8.8.8/32
+    - 8.8.4.4/32
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+
+  # Required for host-networking pods of the connectivity-check
+  - toEndpoints:
+    - matchLabels:
+        name: echo-b
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP

--- a/examples/policies/host/lock-down-dev-vms-remote-node.yaml
+++ b/examples/policies/host/lock-down-dev-vms-remote-node.yaml
@@ -3,7 +3,8 @@ kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: "lock-down-dev-vms"
 spec:
-  description: "Lock down the development VMs. USE ELSEWHERE AT YOUR OWN RISK."
+  description: "Lock down the development VMs when enable-remote-node-identity=true.
+    USE ELSEWHERE AT YOUR OWN RISK."
   nodeSelector:
     {}
   ingress:
@@ -11,9 +12,6 @@ spec:
   - fromEntities:
     - remote-node
     - health
-  # Same as above, but for when remote-node identities are disabled.
-  - fromCIDR:
-    - 192.168.33.0/24
 
   # SSH access to the VMs
   - fromEntities:
@@ -25,22 +23,6 @@ spec:
 
   - fromEntities:
     - remote-node
-    toPorts:
-    - ports:
-      # VXLAN tunnels between nodes
-      - port: "8472"
-        protocol: UDP
-      # etcd connections
-      - port: "2379"
-        protocol: TCP
-      - port: "2380"
-        protocol: TCP
-      # kube-api server
-      - port: "6443"
-        protocol: TCP
-  # Same as above, but for when remote-node identities are disabled.
-  - fromCIDR:
-    - 192.168.33.0/24
     toPorts:
     - ports:
       # VXLAN tunnels between nodes
@@ -73,13 +55,6 @@ spec:
     - ports:
       - port: "4240"
         protocol: TCP
-  # Same as above, but for when remote-node identities are disabled.
-  - fromCIDR:
-    - 192.168.33.0/24
-    toPorts:
-    - ports:
-      - port: "4240"
-        protocol: TCP
 
   # NodePort
   # These two rules are only needed when kube-proxy is used.
@@ -105,9 +80,6 @@ spec:
   - toEntities:
     - remote-node
     - health
-  # Same as above, but for when remote-node identities are disabled.
-  - toCIDR:
-    - 192.168.33.0/24
 
   # DNS traffic to kube-dns
   - toEndpoints:
@@ -138,34 +110,11 @@ spec:
       # kube-api server
       - port: "6443"
         protocol: TCP
-  # Same as above, but for when remote-node identities are disabled.
-  - toCIDR:
-    - 192.168.33.0/24
-    toPorts:
-    - ports:
-      # VXLAN tunnels between nodes
-      - port: "8472"
-        protocol: UDP
-      # etcd connections
-      - port: "2379"
-        protocol: TCP
-      - port: "2380"
-        protocol: TCP
-      # kube-api server
-      - port: "6443"
-        protocol: TCP
 
   # Health checks
   - toEntities:
     - remote-node
     - health
-    toPorts:
-    - ports:
-      - port: "4240"
-        protocol: TCP
-  # Same as above, but for when remote-node identities are disabled.
-  - toCIDR:
-    - 192.168.33.0/24
     toPorts:
     - ports:
       - port: "4240"


### PR DESCRIPTION
The current extensive host policy for the development VMs (implements the most restrictive policy possible) was written to support both values of `enable-remote-node-identity`. When that flag is enabled, rules for the remote node are implemented with the `remote-node` entity; when it is disabled, the node CIDR is used.

Unfortunately, when `enable-remote-node-identity` is given, the policy is not the most restrictive possible anymore, because we now have additional rules matching on node CIDR. To ensure we have the most restrictive policy possible, we need to split the existing host policy into two policies, for each value of the flag.

These files are not tested anywhere and only used for local testing, so no need to run the full CI.