### PR TITLE
docs: Fix egress gateway getting started guide

### DIFF
--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -35,7 +35,8 @@ Additionally enabling feature requires ``enable-bpf-masquerade=true`` and
 .. parsed-literal::
 
     helm install cilium |CHART_RELEASE| \\
-      --set enableEgressGateway=true \\
+      --namespace kube-system \\
+      --set egressGateway.enabled=true \\
       --set bpf.masquerade=true \\
       --set kubeProxyReplacement=strict
 
@@ -97,7 +98,7 @@ will contain something like the following:
 
     $ tail /var/log/nginx/access.log
     [...]
-    192.168.33.11 - - [04/Apr/2021:22:06:57 +0000] "GET / HTTP/1.1" 200 612 "-" "Wget/1.19.4 (linux-gnu)"
+    192.168.33.11 - - [04/Apr/2021:22:06:57 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.52.1"
 
 In the previous example, the client pod is running on the node ``192.168.33.11``, so the result makes sense.
 This is the default Kubernetes behavior without egress NAT.
@@ -140,5 +141,5 @@ following shows that the request is coming from ``192.168.33.100`` now, instead 
 
     $ tail /var/log/nginx/access.log
     [...]
-    192.168.33.100 - - [04/Apr/2021:22:06:57 +0000] "GET / HTTP/1.1" 200 612 "-" "Wget/1.19.4 (linux-gnu)"
+    192.168.33.100 - - [04/Apr/2021:22:06:57 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.52.1"
 

--- a/examples/kubernetes-egress-gateway/egress-ip-deployment.yaml
+++ b/examples/kubernetes-egress-gateway/egress-ip-deployment.yaml
@@ -14,6 +14,22 @@ spec:
       labels:
         name: "egress-ip-assign"
     spec:
+      affinity:
+        # the following pod affinity ensures that the "egress-ip-assign" pod
+        # runs on the same node as the mediabot pod
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: class
+                    operator: In
+                    values:
+                      - mediabot
+                  - key: org
+                    operator: In
+                    values:
+                      - empire
+              topologyKey: "kubernetes.io/hostname"
       hostNetwork: true
       containers:
       - name: egress-ip

--- a/examples/kubernetes-egress-gateway/egress-nat-policy.yaml
+++ b/examples/kubernetes-egress-gateway/egress-nat-policy.yaml
@@ -14,6 +14,6 @@ spec:
     # namespaceSelector:
     #  matchLabels:
     #    ns: default
-  destinationCidrs:
+  destinationCIDRs:
   - 192.168.33.13/32
-  egressSourceIp: "192.168.33.100"
+  egressSourceIP: "192.168.33.100"


### PR DESCRIPTION
This commit fixes various issues discovered while testing the egress
gateway getting started guide:

 - Use the correct Helm value (`egressGateway.enabled`) to enable the
   feature.
 - Use the correct field names in the example `CiliumEgressNATPolicy`.
 - Set the Kubernetes namespace in `helm install` as we do in other
   `helm install` invocations.
 - Ensure that the `egress-ip-assign` depoyment is always co-located
   with the example workload via pod affinity.
 - The examples use `curl` to access the external service, so use `curl`
   in the access log as well.

With these fixes applied, I was able to successfully validate this guide.