### PR TITLE
test: Format test-only's kernel_version to avoid mistakes

### DIFF
--- a/test/get-gh-comment-info.py
+++ b/test/get-gh-comment-info.py
@@ -9,4 +9,9 @@ parser.add_argument('--retrieve', type=str, default="focus")
 
 args = parser.parse_args()
 
+# Update kernel_version to expected format
+args.kernel_version = args.kernel_version.replace('.', '')
+if args.kernel_version == "netnext":
+	args.kernel_version = "net-next"
+
 print(args.__dict__[args.retrieve])


### PR DESCRIPTION
I often try to start test-only builds with e.g.:

    test-only --kernel_version=4.19 --focus="..."

That fails because our tests expect "419". We can extend the Python script used to parse argument to recognize that and update
kernel_version to the expected format.