### PR TITLE
docs: improve the aws-cni chaining page

### DIFF
--- a/Documentation/gettingstarted/k8s-install-connectivity-test.rst
+++ b/Documentation/gettingstarted/k8s-install-connectivity-test.rst
@@ -1,46 +1,23 @@
 Deploy the connectivity test
 ----------------------------
 
-You can deploy the "connectivity-check" to test connectivity between pods. It is
-recommended to create a separate namespace for this.
-
-.. code:: bash
-
-   kubectl create ns cilium-test
-
-Deploy the check with:
-
-.. parsed-literal::
-
-   kubectl apply -n cilium-test -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
-
-It will deploy a series of deployments which will use various connectivity
-paths to connect to each other. Connectivity paths include with and without
-service load-balancing and various network policy combinations. The pod name
-indicates the connectivity variant and the readiness and liveness gate
-indicates success or failure of the test:
+Run the following command to validate that your cluster has proper network
+connectivity:
 
 .. code-block:: shell-session
 
-   $ kubectl get pods -n cilium-test
-   NAME                                                     READY   STATUS    RESTARTS   AGE
-   echo-a-76c5d9bd76-q8d99                                  1/1     Running   0          66s
-   echo-b-795c4b4f76-9wrrx                                  1/1     Running   0          66s
-   echo-b-host-6b7fc94b7c-xtsff                             1/1     Running   0          66s
-   host-to-b-multi-node-clusterip-85476cd779-bpg4b          1/1     Running   0          66s
-   host-to-b-multi-node-headless-dc6c44cb5-8jdz8            1/1     Running   0          65s
-   pod-to-a-79546bc469-rl2qq                                1/1     Running   0          66s
-   pod-to-a-allowed-cnp-58b7f7fb8f-lkq7p                    1/1     Running   0          66s
-   pod-to-a-denied-cnp-6967cb6f7f-7h9fn                     1/1     Running   0          66s
-   pod-to-b-intra-node-nodeport-9b487cf89-6ptrt             1/1     Running   0          65s
-   pod-to-b-multi-node-clusterip-7db5dfdcf7-jkjpw           1/1     Running   0          66s
-   pod-to-b-multi-node-headless-7d44b85d69-mtscc            1/1     Running   0          66s
-   pod-to-b-multi-node-nodeport-7ffc76db7c-rrw82            1/1     Running   0          65s
-   pod-to-external-1111-d56f47579-d79dz                     1/1     Running   0          66s
-   pod-to-external-fqdn-allow-google-cnp-78986f4bcf-btjn7   1/1     Running   0          66s
+   cilium connectivity test
 
-.. note::
+The output should be similar to the following one:
 
-    If you deploy the connectivity check to a single node cluster, pods that check multi-node
-    functionalities will remain in the ``Pending`` state. This is expected since these pods
-    need at least 2 nodes to be scheduled successfully.
+::
+
+   ℹ️  Monitor aggregation detected, will skip some flow validation steps
+   ✨ [k8s-cluster] Creating namespace for connectivity check...
+   (...)
+   ---------------------------------------------------------------------------------------------------------------------
+   📋 Test Report
+   ---------------------------------------------------------------------------------------------------------------------
+   ✅ 69/69 tests successful (0 warnings)
+
+Congratulations! You have a fully functional Kubernetes cluster with Cilium. 🎉

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -225,64 +225,6 @@ pods are failing to be deployed.
    was deployed and the installer has automatically restarted them to ensure
    all pods get networking provided by Cilium.
 
-Validate Installation
-=====================
-
-Check the Status
-----------------
-
-To validate the installation, run the ``cilium status`` command:
-
-.. code-block:: shell-session
-
-    cilium status
-        /¯¯\
-     /¯¯\__/¯¯\    Cilium:         OK
-     \__/¯¯\__/    Operator:       OK
-     /¯¯\__/¯¯\    Hubble:         disabled
-     \__/¯¯\__/    ClusterMesh:    disabled
-        \__/
-
-    DaemonSet         cilium                   Desired: 3, Ready: 3/3, Available: 3/3
-    Deployment        cilium-operator          Desired: 1, Ready: 1/1, Available: 1/1
-    Containers:       cilium                   Running: 3
-                      cilium-operator          Running: 1
-    Image versions    cilium                   quay.io/cilium/cilium:v1.9.4: 3
-                      cilium-operator          quay.io/cilium/operator-generic:v1.9.4: 1
-
-Run the Connectivity Test
--------------------------
-
-Run the ``cilium connectivity test`` to validate that your cluster has proper
-network connectivity:
-
-.. code-block:: shell-session
-
-    cilium connectivity test
-    ✨ [gke_cilium-dev_us-west2-a_32287] Creating namespace for connectivity check...
-    [...]
-
-    ---------------------------------------------------------------------------------------------------------------------
-    🔌 [pod-to-pod] Testing cilium-test/client-77bd7f48dd-5zwkw -> cilium-test/echo-other-node-86774f89b9-xjmkn...
-    ---------------------------------------------------------------------------------------------------------------------
-    ✅ [pod-to-pod] cilium-test/client-77bd7f48dd-5zwkw (10.0.2.188) -> cilium-test/echo-other-node-86774f89b9-xjmkn (10.0.1.125)
-
-    ---------------------------------------------------------------------------------------------------------------------
-    🔌 [pod-to-pod] Testing cilium-test/client-77bd7f48dd-5zwkw -> cilium-test/echo-same-node-f789dd8f7-th9f7...
-    ---------------------------------------------------------------------------------------------------------------------
-    ✅ [pod-to-pod] cilium-test/client-77bd7f48dd-5zwkw (10.0.2.188) -> cilium-test/echo-same-node-f789dd8f7-th9f7 (10.0.2.223)
-
-    ---------------------------------------------------------------------------------------------------------------------
-    🔌 [pod-to-service] Testing cilium-test/client-77bd7f48dd-5zwkw -> echo-other-node:8080 (ClusterIP)...
-    ---------------------------------------------------------------------------------------------------------------------
-    ✅ [pod-to-service] cilium-test/client-77bd7f48dd-5zwkw (10.0.2.188) -> echo-other-node:8080 (ClusterIP) (echo-other-node:8080)
-    [...]
-    ---------------------------------------------------------------------------------------------------------------------
-    📋 Test Report
-    ---------------------------------------------------------------------------------------------------------------------
-    ✅ 9/9 tests successful (0 warnings)
-
-
-Congratulations! You have a fully functional Kubernetes cluster with Cilium. 🎉
+.. include:: k8s-install-validate.rst
 
 .. include:: next-steps.rst

--- a/Documentation/gettingstarted/k8s-install-download-release.rst
+++ b/Documentation/gettingstarted/k8s-install-download-release.rst
@@ -6,7 +6,7 @@
 
 .. note::
 
-   First, make sure you have Helm 3 `installed <https://helm.sh/docs/intro/install/>`_.
+   Make sure you have Helm 3 `installed <https://helm.sh/docs/intro/install/>`_.
    Helm 2 is `no longer supported <https://helm.sh/blog/helm-v2-deprecation-timeline/>`_.
 
 .. only:: stable

--- a/Documentation/gettingstarted/k8s-install-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-validate.rst
@@ -1,24 +1,30 @@
 Validate the Installation
 =========================
 
-You can monitor as Cilium and all required components are being installed:
+.. include:: install-cli.rst
 
-.. parsed-literal::
+To validate that Cilium has been properly installed, you can run
 
-    kubectl -n kube-system get pods --watch
-    NAME                                    READY   STATUS              RESTARTS   AGE
-    cilium-operator-cb4578bc5-q52qk         0/1     Pending             0          8s
-    cilium-s8w5m                            0/1     PodInitializing     0          7s
-    coredns-86c58d9df4-4g7dd                0/1     ContainerCreating   0          8m57s
-    coredns-86c58d9df4-4l6b2                0/1     ContainerCreating   0          8m57s
+.. code-block:: shell-session
 
-It may take a couple of minutes for all components to come up:
+   cilium status --wait
 
-.. parsed-literal::
+The output should be similar to the following one:
 
-    cilium-operator-cb4578bc5-q52qk         1/1     Running   0          4m13s
-    cilium-s8w5m                            1/1     Running   0          4m12s
-    coredns-86c58d9df4-4g7dd                1/1     Running   0          13m
-    coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
+::
+
+      /¯¯\
+   /¯¯\__/¯¯\    Cilium:         OK
+   \__/¯¯\__/    Operator:       OK
+   /¯¯\__/¯¯\    Hubble:         disabled
+   \__/¯¯\__/    ClusterMesh:    disabled
+      \__/
+
+   DaemonSet         cilium             Desired: 2, Ready: 2/2, Available: 2/2
+   Deployment        cilium-operator    Desired: 2, Ready: 2/2, Available: 2/2
+   Containers:       cilium-operator    Running: 2
+                     cilium             Running: 2
+   Image versions    cilium             quay.io/cilium/cilium:v1.9.5: 2
+                     cilium-operator    quay.io/cilium/operator-generic:v1.9.5: 2
 
 .. include:: k8s-install-connectivity-test.rst


### PR DESCRIPTION
Improve the AWS VPC CNI plugin chaining page. Also, make use of the Cilium CLI to check for the status of the installation and for performing the connectivity test.

```release-note
docs: improve the aws-cni chaining page
```
