### PR TITLE
daemon: Remove unnecessary log

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -231,13 +231,11 @@ func initKubeProxyReplacementOptions() (strict bool) {
 		option.Config.EnableHostServicesPeer = true
 		if option.Config.EnableIPv4 {
 			if err := bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET4_GETPEERNAME); err != nil {
-				log.WithError(err).Warn("Disabling HostServicesPeer feature.")
 				option.Config.EnableHostServicesPeer = false
 			}
 		}
 		if option.Config.EnableIPv6 {
 			if err := bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET6_GETPEERNAME); err != nil {
-				log.WithError(err).Warn("Disabling HostServicesPeer feature.")
 				option.Config.EnableHostServicesPeer = false
 			}
 		}


### PR DESCRIPTION
This log msg is unnecessary and was added in 25a90dc6f7 ("daemon: log
errors from bpf.TestDummyProg()"). It is unnecessary because the option
it is warning about is not even exposed to the user, so it is completely
irrelevant and un-actionable.

Fixes: https://github.com/cilium/cilium/issues/15727

Signed-off-by: Chris Tarazi <chris@isovalent.com>
