### PR TITLE
bpf: Adds support for drop IPv4 fragmented packet

### DIFF
--- a/Documentation/concepts/networking/fragmentation.rst
+++ b/Documentation/concepts/networking/fragmentation.rst
@@ -16,7 +16,7 @@ implemented in eBPF using an LRU (*Least Recently Used*) map which requires
 Linux 4.10 or later. This feature may be configured using the following
 options:
 
-- ``--enable-ipv4-fragments-tracking``: Enable or disable IPv4 fragment
+- ``--enable-ipv4-fragment-tracking``: Enable or disable IPv4 fragment
   tracking. Enabled by default.
 - ``--bpf-fragments-map-max``: Control the maximum number of active concurrent
   connections using IP fragmentation. For the defaults, see `bpf_map_limitations`.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -459,6 +459,15 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
+/* If IPv4 fragmentation is disabled
+ * AND a IPv4 fragmented packet is received,
+ * then drop the packet.
+ */
+#ifndef ENABLE_IPV4_FRAGMENTS
+	if (ipv4_is_fragment(ip4))
+		return DROP_FRAG_NOSUPPORT;
+#endif
+
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
 		if (ctx_get_xfer(ctx) != XFER_PKT_NO_SVC &&

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -537,6 +537,16 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+
+/* If IPv4 fragmentation is disabled
+ * AND a IPv4 fragmented packet is received,
+ * then drop the packet.
+ */
+#ifndef ENABLE_IPV4_FRAGMENTS
+	if (ipv4_is_fragment(ip4))
+		return DROP_FRAG_NOSUPPORT;
+#endif
+
 	has_l4_header = ipv4_has_l4_header(ip4);
 
 	tuple.nexthdr = ip4->protocol;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -172,6 +172,16 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 	/* verifier workaround (dereference of modified ctx ptr) */
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+
+/* If IPv4 fragmentation is disabled
+ * AND a IPv4 fragmented packet is received,
+ * then drop the packet.
+ */
+#ifndef ENABLE_IPV4_FRAGMENTS
+	if (ipv4_is_fragment(ip4))
+		return DROP_FRAG_NOSUPPORT;
+#endif
+
 #ifdef ENABLE_NODEPORT
 	if (!bpf_skip_nodeport(ctx)) {
 		int ret = nodeport_lb4(ctx, *identity);


### PR DESCRIPTION
If IPv4 fragmentation is disabled and a IPv4 fragmented packet is received,
then the packet is dropped (`DROP_FRAG_NOSUPPORT`).

Due to this return error, the metrics `cilium_drop_{count,bytes}_total`
are updated.

Besides, fixes IPv4 fragment tracking option in [documentation](https://docs.cilium.io/en/v1.9/concepts/networking/fragmentation/#concepts-fragmentation).

Fixes: #9894

Signed-off-by: Thiago Navarro navarro@accuknox.com
