### PR TITLE
ctmap: do not call InitMapInfo() in init()

### DIFF
--- a/cilium/cmd/bpf_ct.go
+++ b/cilium/cmd/bpf_ct.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/spf13/cobra"
 )
 
@@ -25,5 +27,6 @@ var bpfCtCmd = &cobra.Command{
 }
 
 func init() {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	bpfCmd.AddCommand(bpfCtCmd)
 }

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/loader"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -48,6 +49,10 @@ var (
 	ipv4DummyAddr = []byte{192, 0, 2, 3}
 	ipv6DummyAddr = []byte{0x20, 0x01, 0xdb, 0x8, 0x0b, 0xad, 0xca, 0xfe, 0x60, 0x0d, 0xbe, 0xe2, 0x0b, 0xad, 0xca, 0xfe}
 )
+
+func (s *ConfigSuite) SetUpSuite(c *C) {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+}
 
 func (s *ConfigSuite) SetUpTest(c *C) {
 	err := bpf.ConfigureResourceLimits()

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -19,7 +19,9 @@ package loader
 import (
 	"testing"
 
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 
 	. "gopkg.in/check.v1"
 )
@@ -34,6 +36,7 @@ func Test(t *testing.T) {
 }
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	node.InitDefaultPrefix("")
 	node.SetInternalIPv4Router(templateIPv4)
 	node.SetIPv4Loopback(templateIPv4)

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -31,6 +31,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/elf"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -63,6 +64,8 @@ func Test(t *testing.T) {
 }
 
 func (s *LoaderTestSuite) SetUpSuite(c *C) {
+
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	SetTestIncludes([]string{
 		fmt.Sprintf("-I%s", bpfDir),
 		fmt.Sprintf("-I%s", filepath.Join(bpfDir, "include")),

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -35,6 +35,7 @@ import (
 	pkgLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -78,6 +79,7 @@ var suite = EndpointSuite{repo: policy.NewPolicyRepository(nil, nil)}
 var _ = Suite(&suite)
 
 func (s *EndpointSuite) SetUpSuite(c *C) {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	s.repo = policy.NewPolicyRepository(nil, nil)
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(nil, "")

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -202,10 +202,6 @@ func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6, nodeport bool) {
 		anyMaxEntries, natMaps[mapTypeIPv6AnyGlobal])
 }
 
-func init() {
-	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
-}
-
 // CtEndpoint represents an endpoint for the functions required to manage
 // conntrack maps for the endpoint.
 type CtEndpoint interface {

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -33,6 +34,10 @@ import (
 type CTMapTestSuite struct{}
 
 var _ = Suite(&CTMapTestSuite{})
+
+func init() {
+	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+}
 
 func Test(t *testing.T) {
 	TestingT(t)

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -35,6 +35,10 @@ type CTMapTestSuite struct{}
 
 var _ = Suite(&CTMapTestSuite{})
 
+func init() {
+	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+}
+
 func Test(t *testing.T) {
 	TestingT(t)
 }


### PR DESCRIPTION
PR #14721 introduced changes that removed the
cilium_snat_v{4,6}_external maps if NodePort is not enabled.

Issue #15141 was attributed to the above PR, where controllers were
failing with:
> error=Unable to get object /sys/fs/bpf/tc/globals/cilium_snat_v4_external: no such file or directory  name=bpf-map-sync-cilium_snat_v4_external

In an attempt to address #15141, #15175 added a nodeport argument to
InitMapInfo() so that the cilium_snat_v{4,6}_external maps are not
created if NodePort is not enabled.

PR #15141 did not fix the issue: https://github.com/cilium/cilium/issues/15337#issuecomment-797734599

This PR takes another shot at fixing #15141 by removing a call of
InitMapInfo from init(), where the (new) nodeport argument is always
true.

see the commit message for more details

Fixes: cac5218
Fixes: d639905
Fixes: #15141
Fixes: #15337


Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>
