### PR TITLE
[v1.8] daemon: store Cilium's configuration in a file

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1516,6 +1516,16 @@ func runDaemon() {
 	bootstrapStats.updateMetrics()
 	d.launchHubble()
 
+	err = option.Config.StoreInFile(option.Config.StateDir)
+	if err != nil {
+		log.WithError(err).Error("Unable to store Cilium's configuration")
+	}
+
+	err = option.StoreViperInFile(option.Config.StateDir)
+	if err != nil {
+		log.WithError(err).Error("Unable to store Viper's configuration")
+	}
+
 	select {
 	case err := <-metricsErrs:
 		if err != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -16,6 +16,7 @@ package option
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -1292,6 +1293,7 @@ type IpvlanConfig struct {
 
 // DaemonConfig is the configuration used by Daemon.
 type DaemonConfig struct {
+	CreationTime        time.Time
 	BpfDir              string     // BPF template files directory
 	LibDir              string     // Cilium library files directory
 	RunDir              string     // Cilium runtime directory
@@ -1535,7 +1537,7 @@ type DaemonConfig struct {
 	EnvoyLog                      string
 	DisableEnvoyVersionCheck      bool
 	FixedIdentityMapping          map[string]string
-	FixedIdentityMappingValidator func(val string) (string, error)
+	FixedIdentityMappingValidator func(val string) (string, error) `json:"-"`
 	IPv4Range                     string
 	IPv6Range                     string
 	IPv4ServiceRange              string
@@ -1966,6 +1968,7 @@ type DaemonConfig struct {
 var (
 	// Config represents the daemon configuration
 	Config = &DaemonConfig{
+		CreationTime:                 time.Now(),
 		Opts:                         NewIntOptions(&DaemonOptionLibrary),
 		Monitor:                      &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
 		IPv6ClusterAllocCIDR:         defaults.IPv6ClusterAllocCIDR,
@@ -2974,6 +2977,58 @@ func (c *DaemonConfig) calculateDynamicBPFMapSizes(totalMemory uint64, dynamicSi
 			SockRevNatEntriesName, c.SockRevNatEntries)
 	} else {
 		log.Debugf("option %s set by user to %v", NATMapEntriesGlobalName, c.NATMapEntriesGlobal)
+	}
+}
+
+// StoreInFile stores the configuration in a the given directory under the file
+// name 'daemon-config.json'. If this file already exists, it is renamed to
+// 'daemon-config-1.json', if 'daemon-config-1.json' also exists,
+// 'daemon-config-1.json' is renamed to 'daemon-config-2.json'
+func (c *DaemonConfig) StoreInFile(dir string) error {
+	backupFileNames := []string{
+		"agent-runtime-config.json",
+		"agent-runtime-config-1.json",
+		"agent-runtime-config-2.json",
+	}
+	backupFiles(dir, backupFileNames)
+	f, err := os.Create(backupFileNames[0])
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	e := json.NewEncoder(f)
+	e.SetIndent("", " ")
+	return e.Encode(c)
+}
+
+// StoreViperInFile stores viper's configuration in a the given directory under
+// the file name 'viper-config.yaml'. If this file already exists, it is renamed
+// to 'viper-config-1.yaml', if 'viper-config-1.yaml' also exists,
+// 'viper-config-1.yaml' is renamed to 'viper-config-2.yaml'
+func StoreViperInFile(dir string) error {
+	backupFileNames := []string{
+		"viper-agent-config.yaml",
+		"viper-agent-config-1.yaml",
+		"viper-agent-config-2.yaml",
+	}
+	backupFiles(dir, backupFileNames)
+	return viper.WriteConfigAs(backupFileNames[0])
+}
+
+func backupFiles(dir string, backupFilenames []string) {
+	for i := len(backupFilenames) - 1; i > 0; i-- {
+		newFileName := filepath.Join(dir, backupFilenames[i-1])
+		oldestFilename := filepath.Join(dir, backupFilenames[i])
+		if _, err := os.Stat(newFileName); os.IsNotExist(err) {
+			continue
+		}
+		err := os.Rename(newFileName, oldestFilename)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				"old-name": oldestFilename,
+				"new-name": newFileName,
+			}).Error("Unable to rename configuration files")
+		}
 	}
 }
 

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -975,4 +975,40 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func (s *OptionSuite) Test_backupFiles(c *C) {
+	tempDir := c.MkDir()
+	fileNames := []string{"test.json", "test-1.json", "test-2.json"}
+
+	backupFiles(tempDir, fileNames)
+	files, err := ioutil.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	// No files should have been created
+	c.Assert(len(files), Equals, 0)
+
+	_, err = os.Create(filepath.Join(tempDir, "test.json"))
+	c.Assert(err, IsNil)
+
+	backupFiles(tempDir, fileNames)
+	files, err = ioutil.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	c.Assert(len(files), Equals, 1)
+	c.Assert(files[0].Name(), Equals, "test-1.json")
+
+	backupFiles(tempDir, fileNames)
+	files, err = ioutil.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	c.Assert(len(files), Equals, 1)
+	c.Assert(files[0].Name(), Equals, "test-2.json")
+
+	_, err = os.Create(filepath.Join(tempDir, "test.json"))
+	c.Assert(err, IsNil)
+
+	backupFiles(tempDir, fileNames)
+	files, err = ioutil.ReadDir(tempDir)
+	c.Assert(err, IsNil)
+	c.Assert(len(files), Equals, 2)
+	c.Assert(files[0].Name(), Equals, "test-1.json")
+	c.Assert(files[1].Name(), Equals, "test-2.json")
 }


### PR DESCRIPTION
* #16017 -- daemon: store Cilium's configuration in a file (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16017; do contrib/backporting/set-labels.py $pr done 1.9; done
```