### PR TITLE
test: Quarantine fragment tracking test on GKE

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -2915,7 +2915,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
 		SkipItIf(func() bool {
-			return helpers.DoesNotRunOn419OrLaterKernel()
+			return helpers.DoesNotRunOn419OrLaterKernel() ||
+				(helpers.SkipQuarantined() && helpers.RunsOnGKE())
 		}, "Supports IPv4 fragments", func() {
 			options := map[string]string{}
 			// On GKE we need to disable endpoint routes as fragment tracking


### PR DESCRIPTION
The fragment tracking test is very flaky on GKE. Let's quarantine.

Related: https://github.com/cilium/cilium/issues/16004.