### PR TITLE
datapath: support dhcpv4 discover as a valid lxc source ip

### DIFF
--- a/api/v1/models/endpoint_datapath_configuration.go
+++ b/api/v1/models/endpoint_datapath_configuration.go
@@ -36,6 +36,9 @@ type EndpointDatapathConfiguration struct {
 	// Endpoint requires BPF routing to be enabled, when disabled, routing is delegated to Linux routing.
 	//
 	RequireRouting *bool `json:"require-routing,omitempty"`
+
+	// Endpoint requires dhcp messages to be allowed
+	RequireDHCPMessages bool `json:"require-dhcp-messages,omitempty"`
 }
 
 // Validate validates this endpoint datapath configuration

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -82,6 +82,10 @@ type CompileTimeConfiguration interface {
 	// be enabled, when disabled, routing is delegated to Linux routing
 	RequireRouting() bool
 
+	// RequireDHCPMessages returns true if the endpoint requires DHCP messages
+	// to be allowed as a valid source IP (0.0.0.0).
+	RequireDHCPMessages() bool
+
 	// RequireEndpointRoute returns true if the endpoint wishes to have a
 	// per endpoint route installed in the host's routing table to point to
 	// the endpoint's interface

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -736,6 +736,10 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
+	if e.RequireDHCPMessages() {
+		fmt.Fprintf(fw, "#define ENABLE_DHCP_MESSAGES 1\n")
+	}
+
 	if e.RequireEndpointRoute() {
 		fmt.Fprintf(fw, "#define ENABLE_ENDPOINT_ROUTES 1\n")
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1474,6 +1474,11 @@ func (e *Endpoint) RequireRouting() (required bool) {
 	return
 }
 
+// RequireDHCPMessages returns true if the endpoint requires dhcp to be allowed
+func (e *Endpoint) RequireDHCPMessages() bool {
+	return e.DatapathConfiguration.RequireDHCPMessages
+}
+
 // RequireEndpointRoute returns if the endpoint wants a per endpoint route
 func (e *Endpoint) RequireEndpointRoute() bool {
 	return e.DatapathConfiguration.InstallEndpointRoute

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -49,6 +49,7 @@ type epInfoCache struct {
 	requireARPPassthrough                  bool
 	requireEgressProg                      bool
 	requireRouting                         bool
+	requireDHCPMessages                    bool
 	requireEndpointRoute                   bool
 	policyVerdictLogFilter                 uint32
 	cidr4PrefixLengths, cidr6PrefixLengths []int
@@ -84,6 +85,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		requireARPPassthrough:  e.RequireARPPassthrough(),
 		requireEgressProg:      e.RequireEgressProg(),
 		requireRouting:         e.RequireRouting(),
+		requireDHCPMessages:    e.RequireDHCPMessages(),
 		requireEndpointRoute:   e.RequireEndpointRoute(),
 		policyVerdictLogFilter: e.GetPolicyVerdictLogFilter(),
 		cidr4PrefixLengths:     cidr4,
@@ -188,6 +190,11 @@ func (ep *epInfoCache) RequireEgressProg() bool {
 // enabled, when disabled, routing is delegated to Linux routing
 func (ep *epInfoCache) RequireRouting() bool {
 	return ep.requireRouting
+}
+
+// RequireDHCPMessages returns true if the endpoint requires dhcp to be allowed
+func (ep *epInfoCache) RequireDHCPMessages() bool {
+	return ep.requireDHCPMessages
 }
 
 // RequireEndpointRoute returns if the endpoint wants a per endpoint route

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -66,6 +66,7 @@ func (e *TestEndpoint) ConntrackLocalLocked() bool                  { return fal
 func (e *TestEndpoint) RequireARPPassthrough() bool                 { return false }
 func (e *TestEndpoint) RequireEgressProg() bool                     { return false }
 func (e *TestEndpoint) RequireRouting() bool                        { return false }
+func (e *TestEndpoint) RequireDHCPMessages() bool                   { return false }
 func (e *TestEndpoint) RequireEndpointRoute() bool                  { return false }
 func (e *TestEndpoint) GetPolicyVerdictLogFilter() uint32           { return 0xffff }
 func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)        { return nil, nil }


### PR DESCRIPTION
Add a new datapath option which allows endpoint to send
a DHCP discover message which has been previously dropped by
"Invalid source ip" filter in lxc_bpf program which by default
allows only LXC_IPV4 as a source IP.

With this option endpoints like OpenStack vms can ask for IP
address using DHCP which is the standard way of IPAM in OS.

Signed-off-by: Ondrej Blazek <ondra.blazkuj@gmail.com>


Without these changes:
```
<- endpoint 2942 flow 0x0 identity 52569->0 state new ifindex 0 orig-ip 0.0.0.0: 0.0.0.0:68 -> 255.255.255.255:67 udp
xx drop (Invalid source ip) flow 0x0 to endpoint 0, identity 52569->0: 0.0.0.0:68 -> 255.255.255.255:67 udp
```

With these changes:
```
<- endpoint 3860 flow 0x0 identity 52569->0 state new ifindex 0 orig-ip 0.0.0.0: 0.0.0.0:68 -> 255.255.255.255:67 udp
-> stack flow 0x0 identity 52569->2 state new ifindex 0 orig-ip 0.0.0.0: 0.0.0.0:68 -> 255.255.255.255:67 udp
<- stack flow 0x0 identity 1->0 state new ifindex 0 orig-ip 0.0.0.0: 10.248.14.22:67 -> 10.247.2.17:68 udp
Policy verdict log: flow 0x0 local EP ID 3860, remote ID 1, proto 17, ingress, action allow, match L3-Only, 10.248.14.22:67 -> 10.247.2.17:68 udp
```
