### PR TITLE
contrib: Clean output of submit-backport script

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -52,7 +52,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-git push "$USER_REMOTE" "$PR_BRANCH"
+git push -q "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')


### PR DESCRIPTION
When using `submit-backport` to open the backport pull request, it outputs the following information:

    Sending pull request...
    Enumerating objects: 154, done.
    Counting objects: 100% (115/115), done.
    Delta compression using up to 6 threads
    Compressing objects: 100% (24/24), done.
    Writing objects: 100% (24/24), 3.27 KiB | 3.27 MiB/s, done.
    Total 24 (delta 20), reused 0 (delta 0)
    remote: Resolving deltas: 100% (20/20), completed with 12 local objects.
    remote:
    remote: Create a pull request for 'pr/v1.9-backport-2021-04-22' on GitHub by visiting:
    remote:      https://github.com/pchaigno/cilium/pull/new/pr/v1.9-backport-2021-04-22
    remote:
    To github.com:pchaigno/cilium
     * [new branch]          pr/v1.9-backport-2021-04-22 -> pr/v1.9-backport-2021-04-22
    https://github.com/cilium/cilium/pull/15837

    Updating labels for PRs 15780

This is a bit messy and mostly caused by the `git push` command. We can hide most of this since the script is in charge of opening the pull request.