### PR TITLE
Make LRP restore test logic robust and optimized

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -757,8 +757,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			}
 
 			var wg sync.WaitGroup
-			wg.Add(len(testCases))
 			for _, testCase := range testCases {
+				wg.Add(1)
 				go func(tc lrpTestCase) {
 					defer GinkgoRecover()
 					defer wg.Done()
@@ -816,9 +816,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			}
 
 			var wg sync.WaitGroup
-			wg.Add(len(testCases) * 2)
 			for _, testCase := range testCases {
 				for _, name := range []string{be1Name, be2Name} {
+					wg.Add(1)
 					go func(tc lrpTestCase, want string) {
 						defer GinkgoRecover()
 						defer wg.Done()


### PR DESCRIPTION
The goal of the test is to check if `curl` to a clusterIP svc endpoint is redirected to both the backends when the original svc entry is restored upon LRP removal. The current test logic expects the same backend should be selected for all the pod clients simultaneously, and this can lengthen test duration. This doesn't seem right since backend selection is not exactly deterministic. More importantly, we only need both backends to be selected at least once for all the client pods.

Flip the order in which we loop over backends and client pods.  Loop over client pods first, and then making curl calls to until we hit both the backends on each of the client pods. Also, keep state about which backends have been successfully tested in order to avoid making some of the duplicate `curl` calls, and make the test logic deterministic.

More details - https://github.com/cilium/cilium/issues/16154#issuecomment-842688720.

Deferred to a follow-up PR - Looking at the LRP [test case](https://github.com/cilium/cilium/blob/master/test/k8sT/Services.go#L773) where we check if traffic only goes to the local backend, it doesn't seem reliable since it's possible that the curl request that the test made wasn't redirected to the remote backend by chance. I think the reliable way to validate the correctness is to check for a `LocalRedirect` service entry and its corresponding backends in the `cilium service list `.


Fixes: #16154