### PR TITLE
Update stable releases

### DIFF
--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -3,33 +3,33 @@ column: "In progress"
 move-to-projects-for-labels-xored:
   v1.9:
     needs-backport/1.9:
-      project: "https://github.com/cilium/cilium/projects/150"
+      project: "https://github.com/cilium/cilium/projects/153"
       column: "Needs backport from master"
     backport-pending/1.9:
-      project: "https://github.com/cilium/cilium/projects/150"
+      project: "https://github.com/cilium/cilium/projects/153"
       column: "Backport pending to v1.9"
     backport-done/1.9:
-      project: "https://github.com/cilium/cilium/projects/150"
+      project: "https://github.com/cilium/cilium/projects/153"
       column: "Backport done to v1.9"
   v1.8:
     needs-backport/1.8:
-      project: "https://github.com/cilium/cilium/projects/149"
+      project: "https://github.com/cilium/cilium/projects/152"
       column: "Needs backport from master"
     backport-pending/1.8:
-      project: "https://github.com/cilium/cilium/projects/149"
+      project: "https://github.com/cilium/cilium/projects/152"
       column: "Backport pending to v1.8"
     backport-done/1.8:
-      project: "https://github.com/cilium/cilium/projects/149"
+      project: "https://github.com/cilium/cilium/projects/152"
       column: "Backport done to v1.8"
   v1.7:
     needs-backport/1.7:
-      project: "https://github.com/cilium/cilium/projects/148"
+      project: "https://github.com/cilium/cilium/projects/151"
       column: "Needs backport from master"
     backport-pending/1.7:
-      project: "https://github.com/cilium/cilium/projects/148"
+      project: "https://github.com/cilium/cilium/projects/151"
       column: "Backport pending to v1.7"
     backport-done/1.7:
-      project: "https://github.com/cilium/cilium/projects/148"
+      project: "https://github.com/cilium/cilium/projects/151"
       column: "Backport done to v1.7"
 require-msgs-in-commit:
   - msg: "Signed-off-by"

--- a/README.rst
+++ b/README.rst
@@ -32,11 +32,11 @@ Listed below are the actively maintained release branches along with their lates
 minor release, corresponding image pull tags and their release notes:
 
 +-------------------------------------------------------+------------+--------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.9 <https://github.com/cilium/cilium/tree/v1.9>`__ | 2021-03-10 | ``docker.io/cilium/cilium:v1.9.5``   | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.9.5>`__  | `General Announcement <https://cilium.io/blog/2020/11/10/cilium-19>`__ |
+| `v1.9 <https://github.com/cilium/cilium/tree/v1.9>`__ | 2021-04-20 | ``docker.io/cilium/cilium:v1.9.6``   | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.9.6>`__  | `General Announcement <https://cilium.io/blog/2020/11/10/cilium-19>`__ |
 +-------------------------------------------------------+------------+--------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.8 <https://github.com/cilium/cilium/tree/v1.8>`__ | 2021-03-10 | ``docker.io/cilium/cilium:v1.8.8``   | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.8.8>`__  | `General Announcement <https://cilium.io/blog/2020/06/22/cilium-18>`__ |
+| `v1.8 <https://github.com/cilium/cilium/tree/v1.8>`__ | 2021-04-20 | ``docker.io/cilium/cilium:v1.8.9``   | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.8.9>`__  | `General Announcement <https://cilium.io/blog/2020/06/22/cilium-18>`__ |
 +-------------------------------------------------------+------------+--------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.7 <https://github.com/cilium/cilium/tree/v1.7>`__ | 2021-03-09 | ``docker.io/cilium/cilium:v1.7.15``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.7.15>`__ | `General Announcement <https://cilium.io/blog/2020/02/18/cilium-17>`__ |
+| `v1.7 <https://github.com/cilium/cilium/tree/v1.7>`__ | 2021-04-20 | ``docker.io/cilium/cilium:v1.7.16``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.7.16>`__ | `General Announcement <https://cilium.io/blog/2020/02/18/cilium-17>`__ |
 +-------------------------------------------------------+------------+--------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
 
 Functionality Overview


### PR DESCRIPTION
Update for the following releases:

https://github.com/cilium/cilium/releases/tag/v1.9.6
https://github.com/cilium/cilium/releases/tag/v1.8.9
https://github.com/cilium/cilium/releases/tag/v1.7.16
