### PR TITLE
test: Fix incorrect uninstall in K8sBandwidth

### DIFF
--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -44,8 +44,6 @@ var _ = Describe("K8sBandwidthTest", func() {
 	AfterAll(func() {
 		_ = kubectl.Delete(demoYAML)
 		ExpectAllPodsTerminated(kubectl)
-
-		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
 	})
 
@@ -85,6 +83,10 @@ var _ = Describe("K8sBandwidthTest", func() {
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 			backgroundCancel()
+		})
+
+		AfterAll(func() {
+			UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		})
 
 		waitForTestPods := func() {


### PR DESCRIPTION
The statement to uninstall Cilium in K8sBandwidth/AfterAll doesn't match the statements to install it, meaning we could try to disable Cilium even though we never installed it. This commit fixes it.

Fixes: https://github.com/cilium/cilium/issues/15132.