### PR TITLE
.github: Cancel outdated GitHub workflows

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,5 +1,6 @@
 name: ConformanceAKS (ci-aks)
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   issue_comment:
     types:
@@ -12,6 +13,10 @@ on:
   #  types:
   #    - "labeled"
   ###
+
+concurrency:
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  cancel-in-progress: true
 
 env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}

--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -1,10 +1,15 @@
 name: BPF checks
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 jobs:
   checkpatch:

--- a/.github/workflows/build_commits.yaml
+++ b/.github/workflows/build_commits.yaml
@@ -1,6 +1,11 @@
 name: build_commits
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build_commits:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,10 +1,15 @@
 name: Documentation Updates
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 jobs:
   build-html:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,5 +1,6 @@
 name: ConformanceEKS (ci-eks)
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   issue_comment:
     types:
@@ -12,6 +13,10 @@ on:
   #  types:
   #    - "labeled"
   ###
+
+concurrency:
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  cancel-in-progress: true
 
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,5 +1,6 @@
 name: ConformanceGKE (ci-gke)
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   issue_comment:
     types:
@@ -12,6 +13,10 @@ on:
   #  types:
   #    - "labeled"
   ###
+
+concurrency:
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  cancel-in-progress: true
 
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}

--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -1,10 +1,15 @@
 name: Go-related checks
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 jobs:
   go-mod:

--- a/.github/workflows/images-legacy-base-releases.yaml
+++ b/.github/workflows/images-legacy-base-releases.yaml
@@ -1,5 +1,6 @@
 name: Base Image Release Build
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request_target:
     types:
@@ -9,6 +10,10 @@ on:
     paths:
       - images/runtime/**
       - images/builder/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build-and-push:

--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -1,5 +1,6 @@
 name: Image CI Build
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request_target:
     types:
@@ -9,6 +10,10 @@ on:
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 jobs:
   build-and-push-prs:

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,4 +1,6 @@
 name: Images
+
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -9,6 +11,10 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/kind-1.19.yaml
+++ b/.github/workflows/kind-1.19.yaml
@@ -1,10 +1,15 @@
 name: ConformanceKind1.19
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 env:
   kind_version: v0.9.0

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -1,5 +1,6 @@
 name: Multicluster / Cluster mesh (ci-multicluster)
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   issue_comment:
     types:
@@ -12,6 +13,10 @@ on:
   #  types:
   #    - "labeled"
   ###
+
+concurrency:
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  cancel-in-progress: true
 
 env:
   clusterName1: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-1

--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -1,10 +1,15 @@
 name: Smoke Test with IPv6
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
 
 env:
   KIND_VERSION: v0.9.0

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,10 +1,16 @@
 name: Smoke test
 
+# Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request: {}
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 env:
   KIND_VERSION: v0.9.0
   KIND_CONFIG: .github/kind-config.yaml


### PR DESCRIPTION
We increasingly rely on GitHub actions to run tests on pull requests and branches, including long end-to-end tests and per-commit builds. We are however limited to 20 concurrent workflow jobs, with excess jobs being queued. This recently led to issues where long waiting queues can delay releases and pull requests.

Looking at our queue of running jobs reveals an opportunity to eliminate unnecessary jobs. When updating a pull request, workflows associated with the previous version continue to run if they were not finished (and even if they didn't start yet). This can happen often as contributors notice a quick job failing and push an update version. 

A way to prevent that and cancel outdated workflows is to use [concurrency groups](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/). We can define concurrency groups such that scheduling of a new job in a group will cancel all previously scheduled jobs in the same group.

A concurrency group is defined by its name. It is therefore simply a matter of defining a unique group name for each pull request. At the same time, we should ensure that jobs triggered by schedule or commit push also have a unique group name (if all commits share the same group name, each new push will cancel all jobs for previous commits).

The effect of the concurrency groups can be observed with workflows scheduled by previous versions of this pull request. For example:
- https://github.com/cilium/cilium/actions/runs/852871612
- https://github.com/cilium/cilium/actions/runs/852871620