### PR TITLE
docs: Fix sed in OKD GSG

### DIFF
--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -67,7 +67,7 @@ And set ``networkType: Cilium``:
 
 .. code:: bash
 
-   sed -i 's/networkType:\ OVNKubernetes/networkType:\ Cilium/' "${CLUSTER_NAME}/install-config.yaml"
+   sed -i 's/networkType:\ .*/networkType:\ Cilium/' "${CLUSTER_NAME}/install-config.yaml"
 
 Resulting configuration will look like this:
 


### PR DESCRIPTION
The `sed` was looking for too specific of a match on the `networkType`,
which could lead users into thinking their `sed` worked if the
`networkType` was not originally `OVNKubernetes`. This would then cause
their clusters to be running without Cilium as the CNI.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
