### PR TITLE
CODEOWNERS: add maintainers to be codeowners of .github

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/janitors
+.github/workflows/ @cilium/maintainers
 api/ @cilium/api
 pkg/apisocket/ @cilium/api
 pkg/monitor/payload @cilium/api


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

cc @joestringer I've updated the steps here https://github.com/cilium/cilium/pull/15924