### PR TITLE
docs: Update troubleshooting for 1.10

### DIFF
--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -55,7 +55,7 @@ context of that pod:
 
 .. code-block:: shell-session
 
-   $ kubectl -n kube-system exec -ti cilium-2hq5z -- cilium status
+   $ kubectl -n kube-system exec cilium-2hq5z -- cilium status
    KVStore:                Ok   etcd: 1/1 connected: http://demo-etcd-lab--a.etcd.tgraf.test1.lab.corp.isovalent.link:2379 - 3.2.5 (Leader)
    ContainerRuntime:       Ok   docker daemon: OK
    Kubernetes:             Ok   OK
@@ -73,7 +73,7 @@ of all nodes in the cluster:
 
 .. code:: bash
 
-   curl -sLO releases.cilium.io/v1.1.0/tools/k8s-cilium-exec.sh
+   curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-cilium-exec.sh
    chmod +x ./k8s-cilium-exec.sh
 
 ... and run ``cilium status`` on all nodes:
@@ -473,7 +473,9 @@ Cilium:
 
 .. code-block:: shell-session
 
-   $ ./contrib/k8s/k8s-unmanaged.sh
+   $ curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-unmanaged.sh
+   $ chmod +x k8s-unmanaged.sh
+   $ ./k8s-unmanaged.sh
    kube-system/cilium-hqpk7
    kube-system/kube-addon-manager-minikube
    kube-system/kube-dns-54cccfbdf8-zmv2c
@@ -929,8 +931,9 @@ Identifies the Cilium pod that is managing a particular pod in a namespace:
 
 .. code:: bash
 
-    $ curl -sLO releases.cilium.io/v1.1.0/tools/k8s-get-cilium-pod.sh
-    $ bash ./k8s-get-cilium-pod.sh luke-pod default
+    $ curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-get-cilium-pod.sh
+    $ chmod +x k8s-get-cilium-pod.sh
+    $ ./k8s-get-cilium-pod.sh luke-pod default
     cilium-zmjj9
     cilium-node-init-v7r9p
     cilium-operator-f576f7977-s5gpq
@@ -948,7 +951,8 @@ Run a command within all Cilium pods of a cluster
 
 .. code:: bash
 
-    $ curl -sLO releases.cilium.io/v1.1.0/tools/k8s-cilium-exec.sh
+    $ curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-cilium-exec.sh
+    $ chmod +x k8s-cilium-exec.sh
     $ ./k8s-cilium-exec.sh uptime
      10:15:16 up 6 days,  7:37,  0 users,  load average: 0.00, 0.02, 0.00
      10:15:16 up 6 days,  7:32,  0 users,  load average: 0.00, 0.03, 0.04
@@ -970,7 +974,8 @@ were started before Cilium was deployed.
 
 .. code-block:: shell-session
 
-   $ curl -sLO releases.cilium.io/v1.1.0/tools/k8s-unmanaged.sh
+   $ curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-unmanaged.sh
+   $ chmod +x k8s-unmanaged.sh
    $ ./k8s-unmanaged.sh
    kube-system/cilium-hqpk7
    kube-system/kube-addon-manager-minikube

--- a/contrib/k8s/k8s-cilium-exec.sh
+++ b/contrib/k8s/k8s-cilium-exec.sh
@@ -36,9 +36,10 @@ function get_cilium_pods {
 }
 
 K8S_NAMESPACE="${K8S_NAMESPACE:-kube-system}"
+CONTAINER="${CONTAINER:-cilium-agent}"
 
 while read -r p; do
-	kubectl -n "${K8S_NAMESPACE}" exec -ti "${p}" -- "${@}" &
+	kubectl -n "${K8S_NAMESPACE}" exec -c "${CONTAINER}" "${p}" -- "${@}" &
 done <<< "$(get_cilium_pods)"
 
 wait

--- a/contrib/k8s/k8s-get-cilium-pod.sh
+++ b/contrib/k8s/k8s-get-cilium-pod.sh
@@ -22,4 +22,6 @@ then
 	exit 1
 fi
 
-kubectl get pods -n kube-system -owide | grep cilium | grep `kubectl get pods $1 -owide -n $2 | awk '{print $7}' | tail -n1` | awk '{print $1}'
+K8S_NAMESPACE="${K8S_NAMESPACE:-kube-system}"
+
+kubectl get pods -n "${K8S_NAMESPACE}" -owide | grep cilium | grep `kubectl get pods $1 -owide -n $2 | awk '{print $7}' | tail -n1` | awk '{print $1}'


### PR DESCRIPTION
This PR fixes a few problems found in the troubleshooting guide while testing the 1.10 Getting Started Guide.

* Update links to download scripts
* Tweak examples
* Update k8s-cilium-exec.sh to handle multiple containers in a pod
* Update k8s-get-cilium-pod.sh to handle non-standard cilium namespace

Signed-off-by: Tom Payne <tom@isovalent.com>
