### PR TITLE
CODEOWNERS: Add pkg/bgp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -145,6 +145,7 @@ Jenkinsfile.nightly @cilium/ci-structure
 /pkg/aws/ @cilium/aws
 /pkg/azure/ @cilium/azure
 /pkg/bandwidth/ @cilium/bpf
+/pkg/bgp/ @cilium/kubernetes @cilium/loadbalancer
 /pkg/bpf/ @cilium/bpf
 /pkg/byteorder/ @cilium/bpf @cilium/api
 /pkg/client @cilium/api


### PR DESCRIPTION
The kubernetes and the loadbalancer teams are assigned as the BGP
integration is mostly K8s code and is relevant to services which the
loadbalancer team is responsible for.

Updates: https://github.com/cilium/cilium/issues/15611

Signed-off-by: Chris Tarazi <chris@isovalent.com>
