### PR TITLE
release: Automate image digest PR creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -43,9 +43,8 @@ assignees: ''
     `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
-  - [ ] Run `contrib/release/pull-docker-manifests.sh` to fetch the image
-        digests, use the URL of the GitHub run here.
-  - [ ] Create a commit and push as a new PR.
+  - [ ] Run `contrib/release/post-release.sh` to fetch the image
+        digests and submit a PR to update these, use the URL of the GitHub run here.
   - [ ] Merge PR
 - [ ] Update helm charts
   - [ ] Pull latest branch locally into the cilium repository.
@@ -59,7 +58,7 @@ assignees: ''
 - [ ] Check draft release from [releases] page
   - [ ] Update the text at the top with 2-3 highlights of the release
   - [ ] Copy the text from `digest-vX.Y.Z.txt` (previously generated with
-        `contrib/release/pull-docker-manifests.sh`) to the end of the release.
+        `contrib/release/post-release.sh`) to the end of the release.
   - [ ] Publish the release
 - [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
 - [ ] Update Grafana dashboards (only for vX.Y.0)

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -35,10 +35,7 @@ assignees: ''
   - Pull latest branch locally and run `contrib/release/tag-release.sh`
 - [ ] Ask a maintainer to approve the build in the following links (keep the URL
       of the GitHub run to be used later):
-  - [Cilium v1.10](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
-  - [Cilium v1.9](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build+v1.9%22)
-  - [Cilium v1.8](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build+v1.8%22)
-  - [Cilium v1.7](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build+v1.7%22)
+  - [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
   - Check if all docker images are available before announcing the release
     `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
@@ -53,8 +50,6 @@ assignees: ''
         branch and push these changes into the helm repository. Make sure the
         generated helm charts point to the commit that contains the image
         digests.
-- [ ] Run sanity check of Helm install using connectivity-check script.
-      Suggested approach: Follow the full [Quick Install]
 - [ ] Check draft release from [releases] page
   - [ ] Update the text at the top with 2-3 highlights of the release
   - [ ] Copy the text from `digest-vX.Y.Z.txt` (previously generated with
@@ -68,7 +63,6 @@ assignees: ''
 ## Post-release
 
 - [ ] Prepare post-release changes to master branch using `contrib/release/bump-readme.sh`
-- [ ] Update the `stable` tags for each Cilium image (`contrib/release/bump-docker-stable.sh`)
 - [ ] Update external tools and guides to point to the new Cilium version:
   - [ ] [kops]
   - [ ] [kubespray]

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -97,16 +97,24 @@ Reference steps for the template
        ``x.y.z`` For more information about how ReadTheDocs does versioning, you can
        read their `Versions Documentation <https://docs.readthedocs.io/en/latest/versions.html>`_.
 
-#. Wait for DockerHub to prepare all docker images.
+#. Approve the release from the `Release Image build UI <https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22>`_.
+
+#. Once the release images are pushed, pull the image digests and prepare a PR with the official release image digests:
+
+   ::
+
+      contrib/release/post-release.sh <URL of workflow run from the release link above>
+
+   This will leave a file with the format ``digest-vX.Y.Z.txt`` in the local
+   directory which can be used to prepare the release in the next step.
 
 #. `Publish a GitHub release <https://github.com/cilium/cilium/releases/>`_:
 
    Following the steps above, the release draft will already be prepared.
    Preview the description and then publish the release.
 
-   #. Use ``contrib/release/pull-docker-manifests.sh`` to fetch the official
-      docker manifests for the release and add these into the Github release
-      announcement.
+   #. Copy the official docker manifests for the release from the previous step
+      into the end of the Github release announcement.
 
 #. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    and push the changes into that repository (not the main cilium repository):

--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2021 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source "${DIR}/lib/common.sh"
+source "${DIR}/../backporting/common.sh"
+
+usage() {
+    logecho "usage: $0 <RUN-URL> [VERSION] [GH-USERNAME]"
+    logecho "RUN-URL      GitHub URL with the RUN for the release images"
+    logecho "             example: https://github.com/cilium/cilium/actions/runs/600920964"
+    logecho "VERSION      Target version (X.Y.Z) (default: read from VERSION file)"
+    logecho "GH-USERNAME  GitHub username for authentication (default: autodetect)"
+    logecho "GITHUB_TOKEN environment variable set with the scope public:repo"
+    logecho
+    logecho "--help     Print this help message"
+}
+
+handle_args() {
+    if ! common::argc_validate 4; then
+        usage 2>&1
+        common::exit 1
+    fi
+
+    if [[ "$1" = "--help" ]] || [[ "$1" = "-h" ]]; then
+        usage
+        common::exit 0
+    fi
+
+    if ! hub help | grep -q "pull-request"; then
+        echo "This tool relies on 'hub' from https://github.com/github/hub." 1>&2
+        echo "Please install this tool first." 1>&2
+        common::exit 1
+    fi
+
+    if ! git diff --quiet; then
+        echo "Local changes found in git tree. Exiting release process..." 1>&2
+        exit 1
+    fi
+
+    if [ ! -z "$2" ] && ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+        usage 2>&1
+        common::exit 1 "Invalid VERSION ARG \"$2\"; Expected X.Y.Z"
+    fi
+
+    if [ -z "${GITHUB_TOKEN}" ]; then
+        usage 2>&1
+        common::exit 1 "GITHUB_TOKEN not set!"
+    fi
+}
+
+main() {
+    handle_args "$@"
+    local ersion version branch user_remote
+    ersion="$(echo ${2:-$(cat VERSION)} | sed 's/^v//')"
+    version="v${ersion}"
+    branch=$(echo $version | sed 's/.*v\([0-9]\.[0-9]\).*/\1/')
+    user_remote=$(get_user_remote ${3:-})
+
+    git checkout -b pr/$version-digests $version
+    ${DIR}/pull-docker-manifests.sh "$@"
+    logecho
+    logecho "Check that the following changes look correct:"
+    # TODO: Make this less interactive when we have used it enough
+    git add --patch install/kubernetes
+    git commit -se -m "install: Update image digests for $version" -m "$(cat digest-$version.txt)"
+    echo "Create PR for v$branch with these changes"
+    if ! common::askyorn ; then
+        common::exit 0 "Aborting post-release updates."
+    fi
+    logecho "Sending pull request for branch v$branch..."
+    PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    git push $user_remote "$PR_BRANCH"
+    hub pull-request -b "v$branch" -l backport/$branch
+}
+
+main "$@"

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright 2021 Authors of Cilium
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source "${DIR}/lib/common.sh"
@@ -32,7 +32,7 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+    if [ -n "$2" ] && ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
         usage 2>&1
         common::exit 1 "Invalid VERSION ARG \"$2\"; Expected X.Y.Z"
     fi
@@ -85,6 +85,7 @@ main() {
     >&2 echo "Generating manifest text for release notes"
     >&2 echo ""
     image_digest_output=$(get_digest_output "${username}" "${run_url_id}" "${version}" image-digest-output.txt)
+    echo > "${PWD}/digest-${version}.txt"
     cat "${image_digest_output}" >> "${PWD}/digest-${version}.txt"
     >&2 echo "Image digests available at ${PWD}/digest-${version}.txt"
 }


### PR DESCRIPTION
Introduce a new script to automate the digest PR creation, and update the template / docs for the latest release process changes.

- contrib: Make docker digest pull more idempotent
- contrib: Automate digest PR creation
- .github: Simplify release process
- docs: Update release process against template
