### PR TITLE
connectivity-check: Reduce chances of port conflict with proxy

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -255,7 +255,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -270,7 +270,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -282,7 +282,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -77,7 +77,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -92,7 +92,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -104,7 +104,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1217,7 +1217,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -1232,7 +1232,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1244,7 +1244,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -1001,7 +1001,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -1016,7 +1016,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1028,7 +1028,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -72,7 +72,7 @@ ingressCNP: "echo-c": ingressL7Policy & {}
 // Expose hostport by deploying a host pod and adding a headless service with no port.
 // No ingress policy will apply in this case.
 deployment: "echo-c-host": _echoDeploymentWithHostPort & {
-	_serverPort: "41001"
+	_serverPort: "41002"
 	_affinity:   "echo-c"
 	metadata: labels: component: "proxy-check"
 }


### PR DESCRIPTION
Cilium's DNS proxy listens on a port allocated by the kernel. That port can however conflict with the port used by echo-c-host-container from the connectivity checks, leading to CI flakes when run regularly.

A kernel comment on [the function allocating the port](https://elixir.bootlin.com/linux/v5.12.1/source/net/ipv4/inet_connection_sock.c#L354) gives us a way out:

    * if snum is zero it means select any available local port.
    * We try to allocate an odd port (and leave even ports for connect())

So using an even-numbered port for `echo-c-host-container` in the connectivity checks should strongly reduce the likelihood of this flake happening again. Other hostns pods already use even-numbered ports.

Fixes: https://github.com/cilium/cilium/issues/15459