### PR TITLE
.github: Test IPsec with high value for keyID

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -198,6 +198,10 @@ jobs:
           cilium uninstall --wait
           pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
 
+      - name: Create custom IPsec secret
+        run: |
+          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+
       - name: Install Cilium with encryption
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -191,6 +191,10 @@ jobs:
           cilium uninstall --wait
           pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
 
+      - name: Create custom IPsec secret
+        run: |
+          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+
       - name: Install Cilium with encryption
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -218,6 +218,10 @@ jobs:
           cilium uninstall --wait
           pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
 
+      - name: Create custom IPsec secret
+        run: |
+          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+
       - name: Install Cilium with encryption
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \


### PR DESCRIPTION
We want to use the highest possible value for the key ID in end-to-end tests to be sure to catch packet mark conflicts if any arises. By using the value corresponding to all bits set to 1, any conflict will be caught.

This change was tested with a previous version of this pull request:
![image](https://user-images.githubusercontent.com/1764210/123485911-5ee54480-d60b-11eb-935e-845f57bdfad9.png)

The workflows were modified to collect a sysdump even in case of success and those sysdumps are attached here:
[keyid-sysdump-gke.zip](https://github.com/cilium/cilium/files/6718861/keyid-sysdump-gke.zip)
[keyid-sysdump-eks.zip](https://github.com/cilium/cilium/files/6718864/keyid-sysdump-eks.zip)
[keyid-sysdump-aks.zip](https://github.com/cilium/cilium/files/6718865/keyid-sysdump-aks.zip)
