### PR TITLE
datapath: optionally disable SIP verification

### DIFF
--- a/api/v1/models/endpoint_datapath_configuration.go
+++ b/api/v1/models/endpoint_datapath_configuration.go
@@ -18,6 +18,10 @@ import (
 // swagger:model EndpointDatapathConfiguration
 type EndpointDatapathConfiguration struct {
 
+	// Disable source IP verification for the endpoint.
+	//
+	DisableSipVerification bool `json:"disable-sip-verification,omitempty"`
+
 	// Indicates that IPAM is done external to Cilium. This will prevent the IP from being released and re-allocation of the IP address is skipped on restore.
 	//
 	ExternalIpam bool `json:"external-ipam,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1203,6 +1203,10 @@ definitions:
           Installs a route in the Linux routing table pointing to the device of
           the endpoint's interface.
         type: boolean
+      disable-sip-verification:
+        description: >
+          Disable source IP verification for the endpoint.
+        type: boolean
   EndpointStatus:
     description: The current state and configuration of the endpoint, its policy & datapath, and subcomponents
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2193,6 +2193,10 @@ func init() {
       "description": "Datapath configuration to be used for the endpoint",
       "type": "object",
       "properties": {
+        "disable-sip-verification": {
+          "description": "Disable source IP verification for the endpoint.\n",
+          "type": "boolean"
+        },
         "external-ipam": {
           "description": "Indicates that IPAM is done external to Cilium. This will prevent the IP from being released and re-allocation of the IP address is skipped on restore.\n",
           "type": "boolean"
@@ -6593,6 +6597,10 @@ func init() {
       "description": "Datapath configuration to be used for the endpoint",
       "type": "object",
       "properties": {
+        "disable-sip-verification": {
+          "description": "Disable source IP verification for the endpoint.\n",
+          "type": "boolean"
+        },
         "external-ipam": {
           "description": "Indicates that IPAM is done external to Cilium. This will prevent the IP from being released and re-allocation of the IP address is skipped on restore.\n",
           "type": "boolean"

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -92,6 +92,10 @@ type CompileTimeConfiguration interface {
 
 	// IsHost returns true if the endpoint is the host endpoint.
 	IsHost() bool
+
+	// DisableSIPVerification returns true if the endpoint wishes to skip
+	// source IP verification
+	DisableSIPVerification() bool
 }
 
 // EndpointConfiguration provides datapath implementations a clean interface

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -732,6 +732,10 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 		fmt.Fprintf(fw, "#define ENABLE_ENDPOINT_ROUTES 1\n")
 	}
 
+	if e.DisableSIPVerification() {
+		fmt.Fprintf(fw, "#define DISABLE_SIP_VERIFICATION 1\n")
+	}
+
 	if !option.Config.EnableHostLegacyRouting && option.Config.DirectRoutingDevice != "" {
 		directRoutingIface := option.Config.DirectRoutingDevice
 		directRoutingIfIndex, err := link.GetIfIndex(directRoutingIface)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1479,6 +1479,12 @@ func (e *Endpoint) RequireEndpointRoute() bool {
 	return e.DatapathConfiguration.InstallEndpointRoute
 }
 
+// DisableSIPVerification returns true if the endpoint wants to skip
+// srcIP verification
+func (e *Endpoint) DisableSIPVerification() bool {
+	return e.DatapathConfiguration.DisableSipVerification
+}
+
 // GetPolicyVerdictLogFilter returns the PolicyVerdictLogFilter that would control
 // the creation of policy verdict logs. Value of VerdictLogFilter needs to be
 // consistent with how it is used in policy_verdict_filter_allow() in bpf/lib/policy_log.h

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -50,6 +50,7 @@ type epInfoCache struct {
 	requireEgressProg                      bool
 	requireRouting                         bool
 	requireEndpointRoute                   bool
+	disableSIPVerification                 bool
 	policyVerdictLogFilter                 uint32
 	cidr4PrefixLengths, cidr6PrefixLengths []int
 	options                                *option.IntOptions
@@ -85,6 +86,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		requireEgressProg:      e.RequireEgressProg(),
 		requireRouting:         e.RequireRouting(),
 		requireEndpointRoute:   e.RequireEndpointRoute(),
+		disableSIPVerification: e.DisableSIPVerification(),
 		policyVerdictLogFilter: e.GetPolicyVerdictLogFilter(),
 		cidr4PrefixLengths:     cidr4,
 		cidr6PrefixLengths:     cidr6,
@@ -193,6 +195,12 @@ func (ep *epInfoCache) RequireRouting() bool {
 // RequireEndpointRoute returns if the endpoint wants a per endpoint route
 func (ep *epInfoCache) RequireEndpointRoute() bool {
 	return ep.requireEndpointRoute
+}
+
+// DisableSIPVerification returns true if the endpoint wants to skip
+// srcIP verification
+func (ep *epInfoCache) DisableSIPVerification() bool {
+	return ep.disableSIPVerification
 }
 
 func (ep *epInfoCache) GetPolicyVerdictLogFilter() uint32 {

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -67,6 +67,7 @@ func (e *TestEndpoint) RequireARPPassthrough() bool                 { return fal
 func (e *TestEndpoint) RequireEgressProg() bool                     { return false }
 func (e *TestEndpoint) RequireRouting() bool                        { return false }
 func (e *TestEndpoint) RequireEndpointRoute() bool                  { return false }
+func (e *TestEndpoint) DisableSIPVerification() bool                { return false }
 func (e *TestEndpoint) GetPolicyVerdictLogFilter() uint32           { return 0xffff }
 func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)        { return nil, nil }
 func (e *TestEndpoint) GetID() uint64                               { return e.Id }


### PR DESCRIPTION
Enable an old datapath option for disabling source IP
verification which prevents IP spoofing. In some cases
it might be beneficial for users to have this option
(for example something like DHCP discover which sends
a packet with srcIP 0.0.0.0).

Signed-off-by: Ondrej Blazek <ondra.blazkuj@gmail.com>

The macro `DISABLE_SIP_VERIFICATION` has been unused,
the new datapath option enables it. 