### PR TITLE
daemon: require BPF masq to enable --install-no-conntrack-iptables-rules

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -51,6 +51,7 @@ bypassing the iptables connection tracker.
 * Kernel >= 4.19.57, >= 5.1.16, >= 5.2
 * Direct-routing configuration
 * eBPF-based kube-proxy replacement
+* eBPF masquerading
 
 To enable the iptables connection-tracking bypass:
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -365,6 +365,11 @@ func initKubeProxyReplacementOptions() (strict bool) {
 			log.Fatalf("%s requires the agent to run with %s=%s.",
 				option.InstallNoConntrackIptRules, option.KubeProxyReplacement, option.KubeProxyReplacementStrict)
 		}
+
+		if !option.Config.EnableBPFMasquerade {
+			log.Fatalf("%s requires the agent to run with %s.",
+				option.InstallNoConntrackIptRules, option.EnableBPFMasquerade)
+		}
 	}
 
 	return


### PR DESCRIPTION
It's currently possible to enable the no CT Iptables rules together with
Iptables masquerading, which results in Iptables failing to masquerade
traffic.

With this commit, when this setup is detected, we return a fatal error.

Fixes: #16046

Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>