### PR TITLE
cilium-etcd-operator, support kube-proxy less install

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
@@ -67,6 +67,12 @@ spec:
         command:
         - /usr/bin/cilium-etcd-operator
         env:
+        {{- if and (.Values.k8sServiceHost) (.Values.k8sServicePort) }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{ .Values.k8sServicePort }}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.k8sServiceHost }}
+        {{- end }}
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: "{{ .Values.etcd.clusterDomain }}"
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE


### PR DESCRIPTION
When attempting to install Cilium with kube-proxy less and managed etcd,
the cilium etcd operator was unable to find the kubernetes api

helm: add k8sServicePort and Host to the cilium-etcd-operator deployment.

Signed-off-by: Dan Molik <dan@danmolik.com>