### PR TITLE
ci-gke: Add -v=6 for `kubectl get pods`

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -228,7 +228,7 @@ jobs:
         if: ${{ always() }}
         run: |
           cilium status
-          kubectl get pods --all-namespaces -o wide
+          kubectl get pods --all-namespaces -o wide -v=6
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out
         shell: bash {0}


### PR DESCRIPTION
Increase the verbosity to print the k8s api server response time. This
will print two additional lines:

    I0503 17:51:03.336177   71199 loader.go:379] Config loaded from file:  /path/to/.kube/config
    I0503 17:51:03.428938   71199 round_trippers.go:445] GET https://x.x.x.x/api/v1/pods?limit=500 200 OK in 85 milliseconds

The "Post-test information gathering" step is taking a long time (>7m)
for some runs. This will show if it's the api server that's slow.

An example of a slow run: https://github.com/cilium/cilium/runs/2496703189?check_suite_focus=true

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>