### PR TITLE
docs: Hide "Edit on GitHub" buttons

### DIFF
--- a/Documentation/_static/editbutton.css
+++ b/Documentation/_static/editbutton.css
@@ -1,0 +1,4 @@
+/* Hide "On GitHub" section from versions menu */
+div.rst-versions > div.rst-other-versions > div.injected > dl:nth-child(4) {
+    display: none;
+}

--- a/Documentation/_templates/breadcrumbs.html
+++ b/Documentation/_templates/breadcrumbs.html
@@ -1,0 +1,4 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -243,5 +243,6 @@ default_role = 'any'
 def setup(app):
     app.add_stylesheet('parsed-literal.css')
     app.add_stylesheet('copybutton.css')
+    app.add_stylesheet('editbutton.css')
     app.add_javascript('clipboardjs.min.js')
     app.add_javascript("copybutton.js")


### PR DESCRIPTION
Following the instructions here, remove the buttons to edit on github
since this is confusing for contributors since it opens PRs against
branches where we don't accept contributions, bypasses the standard
instructions like requiring signoffs, etc.

https://github.com/readthedocs/readthedocs.org/blob/master/docs/guides/remove-edit-buttons.rst
