### PR TITLE
test: Wait for cilium monitor to match expected output

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1580,10 +1580,9 @@ var _ = Describe("RuntimePolicies", func() {
 					"No ingress traffic to endpoint")
 
 				By("Testing cilium monitor output")
-				monitorRes.ExpectContains(
-					fmt.Sprintf("local EP ID %s, remote ID host, proto 1, ingress, action audit", endpointID),
-					"No ingress policy log record",
-				)
+				auditVerdict := fmt.Sprintf("local EP ID %s, remote ID host, proto 1, ingress, action audit", endpointID)
+				monitorRes.WaitUntilMatch(auditVerdict)
+				monitorRes.ExpectContains(auditVerdict, "No ingress policy log record")
 
 				By("Testing cilium endpoint list output")
 				res = vm.Exec("cilium endpoint list")
@@ -1621,10 +1620,9 @@ var _ = Describe("RuntimePolicies", func() {
 					"Default policy verdict on egress failed")
 
 				By("Testing cilium monitor output")
-				monitorRes.ExpectContains(
-					fmt.Sprintf("ID %s, remote ID host, proto 1, egress, action audit", endpointID),
-					"No egress policy log record",
-				)
+				auditVerdict := fmt.Sprintf("ID %s, remote ID host, proto 1, egress, action audit", endpointID)
+				monitorRes.WaitUntilMatch(auditVerdict)
+				monitorRes.ExpectContains(auditVerdict, "No egress policy log record")
 
 				By("Testing cilium endpoint list output")
 				res := vm.Exec("cilium endpoint list")

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -404,7 +404,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		res := vm.ContainerExec(helpers.App1, helpers.CurlFail(world1Target))
 		res.ExpectSuccess("Cannot access to %q", world1Target)
 
-		_ = monitorCMD.WaitUntilMatch(allowVerdict)
+		monitorCMD.WaitUntilMatch(allowVerdict)
 		monitorCMD.ExpectContains(allowVerdict)
 		monitorCMD.Reset()
 
@@ -921,6 +921,7 @@ INITSYSTEM=SYSTEMD`
 			monitorCMD.Reset()
 			res = vm.ContainerExec(helpers.App1, curlCmd)
 			res.ExpectFail("Can access to %q when should not (No DNS request to allow the IP)", world1Target)
+			monitorCMD.WaitUntilMatch("xx drop (Policy denied)")
 			monitorCMD.ExpectContains("xx drop (Policy denied)")
 
 			By("Testing connectivity to %q", world1Target)
@@ -987,12 +988,14 @@ INITSYSTEM=SYSTEMD`
 			monitorCMD.Reset()
 			res = vm.ContainerExec(helpers.App1, curlCmd)
 			res.ExpectFail("Can access to %q when should not (No DNS request to allow the IP)", world1Target)
+			monitorCMD.WaitUntilMatch("xx drop (Policy denied)")
 			monitorCMD.ExpectContains("xx drop (Policy denied)")
 
 			By("Testing connectivity to %q", world1Target)
 			monitorCMD.Reset()
 			res = vm.ContainerExec(helpers.App1, helpers.CurlFail(world1Target))
 			res.ExpectSuccess("Cannot access to %q when it should work", world1Target)
+			monitorCMD.WaitUntilMatch("verdict Forwarded GET http://world1.cilium.test/ => 200")
 			monitorCMD.ExpectContains("verdict Forwarded GET http://world1.cilium.test/ => 200")
 		})
 	})

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -187,6 +187,7 @@ var _ = Describe("RuntimeKafka", func() {
 		res = consumer(disallowTopic, MaxMessages)
 		res.ExpectFail("Kafka consumer can access to disallowTopic")
 
+		monitorRes.WaitUntilMatch("verdict Denied offsetfetch topic disallowTopic => 29")
 		monitorRes.ExpectContains("verdict Denied offsetfetch topic disallowTopic => 29")
 	})
 
@@ -220,6 +221,7 @@ var _ = Describe("RuntimeKafka", func() {
 		err = res.WaitUntilMatch("{disallowTopic=TOPIC_AUTHORIZATION_FAILED}")
 		Expect(err).To(BeNil(), "Traffic in disallowTopic is allowed")
 
+		monitorRes.WaitUntilMatch("verdict Denied metadata topic disallowTopic => 29")
 		monitorRes.ExpectContains("verdict Denied metadata topic disallowTopic => 29")
 	})
 })


### PR DESCRIPTION
In some tests we check the output of `cilium monitor` and compare it against expected substrings (e.g., allowed verdict). When doing so, we however need to repeat with a timeout until it matches as the `cilium monitor` output may be buffered and may not match the expected output as soon as we check. This pull request fixes a couple cases where we forgot to wait for the output to match.

It is expected to fix flake https://github.com/cilium/cilium/issues/14676. See details at https://github.com/cilium/cilium/issues/14676#issuecomment-825766970