### PR TITLE
v1.9 backports 2021-04-22

### DIFF
--- a/bpf/include/bpf/access.h
+++ b/bpf/include/bpf/access.h
@@ -22,7 +22,7 @@ map_array_get_16(const __u16 *array, __u32 index, const __u32 limit)
 	 * always valid.
 	 */
 	asm volatile("%[index] <<= 1\n\t"
-		     "if %[index] >= %[limit] goto +1\n\t"
+		     "if %[index] > %[limit] goto +1\n\t"
 		     "%[array] += %[index]\n\t"
 		     "%[datum] = *(u16 *)(%[array] + 0)\n\t"
 		     : [datum]"=r"(datum)

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -637,7 +637,7 @@ lb6_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 		return 0;
 
 	index = hash_from_tuple_v6(tuple) % LB_MAGLEV_LUT_SIZE;
-	return map_array_get_16(backend_ids, index, LB_MAGLEV_LUT_SIZE);
+	return map_array_get_16(backend_ids, index, (LB_MAGLEV_LUT_SIZE - 1) << 1);
 }
 #else
 # error "Invalid load balancer backend selection algorithm!"
@@ -1157,7 +1157,7 @@ lb4_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 		return 0;
 
 	index = hash_from_tuple_v4(tuple) % LB_MAGLEV_LUT_SIZE;
-	return map_array_get_16(backend_ids, index, LB_MAGLEV_LUT_SIZE);
+	return map_array_get_16(backend_ids, index, (LB_MAGLEV_LUT_SIZE - 1) << 1);
 }
 #else
 # error "Invalid load balancer backend selection algorithm!"

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -295,12 +295,4 @@ static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
 	ctx_store_meta(ctx, CB_POLICY, 0);
 }
 #endif /* SOCKMAP */
-#else
-static __always_inline void policy_mark_skip(struct __ctx_buff *ctx)
-{
-}
-
-static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
-{
-}
 #endif

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -108,7 +108,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"iptables-legacy-save -c",
 		// xfrm
 		"ip xfrm policy",
-		"ip -s xfrm state | awk '!/auth|enc|aead|auth-trunc|comp/'",
+		"ip -s xfrm state",
 		// gops
 		fmt.Sprintf("gops memstats $(pidof %s)", components.CiliumAgentName),
 		fmt.Sprintf("gops stack $(pidof %s)", components.CiliumAgentName),

--- a/bugtool/cmd/helper.go
+++ b/bugtool/cmd/helper.go
@@ -17,10 +17,13 @@ package cmd
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -164,4 +167,46 @@ func createGzip(dbgDir string, sendArchiveToStdout bool) (string, error) {
 	}
 
 	return target, nil
+}
+
+// hashEncryptionKeys processes the buffer containing the output of `ip -s xfrm state`.
+// It searches for IPsec keys in the output and replaces them by their hash.
+func hashEncryptionKeys(output string) string {
+	var finalOutput []string
+	// Split the result as a slice of strings.
+	lines := strings.Split(output, "\n")
+	// Search for lines containing encryption keys.
+	// Note that `auth-trunc` is also a relevant pattern, but we already match on
+	// the more generic `auth` pattern.
+	for _, line := range lines {
+		r, _ := regexp.Compile("(auth|enc|aead|comp)(.*[[:blank:]](0[xX][[:xdigit:]]+))?")
+		// r.FindStringSubmatchIndex(line) will return:
+		// - [], if the global pattern is not found
+		// - a slice of integers, if the global pattern is found. The
+		//   first two integers are the start and end offsets of the
+		//   global pattern. The remaining integers are the start and
+		//   end offset of each submatch group (delimited in the
+		//   regular expressions by parenthesis).
+		//
+		// If the global pattern is found, the start and end offset of
+		// the hexadecimal string (the third submatch) will be at index
+		// 6 and 7 in the slice. They may be equal to -1 if the
+		// submatch, marked as optional ('?'), is not found.
+		matched := r.FindStringSubmatchIndex(line)
+		if matched != nil && matched[6] > 0 {
+			key := line[matched[6]:matched[7]]
+			h := sha256.New()
+			h.Write([]byte(key))
+			hashedKey := hex.EncodeToString(h.Sum(nil))
+			line = line[:matched[6]] + "[hash:" + hashedKey + "]" + line[matched[7]:]
+		} else if matched != nil && matched[6] < 0 {
+			line = ""
+		}
+		if line != "" {
+			finalOutput = append(finalOutput, line+"\n")
+		} else {
+			finalOutput = append(finalOutput, line)
+		}
+	}
+	return strings.Join(finalOutput, "")
 }

--- a/bugtool/cmd/helper.go
+++ b/bugtool/cmd/helper.go
@@ -200,13 +200,10 @@ func hashEncryptionKeys(output string) string {
 			hashedKey := hex.EncodeToString(h.Sum(nil))
 			line = line[:matched[6]] + "[hash:" + hashedKey + "]" + line[matched[7]:]
 		} else if matched != nil && matched[6] < 0 {
-			line = ""
+			line = "[redacted]"
 		}
-		if line != "" {
-			finalOutput = append(finalOutput, line+"\n")
-		} else {
-			finalOutput = append(finalOutput, line)
-		}
+		finalOutput = append(finalOutput, line)
 	}
-	return strings.Join(finalOutput, "")
+
+	return strings.Join(finalOutput, "\n")
 }

--- a/bugtool/cmd/helper_test.go
+++ b/bugtool/cmd/helper_test.go
@@ -39,6 +39,11 @@ var (
 	baseDir, tmpDir string
 )
 
+type testStrings struct {
+	input  string
+	output string
+}
+
 type dummyTarWriter struct{}
 
 func (t *dummyTarWriter) Write(p []byte) (n int, err error) {
@@ -122,4 +127,37 @@ func (b *BugtoolSuite) TestWalkPath(c *C) {
 	c.Assert(err, IsNil)
 	err = w.walkPath(nestedDir, info, nil)
 	c.Assert(err, IsNil)
+}
+
+// TestHashEncryptionKeys tests proper hashing of keys. Lines in which `auth` or
+// other relevant pattern are found but not the hexadecimal keys are intentionally
+// redacted from the output to avoid accidental leaking of keys.
+func (b *BugtoolSuite) TestHashEncryptionKeys(c *C) {
+	testdata := []testStrings{
+		{
+			// `auth` and hexa string
+			input:  "<garbage> auth foo bar 0x123456af baz",
+			output: "<garbage> auth foo bar [hash:21d466b493f5c133edc008ee375e849fe5babb55d31550c25b993d151038c8a8] baz",
+		},
+		{
+			// `auth` but no hexa string
+			input:  "<garbage> auth foo bar ###23456af baz",
+			output: "[redacted]",
+		},
+		{
+			// `enc` and hexa string
+			input:  "<garbage> enc foo bar 0x123456af baz",
+			output: "<garbage> enc foo bar [hash:21d466b493f5c133edc008ee375e849fe5babb55d31550c25b993d151038c8a8] baz",
+		},
+		{
+			// nothing
+			input:  "<garbage> xxxx foo bar 0x123456af baz",
+			output: "<garbage> xxxx foo bar 0x123456af baz",
+		},
+	}
+
+	for _, v := range testdata {
+		modifiedString := hashEncryptionKeys(v.input)
+		c.Assert(modifiedString, Equals, v.output)
+	}
 }

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -313,7 +313,7 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 			// iptables commands hold locks so we can't have multiple runs. They
 			// have to be run one at a time to avoid 'Another app is currently
 			// holding the xtables lock...'
-			writeCmdToFile(cmdDir, cmd, k8sPods, enableMarkdown)
+			writeCmdToFile(cmdDir, cmd, k8sPods, enableMarkdown, nil)
 			continue
 		}
 		// Tell the wait group it needs to track another goroutine
@@ -332,7 +332,13 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 			// When we are done we return the thing we took from
 			// the semaphore, so another goroutine can get it
 			defer func() { semaphore <- true }()
-			writeCmdToFile(cmdDir, cmd, k8sPods, enableMarkdown)
+			if strings.Contains(cmd, "xfrm state") {
+				//  Output of 'ip -s xfrm state' needs additional processing to replace
+				// raw keys by their hash.
+				writeCmdToFile(cmdDir, cmd, k8sPods, enableMarkdown, hashEncryptionKeys)
+			} else {
+				writeCmdToFile(cmdDir, cmd, k8sPods, enableMarkdown, nil)
+			}
 		}(cmd)
 	}
 	// Wait for all the spawned goroutines to finish up.
@@ -350,7 +356,7 @@ func execCommand(prompt string) (string, error) {
 }
 
 // writeCmdToFile will execute command and write markdown output to a file
-func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool) {
+func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool, postProcess func(output string) string) {
 	// Clean up the filename
 	name := strings.Replace(prompt, "/", " ", -1)
 	name = strings.Replace(name, " ", "-", -1)
@@ -383,6 +389,11 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool
 	}
 	// Write prompt as header and the output as body, and / or error but delete empty output.
 	output, err := execCommand(prompt)
+	// Post-process the output if necessary
+	if postProcess != nil {
+		output = postProcess(output)
+	}
+
 	if err != nil {
 		fmt.Fprintf(f, "> Error while running '%s':  %s\n\n", prompt, err)
 	}
@@ -463,13 +474,13 @@ func pprofTraces(rootDir string) error {
 	}
 
 	cmd := fmt.Sprintf("gops stack $(pidof %s)", components.CiliumAgentName)
-	writeCmdToFile(rootDir, cmd, nil, enableMarkdown)
+	writeCmdToFile(rootDir, cmd, nil, enableMarkdown, nil)
 
 	cmd = fmt.Sprintf("gops stats $(pidof %s)", components.CiliumAgentName)
-	writeCmdToFile(rootDir, cmd, nil, enableMarkdown)
+	writeCmdToFile(rootDir, cmd, nil, enableMarkdown, nil)
 
 	cmd = fmt.Sprintf("gops memstats $(pidof %s)", components.CiliumAgentName)
-	writeCmdToFile(rootDir, cmd, nil, enableMarkdown)
+	writeCmdToFile(rootDir, cmd, nil, enableMarkdown, nil)
 
 	wg.Wait()
 	if profileErr != nil {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -309,17 +309,16 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	if epTemplate.DatapathConfiguration == nil {
 		dpConfig := endpoint.NewDatapathConfiguration()
 		epTemplate.DatapathConfiguration = &dpConfig
+	}
+	if option.Config.EnableEndpointRoutes {
+		epTemplate.DatapathConfiguration.InstallEndpointRoute = true
+		epTemplate.DatapathConfiguration.RequireEgressProg = true
+		disabled := false
+		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	} else {
-		if option.Config.EnableEndpointRoutes {
-			epTemplate.DatapathConfiguration.InstallEndpointRoute = true
-			epTemplate.DatapathConfiguration.RequireEgressProg = true
-			disabled := false
-			epTemplate.DatapathConfiguration.RequireRouting = &disabled
-		} else {
-			epTemplate.DatapathConfiguration.InstallEndpointRoute = false
-			epTemplate.DatapathConfiguration.RequireEgressProg = false
-			epTemplate.DatapathConfiguration.RequireRouting = nil
-		}
+		epTemplate.DatapathConfiguration.InstallEndpointRoute = false
+		epTemplate.DatapathConfiguration.RequireEgressProg = false
+		epTemplate.DatapathConfiguration.RequireRouting = nil
 	}
 
 	log.WithFields(logrus.Fields{

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/status"
+	"github.com/cilium/cilium/pkg/version"
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -592,16 +593,22 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 
 	sr.Stale = stale
 
+	//CiliumVersion definition
+	ver := version.GetCiliumVersion()
+	ciliumVer := fmt.Sprintf("%s (v.%s-r.%s)", ver.Version, ver.Version, ver.Revision)
+
 	switch {
 	case len(sr.Stale) > 0:
+		msg := "Stale status data"
 		sr.Cilium = &models.Status{
 			State: models.StatusStateWarning,
-			Msg:   "Stale status data",
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.statusResponse.Kvstore != nil && d.statusResponse.Kvstore.State != models.StatusStateOk:
+		msg := "Kvstore service is not ready"
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.Kvstore.State,
-			Msg:   "Kvstore service is not ready",
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.statusResponse.ContainerRuntime != nil && d.statusResponse.ContainerRuntime.State != models.StatusStateOk:
 		msg := "Container runtime is not ready"
@@ -610,15 +617,19 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 		}
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.ContainerRuntime.State,
-			Msg:   msg,
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case k8s.IsEnabled() && d.statusResponse.Kubernetes != nil && d.statusResponse.Kubernetes.State != models.StatusStateOk:
+		msg := "Kubernetes service is not ready"
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.Kubernetes.State,
-			Msg:   "Kubernetes service is not ready",
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	default:
-		sr.Cilium = &models.Status{State: models.StatusStateOk, Msg: "OK"}
+		sr.Cilium = &models.Status{
+			State: models.StatusStateOk,
+			Msg:   ciliumVer,
+		}
 	}
 
 	return sr

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -593,9 +593,9 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 
 	sr.Stale = stale
 
-	//CiliumVersion definition
+	// CiliumVersion definition
 	ver := version.GetCiliumVersion()
-	ciliumVer := fmt.Sprintf("%s (v.%s-r.%s)", ver.Version, ver.Version, ver.Revision)
+	ciliumVer := fmt.Sprintf("%s (v%s-%s)", ver.Version, ver.Version, ver.Revision)
 
 	switch {
 	case len(sr.Stale) > 0:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -317,7 +317,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 		}
 	}
 	if sr.Cilium != nil {
-		fmt.Fprintf(w, "Cilium:\t%s\t%s\n", sr.Cilium.State, sr.Cilium.Msg)
+		fmt.Fprintf(w, "Cilium:\t%s   %s\n", sr.Cilium.State, sr.Cilium.Msg)
 	}
 
 	if sr.Stale != nil {

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/envoy/xds"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -77,13 +76,13 @@ func (cache *NPHDSCache) OnIPIdentityCacheGC() {
 // OnIPIdentityCacheChange pushes modifications to the IP<->Identity mapping
 // into the Network Policy Host Discovery Service (NPHDS).
 func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
-	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity,
+	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
 	encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
 	// An upsert where an existing pair exists should translate into a
 	// delete (for the old Identity) followed by an upsert (for the new).
 	if oldID != nil && modType == ipcache.Upsert {
 		// Skip update if identity is identical
-		if *oldID == newID {
+		if oldID.ID == newID.ID {
 			return
 		}
 
@@ -99,7 +98,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 	})
 
 	// Look up the current resources for the specified Identity.
-	resourceName := newID.StringID()
+	resourceName := newID.ID.StringID()
 	msg, err := cache.Lookup(NetworkPolicyHostsTypeURL, resourceName)
 	if err != nil {
 		scopedLog.WithError(err).Warning("Can't lookup NPHDS cache")
@@ -122,7 +121,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 		sort.Strings(hostAddresses)
 
 		newNpHost := envoyAPI.NetworkPolicyHosts{
-			Policy:        uint64(newID),
+			Policy:        uint64(newID.ID),
 			HostAddresses: hostAddresses,
 		}
 		if err := newNpHost.Validate(); err != nil {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -519,12 +519,12 @@ func newDummyListener(ipc *IPCache) *dummyListener {
 }
 
 func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
-	cidr net.IPNet, oldHostIP, newHostIP net.IP, oldID *identityPkg.NumericIdentity,
-	newID identityPkg.NumericIdentity, encryptKey uint8, k8sMeta *K8sMetadata) {
+	cidr net.IPNet, oldHostIP, newHostIP net.IP, oldID *Identity,
+	newID Identity, encryptKey uint8, k8sMeta *K8sMetadata) {
 
 	switch modType {
 	case Upsert:
-		dl.entries[cidr.String()] = newID
+		dl.entries[cidr.String()] = newID.ID
 	default:
 		// Ignore, for simplicity we just clear the cache every time
 	}

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -16,8 +16,6 @@ package ipcache
 
 import (
 	"net"
-
-	"github.com/cilium/cilium/pkg/identity"
 )
 
 // CacheModification represents the type of operation performed upon IPCache.
@@ -42,7 +40,7 @@ type IPIdentityMappingListener interface {
 	// k8sMeta contains the Kubernetes pod namespace and name behind the IP
 	// and may be nil.
 	OnIPIdentityCacheChange(modType CacheModification, cidr net.IPNet, oldHostIP, newHostIP net.IP,
-		oldID *identity.NumericIdentity, newID identity.NumericIdentity, encryptKey uint8, k8sMeta *K8sMetadata)
+		oldID *Identity, newID Identity, encryptKey uint8, k8sMeta *K8sMetadata)
 
 	// OnIPIdentityCacheGC will be called to sync other components which are
 	// reliant upon the IPIdentityCache with the IPIdentityCache.

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,6 +87,10 @@ func (k *K8sWatcher) createPodController(getter cache.Getter, fieldSelector fiel
 						} else {
 							metrics.EventLagK8s.Set(timeSinceEpCreated.Round(time.Second).Seconds())
 						}
+					} else {
+						// If the ep is nil then we reset to zero, otherwise
+						// the previous value set is kept forever.
+						metrics.EventLagK8s.Set(0)
 					}
 					err := k.addK8sPodV1(pod)
 					k.K8sEventProcessed(metricPod, metricCreate, err == nil)

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -26,11 +26,11 @@ import (
 
 var (
 	// allowedMatchNameChars tests that MatchName contains only valid DNS characters
-	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9.]+$")
+	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9_.]+$")
 
 	// allowedPatternChars tests that the MatchPattern field contains only the
 	// characters we want in our wilcard scheme.
-	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9.*]+$") // the * inside the [] is a literal *
+	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
 
 	// FQDNMatchNameRegexString is a regex string which matches what's expected
 	// in the MatchName field in the FQDNSelector. This should be kept in-sync

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -28,7 +28,9 @@ func (s *PolicyAPITestSuite) TestFQDNSelectorSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*._cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {
@@ -54,7 +56,9 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 		{MatchName: "get-cilium.io."},
 		{MatchName: "foo.cilium.io."},
 		{MatchName: "cilium.io"},
+		{MatchName: "_cilium.io"},
 		{MatchPattern: "*.cilium.io"},
+		{MatchPattern: "*._cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {


### PR DESCRIPTION
* #14492 -- Agent: Include Cilium version in output of 'cilium status --verbose' (@romanspb80)
 * #15649 -- daemon/cmd: fix Cilium version status output (@aanm)
 * #15668 -- Fix channel panic from ipcache kvstore reconnect (@jomenxiao)
 * #15742 -- kvstore/etcd: fix etcd rate limit (QPS) not working (@ArthurChiao)
 * #15763 -- bpf: Fix defines in policy.h (@pchaigno)
 * #15550 -- Hash IPSec keys in the bugtool. Unit test are also added. (@h3llix)
 * #15706 -- ipcache: Expose correct source in Cilium API (@gandro) 
      * NOTE: pkg/wireguard one-line change dropped from #15706.
 * #15801 -- policy: Add underscore to the set of allowed characters in FQDN patterns (@jrajahalme)
 * #15808 -- bpf: fix map_array_get_16 backend retrieval (@borkmann)
 * #15785 -- daemon: Fix the init of the endpoints' datapath config (@pchaigno)
 * #15804 -- pkg/k8s: reset k8s event lag metric on pod add (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14492 15649 15668 15742 15763 15550 15706 15801 15785 15808 15804; do contrib/backporting/set-labels.py $pr done 1.9; done
```

Not backported:
>  #15688 -- pkg/client/client.go: Set EnabledProtocols when pointer is nil (@johngv2) 

The EnabledProtocols variable doesn't exist in v1.9 yet. @johngv2 Can you take a look
and see if it makes sense to port the related changes?
 
> #15780 -- Fix the initialization of host endpoint labels (@pchaigno)

Non-trivial to port. At least `AddFunc` in `pkg/k8s/watchers/node.go` missing.
@pchaigno Could you take a look?

