### PR TITLE
test: Extend the clusterIP tests with policy

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -310,16 +310,20 @@ var _ = Describe("K8sServicesTest", func() {
 			echoSVCYAML          string
 			echoSVCYAMLV6        string
 			echoSVCYAMLDualStack string
+			echoPolicyYAML       string
 		)
 
 		BeforeAll(func() {
 			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 			echoSVCYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-svc.yaml")
+			echoPolicyYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-policy.yaml")
 
 			res := kubectl.ApplyDefault(demoYAML)
 			Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", demoYAML)
 			res = kubectl.ApplyDefault(echoSVCYAML)
 			Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", echoSVCYAML)
+			res = kubectl.ApplyDefault(echoPolicyYAML)
+			Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", echoPolicyYAML)
 
 			if helpers.DualStackSupported() {
 				demoYAMLV6 = helpers.ManifestGet(kubectl.BasePath(), "demo_v6.yaml")
@@ -351,6 +355,7 @@ var _ = Describe("K8sServicesTest", func() {
 			// teardown if any step fails.
 			_ = kubectl.Delete(demoYAML)
 			_ = kubectl.Delete(echoSVCYAML)
+			_ = kubectl.Delete(echoPolicyYAML)
 			if helpers.DualStackSupported() {
 				_ = kubectl.Delete(demoYAMLV6)
 				_ = kubectl.Delete(echoSVCYAMLV6)

--- a/test/k8sT/manifests/echo-policy.yaml
+++ b/test/k8sT/manifests/echo-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-all-within-namespace"
+spec:
+  endpointSelector:
+    matchLabels:
+      name: echo
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": default
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": default


### PR DESCRIPTION
Mainly for PR #15321 -  tests the case where a pod connects to itself via service clusterIP when selected by a policy.

Signed-off-by: Aditi Ghag <aditi@cilium.io>

