### PR TITLE
bpf: Fix defines in policy.h

### DIFF
--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -295,12 +295,4 @@ static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
 	ctx_store_meta(ctx, CB_POLICY, 0);
 }
 #endif /* SOCKMAP */
-#else
-static __always_inline void policy_mark_skip(struct __ctx_buff *ctx)
-{
-}
-
-static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
-{
-}
 #endif


### PR DESCRIPTION
Commit 501332b ("bpf: Remove DROP_ALL define") forgot to remove an `#else` statement, resulting in a compilation error if `policy.h` is  included twice.

Marking for backports as I hit this while working on a v1.8 backport.

IMO, we should really enforce the use of #ifdef comments and indentations to avoid this sort of bugs.

Fixes: https://github.com/cilium/cilium/pull/5379