### PR TITLE
daemon: Fix the init of the endpoints' datapath config

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -309,17 +309,16 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	if epTemplate.DatapathConfiguration == nil {
 		dpConfig := endpoint.NewDatapathConfiguration()
 		epTemplate.DatapathConfiguration = &dpConfig
+	}
+	if option.Config.EnableEndpointRoutes {
+		epTemplate.DatapathConfiguration.InstallEndpointRoute = true
+		epTemplate.DatapathConfiguration.RequireEgressProg = true
+		disabled := false
+		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	} else {
-		if option.Config.EnableEndpointRoutes {
-			epTemplate.DatapathConfiguration.InstallEndpointRoute = true
-			epTemplate.DatapathConfiguration.RequireEgressProg = true
-			disabled := false
-			epTemplate.DatapathConfiguration.RequireRouting = &disabled
-		} else {
-			epTemplate.DatapathConfiguration.InstallEndpointRoute = false
-			epTemplate.DatapathConfiguration.RequireEgressProg = false
-			epTemplate.DatapathConfiguration.RequireRouting = nil
-		}
+		epTemplate.DatapathConfiguration.InstallEndpointRoute = false
+		epTemplate.DatapathConfiguration.RequireEgressProg = false
+		epTemplate.DatapathConfiguration.RequireRouting = nil
 	}
 
 	log.WithFields(logrus.Fields{


### PR DESCRIPTION
An incorrect refactor, 0875453 ("endpoint: Refactor init of EndpointDatapathConfiguration"), changed the behavior of that function. This pull request fixes it to restore the intended behavior. See [the discussion in the original PR](https://github.com/cilium/cilium/pull/15228/files#r613633603) for more details.

Fixes: 0875453 ("endpoint: Refactor init of EndpointDatapathConfiguration")
