### PR TITLE
helm: move IPSec options under encryption.ipsec

### DIFF
--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -118,7 +118,7 @@ interface as follows:
 
        .. code-block:: shell-session
 
-           --set encryption.interface=ethX
+           --set encryption.ipsec.interface=ethX
 
 .. _node_to_node_encryption:
 
@@ -217,7 +217,7 @@ Troubleshooting
  * Check for ``level=warning`` and ``level=error`` messages in the Cilium log files
 
    * If there is a warning message similar to ``Device eth0 does not exist``,
-     use ``--set encryption.interface=ethX`` to set the encryption
+     use ``--set encryption.ipsec.interface=ethX`` to set the encryption
      interface.
 
  * Run a ``bash`` in a Cilium and validate the following:

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -409,6 +409,10 @@ Deprecated Options
   been deprecated in favor of ``enable-ipv4-masquerade`` and is planned to
   be removed in 1.11. For 1.10 release this option will have the same effect as
   ``enable-ipv4-masquerade`` where both options must not be used simultaneously.
+* Helm options ``encryption.keyFile``, ``encryption.mountPath``,
+  ``encryption.secretName`` and ``encryption.interface`` are now deprecated in
+  favor of ``encryption.ipsec.keyFile``, ``encryption.ipsec.mountPath``,
+  ``encryption.ipsec.secretName`` and ``encryption.ipsec.interface``.
 
 .. _1.9_upgrade_notes:
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -123,10 +123,15 @@ contributors across the globe, there is almost always someone available to help.
 | enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters. |
 | enableXTSocketFallback | bool | `true` |  |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
-| encryption.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. This option is only effective when encryption.type is set to ipsec. |
-| encryption.mountPath | string | `"/etc/ipsec"` | Path to mount the secret inside the Cilium pod. This option is only effective when encryption.type is set to ipsec. |
+| encryption.interface | string | `""` | Deprecated in favor of encryption.ipsec.interface. The interface to use for encrypted traffic. This option is only effective when encryption.type is set to ipsec. |
+| encryption.ipsec.interface | string | `""` | The interface to use for encrypted traffic. |
+| encryption.ipsec.keyFile | string | `""` | Name of the key file inside the Kubernetes secret configured via secretName. |
+| encryption.ipsec.mountPath | string | `""` | Path to mount the secret inside the Cilium pod. |
+| encryption.ipsec.secretName | string | `""` | Name of the Kubernetes secret containing the encryption keys. |
+| encryption.keyFile | string | `"keys"` | Deprecated in favor of encryption.ipsec.keyFile. Name of the key file inside the Kubernetes secret configured via secretName. This option is only effective when encryption.type is set to ipsec. |
+| encryption.mountPath | string | `"/etc/ipsec"` | Deprecated in favor of encryption.ipsec.mountPath. Path to mount the secret inside the Cilium pod. This option is only effective when encryption.type is set to ipsec. |
 | encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to ipsec. |
-| encryption.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec. |
+| encryption.secretName | string | `"cilium-ipsec-keys"` | Deprecated in favor of encryption.ipsec.secretName. Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec. |
 | encryption.type | string | `"ipsec"` | Encryption method. Can be either ipsec or wireguard. |
 | endpointHealthChecking.enabled | bool | `true` |  |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -327,7 +327,11 @@ spec:
         - mountPath: /run/xtables.lock
           name: xtables-lock
 {{- if and ( .Values.encryption.enabled ) ( eq .Values.encryption.type "ipsec" ) }}
+  {{- if .Values.encryption.ipsec.mountPath }}
+        - mountPath: {{ .Values.encryption.ipsec.mountPath }}
+  {{- else }}
         - mountPath: {{ .Values.encryption.mountPath }}
+  {{- end }}
           name: cilium-ipsec-secrets
 {{- end }}
 {{- if .Values.kubeConfigPath }}
@@ -545,7 +549,11 @@ spec:
 {{- if and ( .Values.encryption.enabled ) ( eq .Values.encryption.type "ipsec" ) }}
       - name: cilium-ipsec-secrets
         secret:
+  {{- if .Values.encryption.ipsec.secretName }}
+          secretName: {{ .Values.encryption.ipsec.secretName }}
+  {{- else }}
           secretName: {{ .Values.encryption.secretName }}
+  {{- end }}
 {{- end }}
 {{- if .Values.cni.configMap }}
       - name: cni-configuration

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -425,10 +425,18 @@ data:
 {{- if .Values.encryption.enabled }}
   {{- if eq .Values.encryption.type "ipsec" }}
   enable-ipsec: {{ .Values.encryption.enabled | quote }}
+
+    {{- if and .Values.encryption.ipsec.mountPath .Values.encryption.ipsec.keyFile }}
+  ipsec-key-file: {{ .Values.encryption.ipsec.mountPath }}/{{ .Values.encryption.ipsec.keyFile }}
+    {{- else }}
   ipsec-key-file: {{ .Values.encryption.mountPath }}/{{ .Values.encryption.keyFile }}
-    {{- if hasKey .Values.encryption "interface" }}
+    {{- end }}
+    {{- if .Values.encryption.ipsec.interface }}
+  encrypt-interface: {{ .Values.encryption.ipsec.interface }}
+    {{- else if .Values.encryption.interface }}
   encrypt-interface: {{ .Values.encryption.interface }}
     {{- end }}
+
     {{- if .Values.encryption.nodeEncryption }}
   encrypt-node: {{ .Values.encryption.nodeEncryption | quote }}
     {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -420,25 +420,42 @@ encryption:
   # -- Encryption method. Can be either ipsec or wireguard.
   type: ipsec
 
-  # -- Name of the key file inside the Kubernetes secret configured via secretName.
-  # This option is only effective when encryption.type is set to ipsec.
-  keyFile: keys
-
-  # -- Path to mount the secret inside the Cilium pod.
-  # This option is only effective when encryption.type is set to ipsec.
-  mountPath: /etc/ipsec
-
-  # -- Name of the Kubernetes secret containing the encryption keys.
-  # This option is only effective when encryption.type is set to ipsec.
-  secretName: cilium-ipsec-keys
-
   # -- Enable encryption for pure node to node traffic.
   # This option is only effective when encryption.type is set to ipsec.
   nodeEncryption: false
 
-  # -- The interface to use for encrypted traffic.
+  ipsec:
+    # -- Name of the key file inside the Kubernetes secret configured via secretName.
+    keyFile: ""
+
+    # -- Path to mount the secret inside the Cilium pod.
+    mountPath: ""
+
+    # -- Name of the Kubernetes secret containing the encryption keys.
+    secretName: ""
+
+    # -- The interface to use for encrypted traffic.
+    interface: ""
+
+  # -- Deprecated in favor of encryption.ipsec.keyFile.
+  # Name of the key file inside the Kubernetes secret configured via secretName.
   # This option is only effective when encryption.type is set to ipsec.
-  # interface: eth0
+  keyFile: keys
+
+  # -- Deprecated in favor of encryption.ipsec.mountPath.
+  # Path to mount the secret inside the Cilium pod.
+  # This option is only effective when encryption.type is set to ipsec.
+  mountPath: /etc/ipsec
+
+  # -- Deprecated in favor of encryption.ipsec.secretName.
+  # Name of the Kubernetes secret containing the encryption keys.
+  # This option is only effective when encryption.type is set to ipsec.
+  secretName: cilium-ipsec-keys
+
+  # -- Deprecated in favor of encryption.ipsec.interface.
+  # The interface to use for encrypted traffic.
+  # This option is only effective when encryption.type is set to ipsec.
+  interface: ""
 
 # TODO: Add documentation
 endpointHealthChecking:

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -664,13 +664,13 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
 			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":               "disabled",
-				"autoDirectNodeRoutes": "true",
-				"encryption.enabled":   "true",
-				"encryption.interface": privateIface,
-				"devices":              "",
-				"hostFirewall":         "false",
-				"kubeProxyReplacement": "disabled",
+				"tunnel":                     "disabled",
+				"autoDirectNodeRoutes":       "true",
+				"encryption.enabled":         "true",
+				"encryption.ipsec.interface": privateIface,
+				"devices":                    "",
+				"hostFirewall":               "false",
+				"kubeProxyReplacement":       "disabled",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
@@ -690,12 +690,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
 			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":               "disabled",
-				"autoDirectNodeRoutes": "true",
-				"encryption.enabled":   "true",
-				"encryption.interface": privateIface,
-				"devices":              devices,
-				"hostFirewall":         "false",
+				"tunnel":                     "disabled",
+				"autoDirectNodeRoutes":       "true",
+				"encryption.enabled":         "true",
+				"encryption.ipsec.interface": privateIface,
+				"devices":                    devices,
+				"hostFirewall":               "false",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})


### PR DESCRIPTION
This commit moves the keyFile, mountPath, secretName and interface Helm
options (IPSec specific) from encryption to encryption.ipsec, while
marking the old options as deprecated.

To avoid breaking existing configurations the new options have
precedence over the deprecated ones, but they don't have default values.

In this way:
* if set, the encryption.ipsec.* options take precedence
* otherwise we fallback to the deprecated encryption.* values (either
  the user specified values or the default ones)
