### PR TITLE
daemon: Don't auto disable session affinity

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1214,10 +1214,15 @@ if needed.
 The source for the affinity depends on the origin of a request. If a request is
 sent from outside the cluster to the service, the request's source IP address is
 used for determining the endpoint affinity. If a request is sent from inside
-the cluster, the client's network namespace cookie is used. The latter was introduced
-in the 5.7 Linux kernel to implement the affinity at the socket layer at which
-:ref:`host-services` operate (a source IP is not available there, as the endpoint
-selection happens before a network packet has been built by the kernel).
+the cluster, then the source depends on whether the :ref:`host-services` feature
+is used to load balance ClusterIP services. If yes, then the client's network
+namespace cookie is used as the source. The latter was introduced in the 5.7
+Linux kernel to implement the affinity at the socket layer at which
+:ref:`host-services` operate (a source IP is not available there, as the
+endpoint selection happens before a network packet has been built by the
+kernel). If :ref:`host-services` is not used (i.e. the loadbalancing is done
+at the pod network interface, on a per-packet basis), then the request's source
+IP address is used as the source.
 
 The session affinity support is enabled by default for Cilium's kube-proxy
 replacement. For users who run on older kernels which do not support the network
@@ -1232,6 +1237,13 @@ given service sent from the same source and to the same service port will be rou
 to the same service endpoints; but two requests for the same service, sent from
 the same source but to different service ports may be routed to distinct service
 endpoints.
+
+For users who run with kube-proxy (i.e. with Cilium's kube-proxy replacement
+disabled), the ClusterIP service loadbalancing when a request is sent from a pod
+running in a non-host network namespace is still performed at the pod network
+interface (until `GH#16197 <https://github.com/cilium/cilium/issues/16197>`__ is
+fixed).  For this case the session affinity support is disabled by default. To
+enable the feature, set ``config.sessionAffinity=true``.
 
 kube-proxy Replacement Health Check server
 ******************************************

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -229,24 +229,25 @@ additional kernel features continues to progress in the Linux community. Some
 of Cilium's features are dependent on newer kernel versions and are thus
 enabled by upgrading to more recent kernel versions as detailed below.
 
-=========================================== ===============================
-Cilium Feature                              Minimum Kernel Version
-=========================================== ===============================
-:ref:`concepts_fragmentation`               >= 4.10
-:ref:`cidr_limitations`                     >= 4.11
-:ref:`encryption_ipsec` in tunneling mode   >= 4.19
-:ref:`encryption_wg`                        >= 5.6
-:ref:`host-services`                        >= 4.19.57, >= 5.1.16,  >= 5.2
-:ref:`kubeproxy-free`                       >= 4.19.57, >= 5.1.16,  >= 5.2
-:ref:`bandwidth-manager`                    >= 5.1
-:ref:`local-redirect-policy`                >= 4.19.57, >= 5.1.16,  >= 5.2
-Full support for :ref:`session-affinity`    >= 5.7
-BPF-based proxy redirection                 >= 5.7
-BPF-based host routing                      >= 5.10
-Socket-level LB bypass in pod netns         >= 5.7
-:ref:`egress-gateway`                       >= 5.2
-VXLAN Tunnel Endpoint (VTEP) Integration    >= 5.2
-=========================================== ===============================
+====================================================== 	===============================
+Cilium Feature                                          Minimum Kernel Version
+====================================================== 	===============================
+:ref:`concepts_fragmentation`				>= 4.10
+:ref:`cidr_limitations`                     		>= 4.11
+:ref:`encryption_ipsec` in tunneling mode   		>= 4.19
+:ref:`encryption_wg`                        		>= 5.6
+:ref:`host-services`                        		>= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`kubeproxy-free`                       		>= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`bandwidth-manager`                    		>= 5.1
+:ref:`local-redirect-policy`				>= 4.19.57, >= 5.1.16,  >= 5.2
+Full support for :ref:`session-affinity`		>= 5.7
+:ref:`session-affinity` for kube-proxy ClusterIP	>= 4.10
+BPF-based proxy redirection				>= 5.7
+BPF-based host routing                      		>= 5.10
+Socket-level LB bypass in pod netns         		>= 5.7
+:ref:`egress-gateway`                       		>= 5.2
+VXLAN Tunnel Endpoint (VTEP) Integration    		>= 5.2
+====================================================== 	===============================
 
 .. _req_kvstore:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -347,6 +347,11 @@ Annotations:
   removed once the upgrade is complete. Backward compatibility will be maintained when
   ``upgradeCompatibility`` is set on the helm chart.
 
+* The ``sessionAffinity`` has to be set to ``true`` in order to enable the
+  feature when running with the ``kubeProxyReplacement=partial``. Previously,
+  the feature was automatically enabled for the ``partial`` when
+  ``upgradeCompatibility`` was not set or it was set to ``>= 1.8``.
+
 New Options
 ~~~~~~~~~~~
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -51,16 +51,22 @@ func initKubeProxyReplacementOptions() (bool, error) {
 	}
 
 	if option.Config.KubeProxyReplacement == option.KubeProxyReplacementDisabled {
-		log.Infof("Auto-disabling %q, %q, %q, %q, %q features and falling back to %q",
+		log.Infof("Auto-disabling %q, %q, %q, %q features and falling back to %q",
 			option.EnableNodePort, option.EnableExternalIPs,
 			option.EnableHostReachableServices, option.EnableHostPort,
-			option.EnableSessionAffinity, option.EnableHostLegacyRouting)
+			option.EnableHostLegacyRouting)
 
 		disableNodePort()
 		option.Config.EnableHostReachableServices = false
 		option.Config.EnableHostServicesTCP = false
 		option.Config.EnableHostServicesUDP = false
-		option.Config.EnableSessionAffinity = false
+
+		if option.Config.EnableSessionAffinity {
+			probesManager := probes.NewProbeManager()
+			if err := disableSessionAffinityIfNeeded(probesManager, true); err != nil {
+				return false, err
+			}
+		}
 
 		return false, nil
 	}
@@ -301,18 +307,10 @@ func initKubeProxyReplacementOptions() (bool, error) {
 		option.Config.EnableHostServicesUDP = false
 	}
 
-	if option.Config.EnableSessionAffinity {
-		if !probesManager.GetMapTypes().HaveLruHashMapType {
-			msg := "SessionAffinity feature requires BPF LRU maps"
-			if strict {
-				return false, fmt.Errorf(msg)
-			} else {
-				log.Warnf("%s. Disabling the feature.", msg)
-				option.Config.EnableSessionAffinity = false
-			}
-
-		}
+	if err := disableSessionAffinityIfNeeded(probesManager, strict); err != nil {
+		return false, err
 	}
+
 	if option.Config.EnableSessionAffinity && option.Config.EnableHostReachableServices {
 		found1, found2 := false, false
 		if h := probesManager.GetHelpers("cgroup_sock"); h != nil {
@@ -798,4 +796,19 @@ func hasFullHostReachableServices() bool {
 	return option.Config.EnableHostReachableServices &&
 		option.Config.EnableHostServicesTCP &&
 		option.Config.EnableHostServicesUDP
+}
+
+func disableSessionAffinityIfNeeded(probesManager *probes.ProbeManager, strict bool) error {
+	if option.Config.EnableSessionAffinity {
+		if !probesManager.GetMapTypes().HaveLruHashMapType {
+			msg := "SessionAffinity feature requires BPF LRU maps"
+			if strict {
+				return fmt.Errorf(msg)
+			} else {
+				log.Warnf("%s. Disabling the feature.", msg)
+				option.Config.EnableSessionAffinity = false
+			}
+		}
+	}
+	return nil
 }

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -6,7 +6,6 @@
 {{- $defaultBpfClockProbe := "false" -}}
 {{- $defaultBpfTProxy := "false" -}}
 {{- $defaultIPAM := "cluster-pool" -}}
-{{- $defaultSessionAffinity := "false" -}}
 {{- $defaultOperatorApiServeAddr := "localhost:9234" -}}
 {{- $defaultBpfCtTcpMax := 524288 -}}
 {{- $defaultBpfCtAnyMax := 262144 -}}
@@ -23,7 +22,6 @@
   {{- $defaultBpfMasquerade = "true" -}}
   {{- $defaultBpfClockProbe = "true" -}}
   {{- $defaultIPAM = "cluster-pool" -}}
-  {{- $defaultSessionAffinity = "true" -}}
   {{- if .Values.ipv4.enabled }}
     {{- $defaultOperatorApiServeAddr = "127.0.0.1:9234" -}}
   {{- else -}}
@@ -635,8 +633,6 @@ data:
 {{- end }}
 {{- if .Values.sessionAffinity }}
   enable-session-affinity: {{ .Values.sessionAffinity | quote }}
-{{- else if eq $defaultSessionAffinity "true" }}
-  enable-session-affinity: {{ $defaultSessionAffinity | quote }}
 {{- end }}
 {{- if .Values.svcSourceRangeCheck }}
   enable-svc-source-range-check: {{ .Values.svcSourceRangeCheck | quote }}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2455,6 +2455,11 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 	}
 
+	if RunsOn419OrLaterKernel() {
+		// To enable SA for both cases when KPR is enabled and disabled
+		addIfNotOverwritten(options, "sessionAffinity", "true")
+	}
+
 	// Disable unsupported features that will just generated unnecessary
 	// warnings otherwise.
 	if DoesNotRunOn419OrLaterKernel() {


### PR DESCRIPTION
This commit doesn't auto disable the session affinity feature when KPR
is disabled.

The session affinity doesn't depend on KPR for a ClusterIP service
translation in a pod netns implemented in bpf_lxc (the host netns case
should be covered by kube-proxy's rules). Therefore, we should allow
users to choose whether the feature should be enabled.

Note, that we don't enable the feature by default, as it might increase
bpf_lxc complexity.

Ref #16163.