### PR TITLE
lib/proxy.h: set variable as maybe unused to avoid compilation error

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -207,6 +207,7 @@ bpf_xdp.o: bpf_xdp.ll
 
 # The following option combinations are compile tested
 LXC_OPTIONS = \
+	 -DHOST_REDIRECT_TO_INGRESS: \
 	 -DALLOW_ICMP_FRAG_NEEDED: \
 	 -DSKIP_DEBUG: \
 	 -DHAVE_LPM_TRIE_MAP_TYPE: \

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -192,7 +192,7 @@ __ctx_redirect_to_proxy(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 			__be16 proxy_port, bool from_host __maybe_unused,
 			bool ipv4 __maybe_unused)
 {
-	int result = CTX_ACT_OK;
+	int result __maybe_unused = CTX_ACT_OK;
 
 #ifdef ENABLE_TPROXY
 	if (!from_host)


### PR DESCRIPTION
Set variable as ```__maybe_unused``` and define the macro ```HOST_REDIRECT_TO_INGRESS``` in the Makefile.

Fixes: #15095
Fixes: #15559

Signed-off-by: Joao Victorino <joao@accuknox.com>