### PR TITLE
v1.9 backports 2021-04-22

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1446,7 +1446,9 @@ func runDaemon() {
 	bootstrapStats.k8sInit.End(true)
 	restoreComplete := d.initRestore(restoredEndpoints)
 
-	if !d.endpointManager.HostEndpointExists() {
+	if d.endpointManager.HostEndpointExists() {
+		d.endpointManager.InitHostEndpointLabels(d.ctx)
+	} else {
 		log.Info("Creating host endpoint")
 		if err := d.endpointManager.AddHostEndpoint(d.ctx, d, d.l7Proxy, d.identityAllocator,
 			"Create host endpoint", nodeTypes.GetName()); err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -48,6 +49,7 @@ import (
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -57,6 +59,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/monitor/notifications"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -1778,6 +1781,30 @@ func (e *Endpoint) ModifyIdentityLabels(addLabels, delLabels labels.Labels) erro
 func (e *Endpoint) IsInit() bool {
 	init, found := e.OpLabels.GetIdentityLabel(labels.IDNameInit)
 	return found && init.Source == labels.LabelSourceReserved
+}
+
+// InitWithNodeLabels initializes the endpoint with the known node labels as
+// well as reserved:host. It should only be used for the host endpoint.
+func (e *Endpoint) InitWithNodeLabels(ctx context.Context, launchTime time.Duration) {
+	if !e.IsHost() {
+		return
+	}
+
+	epLabels := labels.Labels{}
+	epLabels.MergeLabels(labels.LabelHost)
+
+	// Initialize with known node labels.
+	newLabels := labels.Map2Labels(node.GetLabels(), labels.LabelSourceK8s)
+	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
+	epLabels.MergeLabels(newIdtyLabels)
+
+	// Give the endpoint a security identity
+	newCtx, cancel := context.WithTimeout(ctx, launchTime)
+	defer cancel()
+	e.UpdateLabels(newCtx, epLabels, epLabels, true)
+	if errors.Is(newCtx.Err(), context.DeadlineExceeded) {
+		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for host endpoint")
+	}
 }
 
 // UpdateLabels is called to update the labels of an endpoint. Calls to this

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -16,7 +16,6 @@ package endpointmanager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -29,15 +28,12 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/identity/cache"
-	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mcastmanager"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/prometheus/client_golang/prometheus"
@@ -503,21 +499,7 @@ func (mgr *EndpointManager) AddHostEndpoint(ctx context.Context, owner regenerat
 		return err
 	}
 
-	epLabels := labels.Labels{}
-	epLabels.MergeLabels(labels.LabelHost)
-
-	// Initialize with known node labels.
-	newLabels := labels.Map2Labels(node.GetLabels(), labels.LabelSourceK8s)
-	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
-	epLabels.MergeLabels(newIdtyLabels)
-
-	// Give the endpoint a security identity
-	newCtx, cancel := context.WithTimeout(ctx, launchTime)
-	defer cancel()
-	ep.UpdateLabels(newCtx, epLabels, epLabels, true)
-	if errors.Is(newCtx.Err(), context.DeadlineExceeded) {
-		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for host endpoint")
-	}
+	ep.InitWithNodeLabels(ctx, launchTime)
 
 	return nil
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -504,6 +504,13 @@ func (mgr *EndpointManager) AddHostEndpoint(ctx context.Context, owner regenerat
 	return nil
 }
 
+// InitHostEndpointLabels initializes the host endpoint's labels with the
+// node's known labels.
+func (mgr *EndpointManager) InitHostEndpointLabels(ctx context.Context) {
+	ep := mgr.GetHostEndpoint()
+	ep.InitWithNodeLabels(ctx, launchTime)
+}
+
 // WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
 // this function is called to be at a given policy revision.
 // New endpoints appearing while waiting are ignored.

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +36,15 @@ func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
 		&slim_corev1.Node{},
 		0,
 		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				var valid bool
+				if node := k8s.ObjToV1Node(obj); node != nil {
+					valid = true
+					err := k.updateK8sNodeV1(nil, node)
+					k.K8sEventProcessed(metricNode, metricCreate, err == nil)
+				}
+				k.K8sEventReceived(metricNode, metricCreate, valid, false)
+			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
 				if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
@@ -62,12 +72,16 @@ func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
 }
 
 func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) error {
-	oldNodeLabels := oldK8sNode.GetLabels()
+	var oldNodeLabels map[string]string
+	if oldK8sNode != nil {
+		oldNodeLabels = oldK8sNode.GetLabels()
+	}
 	newNodeLabels := newK8sNode.GetLabels()
 
 	nodeEP := k.endpointManager.GetHostEndpoint()
 	if nodeEP == nil {
-		log.Error("Host endpoint not found")
+		log.Debug("Host endpoint not found, updating node labels")
+		node.SetLabels(newNodeLabels)
 		return nil
 	}
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -316,6 +316,9 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
 			// We need to know about active local redirect policy services
 			// before BPF LB datapath is synced.
 			k8sAPIGroupCiliumLocalRedirectPolicyV2,
+			// We need to know the node labels to populate the host endpoint
+			// labels.
+			k8sAPIGroupNodeV1Core,
 		)
 		// CiliumEndpoint is used to synchronize the ipcache, wait for
 		// it unless it is disabled


### PR DESCRIPTION
* #15780 -- Fix the initialization of host endpoint labels (@pchaigno)
    - Some minor conflicts were resolved.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15780; do contrib/backporting/set-labels.py $pr done 1.9; done
```