### PR TITLE
v1.9 backports 2021-04-09

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -90,7 +90,7 @@ Make sure to disable DHCP on ENIs
 ---------------------------------
 
 Cilium will use both the primary and secondary IP addresses assigned to ENIs.
-Use of the primary IP address optimizes the number of IPs available to pods but
+Use of the primary IP address is required for SNAT on the ENI, but this
 can conflict with a DHCP agent running on the node and assigning the primary IP
 of the ENI to the interface of the node. A common scenario where this happens
 is if ``NetworkManager`` is running on the node and automatically performing

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -15,10 +15,7 @@ networking is setup, the Cilium CNI plugin is called to attach eBPF programs to
 the network devices set up by aws-cni to enforce network policies, perform
 load-balancing, and encryption.
 
-.. note::
-
-   When running Cilium in chaining configuration on top of AWS VPC CNI, the L7 policies may not work. 
-   This limitation is currently tracked at `#12454 <https://github.com/cilium/cilium/issues/12454>`_.
+.. include:: cni-chaining-limitations.rst
 
 .. important::
 

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -15,6 +15,8 @@ Azure CNI
    Follow this guide if you specifically want to run Cilium in combination with
    the Azure CNI in a chaining configuration.
 
+.. include:: cni-chaining-limitations.rst
+
 This guide explains how to set up Cilium in combination with Azure CNI in a
 chaining configuration. In this hybrid mode, the Azure CNI plugin is
 responsible for setting up the virtual network devices as well as address

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -11,11 +11,7 @@ Calico
 This guide instructs how to install Cilium in chaining configuration on top of
 `Calico <https://github.com/projectcalico/calico>`_.
 
-.. note::
-
-   When running Cilium in chaining configuration on top of Calico, the L7
-   policies may not work because of conflicting packet mark usage. This
-   limitation is currently tracked at `#12454 <https://github.com/cilium/cilium/issues/12454>`_.
+.. include:: cni-chaining-limitations.rst
 
 Create a CNI configuration
 ==========================

--- a/Documentation/gettingstarted/cni-chaining-generic-veth.rst
+++ b/Documentation/gettingstarted/cni-chaining-generic-veth.rst
@@ -14,6 +14,8 @@ The generic veth chaining plugin enables CNI chaining on top of any CNI plugin
 that is using a veth device model. The majority of CNI plugins use such a
 model.
 
+.. include:: cni-chaining-limitations.rst
+
 Validate that the current CNI plugin is using veth
 ==================================================
 

--- a/Documentation/gettingstarted/cni-chaining-limitations.rst
+++ b/Documentation/gettingstarted/cni-chaining-limitations.rst
@@ -1,0 +1,13 @@
+.. only:: not (epub or latex or html)
+
+   WARNING: You are looking at unreleased Cilium documentation.
+   Please use the official rendered version released here:
+   https://docs.cilium.io
+
+.. note::
+
+   Some advanced Cilium features may be limited when chaining with other
+   CNI plugins, such as:
+
+   * :ref:`Layer 7 Policy <l7_policy>` (see `GitHub issue #12454 <https://github.com/cilium/cilium/issues/12454>`_)
+   * :ref:`encryption` (see `Github issue #15596 <https://github.com/cilium/cilium/issues/15596>`_)

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -11,6 +11,8 @@ Weave Net
 This guide instructs how to install Cilium in chaining configuration on top of
 `Weave Net <https://github.com/weaveworks/weave>`_.
 
+.. include:: cni-chaining-limitations.rst
+
 Create a CNI configuration
 ==========================
 

--- a/Documentation/gettingstarted/cni-chaining.rst
+++ b/Documentation/gettingstarted/cni-chaining.rst
@@ -14,8 +14,8 @@ CNI chaining allows to use Cilium in combination with other CNI plugins.
 
 With Cilium CNI chaining, the base network connectivity and IP address management
 is managed by the non-Cilium CNI plugin, but Cilium attaches eBPF programs to the
-network devices created by the non-Cilium plugin to provide L3/L4/L7 network visibility &
-policy enforcement and other advanced features like transparent encryption.
+network devices created by the non-Cilium plugin to provide L3/L4 network
+visibility, policy enforcement and other advanced features.
 
 .. toctree::
    :maxdepth: 1

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -17,29 +17,32 @@ as Cilium managed host traffic, will be encrypted using IPsec. This guide uses
 Kubernetes secrets to distribute keys. Alternatively, keys may be manually
 distributed, but that is not shown here.
 
+Packets destined to the same node they were sent out of are not encrypted.
+This is a intended behavior as it doesn't provide any benefits because the
+raw traffic on the node can be seen.
+
+Transparent encryption is not currently supported when chaining Cilium on top
+of other CNI plugins. For more information, see
+`GitHub issue #15596 <https://github.com/cilium/cilium/issues/15596>`_.
+
+Generate & import the PSK
+=========================
+
+First, create a Kubernetes secret for the IPsec configuration to be stored. The
+example below demonstrates generation of the necessary IPsec configuration
+which will be distributed as a Kubernetes secret called ``cilium-ipsec-keys``.
+A Kubernetes secret should consist of one key-value pair where the key is the
+name of the file to be mounted as a volume in cilium-agent pods, and the
+value is an IPSec configuration in the following format:
+
+``key-id encryption-algorithms PSK-in-hex-format key-size``
+
 .. note::
 
     ``Secret`` resources need to be deployed in the same namespace as Cilium!
     In our example, we use ``kube-system``.
 
-.. note::
-
-    The encryption feature is stable in combination with the direct-routing and
-    ENI datapath mode. In combination with encapsulation/tunneling, the feature
-    is still in beta phase.
-
-.. note::
-
-    Packets destined to the same node they were sent out of are not encrypted.
-    This is a intended behavior as it doesn't provide any benefits because the
-    raw traffic on the node can be seen.
-
-Generate & import the PSK
-=========================
-
-First, create a Kubernetes secret for the IPsec keys to be stored. This will
-generate the necessary IPsec keys which will be distributed as a Kubernetes
-secret called ``cilium-ipsec-keys``. In this example we use GMC-128-AES, but
+In the example below we use GMC-128-AES, but
 any of the supported Linux algorithms may be used. To generate, use the
 following:
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -375,7 +375,7 @@ func (d *Daemon) startIPAM() {
 	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.k8sWatcher)
+	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.k8sWatcher, &d.mtuConfig)
 	bootstrapStats.ipam.End(true)
 }
 

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -195,7 +195,7 @@ func parseENI(iface *ec2.NetworkInterface, vpcs ipamTypes.VirtualNetworkMap, sub
 	}
 
 	for _, ip := range iface.PrivateIpAddresses {
-		if ip.PrivateIpAddress != nil {
+		if ip.PrivateIpAddress != nil && (ip.Primary == nil || !*ip.Primary) {
 			eni.Addresses = append(eni.Addresses, *ip.PrivateIpAddress)
 		}
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -672,14 +672,13 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	copy(nextHopIPv4, newNodeIP)
 
 	scopedLog := log.WithFields(logrus.Fields{
-		logfields.LogSubsys: "node-neigh",
+		logfields.LogSubsys: "node-neigh-debug",
 		logfields.Interface: n.neighDiscoveryLink.Attrs().Name,
-		logfields.IPAddr:    newNodeIP,
 	})
 
 	srcIPv4, nextHopIPv4, err := n.getSrcAndNextHopIPv4(nextHopIPv4)
 	if err != nil {
-		scopedLog.WithError(err).Error("Failed to determine source and nexthop IP addr")
+		scopedLog.WithError(err).Info("Unable to determine source and nexthop IP addr")
 		return
 	}
 
@@ -706,7 +705,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 						logfields.IPAddr:       neigh.IP,
 						logfields.HardwareAddr: neigh.HardwareAddr,
 						logfields.LinkIndex:    neigh.LinkIndex,
-					}).WithError(err).Warn("Failed to remove neighbor entry")
+					}).WithError(err).Info("Unable to remove neighbor entry")
 				}
 				delete(n.neighByNextHop, nextHopStr)
 				if option.Config.NodePortHairpin {
@@ -727,7 +726,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	if nextHopIsNew || refresh {
 		hwAddr, _, err := arping.PingOverIface(nextHopIPv4, n.neighDiscoveryLink, srcIPv4)
 		if err != nil {
-			scopedLog.WithError(err).Error("arping failed")
+			scopedLog.WithError(err).Info("arping failed")
 			return
 		}
 
@@ -762,7 +761,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		default:
 		}
 		if err := netlink.NeighSet(&neigh); err != nil {
-			scopedLog.WithError(err).Error("Failed to insert neighbor")
+			scopedLog.WithError(err).Info("Unable to insert neighbor")
 			return
 		}
 		n.neighByNextHop[nextHopStr] = &neigh
@@ -793,11 +792,11 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 		if found {
 			if err := netlink.NeighDel(neigh); err != nil {
 				log.WithFields(logrus.Fields{
-					logfields.LogSubsys:    "node-neigh",
+					logfields.LogSubsys:    "node-neigh-debug",
 					logfields.IPAddr:       neigh.IP,
 					logfields.HardwareAddr: neigh.HardwareAddr,
 					logfields.LinkIndex:    neigh.LinkIndex,
-				}).WithError(err).Warn("Failed to remove neighbor entry")
+				}).WithError(err).Info("Unable to remove neighbor entry")
 				return
 			}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2318,8 +2318,8 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 		}).Debug("Deleting endpoint routing rules")
 
 		// This is a best-effort attempt to cleanup. We expect there to be one
-		// ingress rule and one egress rule. If we find more than one rule in
-		// either case, then the rules will be left as-is because there was
+		// ingress rule and multiple egress rules. If we find more rules than
+		// expected, then the rules will be left as-is because there was
 		// likely manual intervention.
 		if err := linuxrouting.Delete(e.IPv4.IP(), option.Config.EgressMultiHomeIPRuleCompat); err != nil {
 			errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %s", err))

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/mtu"
 
 	. "gopkg.in/check.v1"
 )
@@ -32,9 +33,11 @@ func (o *ownerMock) K8sEventReceived(scope string, action string, valid, equal b
 func (o *ownerMock) K8sEventProcessed(scope string, action string, status bool)      {}
 func (o *ownerMock) UpdateCiliumNodeResource()                                       {}
 
+var mtuMock = mtu.NewConfiguration(0, false, false, 1500, nil)
+
 func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{})
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock)
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv6 := fakeIPv6AllocCIDRIP(fakeAddressing)
@@ -66,7 +69,7 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	timeout := 50 * time.Millisecond
 
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{})
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock)
 
 	err := ipam.AllocateIP(ip, "foo")
 	c.Assert(err, IsNil)
@@ -132,7 +135,7 @@ func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
 	timeout := 50 * time.Millisecond
 
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{})
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock)
 
 	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", timeout)
 	c.Assert(err, IsNil)

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -83,18 +83,20 @@ type nodeStore struct {
 	restoreFinished  chan bool
 	restoreCloseOnce sync.Once
 
-	conf Configuration
+	conf      Configuration
+	mtuConfig MtuConfiguration
 }
 
 // newNodeStore initializes a new store which reflects the CiliumNode custom
 // resource of the specified node name
-func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg K8sEventRegister) *nodeStore {
+func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg K8sEventRegister, mtuConfig MtuConfiguration) *nodeStore {
 	log.WithField(fieldName, nodeName).Info("Subscribed to CiliumNode custom resource")
 
 	store := &nodeStore{
 		allocators:         []*crdAllocator{},
 		allocationPoolSize: map[Family]int{},
 		conf:               conf,
+		mtuConfig:          mtuConfig,
 	}
 	store.restoreFinished = make(chan bool)
 	ciliumClient := k8s.CiliumClient()
@@ -435,9 +437,9 @@ type crdAllocator struct {
 }
 
 // newCRDAllocator creates a new CRD-backed IP allocator
-func newCRDAllocator(family Family, c Configuration, owner Owner, k8sEventReg K8sEventRegister) Allocator {
+func newCRDAllocator(family Family, c Configuration, owner Owner, k8sEventReg K8sEventRegister, mtuConfig MtuConfiguration) Allocator {
 	initNodeStore.Do(func() {
-		sharedNodeStore = newNodeStore(nodeTypes.GetName(), c, owner, k8sEventReg)
+		sharedNodeStore = newNodeStore(nodeTypes.GetName(), c, owner, k8sEventReg, mtuConfig)
 	})
 
 	allocator := &crdAllocator{

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -297,6 +297,12 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
+	if n.conf.IPAMMode() == ipamOption.IPAMENI {
+		if err := configureENIDevices(n.ownNode, node, n.mtuConfig); err != nil {
+			log.WithError(err).Errorf("Failed to update routes and rules for ENIs")
+		}
+	}
+
 	n.ownNode = node
 	n.allocationPoolSize[IPv4] = 0
 	n.allocationPoolSize[IPv6] = 0

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -1,0 +1,204 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/backoff"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type eniDeviceConfig struct {
+	name string
+	ip   net.IP
+	cidr *net.IPNet
+	mtu  int
+}
+
+type configMap map[string]eniDeviceConfig // by MAC addr
+type linkMap map[string]netlink.Link      // by MAC addr
+
+func configureENIDevices(oldNode, newNode *ciliumv2.CiliumNode, mtuConfig MtuConfiguration) error {
+	var (
+		existingENIByName map[string]eniTypes.ENI
+		addedENIByMac     = configMap{}
+	)
+
+	if oldNode != nil {
+		existingENIByName = oldNode.Status.ENI.ENIs
+	}
+	firstInterfaceIndex := *newNode.Spec.ENI.FirstInterfaceIndex
+	for name, eni := range newNode.Status.ENI.ENIs {
+		if eni.Number < firstInterfaceIndex {
+			continue
+		}
+
+		if _, ok := existingENIByName[name]; !ok {
+			cfg, err := parseENIConfig(name, &eni, mtuConfig)
+			if err != nil {
+				log.WithError(err).
+					WithField(logfields.Resource, name).
+					Error("Skipping invalid ENI device config")
+				continue
+			}
+			addedENIByMac[eni.MAC] = cfg
+		}
+	}
+
+	go setupENIDevices(addedENIByMac)
+
+	return nil
+}
+
+func setupENIDevices(eniConfigByMac configMap) {
+	// Wait for the interfaces to be attached to the local node
+	eniLinkByMac, err := waitForNetlinkDevices(eniConfigByMac)
+	if err != nil {
+		attachedENIByMac := make(map[string]string, len(eniLinkByMac))
+		for mac, link := range eniLinkByMac {
+			attachedENIByMac[mac] = link.Attrs().Name
+		}
+		requiredENIByMac := make(map[string]string, len(eniConfigByMac))
+		for mac, eni := range eniConfigByMac {
+			requiredENIByMac[mac] = eni.name
+		}
+
+		log.WithError(err).WithFields(logrus.Fields{
+			logfields.AttachedENIs: attachedENIByMac,
+			logfields.ExpectedENIs: requiredENIByMac,
+		}).Error("Timed out waiting for ENIs to be attached")
+	}
+
+	// Configure new interfaces.
+	for mac, link := range eniLinkByMac {
+		cfg, ok := eniConfigByMac[mac]
+		if !ok {
+			log.WithField(logfields.MACAddr, mac).Warning("No configuration found for ENI device")
+			continue
+		}
+		err = configureENINetlinkDevice(link, cfg)
+		if err != nil {
+			log.WithError(err).
+				WithFields(logrus.Fields{
+					logfields.MACAddr:  mac,
+					logfields.Resource: cfg.name,
+				}).
+				Error("Failed to configure ENI device")
+		}
+	}
+}
+
+func parseENIConfig(name string, eni *eniTypes.ENI, mtuConfig MtuConfiguration) (cfg eniDeviceConfig, err error) {
+	ip := net.ParseIP(eni.IP)
+	if ip == nil {
+		return cfg, fmt.Errorf("failed to parse eni primary ip %q", eni.IP)
+	}
+
+	_, cidr, err := net.ParseCIDR(eni.Subnet.CIDR)
+	if err != nil {
+		return cfg, fmt.Errorf("failed to parse eni subnet cidr %q: %w", eni.Subnet.CIDR, err)
+	}
+
+	return eniDeviceConfig{
+		name: name,
+		ip:   ip,
+		cidr: cidr,
+		mtu:  mtuConfig.GetDeviceMTU(),
+	}, nil
+}
+
+const (
+	waitForNetlinkDevicesMaxTries         = 15
+	waitForNetlinkDevicesMinRetryInterval = 100 * time.Millisecond
+	waitForNetlinkDevicesMaxRetryInterval = 30 * time.Second
+)
+
+func waitForNetlinkDevices(configByMac configMap) (linkByMac linkMap, err error) {
+	for try := 0; try < waitForNetlinkDevicesMaxTries; try++ {
+		links, err := netlink.LinkList()
+		if err != nil {
+			return nil, fmt.Errorf("failed to obtain eni link list: %w", err)
+		}
+
+		linkByMac = linkMap{}
+		for _, link := range links {
+			mac := link.Attrs().HardwareAddr.String()
+			if _, ok := configByMac[mac]; ok {
+				linkByMac[mac] = link
+			}
+		}
+
+		if len(linkByMac) == len(configByMac) {
+			return linkByMac, nil
+		}
+
+		sleep := backoff.CalculateDuration(
+			waitForNetlinkDevicesMinRetryInterval,
+			waitForNetlinkDevicesMaxRetryInterval,
+			2.0,
+			false,
+			try)
+		time.Sleep(sleep)
+	}
+
+	// we return the linkByMac also in the error case to allow for better logging
+	return linkByMac, errors.New("timed out waiting for ENIs to be attached")
+}
+
+func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig) error {
+	if err := netlink.LinkSetMTU(link, cfg.mtu); err != nil {
+		return fmt.Errorf("failed to change MTU of link %s to %d: %w", link.Attrs().Name, cfg.mtu, err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("failed to up link %s: %w", link.Attrs().Name, err)
+	}
+
+	// Set the primary IP in order for SNAT to work correctly on this ENI
+	err := netlink.AddrAdd(link, &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   cfg.ip,
+			Mask: cfg.cidr.Mask,
+		},
+	})
+	if err != nil && !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("failed to set eni primary ip address %q on link %q: %w", cfg.ip, link.Attrs().Name, err)
+	}
+
+	// Remove the default route for this ENI, as it can overlap with the
+	// default route of the primary ENI and therefore break node connectivity
+	err = netlink.RouteDel(&netlink.Route{
+		Dst:   cfg.cidr,
+		Src:   cfg.ip,
+		Table: unix.RT_TABLE_MAIN,
+		Scope: netlink.SCOPE_LINK,
+	})
+	if err != nil && !errors.Is(err, unix.ESRCH) {
+		// We ignore ESRCH, as it means the entry was already deleted
+		return fmt.Errorf("failed to delete default route %q on link %q: %w", cfg.ip, link.Attrs().Name, err)
+	}
+
+	return nil
+}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -91,8 +91,12 @@ type K8sEventRegister interface {
 	K8sEventProcessed(scope string, action string, status bool)
 }
 
+type MtuConfiguration interface {
+	GetDeviceMTU() int
+}
+
 // NewIPAM returns a new IP address manager
-func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owner, k8sEventReg K8sEventRegister) *IPAM {
+func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owner, k8sEventReg K8sEventRegister, mtuConfig MtuConfiguration) *IPAM {
 	ipam := &IPAM{
 		nodeAddressing:   nodeAddressing,
 		config:           c,
@@ -120,11 +124,11 @@ func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owne
 	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure:
 		log.Info("Initializing CRD-based IPAM")
 		if c.IPv6Enabled() {
-			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, k8sEventReg)
+			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, k8sEventReg, mtuConfig)
 		}
 
 		if c.IPv4Enabled() {
-			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, k8sEventReg)
+			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, k8sEventReg, mtuConfig)
 		}
 	default:
 		log.Fatalf("Unknown IPAM backend %s", c.IPAMMode())

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -59,7 +59,7 @@ func (t *testConfiguration) IPv4NativeRoutingCIDR() *cidr.CIDR        { return n
 
 func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{})
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock)
 
 	// Since the IPs we have allocated to the endpoints might or might not
 	// be in the allocrange specified in cilium, we need to specify them
@@ -91,7 +91,7 @@ func (s *IPAMSuite) TestLock(c *C) {
 
 func (s *IPAMSuite) TestBlackList(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{})
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock)
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	nextIP(ipv4)
@@ -117,7 +117,7 @@ func (s *IPAMSuite) TestDeriveFamily(c *C) {
 
 func (s *IPAMSuite) TestOwnerRelease(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{})
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock)
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	nextIP(ipv4)

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -104,6 +104,9 @@ const (
 	// DNSRequestID is the DNS request id used by dns-proxy
 	DNSRequestID = "DNSRequestID"
 
+	// MACAddr is a MAC address
+	MACAddr = "macAddr"
+
 	// IPAddr is an IPV4 or IPv6 address
 	IPAddr = "ipAddr"
 
@@ -335,11 +338,17 @@ const (
 	// It is often paired with logfields.Repr to render the object.
 	Response = "resp"
 
+	// Resource is a resource
+	Resource = "resource"
+
 	// Route is a L2 or L3 Linux route
 	Route = "route"
 
 	// RetryUUID is an UUID identical for all retries of a set
 	RetryUUID = "retryUUID"
+
+	// Rule is an ip rule
+	Rule = "rule"
 
 	// Envoy xDS-protocol-specific
 
@@ -498,4 +507,10 @@ const (
 
 	// Mode describes an operations mode
 	Mode = "mode"
+
+	// AttachedENIs are the ENIs which have been attached to the node
+	AttachedENIs = "attachedENIs"
+
+	// ExpectedENIs are the ENIs which are expected to be available
+	ExpectedENIs = "expectedENIs"
 )

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -40,6 +40,8 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		allCIDRs = append(allCIDRs, cidr)
 	}
 	// Coalesce CIDRs into minimum set needed for route rules
+	// The routes set up here will be cleaned up by linuxrouting.Delete.
+	// Therefore the code here should be kept in sync with the deletion code.
 	ipv4CIDRs, _ := ip.CoalesceCIDRs(allCIDRs)
 	cidrs := make([]string, 0, len(ipv4CIDRs))
 	for _, cidr := range ipv4CIDRs {


### PR DESCRIPTION

 * #15453 -- eni: Assign primary IP to support multiple VPC CIDRs (@gandro)
 * #15261 -- node-neigh: Reduce arping related log msg's level (@brb)
 * #15598 -- Make encryption+chaining limitations clearer (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15453 15261 15598; do contrib/backporting/set-labels.py $pr done 1.9; done
```