### PR TITLE
bpf: fix iptables masquerading for node -> remote pod traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -211,15 +211,17 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
 			if (ret < 0)
 				return ret;
 		}
-#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
-		/* See IPv4 case for NO_REDIRECT/ENABLE_REDIRECT_FAST comments */
-		skip_redirect = true;
-#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 	}
 #endif /* ENABLE_NODEPORT */
+
+#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
+	/* See IPv4 case for NO_REDIRECT/ENABLE_REDIRECT_FAST comments */
+	if (!from_host)
+		skip_redirect = true;
+#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {
@@ -478,23 +480,25 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			if (ret < 0)
 				return ret;
 		}
-#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
-		/* Without bpf_redirect_neigh() helper, we cannot redirect a
-		 * packet to a local endpoint in the direct routing mode, as
-		 * the redirect bypasses nf_conntrack table. This makes a
-		 * second reply from the endpoint to be MASQUERADEd or to be
-		 * DROP-ed by k8s's "--ctstate INVALID -j DROP" depending via
-		 * which interface it was inputed. With bpf_redirect_neigh()
-		 * we bypass request and reply path in the host namespace and
-		 * do not run into this issue.
-		 */
-		skip_redirect = true;
-#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 	}
 #endif /* ENABLE_NODEPORT */
+
+#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
+	/* Without bpf_redirect_neigh() helper, we cannot redirect a
+	 * packet to a local endpoint in the direct routing mode, as
+	 * the redirect bypasses nf_conntrack table. This makes a
+	 * second reply from the endpoint to be MASQUERADEd or to be
+	 * DROP-ed by k8s's "--ctstate INVALID -j DROP" depending via
+	 * which interface it was inputed. With bpf_redirect_neigh()
+	 * we bypass request and reply path in the host namespace and
+	 * do not run into this issue.
+	 */
+	if (!from_host)
+		skip_redirect = true;
+#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -810,8 +810,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			testHostFirewall(kubectl)
 		})
 
-		// We need to skip this test when using kube-proxy because of #14859.
-		SkipItIf(helpers.DoesNotRunWithKubeProxyReplacement, "With native routing", func() {
+		It("With native routing", func() {
 			options := map[string]string{
 				"hostFirewall": "true",
 				"tunnel":       "disabled",
@@ -827,8 +826,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			testHostFirewall(kubectl)
 		})
 
-		// We need to skip this test when using kube-proxy because of #14859.
-		SkipItIf(helpers.DoesNotRunWithKubeProxyReplacement, "With native routing and endpoint routes", func() {
+		It("With native routing and endpoint routes", func() {
 			options := map[string]string{
 				"hostFirewall":           "true",
 				"tunnel":                 "disabled",


### PR DESCRIPTION
When Cilium runs with KPR, host-firewall or bandwidth manager, it will
try to auto-derive one or more devices to which the bpf_host program is
attached.

This program will, among other things, redirect ingress traffic destined
to a pod to the pod's lxc device using `bpf_redirect()`.

This causes the traffic to bypass the nf_conntrack table, leading to a
situation where traffic leaving the pod after the connection's been
established will be (incorrectly) masqueraded in case Iptables
masquerading is enabled, since the connection is not tracked by
netfilter.

This commit fixes this by skipping `bpf_redirect()` when we detect this
case (i.e. traffic is flowing through bpf_host attached to a physical
device and Cilium has installed Iptables rules which require conntrack).

Fixes: https://github.com/cilium/cilium/issues/14859.
Fixes: https://github.com/cilium/cilium/issues/12205.