### PR TITLE
.github: fix kind GH action for encryption e2e tests

### DIFF
--- a/.github/workflows/kind-1.19.yaml
+++ b/.github/workflows/kind-1.19.yaml
@@ -83,7 +83,12 @@ jobs:
 
       - name: Install Cilium with Encryption
         run: |
-          cilium install --encryption
+          cilium install \
+            --encryption \
+            --config monitor-aggregation=none \
+            --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --version=${{ steps.vars.outputs.tag }}
 
       - name: Status
         run: |


### PR DESCRIPTION
The cilium install command is missing some arguments that would allow it
to install the right Cilium image version.

Fixes: f35430d6c900 ("CI 3.0: A New Hope")
Signed-off-by: André Martins <andre@cilium.io>