### PR TITLE
Cilium: Encryption, remove ingress IPsec rules when no longer needed

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -604,3 +604,8 @@ func DeleteIPsecEncryptRoute() {
 		}
 	}
 }
+
+func DeleteIPSecXfrmSpi(spi uint8) {
+	time.Sleep(linux_defaults.IPsecKeyDeleteDelay)
+	ipsecDeleteXfrmSpi(spi)
+}


### PR DESCRIPTION
This commit checks if a key exists in ipCache, and if it doesn't then removes it's corresponding Xfrm entries.

Fixes: #15216 

