### PR TITLE
test: Use hubble observe's jsonpb output in artifacts

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -318,7 +318,7 @@ var ciliumCLICommands = map[string]string{
 	"cilium status --all-controllers":       "status.txt",
 	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
 
-	"hubble observe --since 4h -o json": "hubble_observe.txt",
+	"hubble observe --since 4h -o jsonpb": "hubble_observe.json",
 }
 
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
@@ -333,7 +333,7 @@ var ciliumKubCLICommands = map[string]string{
 	"cilium policy get":               "policy_get.txt",
 	"cilium status --all-controllers": "status.txt",
 
-	"hubble observe --since 4h -o json": "hubble_observe.txt",
+	"hubble observe --since 4h -o jsonpb": "hubble_observe.json",
 }
 
 // ciliumKubCLICommandsKVStore contains commands related to querying the kvstore.


### PR DESCRIPTION
`hubble observe` now supports [1] reading flows from stdin if they are in jsonpb format. We should therefore emit jsonpb artifact files for tests, to be able to feed those files back into `hubble observe`. That will allow us to use `hubble observe`'s filters and different output format.

1 - https://github.com/cilium/hubble/pull/524