### PR TITLE
v1.8 backports 2021-04-07

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -670,7 +670,13 @@ do_netdev_encrypt_fib(struct __ctx_buff *ctx __maybe_unused,
 		      int *encrypt_iface __maybe_unused)
 {
 	int ret = 0;
-#ifdef BPF_HAVE_FIB_LOOKUP
+	/* Only do FIB lookup if both the BPF helper is supported and we know
+	 * the egress ineterface. If we don't have an egress interface,
+	 * typically in an environment with many egress devs than we have
+	 * to let the stack decide how to egress the packet. EKS is the
+	 * example of an environment with multiple egress interfaces.
+	 */
+#if defined(BPF_HAVE_FIB_LOOKUP) && defined(ENCRYPT_IFACE)
 	struct bpf_fib_lookup fib_params = {};
 	void *data, *data_end;
 	int err;
@@ -725,7 +731,7 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 {
 	int encrypt_iface = 0;
 	int ret = 0;
-#if defined(ENCRYPT_IFACE)
+#if defined(ENCRYPT_IFACE) && defined(BPF_HAVE_FIB_LOOKUP)
 	encrypt_iface = ENCRYPT_IFACE;
 #endif
 	ret = do_netdev_encrypt_pools(ctx);
@@ -737,8 +743,16 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	bpf_clear_meta(ctx);
+#ifdef BPF_HAVE_FIB_LOOKUP
+	/* Redirect only works if we have a fib lookup to set the MAC
+	 * addresses. Otherwise let the stack do the routing and fib
+	 * Note, without FIB lookup implemented the packet may have
+	 * incorrect dmac leaving bpf_host so will need to mark as
+	 * PACKET_HOST or otherwise fixup MAC addresses.
+	 */
 	if (encrypt_iface)
 		return redirect(encrypt_iface, 0);
+#endif
 	return CTX_ACT_OK;
 }
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1025,6 +1025,15 @@ int to_host(struct __ctx_buff *ctx)
 		traced = true;
 	}
 
+#ifdef ENABLE_IPSEC
+	/* Encryption stack needs this when IPSec headers are
+	 * rewritten without FIB helper because we do not yet
+	 * know correct MAC address which will cause the stack
+	 * to mark as PACKET_OTHERHOST and drop.
+	 */
+	ctx_change_type(ctx, PACKET_HOST);
+#endif
+
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, srcID, 0, 0,
 				  CILIUM_IFINDEX, ret, 0);

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -3,6 +3,7 @@
 
 #include <bpf/ctx/skb.h>
 #include <bpf/api.h>
+#include <linux/ip.h>
 
 #include <node_config.h>
 #include <netdev_config.h>
@@ -11,10 +12,7 @@
 #include "lib/common.h"
 #include "lib/maps.h"
 #include "lib/ipv6.h"
-#include "lib/eth.h"
-#include "lib/dbg.h"
 #include "lib/trace.h"
-#include "lib/l3.h"
 #include "lib/drop.h"
 
 #ifdef ENABLE_IPV6

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -24,20 +24,18 @@ NATIVE_DEVS=$6
 XDP_DEV=$7
 XDP_MODE=$8
 MTU=$9
-IPSEC=${10}
-ENCRYPT_DEV=${11}
-HOSTLB=${12}
-HOSTLB_UDP=${13}
-HOSTLB_PEER=${14}
-CGROUP_ROOT=${15}
-BPFFS_ROOT=${16}
-NODE_PORT=${17}
-NODE_PORT_BIND=${18}
-MCPU=${19}
-NODE_PORT_IPV4_ADDRS=${20}
-NODE_PORT_IPV6_ADDRS=${21}
-NR_CPUS=${22}
-ENDPOINT_ROUTES=${23}
+HOSTLB=${10}
+HOSTLB_UDP=${11}
+HOSTLB_PEER=${12}
+CGROUP_ROOT=${13}
+BPFFS_ROOT=${14}
+NODE_PORT=${15}
+NODE_PORT_BIND=${16}
+MCPU=${17}
+NODE_PORT_IPV4_ADDRS=${18}
+NODE_PORT_IPV6_ADDRS=${19}
+NR_CPUS=${20}
+ENDPOINT_ROUTES=${21}
 
 ID_HOST=1
 ID_WORLD=2
@@ -645,12 +643,6 @@ else
 	bpf_clear_cgroups $CGROUP_ROOT getpeername6
 fi
 
-if [ "$IPSEC" == "true" ]; then
-	if [ "$ENCRYPT_DEV" != "<nil>" ]; then
-		CALLS_MAP="cilium_calls_netdev_ns_${ID_HOST}"
-		bpf_load $ENCRYPT_DEV "" "ingress" bpf_network.c bpf_network.o from-network $CALLS_MAP
-	fi
-fi
 if [ "$HOST_DEV1" != "$HOST_DEV2" ]; then
 	bpf_unload $HOST_DEV2 "egress"
 fi

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1306,8 +1306,7 @@ func (d *Daemon) initKVStore() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice:        option.Config.HostDevice,
-		EncryptInterfaces: option.Config.EncryptInterface,
+		HostDevice: option.Config.HostDevice,
 	}
 
 	log.Info("Initializing daemon")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1170,7 +1170,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && len(option.Config.EncryptInterface) == 0 {
+	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
+	// that may be added or removed at runtime.
+	if option.Config.EnableIPSec &&
+		option.Config.Tunnel == option.TunnelDisabled &&
+		len(option.Config.EncryptInterface) == 0 &&
+		option.Config.IPAM != ipamOption.IPAMENI {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {
 			log.WithError(err).Fatal("Ipsec default interface lookup failed, consider \"encrypt-interface\" to manually configure interface.")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1170,12 +1170,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && option.Config.EncryptInterface == "" {
+	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && len(option.Config.EncryptInterface) == 0 {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {
 			log.WithError(err).Fatal("Ipsec default interface lookup failed, consider \"encrypt-interface\" to manually configure interface.")
 		}
-		option.Config.EncryptInterface = link
+		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
 
 	initClockSourceOption()
@@ -1301,8 +1301,8 @@ func (d *Daemon) initKVStore() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice:       option.Config.HostDevice,
-		EncryptInterface: option.Config.EncryptInterface,
+		HostDevice:        option.Config.HostDevice,
+		EncryptInterfaces: option.Config.EncryptInterface,
 	}
 
 	log.Info("Initializing daemon")

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -324,8 +324,13 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_HOST_FIREWALL"] = "1"
 	}
 
-	if option.Config.EncryptInterface != "" {
-		link, err := netlink.LinkByName(option.Config.EncryptInterface)
+	if len(option.Config.EncryptInterface) > 0 {
+		// When FIB lookup is not supported (older kernels)  we need to
+		// pick an interface so pick first interface in list. Then we pick
+		// an IPv4 address to use by selecting link IPAddr. In case with
+		// kernel support, the kernel datapath will use the FIB lookup helper
+		// and this define is ignored.
+		link, err := netlink.LinkByName(option.Config.EncryptInterface[0])
 		if err == nil {
 			cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -324,11 +324,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_HOST_FIREWALL"] = "1"
 	}
 
-	if iface := option.Config.EncryptInterface; len(iface) != 0 {
+	if option.Config.EnableIPSec {
 		a := byteorder.HostSliceToNetwork(node.GetIPv4(), reflect.Uint32).(uint32)
 		cDefinesMap["IPV4_ENCRYPT_IFACE"] = fmt.Sprintf("%d", a)
-
-		if len(iface) != 0 {
+		if iface := option.Config.EncryptInterface; len(iface) != 0 {
 			link, err := netlink.LinkByName(iface[0])
 			if err == nil {
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -32,6 +32,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -333,10 +334,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 			}
 		}
+		// If we are using IPAMENI always use IP_POOLS datapath, the pod subnets
+		// will be auto-discovered later at runtime.
+		if (option.Config.IPAM == ipamOption.IPAMENI) ||
+			option.Config.IsPodSubnetsDefined() {
+			cDefinesMap["IP_POOLS"] = "1"
+		}
 	}
-	if option.Config.IsPodSubnetsDefined() {
-		cDefinesMap["IP_POOLS"] = "1"
-	}
+
 	if option.Config.EnableNodePort {
 		if option.Config.EnableIPv4 {
 			cDefinesMap["SNAT_MAPPING_IPV4"] = nat.MapNameSnat4Global

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -27,8 +27,8 @@ import (
 type DatapathConfiguration struct {
 	// HostDevice is the name of the device to be used to access the host.
 	HostDevice string
-	// EncryptInterface is the name of the device to be used for direct ruoting encryption
-	EncryptInterface string
+	// EncryptInterfaces is the list of devices used for direct ruoting encryption
+	EncryptInterfaces []string
 }
 
 type linuxDatapath struct {
@@ -52,9 +52,9 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 
 	dp.node = NewNodeHandler(cfg, dp.nodeAddressing)
 
-	if cfg.EncryptInterface != "" {
-		if err := connector.DisableRpFilter(cfg.EncryptInterface); err != nil {
-			log.WithField(logfields.Interface, cfg.EncryptInterface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
+	for _, iface := range cfg.EncryptInterfaces {
+		if err := connector.DisableRpFilter(iface); err != nil {
+			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
 		}
 	}
 

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/loader"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -27,8 +26,6 @@ import (
 type DatapathConfiguration struct {
 	// HostDevice is the name of the device to be used to access the host.
 	HostDevice string
-	// EncryptInterfaces is the list of devices used for direct ruoting encryption
-	EncryptInterfaces []string
 }
 
 type linuxDatapath struct {
@@ -51,13 +48,6 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 	}
 
 	dp.node = NewNodeHandler(cfg, dp.nodeAddressing)
-
-	for _, iface := range cfg.EncryptInterfaces {
-		if err := connector.DisableRpFilter(iface); err != nil {
-			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
-		}
-	}
-
 	return dp
 }
 

--- a/pkg/datapath/linux/ethtool/ethtool.go
+++ b/pkg/datapath/linux/ethtool/ethtool.go
@@ -28,10 +28,6 @@ const (
 	IFNAMSIZ = 16
 )
 
-const (
-	veth = "veth"
-)
-
 type ifreq struct {
 	name [IFNAMSIZ]byte
 	data uintptr
@@ -90,10 +86,5 @@ func IsVirtualDriver(iface string) (bool, error) {
 		return false, err
 	}
 
-	switch drvName {
-	case veth:
-		return true, nil
-	}
-
-	return true, nil
+	return drvName == "veth", nil
 }

--- a/pkg/datapath/linux/ethtool/ethtool.go
+++ b/pkg/datapath/linux/ethtool/ethtool.go
@@ -1,0 +1,97 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethtool
+
+import (
+	"bytes"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	SIOCETHTOOL      = 0x8946
+	ETHTOOL_GDRVINFO = 0x00000003 // Get driver info
+
+	IFNAMSIZ = 16
+)
+
+const (
+	veth = "veth"
+)
+
+type ifreq struct {
+	name [IFNAMSIZ]byte
+	data uintptr
+}
+
+type ethtoolDrvInfo struct {
+	cmd         uint32
+	driver      [32]byte
+	version     [32]byte
+	fwVersion   [32]byte
+	busInfo     [32]byte
+	eromVersion [32]byte
+	reserved2   [12]byte
+	nPrivFlags  uint32
+	nStats      uint32
+	testInfoLen uint32
+	eedumpLen   uint32
+	regdumpLen  uint32
+}
+
+func ethtoolIoctl(iface string, info *ethtoolDrvInfo) error {
+	var ifname [IFNAMSIZ]byte
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_IP)
+	if err != nil {
+		return err
+	}
+	copy(ifname[:], iface)
+	req := ifreq{
+		name: ifname,
+		data: uintptr(unsafe.Pointer(info)),
+	}
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), SIOCETHTOOL, uintptr(unsafe.Pointer(&req)))
+	if ep != 0 {
+		return ep
+	}
+	return nil
+}
+
+func GetDeviceName(iface string) (string, error) {
+	info := ethtoolDrvInfo{
+		cmd: ETHTOOL_GDRVINFO,
+	}
+
+	if err := ethtoolIoctl(iface, &info); err != nil {
+		return "", err
+	}
+	return string(bytes.Trim(info.driver[:], "\x00")), nil
+}
+
+func IsVirtualDriver(iface string) (bool, error) {
+	drvName, err := GetDeviceName(iface)
+	if err != nil {
+		return false, err
+	}
+
+	switch drvName {
+	case veth:
+		return true, nil
+	}
+
+	return true, nil
+}

--- a/pkg/datapath/linux/ethtool/ethtool.go
+++ b/pkg/datapath/linux/ethtool/ethtool.go
@@ -59,6 +59,8 @@ func ethtoolIoctl(iface string, info *ethtoolDrvInfo) error {
 	if err != nil {
 		return err
 	}
+	defer unix.Close(fd)
+
 	copy(ifname[:], iface)
 	req := ifreq{
 		name: ifname,

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -177,6 +177,7 @@ func _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst *net.IPNet, dir netlink
 	// policy because Cilium BPF programs do that.
 	if dir == netlink.XFRM_DIR_FWD {
 		optional = 1
+		policy.Priority = linux_defaults.IPsecFwdPriority
 	}
 	ipSecAttachPolicyTempl(policy, key, tmplSrc.IP, tmplDst.IP, false, optional)
 	return netlink.XfrmPolicyUpdate(policy)
@@ -186,7 +187,7 @@ func ipSecReplacePolicyIn(src, dst, tmplSrc, tmplDst *net.IPNet) error {
 	return _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst, netlink.XFRM_DIR_IN)
 }
 
-func ipSecReplacePolicyFwd(src, dst, tmplSrc, tmplDst *net.IPNet) error {
+func IpSecReplacePolicyFwd(src, dst, tmplSrc, tmplDst *net.IPNet) error {
 	return _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst, netlink.XFRM_DIR_FWD)
 }
 
@@ -342,7 +343,7 @@ func UpsertIPsecEndpoint(local, remote, fwd *net.IPNet, dir IPSecDir, outputMark
 					return 0, fmt.Errorf("unable to replace policy in: %s", err)
 				}
 			}
-			if err = ipSecReplacePolicyFwd(remote, fwd, remote, local); err != nil {
+			if err = IpSecReplacePolicyFwd(remote, fwd, remote, local); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace policy fwd: %s", err)
 				}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -66,10 +66,9 @@ func getIPSecKeys(ip net.IP) *ipSecKey {
 
 func ipSecNewState() *netlink.XfrmState {
 	state := netlink.XfrmState{
-		Mode:         netlink.XFRM_MODE_TUNNEL,
-		Proto:        netlink.XFRM_PROTO_ESP,
-		ESN:          true,
-		ReplayWindow: 1024,
+		Mode:  netlink.XFRM_MODE_TUNNEL,
+		Proto: netlink.XFRM_PROTO_ESP,
+		ESN:   false,
 	}
 	return &state
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -88,6 +88,9 @@ const (
 	// IPsecMarkMaskIn is the mask required for IPsec to lookup encrypt/decrypt bits
 	IPsecMarkMaskIn = 0x0F00
 
+	// IPsecFwdPriority is the priority of the fwd rules placed by IPsec
+	IPsecFwdPriority = 0x0B9F
+
 	// IPsecKeyDeleteDelay is the time to wait before removing old keys when
 	// the IPsec key is changing.
 	IPsecKeyDeleteDelay = 5 * time.Minute

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -832,6 +832,12 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 				n.replaceNodeIPSecOutRoute(new4Net)
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv4", ipsecLocal, ipsecRemote, spi)
+
+				/* Insert wildcard policy rules for traffic skipping back through host */
+				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecLocal, ipsecRemote); err != nil {
+					log.WithError(err).Warning("egress unable to replace policy fwd:")
+				}
 			}
 		}
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1091,7 +1091,7 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 	var device string
 
 	if option.Config.Tunnel == option.TunnelDisabled {
-		device = n.datapathConfig.EncryptInterfaces[0]
+		device = option.Config.EncryptInterface[0]
 	} else {
 		device = linux_defaults.TunnelDeviceName
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1061,6 +1061,10 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 		}
 	}
 
+	if err := route.DeleteRouteTable(linux_defaults.RouteTableIPSec, netlink.FAMILY_V4); err != nil {
+		log.WithError(err).Warn("Deletion of IPSec routes failed")
+	}
+
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
 		if !os.IsNotExist(err) && err != unix.EAFNOSUPPORT {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -455,8 +455,22 @@ func upsertIPsecLog(err error, spec string, loc, rem *net.IPNet, spi uint8) {
 	}
 }
 
+// getDefaultEncryptionInterface() is needed to find the interface used when
+// populating neighbor table and doing arpRequest. For most configurations
+// there is only a single interface so choosing [0] works by choosing the only
+// interface. However EKS, uses multiple interfaces, but fortunately for us
+// in EKS any interface would work so pick the [0] index here as well.
+func getDefaultEncryptionInterface() string {
+	iface := ""
+	if len(option.Config.EncryptInterface) > 0 {
+		iface = option.Config.EncryptInterface[0]
+	}
+	return iface
+}
+
 func getLinkLocalIp(family int) (*net.IPNet, error) {
-	link, err := netlink.LinkByName(option.Config.EncryptInterface)
+	iface := getDefaultEncryptionInterface()
+	link, err := netlink.LinkByName(iface)
 	if err != nil {
 		return nil, err
 	}
@@ -1067,7 +1081,7 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 	var device string
 
 	if option.Config.Tunnel == option.TunnelDisabled {
-		device = n.datapathConfig.EncryptInterface
+		device = n.datapathConfig.EncryptInterfaces[0]
 	} else {
 		device = linux_defaults.TunnelDeviceName
 	}
@@ -1278,8 +1292,14 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		case option.Config.EnableNodePort:
 			ifaceName = option.Config.DirectRoutingDevice
 			n.enableNeighDiscovery = true
-		case n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled:
-			ifaceName = option.Config.EncryptInterface
+		case n.nodeConfig.EnableIPSec &&
+			option.Config.Tunnel == option.TunnelDisabled &&
+			len(option.Config.EncryptInterface) != 0:
+			// When FIB lookup is not supported we need to pick an
+			// interface so pick first interface in the list. On
+			// kernels with FIB lookup helpers we do a lookup from
+			// the datapath side and ignore this value.
+			ifaceName = option.Config.EncryptInterface[0]
 			n.enableNeighDiscovery = true
 		}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -27,10 +27,12 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
+	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -1326,6 +1328,19 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 	n.updateOrRemoveNodeRoutes(prevConfig.AuxiliaryPrefixes, newConfig.AuxiliaryPrefixes, true)
 
 	if newConfig.EnableIPSec {
+		// For the ENI ipam mode on EKS, this will be the interface that
+		// the router (cilium_host) IP is associated to.
+		if option.Config.IPAM == ipamOption.IPAMENI && len(option.Config.IPv4PodSubnets) == 0 {
+			if info := node.GetRouterInfo(); info != nil {
+				var ipv4PodSubnets []*net.IPNet
+				for _, c := range info.GetIPv4CIDRs() {
+					cidr := c // create a copy to be able to take a reference
+					ipv4PodSubnets = append(ipv4PodSubnets, &cidr)
+				}
+				n.nodeConfig.IPv4PodSubnets = ipv4PodSubnets
+			}
+		}
+
 		if err := n.replaceHostRules(); err != nil {
 			log.WithError(err).Warning("Cannot replace Host rules")
 		}

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -549,6 +549,24 @@ func lookupDefaultRoute(family int) (netlink.Route, error) {
 	return routes[0], nil
 }
 
+func DeleteRouteTable(table, family int) error {
+	var routeErr error
+
+	routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("Unable to list table %d routes: %s", table, err)
+	}
+
+	routeErr = nil
+	for _, route := range routes {
+		err := netlink.RouteDel(&route)
+		if err != nil {
+			routeErr = fmt.Errorf("%w: Failed to delete route: %s", routeErr, err)
+		}
+	}
+	return routeErr
+}
+
 // NodeDeviceWithDefaultRoute returns the node's device which handles the
 // default route in the current namespace
 func NodeDeviceWithDefaultRoute(enableIPv4, enableIPv6 bool) (netlink.Link, error) {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -402,14 +402,24 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 		// For the ENI ipam mode on EKS, this will be the interface that
 		// the router (cilium_host) IP is associated to.
-		if len(interfaces) == 0 && option.Config.IPAM == ipamOption.IPAMENI {
-			if info := node.GetRouterInfo(); info != nil {
-				mac := info.GetMac()
-				iface, err := linuxrouting.RetrieveIfaceNameFromMAC(mac.String())
-				if err != nil {
-					log.WithError(err).WithField("mac", mac).Fatal("Failed to set encrypt interface in the ENI ipam mode")
+		if option.Config.IPAM == ipamOption.IPAMENI {
+			if len(interfaces) == 0 {
+				if info := node.GetRouterInfo(); info != nil {
+					mac := info.GetMac()
+					iface, err := linuxrouting.RetrieveIfaceNameFromMAC(mac.String())
+					if err != nil {
+						log.WithError(err).WithField("mac", mac).Fatal("Failed to set encrypt interface in the ENI ipam mode")
+					}
+					interfaces = append(interfaces, iface)
 				}
-				interfaces = append(interfaces, iface)
+			}
+			if len(option.Config.IPv4PodSubnets) == 0 {
+				if info := node.GetRouterInfo(); info != nil {
+					for _, c := range info.GetIPv4CIDRs() {
+						option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &c)
+					}
+				}
+				log.Info("Encryption IPv4PodSubnets in-use")
 			}
 		}
 		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/ethtool"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -196,6 +197,7 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 					}
 				}
 			}
+			option.Config.EncryptInterface = interfaces
 		}
 
 		// For the ENI ipam mode on EKS, this will be the interface that
@@ -211,6 +213,12 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 
 	// No interfaces is valid in tunnel disabled case
 	if len(interfaces) != 0 {
+		for _, iface := range interfaces {
+			if err := connector.DisableRpFilter(iface); err != nil {
+				log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
+			}
+		}
+
 		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {
 			return fmt.Errorf("failed to load encryption program: %w", err)
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -205,7 +205,8 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		if len(option.Config.IPv4PodSubnets) == 0 {
 			if info := node.GetRouterInfo(); info != nil {
 				for _, c := range info.GetIPv4CIDRs() {
-					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &c)
+					cidr := c // create a copy to be able to take a reference
+					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &cidr)
 				}
 			}
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -199,17 +199,6 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 			}
 			option.Config.EncryptInterface = interfaces
 		}
-
-		// For the ENI ipam mode on EKS, this will be the interface that
-		// the router (cilium_host) IP is associated to.
-		if len(option.Config.IPv4PodSubnets) == 0 {
-			if info := node.GetRouterInfo(); info != nil {
-				for _, c := range info.GetIPv4CIDRs() {
-					cidr := c // create a copy to be able to take a reference
-					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &cidr)
-				}
-			}
-		}
 	}
 
 	// No interfaces is valid in tunnel disabled case

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -57,6 +57,10 @@ const (
 	hostEndpointObj          = hostEndpointPrefix + ".o"
 	hostEndpointObjDebug     = hostEndpointPrefix + ".dbg.o"
 	hostEndpointAsm          = hostEndpointPrefix + "." + string(outputAssembly)
+
+	networkPrefix = "bpf_network"
+	networkProg   = networkPrefix + "." + string(outputSource)
+	networkObj    = networkPrefix + ".o"
 )
 
 var (
@@ -144,6 +148,11 @@ var (
 	hostEpProg = &progInfo{
 		Source:     hostEndpointProg,
 		Output:     hostEndpointObj,
+		OutputType: outputObject,
+	}
+	networkTcProg = &progInfo{
+		Source:     networkProg,
+		Output:     networkObj,
 		OutputType: outputObject,
 	}
 )
@@ -403,4 +412,39 @@ func compileTemplate(ctx context.Context, out string, isHost bool) error {
 		State:   out,
 	}
 	return compileDatapath(ctx, &dirs, isHost, option.Config.BPFCompilationDebug, log)
+}
+
+// compileNetwork compiles a BPF program attached to network
+func compileNetwork(ctx context.Context) error {
+	debug := option.Config.BPFCompilationDebug
+	dirs := directoryInfo{
+		Library: option.Config.BpfDir,
+		Runtime: option.Config.StateDir,
+		Output:  option.Config.StateDir,
+		State:   option.Config.StateDir,
+	}
+	scopedLog := log.WithField(logfields.Debug, true)
+
+	versionCmd := exec.CommandContext(ctx, compiler, "--version")
+	compilerVersion, err := versionCmd.CombinedOutput(scopedLog, true)
+	if err != nil {
+		return err
+	}
+	versionCmd = exec.CommandContext(ctx, linker, "--version")
+	linkerVersion, err := versionCmd.CombinedOutput(scopedLog, true)
+	if err != nil {
+		return err
+	}
+	scopedLog.WithFields(logrus.Fields{
+		compiler: string(compilerVersion),
+		linker:   string(linkerVersion),
+	}).Debug("Compiling network programs")
+
+	// Write out assembly and preprocessing files for debugging purposes
+	if err := compile(ctx, networkTcProg, &dirs, debug); err != nil {
+		scopedLog.WithField(logfields.Params, logfields.Repr(networkTcProg)).
+			WithError(err).Warn("Failed to compile")
+		return err
+	}
+	return nil
 }

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -47,6 +47,7 @@ const (
 
 	symbolFromEndpoint = "from-container"
 	symbolToEndpoint   = "to-container"
+	symbolFromNetwork  = "from-network"
 
 	symbolFromHostNetdevEp = "from-netdev"
 	symbolToHostNetdevEp   = "to-netdev"
@@ -343,6 +344,18 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 		}
 	}
 
+	return nil
+}
+
+func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string) error {
+	if err := compileNetwork(ctx); err != nil {
+		log.WithError(err).Fatal("failed to compile encryption programs")
+	}
+	for _, iface := range option.Config.EncryptInterface {
+		if err := l.replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress); err != nil {
+			log.WithField(logfields.Interface, iface).Fatal("Load encryption network failed")
+		}
+	}
 	return nil
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1301,7 +1301,7 @@ type DaemonConfig struct {
 	XDPMode             string     // XDP mode, values: { xdpdrv | xdpgeneric | none }
 	HostV4Addr          net.IP     // Host v4 address of the snooping device
 	HostV6Addr          net.IP     // Host v6 address of the snooping device
-	EncryptInterface    string     // Set with name of network facing interface to encrypt
+	EncryptInterface    []string   // Set of network facing interface to encrypt over
 	EncryptNode         bool       // Set to true for encrypting node IP traffic
 
 	Ipvlan IpvlanConfig // Ipvlan related configuration
@@ -2380,7 +2380,7 @@ func (c *DaemonConfig) Populate() {
 	c.KubeProxyReplacement = viper.GetString(KubeProxyReplacement)
 	c.EnableSessionAffinity = viper.GetBool(EnableSessionAffinity)
 	c.EnableHostFirewall = viper.GetBool(EnableHostFirewall)
-	c.EncryptInterface = viper.GetString(EncryptInterface)
+	c.EncryptInterface = viper.GetStringSlice(EncryptInterface)
 	c.EncryptNode = viper.GetBool(EncryptNode)
 	c.EnvoyLogPath = viper.GetString(EnvoyLog)
 	c.ForceLocalPolicyEvalAtSource = viper.GetBool(ForceLocalPolicyEvalAtSource)


### PR DESCRIPTION
* #15357 -- cilium: encryption, auto-discover interface and subnet (@jrfastab)
* #15669 -- cilium: Fix EKS encryption panic and reinit path and add workflows test (@jrfastab)
  * Note: Cherry-picked directly from v1.9 version (#15726) 
* #15645 -- ipsec: Fix routing CIDR iteration on EKS (@gandro)
  * Note: Cherry-picked directly from v1.9 version (#15726)
* #15622 -- Fix ethtool issues (@tklauser)
  *  Dropped commit 7c8c6376914fa5e6481f99d999114ba37c384498 to avoid pulling in new unix Go library dependency (otherwise we hit `undefined: unix.ETHTOOL_GDRVINFO` when compiling).
* #15867 -- cilium: Encryption EKS 4.14 kernel (default) fixes (@jrfastab)
  * Minor conflicts here.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15357 15669 15645 15622 15867; do contrib/backporting/set-labels.py $pr done 1.8; done
```