### PR TITLE
docs: Update SIG-Datapath meeting time.

### DIFF
--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -79,7 +79,7 @@ and meeting links.
 ====================== ===================================== ============= ================================================================================
 SIG                    Meeting                               Slack         Description
 ====================== ===================================== ============= ================================================================================
-Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
+Datapath               Thursdays, 08:00 PT                   #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
 Documentation          None                                  #sig-docs     All documentation related discussions
 Envoy                  On demand                             #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
 Hubble                 During community meeting              #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.


### PR DESCRIPTION
Following the vote and topic raised on 2021-05-05 SIG-Datapath, since
the primary community meeting is moved to Wednesday, the SIG-Datapath
meeting is moved to Thursday.

Q: When would you prefer for SIG-Datapath to meet?

Votes:
    Tuesday 8am PT, 5pm CET     3
    Tuesday  9am PT, 6pm CET    3
    Thursday 8am PT, 5pm CET    6
    Thursday 9am PT, 6pm CET    2
