### PR TITLE
docs: Delete old CRD create by ACK CNI

### DIFF
--- a/Documentation/gettingstarted/alibabacloud-eni.rst
+++ b/Documentation/gettingstarted/alibabacloud-eni.rst
@@ -57,6 +57,25 @@ the list below has to be deleted to prevent conflicts.
 
    kubectl -n kube-system delete daemonset <terway>
 
+The next step is to remove CRD below created by ``terway*`` CNI
+
+.. code-block:: shell-session
+
+    kubectl delete crd \
+        ciliumclusterwidenetworkpolicies.cilium.io \
+        ciliumendpoints.cilium.io \
+        ciliumidentities.cilium.io \
+        ciliumnetworkpolicies.cilium.io \
+        ciliumnodes.cilium.io \
+        bgpconfigurations.crd.projectcalico.org \
+        clusterinformations.crd.projectcalico.org \
+        felixconfigurations.crd.projectcalico.org \
+        globalnetworkpolicies.crd.projectcalico.org \
+        globalnetworksets.crd.projectcalico.org \
+        hostendpoints.crd.projectcalico.org \
+        ippools.crd.projectcalico.org \
+        networkpolicies.crd.projectcalico.org
+
 
 Create AlibabaCloud Secrets
 ===========================


### PR DESCRIPTION
Add step to delete crd created by ACK CNI.

This is needed for v1.10.