### PR TITLE
daemon: Make Hubble Recorder API opt-out

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -85,7 +85,7 @@ cilium-agent [flags]
       --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
       --enable-host-reachable-services                       Enable reachability of services for host applications
       --enable-hubble                                        Enable hubble server
-      --enable-hubble-recorder-api                           Enable the Hubble recorder API
+      --enable-hubble-recorder-api                           Enable the Hubble recorder API (default true)
       --enable-identity-mark                                 Enable setting identity mark for local traffic (default true)
       --enable-ip-masq-agent                                 Enable BPF ip-masq-agent
       --enable-ipsec                                         Enable IPSec support

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -938,7 +938,7 @@ func init() {
 	flags.Bool(option.HubbleExportFileCompress, exporteroption.Default.Compress, "Compress rotated Hubble export files.")
 	option.BindEnv(option.HubbleExportFileCompress)
 
-	flags.Bool(option.EnableHubbleRecorderAPI, false, "Enable the Hubble recorder API")
+	flags.Bool(option.EnableHubbleRecorderAPI, true, "Enable the Hubble recorder API")
 	option.BindEnv(option.EnableHubbleRecorderAPI)
 
 	flags.String(option.HubbleRecorderStoragePath, defaults.HubbleRecorderStoragePath, "Directory in which pcap files created via the Hubble Recorder API are stored")


### PR DESCRIPTION
This commits switches the default value of
`--enable-hubble-recorder-api` to `true`. It is important to note that
this change does _not_ mean that the recorder API itself is always
enabled by default. For the Hubble Recorder API to actually be served,
both `--enable-hubble` and `--enable-recorder` also need to be enabled
(both of which are `false` by default).

Previous discussion: https://github.com/cilium/cilium/pull/15680#discussion_r614653285