### PR TITLE
.github: Update docs workflow to checkout v2

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Validate & Build HTML
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           persist-credentials: false
       - uses: docker://cilium/docs-builder:latest


### PR DESCRIPTION
Using checkout v1 resulted in a warning as it does not seem to support persist-credentials.

Fixes: https://github.com/cilium/cilium/issues/16128.