### PR TITLE
.github: remove unnecessary docker hub credentials

### DIFF
--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -48,12 +48,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609
 
-      - name: Login to DockerHub to avoid rate limit
-        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
-
       - name: Login to quay.io for CI
         uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
         with:


### PR DESCRIPTION
GHA are not rate limited by DockerHub [1] so we can remove these
credentials

[1] https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495