### PR TITLE
Use correct tolerations value when deploying cilium-operator and cilium-etcd-operator via helm

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -214,7 +214,7 @@ spec:
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.operator.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -83,7 +83,7 @@ spec:
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
 {{- end }}
-{{- with .Values.tolerations }}
+{{- with .Values.etcd.tolerations }}
       tolerations:
       {{- toYaml . | trim | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
<!-- Description of change -->

Use correct tolerations value when deploying cilium-operator via helm. Without this the global `tolerations` value is used and the operator runs on all nodes including ones with taints.


```release-note
Use correct tolerations value when deploying cilium-operator via helm.
```
Signed-off-by: Michael Petrov <petrov.michael@gmail.com>