### PR TITLE
Remove force-local-policy-eval-at-source flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -124,7 +124,7 @@ cilium-agent [flags]
       --envoy-log string                                     Path to a separate Envoy log file, if any
       --exclude-local-address strings                        Exclude CIDR from being recognized as local address
       --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
+      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint
       --gops-port int                                        Port for gops server to listen on (default 9890)
   -h, --help                                                 help for cilium-agent
       --host-reachable-services-protos strings               Only enable reachability of services for host applications for specific protocols (default [tcp,udp])

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -299,9 +299,9 @@ const (
 	EndpointInterfaceNamePrefix = "lxc+"
 
 	// ForceLocalPolicyEvalAtSource is the default value for
-	// option.ForceLocalPolicyEvalAtSource. It is enabled by default to
-	// provide backwards compatibility, it can be disabled via an option
-	ForceLocalPolicyEvalAtSource = true
+	// option.ForceLocalPolicyEvalAtSource. It is disabled by default
+	// it can be enabled via an option
+	ForceLocalPolicyEvalAtSource = false
 
 	// EnableEndpointRoutes is the value for option.EnableEndpointRoutes.
 	// It is disabled by default for backwards compatibility.


### PR DESCRIPTION
The flag is currently enabled by default and force policy evaluation at the source.
Now changes has been done to disable the flag by default,
Making use of existing "connectivity-check-proxy.yaml" tests
to test cilium connectivity test including L7 proxy tests.

Fixes: #15452

Signed-off-by: Venkata Reddy <venkata.reddy@accuknox.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
