### PR TITLE
ipsec: Fix routing CIDR iteration on EKS

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -204,7 +204,8 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		if len(option.Config.IPv4PodSubnets) == 0 {
 			if info := node.GetRouterInfo(); info != nil {
 				for _, c := range info.GetIPv4CIDRs() {
-					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &c)
+					cidr := c // create a copy to be able to take a reference
+					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &cidr)
 				}
 			}
 		}


### PR DESCRIPTION
When taking a reference of the iterated value in Golang, one needs to
take care to copy the value before taking a reference.
See [section 1 in this blogpost](https://medium.com/@betable/3-go-gotchas-590b8c014e0a) for more details.

In the case of EKS (where we can have multiple VPC CIDRs, c.f. #15303)
this meant that we only the last routing CIDR was appended to
`IPv4PodSubnets`.

Fixes: a42d442a096a ("cilium: auto-discovery pod subnets for ENI IPAM")
