### PR TITLE
.github: Skip unnecessary workflow steps

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -24,11 +24,42 @@ env:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      - name: Retrieve pull request's base and head
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
+  # When the test-me-please trigger is used, this job is skipped if the only
+  # modified files were under test/ or Documentation/.
   installation-and-connectivity:
+    needs: check_changes
     if: |
       (github.event.issue.pull_request && (
         startsWith(github.event.comment.body, 'ci-aks') ||
-        startsWith(github.event.comment.body, 'test-me-please')
+        (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/aks'

--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -12,6 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-latest
+    outputs:
+      bpf-tree: ${{ steps.changes.outputs.bpf-tree }}
+      coccinelle: ${{ steps.changes.outputs.coccinelle }}
+    steps:
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: changes
+        with:
+          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          filters: |
+            bpf-tree:
+              - 'bpf/**'
+            coccinelle:
+              - 'contrib/coccinelle/**'
+
   checkpatch:
     name: checkpatch
     runs-on: ubuntu-latest
@@ -31,7 +49,11 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # Runs only if code under bpf/ or contrib/coccinnelle/ is changed.
   coccicheck:
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.bpf-tree == 'true' || needs.check_changes.outputs.coccinelle == 'true' }}
     name: coccicheck
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +71,11 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # Runs only if code under bpf/ is changed.
   build_all:
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.bpf-tree == 'true' }}
     name: build datapath
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_commits.yaml
+++ b/.github/workflows/build_commits.yaml
@@ -56,7 +56,28 @@ jobs:
             ${{ github.event.pull_request.commits_url }})
           PR_FIRST_SHA=$(echo "$PR_COMMITS_API_JSON" | jq -r ".[0].sha")
           PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
-          git rebase --exec "make build -j $(nproc) && make -C bpf build_all -j $(nproc)" $PR_PARENT_SHA
+          git rebase --exec "make build -j $(nproc)" $PR_PARENT_SHA
+
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: bpf-tree
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+          filters: |
+            src:
+              - 'bpf/**'
+
+      # Runs only if code under bpf/ is changed.
+      - name: Check if datapath build works for every commit
+        if: steps.bpf-tree.outputs.src == 'true'
+        run: |
+          PR_COMMITS_API_JSON=$(curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            ${{ github.event.pull_request.commits_url }})
+          PR_FIRST_SHA=$(echo "$PR_COMMITS_API_JSON" | jq -r ".[0].sha")
+          PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
+          git rebase --exec "make -C bpf build_all -j $(nproc)" $PR_PARENT_SHA
         
       - name: Failed commit during the build
         if: ${{ failure() }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,10 +2,26 @@ name: Documentation Updates
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - 'Documentation/**'
+      - 'bugtool/cmd/**'
+      - 'cilium/cmd/**'
+      - 'cilium-health/cmd/**'
+      - 'daemon/cmd/**'
+      - 'hubble-relay/cmd/**'
+      - 'operator/cmd/**'
   push:
     branches:
       - master
+    paths:
+      - 'Documentation/**'
+      - 'bugtool/cmd/**'
+      - 'cilium/cmd/**'
+      - 'cilium-health/cmd/**'
+      - 'daemon/cmd/**'
+      - 'hubble-relay/cmd/**'
+      - 'operator/cmd/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -24,11 +24,42 @@ env:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      - name: Retrieve pull request's base and head
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
+  # When the test-me-please trigger is used, this job is skipped if the only
+  # modified files were under test/ or Documentation/.
   installation-and-connectivity:
+    needs: check_changes
     if: |
       (github.event.issue.pull_request && (
         startsWith(github.event.comment.body, 'ci-eks') ||
-        startsWith(github.event.comment.body, 'test-me-please')
+        (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/eks'

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -24,11 +24,42 @@ env:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      - name: Retrieve pull request's base and head
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
+  # When the test-me-please trigger is used, this job is skipped if the only
+  # modified files were under test/ or Documentation/.
   installation-and-connectivity:
+    needs: check_changes
     if: |
       (github.event.issue.pull_request && (
         startsWith(github.event.comment.body, 'ci-gke') ||
-        startsWith(github.event.comment.body, 'test-me-please')
+        (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/gke'

--- a/.github/workflows/kind-1.19.yaml
+++ b/.github/workflows/kind-1.19.yaml
@@ -2,10 +2,16 @@ name: ConformanceKind1.19
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - 'Documentation/**'
+      - 'test/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'Documentation/**'
+      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -25,11 +25,42 @@ env:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      - name: Retrieve pull request's base and head
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
+  # When the test-me-please trigger is used, this job is skipped if the only
+  # modified files were under test/ or Documentation/.
   installation-and-connectivity:
+    needs: check_changes
     if: |
       (github.event.issue.pull_request && (
         startsWith(github.event.comment.body, 'ci-multicluster') ||
-        startsWith(github.event.comment.body, 'test-me-please')
+        (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event.label.name == 'ci-run/multicluster'

--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -2,10 +2,16 @@ name: Smoke Test with IPv6
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - 'Documentation/**'
+      - 'test/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'Documentation/**'
+      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -2,10 +2,16 @@ name: Smoke test
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - 'Documentation/**'
+      - 'test/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'Documentation/**'
+      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}


### PR DESCRIPTION
We increasingly rely on GitHub actions to run tests on pull requests and branches, including long end-to-end tests and per-commit builds. We are however limited to 20 concurrent workflow jobs, with excess jobs being queued. This recently led to issues where long waiting queues can delay releases and pull requests.

This pull request proposes to use the [dorny/paths-filter](https://github.com/dorny/paths-filter) GitHub action to filter unnecessary workflow steps and jobs. This will in particular allow us to skip unnecessary tests when the documentation or the BPF code are not touched by a pull request. It also enables skipping GitHub-based end-to-end tests when only ginkgo-based tests are touched.

For most workflows changed by this pull request, the effect can be seen in the pull request's action. However, workflows triggered by issue comments run the workflow version from `master`. To allow you to see this in action for such workflows, I have merged this pull request in [my fork](https://github.com/pchaigno/cilium) and created three test cases:
- https://github.com/pchaigno/cilium/pull/16, a `Documentation/`-only change.
- https://github.com/pchaigno/cilium/pull/17, a `test/`-only change.
- https://github.com/pchaigno/cilium/pull/18, a random Go change.

I'm happy to create more test cases if needed.