### PR TITLE
docs: ENIs should not be managed by the OS

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -629,6 +629,7 @@ netfilter
 netperf
 netsec
 netvsc
+networkd
 networkpolicy
 newproto
 newprotoparser


### PR DESCRIPTION
When ENIs are managed by services such as NetworkManager or
systemd-networkd, it can happen that they interfere with Cilium's
configuration. For example, systemd-networkd can remove the ENI IP
assigned by Cilium if the carrier is temporarily down, thus breaking
SNAT.

We previously had a similar section regarding NetworkManager and DHCP in
the EKS installation guide, but the EKS guide has since been replaced by
the Cilium CLI installation guide.

This section here therefore acts as a replacement and states that the
devices need to be unmanaged (e.g. disabling DHCP is not enough for
systemd-networkd).
