### PR TITLE
.github: Don't persist credentials in repository

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -14,6 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Run checkpatch.pl
         uses: docker://quay.io/cilium/cilium-checkpatch:cc7e6b5811f46d7b040dedfe2f6b0010c2c51a12@sha256:9160b6ca58eb99a3ed5d567a494b2e2001325ebad32029c5bd17a8ae4df01044
@@ -22,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: docker://cilium/coccicheck:2.0
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
@@ -48,6 +51,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Build all BPF datapath permutations
         env:

--- a/.github/workflows/build_commits.yaml
+++ b/.github/workflows/build_commits.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
+        persist-credentials: false
         fetch-depth: 1
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/cyclonus-netpol-test.yaml
+++ b/.github/workflows/cyclonus-netpol-test.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Check pre-flight clusterrole
         run: |
           cd install/kubernetes/cilium/templates
@@ -33,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Precheck generated connectivity manifest files
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+        with:
+          persist-credentials: false
       - uses: docker://cilium/docs-builder:latest
         with:
           entrypoint: ./Documentation/check-build.sh

--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -16,6 +16,8 @@ jobs:
           go-version: 1.16.3
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Check module vendoring
         run: |
           go mod tidy
@@ -32,6 +34,8 @@ jobs:
           go-version: 1.16.3
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
@@ -48,6 +52,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           # hard-code the path instead of using ${{ github.repository }} to make sure it works for forked repo as well
           path: src/github.com/cilium/cilium
       - name: Go code prechecks
@@ -65,6 +70,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           # hard-code the path instead of using ${{ github.repository }} to make sure it works for forked repo as well
           path: src/github.com/cilium/cilium
       - name: Check api generated files
@@ -82,6 +88,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           # hard-code the path instead of using ${{ github.repository }} to make sure it works for forked repo as well
           path: src/github.com/cilium/cilium
       - name: Install protobuf dependencies

--- a/.github/workflows/images-legacy-base-releases.yaml
+++ b/.github/workflows/images-legacy-base-releases.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Generating image tag

--- a/.github/workflows/images-legacy-hotfix-releases.yaml
+++ b/.github/workflows/images-legacy-hotfix-releases.yaml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Checkout Source Code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
 
       - name: Release Build ${{ matrix.name }}
         uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f

--- a/.github/workflows/images-legacy-releases.yaml
+++ b/.github/workflows/images-legacy-releases.yaml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Checkout Source Code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
 
       - name: Release Build ${{ matrix.name }}
         uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f

--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -67,6 +67,7 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
+          persist-credentials: false
           ref: ${{ steps.tag.outputs.tag }}
 
       # master branch pushes
@@ -206,6 +207,7 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
+          persist-credentials: false
           ref: ${{ steps.tag.outputs.tag }}
 
       # master branch pushes

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+        with:
+          persist-credentials: false
 
       - uses: docker://quay.io/cilium/image-maker:ca3f9135c0c8cb88c979f829d93a167838776615@sha256:b64f9168f52dae5538cd8ca06922e522eb84e36d3f727583c352266e3ed15894
         name: Run make lint

--- a/.github/workflows/kind-1.19.yaml
+++ b/.github/workflows/kind-1.19.yaml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Checkout king config
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
 
       - name: Create kind cluster
         uses: helm/kind-action@7a937c0fb648064a83b8b9354151e5e543d9fcec

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Add namespace object
         run: |
           cat <<EOT > cilium.yaml

--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set image tag
         id: vars

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
       - name: Check pre-flight clusterrole
         run: |
           cd install/kubernetes/cilium/templates
@@ -33,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Run helm lint
         run: |
@@ -43,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Run helm-docs
         run: |
@@ -55,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set image tag
         id: vars


### PR DESCRIPTION
When using actions/checkout, the default behavior [1] is to persist git credentials in the checked out code. This is ill-advised, so let's disable with `persist-credentials`.

1 - https://github.com/actions/checkout#usage
2 - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/