### PR TITLE
ci: Fix `BGP router does not have route for LB IP`

### DIFF
--- a/test/k8sT/manifests/frr.yaml.tmpl
+++ b/test/k8sT/manifests/frr.yaml.tmpl
@@ -111,7 +111,7 @@ spec:
   - name: frr
     securityContext:
       privileged: true
-    image: frrouting/frr:frr-7.5.1
+    image: docker.io/frrouting/frr:v7.5.1
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - mountPath: /etc/frr


### PR DESCRIPTION
This is an attempt to fix #15737

This updates the image tag of `docker.io/frrouting/frr` to use the `v7.5.1` image tag. It looks like the previous `frrouting/frr:frr-7.5.1` tag might have been deleted by upstream, does not look like a valid image tag at the moment: https://hub.docker.com/r/frrouting/frr/tags

From Google cache (link currently 404s):
![image](https://user-images.githubusercontent.com/50564/115244393-30874c80-a124-11eb-9396-7089a4b24db8.png)

Credit to @borkmann for spotting the ImagePullBackOff


