### PR TITLE
doc: Add Egress Gateway Getting Started Guide

### DIFF
--- a/Documentation/concepts/ebpf/maps.rst
+++ b/Documentation/concepts/ebpf/maps.rst
@@ -30,6 +30,7 @@ IPv4 Fragmentation       node             8k              Max 8k fragmented data
 Session Affinity         node             64k             Max 64k affinities from different clients
 IP Masq                  node             16k             Max 16k IPv4 cidrs used by BPF-based ip-masq-agent
 Service Source Ranges    node             64k             Max 64k cumulative LB source ranges across all services
+Egress Policy            endpoint         16k             Max 16k endpoints across all destination CIDRs across all clusters 
 ======================== ================ =============== =====================================================
 
 For some BPF maps, the upper capacity limit can be overridden using command

--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -1,0 +1,144 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _egress-gateway:
+
+**********************
+Egress Gateway (beta)
+**********************
+
+The egress gateway allows users to redirect egress pod traffic through
+specific, gateway nodes. Packets are masqueraded to the gateway node IP.
+
+This document explains how to enable the egress gateway and configure
+egress NAT policies to route and SNAT the egress traffic for a specific
+workload.
+
+.. include:: ../beta.rst
+
+Configure Cilium
+================
+
+.. include:: k8s-install-download-release.rst
+
+The feature is disabled by default. Enable the feature by setting the
+``enableEgressGateway`` value to ``true``.
+
+Additionally enabling feature requires ``enable-bpf-masquerade=true`` and
+``kube-proxy-replacement=strict``. It cannot be enabled with either of these
+2 options set as ``enable-bpf-masquerade=false`` or
+``kube-proxy-replacement=disabled``.
+
+.. parsed-literal::
+
+    helm install cilium |CHART_RELEASE| \\
+      --set enableEgressGateway=true \\
+      --set bpf.masquerade=true \\
+      --set kubeProxyReplacement=strict
+
+Optionally, Egress Gateway support can be enabled by setting
+``enable-egress-gateway`` to ``true`` in ConfigMap ``cilium-config``, or
+running ``cilium-agent`` with option ``--enable-egress-gateway``.
+
+Create an External Service (Optional)
+=====================================
+
+This feature will change the default behavior how a packet leaves a cluster. As a
+result, from the external service's point of view, it will see different source IP
+address from the cluster. If you don't have an external service to experiment with,
+nginx is a very simple example that can demonstrate the functionality, while nginx's
+access log shows which IP address the request is coming from.
+
+Create an nginx service on a Linux node that is external to the existing Kubernetes
+cluster, and use it as the destination of the egress traffic.
+
+.. code-block:: shell-session
+
+    $ # Install and start nginx
+    $ sudo apt install nginx
+    $ sudo systemctl start nginx
+
+    $ # Make sure the service is started and listens on port :80
+    $ sudo systemctl status nginx
+    ● nginx.service - A high performance web server and a reverse proxy server
+    Loaded: loaded (/lib/systemd/system/nginx.service; enabled; vendor preset: enabled)
+    Active: active (running) since Sun 2021-04-04 21:58:57 UTC; 1min 3s ago
+    [...]
+    $ curl http://192.168.33.13:80  # Assume 192.168.33.13 is the external IP of the node
+    [...]
+    <title>Welcome to nginx!</title>
+    [...]
+
+Create Client Pods
+==================
+
+Deploy a client pod that will generate traffic which will be redirected based on
+the configurations specified in the CiliumEgressNATPolicy.
+
+.. parsed-literal::
+
+    $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
+    $ kubectl get po
+    NAME                             READY   STATUS    RESTARTS   AGE
+    pod/mediabot                     1/1     Running   0          14s
+
+    $ kubectl exec mediabot -- curl http://192.168.33.13:80
+    <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
+    [...]
+
+Verify access log from nginx node or other external services that the request is coming
+from one of the node in Kubernetes cluster. For example, in nginx node, the access log
+will contain something like the following:
+
+.. code-block:: shell-session
+
+    $ tail /var/log/nginx/access.log
+    [...]
+    192.168.33.11 - - [04/Apr/2021:22:06:57 +0000] "GET / HTTP/1.1" 200 612 "-" "Wget/1.19.4 (linux-gnu)"
+
+In the previous example, the client pod is running on the node ``192.168.33.11``, so the result makes sense.
+This is the default Kubernetes behavior without egress NAT.
+
+Configure Egress IPs
+====================
+
+Deploy the following deployment to assign additional egress IP to the gateway node. The node that runs the
+pod will have additional IP addresses configured on the external interface (``enp0s8`` as in the example),
+and become the egress gateway. In the following example, ``192.168.33.100`` and ``192.168.33.101`` becomes
+the egress IP which can be consumed by Egress NAT Policy. Please make sure these IP addresses are routable
+on the interface they are assigned to, otherwise the return traffic won't be able to route back.
+
+.. literalinclude:: ../../examples/kubernetes-egress-gateway/egress-ip-deployment.yaml
+
+Create Egress NAT Policy
+========================
+
+Apply the following Egress NAT Policy, which basically means: when the pod is running in the namespace
+``default`` and the pod itself has label ``org: empire`` and ``class: mediabot``, if it's trying to talk to
+IP CIDR ``192.168.33.13/32``, then use egress IP ``192.168.33.100``. In this example, it tells Cilium to
+forward the packet from client pod to the gateway node with egress IP ``192.168.33.100``, and masquerade
+with that IP address.
+
+.. literalinclude:: ../../examples/kubernetes-egress-gateway/egress-nat-policy.yaml
+
+Let's switch back to the client pod and verify it works.
+
+.. code-block:: shell-session
+
+    $ kubectl exec mediabot -- curl http://192.168.33.13:80
+    <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
+    [...]
+
+Verify access log from nginx node or service of your chose that the request is coming from egress IP now 
+instead of one of the nodes in Kubernetes cluster. In the nginx's case, you will see logs like the
+following shows that the request is coming from ``192.168.33.100`` now, instead of ``192.168.33.11``.
+
+.. code-block:: shell-session
+
+    $ tail /var/log/nginx/access.log
+    [...]
+    192.168.33.100 - - [04/Apr/2021:22:06:57 +0000] "GET / HTTP/1.1" 200 612 "-" "Wget/1.19.4 (linux-gnu)"
+

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -76,6 +76,7 @@ Advanced Networking
    ipam
    local-redirect-policy
    bgp
+   egress-gateway
 
 Cluster Mesh
 ------------

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -256,6 +256,7 @@ bugfix
 bugfixes
 bugtool
 buildx
+busybox
 bytecode
 cBPF
 callee

--- a/examples/kubernetes-egress-gateway/egress-ip-deployment.yaml
+++ b/examples/kubernetes-egress-gateway/egress-ip-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "egress-ip-assign"
+  labels:
+    name: "egress-ip-assign"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: "egress-ip-assign"
+  template:
+    metadata:
+      labels:
+        name: "egress-ip-assign"
+    spec:
+      hostNetwork: true
+      containers:
+      - name: egress-ip
+        image: docker.io/library/busybox:1.31.1
+        command: ["/bin/sh","-c"]
+        securityContext:
+          privileged: true
+        env:
+        - name: EGRESS_IPS
+          value: "192.168.33.100/24 192.168.33.101/24"
+        args:
+        - "for i in $EGRESS_IPS; do ip address add $i dev enp0s8; done; sleep 10000000"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - "for i in $EGRESS_IPS; do ip address del $i dev enp0s8; done"

--- a/examples/kubernetes-egress-gateway/egress-nat-policy.yaml
+++ b/examples/kubernetes-egress-gateway/egress-nat-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEgressNATPolicy
+metadata:
+  name: egress-sample
+spec:
+  egress:
+  - podSelector:
+      matchLabels:
+        org: empire
+        class: mediabot
+        # The following label selects default namespace
+        io.kubernetes.pod.namespace: default
+    # Or use namespace label selector to select multiple namespaces
+    # namespaceSelector:
+    #  matchLabels:
+    #    ns: default
+  destinationCidrs:
+  - 192.168.33.13/32
+  egressSourceIp: "192.168.33.100"


### PR DESCRIPTION
This is a documentation of the detailed instructions on configuring
cilium components to start using the egress nat gateway feature.

RFE: #13575

Signed-off-by: Yongkun Gui <ygui@google.com>
Signed-off-by: Bolun Zhao <blzhao@google.com>