### PR TITLE
[v1.8]  Fix image digest preparation for release commits

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -26,7 +26,7 @@ EXPERIMENTAL_OPTIONS := \
     --set global.hubble.relay.enabled=true \
     --set global.hubble.ui.enabled=true
 
-USE_DIGESTS ?= true
+USE_DIGESTS ?= $(shell if grep -q '""' Makefile.digests; then echo "false"; else echo "true"; fi)
 ifeq ($(USE_DIGESTS),false)
 DIGEST_OPTS :=
 else
@@ -64,6 +64,7 @@ update-versions:
 			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $$chart;		\
 		fi; done
 	$(QUIET)for chart in $(shell find -type f -name values.yaml); do								\
+		sed -i 's/useDigest:.*/useDigest: 'false'/' $(CILIUM_VALUES);								\
 		sed -i '/# cilium-digest.*/{!b;n;s/digest.*/digest: "'$(CILIUM_DIGEST)'"/}' $$chart; 					\
 		sed -i '/# hubble-relay-digest.*/{!b;n;s/digest.*/digest: "'$(HUBBLE_RELAY_DIGEST)'"/}' $$chart;			\
 		sed -i '/# operator-aws-digest.*/{!b;n;s/awsDigest.*/awsDigest: "'$(OPERATOR_AWS_DIGEST)'"/}' $$chart; 			\


### PR DESCRIPTION
[ upstream commit 5ca7c948717539ff168b7f340fa01eb5408d4df7 ]

[ Backporter's notes: Changed 'use_digest' to false by default in the
                      update-versions make target, to avoid forcing
                      existing users into using digests during upgrade;
                      Concerned users can opt in manually by specifying
                      the use digest options in the helm args/config. ]

As digests are not available when prepare a release, digests should not
be set. Once the release is performed and Makefile.digests contains
those digests, we will automatically use the digests available.

v1.8 version of #15817.

Partially backports https://github.com/cilium/cilium/pull/15318.