### PR TITLE
k8s: Fix Wireguard with IPAM != ClusterPool

### DIFF
--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -74,7 +74,7 @@ func retrieveNodeInformation(nodeName string) (*nodeTypes.Node, error) {
 	mightAutoDetectDevices := option.MightAutoDetectDevices()
 	var n *nodeTypes.Node
 
-	if option.Config.IPAM == ipamOption.IPAMClusterPool || option.Config.EnableWireguard {
+	if option.Config.IPAM == ipamOption.IPAMClusterPool {
 		ciliumNode, err := CiliumClient().CiliumV2().CiliumNodes().Get(context.TODO(), nodeName, v1.GetOptions{})
 		if err != nil {
 			// If no CIDR is required, retrieving the node information is


### PR DESCRIPTION
This removes a leftover if-condition from earlier versions of Wireguard
in Cilium where it needed to wait for the operator to allocate a
Wireguard tunnel IP (see #15565 for details). With the removal of
the operator logic, if-statement is not needed anymore for Wireguard
and is breaking other IPAM modes.

This fixes a bug where Cilium agent would indefinitely wait for K8s node
information when using Wireguard in combination with an IPAM mode other
than ClusterPool.

Fixes: 0ecab37c49a3 ("wireguard: Remove operator")
