### PR TITLE
pkg/k8s: reset k8s event lag metric on pod add

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,6 +85,10 @@ func (k *K8sWatcher) createPodController(getter cache.Getter, fieldSelector fiel
 						} else {
 							metrics.EventLagK8s.Set(timeSinceEpCreated.Round(time.Second).Seconds())
 						}
+					} else {
+						// If the ep is nil then we reset to zero, otherwise
+						// the previous value set is kept forever.
+						metrics.EventLagK8s.Set(0)
 					}
 					err := k.addK8sPodV1(pod)
 					k.K8sEventProcessed(metricPod, metricCreate, err == nil)


### PR DESCRIPTION
If we do not have an endpoint for the given pod, we can safely reset the
metric to zero. Failing to do it so, it will wrongly keep the previous
value.

Fixes: 4e2913004340 ("pkg/endpoint: calculate Kube API-Server lag from pod events")
Signed-off-by: André Martins <andre@cilium.io>