### PR TITLE
test: Fix the search for VIPs in `cilium service list`

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -189,6 +189,16 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		}
 	}
 
+	ciliumHasServiceIP := func(pod, vip string) bool {
+		service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
+		vip4 := fmt.Sprintf(" %s:", vip)
+		if strings.Contains(service.Stdout(), vip4) {
+			return true
+		}
+		vip6 := fmt.Sprintf(" [%s]:", vip)
+		return strings.Contains(service.Stdout(), vip6)
+	}
+
 	newlineRegexp := regexp.MustCompile(`\n[ \t\n]*`)
 	trimNewlines := func(script string) string {
 		return newlineRegexp.ReplaceAllLiteralString(script, " ")
@@ -404,8 +414,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				Expect(status).Should(helpers.CMDSuccess(), "cannot curl to service IP from host: %s", status.CombineOutput())
 
 				for _, pod := range ciliumPods {
-					service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
-					service.ExpectContains(clusterIP, "ClusterIP is not present in the cilium service list")
+					Expect(ciliumHasServiceIP(pod, clusterIP)).Should(BeTrue(),
+						"ClusterIP is not present in the cilium service list")
 				}
 				// Send requests from "app2" pod which runs on the same node as
 				// "app1" pods
@@ -430,10 +440,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				Eventually(func() int {
 					validPods := 0
 					for _, pod := range ciliumPods {
-						serviceRes := kubectl.CiliumExecMustSucceed(
-							context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
-
-						if strings.Contains(serviceRes.Stdout(), clusterIP) {
+						if ciliumHasServiceIP(pod, clusterIP) {
 							validPods++
 						}
 					}
@@ -545,10 +552,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				Eventually(func() int {
 					validPods := 0
 					for _, pod := range ciliumPods {
-						serviceRes := kubectl.CiliumExecMustSucceed(
-							context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
-
-						if !strings.Contains(serviceRes.Stdout(), clusterIP) {
+						if !ciliumHasServiceIP(pod, clusterIP) {
 							validPods++
 						}
 					}
@@ -570,10 +574,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				Eventually(func() int {
 					validPods := 0
 					for _, pod := range ciliumPods {
-						serviceRes := kubectl.CiliumExecMustSucceed(
-							context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
-
-						if strings.Contains(serviceRes.Stdout(), clusterIP) {
+						if ciliumHasServiceIP(pod, clusterIP) {
 							validPods++
 						}
 					}
@@ -690,7 +691,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			ciliumPods, err := kubectl.GetCiliumPods()
 			Expect(err).To(BeNil(), "Cannot get cilium pods")
 			for _, pod := range ciliumPods {
-				service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep %s", svcIP), "Cannot retrieve services on cilium pod")
+				service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep \" %s:\"", svcIP), "Cannot retrieve services on cilium pod")
 				service.ExpectContains("LocalRedirect", "LocalRedirect is not present in the cilium service list")
 			}
 
@@ -774,7 +775,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			ciliumPods, err := kubectl.GetCiliumPods()
 			Expect(err).To(BeNil(), "Cannot get cilium pods")
 			for _, pod := range ciliumPods {
-				service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep %s", svcIP), "Cannot retrieve services on cilium pod")
+				service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep \" %s:\"", svcIP), "Cannot retrieve services on cilium pod")
 				service.ExpectContains("ClusterIP", "Original service is not present in the cilium service list")
 			}
 


### PR DESCRIPTION
In several different service tests, we check that cilium is handling or not handling a service VIP. To that end, we search for the given VIP in the output of `cilium service list`. That output looks something like:

    ID   Frontend              Service Type   Backend
    1    10.87.240.1:443       ClusterIP      1 => 35.247.116.7:443
    2    10.87.245.217:443     ClusterIP      1 => 10.84.1.94:443
    3    10.87.240.10:53       ClusterIP      1 => 10.84.1.175:53
                                              2 => 10.84.1.28:53
    4    10.87.241.252:80      ClusterIP      1 => 10.84.1.104:8080

Searching for the VIP directly in the output may return false positives however. For instance, searching for `10.87.241.25` in the above would match the last line when the IP doesn't actually match. Instead we should search for ` VIP:`, that is, with anchors at the beginning and end of the VIP.

Fixes: https://github.com/cilium/cilium/issues/13752