### PR TITLE
docs: Make cross-cluster policy more explicit

### DIFF
--- a/Documentation/policy/kubernetes.rst
+++ b/Documentation/policy/kubernetes.rst
@@ -181,6 +181,14 @@ policies to a particular cluster.
 
         .. literalinclude:: ../../examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
 
+Note the ``io.kubernetes.pod.namespace: default`` in the policy
+rule. It makes sure the policy applies to ``rebel-base`` in the
+``default`` namespace of ``cluster2`` regardless of the namespace in
+``cluster1`` where ``x-wing`` is deployed in. If the namespace label
+of policy rules is omitted it defaults to the same namespace where the
+policy itself is applied in, which may be not what is wanted when
+deploying cross-cluster policies.
+
 Clusterwide Policies
 --------------------
 

--- a/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+++ b/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
@@ -12,4 +12,5 @@ spec:
   - toEndpoints:
     - matchLabels:
         name: rebel-base
+        io.kubernetes.pod.namespace: default
         io.cilium.k8s.policy.cluster: cluster2


### PR DESCRIPTION
Add a namespace label to the policy rule in the cross-cluster policy
example and add explanation of namespace defaulting in CNP rules.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
