### PR TITLE
v1.7 backports 2021-04-08

### DIFF
--- a/Documentation/_static/editbutton.css
+++ b/Documentation/_static/editbutton.css
@@ -1,0 +1,4 @@
+/* Hide "On GitHub" section from versions menu */
+div.rst-versions > div.rst-other-versions > div.injected > dl:nth-child(4) {
+    display: none;
+}

--- a/Documentation/_templates/breadcrumbs.html
+++ b/Documentation/_templates/breadcrumbs.html
@@ -1,0 +1,4 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -238,5 +238,6 @@ default_role = 'any'
 def setup(app):
     app.add_stylesheet('parsed-literal.css')
     app.add_stylesheet('copybutton.css')
+    app.add_stylesheet('editbutton.css')
     app.add_javascript('clipboardjs.min.js')
     app.add_javascript("copybutton.js")


### PR DESCRIPTION
* #15579 -- docs: Hide "Edit on GitHub" buttons (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15579; do contrib/backporting/set-labels.py $pr done 1.7; done
```