### PR TITLE
Fix 5.10+ complexity issue with `kubeProxyReplacement=disabled`

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -96,13 +96,12 @@ MAX_BASE_OPTIONS += -DHAVE_LPM_TRIE_MAP_TYPE=1 -DHAVE_LRU_HASH_MAP_TYPE=1 \
 ifeq ("$(KERNEL)","54")
 MAX_BASE_OPTIONS += -DENABLE_BANDWIDTH_MANAGER=1
 else ifeq ("$(KERNEL)","netnext")
-# We need to define ENABLE_HOST_SERVICES_FULL to work around complexity issue #14234.
 # We define ENABLE_CUSTOM_CALLS only for net-next (vs. net-next and 4.19) to work
 # around program size issue #15539.
 # We define ETH_HLEN only for net-next, as bpf_skb_change_head is non-available
 # on 4.{9,19}.
 MAX_BASE_OPTIONS += -DENABLE_TPROXY=1 -DENABLE_REDIRECT_FAST=1 -DENABLE_BANDWIDTH_MANAGER=1 \
-	-DENABLE_HOST_SERVICES_FULL=1 -DENABLE_CUSTOM_CALLS=1 -DETH_HLEN=0
+	-DENABLE_CUSTOM_CALLS=1 -DETH_HLEN=0
 endif
 endif
 

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -15,6 +15,8 @@ LLC_FLAGS := -march=bpf -mattr=dwarfris
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifeq ("$(KERNEL)","49")
 LLC_FLAGS += -mcpu=v1
+else ifeq ("$(KERNEL)","netnext")
+LLC_FLAGS += -mcpu=v3
 else
 LLC_FLAGS += -mcpu=v2
 endif

--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -68,7 +68,7 @@ ctx_adjust_troom(struct __sk_buff *ctx, const __s32 len_diff)
 	return skb_change_tail(ctx, ctx->len + len_diff, 0);
 }
 
-static __always_inline __maybe_unused __u32
+static __always_inline __maybe_unused __u64
 ctx_full_len(const struct __sk_buff *ctx)
 {
 	return ctx->len;

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -262,7 +262,7 @@ ctx_redirect(const struct xdp_md *ctx, int ifindex, const __u32 flags)
 	return XDP_TX;
 }
 
-static __always_inline __maybe_unused __u32
+static __always_inline __maybe_unused __u64
 ctx_full_len(const struct xdp_md *ctx)
 {
 	/* No non-linear section in XDP. */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -142,7 +142,7 @@ ____revalidate_data_pull(struct __ctx_buff *ctx, void **data_, void **data_end_,
 			 void **l3, const __u32 l3_len, const bool pull,
 			 __u8 eth_hlen)
 {
-	const __u32 tot_len = eth_hlen + l3_len;
+	const __u64 tot_len = eth_hlen + l3_len;
 	void *data_end;
 	void *data;
 

--- a/bpf/lib/csum.h
+++ b/bpf/lib/csum.h
@@ -57,7 +57,7 @@ static __always_inline void csum_l4_offset_and_flags(__u8 nexthdr,
  * @arg to	To value or a csum diff
  * @arg flags	Additional flags to be passed to l4_csum_replace()
  */
-static __always_inline int csum_l4_replace(struct __ctx_buff *ctx, int l4_off,
+static __always_inline int csum_l4_replace(struct __ctx_buff *ctx, __u64 l4_off,
 					   const struct csum_offset *csum,
 					   __be32 from, __be32 to, int flags)
 {

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -63,10 +63,11 @@ encap_remap_v6_host_address(struct __ctx_buff *ctx __maybe_unused,
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr *which;
-	__u32 off, noff;
 	__u8 nexthdr;
 	__u16 proto;
 	__be32 sum;
+	__u32 noff;
+	__u64 off;
 	int ret;
 
 	validate_ethertype(ctx, &proto);

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -21,7 +21,7 @@
  *		is the drop error code.
  * Update the metrics map.
  */
-static __always_inline void update_metrics(__u32 bytes, __u8 direction,
+static __always_inline void update_metrics(__u64 bytes, __u8 direction,
 					   __u8 reason)
 {
 	struct metrics_value *entry, newEntry = {};
@@ -34,10 +34,10 @@ static __always_inline void update_metrics(__u32 bytes, __u8 direction,
 	entry = map_lookup_elem(&METRICS_MAP, &key);
 	if (entry) {
 		entry->count += 1;
-		entry->bytes += (__u64)bytes;
+		entry->bytes += bytes;
 	} else {
 		newEntry.count = 1;
-		newEntry.bytes = (__u64)bytes;
+		newEntry.bytes = bytes;
 		map_update_elem(&METRICS_MAP, &key, &newEntry, 0);
 	}
 }

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -512,8 +512,8 @@ static __always_inline __maybe_unused int snat_v4_process(struct __ctx_buff *ctx
 		__be16 sport;
 		__be16 dport;
 	} l4hdr;
-	__u32 off;
 	bool icmp_echoreply = false;
+	__u64 off;
 	int ret;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -442,8 +442,8 @@ static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 	const __s32 orig_dgram = 64, off = ETH_HLEN;
 	const __u32 l3_max = sizeof(*ip6) + orig_dgram;
 	__be16 type = bpf_htons(ETH_P_IPV6);
-	__s32 len_new = off + sizeof(*ip6) + orig_dgram;
-	__s32 len_old = ctx_full_len(ctx);
+	__u64 len_new = off + sizeof(*ip6) + orig_dgram;
+	__u64 len_old = ctx_full_len(ctx);
 	void *data_end = ctx_data_end(ctx);
 	void *data = ctx_data(ctx);
 	__wsum wsum;


### PR DESCRIPTION
This pull request fixes https://github.com/cilium/cilium/issues/14726, our complexity issue with `kubeProxyReplacement=disabled` when running Linux 5.10+. The fix is less general than originally hoped and only applies to 5.10+; other complexity issues are therefore not fixed by this change. With a bit more work, we may able to extend it to 5.1+ in the future.

See commits for details. As a summary:
1. Implements a couple changes to allow our BPF datapath to pass the verifier when compiled with `mattr=+alu32`.
2. Compile our BPF datapath with `mcpu=v3` (implies `mattr=+alu32`) on kernels 5.10+.
3. Disable a workaround for https://github.com/cilium/cilium/issues/14726 in tests, to make sure the complexity issue is fixed.

In addition to the end-to-end tests, these changes were also tested on kernels 5.10 and 5.11 with datapath configurations `KERNEL=419` and `KERNEL=netnext`.