### PR TITLE
v1.8 backport 2021-04-07

### DIFF
--- a/Documentation/_static/editbutton.css
+++ b/Documentation/_static/editbutton.css
@@ -1,0 +1,4 @@
+/* Hide "On GitHub" section from versions menu */
+div.rst-versions > div.rst-other-versions > div.injected > dl:nth-child(4) {
+    display: none;
+}

--- a/Documentation/_templates/breadcrumbs.html
+++ b/Documentation/_templates/breadcrumbs.html
@@ -1,0 +1,4 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -239,5 +239,6 @@ default_role = 'any'
 def setup(app):
     app.add_stylesheet('parsed-literal.css')
     app.add_stylesheet('copybutton.css')
+    app.add_stylesheet('editbutton.css')
     app.add_javascript('clipboardjs.min.js')
     app.add_javascript("copybutton.js")

--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -149,7 +149,7 @@ callbacks provided by other packages via daemon in cilium-agent.
   query) an error occurred. These errors would come from the internal rule
   lookup in the proxy, the ``allowed`` field.
 - ``Timeout waiting for response to forwarded proxied DNS lookup``: The proxy
-  forwards requests 1:1 and does not cache. It applies a 5s timeout on
+  forwards requests 1:1 and does not cache. It applies a 10s timeout on
   responses to those requests, as the client will retry within this period
   (usually). Bursts of these errors can happen if the DNS target server
   misbehaves and many pods see DNS timeouts. This isn't an actual problem with


### PR DESCRIPTION
 * #15581 -- docs: Update DNS proxy timeout value (@aditighag)
 * #15579 -- docs: Hide "Edit on GitHub" buttons (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15581 15579; do contrib/backporting/set-labels.py $pr done 1.8; done
```
