### PR TITLE
node: Remove SetInternalIPv4From Method

### DIFF
--- a/pkg/node/address_darwin.go
+++ b/pkg/node/address_darwin.go
@@ -33,7 +33,3 @@ func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.
 func getCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
 	return net.IP{}, net.IP{}
 }
-
-func SetInternalIPv4From(_ string) error {
-	return nil
-}

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -199,24 +198,4 @@ func getCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
 	}
 
 	return ipv4GW, ipv6Router
-}
-
-// SetInternalIPv4From sets the internal IPv4 with the first global address
-// found in that interface.
-func SetInternalIPv4From(ifaceName string) error {
-	l, err := netlink.LinkByName(ifaceName)
-	if err != nil {
-		return errors.New("unable to retrieve interface attributes")
-	}
-	v4Addrs, err := netlink.AddrList(l, netlink.FAMILY_V4)
-	if err != nil {
-		return errors.New("unable to retrieve interface IPv4 address")
-	}
-	for _, ip := range v4Addrs {
-		if netlink.Scope(ip.Scope) == netlink.SCOPE_UNIVERSE {
-			SetInternalIPv4Router(ip.IP)
-			return nil
-		}
-	}
-	return errors.New("unable to find IP addresses with scope global")
 }


### PR DESCRIPTION
The `SetInternalIPv4From` method is no longer used
in any part of the codebase and is a red-herring when
trying to figure out places where `SetInternalIPv4Router`
might be called.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>