### PR TITLE
nat: Do not increment delete error metric on nat entry GC

### DIFF
--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -308,6 +308,24 @@ func (s *BPFPrivilegedTestSuite) TestBasicManipulation(c *C) {
 	c.Assert(err, Not(IsNil))
 	c.Assert(value, Equals, nil)
 
+	err = existingMap.Delete(key1)
+	c.Assert(err, Not(IsNil))
+
+	deleted, err := existingMap.SilentDelete(key1)
+	c.Assert(err, IsNil)
+	c.Assert(deleted, Equals, false)
+
+	err = existingMap.Update(key1, value1)
+	c.Assert(err, IsNil)
+
+	deleted, err = existingMap.SilentDelete(key1)
+	c.Assert(err, IsNil)
+	c.Assert(deleted, Equals, true)
+
+	value, err = existingMap.Lookup(key1)
+	c.Assert(err, Not(IsNil))
+	c.Assert(value, Equals, nil)
+
 	err = existingMap.DeleteAll()
 	c.Assert(err, IsNil)
 	value, err = existingMap.Lookup(key1)

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -608,10 +608,10 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 				// No CT entry is found, so delete SNAT for both original and
 				// reverse flows
 				oNatKey := oNatKeyFromReverse(natKey, natVal)
-				if err := natMap.Delete(oNatKey); err == nil {
+				if deleted, _ := natMap.Delete(oNatKey); deleted {
 					stats.EgressDeleted += 1
 				}
-				if err := natMap.Delete(natKey); err == nil {
+				if deleted, _ := natMap.Delete(natKey); deleted {
 					stats.IngressDeleted += 1
 				}
 			} else {

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -119,8 +119,9 @@ func NewMap(name string, v4 bool, entries int) *Map {
 	}
 }
 
-func (m *Map) Delete(k bpf.MapKey) error {
-	return (&m.Map).Delete(k)
+func (m *Map) Delete(k bpf.MapKey) (deleted bool, err error) {
+	deleted, err = (&m.Map).SilentDelete(k)
+	return
 }
 
 func (m *Map) DumpStats() *bpf.DumpStats {
@@ -174,7 +175,7 @@ func statStartGc(m *Map) gcStats {
 func doFlush4(m *Map) gcStats {
 	stats := statStartGc(m)
 	filterCallback := func(key bpf.MapKey, _ bpf.MapValue) {
-		err := m.Delete(key)
+		err := (&m.Map).Delete(key)
 		if err != nil {
 			log.WithError(err).WithField(logfields.Key, key.String()).Error("Unable to delete CT entry")
 		} else {
@@ -188,7 +189,7 @@ func doFlush4(m *Map) gcStats {
 func doFlush6(m *Map) gcStats {
 	stats := statStartGc(m)
 	filterCallback := func(key bpf.MapKey, _ bpf.MapValue) {
-		err := m.Delete(key)
+		err := (&m.Map).Delete(key)
 		if err != nil {
 			log.WithError(err).WithField(logfields.Key, key.String()).Error("Unable to delete CT entry")
 		} else {
@@ -225,8 +226,8 @@ func deleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 		rkey.DestPort = val.Port
 		rkey.Flags = tuple.TUPLE_F_IN
 
-		m.Delete(&key)
-		m.Delete(&rkey)
+		m.SilentDelete(&key)
+		m.SilentDelete(&rkey)
 	}
 	return nil
 }
@@ -249,8 +250,8 @@ func deleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 		rkey.DestPort = val.Port
 		rkey.Flags = tuple.TUPLE_F_IN
 
-		m.Delete(&key)
-		m.Delete(&rkey)
+		m.SilentDelete(&key)
+		m.SilentDelete(&rkey)
 	}
 	return nil
 }
@@ -263,7 +264,7 @@ func deleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	key.SourcePort = key.DestPort
 	key.DestPort = port
 	key.Flags = tuple.TUPLE_F_OUT
-	m.Delete(&key)
+	m.SilentDelete(&key)
 
 	return nil
 }
@@ -276,7 +277,7 @@ func deleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	key.SourcePort = key.DestPort
 	key.DestPort = port
 	key.Flags = tuple.TUPLE_F_OUT
-	m.Delete(&key)
+	m.SilentDelete(&key)
 
 	return nil
 }


### PR DESCRIPTION
This fixes the spurious increments of the snat_v[46]_external delete
fail metric by extending bpf.Map with SilentDelete() which allows
deleting map entries that may not exist without error counter increments
or deferred repeated delete via resolveErrors().

Fixes: #11485
