### PR TITLE
bpf_host: emit '-> network' traces for egress packets

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -563,6 +563,14 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
 #define TC_INDEX_F_SKIP_RECIRCULATION	8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
+/*
+ * For use in ctx_{load,store}_meta(), which operates on sk_buff->cb.
+ * The verifier only exposes the first 5 slots in cb[], so this enum
+ * only contains 5 entries. Aliases are added to the slots to re-use
+ * them under different names in different parts of the datapath.
+ * Take care to not clobber slots used by other functions in the same
+ * code path.
+ */
 /* ctx_{load,store}_meta() usage: */
 enum {
 	CB_SRC_LABEL,

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -14,7 +14,7 @@
 
 # ifdef ENABLE_IPV6
 static __always_inline int
-ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id)
+ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 *monitor)
 {
 	int ret, verdict, l3_off = ETH_HLEN, l4_off, hdrlen;
 	struct ct_state ct_state_new = {}, ct_state = {};
@@ -22,7 +22,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id)
 	__u8 audited = 0;
 	struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple tuple = {};
-	__u32 dst_id = 0, monitor = 0;
+	__u32 dst_id = 0;
 	union v6addr orig_dip;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -44,7 +44,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id)
 		return hdrlen;
 	l4_off = l3_off + hdrlen;
 	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-			 &ct_state, &monitor);
+			 &ct_state, monitor);
 	if (ret < 0)
 		return ret;
 
@@ -241,7 +241,7 @@ whitelist_snated_egress_connections(struct __ctx_buff *ctx, __u32 ipcache_srcid)
 
 static __always_inline int
 ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
-			__u32 ipcache_srcid __maybe_unused)
+			__u32 ipcache_srcid __maybe_unused, __u32 *monitor)
 {
 	struct ct_state ct_state_new = {}, ct_state = {};
 	int ret, verdict, l4_off, l3_off = ETH_HLEN;
@@ -249,7 +249,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	__u8 audited = 0;
 	struct remote_endpoint_info *info;
 	struct ipv4_ct_tuple tuple = {};
-	__u32 dst_id = 0, monitor = 0;
+	__u32 dst_id = 0;
 	void *data, *data_end;
 	struct iphdr *ip4;
 
@@ -271,7 +271,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	tuple.saddr = ip4->saddr;
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-			 &ct_state, &monitor);
+			 &ct_state, monitor);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -141,6 +141,13 @@ static __always_inline bool emit_trace_notify(__u8 obs_point, __u32 monitor)
 		}
 	}
 
+	/*
+	 * Ignore sample when aggregation is enabled and 'monitor' is set to 0.
+	 * Rate limiting (trace message aggregation) relies on connection tracking,
+	 * so if there is no CT information available at the observation point,
+	 * then 'monitor' will be set to 0 to avoid emitting trace notifications
+	 * when aggregation is enabled (the default).
+	 */
 	if (MONITOR_AGGREGATION >= TRACE_AGGREGATE_ACTIVE_CT && !monitor)
 		return false;
 


### PR DESCRIPTION
bpf_host: emit '-> network' traces for egress packets

See the issue below for the full context. The caveat is, this program is only attached to the native device egress if the host firewall is enabled, so there still won't be any TRACE_TO_NETWORK visibility if that's not the case.

I've also added handle_to_netdev_ipv4() to clean up to_netdev() a bit, to bring it on par with the ipv6 handling.

bpf_host: emit '-> network' traces for packets leaving the node when Host Firewall are enabled

Based on: #13485
Fixes: #12561

Co-authored-by: Thiago Navarro <navarro@accuknox.com>
Signed-off-by: Timo Beckers <timo@isovalent.com>
Signed-off-by: Thiago Navarro <navarro@accuknox.com>
