### PR TITLE
iptables: GetProxyPort(): run iptables quietly

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -835,7 +835,7 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 		prog = "ip6tables"
 	}
 
-	res, err := runProgCombinedOutput(prog, []string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, false)
+	res, err := runProgCombinedOutput(prog, []string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, true)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
GetProxyPort() runs an iptable command to determine a previously
installed port. The command will fail if the CILIUM_PRE_mangle chain
does not exist. This is fine: GetProxyPort() will return 0 which
results in the selecting a new available port.

A failed command, however, will result in spurious error messages:

level=error msg="Command execution failed" cmd="[iptables -t mangle -n -L CILIUM_PRE_mangle]" error="exit status 1" subsys=iptables
level=warning msg="iptables: No chain/target/match by that name." subsys=iptables
levelevel=debug msg="DNS Proxy port is configured to 0. A random port will be assigned by the OS."

Pass the quiet flag when executing the command to avoid this.

Fixes: https://github.com/cilium/cilium/issues/15002

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>