### PR TITLE
install/kubernetes: fix upgrade envoy to 1.18.2 for Hubble UI

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -3,7 +3,7 @@
 
 include Makefile.digests ../../Makefile.defs
 
-HUBBLE_PROXY_VERSION := "v1.14.5"
+HUBBLE_PROXY_VERSION := "v1.18.2"
 HUBBLE_UI_VERSION := "v0.7.3"
 MANAGED_ETCD_VERSION := "v2.0.7"
 ETCD_VERSION := "v3.4.13"


### PR DESCRIPTION
Before this patch, `make -C install/kubernetes update-versions` would downgrade the envoy image used by Hubble UI from v1.18.2 to v1.14.5.

`HUBBLE_PROXY_VERSION` was missed by d29efc4c037ba4de58c42fe88a28150cc5e13f44 ("ui deployment: upgrade envoy to 1.18.2, fix config")