### PR TITLE
byteorder: Simplify byteorder package

### DIFF
--- a/bpf/tests/prog_test/prog_test.go
+++ b/bpf/tests/prog_test/prog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -161,8 +161,8 @@ func testMap(spec *ebpf.Collection) error {
 			TupleKey4: tuple.TupleKey4{
 				SourceAddr: types.IPv4{1, 1, 1, 1},
 				DestAddr:   types.IPv4{1, 1, 1, 2},
-				SourcePort: byteorder.HostToNetwork(uint16(1001)).(uint16),
-				DestPort:   byteorder.HostToNetwork(uint16(1002)).(uint16),
+				SourcePort: byteorder.HostToNetwork16(1001),
+				DestPort:   byteorder.HostToNetwork16(1002),
 				NextHeader: 0,
 				Flags:      0,
 			},
@@ -429,8 +429,8 @@ func testCt4Rst(spec *ebpf.Collection) error {
 			TupleKey4: tuple.TupleKey4{
 				SourceAddr: types.IPv4{10, 3, 0, 20},
 				DestAddr:   types.IPv4{10, 3, 0, 10},
-				SourcePort: byteorder.HostToNetwork(uint16(3010)).(uint16),
-				DestPort:   byteorder.HostToNetwork(uint16(3020)).(uint16),
+				SourcePort: byteorder.HostToNetwork16(3010),
+				DestPort:   byteorder.HostToNetwork16(3020),
 				NextHeader: 6,
 				Flags:      0,
 			},

--- a/cilium/cmd/bpf_ct_list_test.go
+++ b/cilium/cmd/bpf_ct_list_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,8 +45,8 @@ var (
 		TupleKey4: tuple.TupleKey4{
 			DestAddr:   types.IPv4{10, 10, 10, 1},
 			SourceAddr: types.IPv4{10, 10, 10, 2},
-			DestPort:   byteorder.HostToNetwork(uint16(80)).(uint16),
-			SourcePort: byteorder.HostToNetwork(uint16(13579)).(uint16),
+			DestPort:   byteorder.HostToNetwork16(80),
+			SourcePort: byteorder.HostToNetwork16(13579),
 			NextHeader: 6,
 			Flags:      123,
 		},
@@ -55,8 +55,8 @@ var (
 		TupleKey6: tuple.TupleKey6{
 			DestAddr:   types.IPv6{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			SourceAddr: types.IPv6{1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 121, 98, 219, 61},
-			DestPort:   byteorder.HostToNetwork(uint16(443)).(uint16),
-			SourcePort: byteorder.HostToNetwork(uint16(7878)).(uint16),
+			DestPort:   byteorder.HostToNetwork16(443),
+			SourcePort: byteorder.HostToNetwork16(7878),
 			NextHeader: 17,
 			Flags:      31,
 		},
@@ -68,7 +68,7 @@ var (
 		TxBytes:          2048,
 		Lifetime:         12345,
 		Flags:            3,
-		RevNAT:           byteorder.HostToNetwork(uint16(27)).(uint16),
+		RevNAT:           byteorder.HostToNetwork16(27),
 		TxFlagsSeen:      88,
 		RxFlagsSeen:      99,
 		SourceSecurityID: 6789,

--- a/cilium/cmd/bpf_nat_list_test.go
+++ b/cilium/cmd/bpf_nat_list_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@ var (
 			TupleKey4: tuple.TupleKey4{
 				DestAddr:   types.IPv4{10, 10, 10, 1},
 				SourceAddr: types.IPv4{10, 10, 10, 2},
-				DestPort:   byteorder.HostToNetwork(uint16(80)).(uint16),
-				SourcePort: byteorder.HostToNetwork(uint16(13579)).(uint16),
+				DestPort:   byteorder.HostToNetwork16(80),
+				SourcePort: byteorder.HostToNetwork16(13579),
 				NextHeader: 6,
 				Flags:      123,
 			},
@@ -51,8 +51,8 @@ var (
 			TupleKey6: tuple.TupleKey6{
 				DestAddr:   types.IPv6{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 				SourceAddr: types.IPv6{1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 121, 98, 219, 61},
-				DestPort:   byteorder.HostToNetwork(uint16(443)).(uint16),
-				SourcePort: byteorder.HostToNetwork(uint16(7878)).(uint16),
+				DestPort:   byteorder.HostToNetwork16(443),
+				SourcePort: byteorder.HostToNetwork16(7878),
 				NextHeader: 17,
 				Flags:      31,
 			},
@@ -62,13 +62,13 @@ var (
 		Created:   12345,
 		HostLocal: 6789,
 		Addr:      types.IPv4{10, 10, 10, 3},
-		Port:      byteorder.HostToNetwork(uint16(53)).(uint16),
+		Port:      byteorder.HostToNetwork16(53),
 	}
 	natValue6 = nat.NatEntry6{
 		Created:   12345,
 		HostLocal: 6789,
 		Addr:      types.IPv6{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53},
-		Port:      byteorder.HostToNetwork(uint16(53)).(uint16),
+		Port:      byteorder.HostToNetwork16(53),
 	}
 )
 

--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -159,13 +159,13 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 		trafficDirectionString := trafficDirection.String()
 		port := models.PortProtocolANY
 		if stat.Key.DestPort != 0 {
-			dport := byteorder.NetworkToHost(stat.Key.DestPort).(uint16)
+			dport := byteorder.NetworkToHost16(stat.Key.DestPort)
 			proto := u8proto.U8proto(stat.Key.Nexthdr)
 			port = fmt.Sprintf("%d/%s", dport, proto.String())
 		}
 		proxyPort := "NONE"
 		if stat.ProxyPort != 0 {
-			proxyPort = strconv.FormatUint(uint64(byteorder.NetworkToHost(stat.ProxyPort).(uint16)), 10)
+			proxyPort = strconv.FormatUint(uint64(byteorder.NetworkToHost16(stat.ProxyPort)), 10)
 		}
 		var policyStr string
 		if policymap.PolicyEntryFlags(stat.Flags).IsDeny() {

--- a/pkg/byteorder/byteorder.go
+++ b/pkg/byteorder/byteorder.go
@@ -15,42 +15,13 @@
 package byteorder
 
 import (
-	"encoding/binary"
-	"fmt"
-	"reflect"
+	"net"
 )
 
-// reverse returns a reversed slice of b.
-func reverse(b []byte) []byte {
-	size := len(b)
-	c := make([]byte, size)
-
-	for i, j := size-1, 0; i >= 0; i, j = i-1, j+1 {
-		c[j] = b[i]
-	}
-
-	return c
-}
-
-// HostSliceToNetwork converts b to the networking byte order.
-func HostSliceToNetwork(b []byte, t reflect.Kind) interface{} {
-	switch t {
-	case reflect.Uint32:
-		if Native != binary.BigEndian {
-			return binary.BigEndian.Uint32(reverse(b))
-		}
-		return binary.BigEndian.Uint32(b)
-	case reflect.Uint16:
-		if Native != binary.BigEndian {
-			return binary.BigEndian.Uint16(reverse(b))
-		}
-		return binary.BigEndian.Uint16(b)
-	default:
-		panic(unsupported(t))
-	}
-}
-
-// unsupported returns a string to used for debugging unhandled types.
-func unsupported(field interface{}) string {
-	return fmt.Sprintf("unsupported type(%v): %v", reflect.TypeOf(field).Kind(), field)
+// NetIPv4ToHost32 converts an net.IP to a uint32 in host byte order. ip
+// must be a IPv4 address, otherwise the function will panic.
+func NetIPv4ToHost32(ip net.IP) uint32 {
+	ipv4 := ip.To4()
+	_ = ipv4[3] // Assert length of ipv4.
+	return Native.Uint32(ipv4)
 }

--- a/pkg/byteorder/byteorder.go
+++ b/pkg/byteorder/byteorder.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,41 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"reflect"
-	"unsafe"
 )
-
-// Native is set to the host ByteOrder type. This should normally be either
-// BigEndian or LittleEndian.
-var Native = getNativeEndian()
-var nativeEndian binary.ByteOrder
-
-func getNativeEndian() binary.ByteOrder {
-	if nativeEndian == nil {
-		var x uint32 = 0x01020304
-		if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
-			nativeEndian = binary.BigEndian
-		} else {
-			nativeEndian = binary.LittleEndian
-		}
-	}
-	return nativeEndian
-}
-
-// Byte swap a 16 bit value if we aren't big endian
-func swap16(i uint16) uint16 {
-	if Native == binary.BigEndian {
-		return i
-	}
-	return (i&0xff00)>>8 | (i&0xff)<<8
-}
-
-// Byte swap a 32 bit value if aren't big endian
-func swap32(i uint32) uint32 {
-	if Native == binary.BigEndian {
-		return i
-	}
-	return (i&0xff000000)>>24 | (i&0xff0000)>>8 | (i&0xff00)<<8 | (i&0xff)<<24
-}
 
 // reverse returns a reversed slice of b.
 func reverse(b []byte) []byte {
@@ -64,30 +30,6 @@ func reverse(b []byte) []byte {
 	}
 
 	return c
-}
-
-// HostToNetwork converts b to the networking byte order.
-func HostToNetwork(b interface{}) interface{} {
-	switch bt := b.(type) {
-	case uint16:
-		return swap16(bt)
-	case uint32:
-		return swap32(bt)
-	default:
-		panic(unsupported(b))
-	}
-}
-
-// NetworkToHost converts n to host byte order.
-func NetworkToHost(n interface{}) interface{} {
-	switch nt := n.(type) {
-	case uint16:
-		return swap16(nt)
-	case uint32:
-		return swap32(nt)
-	default:
-		panic(unsupported(n))
-	}
 }
 
 // HostToNetworkSlice converts b to the networking byte order.

--- a/pkg/byteorder/byteorder.go
+++ b/pkg/byteorder/byteorder.go
@@ -32,42 +32,6 @@ func reverse(b []byte) []byte {
 	return c
 }
 
-// HostToNetworkSlice converts b to the networking byte order.
-func HostToNetworkSlice(b []byte, t reflect.Kind) interface{} {
-	switch t {
-	case reflect.Uint32:
-		return binary.BigEndian.Uint32(b)
-	case reflect.Uint16:
-		return binary.BigEndian.Uint16(b)
-	default:
-		panic(unsupported(b))
-	}
-}
-
-// HostToNetworkPut puts v into b with the networking byte order.
-func HostToNetworkPut(b []byte, v interface{}) {
-	switch reflect.TypeOf(v).Kind() {
-	case reflect.Uint32:
-		binary.BigEndian.PutUint32(b, v.(uint32))
-	case reflect.Uint16:
-		binary.BigEndian.PutUint16(b, v.(uint16))
-	default:
-		panic(unsupported(v))
-	}
-}
-
-// NetworkToHostPut puts v into b with the networking byte order.
-func NetworkToHostPut(b []byte, v interface{}) {
-	switch reflect.TypeOf(v).Kind() {
-	case reflect.Uint32:
-		Native.PutUint32(b, v.(uint32))
-	case reflect.Uint16:
-		Native.PutUint16(b, v.(uint16))
-	default:
-		panic(unsupported(v))
-	}
-}
-
 // HostSliceToNetwork converts b to the networking byte order.
 func HostSliceToNetwork(b []byte, t reflect.Kind) interface{} {
 	switch t {

--- a/pkg/byteorder/byteorder_bigendian.go
+++ b/pkg/byteorder/byteorder_bigendian.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build armbe arm64be mips mips64 ppc64
+
+package byteorder
+
+var Native binary.ByteOrder = binary.BigEndian
+
+func HostToNetwork16(u uint16) uint16 { return u }
+func HostToNetwork32(u uint32) uint32 { return u }
+func NetworkToHost16(u uint16) uint16 { return u }
+func NetworkToHost32(u uint32) uint32 { return u }

--- a/pkg/byteorder/byteorder_littleendian.go
+++ b/pkg/byteorder/byteorder_littleendian.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build 386 amd64 arm arm64 mips64le ppc64le riscv64 wasm
+
+package byteorder
+
+import "encoding/binary"
+
+var Native binary.ByteOrder = binary.LittleEndian
+
+func HostToNetwork16(u uint16) uint16 { return swap16(u) }
+func HostToNetwork32(u uint32) uint32 { return swap32(u) }
+func NetworkToHost16(u uint16) uint16 { return swap16(u) }
+func NetworkToHost32(u uint32) uint32 { return swap32(u) }
+
+func swap16(u uint16) uint16 {
+	return (u&0xff00)>>8 | (u&0xff)<<8
+}
+
+func swap32(u uint32) uint32 {
+	return (u&0xff000000)>>24 | (u&0xff0000)>>8 | (u&0xff00)<<8 | (u&0xff)<<24
+}

--- a/pkg/byteorder/byteorder_test.go
+++ b/pkg/byteorder/byteorder_test.go
@@ -38,20 +38,6 @@ func (b *ByteorderSuite) TestNativeIsInitialized(c *C) {
 	c.Assert(Native, NotNil)
 }
 
-func (b *ByteorderSuite) TestHostToNetworkSlice(c *C) {
-	ip := net.ParseIP("b007::aaaa:bbbb:0:0")
-	c.Assert(HostToNetworkSlice(ip[14:], reflect.Uint16), Equals, uint16(0))
-
-	ip = net.ParseIP("b007::aaaa:bbbb:0:0")
-	c.Assert(HostToNetworkSlice(ip[8:12], reflect.Uint32), Equals, uint32(0xaaaabbbb))
-}
-
-func (b *ByteorderSuite) TestHostToNetworkPutShort(c *C) {
-	ip := net.ParseIP("b007::")
-	HostToNetworkPut(ip[12:14], uint16(0xaabb))
-	c.Assert(HostToNetworkSlice(ip[12:14], reflect.Uint16), Equals, uint16(0xaabb))
-}
-
 func (b *ByteorderSuite) TestHostToNetwork(c *C) {
 	switch Native {
 	case binary.LittleEndian:

--- a/pkg/byteorder/byteorder_test.go
+++ b/pkg/byteorder/byteorder_test.go
@@ -19,7 +19,6 @@ package byteorder
 import (
 	"encoding/binary"
 	"net"
-	"reflect"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -49,7 +48,13 @@ func (b *ByteorderSuite) TestHostToNetwork(c *C) {
 	}
 }
 
-func (b *ByteorderSuite) TestHostSliceToNetworkU32(c *C) {
-	c.Assert(uint32(0x5b810b0a), Equals, HostSliceToNetwork(net.ParseIP("10.11.129.91"), reflect.Uint32).(uint32))
-	c.Assert(uint32(0xd68a0b0a), Equals, HostSliceToNetwork(net.ParseIP("10.11.138.214"), reflect.Uint32).(uint32))
+func (b *ByteorderSuite) TestNetIPv4ToHost32(c *C) {
+	switch Native {
+	case binary.LittleEndian:
+		c.Assert(NetIPv4ToHost32(net.ParseIP("10.11.129.91")), Equals, uint32(0x5b810b0a))
+		c.Assert(NetIPv4ToHost32(net.ParseIP("10.11.138.214")), Equals, uint32(0xd68a0b0a))
+	case binary.BigEndian:
+		c.Assert(NetIPv4ToHost32(net.ParseIP("10.11.129.91")), Equals, uint32(0x0a0b815b))
+		c.Assert(NetIPv4ToHost32(net.ParseIP("10.11.138.214")), Equals, uint32(0x0a0b8ad6))
+	}
 }

--- a/pkg/byteorder/byteorder_test.go
+++ b/pkg/byteorder/byteorder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package byteorder
 
 import (
+	"encoding/binary"
 	"net"
 	"reflect"
 	"testing"
@@ -52,11 +53,14 @@ func (b *ByteorderSuite) TestHostToNetworkPutShort(c *C) {
 }
 
 func (b *ByteorderSuite) TestHostToNetwork(c *C) {
-	c.Assert(HostToNetwork(uint16(0xAABB)), Equals, uint16(0xBBAA),
-		Commentf("TestHostToNetwork failed: HostToNetwork(0xAABB) != 0xBBAA"))
-
-	c.Assert(HostToNetwork(uint32(0xAABBCCDD)), Equals, uint32(0xDDCCBBAA),
-		Commentf("TestHostToNetwork failed: HostToNetwork(0xAABBCCDD) != 0xDDCCBBAA"))
+	switch Native {
+	case binary.LittleEndian:
+		c.Assert(HostToNetwork16(0xAABB), Equals, uint16(0xBBAA))
+		c.Assert(HostToNetwork32(0xAABBCCDD), Equals, uint32(0xDDCCBBAA))
+	case binary.BigEndian:
+		c.Assert(HostToNetwork16(0xAABB), Equals, uint16(0xAABB))
+		c.Assert(HostToNetwork32(0xAABBCCDD), Equals, uint32(0xAABBCCDD))
+	}
 }
 
 func (b *ByteorderSuite) TestHostSliceToNetworkU32(c *C) {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -523,7 +523,7 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 
 func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
 	// Match
-	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
+	port := uint32(byteorder.HostToNetwork16(proxyPort)) << 16
 	ingressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
 	// TPROXY params
 	ingressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
@@ -559,7 +559,7 @@ func (m *IptablesManager) egressProxyRule(cmd, l4Match, markMatch, mark, port, n
 
 func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
 	// Match
-	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
+	port := uint32(byteorder.HostToNetwork16(proxyPort)) << 16
 	egressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
 	// TPROXY params
 	egressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -690,7 +690,7 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 
 	secID := e.GetIdentityLocked().Uint32()
 	fmt.Fprint(fw, defineUint32("SECLABEL", secID))
-	fmt.Fprint(fw, defineUint32("SECLABEL_NB", byteorder.HostToNetwork(secID).(uint32)))
+	fmt.Fprint(fw, defineUint32("SECLABEL_NB", byteorder.HostToNetwork32(secID)))
 	fmt.Fprint(fw, defineUint32("POLICY_VERDICT_LOG_FILTER", e.GetPolicyVerdictLogFilter()))
 
 	epID := uint16(e.GetID())

--- a/pkg/datapath/linux/config/utils.go
+++ b/pkg/datapath/linux/config/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package config
 import (
 	"fmt"
 	"net"
-	"reflect"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/common"
@@ -41,7 +40,7 @@ func defineIPv4(name string, addr []byte) string {
 	if len(addr) != net.IPv4len {
 		return fmt.Sprintf("/* BUG: bad ip define %s %s */\n", name, common.GoArray2C(addr))
 	}
-	nboAddr := byteorder.HostSliceToNetwork(addr, reflect.Uint32).(uint32)
+	nboAddr := byteorder.NetIPv4ToHost32(addr)
 	return defineUint32(name, nboAddr)
 }
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"os"
 	"path"
-	"reflect"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -181,7 +180,7 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade && bpfMasqIPv4Addrs != nil {
 		if option.Config.EnableIPv4 {
 			ipv4 := bpfMasqIPv4Addrs[ifName]
-			opts["IPV4_MASQUERADE"] = byteorder.HostSliceToNetwork(ipv4, reflect.Uint32).(uint32)
+			opts["IPV4_MASQUERADE"] = byteorder.NetIPv4ToHost32(ipv4)
 		}
 	}
 

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -16,7 +16,7 @@ package loader
 
 import (
 	"fmt"
-	"reflect"
+	"net"
 
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -228,7 +228,7 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 		result["LXC_IP_4"] = sliceToBe32(ipv6[12:16])
 	}
 	if ipv4 := ep.IPv4Address(); ipv4 != nil {
-		result["LXC_IPV4"] = byteorder.HostSliceToNetwork(ipv4, reflect.Uint32).(uint32)
+		result["LXC_IPV4"] = byteorder.NetIPv4ToHost32(net.IP(ipv4))
 	}
 
 	mac := ep.GetNodeMAC()

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -197,7 +197,7 @@ func sliceToU16(input []byte) uint16 {
 
 // sliceToBe16 converts the input slice of two bytes to a big-endian uint16.
 func sliceToBe16(input []byte) uint16 {
-	return byteorder.HostToNetwork(sliceToU16(input)).(uint16)
+	return byteorder.HostToNetwork16(sliceToU16(input))
 }
 
 // sliceToU32 converts the input slice of four bytes to a uint32.
@@ -211,7 +211,7 @@ func sliceToU32(input []byte) uint32 {
 
 // sliceToBe32 converts the input slice of four bytes to a big-endian uint32.
 func sliceToBe32(input []byte) uint32 {
-	return byteorder.HostToNetwork(sliceToU32(input)).(uint32)
+	return byteorder.HostToNetwork32(sliceToU32(input))
 }
 
 // elfVariableSubstitutions returns the set of data substitutions that must
@@ -251,7 +251,7 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 
 	identity := ep.GetIdentity().Uint32()
 	result["SECLABEL"] = identity
-	result["SECLABEL_NB"] = byteorder.HostToNetwork(identity).(uint32)
+	result["SECLABEL_NB"] = byteorder.HostToNetwork32(identity)
 	result["POLICY_VERDICT_LOG_FILTER"] = ep.GetPolicyVerdictLogFilter()
 	return result
 

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -1,5 +1,5 @@
 // Copyright 2019 Authors of Hubble
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -679,7 +679,7 @@ func decodeProxyPort(dbg *monitor.DebugCapture) uint32 {
 		switch dbg.SubType {
 		case monitor.DbgCaptureProxyPre,
 			monitor.DbgCaptureProxyPost:
-			return byteorder.NetworkToHost(dbg.Arg1).(uint32)
+			return byteorder.NetworkToHost32(dbg.Arg1)
 		}
 	}
 

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -1,5 +1,5 @@
 // Copyright 2019 Authors of Hubble
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -986,7 +986,7 @@ func TestDebugCapture(t *testing.T) {
 	dbg = monitor.DebugCapture{
 		Type:    api.MessageTypeCapture,
 		SubType: monitor.DbgCaptureProxyPost,
-		Arg1:    byteorder.HostToNetwork(uint32(1234)).(uint32),
+		Arg1:    byteorder.HostToNetwork32(1234),
 	}
 	data, err = testutils.CreateL3L4Payload(dbg)
 	require.NoError(t, err)

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -169,16 +169,16 @@ func (k *CtKey4) NewValue() bpf.MapValue { return &CtEntry{} }
 // ToNetwork converts CtKey4 ports to network byte order.
 func (k *CtKey4) ToNetwork() CtKey {
 	n := *k
-	n.SourcePort = byteorder.HostToNetwork(n.SourcePort).(uint16)
-	n.DestPort = byteorder.HostToNetwork(n.DestPort).(uint16)
+	n.SourcePort = byteorder.HostToNetwork16(n.SourcePort)
+	n.DestPort = byteorder.HostToNetwork16(n.DestPort)
 	return &n
 }
 
 // ToHost converts CtKey ports to host byte order.
 func (k *CtKey4) ToHost() CtKey {
 	n := *k
-	n.SourcePort = byteorder.NetworkToHost(n.SourcePort).(uint16)
-	n.DestPort = byteorder.NetworkToHost(n.DestPort).(uint16)
+	n.SourcePort = byteorder.NetworkToHost16(n.SourcePort)
+	n.DestPort = byteorder.NetworkToHost16(n.DestPort)
 	return &n
 }
 
@@ -592,7 +592,7 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		c.TxFlagsSeen,
 		c.LastTxReport,
 		c.flagsString(),
-		byteorder.NetworkToHost(c.RevNAT),
+		byteorder.NetworkToHost16(c.RevNAT),
 		c.SourceSecurityID,
 		c.IfIndex)
 }

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,14 +127,14 @@ func (k *AffinityMatchKey) ToNetwork() *AffinityMatchKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in
 	// the SVC BPF maps
-	n.RevNATID = byteorder.HostToNetwork(n.RevNATID).(uint16)
+	n.RevNATID = byteorder.HostToNetwork16(n.RevNATID)
 	return &n
 }
 
 // ToHost returns the key in the host byte order
 func (k *AffinityMatchKey) ToHost() *AffinityMatchKey {
 	h := *k
-	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
+	h.RevNATID = byteorder.NetworkToHost16(h.RevNATID)
 	return &h
 }
 

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -158,14 +158,14 @@ func (k *RevNat4Key) GetKey() uint16            { return k.Key }
 // ToNetwork converts RevNat4Key to network byte order.
 func (k *RevNat4Key) ToNetwork() RevNatKey {
 	n := *k
-	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
+	n.Key = byteorder.HostToNetwork16(n.Key)
 	return &n
 }
 
 // ToHost converts RevNat4Key to host byte order.
 func (k *RevNat4Key) ToHost() RevNatKey {
 	h := *k
-	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	h.Key = byteorder.NetworkToHost16(h.Key)
 	return &h
 }
 
@@ -181,14 +181,14 @@ func (v *RevNat4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 // ToNetwork converts RevNat4Value to network byte order.
 func (v *RevNat4Value) ToNetwork() RevNatValue {
 	n := *v
-	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
+	n.Port = byteorder.HostToNetwork16(n.Port)
 	return &n
 }
 
 // ToHost converts RevNat4Value to host byte order.
 func (k *RevNat4Value) ToHost() RevNatValue {
 	h := *k
-	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	h.Port = byteorder.NetworkToHost16(h.Port)
 	return &h
 }
 
@@ -261,14 +261,14 @@ func (k *Service4Key) RevNatValue() RevNatValue {
 
 func (k *Service4Key) ToNetwork() ServiceKey {
 	n := *k
-	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
+	n.Port = byteorder.HostToNetwork16(n.Port)
 	return &n
 }
 
 // ToHost converts Service4Key to host byte order.
 func (k *Service4Key) ToHost() ServiceKey {
 	h := *k
-	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	h.Port = byteorder.NetworkToHost16(h.Port)
 	return &h
 }
 
@@ -320,14 +320,14 @@ func (s *Service4Value) GetBackendID() loadbalancer.BackendID {
 
 func (s *Service4Value) ToNetwork() ServiceValue {
 	n := *s
-	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
+	n.RevNat = byteorder.HostToNetwork16(n.RevNat)
 	return &n
 }
 
 // ToHost converts Service4Value to host byte order.
 func (s *Service4Value) ToHost() ServiceValue {
 	h := *s
-	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	h.RevNat = byteorder.NetworkToHost16(h.RevNat)
 	return &h
 }
 
@@ -385,14 +385,14 @@ func (b *Backend4Value) GetPort() uint16    { return b.Port }
 
 func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v
-	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
+	n.Port = byteorder.HostToNetwork16(n.Port)
 	return &n
 }
 
 // ToHost converts Backend4Value to host byte order.
 func (v *Backend4Value) ToHost() BackendValue {
 	h := *v
-	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	h.Port = byteorder.NetworkToHost16(h.Port)
 	return &h
 }
 

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -87,14 +87,14 @@ func (v *RevNat6Key) GetKey() uint16            { return v.Key }
 // ToNetwork converts RevNat6Key to network byte order.
 func (v *RevNat6Key) ToNetwork() RevNatKey {
 	n := *v
-	n.Key = byteorder.HostToNetwork(n.Key).(uint16)
+	n.Key = byteorder.HostToNetwork16(n.Key)
 	return &n
 }
 
 // ToNetwork converts RevNat6Key to host byte order.
 func (v *RevNat6Key) ToHost() RevNatKey {
 	h := *v
-	h.Key = byteorder.NetworkToHost(h.Key).(uint16)
+	h.Key = byteorder.NetworkToHost16(h.Key)
 	return &h
 }
 
@@ -115,14 +115,14 @@ func (v *RevNat6Value) String() string {
 // ToNetwork converts RevNat6Value to network byte order.
 func (v *RevNat6Value) ToNetwork() RevNatValue {
 	n := *v
-	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
+	n.Port = byteorder.HostToNetwork16(n.Port)
 	return &n
 }
 
 // ToNetwork converts RevNat6Value to Host byte order.
 func (v *RevNat6Value) ToHost() RevNatValue {
 	h := *v
-	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	h.Port = byteorder.NetworkToHost16(h.Port)
 	return &h
 }
 
@@ -182,14 +182,14 @@ func (k *Service6Key) RevNatValue() RevNatValue {
 
 func (k *Service6Key) ToNetwork() ServiceKey {
 	n := *k
-	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
+	n.Port = byteorder.HostToNetwork16(n.Port)
 	return &n
 }
 
 // ToHost converts Service6Key to host byte order.
 func (k *Service6Key) ToHost() ServiceKey {
 	h := *k
-	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	h.Port = byteorder.NetworkToHost16(h.Port)
 	return &h
 }
 
@@ -240,14 +240,14 @@ func (s *Service6Value) GetBackendID() loadbalancer.BackendID {
 
 func (s *Service6Value) ToNetwork() ServiceValue {
 	n := *s
-	n.RevNat = byteorder.HostToNetwork(n.RevNat).(uint16)
+	n.RevNat = byteorder.HostToNetwork16(n.RevNat)
 	return &n
 }
 
 // ToHost converts Service6Value to host byte order.
 func (s *Service6Value) ToHost() ServiceValue {
 	h := *s
-	h.RevNat = byteorder.NetworkToHost(h.RevNat).(uint16)
+	h.RevNat = byteorder.NetworkToHost16(h.RevNat)
 	return &h
 }
 
@@ -305,14 +305,14 @@ func (b *Backend6Value) GetPort() uint16    { return b.Port }
 
 func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v
-	n.Port = byteorder.HostToNetwork(n.Port).(uint16)
+	n.Port = byteorder.HostToNetwork16(n.Port)
 	return &n
 }
 
 // ToHost converts Backend6Value to host byte order.
 func (v *Backend6Value) ToHost() BackendValue {
 	h := *v
-	h.Port = byteorder.NetworkToHost(h.Port).(uint16)
+	h.Port = byteorder.NetworkToHost16(h.Port)
 	return &h
 }
 

--- a/pkg/maps/lbmap/maglev.go
+++ b/pkg/maps/lbmap/maglev.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -218,7 +218,7 @@ func (k *MaglevOuterKey) ToNetwork() *MaglevOuterKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in
 	// the SVC BPF maps
-	n.RevNatID = byteorder.HostToNetwork(n.RevNatID).(uint16)
+	n.RevNatID = byteorder.HostToNetwork16(n.RevNatID)
 	return &n
 }
 

--- a/pkg/maps/lbmap/source_range.go
+++ b/pkg/maps/lbmap/source_range.go
@@ -63,14 +63,14 @@ func (k *SourceRangeKey4) ToNetwork() SourceRangeKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in
 	// the SVC BPF maps
-	n.RevNATID = byteorder.HostToNetwork(n.RevNATID).(uint16)
+	n.RevNATID = byteorder.HostToNetwork16(n.RevNATID)
 	return &n
 }
 
 // ToHost returns the key in the host byte order
 func (k *SourceRangeKey4) ToHost() SourceRangeKey {
 	h := *k
-	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
+	h.RevNATID = byteorder.NetworkToHost16(h.RevNATID)
 	return &h
 }
 
@@ -104,14 +104,14 @@ func (k *SourceRangeKey6) ToNetwork() SourceRangeKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in
 	// the SVC BPF maps
-	n.RevNATID = byteorder.HostToNetwork(n.RevNATID).(uint16)
+	n.RevNATID = byteorder.HostToNetwork16(n.RevNATID)
 	return &n
 }
 
 // ToHost returns the key in the host byte order
 func (k *SourceRangeKey6) ToHost() SourceRangeKey {
 	h := *k
-	h.RevNATID = byteorder.NetworkToHost(h.RevNATID).(uint16)
+	h.RevNATID = byteorder.NetworkToHost16(h.RevNATID)
 	return &h
 }
 
@@ -177,7 +177,7 @@ func initSourceRange(params InitParams) {
 
 func srcRangeKey(cidr *cidr.CIDR, revNATID uint16, ipv6 bool) bpf.MapKey {
 	ones, _ := cidr.Mask.Size()
-	id := byteorder.HostToNetwork(revNATID).(uint16)
+	id := byteorder.HostToNetwork16(revNATID)
 	if ipv6 {
 		key := &SourceRangeKey6{PrefixLen: uint32(ones) + lpmPrefixLen6, RevNATID: id}
 		copy(key.Address[:], cidr.IP.To16())

--- a/pkg/maps/nat/ipv4.go
+++ b/pkg/maps/nat/ipv4.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,6 +70,6 @@ func (n *NatEntry4) Dump(key NatKey, start uint64) string {
 // ToHost converts NatEntry4 ports to host byte order.
 func (n *NatEntry4) ToHost() NatEntry {
 	x := *n
-	x.Port = byteorder.NetworkToHost(n.Port).(uint16)
+	x.Port = byteorder.NetworkToHost16(n.Port)
 	return &x
 }

--- a/pkg/maps/nat/ipv6.go
+++ b/pkg/maps/nat/ipv6.go
@@ -70,6 +70,6 @@ func (n *NatEntry6) Dump(key NatKey, start uint64) string {
 // ToHost converts NatEntry4 ports to host byte order.
 func (n *NatEntry6) ToHost() NatEntry {
 	x := *n
-	x.Port = byteorder.NetworkToHost(n.Port).(uint16)
+	x.Port = byteorder.NetworkToHost16(n.Port)
 	return &x
 }

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ func (pe *PolicyEntry) ToHost() PolicyEntry {
 	}
 
 	n := *pe
-	n.ProxyPort = byteorder.NetworkToHost(n.ProxyPort).(uint16)
+	n.ProxyPort = byteorder.NetworkToHost16(n.ProxyPort)
 	return n
 }
 
@@ -247,7 +247,7 @@ func (key *PolicyKey) String() string {
 
 	trafficDirectionString := (trafficdirection.TrafficDirection)(key.TrafficDirection).String()
 	if key.DestPort != 0 {
-		return fmt.Sprintf("%s: %d %d/%d", trafficDirectionString, key.Identity, byteorder.NetworkToHost(key.DestPort), key.Nexthdr)
+		return fmt.Sprintf("%s: %d %d/%d", trafficDirectionString, key.Identity, byteorder.NetworkToHost16(key.DestPort), key.Nexthdr)
 	}
 	return fmt.Sprintf("%s: %d", trafficDirectionString, key.Identity)
 }
@@ -260,7 +260,7 @@ func (key *PolicyKey) ToHost() PolicyKey {
 	}
 
 	n := *key
-	n.DestPort = byteorder.NetworkToHost(n.DestPort).(uint16)
+	n.DestPort = byteorder.NetworkToHost16(n.DestPort)
 	return n
 }
 
@@ -272,7 +272,7 @@ func (key *PolicyKey) ToNetwork() PolicyKey {
 	}
 
 	n := *key
-	n.DestPort = byteorder.HostToNetwork(n.DestPort).(uint16)
+	n.DestPort = byteorder.HostToNetwork16(n.DestPort)
 	return n
 }
 
@@ -281,7 +281,7 @@ func (key *PolicyKey) ToNetwork() PolicyKey {
 func newKey(id uint32, dport uint16, proto u8proto.U8proto, trafficDirection trafficdirection.TrafficDirection) PolicyKey {
 	return PolicyKey{
 		Identity:         id,
-		DestPort:         byteorder.HostToNetwork(dport).(uint16),
+		DestPort:         byteorder.HostToNetwork16(dport),
 		Nexthdr:          uint8(proto),
 		TrafficDirection: trafficDirection.Uint8(),
 	}
@@ -291,7 +291,7 @@ func newKey(id uint32, dport uint16, proto u8proto.U8proto, trafficDirection tra
 // network byte-order.
 func newEntry(proxyPort uint16, flags PolicyEntryFlags) PolicyEntry {
 	return PolicyEntry{
-		ProxyPort: byteorder.HostToNetwork(proxyPort).(uint16),
+		ProxyPort: byteorder.HostToNetwork16(proxyPort),
 		Flags:     flags.UInt8(),
 	}
 }

--- a/pkg/maps/recorder/ipv4.go
+++ b/pkg/maps/recorder/ipv4.go
@@ -75,8 +75,8 @@ func (k *CaptureWcard4) String() string {
 
 func (k *CaptureWcard4) ToHost() RecorderKey {
 	x := *k
-	x.DestPort = byteorder.NetworkToHost(k.DestPort).(uint16)
-	x.SrcPort = byteorder.NetworkToHost(k.SrcPort).(uint16)
+	x.DestPort = byteorder.NetworkToHost16(k.DestPort)
+	x.SrcPort = byteorder.NetworkToHost16(k.SrcPort)
 	return &x
 }
 

--- a/pkg/maps/recorder/ipv6.go
+++ b/pkg/maps/recorder/ipv6.go
@@ -75,8 +75,8 @@ func (k *CaptureWcard6) String() string {
 
 func (k *CaptureWcard6) ToHost() RecorderKey {
 	x := *k
-	x.DestPort = byteorder.NetworkToHost(k.DestPort).(uint16)
-	x.SrcPort = byteorder.NetworkToHost(k.SrcPort).(uint16)
+	x.DestPort = byteorder.NetworkToHost16(k.DestPort)
+	x.SrcPort = byteorder.NetworkToHost16(k.SrcPort)
 	return &x
 }
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -508,7 +508,7 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 				}
 				if ipv4GWUint64 != 0 {
 					bs := make([]byte, net.IPv4len)
-					byteorder.NetworkToHostPut(bs, uint32(ipv4GWUint64))
+					byteorder.Native.PutUint32(bs, uint32(ipv4GWUint64))
 					ipv4GW = net.IPv4(bs[0], bs[1], bs[2], bs[3])
 					hasIPv4 = true
 				}

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -276,8 +276,8 @@ func recorderTupleToMapTuple4(ri *RecInfo, t *RecorderTuple) (*recorder.CaptureW
 		DestMask: uint8(onesDst),
 		SrcMask:  uint8(onesSrc),
 	}
-	k.DestPort = byteorder.HostToNetwork(t.DstPort).(uint16)
-	k.SrcPort = byteorder.HostToNetwork(t.SrcPort).(uint16)
+	k.DestPort = byteorder.HostToNetwork16(t.DstPort)
+	k.SrcPort = byteorder.HostToNetwork16(t.SrcPort)
 	copy(k.DestAddr[:], t.DstPrefix.IP.To4()[:])
 	copy(k.SrcAddr[:], t.SrcPrefix.IP.To4()[:])
 	v := &recorder.CaptureRule4{
@@ -296,8 +296,8 @@ func recorderTupleToMapTuple6(ri *RecInfo, t *RecorderTuple) (*recorder.CaptureW
 		DestMask: uint8(onesDst),
 		SrcMask:  uint8(onesSrc),
 	}
-	k.DestPort = byteorder.HostToNetwork(t.DstPort).(uint16)
-	k.SrcPort = byteorder.HostToNetwork(t.SrcPort).(uint16)
+	k.DestPort = byteorder.HostToNetwork16(t.DstPort)
+	k.SrcPort = byteorder.HostToNetwork16(t.SrcPort)
 	copy(k.DestAddr[:], t.DstPrefix.IP.To16()[:])
 	copy(k.SrcAddr[:], t.SrcPrefix.IP.To16()[:])
 	v := &recorder.CaptureRule6{

--- a/pkg/tuple/ipv4.go
+++ b/pkg/tuple/ipv4.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,16 +48,16 @@ func (k *TupleKey4) NewValue() bpf.MapValue { return &TupleValStub{} }
 // ToNetwork converts TupleKey4 ports to network byte order.
 func (k *TupleKey4) ToNetwork() TupleKey {
 	n := *k
-	n.SourcePort = byteorder.HostToNetwork(n.SourcePort).(uint16)
-	n.DestPort = byteorder.HostToNetwork(n.DestPort).(uint16)
+	n.SourcePort = byteorder.HostToNetwork16(n.SourcePort)
+	n.DestPort = byteorder.HostToNetwork16(n.DestPort)
 	return &n
 }
 
 // ToHost converts TupleKey4 ports to host byte order.
 func (k *TupleKey4) ToHost() TupleKey {
 	n := *k
-	n.SourcePort = byteorder.NetworkToHost(n.SourcePort).(uint16)
-	n.DestPort = byteorder.NetworkToHost(n.DestPort).(uint16)
+	n.SourcePort = byteorder.NetworkToHost16(n.SourcePort)
+	n.DestPort = byteorder.NetworkToHost16(n.DestPort)
 	return &n
 }
 

--- a/pkg/tuple/ipv6.go
+++ b/pkg/tuple/ipv6.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,16 +48,16 @@ func (k *TupleKey6) NewValue() bpf.MapValue { return &TupleValStub{} }
 // ToNetwork converts TupleKey6 ports to network byte order.
 func (k *TupleKey6) ToNetwork() TupleKey {
 	n := *k
-	n.SourcePort = byteorder.HostToNetwork(n.SourcePort).(uint16)
-	n.DestPort = byteorder.HostToNetwork(n.DestPort).(uint16)
+	n.SourcePort = byteorder.HostToNetwork16(n.SourcePort)
+	n.DestPort = byteorder.HostToNetwork16(n.DestPort)
 	return &n
 }
 
 // ToHost converts TupleKey6 ports to network byte order.
 func (k *TupleKey6) ToHost() TupleKey {
 	n := *k
-	n.SourcePort = byteorder.NetworkToHost(n.SourcePort).(uint16)
-	n.DestPort = byteorder.NetworkToHost(n.DestPort).(uint16)
+	n.SourcePort = byteorder.NetworkToHost16(n.SourcePort)
+	n.DestPort = byteorder.NetworkToHost16(n.DestPort)
 	return &n
 }
 


### PR DESCRIPTION
`pkg/byteorder` introduced in #730 uses a mix of `unsafe`, reflection, unchecked type assertions, and panics to handle byte order conversions, and the tests would only pass on little endian machines.

This PR replaces the package with much simpler functions and fixes the tests.

As this PR touches several parts of the code it should probably only be merged once 1.10 is released.