### PR TITLE
doc: update Hubble/Hubble Relay guides for recent CLI changes

### DIFF
--- a/Documentation/gettingstarted/hubble_cli.rst
+++ b/Documentation/gettingstarted/hubble_cli.rst
@@ -33,15 +33,8 @@ across the globe, there is almost always someone available to help.
 Inspecting the cluster's network traffic with Hubble Relay
 ==========================================================
 
-In order to avoid passing ``--server`` argument to every command, you may
-export the following environment variable:
-
-.. code-block:: shell-session
-
-   export HUBBLE_SERVER=localhost:4245
-
-Let's now issue some requests to emulate some traffic again. This first request
-is allowed by the policy.
+Let's issue some requests to emulate some traffic again. This first request is
+allowed by the policy.
 
 .. code-block:: shell-session
 
@@ -70,10 +63,10 @@ traffic on the application layer (L7, HTTP) to the ``deathstar`` pod:
 .. code-block:: shell-session
 
     hubble observe --pod deathstar --protocol http
-    TIMESTAMP             SOURCE                                  DESTINATION                             TYPE            VERDICT     SUMMARY
-    Jun 18 13:52:23.843   default/tiefighter:52568                default/deathstar-5b7489bc84-8wvng:80   http-request    FORWARDED   HTTP/1.1 POST http://deathstar.default.svc.cluster.local/v1/request-landing
-    Jun 18 13:52:23.844   default/deathstar-5b7489bc84-8wvng:80   default/tiefighter:52568                http-response   FORWARDED   HTTP/1.1 200 0ms (POST http://deathstar.default.svc.cluster.local/v1/request-landing)
-    Jun 18 13:52:31.019   default/tiefighter:52628                default/deathstar-5b7489bc84-8wvng:80   http-request    DROPPED     HTTP/1.1 PUT http://deathstar.default.svc.cluster.local/v1/exhaust-port
+    May  4 13:23:40.501: default/tiefighter:42690 -> default/deathstar-c74d84667-cx5kp:80 http-request FORWARDED (HTTP/1.1 POST http://deathstar.default.svc.cluster.local/v1/request-landing)
+    May  4 13:23:40.502: default/tiefighter:42690 <- default/deathstar-c74d84667-cx5kp:80 http-response FORWARDED (HTTP/1.1 200 0ms (POST http://deathstar.default.svc.cluster.local/v1/request-landing))
+    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar.default.svc.cluster.local/v1/exhaust-port)
+
 
 
 The following command shows all traffic to the ``deathstar`` pod that has been
@@ -82,11 +75,10 @@ dropped:
 .. code-block:: shell-session
 
     hubble observe --pod deathstar --verdict DROPPED
-    TIMESTAMP             SOURCE                     DESTINATION                             TYPE            VERDICT   SUMMARY
-    Jun 18 13:52:31.019   default/tiefighter:52628   default/deathstar-5b7489bc84-8wvng:80   http-request    DROPPED   HTTP/1.1 PUT http://deathstar.default.svc.cluster.local/v1/exhaust-port
-    Jun 18 13:52:38.321   default/xwing:34138        default/deathstar-5b7489bc84-v4s7d:80   Policy denied   DROPPED   TCP Flags: SYN
-    Jun 18 13:52:38.321   default/xwing:34138        default/deathstar-5b7489bc84-v4s7d:80   Policy denied   DROPPED   TCP Flags: SYN
-    Jun 18 13:52:39.327   default/xwing:34138        default/deathstar-5b7489bc84-v4s7d:80   Policy denied   DROPPED   TCP Flags: SYN
+    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar.default.svc.cluster.local/v1/exhaust-port)
+    May  4 13:23:47.852: default/xwing:42818 <> default/deathstar-c74d84667-cx5kp:80 Policy denied DROPPED (TCP Flags: SYN)
+    May  4 13:23:47.852: default/xwing:42818 <> default/deathstar-c74d84667-cx5kp:80 Policy denied DROPPED (TCP Flags: SYN)
+    May  4 13:23:48.854: default/xwing:42818 <> default/deathstar-c74d84667-cx5kp:80 Policy denied DROPPED (TCP Flags: SYN)
 
 Feel free to further inspect the traffic. To get help for the ``observe``
 command, use ``hubble help observe``.

--- a/Documentation/gettingstarted/hubble_setup.rst
+++ b/Documentation/gettingstarted/hubble_setup.rst
@@ -119,18 +119,26 @@ Now you can validate that you can access the Hubble API via the installed CLI:
 
 .. code:: shell-session
 
-    hubble status --server localhost:4245
-    Handling connection for 4245
+    hubble status
     Healthcheck (via localhost:4245): Ok
     Current/Max Flows: 11917/12288 (96.98%)
     Flows/s: 11.74
     Connected Nodes: 3/3
 
-You can now query the flow API and look for flows
+You can also query the flow API and look for flows:
 
 .. code:: bash
 
-   hubble --server localhost:4245 observe
+   hubble observe
+
+.. note::
+
+   If you port forward to a port other than ``4245``, make sure to use the
+   ``--server`` flag or ``HUBBLE_SERVER`` environment variable to set the
+   Hubble server address (default: ``localhost:4245``). For more information,
+   check out Hubble CLI's help message by running ``hubble help status`` or
+   ``hubble help observe`` as well as ``hubble config`` for  configuring Hubble
+   CLI.
 
 Next Steps
 ==========

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -148,6 +148,38 @@ Observing Flows with Hubble
 Hubble is a built-in observability tool which allows you to inspect recent flow
 events on all endpoints managed by Cilium.
 
+Ensure Hubble is running correctly
+----------------------------------
+
+To ensure the Hubble client can connect to the Hubble server running inside
+Cilium, you may use the ``hubble status`` command:
+
+.. code-block:: shell-session
+
+   $ hubble status
+   Healthcheck (via unix:///var/run/cilium/hubble.sock): Ok
+   Max Flows: 4096
+   Current Flows: 2542 (62.06%)
+
+``cilium-agent`` must be running with the ``--enable-hubble`` option (default) in order
+for the Hubble server to be enabled. When deploying Cilium with Helm, make sure
+to set the ``hubble.enabled=true`` value.
+
+To check if Hubble is enabled in your deployment, you may look for the
+following output in ``cilium status``:
+
+.. code-block:: shell-session
+
+   $ cilium status
+   ...
+   Hubble:   Ok   Current/Max Flows: 2542/4096 (62.06%), Flows/s: 164.21   Metrics: Disabled
+   ...
+
+.. note::
+   Pods need to be managed by Cilium in order to be observable by Hubble.
+   See how to :ref:`ensure a pod is managed by Cilium<ensure_managed_pod>`
+   for more details.
+
 Observing flows of a specific pod
 ---------------------------------
 
@@ -213,38 +245,6 @@ more details about how to troubleshoot policy related drops.
    **Hubble Relay**  allows you to query multiple Hubble instances
    simultaneously without having to first manually target a specific node.  See
    `Observing flows with Hubble Relay`_ for more information.
-
-Ensure Hubble is running correctly
-----------------------------------
-
-To ensure the Hubble client can connect to the Hubble server running inside
-Cilium, you may use the ``hubble status`` command:
-
-.. code-block:: shell-session
-
-   $ hubble status
-   Healthcheck (via unix:///var/run/cilium/hubble.sock): Ok
-   Max Flows: 4096
-   Current Flows: 2542 (62.06%)
-
-``cilium-agent`` must be running with the ``--enable-hubble`` option (default) in order
-for the Hubble server to be enabled. When deploying Cilium with Helm, make sure
-to set the ``hubble.enabled=true`` value.
-
-To check if Hubble is enabled in your deployment, you may look for the
-following output in ``cilium status``:
-
-.. code-block:: shell-session
-
-   $ cilium status
-   ...
-   Hubble:   Ok   Current/Max Flows: 2542/4096 (62.06%), Flows/s: 164.21   Metrics: Disabled
-   ...
-
-.. note::
-   Pods need to be managed by Cilium in order to be observable by Hubble.
-   See how to :ref:`ensure a pod is managed by Cilium<ensure_managed_pod>`
-   for more details.
 
 Observing flows with Hubble Relay
 =================================

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -152,14 +152,14 @@ Ensure Hubble is running correctly
 ----------------------------------
 
 To ensure the Hubble client can connect to the Hubble server running inside
-Cilium, you may use the ``hubble status`` command:
+Cilium, you may use the ``hubble status`` command from within a Cilium pod:
 
 .. code-block:: shell-session
 
    $ hubble status
    Healthcheck (via unix:///var/run/cilium/hubble.sock): Ok
-   Max Flows: 4096
-   Current Flows: 2542 (62.06%)
+   Current/Max Flows: 4095/4095 (100.00%)
+   Flows/s: 164.21
 
 ``cilium-agent`` must be running with the ``--enable-hubble`` option (default) in order
 for the Hubble server to be enabled. When deploying Cilium with Helm, make sure
@@ -172,7 +172,7 @@ following output in ``cilium status``:
 
    $ cilium status
    ...
-   Hubble:   Ok   Current/Max Flows: 2542/4096 (62.06%), Flows/s: 164.21   Metrics: Disabled
+   Hubble:   Ok   Current/Max Flows: 4095/4095 (100.00%), Flows/s: 164.21   Metrics: Disabled
    ...
 
 .. note::
@@ -193,19 +193,18 @@ in the last three minutes:
 .. code-block:: shell-session
 
    $ kubectl exec -n kube-system cilium-77lk6 -- hubble observe --since 3m --pod default/tiefighter
-   Jun  2 11:14:46.041   default/tiefighter:38314                  kube-system/coredns-66bff467f8-ktk8c:53   to-endpoint   FORWARDED   UDP
-   Jun  2 11:14:46.041   kube-system/coredns-66bff467f8-ktk8c:53   default/tiefighter:38314                  to-endpoint   FORWARDED   UDP
-   Jun  2 11:14:46.041   default/tiefighter:38314                  kube-system/coredns-66bff467f8-ktk8c:53   to-endpoint   FORWARDED   UDP
-   Jun  2 11:14:46.042   kube-system/coredns-66bff467f8-ktk8c:53   default/tiefighter:38314                  to-endpoint   FORWARDED   UDP
-   Jun  2 11:14:46.042   default/tiefighter:57746                  default/deathstar-5b7489bc84-9bftc:80     L3-L4         FORWARDED   TCP Flags: SYN
-   Jun  2 11:14:46.042   default/tiefighter:57746                  default/deathstar-5b7489bc84-9bftc:80     to-endpoint   FORWARDED   TCP Flags: SYN
-   Jun  2 11:14:46.042   default/deathstar-5b7489bc84-9bftc:80     default/tiefighter:57746                  to-endpoint   FORWARDED   TCP Flags: SYN, ACK
-   Jun  2 11:14:46.042   default/tiefighter:57746                  default/deathstar-5b7489bc84-9bftc:80     to-endpoint   FORWARDED   TCP Flags: ACK
-   Jun  2 11:14:46.043   default/tiefighter:57746                  default/deathstar-5b7489bc84-9bftc:80     to-endpoint   FORWARDED   TCP Flags: ACK, PSH
-   Jun  2 11:14:46.043   default/deathstar-5b7489bc84-9bftc:80     default/tiefighter:57746                  to-endpoint   FORWARDED   TCP Flags: ACK, PSH
-   Jun  2 11:14:46.043   default/tiefighter:57746                  default/deathstar-5b7489bc84-9bftc:80     to-endpoint   FORWARDED   TCP Flags: ACK, FIN
-   Jun  2 11:14:46.048   default/deathstar-5b7489bc84-9bftc:80     default/tiefighter:57746                  to-endpoint   FORWARDED   TCP Flags: ACK, FIN
-   Jun  2 11:14:46.048   default/tiefighter:57746                  default/deathstar-5b7489bc84-9bftc:80     to-endpoint   FORWARDED   TCP Flags: ACK
+   May  4 12:47:08.811: default/tiefighter:53875 -> kube-system/coredns-74ff55c5b-66f4n:53 to-endpoint FORWARDED (UDP)
+   May  4 12:47:08.811: default/tiefighter:53875 -> kube-system/coredns-74ff55c5b-66f4n:53 to-endpoint FORWARDED (UDP)
+   May  4 12:47:08.811: default/tiefighter:53875 <- kube-system/coredns-74ff55c5b-66f4n:53 to-endpoint FORWARDED (UDP)
+   May  4 12:47:08.811: default/tiefighter:53875 <- kube-system/coredns-74ff55c5b-66f4n:53 to-endpoint FORWARDED (UDP)
+   May  4 12:47:08.811: default/tiefighter:50214 <> default/deathstar-c74d84667-cx5kp:80 to-overlay FORWARDED (TCP Flags: SYN)
+   May  4 12:47:08.812: default/tiefighter:50214 <- default/deathstar-c74d84667-cx5kp:80 to-endpoint FORWARDED (TCP Flags: SYN, ACK)
+   May  4 12:47:08.812: default/tiefighter:50214 <> default/deathstar-c74d84667-cx5kp:80 to-overlay FORWARDED (TCP Flags: ACK)
+   May  4 12:47:08.812: default/tiefighter:50214 <> default/deathstar-c74d84667-cx5kp:80 to-overlay FORWARDED (TCP Flags: ACK, PSH)
+   May  4 12:47:08.812: default/tiefighter:50214 <- default/deathstar-c74d84667-cx5kp:80 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
+   May  4 12:47:08.812: default/tiefighter:50214 <> default/deathstar-c74d84667-cx5kp:80 to-overlay FORWARDED (TCP Flags: ACK, FIN)
+   May  4 12:47:08.812: default/tiefighter:50214 <- default/deathstar-c74d84667-cx5kp:80 to-endpoint FORWARDED (TCP Flags: ACK, FIN)
+   May  4 12:47:08.812: default/tiefighter:50214 <> default/deathstar-c74d84667-cx5kp:80 to-overlay FORWARDED (TCP Flags: ACK)
 
 You may also use ``-o json`` to obtain more detailed information about each
 flow event.
@@ -277,25 +276,16 @@ command:
 
 .. code:: bash
 
-   hubble status --server localhost:4245
+   hubble status
 
 This command should return an output similar to the following:
 
 .. code-block:: shell-session
 
    Healthcheck (via localhost:4245): Ok
-   Max Flows: 16384
-   Current Flows: 16384 (100.00%)
-
-For convenience, you may set and export the ``HUBBLE_SERVER`` environment
-variable:
-
-.. code:: bash
-
-   export HUBBLE_SERVER=localhost:4245
-
-This will allow you to use ``hubble status`` and ``hubble observe`` commands
-without having to specify the server address via the ``--server`` flag.
+   Current/Max Flows: 16380/16380 (100.00%)
+   Flows/s: 46.19
+   Connected Nodes: 4/4
 
 As Hubble Relay shares the same API as individual Hubble instances, you may
 follow the `Observing flows with Hubble`_ section keeping in mind that

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -249,30 +249,21 @@ Observing flows with Hubble Relay
 =================================
 
 Hubble Relay is a service which allows to query multiple Hubble instances
-simultaneously and aggregate the results. The Hubble service needs to be exposed
-on TCP port ``4244`` to allow Hubble Relay to connect to individual instances.
-This can be done via Helm values or option ``--hubble-listen-address :4244`` on
-cilium-agent.
+simultaneously and aggregate the results. See :ref:`hubble_setup` to enable
+Hubble Relay if it is not yet enabled and install the Hubble CLI on your local
+machine.
 
-Hubble Relay can be deployed using Helm by setting
-``hubble.relay.enabled=true``. This will deploy Hubble Relay with one
-replica by default. Once the Hubble Relay pod is running, you may access the
-service by port-forwarding it:
+You may access the Hubble Relay service by port-forwarding it locally:
 
 .. code:: bash
 
    kubectl -n kube-system port-forward service/hubble-relay --address 0.0.0.0 --address :: 4245:80
 
 This will forward the Hubble Relay service port (``80``) to your local machine
-on port ``4245`` on all of it's IP addresses. The next step consists of
-downloading the latest binary release of Hubble CLI from the
-`GitHub release page <https://github.com/cilium/hubble/releases>`_. Make sure to
-download the tarball for your platform, verify the checksum and extract the
-``hubble`` binary from the tarball. Optionally, add the binary to your
-``$PATH`` if using Linux or MacOS or your ``%PATH%`` if using Windows.
+on port ``4245`` on all of it's IP addresses.
 
-You can verify that Hubble Relay can be reached by running the following
-command:
+You can verify that Hubble Relay can be reached by using the Hubble CLI and
+running the following command from your local machine:
 
 .. code:: bash
 
@@ -286,6 +277,13 @@ This command should return an output similar to the following:
    Current/Max Flows: 16380/16380 (100.00%)
    Flows/s: 46.19
    Connected Nodes: 4/4
+
+You may see details about nodes that Hubble Relay is connected to by running
+the following command:
+
+.. code-block:: bash
+
+   hubble list nodes
 
 As Hubble Relay shares the same API as individual Hubble instances, you may
 follow the `Observing flows with Hubble`_ section keeping in mind that


### PR DESCRIPTION
This PR updates the troubleshooting with Hubble/Hubble Relay sections as well as the getting started with Hubble guide to recent Hubble CLI changes. Namely, the output of `hubble status` and `hubble observe` is now slightly different and the CLI defaults to `localhost:4245` a the server address, which allows removing instructions about setting the server address when targeting Hubble Relay.

This PR also includes other minor improvements, see commits for details.