### PR TITLE
Adding error checks for ctx_load_bytes.

### DIFF
--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -148,8 +148,10 @@ static __always_inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
 {
 	__u8 hl;
 
-	ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, hop_limit),
-		       &hl, sizeof(hl));
+	if (ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, hop_limit),
+			   &hl, sizeof(hl)) < 0)
+		return DROP_INVALID;
+
 	if (hl <= 1)
 		return 1;
 	hl--;


### PR DESCRIPTION
The function ctx_load_bytes() was being called without checking for return errors.
This could let to a possible evaluation of an uninitialized variable.

Added a verification to drop packets when ctx_load_bytes() returns error.

Signed-off-by: Thales Paiva thales@accuknox.com



Fixes: #16076
