### PR TITLE
helm: consolidate IPSec and Wireguard encryption options

### DIFF
--- a/Documentation/gettingstarted/encryption-wireguard.rst
+++ b/Documentation/gettingstarted/encryption-wireguard.rst
@@ -55,7 +55,8 @@ Wireguard module on older kernels).
            helm install cilium |CHART_RELEASE| \\
              --namespace kube-system \\
              --set l7Proxy=false \\
-             --set wireguard.enabled=true
+             --set encryption.enabled=true \\
+             --set encryption.type=wireguard
 
 Wireguard may also be enabled manually by setting setting the
 ``enable-wireguard: true`` option in the Cilium ``ConfigMap`` and restarting

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -122,10 +122,11 @@ contributors across the globe, there is almost always someone available to help.
 | enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters. |
 | enableXTSocketFallback | bool | `true` |  |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
-| encryption.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |
-| encryption.mountPath | string | `"/etc/ipsec"` | Path to mount the secret inside the Cilium pod. |
-| encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. |
-| encryption.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. |
+| encryption.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. This option is only effective when encryption.type is set to ipsec. |
+| encryption.mountPath | string | `"/etc/ipsec"` | Path to mount the secret inside the Cilium pod. This option is only effective when encryption.type is set to ipsec. |
+| encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to ipsec. |
+| encryption.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec. |
+| encryption.type | string | `"ipsec"` | Encryption method. Can be either ipsec or wireguard. |
 | endpointHealthChecking.enabled | bool | `true` |  |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -326,7 +326,7 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
-{{- if .Values.encryption.enabled }}
+{{- if and ( .Values.encryption.enabled ) ( eq .Values.encryption.type "ipsec" ) }}
         - mountPath: {{ .Values.encryption.mountPath }}
           name: cilium-ipsec-secrets
 {{- end }}
@@ -542,7 +542,7 @@ spec:
             path: ip-masq-agent
         name: ip-masq-agent
 {{- end }}
-{{- if .Values.encryption.enabled }}
+{{- if and ( .Values.encryption.enabled ) ( eq .Values.encryption.type "ipsec" ) }}
       - name: cilium-ipsec-secrets
         secret:
           secretName: {{ .Values.encryption.secretName }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -422,22 +422,21 @@ data:
   enable-ip-masq-agent: "true"
 {{- end }}
 
-{{- if hasKey .Values "wireguard" }}
-{{- if .Values.wireguard.enabled }}
-  enable-wireguard: {{ .Values.wireguard.enabled | quote }}
-{{- end }}
-{{- end }}
-
 {{- if .Values.encryption.enabled }}
+  {{- if eq .Values.encryption.type "ipsec" }}
   enable-ipsec: {{ .Values.encryption.enabled | quote }}
   ipsec-key-file: {{ .Values.encryption.mountPath }}/{{ .Values.encryption.keyFile }}
-{{- if hasKey .Values.encryption "interface" }}
+    {{- if hasKey .Values.encryption "interface" }}
   encrypt-interface: {{ .Values.encryption.interface }}
-{{- end }}
-{{- if .Values.encryption.nodeEncryption }}
+    {{- end }}
+    {{- if .Values.encryption.nodeEncryption }}
   encrypt-node: {{ .Values.encryption.nodeEncryption | quote }}
+    {{- end }}
+  {{- else if eq .Values.encryption.type "wireguard" }}
+  enable-wireguard: {{ .Values.encryption.enabled | quote }}
+  {{- end }}
 {{- end }}
-{{- end }}
+
 {{- if hasKey .Values "datapathMode" }}
 {{- if eq .Values.datapathMode "ipvlan" }}
   datapath-mode: ipvlan

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -417,19 +417,27 @@ encryption:
   # -- Enable transparent network encryption.
   enabled: false
 
+  # -- Encryption method. Can be either ipsec or wireguard.
+  type: ipsec
+
   # -- Name of the key file inside the Kubernetes secret configured via secretName.
+  # This option is only effective when encryption.type is set to ipsec.
   keyFile: keys
 
   # -- Path to mount the secret inside the Cilium pod.
+  # This option is only effective when encryption.type is set to ipsec.
   mountPath: /etc/ipsec
 
   # -- Name of the Kubernetes secret containing the encryption keys.
+  # This option is only effective when encryption.type is set to ipsec.
   secretName: cilium-ipsec-keys
 
   # -- Enable encryption for pure node to node traffic.
+  # This option is only effective when encryption.type is set to ipsec.
   nodeEncryption: false
 
   # -- The interface to use for encrypted traffic.
+  # This option is only effective when encryption.type is set to ipsec.
   # interface: eth0
 
 # TODO: Add documentation

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -563,7 +563,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":               "disabled",
 				"autoDirectNodeRoutes": "true",
-				"wireguard.enabled":    "true",
+				"encryption.enabled":   "true",
+				"encryption.type":      "wireguard",
 				"l7Proxy":              "false",
 			}, DeployCiliumOptionsAndDNS)
 
@@ -574,9 +575,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		It("Pod2pod is encrypted in tunneling mode", func() {
 			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":            "vxlan",
-				"wireguard.enabled": "true",
-				"l7Proxy":           "false",
+				"tunnel":             "vxlan",
+				"encryption.enabled": "true",
+				"encryption.type":    "wireguard",
+				"l7Proxy":            "false",
 			}, DeployCiliumOptionsAndDNS)
 
 			testWireguard("cilium_vxlan")


### PR DESCRIPTION
This commit introduces a new helm option, encryption.type, which can be
used to specifies what method should be used for encryption (either
ipsec or wireguard).

The goal here is to add support for wireguard without introducing any
breaking change in the helm charts.

Fixes: #15483