### PR TITLE
Improve the docs CRD schema version update script

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -136,7 +136,8 @@ if [[ "$#" -ne 1 ]]; then
   exit 1
 fi
 
-release_version="${1}"
+release_ersion="$(echo $1 | sed 's/^v//')"
+release_version="v$release_ersion"
 
 create_file ${release_version} "${dst_file}"
 

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -25,7 +25,7 @@ get_line_of_schema_version(){
 
 get_schema_of_branch(){
    stable_branch="${1}"
-   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//'
+   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq
 }
 
 get_stable_branches(){

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -34,7 +34,14 @@ get_stable_branches(){
 
 get_stable_tags_for_minor(){
    minor_ver="${1}"
-   git ls-remote --tags ${remote} v\* | awk '{ print $2 }' | grep "${minor_ver}" | grep -v '\^' | grep -v '\-' | sed 's+refs/tags/++' | sort -V
+   git ls-remote --tags ${remote} v\* \
+       | awk '{ print $2 }' \
+       | grep "${minor_ver}" \
+       | grep -v '\^' \
+       | grep -v '\-' \
+       | sed 's+refs/tags/++' \
+       | sort -V \
+   || echo ""
 }
 
 get_rc_tags_for_minor(){

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-remote="origin"
 dst_file="${dir}/concepts/kubernetes/compatibility-table.rst"
+
+. "${dir}/../contrib/backporting/common.sh"
+remote="$(get_remote)"
 
 set -o nounset
 set -o pipefail

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -49,6 +49,10 @@ get_rc_tags_for_minor(){
    git ls-remote --tags ${remote} v\* | awk '{ print $2 }' | grep "${minor_ver}" | grep -v '\^' | grep '\-' | sed 's+refs/tags/++' | sort -V
 }
 
+filter_out_oldest() {
+    echo "${@}" | cut -d' ' -f2- -
+}
+
 create_file(){
   release_version="${1}"
   dst_file="${2}"
@@ -59,7 +63,7 @@ create_file(){
   echo   "+-----------------+----------------+" >> "${dst_file}"
   stable_branches=$(get_stable_branches)
   if [[ ${stable_branches} != *"${release_version}"* ]]; then
-    stable_branches="${stable_branches} ${release_version}"
+      stable_branches="$(filter_out_oldest ${stable_branches} ${release_version})"
   fi
   for stable_branch in ${stable_branches}; do
       rc_tags=$(get_rc_tags_for_minor "${stable_branch}")


### PR DESCRIPTION
Review commit-by-commit.

Fix a bunch of quality-of-life things in the CRD schema docs generator script
so it runs, correctly, in my env (different git remote) against prerelease
versions like the upcoming v1.10 release, with the latest branch, with a wider
variety of inputs; and allow it to more clearly state what it is doing while it
is generating the CRD schema versions.

Also fix up the script so it will reliably tell you whether you need to bump the
schema version or not, based on the diff in the tree since the most recent
tagged release on the target branch.

Related: #15797