### PR TITLE
v1.8 backports 2021-05-07

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -21,6 +21,7 @@ cilium-agent [flags]
       --allow-localhost string                          Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --annotate-k8s-node                               Annotate Kubernetes node (default true)
       --api-rate-limit map                              API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
+      --arping-refresh-period duration                  Period for remote node ARP entry refresh (set 0 to disable) (default 5m0s)
       --auto-create-cilium-node-resource                Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                         Enable automatic L2 routing between nodes
       --blacklist-conflicting-routes                    Don't blacklist IP allocations conflicting with local non-cilium routes (default true)

--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -7,7 +7,7 @@
 Weekly Community Meeting
 ========================
 
-The Cilium contributors gather every Monday at 8am PDT, 17:00 CEST, for a
+The Cilium contributors gather every Wednesday at 8am PDT, 17:00 CEST, for a
 one-hour Zoom call open to everyone. During that time, we discuss:
 
 - the statuses of the next releases for each supported Cilium release

--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -4,6 +4,68 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+Weekly Community Meeting
+========================
+
+The Cilium contributors gather every Monday at 8am PDT, 17:00 CEST, for a
+one-hour Zoom call open to everyone. During that time, we discuss:
+
+- the statuses of the next releases for each supported Cilium release
+- the current state of our CI: flakes being investigated and upcoming
+  changes
+- the development items for the next release
+- miscellaneous topics during the open session
+
+If you want to discuss something during the next meeting's open session,
+you can add it to `the meeting's Google doc
+<https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#>`_.
+The Zoom link to the meeting is available in the #development Slack
+channel and in `the meeting notes
+<https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#>`_.
+
+Slack
+=====
+
+Our Cilium & eBPF Slack is the main discussion space for the Cilium community.
+Click `here <https://cilium.herokuapp.com>`_ to request an invite. 
+
+Slack channels
+--------------
+
+==================== ====================================
+Name                 Purpose
+==================== ====================================
+#general             General user discussions & questions
+#hubble              Questions on Hubble
+#kubernetes          Kubernetes-specific questions
+#networkpolicy       Questions on network policies
+#release             Release announcements only
+==================== ====================================
+
+You can join the following channels if you are looking to contribute to
+Cilium:
+
+==================== ====================================
+Name                 Purpose
+==================== ====================================
+#development         Development discussions
+#git                 GitHub notifications
+#sig-*               SIG-specific discussions (see below)
+#testing             Testing and CI discussions
+==================== ====================================
+
+If you are interested in eBPF, then the following channels are for you:
+
+==================== ====================================================================
+Name                 Purpose
+==================== ====================================================================
+#ebpf                eBPF-specific questions
+#ebpf-lsm            Questions on BPF LSM
+#ebpf-news           Contributions to the `eBPF Updates <https://ebpf.io/blog>`_
+#libbpf-go           Questions on the `eBPF Go library <https://github.com/cilium/ebpf>`_
+==================== ====================================================================
+
+
 Special Interest Groups
 =======================
 
@@ -19,7 +81,8 @@ SIG                    Meeting                               Slack         Descr
 ====================== ===================================== ============= ================================================================================
 Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
 Documentation          None                                  #sig-docs     All documentation related discussions
-Envoy                  Biweekly on Thursdays, 09:00 PT       #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
+Envoy                  On demand                             #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
+Hubble                 During community meeting              #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.
 Policy                 None                                  #sig-policy   All topics related to policy. The SIG is responsible for all security relevant APIs and the enforcement logic.
 Release Management     None                                  #launchpad    Responsible for the release management and backport process.
 ====================== ===================================== ============= ================================================================================
@@ -33,27 +96,3 @@ How to create a SIG
 4. Find two Cilium committers to support the SIG.
 5. Ask on #development to get the Slack channel and Zoom meeting created
 6. Submit a PR to update the documentation to get your new SIG listed
-
-Slack
-=====
-
-The Cilium community is maintaining an active Slack channel. Click `here
-<https://cilium.herokuapp.com>`_ to request an invite. 
-
-Slack channels
---------------
-
-
-==================== ============================================================
-Name                 Purpose
-==================== ============================================================
-#development         Development discussions
-#ebpf                eBPF-specific questions
-#general             General user discussions & questions
-#git                 GitHub notifications
-#kubernetes          Kubernetes specific questions
-#sig-*               SIG specific discussions
-#testing             CI and testing related discussions
-==================== ============================================================
-
-.. _`Policy-Zoom`: https://zoom.us/j/878657504

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -88,6 +88,7 @@ Loadbalancing
 Login
 Lookup
 Lund
+lsm
 Lx
 Majkowski
 Marek
@@ -509,6 +510,7 @@ netfilter
 netperf
 netsec
 netvsc
+networkpolicy
 newproto
 newprotoparser
 nfp

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -221,6 +221,9 @@ func init() {
 	flags.Bool(option.BlacklistConflictingRoutes, defaults.BlacklistConflictingRoutes, "Don't blacklist IP allocations conflicting with local non-cilium routes")
 	option.BindEnv(option.BlacklistConflictingRoutes)
 
+	flags.Duration(option.ARPPingRefreshPeriod, 5*time.Minute, "Period for remote node ARP entry refresh (set 0 to disable)")
+	option.BindEnv(option.ARPPingRefreshPeriod)
+
 	flags.Bool(option.AutoCreateCiliumNodeResource, defaults.AutoCreateCiliumNodeResource, "Automatically create CiliumNode resource for own node on startup")
 	option.BindEnv(option.AutoCreateCiliumNodeResource)
 
@@ -1477,7 +1480,7 @@ func runDaemon() {
 	}
 
 	// Start periodical arping to refresh neighbor table
-	if d.datapath.Node().NodeNeighDiscoveryEnabled() {
+	if d.datapath.Node().NodeNeighDiscoveryEnabled() && option.Config.ARPPingRefreshPeriod != 0 {
 		d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1404,13 +1404,9 @@ func (n *linuxNodeHandler) NodeNeighborRefresh(ctx context.Context, nodeToRefres
 
 	refreshComplete := make(chan struct{})
 	go n.refreshNeighbor(ctx, &nodeToRefresh, refreshComplete)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-refreshComplete:
-			return
-		}
+	select {
+	case <-ctx.Done():
+	case <-refreshComplete:
 	}
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
@@ -735,7 +736,8 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	if nextHopIsNew || refresh {
 		hwAddr, err = arp.PingOverLink(link, srcIPv4, nextHopIPv4)
 		if err != nil {
-			scopedLog.WithError(err).Info("arping failed")
+			scopedLog.WithError(err).Debug("arping failed")
+			metrics.ArpingRequestsTotal.WithLabelValues(failed).Inc()
 			return
 		}
 		metrics.ArpingRequestsTotal.WithLabelValues(success).Inc()

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -715,7 +715,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 						logfields.LinkIndex:    neigh.LinkIndex,
 					}).WithError(err).Info("Unable to remove neighbor entry")
 				}
-				delete(n.neighByNextHop, nextHopStr)
+				delete(n.neighByNextHop, existingNextHopStr)
 				delete(n.neighLastPingByNextHop, existingNextHopStr)
 				if option.Config.NodePortHairpin {
 					neighborsmap.NeighRetire(net.ParseIP(existingNextHopStr))

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -44,6 +44,8 @@ import (
 const (
 	wildcardIPv4 = "0.0.0.0"
 	wildcardIPv6 = "0::0"
+	success      = "success"
+	failed       = "failed"
 )
 
 type linuxNodeHandler struct {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -626,7 +626,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 }
 
-func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextHopIPv4 net.IP, err error) {
+func getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextHopIPv4 net.IP, err error) {
 	// Figure out whether nodeIPv4 is directly reachable (i.e. in the same L2)
 	routes, err := netlink.RouteGet(nodeIPv4)
 	if err != nil {
@@ -665,9 +665,6 @@ func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextH
 // this case it does not bail out early if the ARP entry already exists, and
 // sends the ARP request anyway.
 func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, refresh bool) {
-	n.neighLock.Lock()
-	defer n.neighLock.Unlock()
-
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
 	copy(nextHopIPv4, newNodeIP)
@@ -677,15 +674,18 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		logfields.Interface: n.neighDiscoveryLink.Attrs().Name,
 	})
 
-	srcIPv4, nextHopIPv4, err := n.getSrcAndNextHopIPv4(nextHopIPv4)
+	srcIPv4, nextHopIPv4, err := getSrcAndNextHopIPv4(nextHopIPv4)
 	if err != nil {
 		scopedLog.WithError(err).Info("Unable to determine source and nexthop IP addr")
 		return
 	}
+	nextHopStr := nextHopIPv4.String()
 
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
-	nextHopStr := nextHopIPv4.String()
+	n.neighLock.Lock()
+	defer n.neighLock.Unlock()
+
 	if existingNextHopStr, found := n.neighNextHopByNode[newNode.Identity()]; found {
 		if existingNextHopStr == nextHopStr {
 			// We already know about the nextHop of the given newNode. Can happen
@@ -701,6 +701,9 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 			// nextHop has changed and nobody else is using it, so remove the old one.
 			neigh, found := n.neighByNextHop[existingNextHopStr]
 			if found {
+				// Note that we don't move the removal via netlink which might
+				// block from the hot path (e.g. with defer), as this case can
+				// happen very rarely.
 				if err := netlink.NeighDel(neigh); err != nil {
 					scopedLog.WithFields(logrus.Fields{
 						logfields.IPAddr:       neigh.IP,
@@ -739,12 +742,10 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		}
 
 		if option.Config.NodePortHairpin {
-			defer func() {
-				// Remove nextHopIPv4 entry in the neigh BPF map. Otherwise,
-				// we risk to silently blackhole packets instead of emitting
-				// DROP_NO_FIB if the netlink.NeighSet() below fails.
-				neighborsmap.NeighRetire(nextHopIPv4)
-			}()
+			// Remove nextHopIPv4 entry in the neigh BPF map. Otherwise,
+			// we risk to silently blackhole packets instead of emitting
+			// DROP_NO_FIB if the netlink.NeighSet() below fails.
+			defer neighborsmap.NeighRetire(nextHopIPv4)
 		}
 
 		scopedLog = scopedLog.WithField(logfields.HardwareAddr, hwAddr)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/counter"
@@ -665,13 +666,23 @@ func getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextHopIPv4 net.IP, err err
 // this case it does not bail out early if the ARP entry already exists, and
 // sends the ARP request anyway.
 func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, refresh bool) {
+	var link netlink.Link
+	n.neighLock.Lock()
+	if n.neighDiscoveryLink == nil || reflect.ValueOf(n.neighDiscoveryLink).IsNil() {
+		n.neighLock.Unlock()
+		// Nothing to do - the discovery link was not set yet
+		return
+	}
+	link = n.neighDiscoveryLink
+	n.neighLock.Unlock()
+
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
 	copy(nextHopIPv4, newNodeIP)
 
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.LogSubsys: "node-neigh-debug",
-		logfields.Interface: n.neighDiscoveryLink.Attrs().Name,
+		logfields.Interface: link.Attrs().Name,
 	})
 
 	srcIPv4, nextHopIPv4, err := getSrcAndNextHopIPv4(nextHopIPv4)
@@ -684,7 +695,12 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
 	n.neighLock.Lock()
-	defer n.neighLock.Unlock()
+	locked := true
+	defer func() {
+		if locked {
+			n.neighLock.Unlock()
+		}
+	}()
 
 	if existingNextHopStr, found := n.neighNextHopByNode[newNode.Identity()]; found {
 		if existingNextHopStr == nextHopStr {
@@ -726,14 +742,24 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		nextHopIsNew = n.neighNextHopRefCount.Add(nextHopStr)
 	}
 
+	n.neighLock.Unlock() // to allow concurrent arpings below
+	locked = false
+
 	// nextHop hasn't been arpinged before OR we are refreshing neigh entry
+	var hwAddr net.HardwareAddr
 	if nextHopIsNew || refresh {
-		hwAddr, err := arp.PingOverLink(n.neighDiscoveryLink, srcIPv4, nextHopIPv4)
+		hwAddr, err = arp.PingOverLink(link, srcIPv4, nextHopIPv4)
 		if err != nil {
 			scopedLog.WithError(err).Info("arping failed")
 			return
 		}
+		metrics.ArpingRequestsTotal.WithLabelValues(success).Inc()
+	}
 
+	n.neighLock.Lock()
+	locked = true
+
+	if hwAddr != nil {
 		if prevHwAddr, found := n.neighByNextHop[nextHopStr]; found && prevHwAddr.String() == hwAddr.String() {
 			// Nothing to update, return early to avoid calling to netlink. This
 			// is based on the assumption that n.neighByNextHop gets populated
@@ -751,7 +777,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		scopedLog = scopedLog.WithField(logfields.HardwareAddr, hwAddr)
 
 		neigh := netlink.Neigh{
-			LinkIndex:    n.neighDiscoveryLink.Attrs().Index,
+			LinkIndex:    link.Attrs().Index,
 			IP:           nextHopIPv4,
 			HardwareAddr: hwAddr,
 			State:        netlink.NUD_PERMANENT,
@@ -1325,7 +1351,11 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 				return fmt.Errorf("cannot find link by name %s for neigh discovery: %w",
 					ifaceName, err)
 			}
+			// neighDiscoveryLink can be accessed by a concurrent insertNeighbor
+			// goroutine.
+			n.neighLock.Lock()
 			n.neighDiscoveryLink = link
+			n.neighLock.Unlock()
 		}
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -695,25 +695,10 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
 	n.neighLock.Lock()
-	locked := true
-	defer func() {
-		if locked {
-			n.neighLock.Unlock()
-		}
-	}()
 
+	nextHopIsNew := false
 	if existingNextHopStr, found := n.neighNextHopByNode[newNode.Identity()]; found {
-		if existingNextHopStr == nextHopStr {
-			// We already know about the nextHop of the given newNode. Can happen
-			// when insertNeighbor is called by NodeUpdate multiple times for
-			// the same node.
-			if !refresh {
-				// In the case of refresh, don't return early, as we want to
-				// update the related neigh entry even if the nextHop is the same
-				// (e.g. to detect the GW MAC addr change).
-				return
-			}
-		} else if n.neighNextHopRefCount.Delete(existingNextHopStr) {
+		if existingNextHopStr != nextHopStr && n.neighNextHopRefCount.Delete(existingNextHopStr) {
 			// nextHop has changed and nobody else is using it, so remove the old one.
 			neigh, found := n.neighByNextHop[existingNextHopStr]
 			if found {
@@ -733,17 +718,17 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 				}
 			}
 		}
+	} else {
+		// nextHop for the given node was previously not found, so let's
+		// increment ref counter.  This can happen upon regular NodeUpdate event
+		// or by the periodic ARP refresher which got executed before
+		// NodeUpdate().
+		nextHopIsNew = n.neighNextHopRefCount.Add(nextHopStr)
 	}
 
 	n.neighNextHopByNode[newNode.Identity()] = nextHopStr
 
-	nextHopIsNew := false
-	if !refresh {
-		nextHopIsNew = n.neighNextHopRefCount.Add(nextHopStr)
-	}
-
 	n.neighLock.Unlock() // to allow concurrent arpings below
-	locked = false
 
 	// nextHop hasn't been arpinged before OR we are refreshing neigh entry
 	var hwAddr net.HardwareAddr
@@ -757,7 +742,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	}
 
 	n.neighLock.Lock()
-	locked = true
+	defer n.neighLock.Unlock()
 
 	if hwAddr != nil {
 		if prevHwAddr, found := n.neighByNextHop[nextHopStr]; found && prevHwAddr.String() == hwAddr.String() {
@@ -813,6 +798,7 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 	defer func() { delete(n.neighNextHopByNode, oldNode.Identity()) }()
 
 	if n.neighNextHopRefCount.Delete(nextHopStr) {
+
 		neigh, found := n.neighByNextHop[nextHopStr]
 		delete(n.neighByNextHop, nextHopStr)
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/counter"
@@ -51,30 +52,32 @@ const (
 )
 
 type linuxNodeHandler struct {
-	mutex                lock.Mutex
-	isInitialized        bool
-	nodeConfig           datapath.LocalNodeConfiguration
-	nodeAddressing       datapath.NodeAddressing
-	datapathConfig       DatapathConfiguration
-	nodes                map[nodeTypes.Identity]*nodeTypes.Node
-	enableNeighDiscovery bool
-	neighLock            lock.Mutex // protects neigh* fields below
-	neighDiscoveryLink   netlink.Link
-	neighNextHopByNode   map[nodeTypes.Identity]string // val = string(net.IP)
-	neighNextHopRefCount counter.StringCounter
-	neighByNextHop       map[string]*netlink.Neigh // key = string(net.IP)
+	mutex                  lock.Mutex
+	isInitialized          bool
+	nodeConfig             datapath.LocalNodeConfiguration
+	nodeAddressing         datapath.NodeAddressing
+	datapathConfig         DatapathConfiguration
+	nodes                  map[nodeTypes.Identity]*nodeTypes.Node
+	enableNeighDiscovery   bool
+	neighLock              lock.Mutex // protects neigh* fields below
+	neighDiscoveryLink     netlink.Link
+	neighNextHopByNode     map[nodeTypes.Identity]string // val = string(net.IP)
+	neighNextHopRefCount   counter.StringCounter
+	neighByNextHop         map[string]*netlink.Neigh // key = string(net.IP)
+	neighLastPingByNextHop map[string]time.Time      // key = string(net.IP)
 }
 
 // NewNodeHandler returns a new node handler to handle node events and
 // implement the implications in the Linux datapath
 func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapath.NodeAddressing) datapath.NodeHandler {
 	return &linuxNodeHandler{
-		nodeAddressing:       nodeAddressing,
-		datapathConfig:       datapathConfig,
-		nodes:                map[nodeTypes.Identity]*nodeTypes.Node{},
-		neighNextHopByNode:   map[nodeTypes.Identity]string{},
-		neighNextHopRefCount: counter.StringCounter{},
-		neighByNextHop:       map[string]*netlink.Neigh{},
+		nodeAddressing:         nodeAddressing,
+		datapathConfig:         datapathConfig,
+		nodes:                  map[nodeTypes.Identity]*nodeTypes.Node{},
+		neighNextHopByNode:     map[nodeTypes.Identity]string{},
+		neighNextHopRefCount:   counter.StringCounter{},
+		neighByNextHop:         map[string]*netlink.Neigh{},
+		neighLastPingByNextHop: map[string]time.Time{},
 	}
 }
 
@@ -692,7 +695,6 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		return
 	}
 	nextHopStr := nextHopIPv4.String()
-
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
 	n.neighLock.Lock()
@@ -714,6 +716,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 					}).WithError(err).Info("Unable to remove neighbor entry")
 				}
 				delete(n.neighByNextHop, nextHopStr)
+				delete(n.neighLastPingByNextHop, existingNextHopStr)
 				if option.Config.NodePortHairpin {
 					neighborsmap.NeighRetire(net.ParseIP(existingNextHopStr))
 				}
@@ -728,6 +731,18 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	}
 
 	n.neighNextHopByNode[newNode.Identity()] = nextHopStr
+
+	if refresh {
+		if lastPing, found := n.neighLastPingByNextHop[nextHopStr]; found &&
+			time.Now().Sub(lastPing) < option.Config.ARPPingRefreshPeriod {
+
+			n.neighLock.Unlock()
+			// Last ping was issued less than option.Config.ARPPingRefreshPeriod
+			// ago, so skip it (e.g. to avoid ddos'ing the same GW if nodes are
+			// L3 connected)
+			return
+		}
+	}
 
 	n.neighLock.Unlock() // to allow concurrent arpings below
 
@@ -744,6 +759,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	}
 
 	n.neighLock.Lock()
+	n.neighLastPingByNextHop[nextHopStr] = time.Now()
 	defer n.neighLock.Unlock()
 
 	if hwAddr != nil {
@@ -803,6 +819,7 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 
 		neigh, found := n.neighByNextHop[nextHopStr]
 		delete(n.neighByNextHop, nextHopStr)
+		delete(n.neighLastPingByNextHop, nextHopStr)
 
 		if found {
 			if err := netlink.NeighDel(neigh); err != nil {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -56,6 +56,7 @@ type linuxNodeHandler struct {
 	datapathConfig       DatapathConfiguration
 	nodes                map[nodeTypes.Identity]*nodeTypes.Node
 	enableNeighDiscovery bool
+	neighLock            lock.Mutex // protects neigh* fields below
 	neighDiscoveryLink   netlink.Link
 	neighNextHopByNode   map[nodeTypes.Identity]string // val = string(net.IP)
 	neighNextHopRefCount counter.StringCounter
@@ -663,12 +664,9 @@ func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextH
 // which tries to update ARP entries previously inserted by insertNeighbor(). In
 // this case it does not bail out early if the ARP entry already exists, and
 // sends the ARP request anyway.
-//
-// The method must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, refresh bool) {
-	if newNode.IsLocal() {
-		return
-	}
+	n.neighLock.Lock()
+	defer n.neighLock.Unlock()
 
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
@@ -774,14 +772,13 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 func (n *linuxNodeHandler) refreshNeighbor(ctx context.Context, nodeToRefresh *nodeTypes.Node, completed chan struct{}) {
 	defer close(completed)
 
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
-
 	n.insertNeighbor(ctx, nodeToRefresh, true)
 }
 
-// Must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
+	n.neighLock.Lock()
+	defer n.neighLock.Unlock()
+
 	nextHopStr, found := n.neighNextHopByNode[oldNode.Identity()]
 	if !found {
 		return
@@ -896,8 +893,12 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		newKey = newNode.EncryptionKey
 	}
 
-	if n.enableNeighDiscovery {
-		n.insertNeighbor(context.Background(), newNode, false)
+	if n.enableNeighDiscovery && !newNode.IsLocal() {
+		// Running insertNeighbor in a separate goroutine relies on the following
+		// assumptions:
+		// 1. newNode is accessed only by reads.
+		// 2. It is safe to invoke insertNeighbor for the same node.
+		go n.insertNeighbor(context.Background(), newNode, false)
 	}
 
 	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
@@ -993,7 +994,7 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	}
 
 	if n.enableNeighDiscovery {
-		n.deleteNeighbor(oldNode)
+		go n.deleteNeighbor(oldNode)
 	}
 
 	if n.nodeConfig.EnableIPSec {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -18,8 +18,10 @@ package linux
 
 import (
 	"context"
+	"crypto/rand"
 	"net"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -1091,6 +1093,86 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}
 	}
 	c.Assert(found, check.Equals, false)
+
+	// Create multiple goroutines which call insertNeighbor and check whether
+	// MAC changes of veth1 are properly handled. This is a basic randomized
+	// testing of insertNeighbor() fine-grained locking.
+	err = linuxNodeHandler.NodeAdd(nodev1)
+	c.Assert(err, check.IsNil)
+	time.Sleep(100 * time.Millisecond)
+
+	rndHWAddr := func() net.HardwareAddr {
+		mac := make([]byte, 6)
+		_, err := rand.Read(mac)
+		c.Assert(err, check.IsNil)
+		mac[0] = (mac[0] | 2) & 0xfe
+		return net.HardwareAddr(mac)
+	}
+	neighRefCount := func(nextHopStr string) int {
+		linuxNodeHandler.neighLock.Lock()
+		defer linuxNodeHandler.neighLock.Unlock()
+		return linuxNodeHandler.neighNextHopRefCount[nextHopStr]
+	}
+	neighHwAddr := func(nextHopStr string) string {
+		linuxNodeHandler.neighLock.Lock()
+		defer linuxNodeHandler.neighLock.Unlock()
+		if neigh, found := linuxNodeHandler.neighByNextHop[nextHopStr]; found {
+			return neigh.HardwareAddr.String()
+		}
+		return ""
+	}
+
+	done := make(chan struct{})
+	count := 30
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(100 * time.Millisecond)
+			for {
+				linuxNodeHandler.insertNeighbor(context.Background(), &nodev1, true)
+				select {
+				case <-ticker.C:
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		mac := rndHWAddr()
+		// Change MAC
+		netns0.Do(func(ns.NetNS) error {
+			veth1, err := netlink.LinkByName("veth1")
+			c.Assert(err, check.IsNil)
+			err = netlink.LinkSetHardwareAddr(veth1, mac)
+			c.Assert(err, check.IsNil)
+			return nil
+		})
+		// Check that MAC has been changed in the neigh table
+		time.Sleep(500 * time.Millisecond)
+		neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+		c.Assert(err, check.IsNil)
+		found = false
+		for _, n := range neighs {
+			if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+				c.Assert(n.HardwareAddr.String(), check.Equals, mac.String())
+				c.Assert(neighHwAddr(ip1.String()), check.Equals, mac.String())
+				c.Assert(neighRefCount(ip1.String()), check.Equals, 1)
+				found = true
+				break
+			}
+		}
+		c.Assert(found, check.Equals, true)
+
+	}
+	// Cleanup
+	close(done)
+	wg.Wait()
+	err = linuxNodeHandler.NodeDelete(nodev1)
+	c.Assert(err, check.IsNil)
+	time.Sleep(100 * time.Millisecond) // deleteNeighbor is invoked async
 
 	// Setup routine for the 2. test
 	setupRemoteNode := func(vethName, vethPeerName, netnsName, vethCIDR, vethIPAddr,

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1012,6 +1012,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.EnableNodePort = prevNP }()
 	option.Config.EnableNodePort = true
 	dpConfig := DatapathConfiguration{HostDevice: "veth0"}
+	prevARPPeriod := option.Config.ARPPingRefreshPeriod
+	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
+	option.Config.ARPPingRefreshPeriod = time.Duration(10 * time.Millisecond)
 
 	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,6 +71,9 @@ const (
 	// SubsystemAPILimiter is the subsystem to scope metrics related to the API limiter package.
 	SubsystemAPILimiter = "api_limiter"
 
+	// SubsystemNodeNeigh is the subsystem to scope metrics related to management of node neighbor.
+	SubsystemNodeNeigh = "node_neigh"
+
 	// Namespace is used to scope metrics from cilium. It is prepended to metric
 	// names and separated with a '_'
 	Namespace = "cilium"
@@ -440,6 +443,10 @@ var (
 	// APILimiterProcessedRequests is the counter of the number of
 	// processed (successful and failed) requests
 	APILimiterProcessedRequests = NoOpCounterVec
+
+	// ArpingRequestsTotal is the counter of the number of sent
+	// (successful and failed) arping requests
+	ArpingRequestsTotal = NoOpCounterVec
 )
 
 type Configuration struct {
@@ -504,6 +511,7 @@ type Configuration struct {
 	APILimiterRateLimit                     bool
 	APILimiterAdjustmentFactor              bool
 	APILimiterProcessedRequests             bool
+	ArpingRequestsTotalEnabled              bool
 }
 
 func DefaultMetrics() map[string]struct{} {
@@ -564,6 +572,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemAPILimiter + "_rate_limit":                        {},
 		Namespace + "_" + SubsystemAPILimiter + "_adjustment_factor":                 {},
 		Namespace + "_" + SubsystemAPILimiter + "_processed_requests_total":          {},
+		Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":              {},
 	}
 }
 
@@ -1236,6 +1245,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, APILimiterProcessedRequests)
 			c.APILimiterProcessedRequests = true
+
+		case Namespace + "_arping_requests_total":
+			ArpingRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemNodeNeigh,
+				Name:      "arping_requests_total",
+				Help:      "Number of arping requests sent labeled by status",
+			}, []string{LabelStatus})
+
+			collectors = append(collectors, ArpingRequestsTotal)
+			c.ArpingRequestsTotalEnabled = true
 		}
 	}
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"math"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
@@ -32,19 +31,13 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/source"
-	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
 	baseBackgroundSyncInterval = time.Minute
-	// The default value of kernel parameter net.ipv4.neigh.default.base_reachable_time_ms.
-	// If option.NeighborRefreshBaseInterval is not configured and we failed to
-	// read from sysctl, refresh at this interval.
-	neighborRefreshBaseInterval = 30 * time.Second
-
-	randGen = rand.NewSafeRand(time.Now().UnixNano())
+	randGen                    = rand.NewSafeRand(time.Now().UnixNano())
 )
 
 type nodeEntry struct {
@@ -600,28 +593,13 @@ func (m *Manager) DeleteAllNodes() {
 }
 
 // StartNeighborRefresh spawns a controller which refreshes neighbor table
-// by sending arping periodically. Linux keeps an arp entry in reachable
-// state for (0.5 ~ 1.5) * base_reachable_time_ms, default by 15 to 45 seconds:
-// https://elixir.bootlin.com/linux/v5.7.19/source/net/core/neighbour.c#L113
-// We do the refresh in a similar way.
+// by sending arping periodically.
 func (m *Manager) StartNeighborRefresh(nh datapath.NodeHandler) {
-	var interval time.Duration
-	baseReachableStr, err := sysctl.Read("net.ipv4.neigh.default.base_reachable_time_ms")
-	if err != nil {
-		interval = neighborRefreshBaseInterval
-	} else {
-		baseReachableU32, err := strconv.ParseUint(baseReachableStr, 10, 32)
-		if err != nil {
-			interval = neighborRefreshBaseInterval
-		} else {
-			interval = time.Duration(baseReachableU32) * time.Millisecond
-		}
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	controller.NewManager().UpdateController("neighbor-table-refresh",
 		controller.ControllerParams{
 			DoFunc: func(controllerCtx context.Context) error {
-				// cancel previous go routines from previous controller run
+				// Cancel previous go routines from previous controller run
 				cancel()
 				ctx, cancel = context.WithCancel(controllerCtx)
 				m.mutex.RLock()
@@ -634,14 +612,17 @@ func (m *Manager) StartNeighborRefresh(nh datapath.NodeHandler) {
 						continue
 					}
 					go func(c context.Context, e nodeTypes.Node) {
-						n := randGen.Int63n(int64(interval / 2))
-						time.Sleep(interval/2 + time.Duration(n))
+						// To avoid flooding network with arping requests
+						// at the same time, spread them over the
+						// [0; ARPPingRefreshPeriod/2) period.
+						n := randGen.Int63n(int64(option.Config.ARPPingRefreshPeriod / 2))
+						time.Sleep(time.Duration(n))
 						nh.NodeNeighborRefresh(c, e)
 					}(ctx, entryNode)
 				}
 				return nil
 			},
-			RunInterval: interval,
+			RunInterval: option.Config.ARPPingRefreshPeriod,
 		},
 	)
 	return

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -87,6 +87,9 @@ const (
 	// the daemon, which can also be disbled using this option.
 	AnnotateK8sNode = "annotate-k8s-node"
 
+	// ARPPingRefreshPeriod is the ARP entries refresher period
+	ARPPingRefreshPeriod = "arping-refresh-period"
+
 	// BPFRoot is the Path to BPF filesystem
 	BPFRoot = "bpf-root"
 
@@ -1955,6 +1958,9 @@ type DaemonConfig struct {
 	// to introduce state pruning points for the verifier in the datapath
 	// program.
 	NeedsRelaxVerifier bool
+
+	// ARPPingRefreshPeriod is the ARP entries refresher period.
+	ARPPingRefreshPeriod time.Duration
 }
 
 var (
@@ -2334,6 +2340,7 @@ func (c *DaemonConfig) Populate() {
 	c.AllowICMPFragNeeded = viper.GetBool(AllowICMPFragNeeded)
 	c.AllowLocalhost = viper.GetString(AllowLocalhost)
 	c.AnnotateK8sNode = viper.GetBool(AnnotateK8sNode)
+	c.ARPPingRefreshPeriod = viper.GetDuration(ARPPingRefreshPeriod)
 	c.AutoCreateCiliumNodeResource = viper.GetBool(AutoCreateCiliumNodeResource)
 	c.BPFCompilationDebug = viper.GetBool(BPFCompileDebugName)
 	c.BPFRoot = viper.GetString(BPFRoot)


### PR DESCRIPTION
v1.8 backports 2021-05-07

 * #14816 -- node-neigh: add metric to count arping requests (@jaffcheng)
 * #14968 -- docs: Update our community docs page (@pchaigno)
 * #15985 -- Update weekly community meeting timeslot (@joestringer)
 * #15783 -- node-neigh: Locking, logging, misc improvements (@brb)
 * #15882 -- node-neigh: Avoid flooding the same next hop (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14816 14968 15985 15783 15882; do contrib/backporting/set-labels.py $pr done 1.8; done
```