### PR TITLE
cilium: Make CLI more graceful on environments with IPv6 disabled

### DIFF
--- a/cilium/cmd/bpf_ct_flush.go
+++ b/cilium/cmd/bpf_ct_flush.go
@@ -51,7 +51,7 @@ func (d dummyEndpoint) GetID() uint64 {
 func flushCt(eID string) {
 	var maps []*ctmap.Map
 	if eID == "global" {
-		maps = ctmap.GlobalMaps(true, true)
+		maps = ctmap.GlobalMaps(true, getIpv6EnableStatus())
 	} else {
 		id, _ := strconv.Atoi(eID)
 		maps = ctmap.LocalMaps(&dummyEndpoint{ID: id}, true, true)

--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -64,7 +64,7 @@ func init() {
 
 func getMaps(eID string) []*ctmap.Map {
 	if eID == "global" {
-		return ctmap.GlobalMaps(true, true)
+		return ctmap.GlobalMaps(true, getIpv6EnableStatus())
 	}
 	id, _ := strconv.Atoi(eID)
 	return ctmap.LocalMaps(&dummyEndpoint{ID: id}, true, true)

--- a/cilium/cmd/bpf_nat_flush.go
+++ b/cilium/cmd/bpf_nat_flush.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func flushNat() {
-	ipv4, ipv6 := nat.GlobalMaps(true, true, true)
+	ipv4, ipv6 := nat.GlobalMaps(true, getIpv6EnableStatus(), true)
 
 	for _, m := range []*nat.Map{ipv4, ipv6} {
 		if m == nil {

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command"
@@ -33,7 +34,7 @@ var bpfNatListCmd = &cobra.Command{
 	Short:   "List all NAT mapping entries",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf nat list")
-		ipv4, ipv6 := nat.GlobalMaps(true, true, true)
+		ipv4, ipv6 := nat.GlobalMaps(true, getIpv6EnableStatus(), true)
 		globalMaps := make([]interface{}, 2)
 		globalMaps[0] = ipv4
 		globalMaps[1] = ipv6
@@ -50,7 +51,7 @@ func dumpNat(maps []interface{}, args ...interface{}) {
 	entries := make([]nat.NatMapRecord, 0)
 
 	for _, m := range maps {
-		if m == nil {
+		if m == nil || reflect.ValueOf(m).IsNil() {
 			continue
 		}
 		path, err := m.(nat.NatMap).Path()

--- a/cilium/cmd/bpf_recorder_list.go
+++ b/cilium/cmd/bpf_recorder_list.go
@@ -35,7 +35,9 @@ var bpfRecorderListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf recorder list")
 		maps := make([]interface{}, 2)
 		maps[0] = recorder.CaptureMap4
-		maps[1] = recorder.CaptureMap6
+		if getIpv6EnableStatus() {
+			maps[1] = recorder.CaptureMap6
+		}
 		dumpRecorderEntries(maps)
 	},
 }

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -19,13 +19,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
+	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/defaults"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/policymap"
@@ -384,4 +388,32 @@ func dumpConfig(Opts map[string]string) {
 			fmt.Printf("%-24s %s\n", k, "Enabled")
 		}
 	}
+}
+
+// getIpv6EnableStatus api returns the EnableIPv6 status
+// by consulting the cilium-agent otherwise reads from the
+// runtime system config
+func getIpv6EnableStatus() bool {
+	params := daemon.NewGetHealthzParamsWithTimeout(5 * time.Second)
+	brief := true
+	params.SetBrief(&brief)
+	// If cilium-agent is running get the ipv6 enable status
+	if _, err := client.Daemon.GetHealthz(params); err == nil {
+		if resp, err := client.ConfigGet(); err == nil {
+			if resp.Status != nil {
+				return resp.Status.Addressing.IPV6 != nil && resp.Status.Addressing.IPV6.Enabled == true
+			}
+		}
+	} else { // else read the EnableIPv6 status from the file-system
+		agentConfigFile := filepath.Join(defaults.RuntimePath, defaults.StateDir,
+			"agent-runtime-config.json")
+
+		if byteValue, err := os.ReadFile(agentConfigFile); err == nil {
+			if err = json.Unmarshal(byteValue, &option.Config); err == nil {
+				return option.Config.EnableIPv6
+			}
+		}
+	}
+	// returning the EnableIPv6 default status
+	return defaults.EnableIPv6
 }


### PR DESCRIPTION
cilium: Make CLI more graceful on environments with IPv6 disabled

Description:
Issue: Some CLI's are complaining to stderr even on environments with IPV6 disabled
Root cause: As part of CLI implementation, it is always retrieving the GlobalMaps using true flag irrespective of IPV6 is enabled/disabled
Suggested fix: Now, GlobalMaps are based on correct IPV6 status from the cilium-agent else read from the system config (absence of agent)

Affected CLIs:
```
    $ cilium bpf ct ...
    $ cilium bpf nat ...
    $ cilium bpf recorder ...
```

Fixes: #13834

Signed-off-by: Mahadev Panchal <mahadev.panchal@accuknox.com>

