### PR TITLE
daemon: store Cilium's configuration in a file

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1725,6 +1725,16 @@ func runDaemon() {
 	bootstrapStats.updateMetrics()
 	go d.launchHubble()
 
+	err = option.Config.StoreInFile(option.Config.StateDir)
+	if err != nil {
+		log.WithError(err).Error("Unable to store Cilium's configuration")
+	}
+
+	err = option.StoreViperInFile(option.Config.StateDir)
+	if err != nil {
+		log.WithError(err).Error("Unable to store Viper's configuration")
+	}
+
 	select {
 	case err := <-metricsErrs:
 		if err != nil {

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -983,4 +983,40 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func (s *OptionSuite) Test_backupFiles(c *C) {
+	tempDir := c.MkDir()
+	fileNames := []string{"test.json", "test-1.json", "test-2.json"}
+
+	backupFiles(tempDir, fileNames)
+	files, err := os.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	// No files should have been created
+	c.Assert(len(files), Equals, 0)
+
+	_, err = os.Create(filepath.Join(tempDir, "test.json"))
+	c.Assert(err, IsNil)
+
+	backupFiles(tempDir, fileNames)
+	files, err = os.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	c.Assert(len(files), Equals, 1)
+	c.Assert(files[0].Name(), Equals, "test-1.json")
+
+	backupFiles(tempDir, fileNames)
+	files, err = os.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	c.Assert(len(files), Equals, 1)
+	c.Assert(files[0].Name(), Equals, "test-2.json")
+
+	_, err = os.Create(filepath.Join(tempDir, "test.json"))
+	c.Assert(err, IsNil)
+
+	backupFiles(tempDir, fileNames)
+	files, err = os.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	c.Assert(len(files), Equals, 2)
+	c.Assert(files[0].Name(), Equals, "test-1.json")
+	c.Assert(files[1].Name(), Equals, "test-2.json")
 }


### PR DESCRIPTION
To make it easier debug or share configurations across users and
developers, Cilium will store its viper.Config as well as agent's
configuration in files under `/var/run/cilium`. It will store up to
the last 3 previous configurations.

Another use case for it will be to check the previous configuration run
by Cilium in case certain steps need to be executed, for example, to
clean up state left from a previous run that will not be cleaned up by a
new set of flags.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Store the previous Cilium's configuration options in the host
```
