### PR TITLE
daemon/ipam: correct total IP count in `cilium status` output

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -29,17 +29,19 @@ const (
 
 // CountIPsInCIDR takes a RFC4632/RFC4291-formatted IPv4/IPv6 CIDR and
 // determines how many IP addresses reside within that CIDR.
+// The first and the last (base and broadcast) IPs are excluded.
+//
 // Returns 0 if the input CIDR cannot be parsed.
 func CountIPsInCIDR(ipnet *net.IPNet) *big.Int {
 	subnet, size := ipnet.Mask.Size()
 	if subnet == size {
-		return big.NewInt(1)
+		return big.NewInt(0)
 	}
 	return big.NewInt(0).
 		Sub(
 			big.NewInt(2).Exp(big.NewInt(2),
 				big.NewInt(int64(size-subnet)), nil),
-			big.NewInt(1),
+			big.NewInt(2),
 		)
 }
 

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -39,14 +39,14 @@ func Test(t *testing.T) {
 
 func (s *IPTestSuite) TestCountIPs(c *C) {
 	tests := map[string]*big.Int{
-		"192.168.0.1/32": big.NewInt(1),
-		"192.168.0.1/31": big.NewInt(1),
-		"192.168.0.1/30": big.NewInt(3),
-		"192.168.0.1/24": big.NewInt(255),
-		"192.168.0.1/16": big.NewInt(65535),
-		"::1/128":        big.NewInt(1),
-		"::1/120":        big.NewInt(255),
-		"fd02:1::/32":    big.NewInt(0).Sub(big.NewInt(2).Exp(big.NewInt(2), big.NewInt(96), nil), big.NewInt(1)),
+		"192.168.0.1/32": big.NewInt(0),
+		"192.168.0.1/31": big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1)),
+		"192.168.0.1/30": big.NewInt(2),
+		"192.168.0.1/24": big.NewInt(254),
+		"192.168.0.1/16": big.NewInt(65534),
+		"::1/128":        big.NewInt(0),
+		"::1/120":        big.NewInt(254),
+		"fd02:1::/32":    big.NewInt(0).Sub(big.NewInt(2).Exp(big.NewInt(2), big.NewInt(96), nil), big.NewInt(2)),
 	}
 	for cidr, nIPs := range tests {
 		_, ipnet, err := net.ParseCIDR(cidr)


### PR DESCRIPTION
Ref: https://github.com/cilium/ipam/blob/master/service/ipallocator/allocator.go#L61

Currently two (the base and broadcast) IPs are excluded from IPAM when
using hostscope mode (see above link), but the status output only excludes one.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>