### PR TITLE
docs/policy: Clarify table for deny policy scenarios

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1119,21 +1119,21 @@ If multiple allow and deny policies are applied to the same pod, the following
 table represents the expected enforcement for that Pod:
 
 +--------------------------------------------------------------------------------------------+
-| **Ingress Policies Deployed to Server Pod (Yes / No)**                                     |
+| **Set of Ingress Policies Deployed to Server Pod**                                         |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 7 (HTTP)        | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 7 (HTTP)        | ✓       | ✓       | ✓      | ✓      |        |
 |                     +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 4 (80/TCP)      | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 4 (80/TCP)      | ✓       | ✓       | ✓      | ✓      |        |
 | **Allow Policies**  +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 4 (81/TCP)      | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 4 (81/TCP)      | ✓       | ✓       | ✓      | ✓      |        |
 |                     +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 3 (Pod: Client) | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 3 (Pod: Client) | ✓       | ✓       | ✓      | ✓      |        |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 4 (80/TCP)      | No      | Yes     | No     | Yes    | Yes    |
+|                     | Layer 4 (80/TCP)      |         | ✓       |        | ✓      | ✓      |
 | **Deny Policies**   +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 3 (Pod: Client) | No      | No      | Yes    | Yes    | No     |
+|                     | Layer 3 (Pod: Client) |         |         | ✓      | ✓      |        |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
-| **Traffic connection (Allowed / Denied)**                                                  |
+| **Result for Traffic Connections (Allowed / Denied)**                                      |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
 |                     | curl server:81        | Allowed | Allowed | Denied | Denied | Denied |
 |                     +-----------------------+---------+---------+--------+--------+--------+


### PR DESCRIPTION
This pull request attempts to clarify the table detailed different deny policy scenarios. The titles are changed to clarify that the bottom part gives the result from each scenario detailed in the top part. `Yes`/`No` are replaced by `✓`s as that makes the table a bit easier to parse visually and probably also better represents the presence/absence of policies.

![image](https://user-images.githubusercontent.com/1764210/115857336-dc36e200-a42d-11eb-8936-2b8737df45b4.png)