### PR TITLE
Update kube-router YAML to a newer release in the guide

### DIFF
--- a/Documentation/gettingstarted/kube-router.rst
+++ b/Documentation/gettingstarted/kube-router.rst
@@ -23,7 +23,7 @@ Download the kube-router DaemonSet template:
 
 .. code:: bash
 
-    curl -LO https://raw.githubusercontent.com/cloudnativelabs/kube-router/v0.4.0/daemonset/generic-kuberouter-only-advertise-routes.yaml
+    curl -LO https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.2/daemonset/generic-kuberouter-only-advertise-routes.yaml
 
 Open the file ``generic-kuberouter-only-advertise-routes.yaml`` and edit the
 ``args:`` section. The following arguments are **requried** to be set to


### PR DESCRIPTION
The connectivity tests pass after switching to the newer release.

Fixes #15613


