### PR TITLE
jenkinsfiles: increase and standardize VM CPUs and memory

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -7,8 +7,8 @@ pipeline {
 
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
-        VM_MEMORY = "8192"
-        VM_CPUS = "3"
+        VM_MEMORY = "15360"
+        VM_CPUS = "4"
         GOPATH="${WORKSPACE}"
         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
         GINKGO_TIMEOUT="170m"

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
-        VM_MEMORY = "8192"
+        VM_MEMORY = "15360"
         VM_CPUS = "4"
         GINKGO_TIMEOUT="150m"
         DEFAULT_KERNEL="""${sh(

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -8,7 +8,8 @@ pipeline {
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-        VM_MEMORY = "5120"
+        VM_MEMORY = "15360"
+        VM_CPUS = "4"
         K8S_VERSION="1.21"
         KERNEL="419"
         SERVER_BOX = "cilium/ubuntu-4-19"


### PR DESCRIPTION
Our Equinix Metal machines for running Jenkins jobs all have:
- 4 cores (8 threads)
- 32GB memory

We only ever have a maximum of 2 VMs per machine: let's make use of all resources that we pay for.

Using more resources should also help fix OOM issues when running jobs with race detector enabled.