### PR TITLE
docs: include maintainers CODEOWNERS release process

### DIFF
--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -32,6 +32,7 @@ On Freeze date
    ::
 
         * @cilium/janitors
+        .github/workflows/ @cilium/maintainers
         api/ @cilium/api
         pkg/apisocket/ @cilium/api
         pkg/monitor/payload @cilium/api


### PR DESCRIPTION
This commit adds maintainers as codeowners of .github directory as we
have been doing for stable branches.

Signed-off-by: André Martins <andre@cilium.io>