### PR TITLE
maps: Do not create cache for SNAT BPF maps

### DIFF
--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -114,7 +114,7 @@ func NewMap(name string, v4 bool, entries int) *Map {
 			entries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache(),
+		),
 		v4: v4,
 	}
 }


### PR DESCRIPTION
There is no need to create the user-space cache for the SNAT BPF maps, as they can be dumped with the `cilium bpf nat list` cli cmd.

(Discovered while taking a look into https://github.com/cilium/cilium/pull/15590).