### PR TITLE
Removes CEP subresource.

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -454,8 +454,7 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -34,7 +34,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.23.1"
+	CustomResourceDefinitionSchemaVersion = "1.23.2"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -39,7 +39,6 @@ import (
 // +kubebuilder:printcolumn:JSONPath=".status.state",description="Endpoint current state",name="Endpoint State",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.networking.addressing[0].ipv4",description="Endpoint IPv4 address",name="IPv4",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.networking.addressing[0].ipv6",description="Endpoint IPv6 address",name="IPv6",type=string
-// +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 
 // CiliumEndpoint is the status of a Cilium policy rule.

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -180,6 +180,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 								// label based selection for CiliumEndpoints.
 								Labels: pod.GetObjectMeta().GetLabels(),
 							},
+							Status: *mdl,
 						}
 						localCEP, err = ciliumClient.CiliumEndpoints(namespace).Create(ctx, cep, meta_v1.CreateOptions{})
 						if err != nil {
@@ -204,6 +205,8 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					// We return earlier for all error cases so we don't need
 					// to init the local endpoint in non-error cases.
 					needInit = false
+					lastMdl = mdl
+					return nil
 				}
 				// We have no localCEP copy. We need to fetch it for updates, below.
 				// This is unexpected as there should be only 1 writer per CEP, this
@@ -255,8 +258,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					ctx, podName,
 					types.JSONPatchType,
 					createStatusPatch,
-					meta_v1.PatchOptions{},
-					"status")
+					meta_v1.PatchOptions{})
 
 				// Handle Update errors or return successfully
 				switch {
@@ -266,42 +268,6 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					scopedLog.WithError(err).Warn("Cannot update CEP due to a revision conflict. The next controller execution will try again")
 					needInit = true
 					return nil
-
-				case err != nil && k8serrors.IsNotFound(err):
-					scopedLog.WithError(err).Warn("Cannot update CEP via subresource, trying direct patch")
-					// Tries to update CEP without specifying `status` as subresource.
-					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Patch(
-						ctx, podName,
-						types.JSONPatchType,
-						createStatusPatch,
-						meta_v1.PatchOptions{})
-					// Handle Update errors or return successfully
-					switch {
-					// Return no error when we see a conflict. We want to retry without a
-					// backoff and the Update* calls returned the current localCEP
-					case err != nil && k8serrors.IsConflict(err):
-						scopedLog.WithError(err).Warn("Cannot update CEP due to a revision conflict. The next controller execution will try again")
-						needInit = true
-						return nil
-
-					// Ensure we re-init when we see a generic error. This will recrate the
-					// CEP.
-					case err != nil:
-						// Suppress logging an error if ep backing the pod was terminated
-						// before CEP could be updated and shut down the controller.
-						if errors.Is(err, context.Canceled) {
-							return nil
-						}
-						scopedLog.WithError(err).Error("Cannot update CEP")
-
-						needInit = true
-						return err
-
-					// A successful update means no more updates unless the endpoint status, aka mdl, changes
-					default:
-						lastMdl = mdl
-						return nil
-					}
 
 				// Ensure we re-init when we see a generic error. This will recrate the
 				// CEP.


### PR DESCRIPTION
This is part 2/2 of trimmming CEP subresource to improve scalability.
Part 1/2 is PR #15230.

This will bump cilium CRD schema version and is only backward-compatible
with agent that has part 1/2.

Signed-off-by: Weilong Cui <cuiwl@google.com>

Fixes: #15153 
