### PR TITLE
examples: add 'rebel-base-global-shared.yaml'

### DIFF
--- a/Documentation/gettingstarted/clustermesh/services.rst
+++ b/Documentation/gettingstarted/clustermesh/services.rst
@@ -21,20 +21,8 @@ Kubernetes service with identical name and namespace in each cluster and adding
 the annotation ``io.cilium/global-service: "true"`` to declare it global.
 Cilium will automatically perform load-balancing to pods in both clusters.
 
-.. code-block:: yaml
-
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: rebel-base
-     annotations:
-       io.cilium/global-service: "true"
-   spec:
-     type: ClusterIP
-     ports:
-     - port: 80
-     selector:
-       name: rebel-base
+.. literalinclude:: ../../../examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
+  :language: YAML
 
 Load-balancing Only to a Remote Cluster
 #######################################
@@ -71,12 +59,14 @@ Deploying a Simple Example Service
 
    .. parsed-literal::
 
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
        kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
 
 2. In cluster 2, deploy:
 
    .. parsed-literal::
 
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
        kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
 
 3. From either cluster, access the global service:

--- a/examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rebel-base
+  annotations:
+    io.cilium/global-service: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    name: rebel-base


### PR DESCRIPTION
This allows for `kubectl apply -f`-ing the manifest directly in demo material or when users are trying things out. I guess it also allows for making it clearer in the documentation that the users actually must create the service in both clusters for load-balancing between clusters to work, as per the updated instructions.