### PR TITLE
v1.8 backports 2021-04-28

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -136,7 +136,8 @@ if [[ "$#" -ne 1 ]]; then
   exit 1
 fi
 
-release_version="${1}"
+release_ersion="$(echo $1 | sed 's/^v//')"
+release_version="v$release_ersion"
 
 create_file ${release_version} "${dst_file}"
 

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -25,7 +25,7 @@ get_line_of_schema_version(){
 
 get_schema_of_branch(){
    stable_branch="${1}"
-   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//'
+   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq
 }
 
 get_stable_branches(){

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -34,7 +34,14 @@ get_stable_branches(){
 
 get_stable_tags_for_minor(){
    minor_ver="${1}"
-   git ls-remote --tags ${remote} v\* | awk '{ print $2 }' | grep "${minor_ver}" | grep -v '\^' | grep -v '\-' | sed 's+refs/tags/++' | sort -V
+   git ls-remote --tags ${remote} v\* \
+       | awk '{ print $2 }' \
+       | grep "${minor_ver}" \
+       | grep -v '\^' \
+       | grep -v '\-' \
+       | sed 's+refs/tags/++' \
+       | sort -V \
+   || echo ""
 }
 
 get_rc_tags_for_minor(){

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-remote="origin"
 dst_file="${dir}/concepts/kubernetes/compatibility-table.rst"
+
+. "${dir}/../contrib/backporting/common.sh"
+remote="$(get_remote)"
 
 set -o nounset
 set -o pipefail

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -49,6 +49,10 @@ get_rc_tags_for_minor(){
    git ls-remote --tags ${remote} v\* | awk '{ print $2 }' | grep "${minor_ver}" | grep -v '\^' | grep '\-' | sed 's+refs/tags/++' | sort -V
 }
 
+filter_out_oldest() {
+    echo "${@}" | cut -d' ' -f2- -
+}
+
 create_file(){
   release_version="${1}"
   dst_file="${2}"
@@ -59,7 +63,7 @@ create_file(){
   echo   "+-----------------+----------------+" >> "${dst_file}"
   stable_branches=$(get_stable_branches)
   if [[ ${stable_branches} != *"${release_version}"* ]]; then
-    stable_branches="${stable_branches} ${release_version}"
+      stable_branches="$(filter_out_oldest ${stable_branches} ${release_version})"
   fi
   for stable_branch in ${stable_branches}; do
       rc_tags=$(get_rc_tags_for_minor "${stable_branch}")

--- a/cilium/cmd/bpf_ct.go
+++ b/cilium/cmd/bpf_ct.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/spf13/cobra"
 )
 
@@ -25,5 +27,6 @@ var bpfCtCmd = &cobra.Command{
 }
 
 func init() {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	bpfCmd.AddCommand(bpfCtCmd)
 }

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -15,8 +15,7 @@ trap cleanup EXIT
 
 cherry_pick () {
   CID=$1
-  BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
-  if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
+  if ! commit_in_upstream "$CID" "master"; then
     echo "Commit $CID not in $REM/master!"
     exit 1
   fi

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -50,3 +50,11 @@ require_linux() {
       exit 1
   fi
 }
+
+commit_in_upstream() {
+    local commit="$1"
+    local branch="$2"
+    local remote="$(get_remote)"
+    local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
+    echo "$branches" | grep -q ".*$remote/$branch"
+}

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -52,7 +52,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-git push "$USER_REMOTE" "$PR_BRANCH"
+git push -q "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -57,8 +57,16 @@ main() {
         common::exit 1 "Generate release notes via contrib/release/start-release.sh"
     fi
 
+    git fetch $REMOTE
+
+    local commit="$(git rev-parse HEAD)"
+    BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
     echo "Current HEAD is:"
-    git log --oneline -1 $(git rev-parse HEAD)
+    git log --oneline -1 "$commit"
+    if ! commit_in_upstream "$commit" "$BRANCH"; then
+        common::exit 1 "Commit $commit not in $REMOTE/$BRANCH!"
+    fi
+
     echo "Create git tags for $version with this commit"
     if ! common::askyorn ; then
         common::exit 0 "Aborting release preparation."

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/status"
+	"github.com/cilium/cilium/pkg/version"
 	"github.com/sirupsen/logrus"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -439,16 +440,22 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 
 	sr.Stale = stale
 
+	//CiliumVersion definition
+	ver := version.GetCiliumVersion()
+	ciliumVer := fmt.Sprintf("%s (v.%s-r.%s)", ver.Version, ver.Version, ver.Revision)
+
 	switch {
 	case len(sr.Stale) > 0:
+		msg := "Stale status data"
 		sr.Cilium = &models.Status{
 			State: models.StatusStateWarning,
-			Msg:   "Stale status data",
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.statusResponse.Kvstore != nil && d.statusResponse.Kvstore.State != models.StatusStateOk:
+		msg := "Kvstore service is not ready"
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.Kvstore.State,
-			Msg:   "Kvstore service is not ready",
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.statusResponse.ContainerRuntime != nil && d.statusResponse.ContainerRuntime.State != models.StatusStateOk:
 		msg := "Container runtime is not ready"
@@ -457,15 +464,19 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 		}
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.ContainerRuntime.State,
-			Msg:   msg,
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case k8s.IsEnabled() && d.statusResponse.Kubernetes != nil && d.statusResponse.Kubernetes.State != models.StatusStateOk:
+		msg := "Kubernetes service is not ready"
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.Kubernetes.State,
-			Msg:   "Kubernetes service is not ready",
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	default:
-		sr.Cilium = &models.Status{State: models.StatusStateOk, Msg: "OK"}
+		sr.Cilium = &models.Status{
+			State: models.StatusStateOk,
+			Msg:   ciliumVer,
+		}
 	}
 
 	return sr

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -440,9 +440,9 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 
 	sr.Stale = stale
 
-	//CiliumVersion definition
+	// CiliumVersion definition
 	ver := version.GetCiliumVersion()
-	ciliumVer := fmt.Sprintf("%s (v.%s-r.%s)", ver.Version, ver.Version, ver.Revision)
+	ciliumVer := fmt.Sprintf("%s (v%s-%s)", ver.Version, ver.Version, ver.Revision)
 
 	switch {
 	case len(sr.Stale) > 0:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -307,7 +307,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 		}
 	}
 	if sr.Cilium != nil {
-		fmt.Fprintf(w, "Cilium:\t%s\t%s\n", sr.Cilium.State, sr.Cilium.Msg)
+		fmt.Fprintf(w, "Cilium:\t%s   %s\n", sr.Cilium.State, sr.Cilium.Msg)
 	}
 
 	if sr.Stale != nil {

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/loader"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -48,6 +49,10 @@ var (
 	ipv4DummyAddr = []byte{192, 0, 2, 3}
 	ipv6DummyAddr = []byte{0x20, 0x01, 0xdb, 0x8, 0x0b, 0xad, 0xca, 0xfe, 0x60, 0x0d, 0xbe, 0xe2, 0x0b, 0xad, 0xca, 0xfe}
 )
+
+func (s *ConfigSuite) SetUpSuite(c *C) {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+}
 
 func (s *ConfigSuite) SetUpTest(c *C) {
 	err := bpf.ConfigureResourceLimits()

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -19,7 +19,9 @@ package loader
 import (
 	"testing"
 
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 
 	. "gopkg.in/check.v1"
 )
@@ -34,6 +36,7 @@ func Test(t *testing.T) {
 }
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	node.InitDefaultPrefix("")
 	node.SetInternalIPv4Router(templateIPv4)
 	node.SetIPv4Loopback(templateIPv4)

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -32,6 +32,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/elf"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -64,6 +65,8 @@ func Test(t *testing.T) {
 }
 
 func (s *LoaderTestSuite) SetUpSuite(c *C) {
+
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	SetTestIncludes([]string{
 		fmt.Sprintf("-I%s", bpfDir),
 		fmt.Sprintf("-I%s", filepath.Join(bpfDir, "include")),

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -37,6 +37,7 @@ import (
 	pkgLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -80,6 +81,7 @@ var suite = EndpointSuite{repo: policy.NewPolicyRepository(nil, nil)}
 var _ = Suite(&suite)
 
 func (s *EndpointSuite) SetUpSuite(c *C) {
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	s.repo = policy.NewPolicyRepository(nil, nil)
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(nil, "")

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,6 +80,10 @@ func (k *K8sWatcher) createPodController(getter cache.Getter, fieldSelector fiel
 						} else {
 							metrics.EventLagK8s.Set(timeSinceEpCreated.Round(time.Second).Seconds())
 						}
+					} else {
+						// If the ep is nil then we reset to zero, otherwise
+						// the previous value set is kept forever.
+						metrics.EventLagK8s.Set(0)
 					}
 					err := k.addK8sPodV1(pod)
 					k.K8sEventProcessed(metricPod, metricCreate, err == nil)

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -201,10 +201,6 @@ func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6, nodeport bool) {
 		anyMaxEntries, natMaps[mapTypeIPv6AnyGlobal])
 }
 
-func init() {
-	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
-}
-
 // CtEndpoint represents an endpoint for the functions required to manage
 // conntrack maps for the endpoint.
 type CtEndpoint interface {

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -33,6 +34,10 @@ import (
 type CTMapTestSuite struct{}
 
 var _ = Suite(&CTMapTestSuite{})
+
+func init() {
+	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+}
 
 func Test(t *testing.T) {
 	TestingT(t)

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -35,6 +35,10 @@ type CTMapTestSuite struct{}
 
 var _ = Suite(&CTMapTestSuite{})
 
+func init() {
+	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+}
+
 func Test(t *testing.T) {
 	TestingT(t)
 }

--- a/pkg/mtu/detect_linux.go
+++ b/pkg/mtu/detect_linux.go
@@ -82,35 +82,25 @@ func autoDetect() (int, error) {
 
 // getMTUFromIf finds the interface that holds the ip and returns its mtu
 func getMTUFromIf(ip net.IP) (int, error) {
-	ifaces, err := net.Interfaces()
+	ifaces, err := netlink.LinkList()
 	if err != nil {
 		return 0, errors.Wrap(err, "Unable to list interfaces")
 	}
 
 	for _, iface := range ifaces {
-		addrs, err := iface.Addrs()
+		addrs, err := netlink.AddrList(iface, netlink.FAMILY_ALL)
 		if err != nil {
 			log.WithFields(logrus.Fields{
-				logfields.Device: iface.Name,
+				logfields.Device: iface.Attrs().Name,
 			}).Warning("Unable to list all addresses")
 			continue
 		}
 
 		for _, addr := range addrs {
-			myIP, _, err := net.ParseCIDR(addr.String())
-
-			if err != nil {
+			if addr.IPNet.IP.Equal(ip) == true {
+				myMTU := iface.Attrs().MTU
 				log.WithFields(logrus.Fields{
-					logfields.Device: iface.Name,
-					logfields.IPAddr: addr,
-				}).Warning("Unable parse the address")
-				continue
-			}
-
-			if myIP.Equal(ip) == true {
-				myMTU := iface.MTU
-				log.WithFields(logrus.Fields{
-					logfields.Device: iface.Name,
+					logfields.Device: iface.Attrs().Name,
 					logfields.IPAddr: ip,
 					logfields.MTU:    myMTU,
 				}).Info("Inheriting MTU from external network interface")

--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -642,6 +642,18 @@ func FailWithToggle(message string, callerSkip ...int) {
 	}
 }
 
+// SkipDescribeIf is a wrapper for the Describe block which is being executed
+// if the given condition is NOT met.
+func SkipDescribeIf(condition func() bool, text string, body func()) bool {
+	if condition() {
+		return It(text, func() {
+			Skip("skipping due to unmet condition")
+		})
+	}
+
+	return Describe(text, body)
+}
+
 // SkipContextIf is a wrapper for the Context block which is being executed
 // if the given condition is NOT met.
 func SkipContextIf(condition func() bool, text string, body func()) bool {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -34,7 +34,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("K8sPolicyTest", func() {
+var _ = SkipDescribeIf(func() bool {
+	// We only need to run on 4.9 with kube-proxy and net-next with KPR
+	// and the third node. Other CI jobs are not expected to increase
+	// code coverage.
+	return helpers.IsIntegration(helpers.CIIntegrationGKE) || helpers.RunsOn419Kernel()
+}, "K8sPolicyTest", func() {
 
 	var (
 		kubectl *helpers.Kubectl


### PR DESCRIPTION
* #14492 -- Agent: Include Cilium version in output of 'cilium status --verbose' (@romanspb80)
 * #15590 -- ctmap: do not call InitMapInfo() in init() (@kkourt)
 * #15260 -- mtu: Switch to v/netlink for querying netdevs (@brb)
 * #15649 -- daemon/cmd: fix Cilium version status output (@aanm)
 * #15668 -- Fix channel panic from ipcache kvstore reconnect (@jomenxiao)
 * #15742 -- kvstore/etcd: fix etcd rate limit (QPS) not working (@ArthurChiao)
 * #15762 -- test: Skip K8sPolicy on GKE and 4.19 (@pchaigno)
 * #15804 -- pkg/k8s: reset k8s event lag metric on pod add (@aanm)
 * #15838 -- contrib: Clean output of submit-backport script (@pchaigno)
 * #15869 -- Improve the docs CRD schema version update script (@joestringer)
 * #15903 -- contrib: Ensure release tag is upstream before push (@joestringer)

Skipped due to conflicts:

 * #15622 -- Fix ethtool issues (@tklauser)
 * #15841 -- .github: remove unnecessary docker hub credentials (@aanm)
 * #15803 -- handle IP addresses modification in running nodes and CEPs (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14492 15590 15260 15649 15668 15742 15762 15804 15838 15869 15903; do contrib/backporting/set-labels.py $pr done 1.8; done
```