### PR TITLE
policy: Add underscore to the set of allowed characters in FQDNs

### DIFF
--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -26,11 +26,11 @@ import (
 
 var (
 	// allowedMatchNameChars tests that MatchName contains only valid DNS characters
-	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9.]+$")
+	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9_.]+$")
 
 	// allowedPatternChars tests that the MatchPattern field contains only the
 	// characters we want in our wilcard scheme.
-	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9.*]+$") // the * inside the [] is a literal *
+	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
 )
 
 type FQDNSelector struct {

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -28,7 +28,9 @@ func (s *PolicyAPITestSuite) TestFQDNSelectorSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*._cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {
@@ -54,7 +56,9 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*._cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {


### PR DESCRIPTION
[ upstream commit 641c37a182f9ec2025ea8eee9b28a9b15fa8fbf2 ]

CRD validation already allows underscores, allow them also in policy
import.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
toFQDNs rules now allow underscores in match patterns and names
```

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15801; do contrib/backporting/set-labels.py $pr done 1.8; done
```
