### PR TITLE
workflows: lessen clustermesh clusters names

### DIFF
--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -14,8 +14,8 @@ on:
   ###
 
 env:
-  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-multicluster-1
-  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-multicluster-2
+  clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1
+  clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   zone: us-west2-a
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
GKE has a 40-character limit for cluster names, which we are dangerously close to with clustermesh clusters.

This change makes it less likely to break when workflow runs IDs get more digits, and also give more leeway for developers working on workflows from forks to have longer usernames.

(Yes, I did hit the issue on my fork :D)
