### PR TITLE
docs: remove misplaced sentence from Quick Installation guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -107,9 +107,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 Install Cilium
 ==============
 
-You can install Cilium on any Kubernetes cluster. If you already have a
-Kubernetes cluster, skip this step. If you want to create a cluster, pick one
-of the options below:
+You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
 .. tabs::
 


### PR DESCRIPTION
Hi there 👋 , while following the Cilium installation guide I noticed that in the [Install Cilium step](https://docs.cilium.io/en/latest/gettingstarted/k8s-install-default/#install-cilium), there seems to be a sentence that belongs to [the previous step](https://docs.cilium.io/en/latest/gettingstarted/k8s-install-default/#install-cilium). This PR removes that sentence to avoid confusion. No need to move the sentence to the previous step as it is already clear.

Fixes: [#15970](https://github.com/cilium/cilium/issues/15970)

Signed-off-by: Lorenzo Fundaró <lorenzofundaro@gmail.com>
