### PR TITLE
datapath/linux/arp: avoid leaking sock fd if unix.SetNonblock fails in func listen

### DIFF
--- a/pkg/datapath/linux/arp/ping_linux.go
+++ b/pkg/datapath/linux/arp/ping_linux.go
@@ -45,6 +45,7 @@ func listen(link netlink.Link) (*packetConn, error) {
 	}
 
 	if err := unix.SetNonblock(us, true); err != nil {
+		unix.Close(us)
 		return nil, err
 	}
 


### PR DESCRIPTION
At this point, the sock fd is not yet wrapped in an *os.File, so it
needs to be closed explicitly on error.
