### PR TITLE
test: ensure kubectl version is available for test run

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -49,6 +49,7 @@ type CiliumTestConfigType struct {
 	ProvisionK8s         bool
 	Timeout              time.Duration
 	Kubeconfig           string
+	KubectlPath          string
 	RegistryCredentials  string
 	Benchmarks           bool
 	// Multinode enables the running of tests that involve more than one
@@ -99,6 +100,8 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies timeout for test run")
 	flagset.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",
 		"Kubeconfig to be used for k8s tests")
+	flagset.StringVar(&c.KubectlPath, "cilium.kubectl-path", "/tmp/kubectl",
+		"Path that holds version-specific kubectl binaries")
 	flagset.StringVar(&c.RegistryCredentials, "cilium.registryCredentials", "",
 		"Registry credentials to be used to download images")
 	flagset.BoolVar(&c.Benchmarks, "cilium.benchmarks", false,


### PR DESCRIPTION
This change makes K8s ginkgo test suite download kubectl version
compatible with current cluster version if it's not available.