### PR TITLE
daemon/cmd: fix Cilium version status output

### DIFF
--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -617,9 +617,9 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 
 	sr.Stale = stale
 
-	//CiliumVersion definition
+	// CiliumVersion definition
 	ver := version.GetCiliumVersion()
-	ciliumVer := fmt.Sprintf("%s (v.%s-r.%s)", ver.Version, ver.Version, ver.Revision)
+	ciliumVer := fmt.Sprintf("%s (v%s-%s)", ver.Version, ver.Version, ver.Revision)
 
 	switch {
 	case len(sr.Stale) > 0:


### PR DESCRIPTION
Similarly to other software, Cilium should print the version in a
non-ambiguous format such as "v\<Version>-\<Commit>".

Fixes: 65dd482bac77 ("Agent: Include Cilium version in output of cilium status --verbose")
Signed-off-by: André Martins <andre@cilium.io>

I was getting confused by the presence of `r` in the release and I thought it was a bug in status version for which it was wrongly assuming the version was an RC, `Ok   1.9.90 (v.1.9.90-r.9bfce30189)`, thus I'm proposing these changes to make it more clear.