### PR TITLE
docs: add 'endpointRoutes.enabled=true' to aws-cni

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -50,7 +50,8 @@ Deploy Cilium release via Helm:
      --set cni.chainingMode=aws-cni \\
      --set enableIPv4Masquerade=false \\
      --set tunnel=disabled \\
-     --set nodeinit.enabled=true
+     --set nodeinit.enabled=true \\
+     --set endpointRoutes.enabled=true
 
 This will enable chaining with the aws-cni plugin. It will also disable
 tunneling. Tunneling is not required as ENI IP addresses can be directly routed


### PR DESCRIPTION
This is meant as a temporary workaround for #16007.