### PR TITLE
masquerade cilium_host ip on non-overlay device

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1167,7 +1167,8 @@ static __always_inline bool snat_v4_needed(struct __ctx_buff *ctx, __be32 *addr,
 #endif
 
 	ep = __lookup_ip4_endpoint(ip4->saddr);
-	if (ep && !(ep->flags & ENDPOINT_F_HOST)) {
+	/* if saddr == cilium_host IP, treats it the same as pods and SNAT it. */
+	if (ep && (!(ep->flags & ENDPOINT_F_HOST) || ip4->saddr == IPV4_GATEWAY)) {
 		struct remote_endpoint_info *info;
 		*from_endpoint = true;
 


### PR DESCRIPTION
In tunnel mode, this commit masquerades cilium_host IP to node IP on
non-overlay devices.

This matches the iptables masquerading behavior. Also this helps
supporting host reachable services via kube-proxy when bpf masq is
enabled.

Signed-off-by: Yuan Liu <liuyuan@google.com>

```release-note
 Masquerade cilium_host IP on non-overlay devices in tunneling mode.
```
