### PR TITLE
ENI migration followups

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -68,7 +68,7 @@ cilium-agent [flags]
       --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
       --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
       --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
-      --egress-multi-home-ip-rule-compat                     Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.
+      --egress-multi-home-ip-rule-compat                     Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bandwidth-manager                             Enable BPF bandwidth manager
       --enable-bpf-clock-probe                               Enable BPF clock source probing for more efficient tick retrieval

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/api/v1/server/restapi"
-	enitypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cleanup"
 	"github.com/cilium/cilium/pkg/common"
@@ -53,7 +53,6 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -87,7 +86,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -1671,7 +1669,7 @@ func runDaemon() {
 	// logic runs before any endpoint creates.
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		migrated, failed := linuxrouting.NewMigrator(
-			&interfaceNumberGetter{},
+			&eni.InterfaceDB{},
 		).MigrateENIDatapath(option.Config.EgressMultiHomeIPRuleCompat)
 		switch {
 		case failed == -1:
@@ -1919,86 +1917,4 @@ func initClockSourceOption() {
 			}
 		}
 	}
-}
-
-// GetInterfaceNumberByMAC implements the linuxrouting.interfaceDB interface.
-// It retrieves the number associated with the ENI device for the given MAC
-// address. The interface number is retrieved from the CiliumNode resource, as
-// this functionality is needed for ENI mode.
-func (in *interfaceNumberGetter) GetInterfaceNumberByMAC(mac string) (int, error) {
-	// Update the cache on the first run. After retrieving the CiliumNode
-	// resource, we use the cached result for the remainder of the migration.
-	if len(in.cache.ENIs) == 0 {
-		cn, err := in.fetchFromK8s(nodeTypes.GetName())
-		if err != nil {
-			return -1, err
-		}
-
-		in.cache = cn.Status.ENI
-	}
-
-	var (
-		eni   enitypes.ENI
-		found bool
-	)
-	for _, e := range in.cache.ENIs {
-		if e.MAC == mac {
-			eni = e
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return -1, fmt.Errorf("could not find interface with MAC %q in CiliumNode resource", mac)
-	}
-
-	return eni.Number, nil
-}
-
-// GetInterfaceNumberByMAC retrieves the number associated with the ENI device
-// for the given MAC address. The interface number is retrieved from the
-// CiliumNode resource, as this functionality is needed for ENI mode. This
-// implements the linuxrouting.interfaceDB interface.
-func (in *interfaceNumberGetter) GetMACByInterfaceNumber(ifaceNum int) (string, error) {
-	// Update the cache on the first run. After retrieving the CiliumNode
-	// resource, we use the cached result for the remainder of the migration.
-	if len(in.cache.ENIs) == 0 {
-		cn, err := in.fetchFromK8s(nodeTypes.GetName())
-		if err != nil {
-			return "", err
-		}
-
-		in.cache = cn.Status.ENI
-	}
-
-	var (
-		eni   enitypes.ENI
-		found bool
-	)
-	for _, e := range in.cache.ENIs {
-		if e.Number == ifaceNum {
-			eni = e
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return "", fmt.Errorf("could not find interface with number %q in CiliumNode resource", ifaceNum)
-	}
-
-	return eni.MAC, nil
-}
-
-func (in *interfaceNumberGetter) fetchFromK8s(name string) (*v2.CiliumNode, error) {
-	return k8s.CiliumClient().CiliumV2().CiliumNodes().Get(
-		context.TODO(),
-		nodeTypes.GetName(),
-		v1.GetOptions{},
-	)
-}
-
-type interfaceNumberGetter struct {
-	cache enitypes.ENIStatus
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -964,7 +964,7 @@ func init() {
 	option.BindEnv(option.CRDWaitTimeout)
 
 	flags.Bool(option.EgressMultiHomeIPRuleCompat, false,
-		"Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.")
+		"Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.")
 	option.BindEnv(option.EgressMultiHomeIPRuleCompat)
 
 	flags.Bool(option.EnableBPFBypassFIBLookup, defaults.EnableBPFBypassFIBLookup, "Enable FIB lookup bypass optimization for nodeport reverse NAT handling")

--- a/pkg/aws/eni/migration.go
+++ b/pkg/aws/eni/migration.go
@@ -1,0 +1,110 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eni
+
+import (
+	"context"
+	"fmt"
+
+	enitypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	nodetypes "github.com/cilium/cilium/pkg/node/types"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetInterfaceNumberByMAC implements the linuxrouting.interfaceDB interface.
+// It retrieves the number associated with the ENI device for the given MAC
+// address. The interface number is retrieved from the CiliumNode resource, as
+// this functionality is needed for ENI mode.
+func (in *InterfaceDB) GetInterfaceNumberByMAC(mac string) (int, error) {
+	// Update the cache on the first run. After retrieving the CiliumNode
+	// resource, we use the cached result for the remainder of the migration.
+	if len(in.cache.ENIs) == 0 {
+		cn, err := in.fetchFromK8s(nodetypes.GetName())
+		if err != nil {
+			return -1, err
+		}
+
+		in.cache = cn.Status.ENI
+	}
+
+	var (
+		eni   enitypes.ENI
+		found bool
+	)
+	for _, e := range in.cache.ENIs {
+		if e.MAC == mac {
+			eni = e
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return -1, fmt.Errorf("could not find interface with MAC %q in CiliumNode resource", mac)
+	}
+
+	return eni.Number, nil
+}
+
+// GetMACByInterfaceNumber retrieves the MAC address from a given ENI's
+// interface number. This implements the linuxrouting.interfaceDB interface.
+func (in *InterfaceDB) GetMACByInterfaceNumber(ifaceNum int) (string, error) {
+	// Update the cache on the first run. After retrieving the CiliumNode
+	// resource, we use the cached result for the remainder of the migration.
+	if len(in.cache.ENIs) == 0 {
+		cn, err := in.fetchFromK8s(nodetypes.GetName())
+		if err != nil {
+			return "", err
+		}
+
+		in.cache = cn.Status.ENI
+	}
+
+	var (
+		eni   enitypes.ENI
+		found bool
+	)
+	for _, e := range in.cache.ENIs {
+		if e.Number == ifaceNum {
+			eni = e
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return "", fmt.Errorf("could not find interface with number %q in CiliumNode resource", ifaceNum)
+	}
+
+	return eni.MAC, nil
+}
+
+func (in *InterfaceDB) fetchFromK8s(name string) (*v2.CiliumNode, error) {
+	return k8s.CiliumClient().CiliumV2().CiliumNodes().Get(
+		context.TODO(),
+		nodetypes.GetName(),
+		v1.GetOptions{},
+	)
+}
+
+// InterfaceDB contains all the ENIs on a given node. It is used to convert ENI
+// MAC addrs from interface numbers and vice versa, needed for the ENI
+// migration. See https://github.com/cilium/cilium/issues/14336.
+type InterfaceDB struct {
+	cache enitypes.ENIStatus
+}

--- a/pkg/datapath/linux/routing/migrate.go
+++ b/pkg/datapath/linux/routing/migrate.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -245,7 +245,7 @@ func (m *migrator) MigrateENIDatapath(compat bool) (int, int) {
 			scopedLog := log.WithField("rule", rule)
 			scopedLog.WithError(err).WithField("routes", routes).
 				Warnf("Failed to cleanup after successfully migrating endpoint to %s ENI datapath. "+
-					"It is recommended that theses routes are cleaned up, as it is possible in the future "+
+					"It is recommended that theses routes are cleaned up (by running `ip route del`), as it is possible in the future "+
 					"to collide with another endpoint with the same IP.", version)
 		}
 	}
@@ -421,7 +421,7 @@ const (
 	downgradeRevertWarning = "Reverting the new ENI datapath failed. However, both the new and previous datapaths are still intact. " +
 		"Endpoint connectivity should not be affected. It is advised to retry the migration."
 	downgradeFailedRuleDeleteWarning = "Downgrading the datapath has succeeded, but failed to cleanup the original datapath. " +
-		"It is advised to manually remove the old rule."
+		"It is advised to manually remove the old rule (priority 110)."
 )
 
 // retrieveTableIDFromIfIndex computes the correct table ID based on the

--- a/pkg/datapath/linux/routing/migrate_test.go
+++ b/pkg/datapath/linux/routing/migrate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR addresses https://github.com/cilium/cilium/issues/15174. The changes
are cosmetic and don't have any functional effect.

See commit msgs.

- daemon, eni: Move ENI migration logic to specific package
- daemon: Clarify EgressMultiHomeIPRuleCompat flag description
- datapath/linux/routing: Clarify warning msgs to user
