### PR TITLE
Make backporting responsibility more clear

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -190,6 +190,15 @@ Creating the Backports Branch
    backport reviewers towards which changes may deviate from the original
    commits to ensure that the changes are correctly backported.
 
+   **It is the backporter's responsibility to check that the backport commits
+   they are preparing are identical to the original commits**. This can be
+   achieved by preparing the commits, then running ``git show <commit>`` for
+   both the original upstream commit and the prepared backport, and read
+   through the commits side-by-side, line-by-line to check that the changes are
+   the same. If there is any uncertainty about the backport, reach out to the
+   original author directly to coordinate how to prepare the backport for the
+   target branch.
+
 #. (Optional) If there are any commits or pull requests that are tricky or
    time-consuming to backport, consider reaching out for help on Slack. If the
    commit does not cherry-pick cleanly, please mention the necessary changes in

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -145,6 +145,12 @@ and if so, change the label to ``backport-done/X.Y``.
 Creating the Backports Branch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+#. Check whether there are any `outstanding backport PRs for the target branch
+   <https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Akind%2Fbackports>`__.
+   If there are already backports for that branch, create a thread in the
+   #launchpad channel in Slack and reach out to the author to coordinate
+   triage, review and merge of the existing PR into the target branch.
+
 #. Run ``contrib/backporting/start-backport`` for the release version that
    you intend to backport PRs for. This will pull the latest repository commits
    from the Cilium repository (assumed to be the git remote ``origin``), create

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -194,7 +194,23 @@ Creating the Backports Branch
    the changes made in the commit message and collect these to add to the
    backport PR description when creating the PR below. This helps to direct
    backport reviewers towards which changes may deviate from the original
-   commits to ensure that the changes are correctly backported.
+   commits to ensure that the changes are correctly backported. This can be
+   fairly simple, for example inside the commit message of the modified commit::
+
+       commit f0f09158ae7f84fc8d888605aa975ce3421e8d67
+       Author: Joe Stringer <joe@cilium.io>
+       Date:   Tue Apr 20 16:48:18 2021 -0700
+
+           contrib: Automate digest PR creation
+
+           [ upstream commit 893d0e7ec5766c03da2f0e7b8c548f7c4d89fcd7 ]
+
+           [ Backporter's notes: Dropped conflicts in .github/ issue template ]
+
+           There's still some interactive bits here just for safety, but one less
+           step in the template.
+
+           Signed-off-by: Joe Stringer <joe@cilium.io>
 
    **It is the backporter's responsibility to check that the backport commits
    they are preparing are identical to the original commits**. This can be


### PR DESCRIPTION
There have been a few occasions recently where backporters have resolved
conflicts but did not notify the authors or raise any concern about
the conflicts. This can be potentially problematic, because close review
is primarily performed when merging the initial PR and it is easy to pay
less attention to backport PRs. If backport commits are not prepared
carefully, we can introduce regressions in the backport version of the
change when the upstream version of the change is correct.

In order to hopefully reduce the chance of such an issue, clarify that
the backporter has the responsibility to review the changes they are
proposing before they submit the PR. If we make the mechanical steps
clear to the backporter, then they should be able to take these
precautions to either confirm that the changes really are the same, or
at the very least become aware of which areas differ and use that to
raise a discussion with the original author of the PR being backported.
The review process then can be more targeted around having the original
author ensure the backport has the same behaviour as the original PR,
given the different code in the target branch.
