### PR TITLE
policy: Add underscore to the set of allowed characters in fqdns

### DIFF
--- a/.github/workflows/images-legacy-hotfix-releases.yaml
+++ b/.github/workflows/images-legacy-hotfix-releases.yaml
@@ -1,0 +1,107 @@
+name: Hot Fix Image Release Build
+
+on:
+  push:
+    branches:
+      - hf/v1.8/**
+
+jobs:
+  build-and-push:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    environment: release-developer-images
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - name: cilium
+            dockerfile: ./Dockerfile
+          - name: operator
+            dockerfile: ./cilium-operator.Dockerfile
+          - name: operator-aws
+            dockerfile: ./cilium-operator-aws.Dockerfile
+          - name: operator-azure
+            dockerfile: ./cilium-operator-azure.Dockerfile
+          - name: operator-generic
+            dockerfile: ./cilium-operator-generic.Dockerfile
+          - name: hubble-relay
+            dockerfile: ./hubble-relay.Dockerfile
+          - name: docker-plugin
+            dockerfile: ./cilium-docker-plugin.Dockerfile
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609
+
+      - name: Login to quay.io
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DEVELOPER_USERNAME }}
+          password: ${{ secrets.QUAY_DEVELOPER_PASSWORD }}
+
+      - name: Getting image tag
+        id: tag
+        run: |
+          echo ::set-output name=tag::${GITHUB_REF##*/}
+
+      - name: Checking if tag already exists
+        id: tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }} &>/dev/null; then
+            echo "Tag already exists!"
+            exit 1
+          fi
+
+      - name: Checkout Source Code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: Release Build ${{ matrix.name }}
+        uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f
+        id: docker_build_release
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }}
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+
+      - name: Image Release Digest
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
+          echo "" >> image-digest/${{ matrix.name }}.txt
+          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}-dev:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "" >> image-digest/${{ matrix.name }}.txt
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
+        with:
+          name: image-digest ${{ matrix.name }}
+          path: image-digest
+          retention-days: 1
+
+  image-digests:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    name: Display Digests
+    runs-on: ubuntu-20.04
+    needs: build-and-push
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
+        with:
+          path: image-digest/
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -26,11 +26,11 @@ import (
 
 var (
 	// allowedMatchNameChars tests that MatchName contains only valid DNS characters
-	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9.]+$")
+	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9_.]+$")
 
 	// allowedPatternChars tests that the MatchPattern field contains only the
 	// characters we want in our wilcard scheme.
-	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9.*]+$") // the * inside the [] is a literal *
+	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
 )
 
 type FQDNSelector struct {

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -28,7 +28,9 @@ func (s *PolicyAPITestSuite) TestFQDNSelectorSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "www.get_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*.get_cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {
@@ -54,7 +56,9 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "www.get_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*.get_cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {


### PR DESCRIPTION
CRD validation already allows underscores, allow them also in policy
import.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
