### PR TITLE
plugins/cilium-cni: fix aws-cni cni chaining

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -170,7 +170,10 @@ EOF
     {
       "name": "aws-cni",
       "type": "aws-cni",
-      "vethPrefix": "eni"
+      "vethPrefix": "eni",
+      "mtu": "9001",
+      "pluginLogFile": "/var/log/aws-routed-eni/plugin.log",
+      "pluginLogLevel": "DEBUG"
     },
     {
       "type": "portmap",


### PR DESCRIPTION
AWS-CNI seems to require more fields than the ones hard coded in Cilium
image. This patch adds the missing fields.

Error messages that might show up in pod describe are similar as:
```
network: invalid character '{' after top-level value
```
or
```
\n{\n    \"code\": 100,\n    \"msg\": \"add cmd: failed to assign an IP address to container\"\n}": invalid character '{' after top-level value
```

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix aws-cni integration where pods were not being scheduled
```
