### PR TITLE
jenkinsfiles: fix race detector pipelines

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -71,6 +71,9 @@ pipeline {
                     }
                     if (env.run_with_race_detection?.trim()) {
                         env.DOCKER_TAG = env.DOCKER_TAG + "-race"
+                        env.RACE = 1
+                        env.LOCKDEBUG = 1
+                        env.BASE_IMAGE = "quay.io/cilium/cilium-runtime:8fe001a11f25ad9e6676c19b0431f83c893fbab4@sha256:921ab4bf310f562ce7d4aea1f5c2bc8651f273f1a93b36c71b9cb9954869ef68"
                     }
                 }
             }

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -88,6 +88,9 @@ pipeline {
                     }
                     if (env.run_with_race_detection?.trim()) {
                         env.DOCKER_TAG = env.DOCKER_TAG + "-race"
+                        env.RACE = 1
+                        env.LOCKDEBUG = 1
+                        env.BASE_IMAGE = "quay.io/cilium/cilium-runtime:8fe001a11f25ad9e6676c19b0431f83c893fbab4@sha256:921ab4bf310f562ce7d4aea1f5c2bc8651f273f1a93b36c71b9cb9954869ef68"
                     }
                 }
             }

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -51,6 +51,9 @@ pipeline {
                     }
                     if (env.run_with_race_detection?.trim()) {
                         env.DOCKER_TAG = env.DOCKER_TAG + "-race"
+                        env.RACE = 1
+                        env.LOCKDEBUG = 1
+                        env.BASE_IMAGE = "quay.io/cilium/cilium-runtime:8fe001a11f25ad9e6676c19b0431f83c893fbab4@sha256:921ab4bf310f562ce7d4aea1f5c2bc8651f273f1a93b36c71b9cb9954869ef68"
                     }
                 }
             }


### PR DESCRIPTION
PR #15125 broke race detector pipelines due to the `RACE` environment variable not being present, when it is required for `SkipRaceDetectorEnabled` to work properly.

A quick inspection leads me to believe `LOCKDEBUG` also is required for package `lock`. I am less convinced about `BASE_IMAGE` being required, but I'm adding it back anyway in a sort of spiritual revert until we figure it out.

Fixes #15214: the Kafka tests were actually already disabled for race detector pipelines, as per #13757. They were only running the pipelines due to #15125 re-enabling them incidentally.
