### PR TITLE
Fix ethtool issues

### DIFF
--- a/pkg/datapath/linux/ethtool/ethtool.go
+++ b/pkg/datapath/linux/ethtool/ethtool.go
@@ -28,10 +28,6 @@ const (
 	IFNAMSIZ = 16
 )
 
-const (
-	veth = "veth"
-)
-
 type ifreq struct {
 	name [IFNAMSIZ]byte
 	data uintptr
@@ -90,10 +86,5 @@ func IsVirtualDriver(iface string) (bool, error) {
 		return false, err
 	}
 
-	switch drvName {
-	case veth:
-		return true, nil
-	}
-
-	return true, nil
+	return drvName == "veth", nil
 }

--- a/pkg/datapath/linux/ethtool/ethtool.go
+++ b/pkg/datapath/linux/ethtool/ethtool.go
@@ -59,6 +59,8 @@ func ethtoolIoctl(iface string, info *ethtoolDrvInfo) error {
 	if err != nil {
 		return err
 	}
+	defer unix.Close(fd)
+
 	copy(ifname[:], iface)
 	req := ifreq{
 		name: ifname,


### PR DESCRIPTION
Fix two issues in the `pkg/datapath/linux/ethtool` package introduced by #15357, commit 2c878a512de9 `("cilium: auto-detect network interfaces for IPAMENI case")`:

* Avoid leading file descriptors in `ethtoolIoctl`.
* Fix `IsVirtualDriver` return value for non-veth interfaces

Additionally this also gets rid of constants duplicated from the `golang.org/x/sys/unix` package.

See individual commits for details.

Marking for backports to 1.8 and 1.9 as PR #15357 introducing these issues was also backported.
