### PR TITLE
test: Fix fragment tracking test on GKE

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2909,9 +2909,16 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
 		SkipItIf(func() bool {
-			return helpers.DoesNotRunOn419OrLaterKernel() || helpers.RunsOnGKE()
+			return helpers.DoesNotRunOn419OrLaterKernel()
 		}, "Supports IPv4 fragments", func() {
-			DeployCiliumAndDNS(kubectl, ciliumFilename)
+			options := map[string]string{}
+			// On GKE we need to disable endpoint routes as fragment tracking
+			// isn't compatible with that options. See #15958.
+			if helpers.RunsOnGKE() {
+				options["gke.enabled"] = "false"
+				options["tunnel"] = "disabled"
+			}
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 			testIPv4FragmentSupport()
 		})
 	})


### PR DESCRIPTION
The fragment tracking test was disabled on GKE because [it is incompatible with endpoint routes](https://github.com/cilium/cilium/issues/15958). Until that incompatibility is fixed, we can disable endpoint routes when running on GKE.

Fixes: https://github.com/cilium/cilium/issues/14652.