### PR TITLE
cilium: Encryption EKS 4.14 kernel (default) fixes

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1086,6 +1086,15 @@ int to_host(struct __ctx_buff *ctx)
 		traced = true;
 	}
 
+#ifdef ENABLE_IPSEC
+	/* Encryption stack needs this when IPSec headers are
+	 * rewritten without FIB helper because we do not yet
+	 * know correct MAC address which will cause the stack
+	 * to mark as PACKET_OTHERHOST and drop.
+	 */
+	ctx_change_type(ctx, PACKET_HOST);
+#endif
+
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, srcID, 0, 0,
 				  CILIUM_IFINDEX, ret, 0);

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -453,11 +453,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_HOST_FIREWALL"] = "1"
 	}
 
-	if iface := option.Config.EncryptInterface; len(iface) != 0 {
+	if option.Config.EnableIPSec {
 		a := byteorder.HostSliceToNetwork(node.GetIPv4(), reflect.Uint32).(uint32)
 		cDefinesMap["IPV4_ENCRYPT_IFACE"] = fmt.Sprintf("%d", a)
-
-		if len(iface) != 0 {
+		if iface := option.Config.EncryptInterface; len(iface) != 0 {
 			link, err := netlink.LinkByName(iface[0])
 			if err == nil {
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -34,6 +34,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -462,10 +463,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 			}
 		}
+		// If we are using IPAMENI always use IP_POOLS datapath, the pod subnets
+		// will be auto-discovered later at runtime.
+		if (option.Config.IPAM == ipamOption.IPAMENI) ||
+			option.Config.IsPodSubnetsDefined() {
+			cDefinesMap["IP_POOLS"] = "1"
+		}
 	}
-	if option.Config.IsPodSubnetsDefined() {
-		cDefinesMap["IP_POOLS"] = "1"
-	}
+
 	if option.Config.EnableNodePort {
 		if option.Config.EnableIPv4 {
 			cDefinesMap["SNAT_MAPPING_IPV4"] = nat.MapNameSnat4Global

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -29,11 +29,13 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -1356,6 +1358,19 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 	n.updateOrRemoveNodeRoutes(prevConfig.AuxiliaryPrefixes, newConfig.AuxiliaryPrefixes, true)
 
 	if newConfig.EnableIPSec {
+		// For the ENI ipam mode on EKS, this will be the interface that
+		// the router (cilium_host) IP is associated to.
+		if option.Config.IPAM == ipamOption.IPAMENI && len(option.Config.IPv4PodSubnets) == 0 {
+			if info := node.GetRouterInfo(); info != nil {
+				var ipv4PodSubnets []*net.IPNet
+				for _, c := range info.GetIPv4CIDRs() {
+					cidr := c // create a copy to be able to take a reference
+					ipv4PodSubnets = append(ipv4PodSubnets, &cidr)
+				}
+				n.nodeConfig.IPv4PodSubnets = ipv4PodSubnets
+			}
+		}
+
 		if err := n.replaceHostRules(); err != nil {
 			log.WithError(err).Warning("Cannot replace Host rules")
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -198,17 +198,6 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 			}
 			option.Config.EncryptInterface = interfaces
 		}
-
-		// For the ENI ipam mode on EKS, this will be the interface that
-		// the router (cilium_host) IP is associated to.
-		if len(option.Config.IPv4PodSubnets) == 0 {
-			if info := node.GetRouterInfo(); info != nil {
-				for _, c := range info.GetIPv4CIDRs() {
-					cidr := c // create a copy to be able to take a reference
-					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &cidr)
-				}
-			}
-		}
 	}
 
 	// No interfaces is valid in tunnel disabled case


### PR DESCRIPTION
Encryption with default EKS kernel (4.14) was not working because it uses a different path from 5.4 kernels. In 5.4 kernels we have FIB lookup support in kernel and do IPSec header rewrites directly in BPF, but in kernels without FIB lookup support we have to use stack to do these rewrites.

There were additionally a couple issues with ordering that broke the subnet configuration. We were effectively running without pools, which sort of works when you have low node counts (always for 2 nodes) but any larger number of nodes may fail when routes are missing and we pick incorrect IPs. This series ensures we get the correct features enabled in EKS mode. Namely, that subnets are configured and POOLS define is enabled in datapath.

The CI miss here is we need 2+ nodes in EKS testing for encryption tests to be effective. I do not update workflows in this series.