### PR TITLE
cilium: Use build-and-push-with-qemu for builder

### DIFF
--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -242,7 +242,7 @@ jobs:
     if: ${{ github.repository == 'cilium/cilium' }}
     name: Display Digests
     runs-on: ubuntu-20.04
-    needs: [build-and-push-prs, build-and-push-cilium-test]
+    needs: [build-and-push-prs, build-and-push-with-qemu]
     steps:
       - name: Downloading Image Digests
         shell: bash


### PR DESCRIPTION
Fix images-legacy.yaml to use build-and-push-with-qemu.

Fixes: 044afab2ecf30 ("ci: Set up qemu in images workflow and build cilium-test")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>