### PR TITLE
test: Adds test for BPF NAT engine handles unknown protocol packets

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2815,6 +2815,45 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 					testNodePort(true, false, false, 0) // no need to test from outside, as testDSR did it
 				})
 
+				// GKE COS image does not support sctp module.
+				SkipContextIf(func() bool {
+					return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.RunsOnGKE()
+				}, "BPF NAT engine handles unknown protocol packets", func() {
+					var (
+						iperf3Manifest string
+					)
+					BeforeAll(func() {
+						DeployCiliumAndDNS(kubectl, ciliumFilename)
+						iperf3Manifest = helpers.ManifestGet(kubectl.BasePath(), "iperf3-deployment.yaml")
+						kubectl.ApplyDefault(iperf3Manifest).ExpectSuccess("Iperf3 cannot be deployed")
+					})
+
+					AfterFailed(func() {
+						kubectl.CiliumReport("cilium endpoint list")
+					})
+
+					AfterAll(func() {
+						_ = kubectl.Delete(iperf3Manifest)
+					})
+
+					It("Should not drop SCTP packets", func() {
+						By("Defining the first pod as the client in node 1")
+						clientPodInNode1, clientPodInNode1JSON := fetchPodsWithOffset(kubectl, helpers.DefaultNamespace, "iperf3", "zgroup=testapp", "", true, 0)
+						clientPodInNode1IP, err := clientPodInNode1JSON.Filter("{.status.podIP}")
+						Expect(err).Should(BeNil(), "Failure to retrieve IP of pod %s", clientPodInNode1)
+
+						By("Defining the second pod as the server in node 2")
+						serverPodInNode2, serverPodInNode2JSON := fetchPodsWithOffset(kubectl, helpers.DefaultNamespace, "iperf3", "zgroup=testapp", clientPodInNode1IP.String(), true, 0)
+						serverPodInNode2IP, err := serverPodInNode2JSON.Filter("{.status.podIP}")
+						Expect(err).Should(BeNil(), "Failure to retrieve IP of pod %s", serverPodInNode2)
+
+						By("Running iperf3 in client pod with SCTP protocol and 10MBytes to be sent")
+						res := kubectl.ExecPodCmd(helpers.DefaultNamespace, clientPodInNode1, fmt.Sprintf("iperf3 -c %s --sctp -n 10M -J | jq '.end.sum_received.bytes'", serverPodInNode2IP.String()))
+						receivedBytes, _ := strconv.Atoi(res.GetStdOut().ByLines()[0])
+						Expect(receivedBytes).To(BeNumerically(">", 0))
+					})
+				})
+
 				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing, SNAT and Random", func() {
 					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 						"loadBalancer.acceleration": "testing-only",

--- a/test/k8sT/manifests/iperf3-deployment.yaml
+++ b/test/k8sT/manifests/iperf3-deployment.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: iperf3-server
+spec:
+  selector:
+    matchLabels:
+      name: iperf3
+  template:
+    metadata:
+      labels:
+        name: iperf3
+        zgroup: testapp
+    spec:
+      hostNetwork: true
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: iperf3
+          image: docker.io/cilium/netperf:2.0
+          command: ["iperf3", "-s"]

--- a/test/k8sT/manifests/test-cli.yaml
+++ b/test/k8sT/manifests/test-cli.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: netperf
-    image: docker.io/cilium/netperf:1.0
+    image: docker.io/cilium/netperf:2.0
   nodeSelector:
     "cilium.io/ci-node": k8s1
 ---
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
   - name: netperf
-    image: docker.io/cilium/netperf:1.0
+    image: docker.io/cilium/netperf:2.0
   nodeSelector:
     "cilium.io/ci-node": k8s1
 ---
@@ -33,6 +33,6 @@ metadata:
 spec:
   containers:
   - name: netperf
-    image: docker.io/cilium/netperf:1.0
+    image: docker.io/cilium/netperf:2.0
   nodeSelector:
     "cilium.io/ci-node": k8s1


### PR DESCRIPTION
Test Case:

- Startup Cilium in k8s1 and k8s2
- Create an iperf3 server DaemonSet  
- Start communication with SCTP packets between iperf3 client (k8s1) and iperf3 server (k8s2)
- Check if the client received bytes

Fixes: #10541

Signed-off-by: Thiago Navarro <navarro@accuknox.com>