### PR TITLE
v1.9 backports 2021-04-28

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -136,7 +136,8 @@ if [[ "$#" -ne 1 ]]; then
   exit 1
 fi
 
-release_version="${1}"
+release_ersion="$(echo $1 | sed 's/^v//')"
+release_version="v$release_ersion"
 
 create_file ${release_version} "${dst_file}"
 

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -25,7 +25,7 @@ get_line_of_schema_version(){
 
 get_schema_of_branch(){
    stable_branch="${1}"
-   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//'
+   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq
 }
 
 get_stable_branches(){

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -34,7 +34,14 @@ get_stable_branches(){
 
 get_stable_tags_for_minor(){
    minor_ver="${1}"
-   git ls-remote --tags ${remote} v\* | awk '{ print $2 }' | grep "${minor_ver}" | grep -v '\^' | grep -v '\-' | sed 's+refs/tags/++' | sort -V
+   git ls-remote --tags ${remote} v\* \
+       | awk '{ print $2 }' \
+       | grep "${minor_ver}" \
+       | grep -v '\^' \
+       | grep -v '\-' \
+       | sed 's+refs/tags/++' \
+       | sort -V \
+   || echo ""
 }
 
 get_rc_tags_for_minor(){

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-remote="origin"
 dst_file="${dir}/concepts/kubernetes/compatibility-table.rst"
+
+. "${dir}/../contrib/backporting/common.sh"
+remote="$(get_remote)"
 
 set -o nounset
 set -o pipefail

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -49,6 +49,10 @@ get_rc_tags_for_minor(){
    git ls-remote --tags ${remote} v\* | awk '{ print $2 }' | grep "${minor_ver}" | grep -v '\^' | grep '\-' | sed 's+refs/tags/++' | sort -V
 }
 
+filter_out_oldest() {
+    echo "${@}" | cut -d' ' -f2- -
+}
+
 create_file(){
   release_version="${1}"
   dst_file="${2}"
@@ -59,7 +63,7 @@ create_file(){
   echo   "+-----------------+----------------+" >> "${dst_file}"
   stable_branches=$(get_stable_branches)
   if [[ ${stable_branches} != *"${release_version}"* ]]; then
-    stable_branches="${stable_branches} ${release_version}"
+      stable_branches="$(filter_out_oldest ${stable_branches} ${release_version})"
   fi
   for stable_branch in ${stable_branches}; do
       rc_tags=$(get_rc_tags_for_minor "${stable_branch}")

--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -322,20 +322,8 @@ Kubernetes service with identical name and namespace in each cluster and adding
 the annotation ``io.cilium/global-service: "true"``` to declare it global.
 Cilium will automatically perform load-balancing to pods in both clusters.
 
-.. code-block:: yaml
-
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: rebel-base
-     annotations:
-       io.cilium/global-service: "true"
-   spec:
-     type: ClusterIP
-     ports:
-     - port: 80
-     selector:
-       name: rebel-base
+.. literalinclude:: ../../examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
+  :language: YAML
 
 Load-balancing only to a remote cluster
 #######################################

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -15,8 +15,7 @@ trap cleanup EXIT
 
 cherry_pick () {
   CID=$1
-  BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
-  if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
+  if ! commit_in_upstream "$CID" "master"; then
     echo "Commit $CID not in $REM/master!"
     exit 1
   fi

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -50,3 +50,11 @@ require_linux() {
       exit 1
   fi
 }
+
+commit_in_upstream() {
+    local commit="$1"
+    local branch="$2"
+    local remote="$(get_remote)"
+    local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
+    echo "$branches" | grep -q ".*$remote/$branch"
+}

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -57,8 +57,16 @@ main() {
         common::exit 1 "Generate release notes via contrib/release/start-release.sh"
     fi
 
+    git fetch $REMOTE
+
+    local commit="$(git rev-parse HEAD)"
+    BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
     echo "Current HEAD is:"
-    git log --oneline -1 $(git rev-parse HEAD)
+    git log --oneline -1 "$commit"
+    if ! commit_in_upstream "$commit" "$BRANCH"; then
+        common::exit 1 "Commit $commit not in $REMOTE/$BRANCH!"
+    fi
+
     echo "Create git tags for $version with this commit"
     if ! common::askyorn ; then
         common::exit 0 "Aborting release preparation."

--- a/examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rebel-base
+  annotations:
+    io.cilium/global-service: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    name: rebel-base

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -69,8 +69,8 @@ spec:
                       # Works for COS, ubuntu
                       while docker ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     else
-                      # COS-beta (with containerd)
-                      while crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
+                      # COS-beta (with containerd). Some versions of COS have crictl in /home/kubernetes/bin.
+                      while PATH="${PATH}:/home/kubernetes/bin" crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     fi
 
                     systemctl disable sys-fs-bpf.mount || true
@@ -222,8 +222,8 @@ spec:
                   docker kill "${container_id}" || true
                 done
               else
-                # COS-beta (with containerd)
-                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
+                # COS-beta (with containerd). Some versions of COS have crictl in /home/kubernetes/bin.
+                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do PATH="${PATH}:/home/kubernetes/bin" crictl stopp "$(sed 's/\r//;1q' $f)" || true; done
               fi
 {{- end }}
 


### PR DESCRIPTION
 * #14708 -- node-init: Fixing pods restart on nodes running containerd on COS (@fallard84)
 * #15886 -- examples: add 'rebel-base-global-shared.yaml' (@bmcustodio)
 * #15869 -- Improve the docs CRD schema version update script (@joestringer)
 * #15903 -- contrib: Ensure release tag is upstream before push (@joestringer)

Skipped due to conflicts:
* #15803 -- handle IP addresses modification in running nodes and CEPs (@aanm)
  * PTAL @aanm 

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14708 15886 15869 15903; do contrib/backporting/set-labels.py $pr done 1.9; done
```