### PR TITLE
v1.8 backports 2021-05-11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:b3bb275dcaf4a74ae956e52fa408b196c0d52152@sha256:f3c7645c0ff1d7552b79927023cf540f82b40263780644f75291ed0bb1965bee as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:1243d3855411ea5cfc3e8cfae0d552394754c186@sha256:3764904459830c2b8380922571a9f6d982795dc80cd9950ae600b8009604bbf0 as cilium-envoy
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 

--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -79,7 +79,7 @@ and meeting links.
 ====================== ===================================== ============= ================================================================================
 SIG                    Meeting                               Slack         Description
 ====================== ===================================== ============= ================================================================================
-Datapath               Wednesdays, 08:00 PT                  #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
+Datapath               Thursdays, 08:00 PT                   #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
 Documentation          None                                  #sig-docs     All documentation related discussions
 Envoy                  On demand                             #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
 Hubble                 During community meeting              #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -158,6 +158,7 @@ pipeline {
                         returnStdout: true,
                         script: 'echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s*/" | tr -d \'\n\''
                         )}"""
+                KERNEL="419"
             }
             steps {
                 dir("${TESTDIR}"){

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -217,7 +217,9 @@ type LogRecordHTTP struct {
 	// Protocol is the HTTP protocol in use
 	Protocol string
 
-	// Headers are all HTTP headers present in the request
+	// Headers are all HTTP headers present in the request and response. Request records
+	// contain request headers, while response headers contain both request and response
+	// headers.
 	Headers http.Header
 
 	// MissingHeaders are HTTP request headers that were deemed missing from the request

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1886,7 +1886,14 @@ var _ = Describe("K8sServicesTest", func() {
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
 		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Supports IPv4 fragments", func() {
-			DeployCiliumAndDNS(kubectl, ciliumFilename)
+			options := map[string]string{}
+			// On GKE we need to disable endpoint routes as fragment tracking
+			// isn't compatible with that options. See #15958.
+			if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
+				options["global.gke.enabled"] = "false"
+				options["global.tunnel"] = "disabled"
+			}
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 			testIPv4FragmentSupport()
 		})
 	})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1589,9 +1589,17 @@ var _ = Describe("K8sServicesTest", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+							options := map[string]string{
 								"global.hostFirewall": "true",
-							})
+							}
+							// We can't rely on gke.enabled because it enables
+							// per-endpoint routes which are incompatible with
+							// the host firewall.
+							if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
+								options["global.gke.enabled"] = "false"
+								options["global.tunnel"] = "disabled"
+							}
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
 							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
 							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
@@ -1668,11 +1676,19 @@ var _ = Describe("K8sServicesTest", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+							options := map[string]string{
 								"global.tunnel":               "disabled",
 								"global.autoDirectNodeRoutes": "true",
 								"global.hostFirewall":         "true",
-							})
+							}
+							// We can't rely on gke.enabled because it enables
+							// per-endpoint routes which are incompatible with
+							// the host firewall.
+							if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
+								options["global.gke.enabled"] = "false"
+								options["global.tunnel"] = "disabled"
+							}
+							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
 							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
 							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1885,15 +1885,10 @@ var _ = Describe("K8sServicesTest", func() {
 
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
-		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Supports IPv4 fragments", func() {
-			options := map[string]string{}
-			// On GKE we need to disable endpoint routes as fragment tracking
-			// isn't compatible with that options. See #15958.
-			if helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE {
-				options["global.gke.enabled"] = "false"
-				options["global.tunnel"] = "disabled"
-			}
-			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
+		SkipItIf(func() bool {
+			return helpers.DoesNotRunOnNetNextOr419Kernel() || helpers.GetCurrentIntegration() == helpers.CIIntegrationGKE
+		}, "Supports IPv4 fragments", func() {
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
 			testIPv4FragmentSupport()
 		})
 	})


### PR DESCRIPTION
* #14639 -- test: Mark GKE CI pipeline as running Linux 4.19 (@pchaigno)
 * #16027 -- docs: Update SIG-Datapath meeting time. (@joestringer)
 * #16013 -- envoy: Add response headers access logging (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 14639 16027 16013; do contrib/backporting/set-labels.py $pr done 1.8; done
```