### PR TITLE
test: Use node labels when testing host policies

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -735,6 +735,14 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("Host firewall", func() {
+		BeforeAll(func() {
+			kubectl.Exec("kubectl label nodes --all status=lockdown")
+		})
+
+		AfterAll(func() {
+			kubectl.Exec("kubectl label nodes --all status-")
+		})
+
 		AfterEach(func() {
 			kubectl.Exec(fmt.Sprintf("%s delete --all ccnp", helpers.KubectlCmd))
 		})

--- a/test/k8sT/manifests/host-policies.yaml
+++ b/test/k8sT/manifests/host-policies.yaml
@@ -4,7 +4,9 @@ metadata:
   name: "host-policy"
 specs:
   - description: "Allow only test client <-> server communications on node <-> pod paths (local and remote pods)"
-    nodeSelector: {}
+    nodeSelector:
+      matchLabels:
+        status: lockdown
     ingress:
     - fromEndpoints:
       - matchLabels:


### PR DESCRIPTION
Our current host policy tests need to the policy on all nodes. They therefore use an empty `nodeSelector`. However, if we want a basic test of the node label watcher, we can instead implement this with a `nodeSelector` matching on a label added to all nodes. This pull request implements that change.

The goal is also to help us catch such potential bugs as https://github.com/cilium/cilium/issues/13676 and https://github.com/cilium/cilium/issues/13455.