### PR TITLE
wireguard: Fix traffic counters in `cilium debuginfo`

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -489,6 +489,8 @@ func (a *Agent) Status(withPeers bool) (*models.WireguardStatus, error) {
 				Endpoint:          p.Endpoint.String(),
 				LastHandshakeTime: strfmt.DateTime(p.LastHandshakeTime),
 				AllowedIps:        allowedIPs,
+				TransferTx:        p.TransmitBytes,
+				TransferRx:        p.ReceiveBytes,
 			}
 			peers = append(peers, peer)
 		}


### PR DESCRIPTION
Wireguard keeps track of the traffic sent and receive for each peer. We
print this information in `cilium debuginfo`. Because the agent failed
to populate them the JSON response, the counters were always wrongly
reported as zero.