### PR TITLE
datapath/linux/probes: remove unused (*ProbeManager).GetMisc

### DIFF
--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -137,17 +137,11 @@ type MapTypes struct {
 	HaveStackMapType               bool `json:"have_stack_map_type"`
 }
 
-// Misc contains bools exposing miscellaneous eBPF features.
-type Misc struct {
-	HaveLargeInsnLimit bool `json:"have_large_insn_limit"`
-}
-
 // Features contains BPF feature checks returned by bpftool.
 type Features struct {
 	SystemConfig `json:"system_config"`
 	MapTypes     `json:"map_types"`
 	Helpers      map[string][]string `json:"helpers"`
-	Misc         `json:"misc"`
 }
 
 // ProbeManager is a manager of BPF feature checks.
@@ -321,11 +315,6 @@ func (p *ProbeManager) GetOptionalConfig() map[KernelParam]kernelOption {
 // GetMapTypes returns information about supported BPF map types.
 func (p *ProbeManager) GetMapTypes() *MapTypes {
 	return &p.features.MapTypes
-}
-
-// GetMisc returns information about miscellaneous eBPF features.
-func (p *ProbeManager) GetMisc() *Misc {
-	return &p.features.Misc
 }
 
 // GetHelpers returns information about available BPF helpers for the given


### PR DESCRIPTION
After commit 27eda2c934dd ("Remove NEEDS_RELAX_VERIFIER") the method.
its corresponding member in type Features and the type Misc are no
longer used in the code.