### PR TITLE
docs: gsg/operations - use parsed-literal for all blocks referring SCM_WEB

### DIFF
--- a/Documentation/gettingstarted/host-firewall.rst
+++ b/Documentation/gettingstarted/host-firewall.rst
@@ -20,7 +20,7 @@ Enable the Host Firewall in Cilium
 
 Deploy Cilium release via Helm:
 
-.. parsed-literal ::
+.. parsed-literal::
 
     helm install cilium |CHART_RELEASE|        \\
       --namespace kube-system                  \\
@@ -98,7 +98,7 @@ the outside of the cluster, except if those pods are host-networking pods.
 
 To apply this policy, run:
 
-.. code-block:: shell-session
+.. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/policies/host/demo-host-policy.yaml
     ciliumclusterwidenetworkpolicy.cilium.io/demo-host-policy created

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -321,7 +321,7 @@ and various network policy combinations.
 To run the connectivity tests create an isolated test namespace called
 ``cilium-test`` to deploy the tests with.
 
-.. code:: bash
+.. parsed-literal::
 
    kubectl create ns cilium-test
    kubectl apply --namespace=cilium-test -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml


### PR DESCRIPTION
Found these `SCM_WEB` rendered verbatim in the docs. Checked the HTML output of the build, and couldn't find any other `SCM_` or `_RELEASE` variables in the HTML output.