### PR TITLE
daemon: Ignore cilium_* interfaces when deriving NodePort device

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -626,7 +626,18 @@ func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 			"Cannot retrieve host IP addrs for BPF NodePort device detection")
 	} else {
 		for _, a := range addrs {
-			ifidxByAddr[a.IP.String()] = a.LinkIndex
+			// Any cilium_* interface will never be a valid NodePort or Direct Routing
+			// interface. Skip interface if we cannot resolve it from Netlink via its
+			// ifIndex or if its name begins with cilium_.
+			if link, err := netlink.LinkByIndex(a.LinkIndex); err != nil {
+				log.WithError(err).WithField(logfields.LinkIndex, a.LinkIndex).Warn(
+					"Unable to resolve link from ifIndex, skipping interface for device detection")
+			} else if strings.HasPrefix(link.Attrs().Name, "cilium_") {
+				log.WithField(logfields.Device, link.Attrs().Name).Debug(
+					"Skipping Cilium-generated interface for device detection")
+			} else {
+				ifidxByAddr[a.IP.String()] = a.LinkIndex
+			}
 		}
 	}
 

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -102,6 +102,15 @@ func (s *KubeProxySuite) TestDetectDevices(c *C) {
 		c.Assert(detectDevices(true, true), IsNil)
 		c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy1"})
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy1")
+
+		// 7. With IPv6 node address on dummy3, set cilium_foo interface to node IP,
+		// only dummy3 should be detected matching node IP (no IPv6 default route present)
+		option.Config.EnableIPv6 = true
+		c.Assert(createDummy("dummy3", "2001:db8::face/64"), IsNil)
+		c.Assert(createDummy("cilium_foo", "2001:db8::face/128"), IsNil)
+		node.SetK8sNodeIP(net.ParseIP("2001:db8::face"))
+		c.Assert(detectDevices(true, true), IsNil)
+		c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy3"})
 	})
 }
 


### PR DESCRIPTION
Any Cilium-created interface (`cilium_host`, etc) will never be a valid
interface for kube-proxy-replacement NodePort (or direct routing). In
certain cases, it is possible for the NodePort auto-derivation code to
select one of these interfaces. This notably happens when the k8s node
IP is an IPv6 address: the node IP is cloned to `cilium_host`, and the IP
(sans netmask) is used as a map key - so `cilium_host` may be viewed as
the only interface with an address matching the node IP. 

Add a check bypassing any interface whose name is prefixed with
`cilium_` during NodePort device detection.

Add a test mimicking the IPv6 `cilium_host` case: node IP assigned to a
"real" interface and a `cilium_foo` interface, we should ignore
`cilium_foo`.

Fixes: #16019

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!