### PR TITLE
workflows: increase multicluster timeout to 30 minutes

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -29,7 +29,7 @@ jobs:
       github.event_name == 'push' ||
       github.event.label.name == 'ci-run/multicluster'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Set up job variables
         id: vars


### PR DESCRIPTION
We are hitting the 20 minutes limit quite a lot:

> installation-and-connectivity
> The job running on runner GitHub Actions 8 has exceeded the maximum execution time of 20 minutes.

Bumping to 30 minutes should be enough to get us through until we switch to a more intelligent step-based timeout rather than using global job timeouts.