### PR TITLE
workflows: update cluster names and tags

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -14,7 +14,7 @@ on:
   ###
 
 env:
-  name: cilium-cli-ci-${{ github.run_id }}
+  name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -92,7 +92,7 @@ jobs:
           az group create \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --tags "owner=${{ steps.vars.outputs.owner }}"
+            --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
           az aks create \
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -14,7 +14,7 @@ on:
   ###
 
 env:
-  clusterName: cilium-cli-ci-${{ github.run_id }}
+  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -88,7 +88,7 @@ jobs:
         run: |
           eksctl create cluster \
             --name ${{ env.clusterName }} \
-            --tags "usage=pr,owner=${{ steps.vars.outputs.owner }}" \
+            --tags "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --without-nodegroup
 
       - name: Wait for images to be available

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -14,7 +14,7 @@ on:
   ###
 
 env:
-  clusterName: cilium-cli-ci-${{ github.run_id }}
+  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -85,7 +85,7 @@ jobs:
       - name: Create GKE cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }} \
-            --labels "usage=pr,owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -14,8 +14,8 @@ on:
   ###
 
 env:
-  clusterName1: cilium-cli-ci-${{ github.run_id }}-multicluster-1
-  clusterName2: cilium-cli-ci-${{ github.run_id }}-multicluster-2
+  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-multicluster-1
+  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-multicluster-2
   zone: us-west2-a
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -85,7 +85,7 @@ jobs:
       - name: Create GKE cluster 1
         run: |
           gcloud container clusters create ${{ env.clusterName1 }} \
-            --labels "usage=pr,owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
@@ -97,7 +97,7 @@ jobs:
       - name: Create GKE cluster 2
         run: |
           gcloud container clusters create ${{ env.clusterName2 }} \
-            --labels "usage=pr,owner=${{ steps.vars.outputs.owner }}" \
+            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \


### PR DESCRIPTION
- Remove leftovers from `cilium-cli` migration.
- Prefix names with organization name.
- Use `usage` tag to group clusters by repository.