### PR TITLE
envoy: Add response headers access logging

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:8fe001a11f25ad9e6676c19b0
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:b3bb275dcaf4a74ae956e52fa408b196c0d52152@sha256:f3c7645c0ff1d7552b79927023cf540f82b40263780644f75291ed0bb1965bee as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:1243d3855411ea5cfc3e8cfae0d552394754c186@sha256:3764904459830c2b8380922571a9f6d982795dc80cd9950ae600b8009604bbf0 as cilium-envoy
 
 #
 # Hubble CLI

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -217,7 +217,9 @@ type LogRecordHTTP struct {
 	// Protocol is the HTTP protocol in use
 	Protocol string
 
-	// Headers are all HTTP headers present in the request
+	// Headers are all HTTP headers present in the request and response. Request records
+	// contain request headers, while response headers contain both request and response
+	// headers.
 	Headers http.Header
 
 	// MissingHeaders are HTTP request headers that were deemed missing from the request


### PR DESCRIPTION
Use cilium-envoy image that adds response headers to response access
log messages.

```release-note
Hubble logs for HTTP responses now include HTTP response headers.
```
