### PR TITLE
test: Fix flake in ValidateEndpointsAreCorrect

### DIFF
--- a/test/runtime/assertionHelpers.go
+++ b/test/runtime/assertionHelpers.go
@@ -66,6 +66,7 @@ func ExpectCiliumNotRunning(vm *helpers.SSHMeta) {
 // ExpectDockerContainersMatchCiliumEndpoints asserts that docker containers in
 // Cilium network match with the endpoint list
 func ExpectDockerContainersMatchCiliumEndpoints(vm *helpers.SSHMeta) {
+	ExpectWithOffset(1, vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 	ExpectWithOffset(1, vm.ValidateEndpointsAreCorrect(helpers.CiliumDockerNetwork)).To(BeNil(),
 		"Docker containers mistmach with Cilium Endpoints")
 }


### PR DESCRIPTION
`ValidateEndpointsAreCorrect` ensures that all Docker containers have a corresponding Cilium endpoints. The information necessary to match containers with Cilium endpoints is however only available once the endpoints are ready (have received labels, identity, and other information). We therefore need to wait for all endpoints to be ready before running `ValidateEndpointsAreCorrect`.

Fixes: https://github.com/cilium/cilium/issues/14463.