### PR TITLE
workflows: only gather artifacts on failure

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -172,7 +172,7 @@ jobs:
           cilium connectivity test
 
       - name: Post-test information gathering
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
@@ -186,7 +186,7 @@ jobs:
           az group delete --name ${{ env.name }} --yes
 
       - name: Upload artifacts
-        if: ${{ always() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -165,7 +165,7 @@ jobs:
           cilium connectivity test
 
       - name: Post-test information gathering
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
@@ -179,7 +179,7 @@ jobs:
           eksctl delete cluster --name ${{ env.clusterName }}
 
       - name: Upload artifacts
-        if: ${{ always() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -225,7 +225,7 @@ jobs:
           cilium connectivity test
 
       - name: Post-test information gathering
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: |
           cilium status
           kubectl get pods --all-namespaces -o wide
@@ -239,7 +239,7 @@ jobs:
           gcloud container clusters delete ${{ env.clusterName }} --zone ${{ env.zone }} --quiet
 
       - name: Upload artifacts
-        if: ${{ always() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -184,7 +184,7 @@ jobs:
             --test '!pod-to-local-nodeport'
 
       - name: Post-test information gathering
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: |
           cilium status --context ${{ steps.contexts.outputs.context1 }}
           cilium clustermesh status --context ${{ steps.contexts.outputs.context1 }}
@@ -203,7 +203,7 @@ jobs:
         shell: bash {0}
 
       - name: Upload artifacts
-        if: ${{ always() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: cilium-sysdump-out.zip


### PR DESCRIPTION
Should help reduce the time it takes to run jobs, as well as the number of jobs getting cancelled due to hitting global job timeout even though everything went fine.
