### PR TITLE
Improve author attribution scripts

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -45,7 +45,7 @@ Jun Chen <answer1991.chen@gmail.com>
 Junli Ou <oujunli306@gmail.com>
 Kaito Ii <kaitoii1111@gmail.com>
 Karl Heins <karlheins@northwesternmutual.com>
-Libo Kang <libokang.dev@gmail.com>
+Bokang Li <libokang.dev@gmail.com>
 Lior Rozen <liorr@tailorbrands.com> <liorrozen@users.noreply.github.com>
 Liu Qun <qunliu@zyhx-group.com>
 Livingstone S E <livingstone.s.e@gmail.com>
@@ -72,6 +72,7 @@ Tam Mach <sayboras@yahoo.com>
 Thomas Graf <thomas@cilium.io>
 Tomoki Sugiura <cheztomo513@gmail.com>
 Tony Lu <tonylu@linux.alibaba.com>
+Trevor Tao <trevor.tao@arm.com>
 Vance Li <liyannois@gmail.com>
 Vlad Ungureanu <vladu@palantir.com> <ungureanuvladvictor@gmail.com>
 Wayne Haber <whaber@gitlab.com> <41373231+whaber@users.noreply.github.com>
@@ -79,5 +80,6 @@ Weilong Cui <cuiwl@google.com>
 Yiannis Yiakoumis <yiannis@selfienetworks.com>
 Youssef Azrak <yazrak.tech@gmail.com>
 Yurii Dzobak <yurii.dzobak@lotusflare.com>
+Yurii Komar <Subreptivus@gmail.com>
 Yves Blusseau <yves.blusseau@acoss.fr>
 Zhu Yan <hackzhuyan@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,7 @@
 Alexei Starovoitov <alexei.starovoitov@gmail.com>
 André Martins <andre@cilium.io>
 Andrew Sy Kim <kim.andrewsy@gmail.com>
+Anthony Rabbito <hello@anthonyrabbito.com>
 Arika Chen <eaglesora@gmail.com>
 Arthur Chiao <arthurchiao@hotmail.com>
 Arthur Evstifeev <aevstifeev@gitlab.com>
@@ -10,19 +11,26 @@ Ashwin Paranjpe <ashwin@covalent.io>
 Ashwin Paranjpe <ashwinp.work@gmail.com>
 Bingwu Yang <detailyang@gmail.com>
 Bob Bouteillier <bob.bouteillier@datadoghq.com>
+Changyu Wang <changyuwang@tencent.com>
 Charles-Henri Guérin <charles-henri.guerin@zenika.com>
 Christine Chen <christine.chen@datadoghq.com>
 Christopher Biscardi <chris@christopherbiscardi.com>
 Craig Box <craig.box@gmail.com>
 Dan Wendlandt <dan@isovalent.com>
 Daniel Qian <qsj.daniel@gmail.com>
+Darren Mackintosh <unixdaddy@gmail.com>
 Darshan Chaudhary <deathbullet@gmail.com>
+Dawn <lx1960753013@gmail.com>
 Devarshi Sathiya <devarshisathiya5@gmail.com>
 El-Fadel Bonfoh <elfadel@accuknox.com> <bonfohelfadel@gmail.com>
+Fankaixi Li <fankaixi.li@bytedance.com>
 Florian Koch <f0@users.noreply.github.com>
 François Joulaud <francois.joulaud@radiofrance.com> <48206448+joulaud@users.noreply.github.com>
+Gaurav Genani <h3llix.pvt@gmail.com>
 Gaurav Yadav <gaurav.dev.iiitm@gmail.com>
 George Kontridze <gkontridze@plaid.com>
+Gowtham Sundara <gowtham.sundara@rapyuta-robotics.com>
+huangxuesen <huangxuesen@kuaishou.com>
 Hui Kong <hui.kong@qunar.com> <konghui@live.cn>
 Ian Vernon <ian@cilium.io> <vagrant@k8s1>
 Ifeanyi Ubah <ify1992@yahoo.com>
@@ -33,12 +41,18 @@ Jerry J. Muzsik <jerrymuzsik@icloud.com>
 Jomen Xiao <jomenxiao@gmail.com>
 Jonathan Davies <jpds@protonmail.com>
 Joshua Roppo <joshroppo@gmail.com>
+Jun Chen <answer1991.chen@gmail.com>
 Junli Ou <oujunli306@gmail.com>
+Kaito Ii <kaitoii1111@gmail.com>
 Karl Heins <karlheins@northwesternmutual.com>
+Libo Kang <libokang.dev@gmail.com>
 Lior Rozen <liorr@tailorbrands.com> <liorrozen@users.noreply.github.com>
 Liu Qun <qunliu@zyhx-group.com>
+Livingstone S E <livingstone.s.e@gmail.com>
 Madhu Challa <challa@gmail.com>
+Mahadev Panchal <mahadev.panchal@accuknox.com>
 Mandar U Jog <mjog@google.com> <mandarjog@gmail.com>
+Marc Stulz <m@footek.ch>
 Matthew Gumport <me@gum.pt>
 Michael Kashin <mmkashin@gmail.com>
 Michael Vorburger <vorburger@redhat.com>
@@ -46,15 +60,23 @@ Neela Jacques <neela@isovalent.com> <68304471+Neelajacques@users.noreply.github.
 Peiqi Shi <uestc.shi@gmail.com>
 Philippe Lafoucrière <philippe.lafoucriere@gmail.com>
 Pierre-Yves Aillet <pyaillet@gmail.com> <pyaillet@users.noreply.github.com>
+Raphael Campos <raphael@accuknox.com>
+Rei Shimizu <Shikugawa@gmail.com>
 Roman Ptitcyn <romanspb@yahoo.com>
+Salvatore Mazzarino <salvatore@accuknox.com> <dev@mazzarino.cz>
+Sami Yessou <fnzv@users.noreply.github.com>
 Sander Timmerman <stimmerman@schubergphilis.com>
 Sean Winn <sean@isovalent.com> <seanmwinn@hotmail.com>
 Sergey Generalov <sergey@isovalent.com> <sergey@genbit.ru>
 Tam Mach <sayboras@yahoo.com>
 Thomas Graf <thomas@cilium.io>
+Tomoki Sugiura <cheztomo513@gmail.com>
 Tony Lu <tonylu@linux.alibaba.com>
+Vance Li <liyannois@gmail.com>
+Vlad Ungureanu <vladu@palantir.com> <ungureanuvladvictor@gmail.com>
 Wayne Haber <whaber@gitlab.com> <41373231+whaber@users.noreply.github.com>
 Weilong Cui <cuiwl@google.com>
+Yiannis Yiakoumis <yiannis@selfienetworks.com>
 Youssef Azrak <yazrak.tech@gmail.com>
 Yurii Dzobak <yurii.dzobak@lotusflare.com>
 Yves Blusseau <yves.blusseau@acoss.fr>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 The following people, in alphabetical order, have either authored or signed
 off on commits in the Cilium repository:
 
+                                        
 AdamKorcz                               adam@adalogics.com
 Adam Wolfe Gordon                       awg@digitalocean.com
 Aditi Ghag                              aditi@cilium.io
@@ -18,9 +19,10 @@ André Martins                           andre@cilium.io
 Andrew Sy Kim                           kim.andrewsy@gmail.com
 Andrey Devyatkin                        andrey.devyatkin@fivexl.io
 Andrey Voronkov                         voronkovaa@gmail.com
+Andrzej Mamak                           nqaegg@gmail.com
 Anish Shah                              anishshah@google.com
 Anit Gandhi                             anitgandhi@gmail.com
-answer1991                              answer1991.chen@gmail.com
+Ankur Kothiwal                          ankur.kothiwal@accuknox.com
 Archana Shinde                          archana.m.shinde@intel.com
 Arika Chen                              eaglesora@gmail.com
 Arthur Chiao                            arthurchiao@hotmail.com
@@ -33,6 +35,7 @@ Beatriz Martínez                        beatriz@isovalent.com
 Benjamin Pineau                         benjamin.pineau@datadoghq.com
 Bingshen Wang                           bingshen.wbs@alibaba-inc.com
 Bingwu Yang                             detailyang@gmail.com
+Blazek, Ondrej                          ondrej.blazek@firma.seznam.cz
 Bob Bouteillier                         bob.bouteillier@datadoghq.com
 Bolun Zhao                              blzhao@google.com
 Boran Car                               boran.car@gmail.com
@@ -40,7 +43,8 @@ Brian Topping                           brian@coglative.com
 Bruno Miguel Custódio                   brunomcustodio@gmail.com
 Calum MacRae                            hi@cmacr.ae
 Camilo Schoeningh                       camilo.schoeningh@dunnhumby.com
-changyuwang                             changyuwang@tencent.com
+Carlos Castro                           carlos.castro@jumo.world
+Changyu Wang                            changyuwang@tencent.com
 Charles-Henri Guérin                    charles-henri.guerin@zenika.com
 Chris Tarazi                            chris@isovalent.com
 Christian Hüning                        christian.huening@finleap.com
@@ -57,16 +61,19 @@ Daniel T. Lee                           danieltimlee@gmail.com
 Danni Skov Høglund                      skuffe@pwnz.dk
 Dan Sexton                              dan.b.sexton@gmail.com
 Dan Wendlandt                           dan@covalent.io
+Darren Mackintosh                       unixdaddy@gmail.com
 Darshan Chaudhary                       deathbullet@gmail.com
 David Birks                             davidebirks@gmail.com
 David Bouchare                          david.bouchare@datadoghq.com
 David Chen                              davidchen94@outlook.com
 David Donchez                           donch@dailymotion.com
+Dawn                                    lx1960753013@gmail.com
 Deepesh Pathak                          deepshpathak@gmail.com
 Devarshi Sathiya                        devarshisathiya5@gmail.com
 Dharma Bellamkonda                      dharma.bellamkonda@gmail.com
 Didier Durand                           durand.didier@gmail.com
 Diego Casati                            diego.casati@gmail.com
+Divyansh Kamboj                         divyansh.kamboj@accuknox.com
 Dmitry Kharitonov                       geakstr@me.com
 Dmitry Savintsev                        dsavints@verizonmedia.com
 Dom Del Nano                            ddelnano@gmail.com
@@ -77,22 +84,23 @@ Eohyung Lee                             liquidnuker@gmail.com
 Eric Bailey                             e.bailey@sportradar.com
 Erik Chang                              erik.chang@nordstrom.com
 Ewout Prangsma                          ewout@prangsma.net
-fafucoder                               lx1960753013@gmail.com
 Faiyaz Ahmed                            faiyaza@gmail.com
-fankaixi.li                             fankaixi.li@bytedance.com
+Fankaixi Li                             fankaixi.li@bytedance.com
 Florian Koch                            f0@users.noreply.github.com
+Francois Allard                         francois@breathelife.com
 François Joulaud                        francois.joulaud@radiofrance.com
 Frank Villaro-Dixon                     frank.villaro@infomaniak.com
 Fred Hsu                                fredlhsu@gmail.com
 Fredrik Lönnegren                       fredrik.lonnegren@gmail.com
 Fulvio Risso                            fulvio.risso@polito.it
+Gaurav Genani                           h3llix.pvt@gmail.com
 Gaurav Yadav                            gaurav.dev.iiitm@gmail.com
 George Gaál                             gb12335@gmail.com
 George Kontridze                        gkontridze@plaid.com
 Gianluca Arbezzano                      gianarb92@gmail.com
 Gilberto Bertin                         gilberto@isovalent.com
 Glib Smaga                              code@gsmaga.com
-Gowtham S                               gowtham.sundara@rapyuta-robotics.com
+Gowtham Sundara                         gowtham.sundara@rapyuta-robotics.com
 Guilherme Oki                           guilherme.oki@wildlifestudios.com
 Guilherme Souza                         101073+guilhermef@users.noreply.github.com
 Han Zhou                                hzhou8@ebay.com
@@ -116,6 +124,7 @@ Jianlin Lv                              Jianlin.Lv@arm.com
 JieJhih Jhang                           jiejhihjhang@gmail.com
 Jim Angel                               jimangel@google.com.com
 Jiong Wang                              jiong.wang@netronome.com
+Joao Victorino                          joao@accuknox.com
 Joe Farrell                             joe2farrell@gmail.com
 Joe Stringer                            joe@cilium.io
 Joey Espinosa                           jlouis.espinosa@gmail.com
@@ -131,8 +140,10 @@ Joshua Roppo                            joshroppo@gmail.com
 Juan Jimenez-Anca                       cortopy@users.noreply.github.com
 Julien Balestra                         julien.balestra@datadoghq.com
 Julien Kassar                           github@kassisol.com
+Jun Chen                                answer1991.chen@gmail.com
 Junli Ou                                oujunli306@gmail.com
-kaitoii11                               kaitoii1111@gmail.com
+Jussi Maki                              jussi@isovalent.com
+Kaito Ii                                kaitoii1111@gmail.com
 Karl Heins                              karlheins@northwesternmutual.com
 Katarzyna Borkmann                      kasia@iogearbox.net
 Kevin Burke                             kevin@burke.dev
@@ -142,11 +153,12 @@ Koichiro Den                            den@klaipeden.com
 Kornilios Kourtis                       kornilios@isovalent.com
 Laurent Bernaille                       laurent.bernaille@datadoghq.com
 Lehner Florian                          dev@der-flo.net
+Liang Zhou                              zhoul110@chinatelecom.cn
+Libo Kang                               libokang.dev@gmail.com
 Lior Rozen                              liorr@tailorbrands.com
 Liu Qun                                 qunliu@zyhx-group.com
+Livingstone S E                         livingstone.s.e@gmail.com
 Li Yi                                   denverdino@gmail.com
-lyveng                                  livingstone.s.e@gmail.com
-m4rx0                                   m@footek.ch
 Maciej Fijalkowski                      maciej.fijalkowski@intel.com
 Maciej Kwiek                            maciej@isovalent.com
 Maciej Skrocki                          maciejskrocki@google.com
@@ -157,6 +169,7 @@ Manali Bhutiyani                        manali@covalent.io
 Mandar U Jog                            mjog@google.com
 Manuel Buil                             mbuil@suse.com
 Marcin Skarbek                          git@skarbek.name
+Marc Stulz                              m@footek.ch
 Marius Gerling                          marius.gerling@uniberg.com
 Mark deVilliers                         markdevilliers@gmail.com
 Martin Charles                          martincharles07@gmail.com
@@ -164,8 +177,10 @@ Martin Koppehel                         martin.koppehel@st.ovgu.de
 Martynas Pumputis                       m@lambda.lt
 Matej Gera                              matejgera@gmail.com
 Mathias Herzog                          mathu@gmx.ch
+Matthew Fenwick                         mfenwick100@gmail.com
 Matthew Gumport                         me@gum.pt
 Matt Layher                             mdlayher@gmail.com
+Mauricio Vásquez                        mauricio@kinvolk.io
 Maxime VISONNEAU                        maxime.visonneau@gmail.com
 Maximilian Bischoff                     maximilian.bischoff@inovex.de
 Maximilian Mack                         max@mack.io
@@ -205,9 +220,12 @@ Quentin Monnet                          quentin@isovalent.com
 Raghu Gyambavantha                      raghug@bld-ml-loan4.olympus.f5net.com
 Rahul Jadhav                            nyrahul@gmail.com
 Rajat Jindal                            rajatjindal83@gmail.com
+Raphael Campos                          raphael@accuknox.com
 Ray Bejjani                             ray@isovalent.com
+Rei Shimizu                             Shikugawa@gmail.com
 Renat Tuktarov                          yandzeek@gmail.com
 Rene Zbinden                            rene.zbinden@postfinance.ch
+Robin Gögge                             r.goegge@outlook.com
 Robin Hahling                           robin.hahling@gw-computing.net
 Rodrigo Chacon                          rochacon@gmail.com
 Romain Lenglet                          rlenglet@google.com
@@ -218,12 +236,13 @@ Rui Gu                                  rui@covalent.io
 Russell Bryant                          russell@russellbryant.net
 Ryan McNamara                           rmcnamara@palantir.com
 Salvatore Mazzarino                     salvatore@accuknox.com
-Sami                                    fnzv@users.noreply.github.com
+Sami Yessou                             fnzv@users.noreply.github.com
 Sander Timmerman                        stimmerman@schubergphilis.com
 Scott Albertson                         ascottalbertson@gmail.com
 Sean Winn                               sean@isovalent.com
 Sebastian Wicki                         sebastian@isovalent.com
 Sergey Generalov                        sergey@isovalent.com
+Sergey Monakhov                         monakhov@puzl.ee
 Shantanu Deshpande                      shantanud106@gmail.com
 Simon Pasquier                          spasquier@mirantis.com
 Stephen Martin                          lockwood@opperline.com
@@ -237,6 +256,7 @@ Taeung Song                             treeze.taeung@gmail.com
 Tam Mach                                sayboras@yahoo.com
 Tasdik Rahman                           prodicus@outlook.com
 Te-Yu Chang                             dale.teyuchang@gmail.com
+Thiago Navarro                          navarro@accuknox.com
 Thomas Bachman                          tbachman@yahoo.com
 Thomas Gosteli                          thomas.gosteli@protonmail.com
 Thomas Graf                             thomas@cilium.io
@@ -245,6 +265,7 @@ Timo Reimann                            ttr314@googlemail.com
 Tobias Klauser                          tobias@cilium.io
 Tobias Kohlbau                          tobias@kohlbau.de
 Tom Hadlaw                              thomas.hadlaw@hootsuite.com
+Tomoki Sugiura                          cheztomo513@gmail.com
 Tom Payne                               tom@isovalent.com
 Tony Lambiris                           tony@criticalstack.com
 Tony Lu                                 tonylu@linux.alibaba.com
@@ -252,9 +273,9 @@ Travis Glenn Hansen                     travisghansen@yahoo.com
 Trevor Roberts Jr                       Trevor.Roberts.Jr@gmail.com
 trevor tao                              trevor.tao@arm.com
 Umesh Keerthy B S                       umesh.freelance@gmail.com
-unixdaddy                               unixdaddy@gmail.com
 Vadim Ponomarev                         velizarx@gmail.com
 Valas Valancius                         valas@google.com
+Vance Li                                liyannois@gmail.com
 Vigneshwaren Sunder                     vickymailed@gmail.com
 Vishnu Soman K                          vishnusomank05@gmail.com
 Vlad Artamonov                          742047+vladdy@users.noreply.github.com
@@ -266,6 +287,7 @@ Wayne Haber                             whaber@gitlab.com
 Weilong Cui                             cuiwl@google.com
 Wenxian Li                              wofanli@gmail.com
 Will Deuschle                           wdeuschle@palantir.com
+Yiannis Yiakoumis                       yiannis@selfienetworks.com
 Yongkun Gui                             ygui@google.com
 Yosh de Vos                             yosh@elzorro.nl
 Youssef Azrak                           yazrak.tech@gmail.com

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,6 @@
 The following people, in alphabetical order, have either authored or signed
 off on commits in the Cilium repository:
 
-                                        
 AdamKorcz                               adam@adalogics.com
 Adam Wolfe Gordon                       awg@digitalocean.com
 Aditi Ghag                              aditi@cilium.io
@@ -23,6 +22,7 @@ Andrzej Mamak                           nqaegg@gmail.com
 Anish Shah                              anishshah@google.com
 Anit Gandhi                             anitgandhi@gmail.com
 Ankur Kothiwal                          ankur.kothiwal@accuknox.com
+Anthony Rabbito                         hello@anthonyrabbito.com
 Archana Shinde                          archana.m.shinde@intel.com
 Arika Chen                              eaglesora@gmail.com
 Arthur Chiao                            arthurchiao@hotmail.com
@@ -37,6 +37,7 @@ Bingshen Wang                           bingshen.wbs@alibaba-inc.com
 Bingwu Yang                             detailyang@gmail.com
 Blazek, Ondrej                          ondrej.blazek@firma.seznam.cz
 Bob Bouteillier                         bob.bouteillier@datadoghq.com
+Bokang Li                               libokang.dev@gmail.com
 Bolun Zhao                              blzhao@google.com
 Boran Car                               boran.car@gmail.com
 Brian Topping                           brian@coglative.com
@@ -154,15 +155,16 @@ Kornilios Kourtis                       kornilios@isovalent.com
 Laurent Bernaille                       laurent.bernaille@datadoghq.com
 Lehner Florian                          dev@der-flo.net
 Liang Zhou                              zhoul110@chinatelecom.cn
-Libo Kang                               libokang.dev@gmail.com
 Lior Rozen                              liorr@tailorbrands.com
 Liu Qun                                 qunliu@zyhx-group.com
 Livingstone S E                         livingstone.s.e@gmail.com
 Li Yi                                   denverdino@gmail.com
+Lorenzo Fundaró                         lorenzofundaro@gmail.com
 Maciej Fijalkowski                      maciej.fijalkowski@intel.com
 Maciej Kwiek                            maciej@isovalent.com
 Maciej Skrocki                          maciejskrocki@google.com
 Madhu Challa                            madhu@cilium.io
+Mahadev Panchal                         mahadev.panchal@accuknox.com
 MaiReo                                  sawako.saki@gmail.com
 Maksym Lushpenko                        iviakciivi@gmail.com
 Manali Bhutiyani                        manali@covalent.io
@@ -245,12 +247,12 @@ Sergey Generalov                        sergey@isovalent.com
 Sergey Monakhov                         monakhov@puzl.ee
 Shantanu Deshpande                      shantanud106@gmail.com
 Simon Pasquier                          spasquier@mirantis.com
+Smaine Kahlouch                         smainklh@gmail.com
 Stephen Martin                          lockwood@opperline.com
 Steven Ceuppens                         steven.ceuppens@icloud.com
 Steven Normore                          snormore@digitalocean.com
 Stevo Slavić                            sslavic@gmail.com
 Strukov Anton                           anstrukov@luxoft.com
-Subreptivus                             Subreptivus@gmail.com
 Swaminathan Vasudevan                   svasudevan@suse.com
 Taeung Song                             treeze.taeung@gmail.com
 Tam Mach                                sayboras@yahoo.com
@@ -271,7 +273,7 @@ Tony Lambiris                           tony@criticalstack.com
 Tony Lu                                 tonylu@linux.alibaba.com
 Travis Glenn Hansen                     travisghansen@yahoo.com
 Trevor Roberts Jr                       Trevor.Roberts.Jr@gmail.com
-trevor tao                              trevor.tao@arm.com
+Trevor Tao                              trevor.tao@arm.com
 Umesh Keerthy B S                       umesh.freelance@gmail.com
 Vadim Ponomarev                         velizarx@gmail.com
 Valas Valancius                         valas@google.com
@@ -293,6 +295,7 @@ Yosh de Vos                             yosh@elzorro.nl
 Youssef Azrak                           yazrak.tech@gmail.com
 Yuan Liu                                liuyuan@google.com
 Yurii Dzobak                            yurii.dzobak@lotusflare.com
+Yurii Komar                             Subreptivus@gmail.com
 Yves Blusseau                           yves.blusseau@acoss.fr
 Zang Li                                 zangli@google.com
 Zhiyuan Hou                             zhiyuan2048@linux.alibaba.com

--- a/contrib/scripts/extract_authors.sh
+++ b/contrib/scripts/extract_authors.sh
@@ -6,15 +6,11 @@ export LC_ALL=en_US.UTF-8
 
 function extract_authors() {
 	authors=$(git shortlog --summary | awk '{$1=""; print $0}' | sed -e 's/^ //')
+
+	# Iterate $authors by line
 	IFS=$'\n'
-	pad=$(printf '%0.1s' " "{1..60})
-	padlen=40
 	for i in $authors; do
-		name=$(git log --use-mailmap --author="$i" --format="%aN" | head -1)
-		mail=$(git log --use-mailmap --author="$i" --format="%aE" | head -1)
-		printf '%s' "$name"
-		printf '%*.*s' 0 $((padlen - ${#name})) "$pad"
-		printf '%s\n' "$mail"
+		git log --use-mailmap --author="$i" --format="%<|(40)%aN%aE" | head -1
 	done
 }
 

--- a/contrib/scripts/extract_authors.sh
+++ b/contrib/scripts/extract_authors.sh
@@ -5,7 +5,10 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 function extract_authors() {
-	authors=$(git shortlog --summary | awk '{$1=""; print $0}' | sed -e 's/^ //')
+	authors=$(git shortlog --summary \
+		  | awk '{$1=""; print $0}' \
+		  | sed -e 's/^ //' \
+			-e '/vagrant/d')
 
 	# Iterate $authors by line
 	IFS=$'\n'


### PR DESCRIPTION
* Optimize the `extract_authors.sh` script to run 2x faster, saving 30s per release.
* Fix the issue where a blank line gets randomly added into the authors list
* Pull in v1.10 commit 622d841c9b5408f33170179eabdc71923d8a2b28 for the mailmap updates.
* Update the authors in the tree.
