### PR TITLE
v1.9 backports 2021-05-07

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -21,6 +21,7 @@ cilium-agent [flags]
       --allow-localhost string                               Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --annotate-k8s-node                                    Annotate Kubernetes node (default true)
       --api-rate-limit map                                   API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
+      --arping-refresh-period duration                       Period for remote node ARP entry refresh (set 0 to disable) (default 5m0s)
       --auto-create-cilium-node-resource                     Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                              Enable automatic L2 routing between nodes
       --bpf-compile-debug                                    Enable debugging of the BPF compilation process

--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -4,6 +4,68 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+Weekly Community Meeting
+========================
+
+The Cilium contributors gather every Monday at 8am PDT, 17:00 CEST, for a
+one-hour Zoom call open to everyone. During that time, we discuss:
+
+- the statuses of the next releases for each supported Cilium release
+- the current state of our CI: flakes being investigated and upcoming
+  changes
+- the development items for the next release
+- miscellaneous topics during the open session
+
+If you want to discuss something during the next meeting's open session,
+you can add it to `the meeting's Google doc
+<https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#>`_.
+The Zoom link to the meeting is available in the #development Slack
+channel and in `the meeting notes
+<https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#>`_.
+
+Slack
+=====
+
+Our Cilium & eBPF Slack is the main discussion space for the Cilium community.
+Click `here <https://cilium.herokuapp.com>`_ to request an invite. 
+
+Slack channels
+--------------
+
+==================== ====================================
+Name                 Purpose
+==================== ====================================
+#general             General user discussions & questions
+#hubble              Questions on Hubble
+#kubernetes          Kubernetes-specific questions
+#networkpolicy       Questions on network policies
+#release             Release announcements only
+==================== ====================================
+
+You can join the following channels if you are looking to contribute to
+Cilium:
+
+==================== ====================================
+Name                 Purpose
+==================== ====================================
+#development         Development discussions
+#git                 GitHub notifications
+#sig-*               SIG-specific discussions (see below)
+#testing             Testing and CI discussions
+==================== ====================================
+
+If you are interested in eBPF, then the following channels are for you:
+
+==================== ====================================================================
+Name                 Purpose
+==================== ====================================================================
+#ebpf                eBPF-specific questions
+#ebpf-lsm            Questions on BPF LSM
+#ebpf-news           Contributions to the `eBPF Updates <https://ebpf.io/blog>`_
+#libbpf-go           Questions on the `eBPF Go library <https://github.com/cilium/ebpf>`_
+==================== ====================================================================
+
+
 Special Interest Groups
 =======================
 
@@ -19,8 +81,8 @@ SIG                    Meeting                               Slack         Descr
 ====================== ===================================== ============= ================================================================================
 Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
 Documentation          None                                  #sig-docs     All documentation related discussions
-Envoy                  Biweekly on Thursdays, 09:00 PT       #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
-Hubble                 Thursdays, 09:00 PT                   #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.
+Envoy                  On demand                             #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
+Hubble                 During community meeting              #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.
 Policy                 None                                  #sig-policy   All topics related to policy. The SIG is responsible for all security relevant APIs and the enforcement logic.
 Release Management     None                                  #launchpad    Responsible for the release management and backport process.
 ====================== ===================================== ============= ================================================================================
@@ -34,27 +96,3 @@ How to create a SIG
 4. Find two Cilium committers to support the SIG.
 5. Ask on #development to get the Slack channel and Zoom meeting created
 6. Submit a PR to update the documentation to get your new SIG listed
-
-Slack
-=====
-
-The Cilium community is maintaining an active Slack channel. Click `here
-<https://cilium.herokuapp.com>`_ to request an invite. 
-
-Slack channels
---------------
-
-
-==================== ============================================================
-Name                 Purpose
-==================== ============================================================
-#development         Development discussions
-#ebpf                eBPF-specific questions
-#general             General user discussions & questions
-#git                 GitHub notifications
-#kubernetes          Kubernetes specific questions
-#sig-*               SIG specific discussions
-#testing             CI and testing related discussions
-==================== ============================================================
-
-.. _`Policy-Zoom`: https://zoom.us/j/878657504

--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -7,7 +7,7 @@
 Weekly Community Meeting
 ========================
 
-The Cilium contributors gather every Monday at 8am PDT, 17:00 CEST, for a
+The Cilium contributors gather every Wednesday at 8am PDT, 17:00 CEST, for a
 one-hour Zoom call open to everyone. During that time, we discuss:
 
 - the statuses of the next releases for each supported Cilium release

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -553,6 +553,7 @@ lookup
 lookups
 loopback
 lrp
+lsm
 lspci
 luke
 lwt
@@ -610,6 +611,7 @@ netfilter
 netperf
 netsec
 netvsc
+networkpolicy
 newproto
 newprotoparser
 nfp

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -683,7 +683,13 @@ do_netdev_encrypt_fib(struct __ctx_buff *ctx __maybe_unused,
 		      int *encrypt_iface __maybe_unused)
 {
 	int ret = 0;
-#ifdef BPF_HAVE_FIB_LOOKUP
+	/* Only do FIB lookup if both the BPF helper is supported and we know
+	 * the egress ineterface. If we don't have an egress interface,
+	 * typically in an environment with many egress devs than we have
+	 * to let the stack decide how to egress the packet. EKS is the
+	 * example of an environment with multiple egress interfaces.
+	 */
+#if defined(BPF_HAVE_FIB_LOOKUP) && defined(ENCRYPT_IFACE)
 	struct bpf_fib_lookup fib_params = {};
 	void *data, *data_end;
 	int err;
@@ -738,7 +744,7 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 {
 	int encrypt_iface = 0;
 	int ret = 0;
-#if defined(ENCRYPT_IFACE)
+#if defined(ENCRYPT_IFACE) && defined(BPF_HAVE_FIB_LOOKUP)
 	encrypt_iface = ENCRYPT_IFACE;
 #endif
 	ret = do_netdev_encrypt_pools(ctx);
@@ -750,8 +756,16 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	bpf_clear_meta(ctx);
+#ifdef BPF_HAVE_FIB_LOOKUP
+	/* Redirect only works if we have a fib lookup to set the MAC
+	 * addresses. Otherwise let the stack do the routing and fib
+	 * Note, without FIB lookup implemented the packet may have
+	 * incorrect dmac leaving bpf_host so will need to mark as
+	 * PACKET_HOST or otherwise fixup MAC addresses.
+	 */
 	if (encrypt_iface)
 		return redirect(encrypt_iface, 0);
+#endif
 	return CTX_ACT_OK;
 }
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1077,6 +1077,15 @@ int to_host(struct __ctx_buff *ctx)
 		traced = true;
 	}
 
+#ifdef ENABLE_IPSEC
+	/* Encryption stack needs this when IPSec headers are
+	 * rewritten without FIB helper because we do not yet
+	 * know correct MAC address which will cause the stack
+	 * to mark as PACKET_OTHERHOST and drop.
+	 */
+	ctx_change_type(ctx, PACKET_HOST);
+#endif
+
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, srcID, 0, 0,
 				  CILIUM_IFINDEX, ret, 0);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -844,7 +844,6 @@ int handle_xgress(struct __ctx_buff *ctx)
 	int ret;
 
 	bpf_clear_meta(ctx);
-	edt_set_aggregate(ctx, LXC_ID);
 
 	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
 			  TRACE_PAYLOAD_LEN);
@@ -857,6 +856,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 	switch (proto) {
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
+		edt_set_aggregate(ctx, LXC_ID);
 		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
 					is_defined(DEBUG)),
 				   CILIUM_CALL_IPV6_FROM_LXC, tail_handle_ipv6);
@@ -864,6 +864,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 #endif /* ENABLE_IPV6 */
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
+		edt_set_aggregate(ctx, LXC_ID);
 		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
 					is_defined(DEBUG)),
 				   CILIUM_CALL_IPV4_FROM_LXC, tail_handle_ipv4);

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -220,6 +220,9 @@ func init() {
 	flags.Bool(option.AnnotateK8sNode, defaults.AnnotateK8sNode, "Annotate Kubernetes node")
 	option.BindEnv(option.AnnotateK8sNode)
 
+	flags.Duration(option.ARPPingRefreshPeriod, 5*time.Minute, "Period for remote node ARP entry refresh (set 0 to disable)")
+	option.BindEnv(option.ARPPingRefreshPeriod)
+
 	flags.Bool(option.BlacklistConflictingRoutes, false, "Don't blacklist IP allocations conflicting with local non-cilium routes")
 	flags.MarkDeprecated(option.BlacklistConflictingRoutes, "This flag is no longer available and will be removed in the v1.10")
 	option.BindEnv(option.BlacklistConflictingRoutes)
@@ -1550,7 +1553,7 @@ func runDaemon() {
 	}
 
 	// Start periodical arping to refresh neighbor table
-	if d.datapath.Node().NodeNeighDiscoveryEnabled() {
+	if d.datapath.Node().NodeNeighDiscoveryEnabled() && option.Config.ARPPingRefreshPeriod != 0 {
 		d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
 	}
 

--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -255,7 +255,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
@@ -270,7 +270,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -282,7 +282,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -77,7 +77,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
@@ -92,7 +92,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -104,7 +104,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1217,7 +1217,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
@@ -1232,7 +1232,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1244,7 +1244,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -1001,7 +1001,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41001"
+          value: "41002"
         ports: []
         image: docker.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
@@ -1016,7 +1016,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1028,7 +1028,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41001
+            - localhost:41002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -72,7 +72,7 @@ ingressCNP: "echo-c": ingressL7Policy & {}
 // Expose hostport by deploying a host pod and adding a headless service with no port.
 // No ingress policy will apply in this case.
 deployment: "echo-c-host": _echoDeploymentWithHostPort & {
-	_serverPort: "41001"
+	_serverPort: "41002"
 	_affinity:   "echo-c"
 	metadata: labels: component: "proxy-check"
 }

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -98,8 +98,11 @@ func InitBandwidthManager() {
 		{"net.core.netdev_max_backlog", "1000"},
 		{"net.core.somaxconn", "4096"},
 		{"net.core.default_qdisc", "fq"},
-		{"net.ipv4.tcp_congestion_control", "bbr"},
 		{"net.ipv4.tcp_max_syn_backlog", "4096"},
+		// Temporary disable setting bbr for now until we have a
+		// kernel fix for pacing out of Pods as described in #15324.
+		// Then, kernels with the fix can use bbr, and others cubic.
+		{"net.ipv4.tcp_congestion_control", "cubic"},
 	}
 	for _, s := range baseSettings {
 		log.WithFields(logrus.Fields{

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -32,6 +32,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
@@ -364,10 +365,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 			}
 		}
+		// If we are using IPAMENI always use IP_POOLS datapath, the pod subnets
+		// will be auto-discovered later at runtime.
+		if (option.Config.IPAM == ipamOption.IPAMENI) ||
+			option.Config.IsPodSubnetsDefined() {
+			cDefinesMap["IP_POOLS"] = "1"
+		}
 	}
-	if option.Config.IsPodSubnetsDefined() {
-		cDefinesMap["IP_POOLS"] = "1"
-	}
+
 	if option.Config.EnableNodePort {
 		if option.Config.EnableIPv4 {
 			cDefinesMap["SNAT_MAPPING_IPV4"] = nat.MapNameSnat4Global

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -355,11 +355,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_HOST_FIREWALL"] = "1"
 	}
 
-	if iface := option.Config.EncryptInterface; len(iface) != 0 {
+	if option.Config.EnableIPSec {
 		a := byteorder.HostSliceToNetwork(node.GetIPv4(), reflect.Uint32).(uint32)
 		cDefinesMap["IPV4_ENCRYPT_IFACE"] = fmt.Sprintf("%d", a)
-
-		if len(iface) != 0 {
+		if iface := option.Config.EncryptInterface; len(iface) != 0 {
 			link, err := netlink.LinkByName(iface[0])
 			if err == nil {
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -356,24 +356,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 
 	if iface := option.Config.EncryptInterface; len(iface) != 0 {
-		// When FIB lookup is not supported (older kernels)  we need to
-		// pick an interface so pick first interface in list. Then we pick
-		// an IPv4 address to use by selecting link IPAddr. In case with
-		// kernel support, the kernel datapath will use the FIB lookup helper
-		// and this define is ignored.
-		link, err := netlink.LinkByName(iface[0])
-		if err == nil {
-			cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
+		a := byteorder.HostSliceToNetwork(node.GetIPv4(), reflect.Uint32).(uint32)
+		cDefinesMap["IPV4_ENCRYPT_IFACE"] = fmt.Sprintf("%d", a)
 
-			addr, err := netlink.AddrList(link, netlink.FAMILY_V4)
-			if err != nil {
-				return err
+		if len(iface) != 0 {
+			link, err := netlink.LinkByName(iface[0])
+			if err == nil {
+				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 			}
-			if len(addr) == 0 {
-				return fmt.Errorf("no IPv4 addresses available in encrypt interface %q", iface)
-			}
-			a := byteorder.HostSliceToNetwork(addr[0].IPNet.IP, reflect.Uint32).(uint32)
-			cDefinesMap["IPV4_ENCRYPT_IFACE"] = fmt.Sprintf("%d", a)
 		}
 	}
 	if option.Config.IsPodSubnetsDefined() {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
+	"github.com/cilium/cilium/pkg/metrics"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -43,6 +44,8 @@ import (
 const (
 	wildcardIPv4 = "0.0.0.0"
 	wildcardIPv6 = "0::0"
+	success      = "success"
+	failed       = "failed"
 )
 
 type linuxNodeHandler struct {
@@ -727,8 +730,10 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		hwAddr, err := arp.PingOverLink(n.neighDiscoveryLink, srcIPv4, nextHopIPv4)
 		if err != nil {
 			scopedLog.WithError(err).Info("arping failed")
+			metrics.ArpingRequestsTotal.WithLabelValues(failed).Inc()
 			return
 		}
+		metrics.ArpingRequestsTotal.WithLabelValues(success).Inc()
 
 		if prevHwAddr, found := n.neighByNextHop[nextHopStr]; found && prevHwAddr.String() == hwAddr.String() {
 			// Nothing to update, return early to avoid calling to netlink. This

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -716,7 +716,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 						logfields.LinkIndex:    neigh.LinkIndex,
 					}).WithError(err).Info("Unable to remove neighbor entry")
 				}
-				delete(n.neighByNextHop, nextHopStr)
+				delete(n.neighByNextHop, existingNextHopStr)
 				delete(n.neighLastPingByNextHop, existingNextHopStr)
 				if option.Config.NodePortHairpin {
 					neighborsmap.NeighRetire(net.ParseIP(existingNextHopStr))

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -695,25 +695,10 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
 	n.neighLock.Lock()
-	locked := true
-	defer func() {
-		if locked {
-			n.neighLock.Unlock()
-		}
-	}()
 
+	nextHopIsNew := false
 	if existingNextHopStr, found := n.neighNextHopByNode[newNode.Identity()]; found {
-		if existingNextHopStr == nextHopStr {
-			// We already know about the nextHop of the given newNode. Can happen
-			// when insertNeighbor is called by NodeUpdate multiple times for
-			// the same node.
-			if !refresh {
-				// In the case of refresh, don't return early, as we want to
-				// update the related neigh entry even if the nextHop is the same
-				// (e.g. to detect the GW MAC addr change).
-				return
-			}
-		} else if n.neighNextHopRefCount.Delete(existingNextHopStr) {
+		if existingNextHopStr != nextHopStr && n.neighNextHopRefCount.Delete(existingNextHopStr) {
 			// nextHop has changed and nobody else is using it, so remove the old one.
 			neigh, found := n.neighByNextHop[existingNextHopStr]
 			if found {
@@ -733,17 +718,17 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 				}
 			}
 		}
+	} else {
+		// nextHop for the given node was previously not found, so let's
+		// increment ref counter.  This can happen upon regular NodeUpdate event
+		// or by the periodic ARP refresher which got executed before
+		// NodeUpdate().
+		nextHopIsNew = n.neighNextHopRefCount.Add(nextHopStr)
 	}
 
 	n.neighNextHopByNode[newNode.Identity()] = nextHopStr
 
-	nextHopIsNew := false
-	if !refresh {
-		nextHopIsNew = n.neighNextHopRefCount.Add(nextHopStr)
-	}
-
 	n.neighLock.Unlock() // to allow concurrent arpings below
-	locked = false
 
 	// nextHop hasn't been arpinged before OR we are refreshing neigh entry
 	var hwAddr net.HardwareAddr
@@ -758,7 +743,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	}
 
 	n.neighLock.Lock()
-	locked = true
+	defer n.neighLock.Unlock()
 
 	if hwAddr != nil {
 		if prevHwAddr, found := n.neighByNextHop[nextHopStr]; found && prevHwAddr.String() == hwAddr.String() {
@@ -814,6 +799,7 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 	defer func() { delete(n.neighNextHopByNode, oldNode.Identity()) }()
 
 	if n.neighNextHopRefCount.Delete(nextHopStr) {
+
 		neigh, found := n.neighByNextHop[nextHopStr]
 		delete(n.neighByNextHop, nextHopStr)
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -56,6 +56,7 @@ type linuxNodeHandler struct {
 	datapathConfig       DatapathConfiguration
 	nodes                map[nodeTypes.Identity]*nodeTypes.Node
 	enableNeighDiscovery bool
+	neighLock            lock.Mutex // protects neigh* fields below
 	neighDiscoveryLink   netlink.Link
 	neighNextHopByNode   map[nodeTypes.Identity]string // val = string(net.IP)
 	neighNextHopRefCount counter.StringCounter
@@ -663,12 +664,9 @@ func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextH
 // which tries to update ARP entries previously inserted by insertNeighbor(). In
 // this case it does not bail out early if the ARP entry already exists, and
 // sends the ARP request anyway.
-//
-// The method must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, refresh bool) {
-	if newNode.IsLocal() {
-		return
-	}
+	n.neighLock.Lock()
+	defer n.neighLock.Unlock()
 
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
@@ -776,14 +774,13 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 func (n *linuxNodeHandler) refreshNeighbor(ctx context.Context, nodeToRefresh *nodeTypes.Node, completed chan struct{}) {
 	defer close(completed)
 
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
-
 	n.insertNeighbor(ctx, nodeToRefresh, true)
 }
 
-// Must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
+	n.neighLock.Lock()
+	defer n.neighLock.Unlock()
+
 	nextHopStr, found := n.neighNextHopByNode[oldNode.Identity()]
 	if !found {
 		return
@@ -899,8 +896,12 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		newKey = newNode.EncryptionKey
 	}
 
-	if n.enableNeighDiscovery {
-		n.insertNeighbor(context.Background(), newNode, false)
+	if n.enableNeighDiscovery && !newNode.IsLocal() {
+		// Running insertNeighbor in a separate goroutine relies on the following
+		// assumptions:
+		// 1. newNode is accessed only by reads.
+		// 2. It is safe to invoke insertNeighbor for the same node.
+		go n.insertNeighbor(context.Background(), newNode, false)
 	}
 
 	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
@@ -997,7 +998,7 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	}
 
 	if n.enableNeighDiscovery {
-		n.deleteNeighbor(oldNode)
+		go n.deleteNeighbor(oldNode)
 	}
 
 	if n.nodeConfig.EnableIPSec {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1389,13 +1389,9 @@ func (n *linuxNodeHandler) NodeNeighborRefresh(ctx context.Context, nodeToRefres
 
 	refreshComplete := make(chan struct{})
 	go n.refreshNeighbor(ctx, &nodeToRefresh, refreshComplete)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-refreshComplete:
-			return
-		}
+	select {
+	case <-ctx.Done():
+	case <-refreshComplete:
 	}
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -626,7 +626,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 }
 
-func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextHopIPv4 net.IP, err error) {
+func getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextHopIPv4 net.IP, err error) {
 	// Figure out whether nodeIPv4 is directly reachable (i.e. in the same L2)
 	routes, err := netlink.RouteGet(nodeIPv4)
 	if err != nil {
@@ -665,9 +665,6 @@ func (n *linuxNodeHandler) getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextH
 // this case it does not bail out early if the ARP entry already exists, and
 // sends the ARP request anyway.
 func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, refresh bool) {
-	n.neighLock.Lock()
-	defer n.neighLock.Unlock()
-
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
 	copy(nextHopIPv4, newNodeIP)
@@ -677,15 +674,18 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		logfields.Interface: n.neighDiscoveryLink.Attrs().Name,
 	})
 
-	srcIPv4, nextHopIPv4, err := n.getSrcAndNextHopIPv4(nextHopIPv4)
+	srcIPv4, nextHopIPv4, err := getSrcAndNextHopIPv4(nextHopIPv4)
 	if err != nil {
 		scopedLog.WithError(err).Info("Unable to determine source and nexthop IP addr")
 		return
 	}
+	nextHopStr := nextHopIPv4.String()
 
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
-	nextHopStr := nextHopIPv4.String()
+	n.neighLock.Lock()
+	defer n.neighLock.Unlock()
+
 	if existingNextHopStr, found := n.neighNextHopByNode[newNode.Identity()]; found {
 		if existingNextHopStr == nextHopStr {
 			// We already know about the nextHop of the given newNode. Can happen
@@ -701,6 +701,9 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 			// nextHop has changed and nobody else is using it, so remove the old one.
 			neigh, found := n.neighByNextHop[existingNextHopStr]
 			if found {
+				// Note that we don't move the removal via netlink which might
+				// block from the hot path (e.g. with defer), as this case can
+				// happen very rarely.
 				if err := netlink.NeighDel(neigh); err != nil {
 					scopedLog.WithFields(logrus.Fields{
 						logfields.IPAddr:       neigh.IP,
@@ -741,12 +744,10 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		}
 
 		if option.Config.NodePortHairpin {
-			defer func() {
-				// Remove nextHopIPv4 entry in the neigh BPF map. Otherwise,
-				// we risk to silently blackhole packets instead of emitting
-				// DROP_NO_FIB if the netlink.NeighSet() below fails.
-				neighborsmap.NeighRetire(nextHopIPv4)
-			}()
+			// Remove nextHopIPv4 entry in the neigh BPF map. Otherwise,
+			// we risk to silently blackhole packets instead of emitting
+			// DROP_NO_FIB if the netlink.NeighSet() below fails.
+			defer neighborsmap.NeighRetire(nextHopIPv4)
 		}
 
 		scopedLog = scopedLog.WithField(logfields.HardwareAddr, hwAddr)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -735,7 +735,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	if nextHopIsNew || refresh {
 		hwAddr, err = arp.PingOverLink(link, srcIPv4, nextHopIPv4)
 		if err != nil {
-			scopedLog.WithError(err).Info("arping failed")
+			scopedLog.WithError(err).Debug("arping failed")
 			metrics.ArpingRequestsTotal.WithLabelValues(failed).Inc()
 			return
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/counter"
@@ -665,13 +666,23 @@ func getSrcAndNextHopIPv4(nodeIPv4 net.IP) (srcIPv4, nextHopIPv4 net.IP, err err
 // this case it does not bail out early if the ARP entry already exists, and
 // sends the ARP request anyway.
 func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeTypes.Node, refresh bool) {
+	var link netlink.Link
+	n.neighLock.Lock()
+	if n.neighDiscoveryLink == nil || reflect.ValueOf(n.neighDiscoveryLink).IsNil() {
+		n.neighLock.Unlock()
+		// Nothing to do - the discovery link was not set yet
+		return
+	}
+	link = n.neighDiscoveryLink
+	n.neighLock.Unlock()
+
 	newNodeIP := newNode.GetNodeIP(false).To4()
 	nextHopIPv4 := make(net.IP, len(newNodeIP))
 	copy(nextHopIPv4, newNodeIP)
 
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.LogSubsys: "node-neigh-debug",
-		logfields.Interface: n.neighDiscoveryLink.Attrs().Name,
+		logfields.Interface: link.Attrs().Name,
 	})
 
 	srcIPv4, nextHopIPv4, err := getSrcAndNextHopIPv4(nextHopIPv4)
@@ -684,7 +695,12 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
 	n.neighLock.Lock()
-	defer n.neighLock.Unlock()
+	locked := true
+	defer func() {
+		if locked {
+			n.neighLock.Unlock()
+		}
+	}()
 
 	if existingNextHopStr, found := n.neighNextHopByNode[newNode.Identity()]; found {
 		if existingNextHopStr == nextHopStr {
@@ -726,16 +742,25 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		nextHopIsNew = n.neighNextHopRefCount.Add(nextHopStr)
 	}
 
+	n.neighLock.Unlock() // to allow concurrent arpings below
+	locked = false
+
 	// nextHop hasn't been arpinged before OR we are refreshing neigh entry
+	var hwAddr net.HardwareAddr
 	if nextHopIsNew || refresh {
-		hwAddr, err := arp.PingOverLink(n.neighDiscoveryLink, srcIPv4, nextHopIPv4)
+		hwAddr, err = arp.PingOverLink(link, srcIPv4, nextHopIPv4)
 		if err != nil {
 			scopedLog.WithError(err).Info("arping failed")
 			metrics.ArpingRequestsTotal.WithLabelValues(failed).Inc()
 			return
 		}
 		metrics.ArpingRequestsTotal.WithLabelValues(success).Inc()
+	}
 
+	n.neighLock.Lock()
+	locked = true
+
+	if hwAddr != nil {
 		if prevHwAddr, found := n.neighByNextHop[nextHopStr]; found && prevHwAddr.String() == hwAddr.String() {
 			// Nothing to update, return early to avoid calling to netlink. This
 			// is based on the assumption that n.neighByNextHop gets populated
@@ -753,7 +778,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		scopedLog = scopedLog.WithField(logfields.HardwareAddr, hwAddr)
 
 		neigh := netlink.Neigh{
-			LinkIndex:    n.neighDiscoveryLink.Attrs().Index,
+			LinkIndex:    link.Attrs().Index,
 			IP:           nextHopIPv4,
 			HardwareAddr: hwAddr,
 			State:        netlink.NUD_PERMANENT,
@@ -1323,7 +1348,11 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 				return fmt.Errorf("cannot find link by name %s for neigh discovery: %w",
 					ifaceName, err)
 			}
+			// neighDiscoveryLink can be accessed by a concurrent insertNeighbor
+			// goroutine.
+			n.neighLock.Lock()
 			n.neighDiscoveryLink = link
+			n.neighLock.Unlock()
 		}
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -29,11 +29,13 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -1345,6 +1347,19 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 	n.updateOrRemoveNodeRoutes(prevConfig.AuxiliaryPrefixes, newConfig.AuxiliaryPrefixes, true)
 
 	if newConfig.EnableIPSec {
+		// For the ENI ipam mode on EKS, this will be the interface that
+		// the router (cilium_host) IP is associated to.
+		if option.Config.IPAM == ipamOption.IPAMENI && len(option.Config.IPv4PodSubnets) == 0 {
+			if info := node.GetRouterInfo(); info != nil {
+				var ipv4PodSubnets []*net.IPNet
+				for _, c := range info.GetIPv4CIDRs() {
+					cidr := c // create a copy to be able to take a reference
+					ipv4PodSubnets = append(ipv4PodSubnets, &cidr)
+				}
+				n.nodeConfig.IPv4PodSubnets = ipv4PodSubnets
+			}
+		}
+
 		if err := n.replaceHostRules(); err != nil {
 			log.WithError(err).Warning("Cannot replace Host rules")
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/counter"
@@ -52,30 +53,32 @@ const (
 )
 
 type linuxNodeHandler struct {
-	mutex                lock.Mutex
-	isInitialized        bool
-	nodeConfig           datapath.LocalNodeConfiguration
-	nodeAddressing       datapath.NodeAddressing
-	datapathConfig       DatapathConfiguration
-	nodes                map[nodeTypes.Identity]*nodeTypes.Node
-	enableNeighDiscovery bool
-	neighLock            lock.Mutex // protects neigh* fields below
-	neighDiscoveryLink   netlink.Link
-	neighNextHopByNode   map[nodeTypes.Identity]string // val = string(net.IP)
-	neighNextHopRefCount counter.StringCounter
-	neighByNextHop       map[string]*netlink.Neigh // key = string(net.IP)
+	mutex                  lock.Mutex
+	isInitialized          bool
+	nodeConfig             datapath.LocalNodeConfiguration
+	nodeAddressing         datapath.NodeAddressing
+	datapathConfig         DatapathConfiguration
+	nodes                  map[nodeTypes.Identity]*nodeTypes.Node
+	enableNeighDiscovery   bool
+	neighLock              lock.Mutex // protects neigh* fields below
+	neighDiscoveryLink     netlink.Link
+	neighNextHopByNode     map[nodeTypes.Identity]string // val = string(net.IP)
+	neighNextHopRefCount   counter.StringCounter
+	neighByNextHop         map[string]*netlink.Neigh // key = string(net.IP)
+	neighLastPingByNextHop map[string]time.Time      // key = string(net.IP)
 }
 
 // NewNodeHandler returns a new node handler to handle node events and
 // implement the implications in the Linux datapath
 func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapath.NodeAddressing) datapath.NodeHandler {
 	return &linuxNodeHandler{
-		nodeAddressing:       nodeAddressing,
-		datapathConfig:       datapathConfig,
-		nodes:                map[nodeTypes.Identity]*nodeTypes.Node{},
-		neighNextHopByNode:   map[nodeTypes.Identity]string{},
-		neighNextHopRefCount: counter.StringCounter{},
-		neighByNextHop:       map[string]*netlink.Neigh{},
+		nodeAddressing:         nodeAddressing,
+		datapathConfig:         datapathConfig,
+		nodes:                  map[nodeTypes.Identity]*nodeTypes.Node{},
+		neighNextHopByNode:     map[nodeTypes.Identity]string{},
+		neighNextHopRefCount:   counter.StringCounter{},
+		neighByNextHop:         map[string]*netlink.Neigh{},
+		neighLastPingByNextHop: map[string]time.Time{},
 	}
 }
 
@@ -693,7 +696,6 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 		return
 	}
 	nextHopStr := nextHopIPv4.String()
-
 	scopedLog = scopedLog.WithField(logfields.IPAddr, nextHopIPv4)
 
 	n.neighLock.Lock()
@@ -715,6 +717,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 					}).WithError(err).Info("Unable to remove neighbor entry")
 				}
 				delete(n.neighByNextHop, nextHopStr)
+				delete(n.neighLastPingByNextHop, existingNextHopStr)
 				if option.Config.NodePortHairpin {
 					neighborsmap.NeighRetire(net.ParseIP(existingNextHopStr))
 				}
@@ -729,6 +732,18 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	}
 
 	n.neighNextHopByNode[newNode.Identity()] = nextHopStr
+
+	if refresh {
+		if lastPing, found := n.neighLastPingByNextHop[nextHopStr]; found &&
+			time.Now().Sub(lastPing) < option.Config.ARPPingRefreshPeriod {
+
+			n.neighLock.Unlock()
+			// Last ping was issued less than option.Config.ARPPingRefreshPeriod
+			// ago, so skip it (e.g. to avoid ddos'ing the same GW if nodes are
+			// L3 connected)
+			return
+		}
+	}
 
 	n.neighLock.Unlock() // to allow concurrent arpings below
 
@@ -745,6 +760,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	}
 
 	n.neighLock.Lock()
+	n.neighLastPingByNextHop[nextHopStr] = time.Now()
 	defer n.neighLock.Unlock()
 
 	if hwAddr != nil {
@@ -804,6 +820,7 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 
 		neigh, found := n.neighByNextHop[nextHopStr]
 		delete(n.neighByNextHop, nextHopStr)
+		delete(n.neighLastPingByNextHop, nextHopStr)
 
 		if found {
 			if err := netlink.NeighDel(neigh); err != nil {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -18,8 +18,10 @@ package linux
 
 import (
 	"context"
+	"crypto/rand"
 	"net"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -1091,6 +1093,86 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}
 	}
 	c.Assert(found, check.Equals, false)
+
+	// Create multiple goroutines which call insertNeighbor and check whether
+	// MAC changes of veth1 are properly handled. This is a basic randomized
+	// testing of insertNeighbor() fine-grained locking.
+	err = linuxNodeHandler.NodeAdd(nodev1)
+	c.Assert(err, check.IsNil)
+	time.Sleep(100 * time.Millisecond)
+
+	rndHWAddr := func() net.HardwareAddr {
+		mac := make([]byte, 6)
+		_, err := rand.Read(mac)
+		c.Assert(err, check.IsNil)
+		mac[0] = (mac[0] | 2) & 0xfe
+		return net.HardwareAddr(mac)
+	}
+	neighRefCount := func(nextHopStr string) int {
+		linuxNodeHandler.neighLock.Lock()
+		defer linuxNodeHandler.neighLock.Unlock()
+		return linuxNodeHandler.neighNextHopRefCount[nextHopStr]
+	}
+	neighHwAddr := func(nextHopStr string) string {
+		linuxNodeHandler.neighLock.Lock()
+		defer linuxNodeHandler.neighLock.Unlock()
+		if neigh, found := linuxNodeHandler.neighByNextHop[nextHopStr]; found {
+			return neigh.HardwareAddr.String()
+		}
+		return ""
+	}
+
+	done := make(chan struct{})
+	count := 30
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(100 * time.Millisecond)
+			for {
+				linuxNodeHandler.insertNeighbor(context.Background(), &nodev1, true)
+				select {
+				case <-ticker.C:
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		mac := rndHWAddr()
+		// Change MAC
+		netns0.Do(func(ns.NetNS) error {
+			veth1, err := netlink.LinkByName("veth1")
+			c.Assert(err, check.IsNil)
+			err = netlink.LinkSetHardwareAddr(veth1, mac)
+			c.Assert(err, check.IsNil)
+			return nil
+		})
+		// Check that MAC has been changed in the neigh table
+		time.Sleep(500 * time.Millisecond)
+		neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+		c.Assert(err, check.IsNil)
+		found = false
+		for _, n := range neighs {
+			if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
+				c.Assert(n.HardwareAddr.String(), check.Equals, mac.String())
+				c.Assert(neighHwAddr(ip1.String()), check.Equals, mac.String())
+				c.Assert(neighRefCount(ip1.String()), check.Equals, 1)
+				found = true
+				break
+			}
+		}
+		c.Assert(found, check.Equals, true)
+
+	}
+	// Cleanup
+	close(done)
+	wg.Wait()
+	err = linuxNodeHandler.NodeDelete(nodev1)
+	c.Assert(err, check.IsNil)
+	time.Sleep(100 * time.Millisecond) // deleteNeighbor is invoked async
 
 	// Setup routine for the 2. test
 	setupRemoteNode := func(vethName, vethPeerName, netnsName, vethCIDR, vethIPAddr,

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1012,6 +1012,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.EnableNodePort = prevNP }()
 	option.Config.EnableNodePort = true
 	dpConfig := DatapathConfiguration{HostDevice: "veth0"}
+	prevARPPeriod := option.Config.ARPPingRefreshPeriod
+	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
+	option.Config.ARPPingRefreshPeriod = time.Duration(10 * time.Millisecond)
 
 	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -206,17 +206,6 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 			}
 			option.Config.EncryptInterface = interfaces
 		}
-
-		// For the ENI ipam mode on EKS, this will be the interface that
-		// the router (cilium_host) IP is associated to.
-		if len(option.Config.IPv4PodSubnets) == 0 {
-			if info := node.GetRouterInfo(); info != nil {
-				for _, c := range info.GetIPv4CIDRs() {
-					cidr := c // create a copy to be able to take a reference
-					option.Config.IPv4PodSubnets = append(option.Config.IPv4PodSubnets, &cidr)
-				}
-			}
-		}
 	}
 
 	// No interfaces is valid in tunnel disabled case

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,6 +71,9 @@ const (
 	// SubsystemAPILimiter is the subsystem to scope metrics related to the API limiter package.
 	SubsystemAPILimiter = "api_limiter"
 
+	// SubsystemNodeNeigh is the subsystem to scope metrics related to management of node neighbor.
+	SubsystemNodeNeigh = "node_neigh"
+
 	// Namespace is used to scope metrics from cilium. It is prepended to metric
 	// names and separated with a '_'
 	Namespace = "cilium"
@@ -478,6 +481,10 @@ var (
 	// APILimiterProcessedRequests is the counter of the number of
 	// processed (successful and failed) requests
 	APILimiterProcessedRequests = NoOpCounterVec
+
+	// ArpingRequestsTotal is the counter of the number of sent
+	// (successful and failed) arping requests
+	ArpingRequestsTotal = NoOpCounterVec
 )
 
 type Configuration struct {
@@ -542,6 +549,7 @@ type Configuration struct {
 	APILimiterRateLimit                     bool
 	APILimiterAdjustmentFactor              bool
 	APILimiterProcessedRequests             bool
+	ArpingRequestsTotalEnabled              bool
 }
 
 func DefaultMetrics() map[string]struct{} {
@@ -607,6 +615,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemAPILimiter + "_rate_limit":                        {},
 		Namespace + "_" + SubsystemAPILimiter + "_adjustment_factor":                 {},
 		Namespace + "_" + SubsystemAPILimiter + "_processed_requests_total":          {},
+		Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":              {},
 	}
 }
 
@@ -1333,6 +1342,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, APILimiterProcessedRequests)
 			c.APILimiterProcessedRequests = true
+
+		case Namespace + "_arping_requests_total":
+			ArpingRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemNodeNeigh,
+				Name:      "arping_requests_total",
+				Help:      "Number of arping requests sent labeled by status",
+			}, []string{LabelStatus})
+
+			collectors = append(collectors, ArpingRequestsTotal)
+			c.ArpingRequestsTotalEnabled = true
 		}
 	}
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"math"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
@@ -32,19 +31,13 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/source"
-	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
 	baseBackgroundSyncInterval = time.Minute
-	// The default value of kernel parameter net.ipv4.neigh.default.base_reachable_time_ms.
-	// If option.NeighborRefreshBaseInterval is not configured and we failed to
-	// read from sysctl, refresh at this interval.
-	neighborRefreshBaseInterval = 30 * time.Second
-
-	randGen = rand.NewSafeRand(time.Now().UnixNano())
+	randGen                    = rand.NewSafeRand(time.Now().UnixNano())
 )
 
 type nodeEntry struct {
@@ -608,28 +601,13 @@ func (m *Manager) DeleteAllNodes() {
 }
 
 // StartNeighborRefresh spawns a controller which refreshes neighbor table
-// by sending arping periodically. Linux keeps an arp entry in reachable
-// state for (0.5 ~ 1.5) * base_reachable_time_ms, default by 15 to 45 seconds:
-// https://elixir.bootlin.com/linux/v5.7.19/source/net/core/neighbour.c#L113
-// We do the refresh in a similar way.
+// by sending arping periodically.
 func (m *Manager) StartNeighborRefresh(nh datapath.NodeHandler) {
-	var interval time.Duration
-	baseReachableStr, err := sysctl.Read("net.ipv4.neigh.default.base_reachable_time_ms")
-	if err != nil {
-		interval = neighborRefreshBaseInterval
-	} else {
-		baseReachableU32, err := strconv.ParseUint(baseReachableStr, 10, 32)
-		if err != nil {
-			interval = neighborRefreshBaseInterval
-		} else {
-			interval = time.Duration(baseReachableU32) * time.Millisecond
-		}
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	controller.NewManager().UpdateController("neighbor-table-refresh",
 		controller.ControllerParams{
 			DoFunc: func(controllerCtx context.Context) error {
-				// cancel previous go routines from previous controller run
+				// Cancel previous go routines from previous controller run
 				cancel()
 				ctx, cancel = context.WithCancel(controllerCtx)
 				m.mutex.RLock()
@@ -642,14 +620,17 @@ func (m *Manager) StartNeighborRefresh(nh datapath.NodeHandler) {
 						continue
 					}
 					go func(c context.Context, e nodeTypes.Node) {
-						n := randGen.Int63n(int64(interval / 2))
-						time.Sleep(interval/2 + time.Duration(n))
+						// To avoid flooding network with arping requests
+						// at the same time, spread them over the
+						// [0; ARPPingRefreshPeriod/2) period.
+						n := randGen.Int63n(int64(option.Config.ARPPingRefreshPeriod / 2))
+						time.Sleep(time.Duration(n))
 						nh.NodeNeighborRefresh(c, e)
 					}(ctx, entryNode)
 				}
 				return nil
 			},
-			RunInterval: interval,
+			RunInterval: option.Config.ARPPingRefreshPeriod,
 		},
 	)
 	return

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -87,6 +87,9 @@ const (
 	// the daemon, which can also be disbled using this option.
 	AnnotateK8sNode = "annotate-k8s-node"
 
+	// ARPPingRefreshPeriod is the ARP entries refresher period
+	ARPPingRefreshPeriod = "arping-refresh-period"
+
 	// BPFRoot is the Path to BPF filesystem
 	BPFRoot = "bpf-root"
 
@@ -2061,6 +2064,9 @@ type DaemonConfig struct {
 	// store rules and routes under ENI and Azure IPAM modes, if false.
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat bool
+
+	// ARPPingRefreshPeriod is the ARP entries refresher period.
+	ARPPingRefreshPeriod time.Duration
 }
 
 var (
@@ -2459,6 +2465,7 @@ func (c *DaemonConfig) Populate() {
 	c.AllowICMPFragNeeded = viper.GetBool(AllowICMPFragNeeded)
 	c.AllowLocalhost = viper.GetString(AllowLocalhost)
 	c.AnnotateK8sNode = viper.GetBool(AnnotateK8sNode)
+	c.ARPPingRefreshPeriod = viper.GetDuration(ARPPingRefreshPeriod)
 	c.AutoCreateCiliumNodeResource = viper.GetBool(AutoCreateCiliumNodeResource)
 	c.BPFCompilationDebug = viper.GetBool(BPFCompileDebugName)
 	c.BPFRoot = viper.GetString(BPFRoot)

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -136,7 +136,10 @@ EOF
     {
       "name": "aws-cni",
       "type": "aws-cni",
-      "vethPrefix": "eni"
+      "vethPrefix": "eni",
+      "mtu": "9001",
+      "pluginLogFile": "/var/log/aws-routed-eni/plugin.log",
+      "pluginLogLevel": "DEBUG"
     },
     {
       "type": "portmap",

--- a/test/get-gh-comment-info.py
+++ b/test/get-gh-comment-info.py
@@ -9,4 +9,9 @@ parser.add_argument('--retrieve', type=str, default="focus")
 
 args = parser.parse_args()
 
+# Update kernel_version to expected format
+args.kernel_version = args.kernel_version.replace('.', '')
+if args.kernel_version == "netnext":
+	args.kernel_version = "net-next"
+
 print(args.__dict__[args.retrieve])

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2233,7 +2233,14 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
 		SkipItIf(helpers.DoesNotRunOn419OrLaterKernel, "Supports IPv4 fragments", func() {
-			DeployCiliumAndDNS(kubectl, ciliumFilename)
+			options := map[string]string{}
+			// On GKE we need to disable endpoint routes as fragment tracking
+			// isn't compatible with that options. See #15958.
+			if helpers.RunsOnGKE() {
+				options["gke.enabled"] = "false"
+				options["tunnel"] = "disabled"
+			}
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 			testIPv4FragmentSupport()
 		})
 	})


### PR DESCRIPTION
v1.9 backports 2021-05-07

 * #14968 -- docs: Update our community docs page (@pchaigno)
 * #14816 -- node-neigh: add metric to count arping requests (@jaffcheng)
 * #15743 -- test: Format test-only's kernel_version to avoid mistakes (@pchaigno)
 * #15934 -- Drop a `@` in clustermesh-apiserver helm chart (@anthr76)
 * #15964 -- bwm: queue mapping & cong fixes (@borkmann)
 * #15959 -- test: Fix fragment tracking test on GKE (@pchaigno)
 * #15988 -- connectivity-check: Reduce chances of port conflict with proxy (@pchaigno)
 * #15985 -- Update weekly community meeting timeslot (@joestringer)
 * #15915 -- plugins/cilium-cni: fix aws-cni cni chaining (@aanm)
 * #15783 -- node-neigh: Locking, logging, misc improvements (@brb)
 * #15867 -- cilium: Encryption EKS 4.14 kernel (default) fixes (@jrfastab)
 * #15882 -- node-neigh: Avoid flooding the same next hop (@brb)


NOT BACKPORTED:
 * #15968 -- test: Fix the search for VIPs in `cilium service list` (@pchaigno) <-- many merge conflicts

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14968 14816 15743 15934 15964 15959 15988 15985 15915 15783 15867 15882; do contrib/backporting/set-labels.py $pr done 1.9; done
```