### PR TITLE
hubble: Hubble node_name field should contain cluster name

### DIFF
--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -51,7 +51,7 @@ func NewConsumer(observer Observer) monitorConsumer.MonitorConsumer {
 func (c *consumer) sendNumLostEvents() {
 	numEventsLostNotification := &observerTypes.MonitorEvent{
 		Timestamp: time.Now(),
-		NodeName:  nodeTypes.GetName(),
+		NodeName:  nodeTypes.GetAbsoluteNodeName(),
 		Payload: &observerTypes.LostEvent{
 			Source:        observerTypes.LostEventSourceEventsQueue,
 			NumLostEvents: c.numEventsLost,
@@ -90,7 +90,7 @@ func (c *consumer) sendEvent(event *observerTypes.MonitorEvent) {
 func (c *consumer) NotifyAgentEvent(typ int, message interface{}) {
 	c.sendEvent(&observerTypes.MonitorEvent{
 		Timestamp: time.Now(),
-		NodeName:  nodeTypes.GetName(),
+		NodeName:  nodeTypes.GetAbsoluteNodeName(),
 		Payload: &observerTypes.AgentEvent{
 			Type:    typ,
 			Message: message,
@@ -102,7 +102,7 @@ func (c *consumer) NotifyAgentEvent(typ int, message interface{}) {
 func (c *consumer) NotifyPerfEvent(data []byte, cpu int) {
 	c.sendEvent(&observerTypes.MonitorEvent{
 		Timestamp: time.Now(),
-		NodeName:  nodeTypes.GetName(),
+		NodeName:  nodeTypes.GetAbsoluteNodeName(),
 		Payload: &observerTypes.PerfEvent{
 			Data: data,
 			CPU:  cpu,
@@ -114,7 +114,7 @@ func (c *consumer) NotifyPerfEvent(data []byte, cpu int) {
 func (c *consumer) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
 	c.sendEvent(&observerTypes.MonitorEvent{
 		Timestamp: time.Now(),
-		NodeName:  nodeTypes.GetName(),
+		NodeName:  nodeTypes.GetAbsoluteNodeName(),
 		Payload: &observerTypes.LostEvent{
 			Source:        observerTypes.LostEventSourcePerfRingBuffer,
 			NumLostEvents: numLostEvents,

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -305,7 +305,7 @@ nextEvent:
 		case *flowpb.LostEvent:
 			resp = &observerpb.GetFlowsResponse{
 				Time:     e.Timestamp,
-				NodeName: nodeTypes.GetName(),
+				NodeName: nodeTypes.GetAbsoluteNodeName(),
 				ResponseTypes: &observerpb.GetFlowsResponse_LostEvents{
 					LostEvents: ev,
 				},
@@ -383,7 +383,7 @@ func (s *LocalObserverServer) GetAgentEvents(
 			eventsReader.eventCount++
 			resp := &observerpb.GetAgentEventsResponse{
 				Time:       e.Timestamp,
-				NodeName:   nodeTypes.GetName(),
+				NodeName:   nodeTypes.GetAbsoluteNodeName(),
 				AgentEvent: ev,
 			}
 			err = server.Send(resp)
@@ -444,7 +444,7 @@ func (s *LocalObserverServer) GetDebugEvents(
 			eventsReader.eventCount++
 			resp := &observerpb.GetDebugEventsResponse{
 				Time:       e.Timestamp,
-				NodeName:   nodeTypes.GetName(),
+				NodeName:   nodeTypes.GetAbsoluteNodeName(),
 				DebugEvent: ev,
 			}
 			err = server.Send(resp)

--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -124,7 +124,7 @@ func (s *Service) Record(stream recorderpb.Recorder_RecordServer) error {
 	}
 
 	err = stream.Send(&recorderpb.RecordResponse{
-		NodeName: nodeTypes.GetName(),
+		NodeName: nodeTypes.GetAbsoluteNodeName(),
 		Time:     timestamppb.Now(),
 		ResponseType: &recorderpb.RecordResponse_Stopped{
 			Stopped: resp,
@@ -144,7 +144,7 @@ func createPcapFile(basedir, prefix string) (f *os.File, filePath string, err er
 	for {
 		startTime := time.Now().Unix()
 		random := rand.Uint32()
-		nodeName := nodeTypes.GetName()
+		nodeName := nodeTypes.GetAbsoluteNodeName()
 		name := fmt.Sprintf("%s_%d_%d_%s.pcap", prefix, startTime, random, nodeName)
 		filePath = path.Join(basedir, name)
 		f, err = os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
@@ -313,7 +313,7 @@ func (s *Service) watchRecording(ctx context.Context, h *sink.Handle, stream rec
 	for {
 		stats := h.Stats()
 		err := stream.Send(&recorderpb.RecordResponse{
-			NodeName: nodeTypes.GetName(),
+			NodeName: nodeTypes.GetAbsoluteNodeName(),
 			Time:     timestamppb.Now(),
 			ResponseType: &recorderpb.RecordResponse_Running{
 				Running: &recorderpb.RecordingRunningResponse{

--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -136,7 +136,7 @@ func nodeStatusError(err error, nodeNames ...string) *observerpb.GetFlowsRespons
 	}
 
 	return &observerpb.GetFlowsResponse{
-		NodeName: nodeTypes.GetName(),
+		NodeName: nodeTypes.GetAbsoluteNodeName(),
 		Time:     timestamppb.New(time.Now()),
 		ResponseTypes: &observerpb.GetFlowsResponse_NodeStatus{
 			NodeStatus: &relaypb.NodeStatusEvent{
@@ -150,7 +150,7 @@ func nodeStatusError(err error, nodeNames ...string) *observerpb.GetFlowsRespons
 
 func nodeStatusEvent(state relaypb.NodeState, nodeNames ...string) *observerpb.GetFlowsResponse {
 	return &observerpb.GetFlowsResponse{
-		NodeName: nodeTypes.GetName(),
+		NodeName: nodeTypes.GetAbsoluteNodeName(),
 		Time:     timestamppb.New(time.Now()),
 		ResponseTypes: &observerpb.GetFlowsResponse_NodeStatus{
 			NodeStatus: &relaypb.NodeStatusEvent{

--- a/pkg/node/types/nodename.go
+++ b/pkg/node/types/nodename.go
@@ -17,8 +17,10 @@ package types
 import (
 	"os"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	k8sConsts "github.com/cilium/cilium/pkg/k8s/constants"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -40,6 +42,18 @@ func SetName(name string) {
 // resort is hardcoded to "localhost".
 func GetName() string {
 	return nodeName
+}
+
+// GetAbsoluteNodeName returns the absolute node name combined of both
+// (prefixed)cluster name and the local node name in case of
+// clustered environments otherwise returns the name of the local node.
+func GetAbsoluteNodeName() string {
+	if option.Config.ClusterName != "" &&
+		option.Config.ClusterName != defaults.ClusterName {
+		return option.Config.ClusterName + "/" + nodeName
+	} else {
+		return nodeName
+	}
 }
 
 func init() {


### PR DESCRIPTION
Description:
This field node_name currently only contains the node name, without its cluster-mesh prefix.
If the cluster name is not the default cluster name then it should show the node_name along with the prefixed cluster name

Its should be shown as below:
cluster<id>/<node_name>
Eg: cluster1/node-ip.compute.internal

$ hubble observe --last 2 -o compact --print-node-name
Nov  3 11:40:45.407 [cluster5/ip-172-0-51-175.us-west-2.compute.internal]: [...]
Nov  3 11:40:46.554 [cluster7/ip-172-0-121-242.us-west-2.compute.internal ]: [...]

Fixes: #13872

Signed-off-by: Maddy007-maha <mahadev.panchal@accuknox.com>
