### PR TITLE
.github: Speed up cluster cleanups in end-to-end tests

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -183,7 +183,7 @@ jobs:
       - name: Clean up AKS
         if: ${{ always() }}
         run: |
-          az group delete --name ${{ env.name }} --yes
+          az group delete --name ${{ env.name }} --yes --no-wait
 
       - name: Upload artifacts
         if: ${{ failure() }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -198,8 +198,16 @@ jobs:
       - name: Clean up GKE
         if: ${{ always() }}
         run: |
-          gcloud container clusters delete ${{ env.clusterName1 }} --zone ${{ env.zone }} --quiet
-          gcloud container clusters delete ${{ env.clusterName2 }} --zone ${{ env.zone }} --quiet
+          i=0
+          for e in ${{ env.clusterName1 }} ${{ env.clusterName2 }}; do
+            gcloud container clusters delete $e --zone ${{ env.zone }} --quiet &
+            pids[$i]=$!
+            ((i++))
+          done
+          # Wait for all cluster-cleanup processes.
+          for pid in ${pids[*]}; do
+            wait $pid
+          done
         shell: bash {0}
 
       - name: Upload artifacts


### PR DESCRIPTION
When a GitHub job is cancelled, we have [5 minutes to perform any cleanup action](https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run). After that time, the job is forcefully stopped. That means for jobs creating Kubernetes clusters, we have 5 minutes to delete the cluster(s) or they will be left behind.

In the GKE test, it takes us around 2 minutes to delete the cluster. In the multicluster test however, deleting the two GKE clusters takes us a bit more than 5 minutes on average.

The first commit parallelize the deletion of the two clusters in the multicluster test to get the cleanup step below the 5-minutes runtime threshold. The second commit removes the wait for long-running operations in the AKS cluster cleanup (already the default in the EKS case).

Tested in https://github.com/cilium/cilium/pull/16245.