### PR TITLE
policy: Add underscore to the set of allowed characters in FQDN patterns

### DIFF
--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -26,11 +26,11 @@ import (
 
 var (
 	// allowedMatchNameChars tests that MatchName contains only valid DNS characters
-	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9.]+$")
+	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9_.]+$")
 
 	// allowedPatternChars tests that the MatchPattern field contains only the
 	// characters we want in our wilcard scheme.
-	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9.*]+$") // the * inside the [] is a literal *
+	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
 
 	// FQDNMatchNameRegexString is a regex string which matches what's expected
 	// in the MatchName field in the FQDNSelector. This should be kept in-sync

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -28,7 +28,9 @@ func (s *PolicyAPITestSuite) TestFQDNSelectorSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*._cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {
@@ -54,7 +56,9 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*._cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {


### PR DESCRIPTION
CRD validation already allows underscores, allow them also in policy
import.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
`toFQDNs` rules now allow underscores in match patterns and names
```
