### PR TITLE
issue_14922: Fixed the 429 response code handling

### DIFF
--- a/api/v1/client/endpoint/delete_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/delete_endpoint_id_responses.go
@@ -50,6 +50,12 @@ func (o *DeleteEndpointIDReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewDeleteEndpointIDTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -158,6 +164,27 @@ func (o *DeleteEndpointIDNotFound) Error() string {
 }
 
 func (o *DeleteEndpointIDNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeleteEndpointIDTooManyRequests creates a DeleteEndpointIDTooManyRequests with default headers values
+func NewDeleteEndpointIDTooManyRequests() *DeleteEndpointIDTooManyRequests {
+	return &DeleteEndpointIDTooManyRequests{}
+}
+
+/*DeleteEndpointIDTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type DeleteEndpointIDTooManyRequests struct {
+}
+
+func (o *DeleteEndpointIDTooManyRequests) Error() string {
+	return fmt.Sprintf("[DELETE /endpoint/{id}][%d] deleteEndpointIdTooManyRequests ", 429)
+}
+
+func (o *DeleteEndpointIDTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/get_endpoint_id_config_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_config_responses.go
@@ -38,6 +38,12 @@ func (o *GetEndpointIDConfigReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewGetEndpointIDConfigTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -94,6 +100,27 @@ func (o *GetEndpointIDConfigNotFound) Error() string {
 }
 
 func (o *GetEndpointIDConfigNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewGetEndpointIDConfigTooManyRequests creates a GetEndpointIDConfigTooManyRequests with default headers values
+func NewGetEndpointIDConfigTooManyRequests() *GetEndpointIDConfigTooManyRequests {
+	return &GetEndpointIDConfigTooManyRequests{}
+}
+
+/*GetEndpointIDConfigTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type GetEndpointIDConfigTooManyRequests struct {
+}
+
+func (o *GetEndpointIDConfigTooManyRequests) Error() string {
+	return fmt.Sprintf("[GET /endpoint/{id}/config][%d] getEndpointIdConfigTooManyRequests ", 429)
+}
+
+func (o *GetEndpointIDConfigTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/get_endpoint_id_healthz_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_healthz_responses.go
@@ -44,6 +44,12 @@ func (o *GetEndpointIDHealthzReader) ReadResponse(response runtime.ClientRespons
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewGetEndpointIDHealthzTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -121,6 +127,27 @@ func (o *GetEndpointIDHealthzNotFound) Error() string {
 }
 
 func (o *GetEndpointIDHealthzNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewGetEndpointIDHealthzTooManyRequests creates a GetEndpointIDHealthzTooManyRequests with default headers values
+func NewGetEndpointIDHealthzTooManyRequests() *GetEndpointIDHealthzTooManyRequests {
+	return &GetEndpointIDHealthzTooManyRequests{}
+}
+
+/*GetEndpointIDHealthzTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type GetEndpointIDHealthzTooManyRequests struct {
+}
+
+func (o *GetEndpointIDHealthzTooManyRequests) Error() string {
+	return fmt.Sprintf("[GET /endpoint/{id}/healthz][%d] getEndpointIdHealthzTooManyRequests ", 429)
+}
+
+func (o *GetEndpointIDHealthzTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/get_endpoint_id_labels_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_labels_responses.go
@@ -38,6 +38,12 @@ func (o *GetEndpointIDLabelsReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewGetEndpointIDLabelsTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -94,6 +100,27 @@ func (o *GetEndpointIDLabelsNotFound) Error() string {
 }
 
 func (o *GetEndpointIDLabelsNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewGetEndpointIDLabelsTooManyRequests creates a GetEndpointIDLabelsTooManyRequests with default headers values
+func NewGetEndpointIDLabelsTooManyRequests() *GetEndpointIDLabelsTooManyRequests {
+	return &GetEndpointIDLabelsTooManyRequests{}
+}
+
+/*GetEndpointIDLabelsTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type GetEndpointIDLabelsTooManyRequests struct {
+}
+
+func (o *GetEndpointIDLabelsTooManyRequests) Error() string {
+	return fmt.Sprintf("[GET /endpoint/{id}/labels][%d] getEndpointIdLabelsTooManyRequests ", 429)
+}
+
+func (o *GetEndpointIDLabelsTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/get_endpoint_id_log_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_log_responses.go
@@ -44,6 +44,12 @@ func (o *GetEndpointIDLogReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewGetEndpointIDLogTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -119,6 +125,27 @@ func (o *GetEndpointIDLogNotFound) Error() string {
 }
 
 func (o *GetEndpointIDLogNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewGetEndpointIDLogTooManyRequests creates a GetEndpointIDLogTooManyRequests with default headers values
+func NewGetEndpointIDLogTooManyRequests() *GetEndpointIDLogTooManyRequests {
+	return &GetEndpointIDLogTooManyRequests{}
+}
+
+/*GetEndpointIDLogTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type GetEndpointIDLogTooManyRequests struct {
+}
+
+func (o *GetEndpointIDLogTooManyRequests) Error() string {
+	return fmt.Sprintf("[GET /endpoint/{id}/log][%d] getEndpointIdLogTooManyRequests ", 429)
+}
+
+func (o *GetEndpointIDLogTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/get_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_id_responses.go
@@ -44,6 +44,12 @@ func (o *GetEndpointIDReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewGetEndpointIDTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -131,6 +137,27 @@ func (o *GetEndpointIDNotFound) Error() string {
 }
 
 func (o *GetEndpointIDNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewGetEndpointIDTooManyRequests creates a GetEndpointIDTooManyRequests with default headers values
+func NewGetEndpointIDTooManyRequests() *GetEndpointIDTooManyRequests {
+	return &GetEndpointIDTooManyRequests{}
+}
+
+/*GetEndpointIDTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type GetEndpointIDTooManyRequests struct {
+}
+
+func (o *GetEndpointIDTooManyRequests) Error() string {
+	return fmt.Sprintf("[GET /endpoint/{id}][%d] getEndpointIdTooManyRequests ", 429)
+}
+
+func (o *GetEndpointIDTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/get_endpoint_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_responses.go
@@ -38,6 +38,12 @@ func (o *GetEndpointReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewGetEndpointTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -92,6 +98,27 @@ func (o *GetEndpointNotFound) Error() string {
 }
 
 func (o *GetEndpointNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewGetEndpointTooManyRequests creates a GetEndpointTooManyRequests with default headers values
+func NewGetEndpointTooManyRequests() *GetEndpointTooManyRequests {
+	return &GetEndpointTooManyRequests{}
+}
+
+/*GetEndpointTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type GetEndpointTooManyRequests struct {
+}
+
+func (o *GetEndpointTooManyRequests) Error() string {
+	return fmt.Sprintf("[GET /endpoint][%d] getEndpointTooManyRequests ", 429)
+}
+
+func (o *GetEndpointTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/patch_endpoint_id_config_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_config_responses.go
@@ -44,6 +44,12 @@ func (o *PatchEndpointIDConfigReader) ReadResponse(response runtime.ClientRespon
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewPatchEndpointIDConfigTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewPatchEndpointIDConfigFailed()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -115,6 +121,27 @@ func (o *PatchEndpointIDConfigNotFound) Error() string {
 }
 
 func (o *PatchEndpointIDConfigNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewPatchEndpointIDConfigTooManyRequests creates a PatchEndpointIDConfigTooManyRequests with default headers values
+func NewPatchEndpointIDConfigTooManyRequests() *PatchEndpointIDConfigTooManyRequests {
+	return &PatchEndpointIDConfigTooManyRequests{}
+}
+
+/*PatchEndpointIDConfigTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type PatchEndpointIDConfigTooManyRequests struct {
+}
+
+func (o *PatchEndpointIDConfigTooManyRequests) Error() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}/config][%d] patchEndpointIdConfigTooManyRequests ", 429)
+}
+
+func (o *PatchEndpointIDConfigTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/patch_endpoint_id_labels_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_labels_responses.go
@@ -38,6 +38,12 @@ func (o *PatchEndpointIDLabelsReader) ReadResponse(response runtime.ClientRespon
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewPatchEndpointIDLabelsTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewPatchEndpointIDLabelsUpdateFailed()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -88,6 +94,27 @@ func (o *PatchEndpointIDLabelsNotFound) Error() string {
 }
 
 func (o *PatchEndpointIDLabelsNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewPatchEndpointIDLabelsTooManyRequests creates a PatchEndpointIDLabelsTooManyRequests with default headers values
+func NewPatchEndpointIDLabelsTooManyRequests() *PatchEndpointIDLabelsTooManyRequests {
+	return &PatchEndpointIDLabelsTooManyRequests{}
+}
+
+/*PatchEndpointIDLabelsTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type PatchEndpointIDLabelsTooManyRequests struct {
+}
+
+func (o *PatchEndpointIDLabelsTooManyRequests) Error() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}/labels][%d] patchEndpointIdLabelsTooManyRequests ", 429)
+}
+
+func (o *PatchEndpointIDLabelsTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/patch_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_responses.go
@@ -44,6 +44,12 @@ func (o *PatchEndpointIDReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewPatchEndpointIDTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewPatchEndpointIDFailed()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -125,6 +131,27 @@ func (o *PatchEndpointIDNotFound) Error() string {
 }
 
 func (o *PatchEndpointIDNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewPatchEndpointIDTooManyRequests creates a PatchEndpointIDTooManyRequests with default headers values
+func NewPatchEndpointIDTooManyRequests() *PatchEndpointIDTooManyRequests {
+	return &PatchEndpointIDTooManyRequests{}
+}
+
+/*PatchEndpointIDTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type PatchEndpointIDTooManyRequests struct {
+}
+
+func (o *PatchEndpointIDTooManyRequests) Error() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}][%d] patchEndpointIdTooManyRequests ", 429)
+}
+
+func (o *PatchEndpointIDTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/put_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/put_endpoint_id_responses.go
@@ -44,6 +44,12 @@ func (o *PutEndpointIDReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewPutEndpointIDTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewPutEndpointIDFailed()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -125,6 +131,27 @@ func (o *PutEndpointIDExists) Error() string {
 }
 
 func (o *PutEndpointIDExists) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewPutEndpointIDTooManyRequests creates a PutEndpointIDTooManyRequests with default headers values
+func NewPutEndpointIDTooManyRequests() *PutEndpointIDTooManyRequests {
+	return &PutEndpointIDTooManyRequests{}
+}
+
+/*PutEndpointIDTooManyRequests handles this case with default header values.
+
+Rate-limiting too many requests in the given time frame
+*/
+type PutEndpointIDTooManyRequests struct {
+}
+
+func (o *PutEndpointIDTooManyRequests) Error() string {
+	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdTooManyRequests ", 429)
+}
+
+func (o *PutEndpointIDTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -111,6 +111,8 @@ paths:
             "$ref": "#/definitions/Error"
         '404':
           description: Endpoint not found
+        '429':
+          description: Rate-limiting too many requests in the given time frame
     put:
       summary: Create endpoint
       description: |
@@ -136,6 +138,8 @@ paths:
           x-go-name: Failed
           schema:
             "$ref": "#/definitions/Error"
+        '429':
+          description: Rate-limiting too many requests in the given time frame
     patch:
       summary: Modify existing endpoint
       deprecated: true
@@ -161,6 +165,8 @@ paths:
           x-go-name: Failed
           schema:
             "$ref": "#/definitions/Error"
+        '429':
+          description: Rate-limiting too many requests in the given time frame
     delete:
       summary: Delete endpoint
       description: |
@@ -194,6 +200,8 @@ paths:
             "$ref": "#/definitions/Error"
         '404':
           description: Endpoint not found
+        '429':
+          description: Rate-limiting too many requests in the given time frame
   "/endpoint":
     get:
       summary: Retrieves a list of endpoints that have metadata matching the provided parameters.
@@ -212,6 +220,8 @@ paths:
               "$ref": "#/definitions/Endpoint"
         '404':
           description: Endpoints with provided parameters not found
+        '429':
+          description: Rate-limiting too many requests in the given time frame
   "/endpoint/{id}/config":
     get:
       summary: Retrieve endpoint configuration
@@ -228,6 +238,8 @@ paths:
             "$ref": "#/definitions/EndpointConfigurationStatus"
         '404':
           description: Endpoint not found
+        '429':
+          description: Rate-limiting too many requests in the given time frame
     patch:
       summary: Modify mutable endpoint configuration
       description: |
@@ -255,6 +267,8 @@ paths:
           x-go-name: Failed
           schema:
             "$ref": "#/definitions/Error"
+        '429':
+          description: Rate-limiting too many requests in the given time frame
   "/endpoint/{id}/labels":
     get:
       summary: Retrieves the list of labels associated with an endpoint.
@@ -269,6 +283,8 @@ paths:
             "$ref": "#/definitions/LabelConfiguration"
         '404':
           description: Endpoint not found
+        '429':
+          description: Rate-limiting too many requests in the given time frame
     patch:
       summary: Set label configuration of endpoint
       description: |
@@ -293,6 +309,8 @@ paths:
           x-go-name: UpdateFailed
           schema:
             "$ref": "#/definitions/Error"
+        '429':
+          description: Rate-limiting too many requests in the given time frame
   "/endpoint/{id}/log":
     get:
       summary: Retrieves the status logs associated with this endpoint.
@@ -310,6 +328,8 @@ paths:
           x-go-name: Invalid
         '404':
           description: Endpoint not found
+        '429':
+          description: Rate-limiting too many requests in the given time frame
 
   "/endpoint/{id}/healthz":
     get:
@@ -328,6 +348,8 @@ paths:
           x-go-name: Invalid
         '404':
           description: Endpoint not found
+        '429':
+          description: Rate-limiting too many requests in the given time frame
   "/identity":
     get:
       summary: Retrieves a list of identities that have metadata matching the provided parameters.

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -158,6 +158,9 @@ func init() {
           },
           "404": {
             "description": "Endpoints with provided parameters not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       }
@@ -190,6 +193,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -221,6 +227,9 @@ func init() {
           "409": {
             "description": "Endpoint already exists",
             "x-go-name": "Exists"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           },
           "500": {
             "description": "Endpoint creation failed",
@@ -262,6 +271,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -294,6 +306,9 @@ func init() {
           "404": {
             "description": "Endpoint does not exist"
           },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
+          },
           "500": {
             "description": "Endpoint update failed",
             "schema": {
@@ -325,6 +340,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -357,6 +375,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           },
           "500": {
             "description": "Update failed. Details in message.",
@@ -392,6 +413,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       }
@@ -416,6 +440,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -444,6 +471,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           },
           "500": {
             "description": "Error while updating labels",
@@ -479,6 +509,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       }
@@ -4179,6 +4212,9 @@ func init() {
           },
           "404": {
             "description": "Endpoints with provided parameters not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       }
@@ -4215,6 +4251,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -4255,6 +4294,9 @@ func init() {
           "409": {
             "description": "Endpoint already exists",
             "x-go-name": "Exists"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           },
           "500": {
             "description": "Endpoint creation failed",
@@ -4300,6 +4342,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -4341,6 +4386,9 @@ func init() {
           "404": {
             "description": "Endpoint does not exist"
           },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
+          },
           "500": {
             "description": "Endpoint update failed",
             "schema": {
@@ -4376,6 +4424,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -4412,6 +4463,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           },
           "500": {
             "description": "Update failed. Details in message.",
@@ -4451,6 +4505,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       }
@@ -4479,6 +4536,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       },
@@ -4511,6 +4571,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           },
           "500": {
             "description": "Error while updating labels",
@@ -4550,6 +4613,9 @@ func init() {
           },
           "404": {
             "description": "Endpoint not found"
+          },
+          "429": {
+            "description": "Rate-limiting too many requests in the given time frame"
           }
         }
       }

--- a/api/v1/server/restapi/endpoint/delete_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/delete_endpoint_id_responses.go
@@ -149,3 +149,27 @@ func (o *DeleteEndpointIDNotFound) WriteResponse(rw http.ResponseWriter, produce
 
 	rw.WriteHeader(404)
 }
+
+// DeleteEndpointIDTooManyRequestsCode is the HTTP code returned for type DeleteEndpointIDTooManyRequests
+const DeleteEndpointIDTooManyRequestsCode int = 429
+
+/*DeleteEndpointIDTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response deleteEndpointIdTooManyRequests
+*/
+type DeleteEndpointIDTooManyRequests struct {
+}
+
+// NewDeleteEndpointIDTooManyRequests creates DeleteEndpointIDTooManyRequests with default headers values
+func NewDeleteEndpointIDTooManyRequests() *DeleteEndpointIDTooManyRequests {
+
+	return &DeleteEndpointIDTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *DeleteEndpointIDTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_config_responses.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_config_responses.go
@@ -83,3 +83,27 @@ func (o *GetEndpointIDConfigNotFound) WriteResponse(rw http.ResponseWriter, prod
 
 	rw.WriteHeader(404)
 }
+
+// GetEndpointIDConfigTooManyRequestsCode is the HTTP code returned for type GetEndpointIDConfigTooManyRequests
+const GetEndpointIDConfigTooManyRequestsCode int = 429
+
+/*GetEndpointIDConfigTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response getEndpointIdConfigTooManyRequests
+*/
+type GetEndpointIDConfigTooManyRequests struct {
+}
+
+// NewGetEndpointIDConfigTooManyRequests creates GetEndpointIDConfigTooManyRequests with default headers values
+func NewGetEndpointIDConfigTooManyRequests() *GetEndpointIDConfigTooManyRequests {
+
+	return &GetEndpointIDConfigTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *GetEndpointIDConfigTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_healthz_responses.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_healthz_responses.go
@@ -107,3 +107,27 @@ func (o *GetEndpointIDHealthzNotFound) WriteResponse(rw http.ResponseWriter, pro
 
 	rw.WriteHeader(404)
 }
+
+// GetEndpointIDHealthzTooManyRequestsCode is the HTTP code returned for type GetEndpointIDHealthzTooManyRequests
+const GetEndpointIDHealthzTooManyRequestsCode int = 429
+
+/*GetEndpointIDHealthzTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response getEndpointIdHealthzTooManyRequests
+*/
+type GetEndpointIDHealthzTooManyRequests struct {
+}
+
+// NewGetEndpointIDHealthzTooManyRequests creates GetEndpointIDHealthzTooManyRequests with default headers values
+func NewGetEndpointIDHealthzTooManyRequests() *GetEndpointIDHealthzTooManyRequests {
+
+	return &GetEndpointIDHealthzTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *GetEndpointIDHealthzTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_labels_responses.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_labels_responses.go
@@ -83,3 +83,27 @@ func (o *GetEndpointIDLabelsNotFound) WriteResponse(rw http.ResponseWriter, prod
 
 	rw.WriteHeader(404)
 }
+
+// GetEndpointIDLabelsTooManyRequestsCode is the HTTP code returned for type GetEndpointIDLabelsTooManyRequests
+const GetEndpointIDLabelsTooManyRequestsCode int = 429
+
+/*GetEndpointIDLabelsTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response getEndpointIdLabelsTooManyRequests
+*/
+type GetEndpointIDLabelsTooManyRequests struct {
+}
+
+// NewGetEndpointIDLabelsTooManyRequests creates GetEndpointIDLabelsTooManyRequests with default headers values
+func NewGetEndpointIDLabelsTooManyRequests() *GetEndpointIDLabelsTooManyRequests {
+
+	return &GetEndpointIDLabelsTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *GetEndpointIDLabelsTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_log_responses.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_log_responses.go
@@ -110,3 +110,27 @@ func (o *GetEndpointIDLogNotFound) WriteResponse(rw http.ResponseWriter, produce
 
 	rw.WriteHeader(404)
 }
+
+// GetEndpointIDLogTooManyRequestsCode is the HTTP code returned for type GetEndpointIDLogTooManyRequests
+const GetEndpointIDLogTooManyRequestsCode int = 429
+
+/*GetEndpointIDLogTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response getEndpointIdLogTooManyRequests
+*/
+type GetEndpointIDLogTooManyRequests struct {
+}
+
+// NewGetEndpointIDLogTooManyRequests creates GetEndpointIDLogTooManyRequests with default headers values
+func NewGetEndpointIDLogTooManyRequests() *GetEndpointIDLogTooManyRequests {
+
+	return &GetEndpointIDLogTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *GetEndpointIDLogTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_responses.go
@@ -125,3 +125,27 @@ func (o *GetEndpointIDNotFound) WriteResponse(rw http.ResponseWriter, producer r
 
 	rw.WriteHeader(404)
 }
+
+// GetEndpointIDTooManyRequestsCode is the HTTP code returned for type GetEndpointIDTooManyRequests
+const GetEndpointIDTooManyRequestsCode int = 429
+
+/*GetEndpointIDTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response getEndpointIdTooManyRequests
+*/
+type GetEndpointIDTooManyRequests struct {
+}
+
+// NewGetEndpointIDTooManyRequests creates GetEndpointIDTooManyRequests with default headers values
+func NewGetEndpointIDTooManyRequests() *GetEndpointIDTooManyRequests {
+
+	return &GetEndpointIDTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *GetEndpointIDTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}

--- a/api/v1/server/restapi/endpoint/get_endpoint_responses.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_responses.go
@@ -86,3 +86,27 @@ func (o *GetEndpointNotFound) WriteResponse(rw http.ResponseWriter, producer run
 
 	rw.WriteHeader(404)
 }
+
+// GetEndpointTooManyRequestsCode is the HTTP code returned for type GetEndpointTooManyRequests
+const GetEndpointTooManyRequestsCode int = 429
+
+/*GetEndpointTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response getEndpointTooManyRequests
+*/
+type GetEndpointTooManyRequests struct {
+}
+
+// NewGetEndpointTooManyRequests creates GetEndpointTooManyRequests with default headers values
+func NewGetEndpointTooManyRequests() *GetEndpointTooManyRequests {
+
+	return &GetEndpointTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *GetEndpointTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_config_responses.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_config_responses.go
@@ -88,6 +88,30 @@ func (o *PatchEndpointIDConfigNotFound) WriteResponse(rw http.ResponseWriter, pr
 	rw.WriteHeader(404)
 }
 
+// PatchEndpointIDConfigTooManyRequestsCode is the HTTP code returned for type PatchEndpointIDConfigTooManyRequests
+const PatchEndpointIDConfigTooManyRequestsCode int = 429
+
+/*PatchEndpointIDConfigTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response patchEndpointIdConfigTooManyRequests
+*/
+type PatchEndpointIDConfigTooManyRequests struct {
+}
+
+// NewPatchEndpointIDConfigTooManyRequests creates PatchEndpointIDConfigTooManyRequests with default headers values
+func NewPatchEndpointIDConfigTooManyRequests() *PatchEndpointIDConfigTooManyRequests {
+
+	return &PatchEndpointIDConfigTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *PatchEndpointIDConfigTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}
+
 // PatchEndpointIDConfigFailedCode is the HTTP code returned for type PatchEndpointIDConfigFailed
 const PatchEndpointIDConfigFailedCode int = 500
 

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_labels_responses.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_labels_responses.go
@@ -64,6 +64,30 @@ func (o *PatchEndpointIDLabelsNotFound) WriteResponse(rw http.ResponseWriter, pr
 	rw.WriteHeader(404)
 }
 
+// PatchEndpointIDLabelsTooManyRequestsCode is the HTTP code returned for type PatchEndpointIDLabelsTooManyRequests
+const PatchEndpointIDLabelsTooManyRequestsCode int = 429
+
+/*PatchEndpointIDLabelsTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response patchEndpointIdLabelsTooManyRequests
+*/
+type PatchEndpointIDLabelsTooManyRequests struct {
+}
+
+// NewPatchEndpointIDLabelsTooManyRequests creates PatchEndpointIDLabelsTooManyRequests with default headers values
+func NewPatchEndpointIDLabelsTooManyRequests() *PatchEndpointIDLabelsTooManyRequests {
+
+	return &PatchEndpointIDLabelsTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *PatchEndpointIDLabelsTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}
+
 // PatchEndpointIDLabelsUpdateFailedCode is the HTTP code returned for type PatchEndpointIDLabelsUpdateFailed
 const PatchEndpointIDLabelsUpdateFailedCode int = 500
 

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_responses.go
@@ -106,6 +106,30 @@ func (o *PatchEndpointIDNotFound) WriteResponse(rw http.ResponseWriter, producer
 	rw.WriteHeader(404)
 }
 
+// PatchEndpointIDTooManyRequestsCode is the HTTP code returned for type PatchEndpointIDTooManyRequests
+const PatchEndpointIDTooManyRequestsCode int = 429
+
+/*PatchEndpointIDTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response patchEndpointIdTooManyRequests
+*/
+type PatchEndpointIDTooManyRequests struct {
+}
+
+// NewPatchEndpointIDTooManyRequests creates PatchEndpointIDTooManyRequests with default headers values
+func NewPatchEndpointIDTooManyRequests() *PatchEndpointIDTooManyRequests {
+
+	return &PatchEndpointIDTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *PatchEndpointIDTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}
+
 // PatchEndpointIDFailedCode is the HTTP code returned for type PatchEndpointIDFailed
 const PatchEndpointIDFailedCode int = 500
 

--- a/api/v1/server/restapi/endpoint/put_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/put_endpoint_id_responses.go
@@ -106,6 +106,30 @@ func (o *PutEndpointIDExists) WriteResponse(rw http.ResponseWriter, producer run
 	rw.WriteHeader(409)
 }
 
+// PutEndpointIDTooManyRequestsCode is the HTTP code returned for type PutEndpointIDTooManyRequests
+const PutEndpointIDTooManyRequestsCode int = 429
+
+/*PutEndpointIDTooManyRequests Rate-limiting too many requests in the given time frame
+
+swagger:response putEndpointIdTooManyRequests
+*/
+type PutEndpointIDTooManyRequests struct {
+}
+
+// NewPutEndpointIDTooManyRequests creates PutEndpointIDTooManyRequests with default headers values
+func NewPutEndpointIDTooManyRequests() *PutEndpointIDTooManyRequests {
+
+	return &PutEndpointIDTooManyRequests{}
+}
+
+// WriteResponse to the client
+func (o *PutEndpointIDTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(429)
+}
+
 // PutEndpointIDFailedCode is the HTTP code returned for type PutEndpointIDFailed
 const PutEndpointIDFailedCode int = 500
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well-written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

Description:
Issue: It states that 429 response code is not honored inside cilium.
What is 429 response?
This 429 response code is returned by the server when there are **Too many requests in a given time frame**
Root cause:: We observed that cilium is not handling the 429 response code when multiple pods are created at the same time.
Fix: We have introduced a change for the support of handling 429 response code in the `openapi.yaml.`

Fixes: #14922 
