### PR TITLE
envoy: Update to release 1.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:e7430b113e09ee4fe900949af1f8e296e485269e@sha256:39e10fd3d353db56b5b719e0176cb74d64c1dda82211a252494650e2f013c253 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:b3bb275dcaf4a74ae956e52fa408b196c0d52152@sha256:f3c7645c0ff1d7552b79927023cf540f82b40263780644f75291ed0bb1965bee as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 


### PR DESCRIPTION
Update Envoy image to release 1.17.2, including the latest security fixes.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy is updated to release 1.17.2
```
