### PR TITLE
test: Log input to `json.Unmarshal` when it fails

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -85,7 +85,7 @@ func (b *CmdStreamBuffer) Filter(filter string) (*FilterBuffer, error) {
 
 	err := json.Unmarshal(b.Bytes(), &data)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse JSON from command %q", b.Cmd())
+		return nil, fmt.Errorf("could not parse JSON from command %q\n%w\n%s", b.Cmd(), err, b.Bytes())
 	}
 	parser := jsonpath.New("").AllowMissingKeys(true)
 	parser.Parse(filter)


### PR DESCRIPTION
`json.Unmarshal` sometimes fails to parse its input. We should log the input in such cases to figure out what happened. This is currently causing a test to (rarely) flake (cf. https://github.com/cilium/cilium/issues/16088).