### PR TITLE
cilium/cmd: don't write copyright header in generated shell completion

### DIFF
--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -95,23 +95,7 @@ func initConfig() {
 	}
 }
 
-const copyRightHeader = `# Copyright 2017-2020 Authors of Cilium
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-`
-
-var (
-	completionExample = `
+const completionExample = `
 # Installing bash completion on macOS using homebrew
 ## If running Bash 3.2 included with macOS
 	brew install bash-completion
@@ -148,7 +132,6 @@ var (
 ## Write fish completion code to fish specific location
 	cilium completion fish > ~/.config/fish/completions/cilium.fish
 `
-)
 
 func newCmdCompletion(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -171,21 +154,10 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 || args[0] == "bash" {
-		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
-			return err
-		}
 		return cmd.Root().GenBashCompletion(out)
-	}
-	if args[0] == "zsh" {
-		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
-			return err
-		}
+	} else if args[0] == "zsh" {
 		return cmd.Root().GenZshCompletion(out)
-	}
-	if args[0] == "fish" {
-		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
-			return err
-		}
+	} else if args[0] == "fish" {
 		return cmd.Root().GenFishCompletion(out, true)
 	}
 	return fmt.Errorf("unsupported shell: %s", args[0])

--- a/hubble-relay/cmd/completion/completion.go
+++ b/hubble-relay/cmd/completion/completion.go
@@ -41,36 +41,15 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 || args[0] == "bash" {
-		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
-			return err
-		}
 		return cmd.Root().GenBashCompletion(out)
 	}
 	if args[0] == "zsh" {
-		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
-			return err
-		}
 		return cmd.Root().GenZshCompletion(out)
 	}
 	return fmt.Errorf("unsupported shell: %s", args[0])
 }
 
-const (
-	copyRightHeader = `# Copyright 2020 Authors of Cilium
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-`
-	completionExample = `
+const completionExample = `
 # Installing bash completion on macOS using homebrew
 ## If running Bash 3.2 included with macOS
 	brew install bash-completion
@@ -101,4 +80,3 @@ const (
           source '$HOME/.hubble-relay/completion.zsh.inc'
           " >> $HOME/.zshrc
         source $HOME/.zshrc`
-)


### PR DESCRIPTION
The copyright header breaks completion for zsh. Per
http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Autoloaded-files
the first line of the completion files must be a zsh autoload tag.

Also the code is auto-generated so it's debatable whether copyright
applies.
