### PR TITLE
logging: fixed log-options/level interpretation

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -246,6 +246,8 @@ func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) 
 		logrus.SetOutput(os.Stdout)
 	}
 
+	// Ensure that ConfigureLogLevel will be able to correctly set the level
+	logOptions = logOpts
 	ConfigureLogLevel(debug)
 
 	// always suppress the default logger so libraries don't print things


### PR DESCRIPTION
Ensure that most components correctly interpret the
`--log-options={"level"="[level]"}` flag. Looking at where
**logging.SetupLogging()** is being called from, I would say:

- agent
- operator
- health
- cni

Fixes: #16002

```release-note
Fix an issue preventing the interpretation of the `--log-options={"level"="[level]"}` flag
```
