### PR TITLE
option: auto enable K8sRequireIPv4PodCIDR in hostscope-legacy mode

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2631,7 +2631,7 @@ func (c *DaemonConfig) Populate() {
 	}
 
 	switch c.IPAM {
-	case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool:
+	case ipamOption.IPAMHostScopeLegacy, ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool:
 		if c.EnableIPv4 {
 			c.K8sRequireIPv4PodCIDR = true
 		}


### PR DESCRIPTION
Fix: #15345

With `hostscope-legacy` mode IPAM and a flapping k8s apiserver, there are
possibilities that the PodCIDR the node is using will be overridden by an
auto-generated one from cilium-agent, resulting in interrupted pod traffic.
Refer to #15345 for more details.

This patch fixed the problem by auto enabling `K8sRequireIPv4PodCIDR` in
this mode, just like what we do in `kubernetes` mode and `cluster-pool` mode.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>