### PR TITLE
examples, connectivity-check, test: Use even-numbered nodePort

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -1478,7 +1478,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1490,7 +1490,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1544,7 +1544,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1556,7 +1556,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1606,7 +1606,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -638,7 +638,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -650,7 +650,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -704,7 +704,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -716,7 +716,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -766,7 +766,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -1002,7 +1002,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -786,7 +786,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -484,7 +484,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -496,7 +496,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -546,7 +546,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -750,7 +750,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -762,7 +762,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -816,7 +816,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -828,7 +828,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -878,7 +878,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -26,7 +26,7 @@ deployment: "echo-b": _echoDeployment & {
 	_serverPort:     "8080"
 	_exposeNodePort: true
 	_exposeHeadless: true
-	_nodePort:       31313
+	_nodePort:       31414
 
 	metadata: labels: component: "services-check"
 	spec: template: spec: containers: [{ports: [{_expose: true, containerPort: 8080, _portName: "http", hostPort: 40000}]}]

--- a/examples/kubernetes/connectivity-check/services.cue
+++ b/examples/kubernetes/connectivity-check/services.cue
@@ -40,7 +40,7 @@ deployment: "pod-to-b-intra-node-hostport": _hostPortDeployment
 // NodePort checks
 _nodePortDeployment: {
 	metadata: labels: component: "nodeport-check"
-	_probeTarget: "echo-b-host-headless:31313"
+	_probeTarget: "echo-b-host-headless:31414"
 }
 deployment: "pod-to-b-multi-node-nodeport": _nodePortDeployment
 deployment: "pod-to-b-intra-node-nodeport": _nodePortDeployment

--- a/examples/policies/host/lock-down-dev-vms-cidr-node.yaml
+++ b/examples/policies/host/lock-down-dev-vms-cidr-node.yaml
@@ -70,14 +70,14 @@ spec:
         name: pod-to-b-intra-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
   - fromEndpoints:
     - matchLabels:
         name: pod-to-b-multi-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
 
 

--- a/examples/policies/host/lock-down-dev-vms-remote-node.yaml
+++ b/examples/policies/host/lock-down-dev-vms-remote-node.yaml
@@ -64,14 +64,14 @@ spec:
         name: pod-to-b-intra-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
   - fromEndpoints:
     - matchLabels:
         name: pod-to-b-multi-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
 
 

--- a/examples/policies/host/lock-down-gke.yaml
+++ b/examples/policies/host/lock-down-gke.yaml
@@ -77,14 +77,14 @@ spec:
         name: pod-to-b-intra-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
   - fromEndpoints:
     - matchLabels:
         name: pod-to-b-multi-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
 
 

--- a/test/k8sT/manifests/policy-stress-test.yaml
+++ b/test/k8sT/manifests/policy-stress-test.yaml
@@ -734,7 +734,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           exec:
             command:
@@ -745,7 +745,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -798,7 +798,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           exec:
             command:
@@ -809,7 +809,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -883,7 +883,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b


### PR DESCRIPTION
Following the same logic as https://github.com/cilium/cilium/pull/15988,
we want to use an even-numbered port to reduce the likelihood that the
underlying kernel allocates a conflicting port for the nodePort.

Fixes: #13071

Signed-off-by: Chris Tarazi <chris@isovalent.com>
