### PR TITLE
pkg/client/client.go: Set EnabledProtocols when pointer is nil

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -405,7 +405,9 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 			return "Disabled"
 		}
 
-		if !sr.Masquerading.EnabledProtocols.IPV4 && !sr.Masquerading.EnabledProtocols.IPV6 {
+		if sr.Masquerading.EnabledProtocols == nil {
+			status = enabled(sr.Masquerading.Enabled)
+		} else if !sr.Masquerading.EnabledProtocols.IPV4 && !sr.Masquerading.EnabledProtocols.IPV6 {
 			status = enabled(false)
 		} else {
 			if sr.Masquerading.Mode == models.MasqueradingModeBPF {


### PR DESCRIPTION
When running cilium-agent <= v1.9.5, a request to /healthz returns a json which does not have the field masquerading.enabledProtocols. But if the same machine has a version of cilium (cli) > v1.9.5, after GET /healthz, it will create a StatusResponse without set the pointer Masquerading.EnabledProtocols.

In this case, ~~we allocate a new struct and fill IPV4 and IPV6 with the value from~~ set `status` based on Masquerading.Enabled. 

Fixes: #15617

Signed-off-by: Joao Victorino <joao@accuknox.com>
