### PR TITLE
examples/kubernetes: add arm64 support for connectivity check

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -80,7 +80,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -135,7 +135,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -202,7 +202,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -257,7 +257,7 @@ spec:
         - name: PORT
           value: "41001"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -319,7 +319,7 @@ spec:
       containers:
       - name: pod-to-a-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -375,7 +375,7 @@ spec:
       containers:
       - name: pod-to-external-1111-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -431,7 +431,7 @@ spec:
       containers:
       - name: pod-to-a-denied-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -477,7 +477,7 @@ spec:
       containers:
       - name: pod-to-a-allowed-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -533,7 +533,7 @@ spec:
       containers:
       - name: pod-to-external-fqdn-allow-google-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -589,7 +589,7 @@ spec:
       containers:
       - name: pod-to-a-intra-node-proxy-egress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -619,7 +619,7 @@ spec:
             - echo-a:8080/public
       - name: pod-to-a-intra-node-proxy-egress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -668,7 +668,7 @@ spec:
       containers:
       - name: pod-to-a-multi-node-proxy-egress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -698,7 +698,7 @@ spec:
             - echo-a:8080/public
       - name: pod-to-a-multi-node-proxy-egress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -747,7 +747,7 @@ spec:
       containers:
       - name: pod-to-c-intra-node-proxy-ingress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -777,7 +777,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-intra-node-proxy-ingress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -826,7 +826,7 @@ spec:
       containers:
       - name: pod-to-c-multi-node-proxy-ingress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -856,7 +856,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-multi-node-proxy-ingress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -905,7 +905,7 @@ spec:
       containers:
       - name: pod-to-c-intra-node-proxy-to-proxy-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -935,7 +935,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-intra-node-proxy-to-proxy-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -984,7 +984,7 @@ spec:
       containers:
       - name: pod-to-c-multi-node-proxy-to-proxy-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1014,7 +1014,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-multi-node-proxy-to-proxy-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1063,7 +1063,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-clusterip-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1129,7 +1129,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-headless-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1195,7 +1195,7 @@ spec:
       containers:
       - name: host-to-b-multi-node-clusterip-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1262,7 +1262,7 @@ spec:
       containers:
       - name: host-to-b-multi-node-headless-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1329,7 +1329,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-hostport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1395,7 +1395,7 @@ spec:
       containers:
       - name: pod-to-b-intra-node-hostport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1461,7 +1461,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-nodeport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -1527,7 +1527,7 @@ spec:
       containers:
       - name: pod-to-b-intra-node-nodeport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -80,7 +80,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -135,7 +135,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -197,7 +197,7 @@ spec:
       containers:
       - name: pod-to-a-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -253,7 +253,7 @@ spec:
       containers:
       - name: pod-to-a-denied-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -299,7 +299,7 @@ spec:
       containers:
       - name: pod-to-a-allowed-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -355,7 +355,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-clusterip-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -421,7 +421,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-headless-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -487,7 +487,7 @@ spec:
       containers:
       - name: host-to-b-multi-node-clusterip-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -554,7 +554,7 @@ spec:
       containers:
       - name: host-to-b-multi-node-headless-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -621,7 +621,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-nodeport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -687,7 +687,7 @@ spec:
       containers:
       - name: pod-to-b-intra-node-nodeport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -24,7 +24,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -79,7 +79,7 @@ spec:
         - name: PORT
           value: "41001"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -141,7 +141,7 @@ spec:
       containers:
       - name: pod-to-a-intra-node-proxy-egress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -171,7 +171,7 @@ spec:
             - echo-a:8080/public
       - name: pod-to-a-intra-node-proxy-egress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -220,7 +220,7 @@ spec:
       containers:
       - name: pod-to-a-multi-node-proxy-egress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -250,7 +250,7 @@ spec:
             - echo-a:8080/public
       - name: pod-to-a-multi-node-proxy-egress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -299,7 +299,7 @@ spec:
       containers:
       - name: pod-to-c-intra-node-proxy-ingress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -329,7 +329,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-intra-node-proxy-ingress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -378,7 +378,7 @@ spec:
       containers:
       - name: pod-to-c-multi-node-proxy-ingress-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -408,7 +408,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-multi-node-proxy-ingress-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -457,7 +457,7 @@ spec:
       containers:
       - name: pod-to-c-intra-node-proxy-to-proxy-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -487,7 +487,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-intra-node-proxy-to-proxy-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -536,7 +536,7 @@ spec:
       containers:
       - name: pod-to-c-multi-node-proxy-to-proxy-policy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -566,7 +566,7 @@ spec:
             - echo-c:8080/public
       - name: pod-to-c-multi-node-proxy-to-proxy-policy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -879,7 +879,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -956,7 +956,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -1032,7 +1032,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -1119,7 +1119,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -1219,7 +1219,7 @@ spec:
         - name: PORT
           value: "41001"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: pod-to-a-multi-node-hostport-proxy-egress-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -49,7 +49,7 @@ spec:
             - echo-c-host-headless:40001/public
       - name: pod-to-a-multi-node-hostport-proxy-egress-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -98,7 +98,7 @@ spec:
       containers:
       - name: pod-to-a-intra-node-hostport-proxy-egress-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -128,7 +128,7 @@ spec:
             - echo-c-host-headless:40001/public
       - name: pod-to-a-intra-node-hostport-proxy-egress-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -177,7 +177,7 @@ spec:
       containers:
       - name: pod-to-c-multi-node-hostport-proxy-ingress-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -207,7 +207,7 @@ spec:
             - echo-c-host-headless:40001/public
       - name: pod-to-c-multi-node-hostport-proxy-ingress-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -256,7 +256,7 @@ spec:
       containers:
       - name: pod-to-c-intra-node-hostport-proxy-ingress-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -286,7 +286,7 @@ spec:
             - echo-c-host-headless:40001/public
       - name: pod-to-c-intra-node-hostport-proxy-ingress-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -335,7 +335,7 @@ spec:
       containers:
       - name: pod-to-c-multi-node-hostport-proxy-to-proxy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -365,7 +365,7 @@ spec:
             - echo-c-host-headless:40001/public
       - name: pod-to-c-multi-node-hostport-proxy-to-proxy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -414,7 +414,7 @@ spec:
       containers:
       - name: pod-to-c-intra-node-hostport-proxy-to-proxy-allow-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -444,7 +444,7 @@ spec:
             - echo-c-host-headless:40001/public
       - name: pod-to-c-intra-node-hostport-proxy-to-proxy-reject-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -663,7 +663,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -740,7 +740,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -816,7 +816,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -903,7 +903,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -1003,7 +1003,7 @@ spec:
         - name: PORT
           value: "41001"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -80,7 +80,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -135,7 +135,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -197,7 +197,7 @@ spec:
       containers:
       - name: pod-to-a-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -253,7 +253,7 @@ spec:
       containers:
       - name: pod-to-external-1111-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -309,7 +309,7 @@ spec:
       containers:
       - name: pod-to-a-denied-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -355,7 +355,7 @@ spec:
       containers:
       - name: pod-to-a-allowed-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -411,7 +411,7 @@ spec:
       containers:
       - name: pod-to-external-fqdn-allow-google-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -467,7 +467,7 @@ spec:
       containers:
       - name: pod-to-b-intra-node-nodeport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -80,7 +80,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -135,7 +135,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -197,7 +197,7 @@ spec:
       containers:
       - name: pod-to-a-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -253,7 +253,7 @@ spec:
       containers:
       - name: pod-to-external-1111-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -309,7 +309,7 @@ spec:
       containers:
       - name: pod-to-a-denied-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -355,7 +355,7 @@ spec:
       containers:
       - name: pod-to-a-allowed-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -411,7 +411,7 @@ spec:
       containers:
       - name: pod-to-external-fqdn-allow-google-cnp-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -467,7 +467,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-clusterip-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -533,7 +533,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-headless-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -599,7 +599,7 @@ spec:
       containers:
       - name: host-to-b-multi-node-clusterip-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -666,7 +666,7 @@ spec:
       containers:
       - name: host-to-b-multi-node-headless-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -733,7 +733,7 @@ spec:
       containers:
       - name: pod-to-b-multi-node-nodeport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash
@@ -799,7 +799,7 @@ spec:
       containers:
       - name: pod-to-b-intra-node-nodeport-container
         ports: []
-        image: docker.io/byrnedo/alpine-curl:0.1.8
+        image: quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3
         imagePullPolicy: IfNotPresent
         command:
         - /bin/ash

--- a/examples/kubernetes/connectivity-check/defaults.cue
+++ b/examples/kubernetes/connectivity-check/defaults.cue
@@ -4,7 +4,7 @@ package connectivity_check
 deployment: [ID=_]: {
 	// General pod parameters
 	if ID =~ "^pod-to-.*$" || ID =~ "^host-to-.*$" {
-		_image: "docker.io/byrnedo/alpine-curl:0.1.8"
+		_image: "quay.io/cilium/alpine-curl:v1.2.0@sha256:bf2f87bb761821bf57b792d45edfd3a46cf5cca4c57da3fa3fc2abcb13b89dd3"
 		_command: ["/bin/ash", "-c", "sleep 1000000000"]
 	}
 

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -2,7 +2,7 @@ package connectivity_check
 
 // Default parameters for echo servers (may be overridden).
 _echoDeployment: {
-	_image:       "docker.io/cilium/json-mock:1.2"
+	_image:       "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b"
 	_probeTarget: *"localhost:8080" | string
 	_probePath:   ""
 }


### PR DESCRIPTION
This commit adds multi-arch docker images. Now, users can run the
connectivity check in their multi-arch clusters.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Add arm64 support for the connectivity test
```
