### PR TITLE
bpf_sock: Implements a new way to detect host netns on Kind.

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -7,7 +7,7 @@ include ../Makefile.defs
 
 SUBDIRS = sockops custom
 
-BPF_SIMPLE = bpf_network.o bpf_alignchecker.o
+BPF_SIMPLE = bpf_network.o bpf_alignchecker.o bpf_sock_aux.o
 BPF_SIMPLE_C = $(patsubst %.o,%.c,${BPF_SIMPLE})
 BPF_SIMPLE_LL = $(patsubst %.o,%.ll,${BPF_SIMPLE})
 BPF_TEST=tests/bpf_ct_tests.o
@@ -31,7 +31,7 @@ build_all: force
 BUILD_PERMUTATIONS ?= ""
 
 ifneq ("$(KERNEL)","49")
-BPF_SIMPLE_OPTIONS += -DHAVE_LPM_TRIE_MAP_TYPE -DHAVE_LRU_HASH_MAP_TYPE
+BPF_SIMPLE_OPTIONS += -DHAVE_LPM_TRIE_MAP_TYPE -DHAVE_LRU_HASH_MAP_TYPE -DSOCKET_MAGIC_COOKIE=1
 endif
 
 $(BPF_SIMPLE_LL): $(BPF_SIMPLE_C)
@@ -48,6 +48,7 @@ space := ${null} ${null}
 
 # The following option combinations are compile tested
 LB_OPTIONS = \
+	-DHOST_NETNS_COOKIE: \
 	-DSKIP_DEBUG: \
 	-DENABLE_IPV4: \
 	-DENABLE_IPV4:-DENCAP_IFINDEX: \

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -82,7 +82,13 @@ void ctx_set_port(struct bpf_sock_addr *ctx, __be16 dport)
 static __always_inline __maybe_unused bool
 ctx_in_hostns(void *ctx __maybe_unused, __net_cookie *cookie)
 {
-#ifdef BPF_HAVE_NETNS_COOKIE
+#if defined(BPF_HAVE_NETNS_COOKIE) && defined(HOST_NETNS_COOKIE)
+	__net_cookie own_cookie = get_netns_cookie(ctx);
+
+	if (cookie)
+		*cookie = own_cookie;
+	return own_cookie == HOST_NETNS_COOKIE;
+#elif defined(BPF_HAVE_NETNS_COOKIE)
 	__net_cookie own_cookie = get_netns_cookie(ctx);
 
 	if (cookie)

--- a/bpf/bpf_sock_aux.c
+++ b/bpf/bpf_sock_aux.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (C) 2019-2020 Authors of Cilium */
+
+#include <bpf/ctx/unspec.h>
+#include <bpf/api.h>
+
+#define SYS_REJECT	0
+
+struct bpf_elf_map __section_maps cilium_netns_cookie = {
+	.type       = BPF_MAP_TYPE_ARRAY,
+	.size_key   = sizeof(__u32),
+	.size_value = sizeof(__net_cookie),
+	.pinning    = PIN_GLOBAL_NS,
+	.max_elem   = 1,
+};
+
+__section("sock_aux_get_netns_cookie")
+int stub_get_netns_cookie(struct bpf_sock_addr *ctx __maybe_unused)
+{
+#if defined(SOCKET_MAGIC_COOKIE)    && \
+    defined(BPF_HAVE_NETNS_COOKIE)  && \
+    defined(BPF_HAVE_SOCKET_COOKIE)
+	__u32 index = 0;
+	__net_cookie netns_cookie;
+	__sock_cookie sock_cookie = get_socket_cookie(ctx);
+
+	if (sock_cookie == SOCKET_MAGIC_COOKIE) {
+		netns_cookie = get_netns_cookie(ctx);
+		map_update_elem(&cilium_netns_cookie, &index, &netns_cookie, 0);
+	}
+#endif
+	return SYS_REJECT;
+}
+
+BPF_LICENSE("GPL");

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -36,6 +36,7 @@ MCPU=${18}
 NR_CPUS=${19}
 ENDPOINT_ROUTES=${20}
 PROXY_RULE=${21}
+NETNS_COOKIE=${22}
 
 ID_HOST=1
 ID_WORLD=2
@@ -497,6 +498,11 @@ if [ "$HOSTLB" = "true" ]; then
 
 	CALLS_MAP="cilium_calls_lb"
 	COPTS=""
+
+	if [ "$NETNS_COOKIE" != "<nil>" ]; then
+		COPTS+="-DHOST_NETNS_COOKIE=$NETNS_COOKIE"
+	fi
+
 	if [ "$IP6_HOST" != "<nil>" ] || [ "$IP4_HOST" != "<nil>" ] && [ -f /proc/sys/net/ipv6/conf/all/forwarding ]; then
 		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr connect6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
 		if [ "$HOSTLB_PEER" = "true" ]; then


### PR DESCRIPTION
This commit follows the suggestion made by @borkmann, @brb and @aditighag with little modifications.

I really appreciate any suggestions.

Fixes: #14956