### PR TITLE
datapath: Move node_config.h generation entirely to Go code

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -324,37 +324,6 @@ function encap_fail()
 	exit 1
 }
 
-# node_config.h header generation
-case "${MODE}" in
-	*)
-		sed -i '/^#.*CILIUM_NET_MAC.*$/d' $RUNDIR/globals/node_config.h
-		CILIUM_NET_MAC=$(ip link show $HOST_DEV2 | grep ether | awk '{print $2}')
-		CILIUM_NET_MAC=$(mac2array $CILIUM_NET_MAC)
-
-		# Remove the entire '#ifndef ... #endif block
-		# Each line must contain the string '#.*CILIUM_NET_MAC.*'
-		sed -i '/^#.*CILIUM_NET_MAC.*$/d' $RUNDIR/globals/node_config.h
-		echo "#ifndef CILIUM_NET_MAC" >> $RUNDIR/globals/node_config.h
-		echo "#define CILIUM_NET_MAC { .addr = ${CILIUM_NET_MAC}}" >> $RUNDIR/globals/node_config.h
-		echo "#endif /* CILIUM_NET_MAC */" >> $RUNDIR/globals/node_config.h
-
-		sed -i '/^#.*HOST_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
-		HOST_IDX=$(cat /sys/class/net/${HOST_DEV2}/ifindex)
-		echo "#define HOST_IFINDEX $HOST_IDX" >> $RUNDIR/globals/node_config.h
-
-		sed -i '/^#.*HOST_IFINDEX_MAC.*$/d' $RUNDIR/globals/node_config.h
-		HOST_MAC=$(ip link show $HOST_DEV1 | grep ether | awk '{print $2}')
-		HOST_MAC=$(mac2array $HOST_MAC)
-		echo "#define HOST_IFINDEX_MAC { .addr = ${HOST_MAC}}" >> $RUNDIR/globals/node_config.h
-
-		sed -i '/^#.*CILIUM_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
-		CILIUM_IDX=$(cat /sys/class/net/${HOST_DEV1}/ifindex)
-		echo "#define CILIUM_IFINDEX $CILIUM_IDX" >> $RUNDIR/globals/node_config.h
-
-		CILIUM_EPHEMERAL_MIN=$(cat /proc/sys/net/ipv4/ip_local_port_range | awk '{print $1}')
-		echo "#define EPHEMERAL_MIN $CILIUM_EPHEMERAL_MIN" >> $RUNDIR/globals/node_config.h
-esac
-
 	# If the host does not have an IPv6 address assigned, assign our generated host
 	# IP to make the host accessible to endpoints
 	if [ "$IP6_HOST" != "<nil>" ]; then

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -230,10 +230,6 @@ func (d *Daemon) init() error {
 	if !option.Config.DryMode {
 		bandwidth.InitBandwidthManager()
 
-		if err := d.createNodeConfigHeaderfile(); err != nil {
-			return err
-		}
-
 		if option.Config.SockopsEnable {
 			eppolicymap.CreateEPPolicyMap()
 			if err := sockops.SockmapEnable(); err != nil {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -59,22 +59,6 @@ func (d *Daemon) LocalConfig() *datapath.LocalNodeConfiguration {
 	return &d.nodeDiscovery.LocalConfig
 }
 
-func (d *Daemon) createNodeConfigHeaderfile() error {
-	nodeConfigPath := option.Config.GetNodeConfigPath()
-	f, err := os.Create(nodeConfigPath)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to create node configuration file")
-		return err
-	}
-	defer f.Close()
-
-	if err = d.datapath.WriteNodeConfig(f, &d.nodeDiscovery.LocalConfig); err != nil {
-		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to write node configuration file")
-		return err
-	}
-	return nil
-}
-
 func deleteHostDevice() {
 	link, err := netlink.LinkByName(option.Config.HostDevice)
 	if err != nil {

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -771,21 +771,9 @@ func expandDevices() {
 // Otherwise, if EnableAutoProtectNodePortRange == true, then append the nodeport
 // range to ip_local_reserved_ports.
 func checkNodePortAndEphemeralPortRanges() error {
-	ephemeralPortRangeStr, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	ephemeralPortRangeStr, ephemeralPortMin, ephemeralPortMax, err := node.EphemeralPortRange()
 	if err != nil {
-		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
-	}
-	ephemeralPortRange := strings.Split(ephemeralPortRangeStr, "\t")
-	if len(ephemeralPortRange) != 2 {
-		return fmt.Errorf("Invalid ephemeral port range: %s", ephemeralPortRangeStr)
-	}
-	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
-	if err != nil {
-		return fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
-	}
-	ephemeralPortMax, err := strconv.Atoi(ephemeralPortRange[1])
-	if err != nil {
-		return fmt.Errorf("Unable to parse max port value %s for ephemeral range", ephemeralPortRange[1])
+		return err
 	}
 
 	if option.Config.NodePortMax < ephemeralPortMin {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -23,10 +23,12 @@ import (
 	"io"
 	"net"
 	"sort"
+	"strconv"
 	"text/template"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
@@ -199,6 +201,25 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	cDefinesMap["TRACE_PAYLOAD_LEN"] = fmt.Sprintf("%dULL", option.Config.TracePayloadlen)
 	cDefinesMap["MTU"] = fmt.Sprintf("%d", cfg.MtuConfig.GetDeviceMTU())
+
+	ciliumHost, err := netlink.LinkByName("cilium_host")
+	if err != nil {
+		return err
+	}
+	ciliumNet, err := netlink.LinkByName("cilium_net")
+	if err != nil {
+		return err
+	}
+	cDefinesMap["CILIUM_NET_MAC"] = common.GoArray2C(ciliumNet.Attrs().HardwareAddr)
+	cDefinesMap["HOST_IFINDEX"] = strconv.Itoa(ciliumNet.Attrs().Index)
+	cDefinesMap["HOST_IFINDEX_MAC"] = common.GoArray2C(ciliumHost.Attrs().HardwareAddr)
+	cDefinesMap["CILIUM_IFINDEX"] = strconv.Itoa(ciliumHost.Attrs().Index)
+
+	_, ephemeralMin, _, err := node.EphemeralPortRange()
+	if err != nil {
+		return err
+	}
+	cDefinesMap["EPHEMERAL_MIN"] = strconv.Itoa(ephemeralMin)
 
 	if option.Config.EnableIPv4 {
 		cDefinesMap["ENABLE_IPV4"] = "1"

--- a/pkg/node/port_range.go
+++ b/pkg/node/port_range.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+// EphemeralPortRange returns the minimal and maximal ports from the ephemeral
+// port range.
+func EphemeralPortRange() (string, int, int, error) {
+	ephemeralPortRangeStr, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
+	}
+	ephemeralPortRange := strings.Split(ephemeralPortRangeStr, "\t")
+	if len(ephemeralPortRange) != 2 {
+		return "", 0, 0, fmt.Errorf("Invalid ephemeral port range: %s", ephemeralPortRangeStr)
+	}
+	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
+	}
+	ephemeralPortMax, err := strconv.Atoi(ephemeralPortRange[1])
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("Unable to parse max port value %s for ephemeral range", ephemeralPortRange[1])
+	}
+	return ephemeralPortRangeStr, ephemeralPortMin, ephemeralPortMax, nil
+}

--- a/pkg/node/port_range_test.go
+++ b/pkg/node/port_range_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package node
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+type PortRangeSuite struct {
+	prevEphemeralPortRange string
+}
+
+var _ = Suite(&PortRangeSuite{})
+
+func (s *PortRangeSuite) SetUpTest(c *C) {
+	prevEphemeralPortRange, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	c.Assert(err, IsNil)
+	s.prevEphemeralPortRange = prevEphemeralPortRange
+}
+
+func (s *PortRangeSuite) TearDownTest(c *C) {
+	err := sysctl.Write("net.ipv4.ip_local_port_range", s.prevEphemeralPortRange)
+	c.Assert(err, IsNil)
+}
+
+func (s *PortRangeSuite) TestEphemeralPortRangeDefault(c *C) {
+	_, _, _, err := EphemeralPortRange()
+	c.Assert(err, IsNil)
+}
+
+func (s *PortRangeSuite) TestEphemralPortRangeCustom(c *C) {
+	tests := []struct {
+		epRange string
+		expMin  int
+		expMax  int
+	}{
+		{
+			"32000\t32999",
+			32000,
+			32999,
+		},
+		{
+			"32768\t60999",
+			32768,
+			60999,
+		},
+	}
+
+	for _, test := range tests {
+		err := sysctl.Write("net.ipv4.ip_local_port_range", test.epRange)
+		c.Assert(err, IsNil)
+
+		epRange, epMin, epMax, err := EphemeralPortRange()
+		c.Assert(epRange, Equals, test.epRange)
+		c.Assert(epMin, Equals, test.expMin)
+		c.Assert(epMax, Equals, test.expMax)
+	}
+}


### PR DESCRIPTION
Before this change, the part of node_config.h with macros containing
information about Cilium network interfaces was generated in init.sh.
This change moves it to the part of Go codebase which is generating the
content of that file.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>
