### PR TITLE
policy: Increment PolicyImportErrorsTotal metric more consistently

### DIFF
--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -271,7 +271,6 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 
 	newPrefixLengths, err := d.prefixLengths.Add(prefixes)
 	if err != nil {
-		metrics.PolicyImportErrorsTotal.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to reference-count prefix lengths in CIDR policy")
 		resChan <- &PolicyAddResult{
@@ -285,7 +284,6 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		logger.Debug("CIDR policy has changed; recompiling base programs")
 		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			_ = d.prefixLengths.Delete(prefixes)
-			metrics.PolicyImportErrorsTotal.Inc()
 			err2 := fmt.Errorf("Unable to recompile base programs: %s", err)
 			logger.WithError(err2).WithField("prefixes", prefixes).Warn(
 				"Failed to recompile base programs due to prefix length count change")
@@ -304,7 +302,6 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	newlyAllocatedIdentities := make(map[string]*identity.Identity)
 	if _, err := ipcache.AllocateCIDRs(prefixes, newlyAllocatedIdentities); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
-		metrics.PolicyImportErrorsTotal.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to allocate identities for CIDRs during policy add")
 		resChan <- &PolicyAddResult{
@@ -712,17 +709,20 @@ func (h *putPolicy) Handle(params PutPolicyParams) middleware.Responder {
 
 	var rules policyAPI.Rules
 	if err := json.Unmarshal([]byte(params.Policy), &rules); err != nil {
+		metrics.PolicyImportErrorsTotal.Inc()
 		return NewPutPolicyInvalidPolicy()
 	}
 
 	for _, r := range rules {
 		if err := r.Sanitize(); err != nil {
+			metrics.PolicyImportErrorsTotal.Inc()
 			return api.Error(PutPolicyFailureCode, err)
 		}
 	}
 
 	rev, err := d.PolicyAdd(rules, &policy.AddOptions{Source: metrics.LabelEventSourceAPI})
 	if err != nil {
+		metrics.PolicyImportErrorsTotal.Inc()
 		return api.Error(PutPolicyFailureCode, err)
 	}
 

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -182,13 +182,16 @@ func (k *K8sWatcher) addCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface
 		policyImportErr = k8s.PreprocessRules(rules, &k.K8sSvcCache)
 		// Replace all rules with the same name, namespace and
 		// resourceTypeCiliumNetworkPolicy
-		rev, policyImportErr = k.policyManager.PolicyAdd(rules, &policy.AddOptions{
-			ReplaceWithLabels: cnp.GetIdentityLabels(),
-			Source:            metrics.LabelEventSourceK8s,
-		})
+		if policyImportErr == nil {
+			rev, policyImportErr = k.policyManager.PolicyAdd(rules, &policy.AddOptions{
+				ReplaceWithLabels: cnp.GetIdentityLabels(),
+				Source:            metrics.LabelEventSourceK8s,
+			})
+		}
 	}
 
 	if policyImportErr != nil {
+		metrics.PolicyImportErrorsTotal.Inc()
 		scopedLog.WithError(policyImportErr).Warn("Unable to add CiliumNetworkPolicy")
 	} else {
 		scopedLog.Info("Imported CiliumNetworkPolicy")
@@ -257,10 +260,12 @@ func (k *K8sWatcher) updateCiliumNetworkPolicyV2(ciliumNPClient clientset.Interf
 		// update to the new policy will be skipped.
 		switch {
 		case ns != "" && !errors.Is(err, cilium_v2.ErrEmptyCNP):
+			metrics.PolicyImportErrorsTotal.Inc()
 			log.WithError(err).WithField(logfields.Object, logfields.Repr(oldRuleCpy)).
 				Warn("Error parsing old CiliumNetworkPolicy rule")
 			return err
 		case ns == "" && !errors.Is(err, cilium_v2.ErrEmptyCCNP):
+			metrics.PolicyImportErrorsTotal.Inc()
 			log.WithError(err).WithField(logfields.Object, logfields.Repr(oldRuleCpy)).
 				Warn("Error parsing old CiliumClusterwideNetworkPolicy rule")
 			return err
@@ -269,6 +274,7 @@ func (k *K8sWatcher) updateCiliumNetworkPolicyV2(ciliumNPClient clientset.Interf
 
 	_, err = newRuleCpy.Parse()
 	if err != nil {
+		metrics.PolicyImportErrorsTotal.Inc()
 		log.WithError(err).WithField(logfields.Object, logfields.Repr(newRuleCpy)).
 			Warn("Error parsing new CiliumNetworkPolicy rule")
 		return err

--- a/pkg/k8s/watchers/network_policy.go
+++ b/pkg/k8s/watchers/network_policy.go
@@ -90,6 +90,7 @@ func (k *K8sWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolic
 	scopedLog := log.WithField(logfields.K8sAPIVersion, k8sNP.TypeMeta.APIVersion)
 	rules, err := k8s.ParseNetworkPolicy(k8sNP)
 	if err != nil {
+		metrics.PolicyImportErrorsTotal.Inc()
 		scopedLog.WithError(err).WithFields(logrus.Fields{
 			logfields.CiliumNetworkPolicy: logfields.Repr(k8sNP),
 		}).Error("Error while parsing k8s kubernetes NetworkPolicy")
@@ -99,6 +100,7 @@ func (k *K8sWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolic
 
 	opts := policy.AddOptions{Replace: true, Source: metrics.LabelEventSourceK8s}
 	if _, err := k.policyManager.PolicyAdd(rules, &opts); err != nil {
+		metrics.PolicyImportErrorsTotal.Inc()
 		scopedLog.WithError(err).WithFields(logrus.Fields{
 			logfields.CiliumNetworkPolicy: logfields.Repr(rules),
 		}).Error("Unable to add NetworkPolicy rules to policy repository")


### PR DESCRIPTION
Move the increments of PolicyImportErrorsTotal metric higher up in the
call stack to cover all API error conditions. Also increment
PolicyImportErrorsTotal metric from k8s policy watcher on errors.

This change helps tracking cases where policy passes k8s CRD validation but still fails for some other reason.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
PolicyImportErrorsTotal metric is now incremented also from k8s policy watchers
```
