### PR TITLE
envoy: Update to build with Envoy 1.17.1 security fixes

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:b91528771beda9e213e08c612
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:400622c4a6a19aacfaab2f08a6bb7a515878b768@sha256:b6d6ed494e7aa772000f77be53c66cff413b439e348c949065e72faec1f03791 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:b3bb275dcaf4a74ae956e52fa408b196c0d52152@sha256:f3c7645c0ff1d7552b79927023cf540f82b40263780644f75291ed0bb1965bee as cilium-envoy
 
 #
 # Hubble CLI

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:b91528771beda9e213e08c612
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:e7430b113e09ee4fe900949af1f8e296e485269e@sha256:39e10fd3d353db56b5b719e0176cb74d64c1dda82211a252494650e2f013c253 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:400622c4a6a19aacfaab2f08a6bb7a515878b768@sha256:b6d6ed494e7aa772000f77be53c66cff413b439e348c949065e72faec1f03791 as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
Envoy 1.17.1 build with Security fixes CVEs that were released on 4/15/2021.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy is updated with security fixes for Envoy CVEs released on 4/15/2021
```
