### PR TITLE
test: Skip K8sPolicy on GKE and 4.19

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -646,6 +646,18 @@ func FailWithToggle(message string, callerSkip ...int) {
 	}
 }
 
+// SkipDescribeIf is a wrapper for the Describe block which is being executed
+// if the given condition is NOT met.
+func SkipDescribeIf(condition func() bool, text string, body func()) bool {
+	if condition() {
+		return It(text, func() {
+			Skip("skipping due to unmet condition")
+		})
+	}
+
+	return Describe(text, body)
+}
+
 // SkipContextIf is a wrapper for the Context block which is being executed
 // if the given condition is NOT met.
 func SkipContextIf(condition func() bool, text string, body func()) bool {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -34,7 +34,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("K8sPolicyTest", func() {
+var _ = SkipDescribeIf(func() bool {
+	// We only need to run on 4.9 with kube-proxy and net-next with KPR
+	// and the third node. Other CI jobs are not expected to increase
+	// code coverage.
+	return helpers.RunsOnGKE() || helpers.RunsOn419Kernel()
+}, "K8sPolicyTest", func() {
 
 	var (
 		kubectl *helpers.Kubectl


### PR DESCRIPTION
Running K8sPolicies on those CI jobs is not expected to increase coverage, so let's disable to reduce cost.