### PR TITLE
Togroups policy fixup

### DIFF
--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -97,7 +97,7 @@ func UpdateDerivativeCNPIfNeeded(newCNP *cilium_v2.CiliumNetworkPolicy, oldCNP *
 		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-cnp-%s", oldCNP.ObjectMeta.Name),
 			controller.ControllerParams{
 				DoFunc: func(ctx context.Context) error {
-					return DeleteDerivativeCNP(oldCNP)
+					return DeleteDerivativeCNP(ctx, oldCNP)
 				},
 			})
 		return false
@@ -131,7 +131,7 @@ func UpdateDerivativeCCNPIfNeeded(newCCNP *cilium_v2.CiliumNetworkPolicy, oldCCN
 		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-ccnp-%s", oldCCNP.ObjectMeta.Name),
 			controller.ControllerParams{
 				DoFunc: func(ctx context.Context) error {
-					return DeleteDerivativeCCNP(oldCCNP)
+					return DeleteDerivativeCCNP(ctx, oldCCNP)
 				},
 			})
 		return false
@@ -158,7 +158,7 @@ func DeleteDerivativeFromCache(cnp *cilium_v2.CiliumNetworkPolicy) {
 
 // DeleteDerivativeCNP if the given policy has a derivative constraint,the
 // given CNP will be deleted from store and the cache.
-func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
+func DeleteDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy) error {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
@@ -170,7 +170,7 @@ func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
 	}
 
 	err := k8s.CiliumClient().CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).DeleteCollection(
-		context.TODO(),
+		ctx,
 		v1.DeleteOptions{},
 		v1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", parentCNP, cnp.ObjectMeta.UID)})
 
@@ -184,7 +184,7 @@ func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
 
 // DeleteDerivativeCCNP if the given policy has a derivative constraint, the
 // given CCNP will be deleted from store and the cache.
-func DeleteDerivativeCCNP(ccnp *cilium_v2.CiliumNetworkPolicy) error {
+func DeleteDerivativeCCNP(ctx context.Context, ccnp *cilium_v2.CiliumNetworkPolicy) error {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumClusterwideNetworkPolicyName: ccnp.ObjectMeta.Name,
 	})
@@ -195,7 +195,7 @@ func DeleteDerivativeCCNP(ccnp *cilium_v2.CiliumNetworkPolicy) error {
 	}
 
 	err := k8s.CiliumClient().CiliumV2().CiliumClusterwideNetworkPolicies().DeleteCollection(
-		context.TODO(),
+		ctx,
 		v1.DeleteOptions{},
 		v1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", parentCNP, ccnp.ObjectMeta.UID)})
 	if err != nil {


### PR DESCRIPTION
This change resolves the comments for followup fixes associated with PR https://github.com/cilium/cilium/pull/12920
- Refactors out API rules modification from createDerivative{CNP, CCNP} functions
- Pass proper contexts from the caller controller functions

I am not sure of the 2nd task mentioned on the issue regarding `Replacing for loop with controller for increasing reliability`, the `addDerivativePolicy` function already runs as a controller in caller functions. Also, the for loop returns CCNP and CNP objects which are used later. @aanm can you please take a look and clarify what you meant [here](https://github.com/cilium/cilium/pull/12920#discussion_r483008873)?

Fixes: https://github.com/cilium/cilium/issues/13083
