### PR TITLE
Add validation of agent flag values for ConfigMap

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -180,7 +180,7 @@ func init() {
 		return
 	}
 
-	cobra.OnInitialize(option.InitConfig("Cilium", "ciliumd"))
+	cobra.OnInitialize(option.InitConfig(RootCmd, "Cilium", "ciliumd"))
 
 	// Reset the help function to also exit, as we block elsewhere in interrupts
 	// and would not exit when called with -h.

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	cobra.OnInitialize(option.InitConfig("Cilium-Operator", "cilium-operators"))
+	cobra.OnInitialize(option.InitConfig(rootCmd, "Cilium-Operator", "cilium-operators"))
 
 	flags := rootCmd.Flags()
 


### PR DESCRIPTION
If the Cilium agent flags are passed via a mounted ConfigMap
(cilium-agent --config-dir=/tmp/cilium/config-map), the default for Helm
deployments, the flag values are not validated. For example if you set
"restore" with invalid value "0SO##ME5_RANDOM" in ConfigMap then Agent
would run with incorrect parameter:
.....
level=info msg=" --restore='0SO##ME5_RANDOM'" subsys=daemon
.....

But if start Agent with CLI then the validation will warn and prevent
starting the agent:
cilium-agent[8654]: invalid argument "0SO##ME5_RANDOM" for "--restore"
flag: strconv.ParseBool: parsing "0SO##ME5_RANDOM": invalid syntax

This commit add agent flag values validation for ConfigMap

Fixes: #13070

Signed-off-by: Roman Ptitcyn romanspb@yahoo.com
