### PR TITLE
 [v1.9] bpf: Skip policy enforcements for service loopback case

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -251,18 +251,22 @@ var _ = Describe("K8sServicesTest", func() {
 	Context("Checks ClusterIP Connectivity", func() {
 
 		var (
-			demoYAML    string
-			echoSVCYAML string
+			demoYAML       string
+			echoSVCYAML    string
+			echoPolicyYAML string
 		)
 
 		BeforeAll(func() {
 			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 			echoSVCYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-svc.yaml")
+			echoPolicyYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-policy.yaml")
 
 			res := kubectl.ApplyDefault(demoYAML)
 			res.ExpectSuccess("unable to apply %s", demoYAML)
 			res = kubectl.ApplyDefault(echoSVCYAML)
 			res.ExpectSuccess("unable to apply %s", echoSVCYAML)
+			res = kubectl.ApplyDefault(echoPolicyYAML)
+			Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", echoPolicyYAML)
 
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
@@ -277,6 +281,7 @@ var _ = Describe("K8sServicesTest", func() {
 			// teardown if any step fails.
 			_ = kubectl.Delete(demoYAML)
 			_ = kubectl.Delete(echoSVCYAML)
+			_ = kubectl.Delete(echoPolicyYAML)
 		})
 
 		SkipItIf(helpers.RunsWithoutKubeProxy, "Checks service on same node", func() {

--- a/test/k8sT/manifests/echo-policy.yaml
+++ b/test/k8sT/manifests/echo-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-all-within-namespace"
+spec:
+  endpointSelector:
+    matchLabels:
+      name: echo
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": default
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": default


### PR DESCRIPTION
* #15321 -- bpf: Skip policy enforcements for service loopback case (@aditighag)
* Fix for complexity issue in v1.9 from https://github.com/cilium/cilium/pull/15321
  * This will be forward-ported to master (as long as it doesn't cause regressions)
* #15928 -- test: Extend the clusterIP tests with policy (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15321 15928; do contrib/backporting/set-labels.py $pr done 1.9; done
```