### PR TITLE
daemon: Create RuntimePath if not equal to StateDir

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1120,6 +1120,12 @@ func initEnv(cmd *cobra.Command) {
 		scopedLog.WithError(err).Fatal("Could not create runtime directory")
 	}
 
+	if option.Config.RunDir != defaults.RuntimePath {
+		if err := os.MkdirAll(defaults.RuntimePath, defaults.RuntimePathRights); err != nil {
+			scopedLog.WithError(err).Fatal("Could not create default runtime directory")
+		}
+	}
+
 	option.Config.StateDir = filepath.Join(option.Config.RunDir, defaults.StateDir)
 	scopedLog = scopedLog.WithField(logfields.Path+".StateDir", option.Config.StateDir)
 	if err := os.MkdirAll(option.Config.StateDir, defaults.StateDirRights); err != nil {


### PR DESCRIPTION
With this change, state-dir can be set to anything and code makes sure that `/var/run/cilium` is always present with correct rights since `/var/run` is clean after reboot.

PidfilePath is set here https://github.com/cilium/cilium/blob/master/daemon/cmd/daemon_main.go#L1143
always set to `RuntimePath + "/cilium.pid"`. By default `StateDir` is set to `defaults.RuntimePath` == `/var/run/cilium` but when changed to something else, `/var/run/cilium` won't be created as in here:
https://github.com/cilium/cilium/blob/master/daemon/cmd/daemon_main.go#L1119 because https://github.com/cilium/cilium/blob/master/pkg/option/config.go#L2449.