### PR TITLE
pkg/bpf: fix panic for inconsistency label cardinality

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -982,7 +982,8 @@ func (m *Map) GetNextKey(key MapKey, nextKey MapKey) error {
 
 	err := GetNextKey(m.fd, key.GetKeyPtr(), nextKey.GetKeyPtr())
 	if option.Config.MetricsConfig.BPFMapOps {
-		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpGetNextKey, metrics.Error2Outcome(err)).Inc()
+		//TODO(sayboras): Remove deprecated label in 1.10
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), m.commonName(), metricOpGetNextKey, metrics.Error2Outcome(err)).Inc()
 	}
 	return err
 }
@@ -1070,7 +1071,8 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 		case Insert:
 			err := UpdateElement(m.fd, e.Key.GetKeyPtr(), e.Value.GetValuePtr(), 0)
 			if option.Config.MetricsConfig.BPFMapOps {
-				metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
+				//TODO(sayboras): Remove deprecated label in 1.10
+				metrics.BPFMapOps.WithLabelValues(m.commonName(), m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
 			}
 			if err == nil {
 				e.DesiredAction = OK
@@ -1085,7 +1087,8 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 		case Delete:
 			_, err := deleteElement(m.fd, e.Key.GetKeyPtr())
 			if option.Config.MetricsConfig.BPFMapOps {
-				metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Error2Outcome(err)).Inc()
+				//TODO(sayboras): Remove deprecated label in 1.10
+				metrics.BPFMapOps.WithLabelValues(m.commonName(), m.commonName(), metricOpDelete, metrics.Error2Outcome(err)).Inc()
 			}
 			if err == 0 || err == unix.ENOENT {
 				delete(m.cache, k)


### PR DESCRIPTION
When labels were marked for deprecation, there were certain places where
the old label was not set. This causes Cilium, running with metrics
enabled, to panic when those certain BPF map operations are attempted.

Such panic will manifest as follow:

```
goroutine 400 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).WithLabelValues(0xc0005239b0, 0xc005f3ed20, 0x3, 0x3, 0x2ad5ce0, 0xc005ef69c0)
	/go/src/github.com/cilium/cilium/vendor/github.com/prometheus/client_golang/prometheus/counter.go:248 +0xda
github.com/cilium/cilium/pkg/bpf.(*Map).resolveErrors(0xc000ea9180, 0x2b3cc60, 0xc005f195c0, 0x0, 0x0)
	/go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:1073 +0xda2
github.com/cilium/cilium/pkg/controller.(*Controller).runController(0xc005632000)
	/go/src/github.com/cilium/cilium/pkg/controller/controller.go:205 +0xa77
created by github.com/cilium/cilium/pkg/controller.(*Manager).updateController
	/go/src/github.com/cilium/cilium/pkg/controller/manager.go:120 +0xb50
```

To avoid this panic, as a temporary workaround, users can run Cilium
with `--metrics=-cilium_bpf_map_ops_total` or setting
`metrics: "-cilium_bpf_map_ops_total"` in Cilium's ConfigMap.

Fixes: fb0c3e592d7a ("metrics: Add new prometheus metrics and related label")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/15865

```release-note
Fix panic when accounting for certain metrics in BPF map operations
```
