### PR TITLE
v1.8 backports 2021-04-16

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -45,6 +45,7 @@ type CiliumTestConfigType struct {
 	ProvisionK8s        bool
 	Timeout             time.Duration
 	Kubeconfig          string
+	KubectlPath         string
 	Registry            string
 	RegistryCredentials string
 	Benchmarks          bool
@@ -89,6 +90,8 @@ func (c *CiliumTestConfigType) ParseFlags() {
 	flagset.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",
 		"Kubeconfig to be used for k8s tests")
 	flagset.StringVar(&c.Registry, "cilium.registry", "", "docker registry hostname for Cilium image")
+	flagset.StringVar(&c.KubectlPath, "cilium.kubectl-path", "/tmp/kubectl",
+		"Path that holds version-specific kubectl binaries")
 	flagset.StringVar(&c.RegistryCredentials, "cilium.registryCredentials", "",
 		"Registry credentials to be used to download images")
 	flagset.BoolVar(&c.Benchmarks, "cilium.benchmarks", false,

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -260,6 +261,19 @@ func Init() {
 // GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment.
 func GetCurrentK8SEnv() string { return os.Getenv("K8S_VERSION") }
 
+func GetExpectedKubectlVersion() string {
+	targetVer := GetCurrentK8SEnv()
+	//this is caused by no json output in kubectl 1.11
+	if targetVer == "1.11" {
+		targetVer = "1.12"
+	}
+	return targetVer
+}
+
+func GetKubectlPath() string {
+	return path.Join(config.CiliumTestConfig.KubectlPath, GetExpectedKubectlVersion())
+}
+
 // GetCurrentIntegration returns CI integration set up to run against Cilium.
 func GetCurrentIntegration() string {
 	integration := strings.ToLower(os.Getenv("CNI_INTEGRATION"))
@@ -327,6 +341,7 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 			environ = append(environ, os.Environ()...)
 		}
 		environ = append(environ, "KUBECONFIG="+config.CiliumTestConfig.Kubeconfig)
+		environ = append(environ, fmt.Sprintf("PATH=%s:%s", GetKubectlPath(), os.Getenv("PATH")))
 
 		// Create the executor
 		exec := CreateLocalExecutor(environ)
@@ -336,6 +351,9 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 			Executor: exec,
 		}
 		k.setBasePath()
+		if err := k.ensureKubectlVersion(); err != nil {
+			ginkgoext.Failf("failed to ensure kubectl version: %s", err.Error())
+		}
 	}
 
 	// config flags are already parsed here
@@ -4296,4 +4314,44 @@ func hasIPAddress(output []string) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+func (kub *Kubectl) ensureKubectlVersion() error {
+	//check current kubectl version
+	type Version struct {
+		ClientVersion struct {
+			Major string `json:"major"`
+			Minor string `json:"minor"`
+		} `json:"clientVersion"`
+	}
+	res := kub.ExecShort(fmt.Sprintf("%s version --client -o json", KubectlCmd))
+	if !res.WasSuccessful() {
+		return fmt.Errorf("failed to run kubectl version")
+	}
+
+	var v Version
+
+	err := json.Unmarshal([]byte(res.GetStdOut().String()), &v)
+	if err != nil {
+		return err
+	}
+
+	versionstring := fmt.Sprintf("%s.%s", v.ClientVersion.Major, v.ClientVersion.Minor)
+	if versionstring == GetExpectedKubectlVersion() {
+		//version available on host is matching current env
+		return nil
+	}
+
+	err = os.MkdirAll(GetKubectlPath(), os.ModePerm)
+	if err != nil {
+		return err
+	}
+	path := path.Join(GetKubectlPath(), "kubectl")
+	res = kub.Exec(
+		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/v%s.0/bin/linux/amd64/kubectl && chmod +x %s",
+			path, GetExpectedKubectlVersion(), path))
+	if !res.WasSuccessful() {
+		return fmt.Errorf("failed to download kubectl")
+	}
+	return nil
 }


### PR DESCRIPTION
* #15748 -- test: ensure kubectl version is available for test run (@nebril)
  * Resolved conflicts (see commit message)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15748; do contrib/backporting/set-labels.py $pr done 1.8; done
```