### PR TITLE
ci: Fix nightly image

### DIFF
--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -168,11 +168,81 @@ jobs:
           path: image-digest
           retention-days: 1
 
+  # we need to build cilium-test separately
+  # this is caused by running apt while building the image
+  # which requires qemu setup in order to avoid x86/arm64 binaries mixups
+  build-and-push-with-qemu:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - name: cilium-test
+            dockerfile: ./images/cilium-test/Dockerfile
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@25f0500ff22e406f7191a2a8ba8cda16901ca018
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609
+
+      - name: Login to quay.io for CI
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_CI }}
+          password: ${{ secrets.QUAY_PASSWORD_CI }}
+
+      - name: Getting image tag
+        id: tag
+        run: |
+          if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
+            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+          else
+            echo ::set-output name=tag::${{ github.sha }}
+          fi
+
+      - name: Checkout Source Code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      # master branch pushes
+      - name: CI Build ${{ matrix.name }}
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f
+        id: docker_build_ci_master
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+
+      - name: CI Image Releases digests
+        if: ${{ github.event_name != 'pull_request_target' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest@${{ steps.docker_build_ci_master.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_master.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
+        with:
+          name: image-digest ${{ matrix.name }}
+          path: image-digest
+          retention-days: 1
+
   image-digests:
     if: ${{ github.repository == 'cilium/cilium' }}
     name: Display Digests
     runs-on: ubuntu-20.04
-    needs: build-and-push-prs
+    needs: [build-and-push-prs, build-and-push-cilium-test]
     steps:
       - name: Downloading Image Digests
         shell: bash

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,16 +8,13 @@ jobs:
     if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-18.04
     steps:
-      - name: Trim git sha
-        id: vars
-        run: echo "::set-output name=sha_short::$(echo ${GITHUB_SHA:0:9})"
       - name: Request GKE test cluster
         uses: docker://quay.io/isovalent/gke-test-cluster-requester:fe34abda190c31680968ba62634c788428d91706
         env:
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --namespace=test-clusters --image=cilium/cilium-test-dev:${{ steps.vars.outputs.sha_short }} "/usr/local/bin/cilium-test-gke.sh" "quay.io/cilium/cilium:latest" "quay.io/cilium/operator-generic:latest" "quay.io/cilium/hubble-relay:latest" "NightlyPolicyStress"
+          args: --namespace=test-clusters --image=quay.io/cilium/cilium-test-ci:${{ env.GITHUB_SHA }} "/usr/local/bin/cilium-test-gke.sh" "quay.io/cilium/cilium-ci:${{ env.GITHUB_SHA }}" "quay.io/cilium/operator-generic-ci:${{ env.GITHUB_SHA }}" "quay.io/cilium/hubble-relay-ci:${{ env.GITHUB_SHA }}" "NightlyPolicyStress"
   baseline-test:
     name: Start performance test
     if: github.repository == 'cilium/cilium'


### PR DESCRIPTION
This change fixes cilium-test image build that was reverted. The image
build failed because qemu wasn't set up properly for buildx on action
host which likely resulted with mixing of x86 and arm binaries in the
image.