### PR TITLE
test/runtime: Wait for endpoints to be ready before querying by labels

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -86,8 +86,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		initContainer = "initContainer"
 
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 	})
@@ -253,8 +252,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		status := vm.PolicyDelAll()
 		status.ExpectSuccess()
-
-		vm.WaitEndpointsReady()
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, true)
 		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, true)
@@ -276,8 +274,7 @@ var _ = Describe("RuntimePolicies", func() {
 		By("Disabling all the policies. All should work")
 
 		vm.PolicyDelAll().ExpectSuccess("cannot delete the policy")
-
-		vm.WaitEndpointsReady()
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		for _, app := range []string{helpers.App1, helpers.App2} {
 			connectivityTest(allRequests, app, helpers.Httpd1, true)
@@ -323,7 +320,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		By("Uninstalling policy")
 		vm.PolicyDelAll().ExpectSuccess("Cannot delete all policies")
-		vm.WaitEndpointsReady()
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		By("Canceling background connections from app2 to httpd1")
 		cancel()
@@ -376,8 +373,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		status := vm.PolicyDelAll()
 		status.ExpectSuccess()
-
-		vm.WaitEndpointsReady()
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, true)
 		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, true)
@@ -426,7 +422,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		status = vm.PolicyDelAll()
 		status.ExpectSuccess()
-		vm.WaitEndpointsReady()
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, true)
 		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, true)
@@ -969,8 +965,7 @@ var _ = Describe("RuntimePolicies", func() {
 			_, err := vm.PolicyRenderAndImport(policy)
 			ExpectWithOffset(1, err).To(BeNil(), "Unable to import policy: %s\n%s", err, policy)
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			ExpectWithOffset(1, areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+			ExpectWithOffset(1, vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			checkEgressToWorld()
 		}
@@ -1120,8 +1115,7 @@ var _ = Describe("RuntimePolicies", func() {
 			_, err := vm.PolicyRenderAndImport(policy)
 			ExpectWithOffset(1, err).To(BeNil(), "Unable to import policy: %s\n%s", err, policy)
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			ExpectWithOffset(1, areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+			ExpectWithOffset(1, vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 		}
 
 		// curlWithRetry retries the curl, to make sure that allowed curls don't
@@ -1744,8 +1738,7 @@ var _ = Describe("RuntimePolicies", func() {
 			vm.ContainerCreate(newContainerName, constants.HttpdImage, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", helpers.Httpd1))
 
 			By("Waiting for newly added endpoint to be ready")
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			// All endpoints should be able to connect to this container on port
 			// 80, but should not be able to ping because ICMP does not use
@@ -1772,8 +1765,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue())
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 	})
 
 	BeforeEach(func() {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -511,6 +511,8 @@ var _ = Describe("RuntimePolicies", func() {
 		_, err := vm.PolicyImportAndWait(vm.GetFullPath(policiesL3DependentL7EgressJSON), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "unable to import %s", policiesL3DependentL7EgressJSON)
 
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
+
 		endpointIDS, err := vm.GetEndpointsIds()
 		Expect(err).To(BeNil(), "Unable to get IDs of endpoints")
 
@@ -1903,6 +1905,8 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 
 		res := vm.Exec(fmt.Sprintf(`cilium policy trace -s %s -d %s/TCP`, httpd2Label, httpd1Label))
 		Expect(res.Stdout()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
+
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		endpointIDS, err := vm.GetEndpointsIds()
 		Expect(err).To(BeNil(), "Unable to get IDs of endpoints")

--- a/test/runtime/cassandra.go
+++ b/test/runtime/cassandra.go
@@ -99,8 +99,7 @@ var _ = Describe("RuntimeCassandra", func() {
 		ExpectCiliumReady(vm)
 
 		containers("create")
-		epsReady := vm.WaitEndpointsReady()
-		Expect(epsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		err := waitForCassandraServer()
 		Expect(err).To(BeNil(), "Cassandra Server failed to come up")

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -423,8 +423,7 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 					Expect(err).To(BeNil(), "Cannot set ConnTrackLocal=%q for endpoint %q",
 						conntrackLocalOptionMode, endpointToConfigure)
 				}
-				areEndpointsReady := vm.WaitEndpointsReady()
-				Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+				Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 				clientServerConnectivity()
 			}
 
@@ -472,8 +471,7 @@ var restartChaosTest = func() {
 		_, err := vm.PolicyImportAndWait(vm.GetFullPath(policiesL4Json), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Cannot install L4 policy")
 
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		By("Starting background connection from app2 to httpd1 container")
 		ctx, cancel := context.WithCancel(context.Background())

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -245,8 +245,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 			helpers.CiliumDockerNetwork,
 			fmt.Sprintf("--dns=%s -l app=test", DNSServerIP))
 
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 	})
 
 	AfterAll(func() {
@@ -856,8 +855,7 @@ INITSYSTEM=SYSTEMD`
 			vm.SetUpCiliumWithOptions(config)
 
 			ExpectCiliumReady(vm)
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 		})
 
 		BeforeEach(func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -115,8 +115,7 @@ var _ = Describe("RuntimeKafka", func() {
 		status.ExpectSuccess()
 
 		containers("create")
-		epsReady := vm.WaitEndpointsReady()
-		Expect(epsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		err := waitForKafkaBroker(client, createTopicCmd(topicTest))
 		Expect(err).To(BeNil(), "Kafka broker failed to come up")

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -90,7 +90,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 			vm.Exec("sudo systemctl restart cilium-docker")
 			helpers.Sleep(2)
 			containers(helpers.Create)
-			vm.WaitEndpointsReady()
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 			eps, err := vm.GetEndpointsNames()
 			Expect(err).Should(BeNil(), "Error getting names of endpoints from cilium")
 			Expect(len(eps)).To(Equal(1), "Number of endpoints in Cilium differs from what is expected")
@@ -111,7 +111,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 			helpers.Sleep(2)
 			containers(helpers.Create)
 
-			vm.WaitEndpointsReady()
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			eps, err := vm.GetEndpointsNames()
 			Expect(err).Should(BeNil(), "Error getting names of endpoints from cilium")

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -69,8 +69,7 @@ var _ = Describe("RuntimeLB", func() {
 		for k, v := range images {
 			vm.ContainerCreate(k, v, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", k))
 		}
-		epStatus := vm.WaitEndpointsReady()
-		Expect(epStatus).Should(BeTrue())
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoint are not ready after timeout")
 	}
 
 	deleteContainers := func() {
@@ -229,8 +228,7 @@ var _ = Describe("RuntimeLB", func() {
 		})
 
 		testServicesWithPolicies := func(svcPort int) {
-			ready := vm.WaitEndpointsReady()
-			Expect(ready).To(BeTrue())
+			Expect(vm.WaitEndpointsReady()).To(BeTrue(), "Endpoint are not ready after timeout")
 
 			httpd1, err := vm.ContainerInspectNet(helpers.Httpd1)
 			Expect(err).Should(BeNil())

--- a/test/runtime/memcache.go
+++ b/test/runtime/memcache.go
@@ -101,8 +101,7 @@ var _ = XDescribe("RuntimeMemcache", func() {
 		ExpectCiliumReady(vm)
 
 		containers("create")
-		epsReady := vm.WaitEndpointsReady()
-		Expect(epsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 	})
 
 	AfterEach(func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -46,8 +46,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		dbgDone := vm.MonitorDebug(true, "")
 		Expect(dbgDone).Should(BeTrue())
 
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue())
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 		endpoints, err := vm.GetEndpointsIds()
 		Expect(err).Should(BeNil())
@@ -112,8 +111,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			res := vm.ExecInBackground(ctx, "cilium monitor -vv")
 			defer cancel()
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			endpoints, err := vm.GetEndpointsIds()
 			Expect(err).Should(BeNil())
@@ -133,8 +131,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			_, err := vm.PolicyImportAndWait(vm.GetFullPath(policiesL3JSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			eventTypes := map[string]string{
 				"drop":    "DROP:",
@@ -171,8 +168,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			By(command)
 			res := vm.ExecInBackground(ctx, command)
 
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			vm.ContainerExec(helpers.App3, helpers.Ping(helpers.Httpd1))
 			vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
@@ -189,8 +185,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		It("cilium monitor check --from", func() {
 			monitorConfig()
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			endpoints, err := vm.GetEndpointsIds()
 			Expect(err).Should(BeNil())
@@ -215,8 +210,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		It("cilium monitor check --to", func() {
 			monitorConfig()
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			endpoints, err := vm.GetEndpointsIds()
 			Expect(err).Should(BeNil())
@@ -239,8 +233,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		It("cilium monitor check --related-to", func() {
 			monitorConfig()
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			endpoints, err := vm.GetEndpointsIds()
 			Expect(err).Should(BeNil())
@@ -263,8 +256,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		It("delivers the same information to multiple monitors", func() {
 			monitorConfig()
 
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			var monitorRes []*helpers.CmdRes
 			ctx, cancelfn := context.WithCancel(context.Background())


### PR DESCRIPTION
See commits and https://github.com/cilium/cilium/issues/14537#issuecomment-831121319 for details.

First commit fixes https://github.com/cilium/cilium/issues/14537.