### PR TITLE
pkg/k8s: ignore certain ipcache errors

### DIFF
--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ipcache/errors.go
+++ b/pkg/ipcache/errors.go
@@ -1,0 +1,73 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/source"
+)
+
+// ErrOverwrite represents an overwrite error where functions return the error
+// to indicate the new source can't overwrite existing source.
+type ErrOverwrite struct {
+	ExistingSrc source.Source
+	NewSrc      source.Source
+}
+
+// NewErrOverwrite returns a new ErrOverwrite.
+func NewErrOverwrite(existing, new source.Source) *ErrOverwrite {
+	return &ErrOverwrite{
+		ExistingSrc: existing,
+		NewSrc:      new,
+	}
+}
+
+func (e ErrOverwrite) Error() string {
+	return fmt.Sprintf("unable to overwrite source %q with source %q", e.ExistingSrc, e.NewSrc)
+}
+
+func (e *ErrOverwrite) Is(target error) bool {
+	t, ok := target.(*ErrOverwrite)
+	if !ok {
+		return false
+	}
+	return (e.ExistingSrc == t.ExistingSrc || t.ExistingSrc == "") &&
+		(e.NewSrc == t.NewSrc || t.NewSrc == "")
+}
+
+// ErrInvalidIP represents an error of an invalid IP.
+type ErrInvalidIP struct {
+	ip string
+}
+
+// NewErrInvalidIP returns a new ErrInvalidIP.
+func NewErrInvalidIP(ip string) *ErrInvalidIP {
+	return &ErrInvalidIP{
+		ip: ip,
+	}
+}
+
+func (e ErrInvalidIP) Error() string {
+	return fmt.Sprintf("attempt to upsert invalid IP %q into ipcache layer", e.ip)
+}
+
+func (e *ErrInvalidIP) Is(target error) bool {
+	t, ok := target.(*ErrInvalidIP)
+	if !ok {
+		return false
+	}
+	return e.ip == t.ip
+}

--- a/pkg/ipcache/fake/ipcache.go
+++ b/pkg/ipcache/fake/ipcache.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,9 +45,9 @@ func NewIPCache(events bool) *IPCache {
 	}
 }
 
-func (i *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, bool) {
+func (i *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
 	i.Events <- NodeEvent{EventUpsert, net.ParseIP(ip)}
-	return true, false
+	return false, nil
 }
 
 func (i *IPCache) Delete(IP string, source source.Source) bool {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -17,6 +17,7 @@
 package ipcache
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -70,7 +71,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 		ID:     identity,
 		Source: source.Kubernetes,
 	})
-	c.Assert(err, Not(IsNil))
+	c.Assert(errors.Is(err, &ErrOverwrite{NewSrc: source.Kubernetes}), Equals, true)
 
 	IPIdentityCache.Upsert(endpointIP, nil, 0, nil, Identity{
 		ID:     identity,

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,11 +66,11 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(cachedIdentity.Source, Equals, source.KVStore)
 
 	// kubernetes source cannot update kvstore source
-	updated, _ := IPIdentityCache.Upsert(endpointIP, nil, 0, nil, Identity{
+	_, err := IPIdentityCache.Upsert(endpointIP, nil, 0, nil, Identity{
 		ID:     identity,
 		Source: source.Kubernetes,
 	})
-	c.Assert(updated, Equals, false)
+	c.Assert(err, Not(IsNil))
 
 	IPIdentityCache.Upsert(endpointIP, nil, 0, nil, Identity{
 		ID:     identity,
@@ -278,11 +278,11 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 		},
 	}
 
-	updated, namedPortsChanged := IPIdentityCache.Upsert(endpointIP, nil, 0, &meta, Identity{
+	namedPortsChanged, err := IPIdentityCache.Upsert(endpointIP, nil, 0, &meta, Identity{
 		ID:     identity,
 		Source: source.Kubernetes,
 	})
-	c.Assert(updated, Equals, true)
+	c.Assert(err, IsNil)
 
 	// Assure both caches are updated..
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
@@ -327,11 +327,11 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 		},
 	}
 
-	updated, namedPortsChanged = IPIdentityCache.Upsert(endpointIP2, nil, 0, &meta2, Identity{
+	namedPortsChanged, err = IPIdentityCache.Upsert(endpointIP2, nil, 0, &meta2, Identity{
 		ID:     identity2,
 		Source: source.Kubernetes,
 	})
-	c.Assert(updated, Equals, true)
+	c.Assert(err, IsNil)
 
 	// Assure both caches are updated..
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 2)
@@ -377,11 +377,11 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 		PodName:   "podname",
 	}
 
-	updated, namedPortsChanged = IPIdentityCache.Upsert(endpointIP, hostIP, 0, k8sMeta, Identity{
+	namedPortsChanged, err = IPIdentityCache.Upsert(endpointIP, hostIP, 0, k8sMeta, Identity{
 		ID:     identity,
 		Source: source.KVStore,
 	})
-	c.Assert(updated, Equals, true)
+	c.Assert(err, IsNil)
 	c.Assert(namedPortsChanged, Equals, false)
 
 	// Assure upsert occurs across all mappings.
@@ -395,11 +395,11 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	c.Assert(IPIdentityCache.GetK8sMetadata(endpointIP), checker.DeepEquals, k8sMeta)
 
 	newIdentity := identityPkg.NumericIdentity(69)
-	updated, namedPortsChanged = IPIdentityCache.Upsert(endpointIP, hostIP, 0, k8sMeta, Identity{
+	namedPortsChanged, err = IPIdentityCache.Upsert(endpointIP, hostIP, 0, k8sMeta, Identity{
 		ID:     newIdentity,
 		Source: source.KVStore,
 	})
-	c.Assert(updated, Equals, true)
+	c.Assert(err, IsNil)
 	c.Assert(namedPortsChanged, Equals, false)
 
 	// Assure upsert occurs across all mappings.
@@ -438,11 +438,11 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 
 	for index := range endpointIPs {
 		k8sMeta.PodName = fmt.Sprintf("pod-%d", int(identities[index]))
-		updated, namedPortsChanged = IPIdentityCache.Upsert(endpointIPs[index], nil, 0, k8sMeta, Identity{
+		namedPortsChanged, err = IPIdentityCache.Upsert(endpointIPs[index], nil, 0, k8sMeta, Identity{
 			ID:     identities[index],
 			Source: source.KVStore,
 		})
-		c.Assert(updated, Equals, true)
+		c.Assert(err, IsNil)
 		npm = IPIdentityCache.GetNamedPorts()
 		c.Assert(npm, NotNil)
 		c.Assert(npm["http2"], checker.HasKey, policy.PortProto{Port: uint16(8080), Proto: uint8(6)})

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -194,7 +194,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV4)
-			_, portsChanged := ipcache.IPIdentityCache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
+				portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource})
 			if portsChanged {
 				namedPortsChanged = true
@@ -203,7 +203,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 
 		if pair.IPV6 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV6)
-			_, portsChanged := ipcache.IPIdentityCache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
+				portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource})
 			if portsChanged {
 				namedPortsChanged = true

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -194,7 +194,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV4)
-				portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
+			portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource})
 			if portsChanged {
 				namedPortsChanged = true
@@ -203,7 +203,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 
 		if pair.IPV6 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV6)
-				portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
+			portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource})
 			if portsChanged {
 				namedPortsChanged = true

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -747,15 +747,15 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 		// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
 		// later updated once the allocator has determined the real identity.
 		// If the endpoint remains unmanaged, the identity remains untouched.
-		selfOwned, npc := ipcache.IPIdentityCache.Upsert(podIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
+		npc, err := ipcache.IPIdentityCache.Upsert(podIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
 			ID:     identity.ReservedIdentityUnmanaged,
 			Source: source.Kubernetes,
 		})
 		if npc {
 			namedPortsChanged = true
 		}
-		if !selfOwned {
-			errs = append(errs, fmt.Sprintf("ipcache entry for podIP %s owned by kvstore or agent", podIP))
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("ipcache entry for podIP %s owned by kvstore or agent: %s", podIP, err))
 		}
 	}
 	if len(errs) != 0 {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -63,7 +63,7 @@ type nodeEntry struct {
 
 // IPCache is the set of interactions the node manager performs with the ipcache
 type IPCache interface {
-	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, bool)
+	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
 }
 
@@ -393,7 +393,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		}
 
 		ipAddrStr := address.IP.String()
-		isOwning, _ := m.ipcache.Upsert(ipAddrStr, tunnelIP, key, nil, ipcache.Identity{
+		_, err := m.ipcache.Upsert(ipAddrStr, tunnelIP, key, nil, ipcache.Identity{
 			ID:     remoteHostIdentity,
 			Source: n.Source,
 		})
@@ -402,7 +402,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// the source of the node update that triggered this node
 		// update (kvstore, k8s, ...) The datapath is only updated if
 		// that source of truth is updated.
-		if !isOwning {
+		if err != nil {
 			dpUpdate = false
 		} else {
 			ipsAdded = append(ipsAdded, ipAddrStr)
@@ -414,11 +414,11 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			continue
 		}
 		addrStr := address.String()
-		isOwning, _ := m.ipcache.Upsert(addrStr, nodeIP, n.EncryptionKey, nil, ipcache.Identity{
+		_, err := m.ipcache.Upsert(addrStr, nodeIP, n.EncryptionKey, nil, ipcache.Identity{
 			ID:     identity.ReservedIdentityHealth,
 			Source: n.Source,
 		})
-		if !isOwning {
+		if err != nil {
 			dpUpdate = false
 		} else {
 			healthIPsAdded = append(healthIPsAdded, addrStr)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -77,9 +77,9 @@ func newIPcacheMock() *ipcacheMock {
 	}
 }
 
-func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, bool) {
+func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
 	i.events <- nodeEvent{"upsert", net.ParseIP(ip)}
-	return true, false
+	return false, nil
 }
 
 func (i *ipcacheMock) Delete(IP string, source source.Source) bool {


### PR DESCRIPTION
Certain errors can be ignored when upserting IP addresses into the
ipcache. Thus, there is need to populate the logs with some red herring
warnings.

When upserting an IP address into ipcache, there are certain errors that
should be returned by this function. This allows the callers to decide
if they can or can't ignore the return errors. Also, since the 'updated'
was always false in case of an error condition, the callers of upsert
will use the return value of 'err' to determine if an IP address was
updated or not.

Fixes https://github.com/cilium/cilium/issues/14918
Fixes https://github.com/cilium/cilium/issues/15088

```release-note
Decrease verbosity of error "Unable to update ipcache map entry on pod add" for certain conditions
```