### PR TITLE
wireguard: Better error message if kernel support is lacking

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -109,6 +109,11 @@ func (a *Agent) Init() error {
 	link := &netlink.Wireguard{LinkAttrs: netlink.LinkAttrs{Name: types.IfaceName}}
 	err := netlink.LinkAdd(link)
 	if err != nil && !errors.Is(err, unix.EEXIST) {
+		if errors.Is(err, unix.EOPNOTSUPP) {
+			return fmt.Errorf("wireguard not supported by the Linux kernel (netlink: %w). "+
+				"Please upgrade your kernel or manually install the kernel module: "+
+				"https://www.wireguard.com/install/", err)
+		}
 		return err
 	}
 


### PR DESCRIPTION
This commit extends the `operation not supported` error with a more
descriptive message that this indicates a lack of kernel-level support.

Example of how this looks in the logs (tested on 4.9):
`
level=fatal msg="Failed to initialize wireguard agent" error="wireguard not supported by the Linux kernel (netlink: operation not supported). Please upgrade your kernel or manually install the kernel module: https://www.wireguard.com/install/" subsys=daemon
`