### PR TITLE
test: set kubeProxyReplacement=probe for upstream k8s tests

### DIFF
--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -24,6 +24,7 @@ helm template --validate install/kubernetes/cilium \
   --set ipv4.enabled=true \
   --set ipv6.enabled=true \
   --set identityChangeGracePeriod="0s" \
+  --set kubeProxyReplacement=probe \
   > cilium.yaml
 
 kubectl apply -f cilium.yaml


### PR DESCRIPTION
Running with kube-proxy-replacement=disabled fails e2e tests for k8s
conformance tests. Therefore we should enable kpr until the underlying
issue is fixed.

Signed-off-by: André Martins <andre@cilium.io>

porting from https://github.com/cilium/cilium/pull/16150