### PR TITLE
Fix logging for expired FQDN IPs

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -801,7 +801,7 @@ func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveN
 			log.WithFields(logrus.Fields{
 				logfields.DNSName: name,
 				logfields.IPAddr:  zombie.IP,
-			}).Warn("FQDN has multiple IPs. One IP has an expired TTL.")
+			}).Debug("FQDN has multiple IPs. One IP has an expired TTL.")
 			return true
 		}
 	}


### PR DESCRIPTION
Current logging has been implemented in #14878 using Warning level.
As reported in #15935 this causes lots of log lines to be generated at
each garbage collection cycle.

The fix here is to move the log generation from Warning to Debug.

Fixes: #15935

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

