### PR TITLE
Adds ipv6 support for local-router-ip

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -185,7 +185,8 @@ cilium-agent [flags]
       --label-prefix-file string                             Valid label prefixes file path
       --labels strings                                       List of label prefixes used to determine identity of an endpoint
       --lib-dir string                                       Directory path to store runtime build environment (default "/var/lib/cilium")
-      --local-router-ip string                               Link-local IP used for Cilium's router devices
+      --local-router-ipv4 string                             Link-local IPv4 used for Cilium's router devices
+      --local-router-ipv6 string                             Link-local IPv6 used for Cilium's router devices
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"} (default map[])
       --log-system-load                                      Enable periodic logging of system load

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -953,8 +953,11 @@ func init() {
 	flags.Int(option.LBMapEntriesName, lbmap.MaxEntries, "Maximum number of entries in Cilium BPF lbmap")
 	option.BindEnv(option.LBMapEntriesName)
 
-	flags.String(option.LocalRouterIP, "", "Link-local IP used for Cilium's router devices")
-	option.BindEnv(option.LocalRouterIP)
+	flags.String(option.LocalRouterIPv4, "", "Link-local IPv4 used for Cilium's router devices")
+	option.BindEnv(option.LocalRouterIPv4)
+
+	flags.String(option.LocalRouterIPv6, "", "Link-local IPv6 used for Cilium's router devices")
+	option.BindEnv(option.LocalRouterIPv6)
 
 	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
 	option.BindEnv(option.K8sServiceProxyName)
@@ -1392,18 +1395,16 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.LocalRouterIP != "" {
-		if option.Config.IPAM != "" {
-			log.Fatalf("Cannot specify %s along with %s, leave router IP unspecified if Cilium is handling IPAM.", option.LocalRouterIP, option.IPAM)
-		}
+	if option.Config.LocalRouterIPv4 != "" || option.Config.LocalRouterIPv6 != "" {
+		// TODO(weil0ng): add a proper check for ipam in PR# 15429.
 		if option.Config.Tunnel != option.TunnelDisabled {
-			log.Fatalf("Cannot specify %s in tunnel mode.", option.LocalRouterIP)
+			log.Fatalf("Cannot specify %s or %s in tunnel mode.", option.LocalRouterIPv4, option.LocalRouterIPv6)
 		}
 		if !option.Config.EnableEndpointRoutes {
-			log.Fatalf("Cannot specify %s without %s.", option.LocalRouterIP, option.EnableEndpointRoutes)
+			log.Fatalf("Cannot specify %s or %s  without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes)
 		}
 		if option.Config.EnableIPSec {
-			log.Fatalf("Cannot specify %s with %s.", option.LocalRouterIP, option.EnableIPSecName)
+			log.Fatalf("Cannot specify %s or %s with %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableIPSecName)
 		}
 	}
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -174,14 +174,26 @@ func (d *Daemon) DumpIPAM() *models.IPAMStatus {
 	return status
 }
 
-func (d *Daemon) allocateRouterIP(family datapath.NodeAddressingFamily) (net.IP, error) {
-	if option.Config.LocalRouterIP != "" {
-		routerIP := net.ParseIP(option.Config.LocalRouterIP)
+func (d *Daemon) allocateRouterIPv4(family datapath.NodeAddressingFamily) (net.IP, error) {
+	if option.Config.LocalRouterIPv4 != "" {
+		routerIP := net.ParseIP(option.Config.LocalRouterIPv4)
 		if routerIP == nil {
-			return nil, fmt.Errorf("Invalid local-router-ip: %s", option.LocalRouterIP)
+			return nil, fmt.Errorf("Invalid local-router-ip: %s", option.Config.LocalRouterIPv4)
 		}
 		if d.datapath.LocalNodeAddressing().IPv4().AllocationCIDR().Contains(routerIP) {
 			log.Warn("Specified router IP is within IPv4 podCIDR.")
+		}
+		return routerIP, nil
+	} else {
+		return d.allocateDatapathIPs(family)
+	}
+}
+
+func (d *Daemon) allocateRouterIPv6(family datapath.NodeAddressingFamily) (net.IP, error) {
+	if option.Config.LocalRouterIPv6 != "" {
+		routerIP := net.ParseIP(option.Config.LocalRouterIPv6)
+		if routerIP == nil {
+			return nil, fmt.Errorf("Invalid local-router-ip: %s", option.Config.LocalRouterIPv6)
 		}
 		if d.datapath.LocalNodeAddressing().IPv6().AllocationCIDR().Contains(routerIP) {
 			log.Warn("Specified router IP is within IPv6 podCIDR.")
@@ -283,7 +295,7 @@ func (d *Daemon) allocateHealthIPs() error {
 func (d *Daemon) allocateIPs() error {
 	bootstrapStats.ipam.Start()
 	if option.Config.EnableIPv4 {
-		routerIP, err := d.allocateRouterIP(d.datapath.LocalNodeAddressing().IPv4())
+		routerIP, err := d.allocateRouterIPv4(d.datapath.LocalNodeAddressing().IPv4())
 		if err != nil {
 			return err
 		}
@@ -293,7 +305,7 @@ func (d *Daemon) allocateIPs() error {
 	}
 
 	if option.Config.EnableIPv6 {
-		routerIP, err := d.allocateRouterIP(d.datapath.LocalNodeAddressing().IPv6())
+		routerIP, err := d.allocateRouterIPv6(d.datapath.LocalNodeAddressing().IPv6())
 		if err != nil {
 			return err
 		}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -716,8 +716,11 @@ const (
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 = "ipv4-service-loopback-address"
 
-	// LocalRouterIP is the link-local IP address to use for Cilium router device
-	LocalRouterIP = "local-router-ip"
+	// LocalRouterIPv4 is the link-local IPv4 address to use for Cilium router device
+	LocalRouterIPv4 = "local-router-ipv4"
+
+	// LocalRouterIPv6 is the link-local IPv6 address to use for Cilium router device
+	LocalRouterIPv6 = "local-router-ipv6"
 
 	// EndpointInterfaceNamePrefix is the prefix name of the interface
 	// names shared by all endpoints
@@ -1580,8 +1583,11 @@ type DaemonConfig struct {
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 string
 
-	// LocalRouterIP is the link-local IP address used for Cilium's router device
-	LocalRouterIP string
+	// LocalRouterIPv4 is the link-local IPv4 address used for Cilium's router device
+	LocalRouterIPv4 string
+
+	// LocalRouterIPv6 is the link-local IPv6 address used for Cilium's router device
+	LocalRouterIPv6 string
 
 	// EndpointInterfaceNamePrefix is the prefix name of the interface
 	// names shared by all endpoints
@@ -2419,7 +2425,8 @@ func (c *DaemonConfig) Populate() {
 	c.LogSystemLoadConfig = viper.GetBool(LogSystemLoadConfigName)
 	c.Logstash = viper.GetBool(Logstash)
 	c.LoopbackIPv4 = viper.GetString(LoopbackIPv4)
-	c.LocalRouterIP = viper.GetString(LocalRouterIP)
+	c.LocalRouterIPv4 = viper.GetString(LocalRouterIPv4)
+	c.LocalRouterIPv6 = viper.GetString(LocalRouterIPv6)
 	c.EnableBPFClockProbe = viper.GetBool(EnableBPFClockProbe)
 	c.EnableIPMasqAgent = viper.GetBool(EnableIPMasqAgent)
 	c.EnableEgressGateway = viper.GetBool(EnableEgressGateway)


### PR DESCRIPTION
- breaks local-router-ip into local-router-ipv4 and local-router-ipv6
- removes a problematic ipam condition check when either of the above is
specified

original option added in PR #14800

Signed-off-by: Weilong Cui <cuiwl@google.com>