### PR TITLE
AUTHORS: Update email

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,7 +107,7 @@ Ivar Lazzaro                            ivarlazzaro@gmail.com
 Jaff Cheng                              jaff.cheng.sh@gmail.com
 Jaime Caamaño Ruiz                      jcaamano@suse.com
 Jan-Erik Rediger                        janerik@fnordig.de
-Jarno Rajahalme                         jarno@covalent.io
+Jarno Rajahalme                         jarno@isovalent.com
 Jean Raby                               jean@raby.sh
 Jed Salazar                             jed@isovalent.com
 Jerry J. Muzsik                         jerrymuzsik@icloud.com


### PR DESCRIPTION
Update outdated email address for Jarno Rajahalme.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
