### PR TITLE
contrib: Ensure release tag is upstream before push

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -15,8 +15,7 @@ trap cleanup EXIT
 
 cherry_pick () {
   CID=$1
-  BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
-  if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
+  if ! commit_in_upstream "$CID" "master"; then
     echo "Commit $CID not in $REM/master!"
     exit 1
   fi

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -50,3 +50,11 @@ require_linux() {
       exit 1
   fi
 }
+
+commit_in_upstream() {
+    local commit="$1"
+    local branch="$2"
+    local remote="$(get_remote)"
+    local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
+    echo "$branches" | grep -q ".*$remote/$branch"
+}

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -57,8 +57,16 @@ main() {
         common::exit 1 "Generate release notes via contrib/release/start-release.sh"
     fi
 
+    git fetch $REMOTE
+
+    local commit="$(git rev-parse HEAD)"
+    BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
     echo "Current HEAD is:"
-    git log --oneline -1 $(git rev-parse HEAD)
+    git log --oneline -1 "$commit"
+    if ! commit_in_upstream "$commit" "$BRANCH"; then
+        common::exit 1 "Commit $commit not in $REMOTE/$BRANCH!"
+    fi
+
     echo "Create git tags for $version with this commit"
     if ! common::askyorn ; then
         common::exit 0 "Aborting release preparation."


### PR DESCRIPTION
Reuse the logic from the backporting cherrypick commit for determining
that the commit is upstream before tagging and pushing the tags for
release preparation. This should catch errors where the tagged release
version is not a commit in the branch where the release is made.
