### PR TITLE
labelsfilter: Ignore flux's sync-gc-mark label

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -21,19 +21,20 @@ application.
 By default, Cilium considers all labels to be relevant for identities, with the
 following exceptions:
 
-================================== ==============================================
-Label                               Description
----------------------------------- ----------------------------------------------
-``any:!io.kubernetes``             Ignore all ``io.kubernetes`` labels
-``any:!kubernetes.io``             Ignore all other ``kubernetes.io`` labels
-``any:!beta.kubernetes.io``        Ignore all ``beta.kubernetes.io`` labels
-``any:!k8s.io``                    Ignore all ``k8s.io`` labels
-``any:!pod-template-generation``   Ignore all ``pod-template-generation`` labels
-``any:!pod-template-hash``         Ignore all ``pod-template-hash`` labels
-``any:!controller-revision-hash``  Ignore all ``controller-revision-hash`` labels
-``any:!annotation.*``              Ignore all ``annotation labels``
-``any:!etcd_node``                 Ignore all ``etcd_node`` labels
-================================== ==============================================
+============================================================== ============================================================================
+Label                                                           Description
+-------------------------------------------------------------- ----------------------------------------------------------------------------
+``any:!io.kubernetes``                                         Ignore all ``io.kubernetes`` labels
+``any:!kubernetes.io``                                         Ignore all other ``kubernetes.io`` labels
+``any:!beta.kubernetes.io``                                    Ignore all ``beta.kubernetes.io`` labels
+``any:!k8s.io``                                                Ignore all ``k8s.io`` labels
+``any:!pod-template-generation``                               Ignore all ``pod-template-generation`` labels
+``any:!pod-template-hash``                                     Ignore all ``pod-template-hash`` labels
+``any:!controller-revision-hash``                              Ignore all ``controller-revision-hash`` labels
+``any:!annotation.*``                                          Ignore all ``annotation labels``
+``any:!etcd_node``                                             Ignore all ``etcd_node`` labels
+``any:!io.cilium.k8s.namespace.labels.fluxcd.io/sync-gc-mark`` Ignore all ``!io.cilium.k8s.namespace.labels.fluxcd.io/sync-gc-mark`` labels
+============================================================== ============================================================================
 
 The above label examples are all *exclusive labels*, that is to say they define
 which label keys should be ignored. These are identified by the presence of the

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -206,6 +206,8 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		"!controller-revision-hash",     // ignore controller-revision-hash
 		"!annotation.*",                 // ignore all annotation labels
 		"!etcd_node",                    // ignore etcd_node label
+
+		"!io.cilium.k8s.namespace.labels.fluxcd.io/sync-gc-mark", // ignore hash from flux
 	}
 
 	for _, e := range expressions {


### PR DESCRIPTION
Flux adds a sync-gc-mark label to all pods. The label is computed via a hash function on the resource ID [1]. As a result, a lot of Cilium security identities are created in the cluster and that doesn't scale well.

1 - https://github.com/fluxcd/flux/blob/1.22.2/pkg/cluster/kubernetes/sync.go#L388