### PR TITLE
pkg/datapath: Assign correct IPv6 router IP to cilium_host interface

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -294,7 +294,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	if option.Config.EnableIPv6 {
-		args[initArgIPv6NodeIP] = node.GetIPv6().String()
+		args[initArgIPv6NodeIP] = node.GetIPv6Router().String()
 		// Docker <17.05 has an issue which causes IPv6 to be disabled in the initns for all
 		// interface (https://github.com/docker/libnetwork/issues/1720)
 		// Enable IPv6 for now


### PR DESCRIPTION
Cilium generates an IPv4 and IPv6 router address from the node CIDRs,
which should then be passed to bpf/init.sh for assignment to the
`cilium_host` veth. However, due to a wrong function call, the IPv6
address being assigned to `cilium_host` was the node IP, rather than the
router IP.

This patch replaces the erroneous call to node.GetIPv6() with a call to
node.GetIPv6Router().

Fixes: #16042