### PR TITLE
workflows: fix GKE `if` condition

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -21,12 +21,12 @@ env:
 jobs:
   installation-and-connectivity:
     if: |
-      ${{ (github.event.issue.pull_request && (
+      (github.event.issue.pull_request && (
         startsWith(github.event.comment.body, 'ci-gke') ||
         startsWith(github.event.comment.body, 'test-me-please')
       )) ||
       github.event_name == 'push' ||
-      github.event.label.name == 'ci-run/gke' }}
+      github.event.label.name == 'ci-run/gke'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
For consistency with other workflows, and also in case it might actually be the reason GKE workflows are triggered on every comment instead of only for specific trigger phrases.
