### PR TITLE
Improve logging when cgroupfs mount fails

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -52,9 +52,11 @@ func CheckOrMountCgrpFS(mapRoot string) {
 		if mapRoot == "" {
 			mapRoot = cgroupRoot
 		}
-		err := cgrpCheckOrMountLocation(mapRoot)
-		// Failed cgroup2 mount is not a fatal error, sockmap will be disabled however
-		if err == nil {
+
+		if err := cgrpCheckOrMountLocation(mapRoot); err != nil {
+			log.WithError(err).
+				Warn("Failed to mount cgroupv2. Any functionality that needs cgroup (e.g.: socket-based LB) will not work.")
+		} else {
 			log.Infof("Mounted cgroupv2 filesystem at %s", mapRoot)
 		}
 	})

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -58,13 +58,10 @@ func cgrpCheckOrMountLocation(cgroupRoot string) error {
 
 	// If the custom location has no mount, let's mount there.
 	if !mounted {
-		if err := mountCgroup(); err != nil {
-			return err
-		}
-	}
-
-	if !cgroupInstance {
+		return mountCgroup()
+	} else if !cgroupInstance {
 		return fmt.Errorf("Mount in the custom directory %s has a different filesystem than cgroup2", cgroupRoot)
 	}
+
 	return nil
 }


### PR DESCRIPTION
When the variable `mounted` is false, we avoid to check the value of `cgroupInstance` because, after mount, it is related to an earlier state.

Fixes: #15997