### PR TITLE
v1.9 backports 2021-05-17

### DIFF
--- a/Documentation/gettingstarted/host-firewall.rst
+++ b/Documentation/gettingstarted/host-firewall.rst
@@ -22,7 +22,7 @@ Enable the Host Firewall in Cilium
 
 Deploy Cilium release via Helm:
 
-.. parsed-literal ::
+.. parsed-literal::
 
     helm install cilium |CHART_RELEASE|        \\
       --namespace kube-system                  \\
@@ -101,7 +101,7 @@ the outside of the cluster, except if those pods are host-networking pods.
 
 To apply this policy, run:
 
-.. code-block:: shell-session
+.. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/policies/host/demo-host-policy.yaml
     ciliumclusterwidenetworkpolicy.cilium.io/demo-host-policy created

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -321,7 +321,7 @@ and various network policy combinations.
 To run the connectivity tests create an isolated test namespace called
 ``cilium-test`` to deploy the tests with.
 
-.. code:: bash
+.. parsed-literal::
 
    kubectl create ns cilium-test
    kubectl apply --namespace=cilium-test -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml


### PR DESCRIPTION
* #15963 -- docs: gsg/operations - use parsed-literal for all blocks referring SCM_WEB (@ti-mo)
  * Applied cleanly

Once this PR is merged, you can update the PR labels via:

```upstream-prs
$ for pr in 15963; do contrib/backporting/set-labels.py $pr done 1.9; done
```