### PR TITLE
wireguard: Set wireguard and route MTU to detected MTU

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -334,7 +334,14 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		externalIP = node.GetIPv6()
 	}
 	// ExternalIP could be nil but we are covering that case inside NewConfiguration
-	mtuConfig = mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.Tunnel != option.TunnelDisabled, configuredMTU, externalIP)
+	mtuConfig = mtu.NewConfiguration(
+		authKeySize,
+		option.Config.EnableIPSec,
+		option.Config.Tunnel != option.TunnelDisabled,
+		option.Config.EnableWireguard,
+		configuredMTU,
+		externalIP,
+	)
 
 	nodeMngr, err := nodemanager.NewManager("all", dp.Node(), ipcache.IPIdentityCache, option.Config)
 	if err != nil {
@@ -554,7 +561,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	if wgAgent := dp.WireguardAgent(); option.Config.EnableWireguard {
-		if err := wgAgent.Init(); err != nil {
+		if err := wgAgent.Init(mtuConfig); err != nil {
 			log.WithError(err).Fatal("Failed to initialize wireguard agent")
 		}
 	}

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -82,7 +82,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "create a client ID and store it locally",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -114,7 +114,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes diff from a client that was already present",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -168,7 +168,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes from an expired client, it should be ok because the clean up only happens when on insertion",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -223,7 +223,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, the expired client should be deleted",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -273,7 +273,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, however the randomizer allocated an existing clientID, so we should return a empty clientID",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -323,7 +323,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a client that does not want to have diffs, leave all other stored clients alone",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{},
@@ -433,7 +433,7 @@ func (g *GetNodesSuite) Test_cleanupClients(c *C) {
 		h := &getNodes{
 			clients: args.clients,
 			d: &Daemon{
-				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{}),
+				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{}),
 			},
 		}
 		h.cleanupClients()

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -79,7 +79,7 @@ const (
 func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath.NodeAddressing, enableIPv6, enableIPv4 bool) {
 	bpf.ConfigureResourceLimits()
 	s.nodeAddressing = addressing
-	s.mtuConfig = mtu.NewConfiguration(0, false, false, 1500, nil)
+	s.mtuConfig = mtu.NewConfiguration(0, false, false, false, 1500, nil)
 	s.enableIPv6 = enableIPv6
 	s.enableIPv4 = enableIPv4
 

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -31,7 +31,7 @@ import (
 var (
 	nh = linuxNodeHandler{
 		nodeConfig: datapath.LocalNodeConfiguration{
-			MtuConfig: mtu.NewConfiguration(0, false, false, 100, net.IP("1.1.1.1")),
+			MtuConfig: mtu.NewConfiguration(0, false, false, false, 100, net.IP("1.1.1.1")),
 		},
 		nodeAddressing: fake.NewNodeAddressing(),
 		datapathConfig: DatapathConfiguration{

--- a/pkg/datapath/wireguard.go
+++ b/pkg/datapath/wireguard.go
@@ -18,11 +18,12 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/mtu"
 )
 
 // WireguardAgent manages the Wireguard peers
 type WireguardAgent interface {
-	Init() error
+	Init(mtuConfig mtu.Configuration) error
 	UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP) error
 	DeletePeer(nodeName string) error
 	Status(includePeers bool) (*models.WireguardStatus, error)

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -33,7 +33,7 @@ func (o *ownerMock) K8sEventReceived(scope string, action string, valid, equal b
 func (o *ownerMock) K8sEventProcessed(scope string, action string, status bool)      {}
 func (o *ownerMock) UpdateCiliumNodeResource()                                       {}
 
-var mtuMock = mtu.NewConfiguration(0, false, false, 1500, nil)
+var mtuMock = mtu.NewConfiguration(0, false, false, false, 1500, nil)
 
 func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -31,63 +31,72 @@ var _ = Suite(&MTUSuite{})
 
 func (m *MTUSuite) TestNewConfiguration(c *C) {
 	// Add routes with no encryption or tunnel
-	conf := NewConfiguration(0, false, false, 0, nil)
+	conf := NewConfiguration(0, false, false, false, 0, nil)
 	c.Assert(conf.GetDeviceMTU(), Not(Equals), 0)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
 	// Add routes with no encryption or tunnel and set MTU
-	conf = NewConfiguration(0, false, false, 1400, nil)
+	conf = NewConfiguration(0, false, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
 	// Add routes with tunnel
-	conf = NewConfiguration(0, false, true, 1400, nil)
+	conf = NewConfiguration(0, false, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
 
 	// Add routes with tunnel and set MTU
-	conf = NewConfiguration(0, false, true, 1400, nil)
+	conf = NewConfiguration(0, false, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
 
 	// Add routes with encryption and set MTU using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, false, 1400, nil)
+	conf = NewConfiguration(16, true, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-EncryptionIPsecOverhead)
 
-	conf = NewConfiguration(32, true, false, 1400, nil)
+	conf = NewConfiguration(32, true, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead+16))
 
-	conf = NewConfiguration(12, true, false, 1400, nil)
+	conf = NewConfiguration(12, true, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead-4))
 
 	// Add routes with encryption and tunnels using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, true, 1400, nil)
+	conf = NewConfiguration(16, true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead))
 
-	conf = NewConfiguration(32, true, true, 1400, nil)
+	conf = NewConfiguration(32, true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
 
-	conf = NewConfiguration(32, true, true, 1400, nil)
+	conf = NewConfiguration(32, true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
+
+	// Add routes with wireguard enabled
+	conf = NewConfiguration(32, false, false, true, 1400, nil)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-WireguardOverhead)
+
+	conf = NewConfiguration(32, false, true, true, 1400, nil)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-WireguardOverhead)
 
 	testIP1 := net.IPv4(0, 0, 0, 0)
 	testIP2 := net.IPv4(127, 0, 0, 1)
 	result, _ := getMTUFromIf(testIP1)
 	c.Assert(result, Equals, 0)
 
-	conf = NewConfiguration(0, true, true, 1400, testIP1)
+	conf = NewConfiguration(0, true, true, false, 1400, testIP1)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 
-	conf = NewConfiguration(0, true, true, 0, testIP1)
+	conf = NewConfiguration(0, true, true, false, 0, testIP1)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1500)
 
 	// Assuming loopback interface always exists and has mtu=65536
-	conf = NewConfiguration(0, true, true, 0, testIP2)
+	conf = NewConfiguration(0, true, true, false, 0, testIP2)
 	c.Assert(conf.GetDeviceMTU(), Equals, 65536)
 }


### PR DESCRIPTION
For more optimal packet sizes in large MTU setups, set the
cilium_wg0 MTU based on the detected MTU minus overhead.

Additionally set the route MTU on container side to detected
MTU minus wireguard overhead when wireguard is enabled.

Tested manually with "--mtu 1400", causing cilium_wg0 and
route MTU to be set to 1320.