### PR TITLE
docs: Fix pip installation

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -14,6 +14,8 @@ RUN apk add --no-cache --virtual --update \
     py-pip \
     python \
     sphinx-python \
+    gcc \
+    musl-dev \
     && true
 
 ADD ./requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
Some recent change in python dependencies started to pull Cython
dependency which requires gcc to be compiled.

Fix this by installing gcc and musl-dev. The latter is required for
headers used by Cython.

Signed-off-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Martynas Pumputis <m@lambda.lt>