### PR TITLE
v1.9 backports 2021-04-15

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1367,8 +1367,7 @@ func (d *Daemon) initKVStore() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice:        option.Config.HostDevice,
-		EncryptInterfaces: option.Config.EncryptInterface,
+		HostDevice: option.Config.HostDevice,
 	}
 
 	log.Info("Initializing daemon")

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/loader"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -27,8 +26,6 @@ import (
 type DatapathConfiguration struct {
 	// HostDevice is the name of the device to be used to access the host.
 	HostDevice string
-	// EncryptInterfaces is the list of devices used for direct ruoting encryption
-	EncryptInterfaces []string
 }
 
 type linuxDatapath struct {
@@ -51,13 +48,6 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 	}
 
 	dp.node = NewNodeHandler(cfg, dp.nodeAddressing)
-
-	for _, iface := range cfg.EncryptInterfaces {
-		if err := connector.DisableRpFilter(iface); err != nil {
-			log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
-		}
-	}
-
 	return dp
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1094,7 +1094,7 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 	var device string
 
 	if option.Config.Tunnel == option.TunnelDisabled {
-		device = n.datapathConfig.EncryptInterfaces[0]
+		device = option.Config.EncryptInterface[0]
 	} else {
 		device = linux_defaults.TunnelDeviceName
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -212,7 +212,8 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		if len(option.Config.IPv4PodSubnets) == 0 {
 			if info := node.GetRouterInfo(); info != nil {
 				for _, c := range info.GetIPv4CIDRs() {
-					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &c)
+					cidr := c // create a copy to be able to take a reference
+					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &cidr)
 				}
 			}
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/ethtool"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -203,6 +204,7 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 					}
 				}
 			}
+			option.Config.EncryptInterface = interfaces
 		}
 
 		// For the ENI ipam mode on EKS, this will be the interface that
@@ -218,6 +220,12 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 
 	// No interfaces is valid in tunnel disabled case
 	if len(interfaces) != 0 {
+		for _, iface := range interfaces {
+			if err := connector.DisableRpFilter(iface); err != nil {
+				log.WithError(err).WithField(logfields.Interface, iface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
+			}
+		}
+
 		if err := l.replaceNetworkDatapath(ctx, interfaces); err != nil {
 			return fmt.Errorf("failed to load encryption program: %w", err)
 		}


### PR DESCRIPTION
* #15669 -- cilium: Fix EKS encryption panic and reinit path and add workflows test (@jrfastab)
 * #15645 -- ipsec: Fix routing CIDR iteration on EKS (@gandro)

Backport notes: Cherry picked encryption fixes out for backport, small conflicts were resolved and dropped .github/workflow updates because we don't have workflow based testing in 1.9 yet.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15669 15645; do contrib/backporting/set-labels.py $pr done 1.9; done
```