### PR TITLE
Add identity GC metrics for CRD allocation mode

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -109,6 +109,12 @@ const (
 
 	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
 	LabelValueOutcomeFail = "fail"
+
+	// LabelValueOutcomeAlive is used as outcome of alive identity entries
+	LabelValueOutcomeAlive = "alive"
+
+	// LabelValueOutcomeDeleted is used as outcome of deleted identity entries
+	LabelValueOutcomeDeleted = "deleted"
 )
 
 func registerMetrics() []prometheus.Collector {


### PR DESCRIPTION
This commit adds some metrics for cilium-operator garbage collector,
when using CRD allocation mode.

The metrics can be "alive" & "deleted" identities during each GC run:
cilium_operator_identity_gc_entries_total{status="alive"}
cilium_operator_identity_gc_entries_total{status="deleted"}

Beside that, there are two other metrics, total GC runs "success" &
"fail":
cilium_operator_identity_gc_runs_total{outcome="success"}
cilium_operator_identity_gc_runs_total{outcome="fail"}

Signed-off-by: Raphael Campos <raphael@accuknox.com>

Fixes: #14549 