### PR TITLE
docs: tell how to deploy demo app in Hubble CLI guide

### DIFF
--- a/Documentation/gettingstarted/hubble_cli.rst
+++ b/Documentation/gettingstarted/hubble_cli.rst
@@ -25,15 +25,10 @@ across the globe, there is almost always someone available to help.
    unsure, run ``cilium status`` and validate that Cilium and Hubble are up and
    running.
 
+.. note::
 
-Generate some network traffic
-=============================
-
-In order to generate some network traffic, run the connectivity test:
-
-.. code-block:: shell-session
-
-   while true; do cilium connectivity test; done 
+    This guide uses examples based on the Demo App. If you would like to run them,
+    deploy the Demo App first. Please refer to :ref:`gs_http` for more details.
 
 Inspecting the cluster's network traffic with Hubble Relay
 ==========================================================


### PR DESCRIPTION
When following the guide on Inspecting the Network flow
with Hubble's CLI the Demo App is required to be deployed
but there is no reference to that anywhere following the
sequence of steps from the Getting Started guide.

Fixes: #15972

Signed-off-by: Lorenzo Fundaró <lorenzofundaro@gmail.com>
