### PR TITLE
Kata: Mention incompatibility with host-reachable services or strict KPR in documentation

### DIFF
--- a/Documentation/gettingstarted/kata.rst
+++ b/Documentation/gettingstarted/kata.rst
@@ -75,6 +75,18 @@ Deploy Cilium release via Helm:
              --namespace kube-system \\
              --set containerRuntime.integration=containerd
 
+.. warning::
+
+   Kata containers do not work with :ref:`host-services`, or with
+   :ref:`kube-proxy replacement <kubeproxy-free>` in strict mode. These
+   features should be disabled with ``--set hostServices.enabled=false``
+   (default) and ``--set kubeProxyReplacement=disabled`` (or ``partial``).
+
+   Both features rely on socket-based load-balancing, which is not possible
+   given that Kata containers are virtual machines running with their own
+   kernel. For kube-proxy replacement, this limitation is tracked with
+   `GitHub issue 15437 <https://github.com/cilium/cilium/issues/15437>`_.
+
 .. include:: k8s-install-validate.rst
 
 Run Kata Containers with Cilium CNI


### PR DESCRIPTION
Host-reachable services are not supported with Kata containers at this time. This is because they use socket-based load-balancing which requires hooking in the kernel at the socket level in the pods, but Kata containers are VMs with their own kernels, making it impossible.

Kube-proxy replacement in strict mode implies host-reachable services, and is therefore not supported either.

Update the documentation accordingly, to avoid users stumbling on it.

Preview:
![warning](https://user-images.githubusercontent.com/17001771/113882817-891a2980-97b5-11eb-855e-a6e7121d195b.png)
