### PR TITLE
workflows: filter out schedule events from forks

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -25,7 +25,7 @@ jobs:
         startsWith(github.event.comment.body, 'ci-aks') ||
         startsWith(github.event.comment.body, 'test-me-please')
       )) ||
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/aks'
     runs-on: ubuntu-latest
     timeout-minutes: 35

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -25,7 +25,7 @@ jobs:
         startsWith(github.event.comment.body, 'ci-eks') ||
         startsWith(github.event.comment.body, 'test-me-please')
       )) ||
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/eks'
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -25,7 +25,7 @@ jobs:
         startsWith(github.event.comment.body, 'ci-gke') ||
         startsWith(github.event.comment.body, 'test-me-please')
       )) ||
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/gke'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -26,7 +26,7 @@ jobs:
         startsWith(github.event.comment.body, 'ci-multicluster') ||
         startsWith(github.event.comment.body, 'test-me-please')
       )) ||
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/multicluster'
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
The general recommendation for forks is to disable Actions from the project settings, since most are contributionforks that don't need to run workflows in the context of the fork.

However, there are cases where one might need to enable Actions from a fork, e.g. for workflow development purposes. This change should alleviate workflow runs pressure for these instances.