### PR TITLE
Revert "ci: retry gke cluster scale up, don't clear cluster at start"

### DIFF
--- a/test/gke/resize-cluster.sh
+++ b/test/gke/resize-cluster.sh
@@ -29,7 +29,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export KUBECONFIG="${script_dir}/resize-kubeconfig"
 gcloud container clusters get-credentials --project "${project}" --region "europe-west4" management-cluster-0
 
-kubectl get containernodepools.container.cnrm.cloud.google.com "${cluster_name}" -n test-clusters -o yaml | sed "s/nodeCount:.*$/nodeCount: ${node_count}/g" | kubectl replace -f -
+kubectl get containernodepools.container.cnrm.cloud.google.com ${cluster_name} -n test-clusters -o yaml | sed "s/nodeCount:.*$/nodeCount: ${node_count}/g" | kubectl replace -f -
 
 gcloud container clusters get-credentials --project "${project}" --region "${region}" "${cluster_uri}"
 
@@ -39,16 +39,4 @@ if [ "${#node_pools[@]}" -ne 1 ] ; then
   exit 1
 fi
 
-resize_retries=0
-scaled=1
-while [ $resize_retries -lt 4 ]; do
-	echo "trying to scale cluster up"
-	if gcloud container clusters resize --project "${project}" --region "${region}" --node-pool "${node_pools[0]}" --num-nodes "${node_count}" --quiet "${cluster_uri}" ; then
-		scaled=0
-		break
-	fi
-	sleep 15
-	((resize_retries++))
-done
-
-exit $scaled
+gcloud container clusters resize --project "${project}" --region "${region}" --node-pool "${node_pools[0]}" --num-nodes ${node_count} --quiet "${cluster_uri}"

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -77,6 +77,9 @@ gcloud container clusters describe --project "${project}" --region "${region}" -
   | sed -E 's/([0-9]+\.[0-9]+)\..*/\1/' | tr -d '\n' > "${script_dir}/cluster-version"
 gcloud container clusters describe --project "${project}" --region "${region}" --format='value(clusterIpv4Cidr)' "${cluster_uri}" > "${script_dir}/cluster-cidr"
 
+echo "cleaning cluster before tests"
+"${script_dir}"/clean-cluster.sh
+
 echo "scaling ${cluster_uri} to 2"
 "${script_dir}"/resize-cluster.sh 2 "${cluster_uri}"
 


### PR DESCRIPTION
Reverts cilium/cilium#14819 since it seems like it broke all GKE Jenkins jobs.