### PR TITLE
.github: Set commit status to error when workflow are cancelled

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -282,7 +282,7 @@ jobs:
           sha: ${{ steps.vars.outputs.sha }}
           context: ${{ github.workflow }}
           description: Connectivity test cancelled
-          state: pending
+          state: error
           target_url: ${{ env.check_url }}
 
       - name: Send slack notification

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -262,7 +262,7 @@ jobs:
           sha: ${{ steps.vars.outputs.sha }}
           context: ${{ github.workflow }}
           description: Connectivity test cancelled
-          state: pending
+          state: error
           target_url: ${{ env.check_url }}
 
       - name: Send slack notification

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -275,7 +275,7 @@ jobs:
           sha: ${{ steps.vars.outputs.sha }}
           context: ${{ github.workflow }}
           description: Connectivity test cancelled
-          state: pending
+          state: error
           target_url: ${{ env.check_url }}
 
       - name: Send slack notification

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -335,7 +335,7 @@ jobs:
           sha: ${{ steps.vars.outputs.sha }}
           context: ${{ github.workflow }}
           description: Connectivity test cancelled
-          state: pending
+          state: error
           target_url: ${{ env.check_url }}
 
       - name: Send slack notification

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -296,7 +296,7 @@ jobs:
           sha: ${{ steps.vars.outputs.sha }}
           context: ${{ github.workflow }}
           description: Connectivity test cancelled
-          state: pending
+          state: error
           target_url: ${{ env.check_url }}
 
       - name: Send slack notification


### PR DESCRIPTION
GitHub jobs are usually set to status 'error' when cancelled. We should do the same for ci-xxx jobs when they are cancelled. Having the state appear as an error clarifies that the author, janitor, and reviewers should take notice of that workflow's result.