### PR TITLE
Helm: Add Wireguard support

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -118,11 +118,12 @@ contributors across the globe, there is almost always someone available to help.
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters. |
 | enableXTSocketFallback | bool | `true` |  |
-| encryption.enabled | bool | `false` | Enable transparent network encryption. |
-| encryption.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |
-| encryption.mountPath | string | `"/etc/ipsec"` | Path to mount the secret inside the Cilium pod. |
-| encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. |
-| encryption.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. |
+| encryption.ipsec.enabled | bool | `false` | Enable transparent network encryption using IPSec. |
+| encryption.ipsec.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |
+| encryption.ipsec.mountPath | string | `"/etc/ipsec"` | Path to mount the secret inside the Cilium pod. |
+| encryption.ipsec.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. |
+| encryption.ipsec.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. |
+| encryption.wireguard.enabled | bool | `false` | Enable transparent network encryption using Wireguard. |
 | endpointHealthChecking.enabled | bool | `true` |  |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -422,20 +422,24 @@ data:
   enable-ip-masq-agent: "true"
 {{- end }}
 
-{{- if hasKey .Values "wireguard" }}
-{{- if .Values.wireguard.enabled }}
-  enable-wireguard: {{ .Values.wireguard.enabled | quote }}
+{{- if .Values.encryption.wireguard.enabled }}
+  enable-wireguard: {{ .Values.encryption.wireguard.enabled | quote }}
+{{- if hasKey .Values.encryption.wireguard "wireguardsubnetv4" }}
+  wireguard-subnet-v4: {{ .Values.encryption.wireguard.wireguardsubnetv4 | quote }}
+{{- end }}
+{{- if hasKey .Values.encryption.wireguard "wireguardsubnetv6" }}
+  wireguard-subnet-v6: {{ .Values.encryption.wireguard.wireguardsubnetv6 | quote }}
 {{- end }}
 {{- end }}
 
-{{- if .Values.encryption.enabled }}
-  enable-ipsec: {{ .Values.encryption.enabled | quote }}
-  ipsec-key-file: {{ .Values.encryption.mountPath }}/{{ .Values.encryption.keyFile }}
-{{- if hasKey .Values.encryption "interface" }}
-  encrypt-interface: {{ .Values.encryption.interface }}
+{{- if .Values.encryption.ipsec.enabled }}
+  enable-ipsec: {{ .Values.encryption.ipsec.enabled | quote }}
+  ipsec-key-file: {{ .Values.encryption.ipsec.mountPath }}/{{ .Values.encryption.ipsec.keyFile }}
+{{- if hasKey .Values.encryption.ipsec "interface" }}
+  encrypt-interface: {{ .Values.encryption.ipsec.interface }}
 {{- end }}
-{{- if .Values.encryption.nodeEncryption }}
-  encrypt-node: {{ .Values.encryption.nodeEncryption | quote }}
+{{- if .Values.encryption.ipsec.nodeEncryption }}
+  encrypt-node: {{ .Values.encryption.ipsec.nodeEncryption | quote }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "datapathMode" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -405,23 +405,34 @@ enableK8sEventHandover: false
 enableXTSocketFallback: true
 
 encryption:
-  # -- Enable transparent network encryption.
-  enabled: false
+  wireguard:
+    # -- Enable transparent network encryption using Wireguard.
+    enabled: false
 
-  # -- Name of the key file inside the Kubernetes secret configured via secretName.
-  keyFile: keys
+    # -- Option to set the wireguard IPv4 subnet. Default set to 172.16.43.0/24
+    # wireguardsubnetv4: 172.16.43.0/24
 
-  # -- Path to mount the secret inside the Cilium pod.
-  mountPath: /etc/ipsec
+    # -- Option to set the Wireguard IPv6 subnet. Default set to fdc9:281f:04d7:9ee9::1/64
+    # wireguardsubnetv6: fdc9:281f:04d7:9ee9::1/64
 
-  # -- Name of the Kubernetes secret containing the encryption keys.
-  secretName: cilium-ipsec-keys
+  ipsec:
+    # -- Enable transparent network encryption using IPSec.
+    enabled: false
 
-  # -- Enable encryption for pure node to node traffic.
-  nodeEncryption: false
+    # -- Name of the key file inside the Kubernetes secret configured via secretName.
+    keyFile: keys
 
-  # -- The interface to use for encrypted traffic.
-  # interface: eth0
+    # -- Path to mount the secret inside the Cilium pod.
+    mountPath: /etc/ipsec
+
+    # -- Name of the Kubernetes secret containing the encryption keys.
+    secretName: cilium-ipsec-keys
+
+    # -- Enable encryption for pure node to node traffic.
+    nodeEncryption: false
+
+    # -- The interface to use for encrypted traffic.
+    # interface: eth0
 
 # TODO: Add documentation
 endpointHealthChecking:


### PR DESCRIPTION
This PR is to add the Wireguard support to the Helm charts.

Following comment from PR #15383 some refactoring has been done for the
encryption part: we are now having two subchoices: IPSec or Wireguard for
the encryption.

Fixes: #15483

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

```release-note
Helm: Add Wireguard support
```
