### PR TITLE
source: Reorder AllowSource switch Statement and Comment Nits

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -48,25 +48,25 @@ const (
 func AllowOverwrite(existing, new Source) bool {
 	switch existing {
 
-	// Kubernetes state can be overwritten by everything except generated
-	// and unspecified state
-	case Kubernetes:
-		return new != Generated && new != Unspec
-
-	// Custom-resource state can be overwritten everything except
-	// generated, unspecified and Kuberntes (non-CRD) state
-	case CustomResource:
-		return new != Generated && new != Unspec && new != Kubernetes
+	// Local state can only be overwritten by other local state
+	case Local:
+		return new == Local
 
 	// KVStore can be overwritten by other kvstore or local state
 	case KVStore:
 		return new == KVStore || new == Local
 
-	// local state can only be overwritten by other local state
-	case Local:
-		return new == Local
+	// Custom-resource state can be overwritten by everything except
+	// generated, unspecified and Kubernetes (non-CRD) state
+	case CustomResource:
+		return new != Generated && new != Unspec && new != Kubernetes
 
-	// Generated and unspecified state can be overwritten by everything
+	// Kubernetes state can be overwritten by everything except generated
+	// and unspecified state
+	case Kubernetes:
+		return new != Generated && new != Unspec
+
+	// Generated can be overwritten by everything except by Unspecified
 	case Generated:
 		return new != Unspec
 


### PR DESCRIPTION
The AllowSource method contains logic that maps the
hierarchical sources of truth for when an entity's existing
source allows a new source of truth to overwrite it.

The method was written so that the cases were not in the order
of their importance, which makes the method confusing to read.
Additionally there were some typos and incorrectly worded comments
that further make the method difficult to read.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

