### PR TITLE
pkg/k8s: set the right api group for EndpointSlice

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1493,6 +1493,7 @@ func (d *Daemon) initKVStore() {
 		d.k8sWatcher.WaitForCacheSync(
 			watchers.K8sAPIGroupServiceV1Core,
 			watchers.K8sAPIGroupEndpointV1Core,
+			watchers.K8sAPIGroupEndpointSliceV1Discovery,
 			watchers.K8sAPIGroupEndpointSliceV1Beta1Discovery,
 		)
 		log := log.WithField(logfields.LogSubsys, "etcd")

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -66,6 +66,7 @@ const (
 	k8sAPIGroupCiliumEndpointV2                 = "cilium/v2::CiliumEndpoint"
 	k8sAPIGroupCiliumLocalRedirectPolicyV2      = "cilium/v2::CiliumLocalRedirectPolicy"
 	K8sAPIGroupEndpointSliceV1Beta1Discovery    = "discovery/v1beta1::EndpointSlice"
+	K8sAPIGroupEndpointSliceV1Discovery         = "discovery/v1::EndpointSlice"
 
 	metricCNP            = "CiliumNetworkPolicy"
 	metricCCNP           = "CiliumClusterwideNetworkPolicy"
@@ -305,6 +306,7 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
 			// with the right service -> backend (k8s endpoints) translation.
 			K8sAPIGroupEndpointV1Core,
 			K8sAPIGroupEndpointSliceV1Beta1Discovery,
+			K8sAPIGroupEndpointSliceV1Discovery,
 			// We need all network policies in place before restoring to make sure
 			// we are enforcing the correct policies for each endpoint before
 			// restarting.


### PR DESCRIPTION
If EndpointSlice V1 is enabled we should set it correctly in the `cilium
status` output.

Fixes: 5ee4c6f4d1 ("add support for EndpointSlice V1")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/15594

@joestringer I'm marking it as fixed just to close the GH issue since I can't replicate it on my side. I did notice this bug in the sysdump. In case we see the #15594 again, we can re-open it and check if the cilium status has the correct API or not.