### PR TITLE
logging: enhanced log level setting interface

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -937,7 +937,9 @@ func changedOption(key string, value option.OptionSetting, data interface{}) {
 	d := data.(*Daemon)
 	if key == option.Debug {
 		// Set the debug toggle (this can be a no-op)
-		logging.ConfigureLogLevel(d.DebugEnabled())
+		if d.DebugEnabled() {
+			logging.SetLogLevelToDebug()
+		}
 		// Reflect log level change to proxies
 		proxy.ChangeLogLevel(logging.GetLevel(logging.DefaultLogger))
 	}

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -225,7 +225,6 @@ func (ds *DaemonSuite) regenerateEndpoint(c *C, e *endpoint.Endpoint) {
 }
 
 func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
-	logging.ConfigureLogLevel(false) // Use 'true' for debugging
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),
@@ -418,7 +417,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 }
 
 func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
-	logging.ConfigureLogLevel(false) // Use 'true' for debugging
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
@@ -503,7 +501,6 @@ func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
 // short-circuiting the HTTP rules (i.e., the network policy sent to
 // envoy does not even have the HTTP rules).
 func (ds *DaemonSuite) TestL4_L7_ShadowingShortCircuit(c *C) {
-	logging.ConfigureLogLevel(false) // Use 'true' for debugging
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
@@ -579,8 +576,8 @@ func (ds *DaemonSuite) TestL4_L7_ShadowingShortCircuit(c *C) {
 }
 
 func (ds *DaemonSuite) TestL3_dependent_L7(c *C) {
-	logging.ConfigureLogLevel(true) // Use 'true' for debugging
-	defer logging.ConfigureLogLevel(false)
+	logging.SetLogLevelToDebug()
+	defer logging.SetDefaultLogLevel()
 
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	v "github.com/cilium/cilium/pkg/version"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -49,17 +48,17 @@ func New() *cobra.Command {
 	// loading the configuration file since on configuration file read failure
 	// we will emit a debug log entry.
 	if vp.GetBool("debug") {
-		logging.SetLogLevel(logrus.DebugLevel)
+		logging.SetLogLevelToDebug()
 	}
+
 	if err := vp.ReadInConfig(); err != nil {
 		logger.WithError(err).Debugf("Failed to read config from file '%s'", configFilePath)
 	}
+
 	// Check for the debug flag again now that the configuration file may has
 	// been loaded, as it might have changed.
 	if vp.GetBool("debug") {
-		logging.SetLogLevel(logrus.DebugLevel)
-	} else {
-		logging.SetLogLevel(logrus.InfoLevel)
+		logging.SetLogLevelToDebug()
 	}
 
 	rootCmd.AddCommand(

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -141,7 +141,9 @@ func New(vp *viper.Viper) *cobra.Command {
 }
 
 func runServe(vp *viper.Viper) error {
-	logging.ConfigureLogLevel(vp.GetBool("debug"))
+	if vp.GetBool("debug") {
+		logging.SetLogLevelToDebug()
+	}
 	logger := logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay")
 
 	opts := []server.Option{

--- a/pkg/command/exec/exec_test.go
+++ b/pkg/command/exec/exec_test.go
@@ -106,8 +106,8 @@ func (h *LoggingHook) Fire(entry *logrus.Entry) error {
 func (s *ExecTestSuite) TestWithFilters(c *C) {
 	hook := &LoggingHook{}
 	logging.DefaultLogger.Hooks.Add(hook)
-	logging.DefaultLogger.SetLevel(logrus.WarnLevel)
-	defer logging.DefaultLogger.SetLevel(logging.LevelStringToLogrusLevel[logging.DefaultLogLevelStr])
+	logging.SetLogLevel(logrus.WarnLevel)
+	defer logging.SetDefaultLogLevel()
 
 	// This command will print the following output to stderr:
 	//

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -118,9 +118,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	} else {
 		// Debug mode takes priority; if not in debug, check what log level user
 		// has set and set the endpoint's log to log at that level.
-		if lvl, ok := logging.GetLogLevelFromConfig(); ok {
-			baseLogger.SetLevel(lvl)
-		}
+		baseLogger.SetLevel(logging.DefaultLogger.Level)
 	}
 
 	// When adding new fields, make sure they are abstracted by a setter

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -77,7 +77,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 		c.Skip("skipping envoy unit test; CILIUM_ENABLE_ENVOY_UNIT_TEST not set")
 	}
 
-	logging.ConfigureLogLevel(true) // Use 'true' for debugging
+	logging.SetLogLevelToDebug()
 	flowdebug.Enable()
 
 	stateLogDir, err := os.MkdirTemp("", "envoy_go_test")

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -48,14 +48,12 @@ const (
 	LogFormatText LogFormat = "text"
 	LogFormatJSON LogFormat = "json"
 
-	// DefaultLogLevelStr is the string representation of DefaultLogLevel. It
-	// is used to allow for injection of the logging level via go's ldflags in
-	// unit tests, as only injection with strings via ldflags is allowed.
-	DefaultLogLevelStr string = "info"
-
 	// DefaultLogFormat is the string representation of the default logrus.Formatter
 	// we want to use (possible values: text or json)
 	DefaultLogFormat LogFormat = LogFormatText
+
+	// DefaultLogLevel is the default log level we want to use for our logrus.Formatter
+	DefaultLogLevel logrus.Level = logrus.InfoLevel
 )
 
 var (
@@ -122,18 +120,6 @@ var (
 		logrus.DebugLevel: syslog.LOG_DEBUG,
 		logrus.TraceLevel: syslog.LOG_DEBUG,
 	}
-
-	// LevelStringToLogrusLevel maps string representations of logrus.Level into
-	// their corresponding logrus.Level.
-	LevelStringToLogrusLevel = map[string]logrus.Level{
-		"panic":   logrus.PanicLevel,
-		"error":   logrus.ErrorLevel,
-		"warning": logrus.WarnLevel,
-		"info":    logrus.InfoLevel,
-		"debug":   logrus.DebugLevel,
-	}
-
-	logOptions = LogOptions{}
 )
 
 func init() {
@@ -167,78 +153,80 @@ func init() {
 type LogOptions map[string]string
 
 // InitializeDefaultLogger returns a logrus Logger with a custom text formatter.
-func InitializeDefaultLogger() *logrus.Logger {
-	logger := logrus.New()
-	logger.Formatter = GetFormatter(DefaultLogFormat)
-	logger.SetLevel(LevelStringToLogrusLevel[DefaultLogLevelStr])
-	return logger
-}
-
-// GetLogLevelFromConfig returns the log level provided via global
-// configuration. If the logging level is invalid, ok will be false.
-func GetLogLevelFromConfig() (logrus.Level, bool) {
-	return logOptions.GetLogLevel()
+func InitializeDefaultLogger() (logger *logrus.Logger) {
+	logger = logrus.New()
+	logger.SetFormatter(GetFormatter(DefaultLogFormat))
+	logger.SetLevel(DefaultLogLevel)
+	return
 }
 
 // GetLogLevel returns the log level specified in the provided LogOptions. If
-// it is not set in the options, ok will be false.
-func (o LogOptions) GetLogLevel() (level logrus.Level, ok bool) {
-	level, ok = LevelStringToLogrusLevel[strings.ToLower(o[LevelOpt])]
+// it is not set in the options, it will return the default level.
+func (o LogOptions) GetLogLevel() (level logrus.Level) {
+	levelOpt, ok := o[LevelOpt]
+	if !ok {
+		return DefaultLogLevel
+	}
+
+	var err error
+	if level, err = logrus.ParseLevel(levelOpt); err != nil {
+		logrus.WithError(err).Warning("Ignoring user-configured log level")
+		return DefaultLogLevel
+	}
+
 	return
 }
 
 // GetLogFormat returns the log format specified in the provided LogOptions. If
-// it is not set in the options or is invalid, ok will be false.
+// it is not set in the options or is invalid, it will return the default format.
 func (o LogOptions) GetLogFormat() LogFormat {
 	formatOpt, ok := o[FormatOpt]
 	if !ok {
 		return DefaultLogFormat
 	}
 
+	formatOpt = strings.ToLower(formatOpt)
 	re := regexp.MustCompile(`^(text|json)$`)
 	if !re.MatchString(formatOpt) {
-		logrus.Errorf("incorrect log format configured '%s', expected 'text' or 'json', defaulting to '%s'", formatOpt, DefaultLogFormat)
+		logrus.WithError(
+			fmt.Errorf("incorrect log format configured '%s', expected 'text' or 'json'", formatOpt),
+		).Warning("Ignoring user-configured log format")
 		return DefaultLogFormat
 	}
 
 	return LogFormat(formatOpt)
 }
 
-// configureLogLevelFromOptions returns the log level based off of the value of
-// LevelOpt in o, or the default log level if the value in the map is invalid or
-// not set.
-func (o LogOptions) configureLogLevelFromOptions() logrus.Level {
-	var level logrus.Level
-	if levelOpt, ok := o[LevelOpt]; ok {
-		if convertedLevel, ok := o.GetLogLevel(); ok {
-			level = convertedLevel
-		} else {
-			// Invalid configuration provided, go with default.
-			DefaultLogger.WithField(logfields.LogSubsys, "logging").Warningf("invalid logging level provided: %s; setting to %s", levelOpt, DefaultLogLevelStr)
-			o[LevelOpt] = DefaultLogLevelStr
-			level = LevelStringToLogrusLevel[DefaultLogLevelStr]
-		}
-	} else {
-		// No logging option provided, default to DefaultLogLevelStr.
-		o[LevelOpt] = DefaultLogLevelStr
-		level = LevelStringToLogrusLevel[DefaultLogLevelStr]
-	}
-	return level
+// SetLogLevel updates the DefaultLogger with a new logrus.Level
+func SetLogLevel(logLevel logrus.Level) {
+	DefaultLogger.SetLevel(logLevel)
 }
 
-// configureLogLevelFromOptions sets the log level of the DefaultLogger based
-// off of the value of LevelOpt in logOpts. If LevelOpt is not set in logOpts,
-// it defaults to DefaultLogLevelStr.
-func setLogLevelFromOptions(logOpts LogOptions) {
-	DefaultLogger.SetLevel(logOpts.configureLogLevelFromOptions())
+// SetDefaultLogLevel updates the DefaultLogger with the DefaultLogLevel
+func SetDefaultLogLevel() {
+	DefaultLogger.SetLevel(DefaultLogLevel)
+}
+
+// SetLogLevelToDebug updates the DefaultLogger with the logrus.DebugLevel
+func SetLogLevelToDebug() {
+	DefaultLogger.SetLevel(logrus.DebugLevel)
+}
+
+// SetLogFormat updates the DefaultLogger with a new LogFormat
+func SetLogFormat(logFormat LogFormat) {
+	DefaultLogger.SetFormatter(GetFormatter(logFormat))
+}
+
+// SetLogLevel updates the DefaultLogger with the DefaultLogFormat
+func SetDefaultLogFormat() {
+	DefaultLogger.SetFormatter(GetFormatter(DefaultLogFormat))
 }
 
 // SetupLogging sets up each logging service provided in loggers and configures
 // each logger with the provided logOpts.
 func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) error {
-	if logFormat := logOpts.GetLogFormat(); logFormat != DefaultLogFormat {
-		DefaultLogger.Formatter = GetFormatter(logFormat)
-	}
+	// Updating the default log format
+	SetLogFormat(logOpts.GetLogFormat())
 
 	// Set default logger to output to stdout if no loggers are provided.
 	if len(loggers) == 0 {
@@ -246,7 +234,12 @@ func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) 
 		logrus.SetOutput(os.Stdout)
 	}
 
-	ConfigureLogLevel(debug)
+	// Updating the default log level, overriding the log options if the debug arg is being set
+	if debug {
+		SetLogLevelToDebug()
+	} else {
+		SetLogLevel(logOpts.GetLogLevel())
+	}
 
 	// always suppress the default logger so libraries don't print things
 	logrus.SetLevel(logrus.PanicLevel)
@@ -275,28 +268,6 @@ func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) 
 	return nil
 }
 
-// SetLogLevel sets the log level on DefaultLogger. This logger is, by
-// convention, the base logger for package specific ones thus setting the level
-// here impacts the default logging behaviour.
-// This function is thread-safe when logging, reading DefaultLogger.LevelOpt is
-// not protected this way, however.
-func SetLogLevel(level logrus.Level) {
-	DefaultLogger.SetLevel(level)
-}
-
-// ConfigureLogLevel configures the logging level of the global logger. If
-// debugging is not enabled, it will set the logging level based off of the
-// logging options configured at bootstrap. Debug being enabled takes precedence
-// over the configuration in the logging options.
-// It is thread-safe.
-func ConfigureLogLevel(debug bool) {
-	if debug {
-		SetLogLevel(logrus.DebugLevel)
-	} else {
-		setLogLevelFromOptions(logOptions)
-	}
-}
-
 // setupSyslog sets up and configures syslog with the provided options in
 // logOpts. If some options are not provided, sensible defaults are used.
 func setupSyslog(logOpts LogOptions, tag string, debug bool) {
@@ -309,13 +280,13 @@ func setupSyslog(logOpts LogOptions, tag string, debug bool) {
 		}
 	}
 
-	//Validate provided log level.
+	// Validate provided log level.
 	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		DefaultLogger.Fatal(err)
 	}
 
-	DefaultLogger.SetLevel(level)
+	SetLogLevel(level)
 
 	network := ""
 	address := ""

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -37,50 +38,70 @@ func (s *LoggingSuite) TestGetLogLevel(c *C) {
 
 	// case doesn't matter with log options
 	opts[LevelOpt] = "DeBuG"
-	lvl, ok := opts.GetLogLevel()
-	c.Assert(ok, Equals, true)
-	c.Assert(lvl, Equals, logrus.DebugLevel)
+	c.Assert(opts.GetLogLevel(), Equals, logrus.DebugLevel)
 
 	opts[LevelOpt] = "Invalid"
-	_, ok = opts.GetLogLevel()
-	c.Assert(ok, Equals, false)
+	c.Assert(opts.GetLogLevel(), Equals, DefaultLogLevel)
 }
 
-func (s *LoggingSuite) TestConfigureLogLevelFromOptions(c *C) {
+func (s *LoggingSuite) TestGetLogFormat(c *C) {
 	opts := LogOptions{}
 
-	// corresponding logrus level correctly returned
-	opts[LevelOpt] = "panic"
-	lvl := opts.configureLogLevelFromOptions()
-	c.Assert(lvl, Equals, logrus.PanicLevel)
+	// case doesn't matter with log options
+	opts[FormatOpt] = "JsOn"
+	c.Assert(opts.GetLogFormat(), Equals, LogFormatJSON)
 
-	// invalid level gets set to default value
-	opts[LevelOpt] = "invalid"
-	lvl = opts.configureLogLevelFromOptions()
-	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
-
-	// no LogOpt provided returns default value and updates the map.
-	delete(opts, LevelOpt)
-	lvl = opts.configureLogLevelFromOptions()
-	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
-	lvl, ok := opts.GetLogLevel()
-	c.Assert(ok, Equals, true)
-	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
-
+	opts[FormatOpt] = "Invalid"
+	c.Assert(opts.GetLogFormat(), Equals, DefaultLogFormat)
 }
 
-func (s *LoggingSuite) TestConfigureLogLevelGlobal(c *C) {
+func (s *LoggingSuite) TestSetLogLevel(c *C) {
 	oldLevel := DefaultLogger.GetLevel()
-
-	// The joys of globals...
 	defer DefaultLogger.SetLevel(oldLevel)
 
-	ConfigureLogLevel(true)
-	lvl := DefaultLogger.GetLevel()
-	c.Assert(lvl, Equals, logrus.DebugLevel)
+	SetLogLevel(logrus.TraceLevel)
+	c.Assert(DefaultLogger.GetLevel(), Equals, logrus.TraceLevel)
+}
 
-	ConfigureLogLevel(false)
-	lvl = DefaultLogger.GetLevel()
-	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
+func (s *LoggingSuite) TestSetDefaultLogLevel(c *C) {
+	oldLevel := DefaultLogger.GetLevel()
+	defer DefaultLogger.SetLevel(oldLevel)
 
+	SetDefaultLogLevel()
+	c.Assert(DefaultLogger.GetLevel(), Equals, DefaultLogLevel)
+}
+
+func (s *LoggingSuite) TestSetLogFormat(c *C) {
+	oldFormatter := DefaultLogger.Formatter
+	defer DefaultLogger.SetFormatter(oldFormatter)
+
+	SetLogFormat(LogFormatJSON)
+	c.Assert(reflect.TypeOf(DefaultLogger.Formatter).String(), Equals, "*logrus.JSONFormatter")
+}
+
+func (s *LoggingSuite) TestSetDefaultLogFormat(c *C) {
+	oldFormatter := DefaultLogger.Formatter
+	defer DefaultLogger.SetFormatter(oldFormatter)
+
+	SetDefaultLogFormat()
+	c.Assert(reflect.TypeOf(DefaultLogger.Formatter).String(), Equals, "*logrus.TextFormatter")
+}
+
+func (s *LoggingSuite) TestSetupLogging(c *C) {
+	oldLevel := DefaultLogger.GetLevel()
+	defer DefaultLogger.SetLevel(oldLevel)
+
+	// Validates that we configure the DefaultLogger correctly
+	logOpts := LogOptions{
+		"format": "json",
+		"level":  "error",
+	}
+
+	SetupLogging([]string{}, logOpts, "", false)
+	c.Assert(DefaultLogger.GetLevel(), Equals, logrus.ErrorLevel)
+	c.Assert(reflect.TypeOf(DefaultLogger.Formatter).String(), Equals, "*logrus.JSONFormatter")
+
+	// Validate that the 'debug' flag/arg overrides the logOptions
+	SetupLogging([]string{}, logOpts, "", true)
+	c.Assert(DefaultLogger.GetLevel(), Equals, logrus.DebugLevel)
 }

--- a/proxylib/kafka/parser_test.go
+++ b/proxylib/kafka/parser_test.go
@@ -26,14 +26,12 @@ import (
 	"github.com/cilium/cilium/proxylib/proxylib"
 	"github.com/cilium/cilium/proxylib/test"
 
-	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
-	// logrus.SetLevel(logrus.DebugLevel)
-	logging.SetLogLevel(logrus.DebugLevel)
+	logging.SetLogLevelToDebug()
 	// flowdebug.Enable()
 	TestingT(t)
 }


### PR DESCRIPTION
Enhance the logging interface so that various levels of logrus logging can be used rather than just hard toggling between "info" and "debug".
    
Managing log `level` is now similarily done as the log `format`:
- default is set with pkg/logging.DefaultLogLevel
- getters and setters have been standardized and leveraged
  across other libraries too, eg:
  - SetLogLevel()
  - SetLogFormat()
  - GetLogLevel()
  - GetLogFormat()

Follow-up: #16002 & #16005

```release-note
logging: enhanced log level setting interface
```
