### PR TITLE
contrib: add dual-stack support for dev VMs

### DIFF
--- a/contrib/vagrant/scripts/02-install-kubernetes-master.sh
+++ b/contrib/vagrant/scripts/02-install-kubernetes-master.sh
@@ -136,7 +136,8 @@ ExecStart=/usr/bin/kube-controller-manager \\
   --configure-cloud-routes=false \\
   --kubeconfig='/var/lib/kubernetes/controller-manager.kubeconfig' \\
   --leader-elect=true \\
-  --node-cidr-mask-size ${k8s_node_cidr_mask_size} \\
+  --node-cidr-mask-size-ipv4=${k8s_node_cidr_v4_mask_size} \\
+  --node-cidr-mask-size-ipv6=${k8s_node_cidr_v6_mask_size} \\
   --use-service-account-credentials \\
   --service-account-private-key-file='/var/lib/kubernetes/k8s-controller-manager-sa-key.pem' \\
   --service-cluster-ip-range=${k8s_service_cluster_ip_range} \\

--- a/contrib/vagrant/scripts/cert-gen-helpers.bash
+++ b/contrib/vagrant/scripts/cert-gen-helpers.bash
@@ -74,7 +74,8 @@ generate_server_certs() {
     "${cli_name}",
     "${master_hostname}",
     "${master_ip}",
-    "${cluster_api_server_ip}",
+    "${cluster_api_server_ipv4}",
+    "${cluster_api_server_ipv6}",
     "${cli_name}.cluster.default"
   ],
   "key": {

--- a/contrib/vagrant/scripts/helpers.bash
+++ b/contrib/vagrant/scripts/helpers.bash
@@ -54,27 +54,18 @@ esac
 
 kubernetes_master="${controllers_ips[0]}"
 
-# Default values for IPv4
+# Default values for IPv4 and IPv6
 #
 # CIDR Range for Pods in cluster.
-k8s_cluster_cidr=${K8S_CLUSTER_CIDR:-"10.16.0.0/12"} # 10.16.0.1-10.31.255.255
+k8s_cluster_cidr=${K8S_CLUSTER_CIDR:-"10.16.0.0/12,FD02::/96"} # 10.16.0.1-10.31.255.255
 # Mask size for node cidr in cluster.
-k8s_node_cidr_mask_size=${K8S_NODE_CIDR_MASK_SIZE:-"16"} # 1st Node: 10.16.0.1-10.16.255.254, 2nd Node: 10.17.0.1-10.17.255.254...
+k8s_node_cidr_v4_mask_size=${K8S_NODE_CIDR_MASK_SIZE:-"16"} # 1st Node: 10.16.0.1-10.16.255.254, 2nd Node: 10.17.0.1-10.17.255.254...
+k8s_node_cidr_v6_mask_size=${K8S_NODE_CIDR_MASK_SIZE:-"112"} # 1st Node: 10.16.0.1-10.16.255.254, 2nd Node: 10.17.0.1-10.17.255.254...
 # CIDR Range for Services in cluster.
-k8s_service_cluster_ip_range=${K8S_SERVICE_CLUSTER_IP_RANGE:-"172.20.0.0/24"}
-cluster_dns_ip=${K8S_CLUSTER_DNS_IP:-"172.20.0.10"}
-cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"172.20.0.1"}
-
-# Default values for IPv6
-#
-# CIDR Range for Pods in cluster.
-#k8s_cluster_cidr=${K8S_CLUSTER_CIDR:-"FD02::/96"} # 10.0.0.1-10.63.255.254
-# Mask size for node cidr in cluster.
-#k8s_node_cidr_mask_size=${K8S_NODE_CIDR_MASK_SIZE:-"112"} # 1st Node: 10.0.0.1-10.0.255.254, 2nd Node: 10.1.0.1-10.1.255.254...
-# CIDR Range for Services in cluster.
-#k8s_service_cluster_ip_range=${K8S_SERVICE_CLUSTER_IP_RANGE:-"FD03::/112"}
-#cluster_dns_ip=${K8S_CLUSTER_DNS_IP:-"FD03::A"}
-#cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"FD03::1"}
+k8s_service_cluster_ip_range=${K8S_SERVICE_CLUSTER_IP_RANGE:-"172.20.0.0/24,FD03::/112"}
+cluster_dns_ip=${K8S_CLUSTER_DNS_IP:-"172.20.0.10,FD03::A"}
+cluster_api_server_ipv4=${K8S_CLUSTER_API_SERVER_IPV4:-"172.20.0.1"}
+cluster_api_server_ipv6=${K8S_CLUSTER_API_SERVER_IPV6:-"FD03::1"}
 
 k8s_version="v1.21.0"
 etcd_version="v3.4.13"


### PR DESCRIPTION
With Kubernetes 1.21 enabling dual-stack support by default we can
configure the dev VMs to also have this feature enabled.

Fixes https://github.com/cilium/cilium/issues/14511

Signed-off-by: André Martins <andre@cilium.io>