### PR TITLE
Fix the initialization of host endpoint labels

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1630,7 +1630,9 @@ func runDaemon() {
 		}
 	}
 
-	if !d.endpointManager.HostEndpointExists() {
+	if d.endpointManager.HostEndpointExists() {
+		d.endpointManager.InitHostEndpointLabels(d.ctx)
+	} else {
 		log.Info("Creating host endpoint")
 		if err := d.endpointManager.AddHostEndpoint(d.ctx, d, d.l7Proxy, d.identityAllocator,
 			"Create host endpoint", nodeTypes.GetName()); err != nil {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -635,6 +635,13 @@ func (mgr *EndpointManager) AddHostEndpoint(ctx context.Context, owner regenerat
 	return nil
 }
 
+// InitHostEndpointLabels initializes the host endpoint's labels with the
+// node's known labels.
+func (mgr *EndpointManager) InitHostEndpointLabels(ctx context.Context) {
+	ep := mgr.GetHostEndpoint()
+	ep.InitWithNodeLabels(ctx, launchTime)
+}
+
 // WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
 // this function is called to be at a given policy revision.
 // New endpoints appearing while waiting are ignored.

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -37,11 +38,13 @@ func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
+				var valid bool
 				if node := k8s.ObjToV1Node(obj); node != nil {
-					if option.Config.BGPAnnounceLBIP {
-						k.bgpSpeakerManager.OnUpdateNode(node) // Need to seed the BGP speaker
-					}
+					valid = true
+					err := k.updateK8sNodeV1(nil, node)
+					k.K8sEventProcessed(metricNode, metricCreate, err == nil)
 				}
+				k.K8sEventReceived(metricNode, metricCreate, valid, false)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
@@ -70,12 +73,16 @@ func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
 }
 
 func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) error {
-	oldNodeLabels := oldK8sNode.GetLabels()
+	var oldNodeLabels map[string]string
+	if oldK8sNode != nil {
+		oldNodeLabels = oldK8sNode.GetLabels()
+	}
 	newNodeLabels := newK8sNode.GetLabels()
 
 	nodeEP := k.endpointManager.GetHostEndpoint()
 	if nodeEP == nil {
-		log.Error("Host endpoint not found")
+		log.Debug("Host endpoint not found, updating node labels")
+		node.SetLabels(newNodeLabels)
 		return nil
 	}
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -342,6 +342,9 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
 			// We need to know about active local redirect policy services
 			// before BPF LB datapath is synced.
 			k8sAPIGroupCiliumLocalRedirectPolicyV2,
+			// We need to know the node labels to populate the host endpoint
+			// labels.
+			k8sAPIGroupNodeV1Core,
 		)
 		// CiliumEndpoint is used to synchronize the ipcache, wait for
 		// it unless it is disabled


### PR DESCRIPTION
To properly initialize the host endpoint with labels added before the agent starts, we need to watch for k8s Node ADD events and use the new set of labels to update the restored host endpoint. See commits for details.

I tested this patch set in https://github.com/cilium/cilium/pull/15714, with an extension to the tests. That extension to the test can't be backported so I'll submit it in a separate PR to ease backporting of the present fix.

Fixes: https://github.com/cilium/cilium/issues/13676.