### PR TITLE
cilium: IPAMENI may add interfaces at runtime add encryption support

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1505,8 +1505,7 @@ func (d *Daemon) initKVStore() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice:        option.Config.HostDevice,
-		EncryptInterfaces: option.Config.EncryptInterface,
+		HostDevice: option.Config.HostDevice,
 	}
 
 	log.Info("Initializing daemon")

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -16,10 +16,8 @@ package linux
 
 import (
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/loader"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -27,8 +25,6 @@ import (
 type DatapathConfiguration struct {
 	// HostDevice is the name of the device to be used to access the host.
 	HostDevice string
-	// EncryptInterfaces is the list of devices used for direct ruoting encryption
-	EncryptInterfaces []string
 }
 
 type linuxDatapath struct {
@@ -53,13 +49,6 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 	}
 
 	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, wgAgent)
-
-	for _, iface := range cfg.EncryptInterfaces {
-		if err := connector.DisableRpFilter(iface); err != nil {
-			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
-		}
-	}
-
 	return dp
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1125,7 +1125,7 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 	var device string
 
 	if option.Config.Tunnel == option.TunnelDisabled {
-		device = n.datapathConfig.EncryptInterfaces[0]
+		device = option.Config.EncryptInterface[0]
 	} else {
 		device = linux_defaults.TunnelDeviceName
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -218,7 +218,7 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 			}
 		}
 
-		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {
+		if err := ReplaceNetworkDatapath(ctx, interfaces); err != nil {
 			return fmt.Errorf("failed to load encryption program: %w", err)
 		}
 	}

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -384,7 +384,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 	return nil
 }
 
-func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string) error {
+func ReplaceNetworkDatapath(ctx context.Context, interfaces []string) error {
 	if err := compileNetwork(ctx); err != nil {
 		log.WithError(err).Fatal("failed to compile encryption programs")
 	}


### PR DESCRIPTION
EKS may add interfaces at runtime, but when this happens and encryption is enabled we fail to attach our decryption program to the new interfaces. If we receive encrypted traffic on this interface we would then fail to decrypt it and it would be dropped. Fix by adding encryption logic to update hook.

Depends on:
https://github.com/cilium/cilium/pull/15669