### PR TITLE
pkg/aws/eni: new subnet-ids parameter

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -207,6 +207,15 @@ allocation:
 
   If unspecified, the security group ids of ``eth0`` will be used.
 
+``spec.eni.subnet-ids``
+  The subnet IDs used to select the AWS subnets for IP allocation. This is an
+  additional requirement on top of requiring to match the availability zone and
+  VPC of the instance. This parameter is mutually exclusive and has priority over
+  ``spec.eni.subnet-tags``.
+
+  If unspecified, it will let the operator pick any available subnet in the AZ 
+  with the most IP addresses available.
+
 ``spec.eni.subnet-tags``
   The tags used to select the AWS subnets for IP allocation. This is an
   additional requirement on top of requiring to match the availability zone and

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -362,14 +362,21 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	resource := *n.k8sObj
 	n.mutex.RUnlock()
 
-	bestSubnet := n.manager.FindSubnetByTags(resource.Spec.ENI.VpcID, resource.Spec.ENI.AvailabilityZone, resource.Spec.ENI.SubnetTags)
+	var bestSubnet *ipamTypes.Subnet
+	if len(resource.Spec.ENI.SubnetIDs) > 0 {
+		bestSubnet = n.manager.FindSubnetByIDs(resource.Spec.ENI.VpcID, resource.Spec.ENI.AvailabilityZone, resource.Spec.ENI.SubnetIDs)
+	} else {
+		bestSubnet = n.manager.FindSubnetByTags(resource.Spec.ENI.VpcID, resource.Spec.ENI.AvailabilityZone, resource.Spec.ENI.SubnetTags)
+	}
+
 	if bestSubnet == nil {
 		return 0,
 			errUnableToFindSubnet,
 			fmt.Errorf(
-				"No matching subnet available for interface creation (VPC=%s AZ=%s SubnetTags=%s",
+				"No matching subnet available for interface creation (VPC=%s AZ=%s SubnetIDs=%v SubnetTags=%s)",
 				resource.Spec.ENI.VpcID,
 				resource.Spec.ENI.AvailabilityZone,
+				resource.Spec.ENI.SubnetIDs,
 				resource.Spec.ENI.SubnetTags,
 			)
 	}

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -97,6 +97,12 @@ type ENISpec struct {
 	// +kubebuilder:validation:Optional
 	SecurityGroupTags map[string]string `json:"security-group-tags,omitempty"`
 
+	// SubnetIDs is the list of subnet ids to use when evaluating what AWS
+	// subnets to use for ENI and IP allocation.
+	//
+	// +kubebuilder:validation:Optional
+	SubnetIDs []string `json:"subnet-ids,omitempty"`
+
 	// SubnetTags is the list of tags to use when evaluating what AWS
 	// subnets to use for ENI and IP allocation.
 	//

--- a/pkg/aws/eni/types/zz_generated.deepcopy.go
+++ b/pkg/aws/eni/types/zz_generated.deepcopy.go
@@ -103,6 +103,11 @@ func (in *ENISpec) DeepCopyInto(out *ENISpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.SubnetIDs != nil {
+		in, out := &in.SubnetIDs, &out.SubnetIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SubnetTags != nil {
 		in, out := &in.SubnetTags, &out.SubnetTags
 		*out = make(map[string]string, len(*in))

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -206,6 +206,23 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 		}
 	}
 
+	if ((in.SubnetIDs != nil) && (other.SubnetIDs != nil)) || ((in.SubnetIDs == nil) != (other.SubnetIDs == nil)) {
+		in, other := &in.SubnetIDs, &other.SubnetIDs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.SubnetTags != nil) && (other.SubnetTags != nil)) || ((in.SubnetTags == nil) != (other.SubnetTags == nil)) {
 		in, other := &in.SubnetTags, &other.SubnetTags
 		if other == nil {

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -179,6 +179,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  subnet-ids:
+                    description: SubnetIDs is the list of subnet ids to use when evaluating
+                      what AWS subnets to use for ENI and IP allocation.
+                    items:
+                      type: string
+                    type: array
                   subnet-tags:
                     additionalProperties:
                       type: string

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -492,6 +492,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 				nodeResource.Spec.ENI.SecurityGroups = c.ENI.SecurityGroups
 			}
 
+			if len(c.ENI.SubnetIDs) > 0 {
+				nodeResource.Spec.ENI.SubnetIDs = c.ENI.SubnetIDs
+			}
+
 			if len(c.ENI.SubnetTags) > 0 {
 				nodeResource.Spec.ENI.SubnetTags = c.ENI.SubnetTags
 			}

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -102,6 +102,9 @@ func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
         "security-groups":[
           "sg-xxx"
         ],
+        "subnet-ids":[
+          "subnet-xxx"
+        ],
         "subnet-tags":{
           "foo":"true"
         }
@@ -120,6 +123,7 @@ func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
 			PreAllocate:         5,
 			FirstInterfaceIndex: &firstInterfaceIndex,
 			SecurityGroups:      []string{"sg-xxx"},
+			SubnetIDs:           []string{"subnet-xxx"},
 			SubnetTags: map[string]string{
 				"foo": "true",
 			},
@@ -138,6 +142,10 @@ func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
     "pre-allocate": 16,
     "first-interface-index": 2,
     "security-groups": [ "sg1", "sg2" ],
+    "subnet-ids":[
+      "subnet-1",
+      "subnet-2"
+    ],
     "subnet-tags": {
       "key1": "val1",
       "key2": "val2"
@@ -158,6 +166,7 @@ func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
 			PreAllocate:         16,
 			FirstInterfaceIndex: &firstInterfaceIndex,
 			SecurityGroups:      []string{"sg1", "sg2"},
+			SubnetIDs:           []string{"subnet-1", "subnet-2"},
 			SubnetTags: map[string]string{
 				"key1": "val1",
 				"key2": "val2",
@@ -183,6 +192,9 @@ func (t *CNITypesSuite) TestReadCNIConfENIv2WithPlugins(c *check.C) {
         "security-groups":[
           "sg-xxx"
         ],
+        "subnet-ids":[
+          "subnet-xxx"
+        ],
         "subnet-tags":{
           "foo":"true"
         }
@@ -203,6 +215,7 @@ func (t *CNITypesSuite) TestReadCNIConfENIv2WithPlugins(c *check.C) {
 		ENI: eniTypes.ENISpec{
 			FirstInterfaceIndex: &firstInterfaceIndex,
 			SecurityGroups:      []string{"sg-xxx"},
+			SubnetIDs:           []string{"subnet-xxx"},
 			SubnetTags: map[string]string{
 				"foo": "true",
 			},


### PR DESCRIPTION
This change permits the configuration of specific `SubnetIDs []string`
as part of the pkg/aws/eni/types.ENISpec. Essentially, it follows
the same principle as what was already in place with SecurityGroups /
SecurityGroupTags.

If `SubnetIDs` is set, it will be considered instead of `SubnetTags`. Here
is an example configuration:

```json
{
  "cniVersion": "0.3.1",
  "name": "cilium",
  "type": "cilium-cni",
  "enable-debug": false,
  "eni": {
    "first-interface-index": 0,
    "pre-allocate": 10,
    "subnet-ids": ["subnet-0661a8d7e35b56e00","subnet-0661a8d7e35b56e01"],
    "subnet-tags": {},
    "security-group-tags": {},
    "security-groups": []
  }
}
```

This will result in the `operator-aws` looking up for subnets matching the
configured list in an exhaustive fashion.

```release-note
pkg/aws/eni: new subnet-ids parameter
```
