### PR TITLE
docs: Revert host firewall to beta for kube-proxy setups

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -84,7 +84,7 @@ cilium-agent [flags]
       --enable-external-ips                                  Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
       --enable-health-check-nodeport                         Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
       --enable-health-checking                               Enable connectivity health checking (default true)
-      --enable-host-firewall                                 Enable host network policies
+      --enable-host-firewall                                 Enable host network policies (beta when using kube-proxy)
       --enable-host-legacy-routing                           Enable the legacy host forwarding model which does not bypass upper stack in host namespace
       --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
       --enable-host-reachable-services                       Enable reachability of services for host applications

--- a/Documentation/gettingstarted/host-firewall.rst
+++ b/Documentation/gettingstarted/host-firewall.rst
@@ -6,12 +6,20 @@
 
 .. _host_firewall:
 
-*************
-Host Firewall
-*************
+******************************************
+Host Firewall (beta when using kube-proxy)
+******************************************
 
 This document serves as an introduction to Cilium's host firewall, to enforce
 security policies for Kubernetes nodes.
+
+.. note::
+
+    The host firewall is a beta feature when running without our kube-proxy
+    replacement. In particular, two bugs need to be addressed before we can
+    consider this feature stable: :gh-issue:`12205` and :gh-issue:`14859`.
+    Please provide feedback and file a GitHub issue if you experience any
+    problems.
 
 Enable the Host Firewall in Cilium
 ==================================

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -631,7 +631,7 @@ func init() {
 	flags.Bool(option.EnableIdentityMark, true, "Enable setting identity mark for local traffic")
 	option.BindEnv(option.EnableIdentityMark)
 
-	flags.Bool(option.EnableHostFirewall, false, "Enable host network policies")
+	flags.Bool(option.EnableHostFirewall, false, "Enable host network policies (beta when using kube-proxy)")
 	option.BindEnv(option.EnableHostFirewall)
 
 	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.")


### PR DESCRIPTION
Two high-impact bugs [1, 2] affecting the host firewall were not resolved in v1.10.0. They affect users running with native routing and without our kube-proxy replacement.

We should therefore consider the host firewall as in beta when running without our kube-proxy replacement.

This commit reverts https://github.com/cilium/cilium/pull/15761.

1 - https://github.com/cilium/cilium/issues/14859
2 - https://github.com/cilium/cilium/issues/12205