### PR TITLE
v1.9 backports 2021-04-27

### DIFF
--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -36,11 +36,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@012185ccbeb554a7f5f987bea0f1a73519b3cdf5
-      - name: Login to DockerHub to avoid rate limit
-        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
       - name: Login to quay.io for CI
         uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
         with:

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1111,21 +1111,21 @@ If multiple allow and deny policies are applied to the same pod, the following
 table represents the expected enforcement for that Pod:
 
 +--------------------------------------------------------------------------------------------+
-| **Ingress Policies Deployed to Server Pod (Yes / No)**                                     |
+| **Set of Ingress Policies Deployed to Server Pod**                                         |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 7 (HTTP)        | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 7 (HTTP)        | ✓       | ✓       | ✓      | ✓      |        |
 |                     +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 4 (80/TCP)      | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 4 (80/TCP)      | ✓       | ✓       | ✓      | ✓      |        |
 | **Allow Policies**  +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 4 (81/TCP)      | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 4 (81/TCP)      | ✓       | ✓       | ✓      | ✓      |        |
 |                     +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 3 (Pod: Client) | Yes     | Yes     | Yes    | Yes    | No     |
+|                     | Layer 3 (Pod: Client) | ✓       | ✓       | ✓      | ✓      |        |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 4 (80/TCP)      | No      | Yes     | No     | Yes    | Yes    |
+|                     | Layer 4 (80/TCP)      |         | ✓       |        | ✓      | ✓      |
 | **Deny Policies**   +-----------------------+---------+---------+--------+--------+--------+
-|                     | Layer 3 (Pod: Client) | No      | No      | Yes    | Yes    | No     |
+|                     | Layer 3 (Pod: Client) |         |         | ✓      | ✓      |        |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
-| **Traffic connection (Allowed / Denied)**                                                  |
+| **Result for Traffic Connections (Allowed / Denied)**                                      |
 +---------------------+-----------------------+---------+---------+--------+--------+--------+
 |                     | curl server:81        | Allowed | Allowed | Denied | Denied | Denied |
 |                     +-----------------------+---------+---------+--------+--------+--------+

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -91,6 +91,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"sysctl -a",
 		"bpftool map show",
 		"bpftool prog show",
+		"bpftool net show",
 		"taskset -pc 1",
 		// iptables
 		"iptables-save -c",

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -52,7 +52,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-git push "$USER_REMOTE" "$PR_BRANCH"
+git push -q "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')

--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -642,6 +642,18 @@ func FailWithToggle(message string, callerSkip ...int) {
 	}
 }
 
+// SkipDescribeIf is a wrapper for the Describe block which is being executed
+// if the given condition is NOT met.
+func SkipDescribeIf(condition func() bool, text string, body func()) bool {
+	if condition() {
+		return It(text, func() {
+			Skip("skipping due to unmet condition")
+		})
+	}
+
+	return Describe(text, body)
+}
+
 // SkipContextIf is a wrapper for the Context block which is being executed
 // if the given condition is NOT met.
 func SkipContextIf(condition func() bool, text string, body func()) bool {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -34,7 +34,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("K8sPolicyTest", func() {
+var _ = SkipDescribeIf(func() bool {
+	// We only need to run on 4.9 with kube-proxy and net-next with KPR
+	// and the third node. Other CI jobs are not expected to increase
+	// code coverage.
+	return helpers.RunsOnGKE() || helpers.RunsOn419Kernel()
+}, "K8sPolicyTest", func() {
 
 	var (
 		kubectl *helpers.Kubectl


### PR DESCRIPTION
* #14895 -- bugtool: Record attached BPF programs (@aditighag)
 * #15762 -- test: Skip K8sPolicy on GKE and 4.19 (@pchaigno)
 * #15838 -- contrib: Clean output of submit-backport script (@pchaigno)
 * #15841 -- .github: remove unnecessary docker hub credentials (@aanm)
 * #15836 -- docs/policy: Clarify table for deny policy scenarios (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14895 15762 15838 15841 15836; do contrib/backporting/set-labels.py $pr done 1.9; done