### PR TITLE
v1.9 backport 2021-04-07

### DIFF
--- a/Documentation/_static/editbutton.css
+++ b/Documentation/_static/editbutton.css
@@ -1,0 +1,4 @@
+/* Hide "On GitHub" section from versions menu */
+div.rst-versions > div.rst-other-versions > div.injected > dl:nth-child(4) {
+    display: none;
+}

--- a/Documentation/_templates/breadcrumbs.html
+++ b/Documentation/_templates/breadcrumbs.html
@@ -1,0 +1,4 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -1940,7 +1940,7 @@ describe some of the differences for the BPF model:
         .max_elem       = 1,
     };
 
-    __section_tail(JMP_MAP_ID, 0)
+    __section_tail(BPF_JMP_MAP_ID, 0)
     int looper(struct __sk_buff *skb)
     {
         printk("skb cb: %u\n", skb->cb[0]++);

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -243,5 +243,6 @@ default_role = 'any'
 def setup(app):
     app.add_stylesheet('parsed-literal.css')
     app.add_stylesheet('copybutton.css')
+    app.add_stylesheet('editbutton.css')
     app.add_javascript('clipboardjs.min.js')
     app.add_javascript("copybutton.js")

--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -149,7 +149,7 @@ callbacks provided by other packages via daemon in cilium-agent.
   query) an error occurred. These errors would come from the internal rule
   lookup in the proxy, the ``allowed`` field.
 - ``Timeout waiting for response to forwarded proxied DNS lookup``: The proxy
-  forwards requests 1:1 and does not cache. It applies a 5s timeout on
+  forwards requests 1:1 and does not cache. It applies a 10s timeout on
   responses to those requests, as the client will retry within this period
   (usually). Bursts of these errors can happen if the DNS target server
   misbehaves and many pods see DNS timeouts. This isn't an actual problem with

--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -27,7 +27,7 @@ for the default CNI plugin:
 
 .. parsed-literal::
 
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none --no-flannel' sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none' sh -
 
 Install Agent Nodes (Optional)
 ==============================
@@ -42,7 +42,7 @@ replace the variables with values from your environment:
 
 .. parsed-literal::
 
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--disable-network-policy --no-flannel' K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
+    curl -sfL https://get.k3s.io | K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
 
 Should you encounter any issues during the installation, please refer to the
 :ref:`troubleshooting_k8s` section and / or seek help on the `Slack channel`.

--- a/install/kubernetes/cilium/templates/cilium-agent-servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-servicemonitor.yaml
@@ -21,6 +21,8 @@ spec:
     interval: 10s
     honorLabels: true
     path: /metrics
+  targetLabels:
+  - k8s-app
 {{- end }}
 {{- if and .Values.hubble.metrics.enabled (.Values.hubble.metrics.serviceMonitor.enabled) }}
 ---

--- a/install/kubernetes/cilium/templates/cilium-operator-servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-servicemonitor.yaml
@@ -21,4 +21,6 @@ spec:
     interval: 10s
     honorLabels: true
     path: /metrics
+  targetLabels:
+  - io.cilium/app
 {{- end }}

--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -385,7 +385,12 @@ func updateV1CRD(
 					context.TODO(),
 					clusterCRD,
 					metav1.UpdateOptions{})
-				if err == nil {
+				switch {
+				case errors.IsConflict(err): // Occurs as Operators race to update CRDs.
+					scopedLog.WithError(err).
+						Debug("The CRD update was based on an older version, retrying...")
+					return false, nil
+				case err == nil:
 					return true, nil
 				}
 


### PR DESCRIPTION
v1.9 backports 2021-04-07

 * #14747 -- Add labels to scrape cilium agent and operator metrics (@lyveng)
 * #15503 -- docs: update k3s installation instructions (@aanm)
 * #15544 -- k8s: Retry CRD update upon conflict (@christarazi)
 * #15576 -- Fix BPF_JMP_MAP_ID on tail call toy example. (@yiannisy)
 * #15581 -- docs: Update DNS proxy timeout value (@aditighag)
 * #15579 -- docs: Hide "Edit on GitHub" buttons (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14747 15503 15544 15576 15581 15579; do contrib/backporting/set-labels.py $pr done 1.9; done
```
