### PR TITLE
cilium: test encryption workflows for GKE

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -120,6 +120,46 @@ jobs:
         run: |
           cilium connectivity test
 
+      - name: Clean up Cilium
+        run: |
+          cilium uninstall --wait
+          pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
+
+      - name: Install Cilium With Encryption
+        run: |
+          cilium install \
+            --encryption \
+            --cluster-name=${{ env.clusterName }} \
+            --wait=false \
+            --restart-unmanaged-pods=false \
+            --config monitor-aggregation=none \
+            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --version ${{ steps.vars.outputs.sha }}
+
+      - name: Enable Relay
+        run: |
+          cilium hubble enable
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
+      - name: Port forward Relay
+        run: |
+          kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245&
+          sleep 5s
+
+      - name: Restart connectivity test pods
+        run: |
+          kubectl delete pod -n cilium-test --selector=kind=client
+          kubectl delete pod -n cilium-test --selector=kind=echo
+          # workaround for github.com/cilium/cilium-cli/issues/156
+
+      - name: Run connectivity test
+        run: |
+          cilium connectivity test
+
       - name: Post-test information gathering
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
Test work flows with encryption and GKE.

This adds an additional run of `cilium test connectivity` to the gke workflow, but this time with encryption enabled. After this commit the workflow is the following.

```
cilium install ...
cilium hubble enable
kubectl port-forward ...
cilium connectivity test
cilium uninstall
cilium install --encryption ...
cilium hubble enable
kubectl port-forward
kubectl delete pod  ... // delete cilium-test pods
cilium connectivity test
```
above omits a few --wait ops and the cluster setup for clarity. For now I manually delete the pods to work-around issue, https://github.com/cilium/cilium-cli/issues/156, where the uninstall does not delete cilium-test pods and the --restart-pods on install does not restart them.

I've done multiple runs of the workflow and most passed. I observed two errors that seem unrelated to this PR. First sometimes the cleanup fails with,
```
Error: We are currently unable to download the log. Please try again later.
```
And then once the initial (without encryption) connectivity test failed the pod->world test. It seems like a flake.

