### PR TITLE
workflows: fix EKS encryption testing not using aws operator image

### DIFF
--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -136,7 +136,7 @@ jobs:
             --wait=false \
             --config monitor-aggregation=none \
             --agent-image=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --operator-image=quay.io/${{ github.repository_owner }}/operator-generic-ci \
+            --operator-image=quay.io/${{ github.repository_owner }}/operator-aws-ci \
             --version ${{ steps.vars.outputs.sha }}
 
       - name: Enable Relay


### PR DESCRIPTION
We missed this when merging #15669. Woops :D