### PR TITLE
v1.9 backports 2021-04-07

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -509,6 +509,18 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 			if iface.ID == ipInfo.Resource {
 				result.PrimaryMAC = iface.MAC
 				result.GatewayIP = iface.GatewayIP
+				// For now, we can hardcode the interface number to a valid
+				// integer because it will not be used in the allocation result
+				// anyway. To elaborate, Azure IPAM mode automatically sets
+				// option.Config.EgressMultiHomeIPRuleCompat to true, meaning
+				// that the CNI will not use the interface number when creating
+				// the pod rules and routes. We are hardcoding simply to bypass
+				// the parsing errors when InterfaceNumber is empty. See
+				// https://github.com/cilium/cilium/issues/15496.
+				//
+				// TODO: Once https://github.com/cilium/cilium/issues/14705 is
+				// resolved, then we don't need to hardcode this anymore.
+				result.InterfaceNumber = "0"
 				return
 			}
 		}


### PR DESCRIPTION
* #15533 -- ipam: Fix empty interface number in Azure (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15533; do contrib/backporting/set-labels.py $pr done 1.9; done
```