### PR TITLE
v1.10 backports 2021-05-18

### DIFF
--- a/Documentation/concepts/kubernetes/configuration.rst
+++ b/Documentation/concepts/kubernetes/configuration.rst
@@ -57,6 +57,13 @@ Any changes that you perform in the Cilium `ConfigMap` and in
 ``cilium-etcd-secrets`` ``Secret`` will require you to restart any existing
 Cilium pods in order for them to pick the latest configuration.
 
+.. attention::
+
+   When updating keys or values in the ConfigMap, the changes might take up to
+   2 minutes to be propagated to all nodes running in the cluster. For more
+   information see the official Kubernetes docs:
+   `Mounted ConfigMaps are updated automatically <https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically>`__
+
 The following `ConfigMap` is an example where the etcd cluster is running in 2
 nodes, ``node-1`` and ``node-2`` with TLS, and client to server authentication
 enabled.

--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -115,6 +115,12 @@ If you do change any of the CIDRs, you will need to make sure that Helm values i
 reflect those changes. Namely ``clusterNetwork`` should match ``nativeRoutingCIDR``, ``clusterPoolIPv4PodCIDR`` and ``clusterPoolIPv4MaskSize``.
 Also make sure that the ``clusterNetwork`` does not conflict with ``machineNetwork`` (which represents the VPC CIDR in AWS).
 
+.. warning::
+
+   Ensure that there are multiple replicas of the ``controlPlane``. A single
+   ``controlPlane`` will lead to failure to bootstrap the cluster during
+   installation.
+
 Next, generate OpenShift manifests:
 
 .. code-block:: shell-session

--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -109,10 +109,11 @@ The resulting configuration will look like this:
    sshKey: |
      ssh-rsa <REDACTED>
 
-You may wish to make a few changes, e.g. increase the number of nodes. If you do change any of the CIDRs,
-you will need to make sure that Helm values used below reflect those changes. Namely ``clusterNetwork``
-should match ``clusterPoolIPv4PodCIDR`` and ``clusterPoolIPv4MaskSize``. Also make sure that the ``clusterNetwork``
-does not conflict with ``machineNetwork`` (which represents the VPC CIDR in AWS).
+You may wish to make a few changes, e.g. increase the number of nodes.
+
+If you do change any of the CIDRs, you will need to make sure that Helm values in ``${CLUSTER_NAME}/manifests/cluster-network-07-cilium-ciliumconfig.yaml``
+reflect those changes. Namely ``clusterNetwork`` should match ``nativeRoutingCIDR``, ``clusterPoolIPv4PodCIDR`` and ``clusterPoolIPv4MaskSize``.
+Also make sure that the ``clusterNetwork`` does not conflict with ``machineNetwork`` (which represents the VPC CIDR in AWS).
 
 Next, generate OpenShift manifests:
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1241,6 +1241,9 @@ in great details:
     * "Liberating Kubernetes from kube-proxy and iptables" (KubeCon North America 2019, `slides
       <https://docs.google.com/presentation/d/1cZJ-pcwB9WG88wzhDm2jxQY4Sh8adYg0-N3qWQ8593I/edit>`__,
       `video <https://www.youtube.com/watch?v=bIRwSIwNHC0>`__)
+    * "Kubernetes service load-balancing at scale with BPF & XDP" (Linux Plumbers 2020, `slides
+      <https://linuxplumbersconf.org/event/7/contributions/674/attachments/568/1002/plumbers_2020_cilium_load_balancer.pdf>`__,
+      `video <https://www.youtube.com/watch?v=UkvxPyIJAko&t=21s>`__)
     * "eBPF as a revolutionary technology for the container landscape" (Fosdem 2020, `slides
       <https://docs.google.com/presentation/d/1VOUcoIxgM_c6M_zAV1dLlRCjyYCMdR3tJv6CEdfLMh8/edit>`__,
       `video <https://fosdem.org/2020/schedule/event/containers_bpf/>`__)

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -51,6 +51,7 @@ bypassing the iptables connection tracker.
 * Kernel >= 4.19.57, >= 5.1.16, >= 5.2
 * Direct-routing configuration
 * eBPF-based kube-proxy replacement
+* eBPF masquerading
 
 To enable the iptables connection-tracking bypass:
 

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -19,11 +19,12 @@ set -e
 get_remote () {
   local remote
   local org=${1:-cilium}
+  local repo=${2:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]${org}/cilium" | \
+    grep "github.com[/:]${org}/${repo}" | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
-      echo "No remote git@github.com:${org}/cilium.git or https://github.com/${org}/cilium found" 1>&2
+      echo "No remote git@github.com:${org}/${repo}.git or https://github.com/${org}/${repo} found" 1>&2
       return 1
   fi
   echo "$remote"
@@ -54,7 +55,9 @@ require_linux() {
 commit_in_upstream() {
     local commit="$1"
     local branch="$2"
-    local remote="$(get_remote)"
+    local org="${3:-"cilium"}"
+    local repo="${4:-"cilium"}"
+    local remote="$(get_remote ${org} ${repo})"
     local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
     echo "$branches" | grep -q ".*$remote/$branch"
 }

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -365,6 +365,11 @@ func initKubeProxyReplacementOptions() (strict bool) {
 			log.Fatalf("%s requires the agent to run with %s=%s.",
 				option.InstallNoConntrackIptRules, option.KubeProxyReplacement, option.KubeProxyReplacementStrict)
 		}
+
+		if !option.Config.EnableBPFMasquerade {
+			log.Fatalf("%s requires the agent to run with %s.",
+				option.InstallNoConntrackIptRules, option.EnableBPFMasquerade)
+		}
 	}
 
 	return

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -801,7 +801,7 @@ func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveN
 			log.WithFields(logrus.Fields{
 				logfields.DNSName: name,
 				logfields.IPAddr:  zombie.IP,
-			}).Warn("FQDN has multiple IPs. One IP has an expired TTL.")
+			}).Debug("FQDN has multiple IPs. One IP has an expired TTL.")
 			return true
 		}
 	}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -489,6 +489,8 @@ func (a *Agent) Status(withPeers bool) (*models.WireguardStatus, error) {
 				Endpoint:          p.Endpoint.String(),
 				LastHandshakeTime: strfmt.DateTime(p.LastHandshakeTime),
 				AllowedIps:        allowedIPs,
+				TransferTx:        p.TransmitBytes,
+				TransferRx:        p.ReceiveBytes,
 			}
 			peers = append(peers, peer)
 		}

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,12 +18,8 @@ REGISTRY_CREDENTIALS ?= "${DOCKER_LOGIN}:${DOCKER_PASSWORD}"
 all: build
 
 build:
-	# This should print a message if ginkgo is missing, but allow the
-	# bash-based test VM to run CI without needing to add Ginkgo to it.
-	# Once the bash-based tests are migrated, the "|| true" can be removed.
-	# GH #1839
 	@$(ECHO_GINKGO)$@
-	$(GINKGO) build || true
+	$(GINKGO) build
 	$(QUIET)$(MAKE) -C bpf/
 
 test: run k8s

--- a/test/helpers/manifest.go
+++ b/test/helpers/manifest.go
@@ -224,7 +224,6 @@ func (m *DeploymentManager) DeployRandomNamespace(manifest Manifest) string {
 
 	d, err := manifest.deploy(m.kubectl, namespace)
 	if err != nil {
-		ginkgoext.By("Deleting namespace %s", namespace)
 		m.kubectl.NamespaceDelete(namespace)
 
 		ginkgoext.Failf("Unable to deploy manifest %s: %s", manifest.GetFilename(), err)
@@ -276,7 +275,6 @@ func (m *DeploymentManager) DeleteAll() {
 
 	wg.Add(len(namespaces))
 	for namespace := range namespaces {
-		ginkgoext.By("Deleting namespace %s", namespace)
 		go func(namespace NamespaceName) {
 			m.kubectl.NamespaceDelete(string(namespace))
 			wg.Done()

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -109,7 +109,7 @@ func (c *TimeoutConfig) Validate() error {
 		return fmt.Errorf("Timeout too short (must be at least 5 seconds): %v", c.Timeout)
 	}
 	if c.Ticker == 0 {
-		c.Ticker = 5 * time.Second
+		c.Ticker = 1 * time.Second
 	} else if c.Ticker < time.Second {
 		return fmt.Errorf("Timeout config Ticker interval too short (must be at least 1 second): %v", c.Ticker)
 	}

--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -44,8 +44,6 @@ var _ = Describe("K8sBandwidthTest", func() {
 	AfterAll(func() {
 		_ = kubectl.Delete(demoYAML)
 		ExpectAllPodsTerminated(kubectl)
-
-		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
 	})
 
@@ -85,6 +83,10 @@ var _ = Describe("K8sBandwidthTest", func() {
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 			backgroundCancel()
+		})
+
+		AfterAll(func() {
+			UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		})
 
 		waitForTestPods := func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -162,41 +163,63 @@ var _ = SkipDescribeIf(func() bool {
 		)
 
 		validateConnectivity := func(expectWorldSuccess, expectClusterSuccess bool) {
-			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
-				By("HTTP connectivity to 1.1.1.1")
-				res := kubectl.ExecPodCmd(
-					namespaceForTest, pod,
-					helpers.CurlWithRetries("http://1.1.1.1/", 5, true))
+			var wg sync.WaitGroup
+			for _, appPod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
+				wg.Add(1)
+				go func(pod string) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					By("HTTP connectivity to 1.1.1.1")
+					res := kubectl.ExecPodCmd(
+						namespaceForTest, pod,
+						helpers.CurlWithRetries("http://1.1.1.1/", 5, true))
 
-				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
-					"HTTP egress connectivity to 1.1.1.1 from pod %q", pod)
+					ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
+						"HTTP egress connectivity to 1.1.1.1 from pod %q", pod)
+				}(appPod)
 
-				By("ICMP connectivity to 8.8.8.8")
-				res = kubectl.ExecPodCmd(
-					namespaceForTest, pod,
-					helpers.Ping("8.8.8.8"))
+				wg.Add(1)
+				go func(pod string) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					By("ICMP connectivity to 8.8.8.8")
+					res := kubectl.ExecPodCmd(
+						namespaceForTest, pod,
+						helpers.Ping("8.8.8.8"))
 
-				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
-					"ICMP egress connectivity to 8.8.8.8 from pod %q", pod)
+					ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
+						"ICMP egress connectivity to 8.8.8.8 from pod %q", pod)
+				}(appPod)
 
-				By("DNS lookup of kubernetes.default.svc.cluster.local")
-				// -R3 retry 3 times, -N1 ndots set to 1, -t A only lookup A records
-				res = kubectl.ExecPodCmd(
-					namespaceForTest, pod,
-					"host -v -R3 -N1 -t A kubernetes.default.svc.cluster.local.")
+				wg.Add(1)
+				go func(pod string) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					By("DNS lookup of kubernetes.default.svc.cluster.local")
+					// -R3 retry 3 times, -N1 ndots set to 1, -t A only lookup A records
+					res := kubectl.ExecPodCmd(
+						namespaceForTest, pod,
+						"host -v -R3 -N1 -t A kubernetes.default.svc.cluster.local.")
 
-				// kube-dns is always whitelisted so this should always work
-				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess || expectClusterSuccess),
-					"DNS connectivity of kubernetes.default.svc.cluster.local from pod %q", pod)
+					// kube-dns is always whitelisted so this should always work
+					ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess || expectClusterSuccess),
+						"DNS connectivity of kubernetes.default.svc.cluster.local from pod %q", pod)
+				}(appPod)
 
-				By("HTTP connectivity from pod to pod")
-				res = kubectl.ExecPodCmd(
-					namespaceForTest, pod,
-					helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
+				wg.Add(1)
+				go func(pod string) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					By("HTTP connectivity from pod to pod")
+					res := kubectl.ExecPodCmd(
+						namespaceForTest, pod,
+						helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 
-				ExpectWithOffset(1, res).To(getMatcher(expectClusterSuccess),
-					"HTTP connectivity to clusterIP %q of app1 from pod %q", clusterIP, appPods[helpers.App2])
+					ExpectWithOffset(1, res).To(getMatcher(expectClusterSuccess),
+						"HTTP connectivity to clusterIP %q of app1 from pod %q", clusterIP, appPods[helpers.App2])
+				}(appPod)
 			}
+			wg.Wait()
 		}
 
 		BeforeAll(func() {
@@ -1642,31 +1665,53 @@ var _ = SkipDescribeIf(func() bool {
 			}
 
 			validateConnectivity := func(expectHostSuccess, expectRemoteNodeSuccess, expectPodSuccess, expectWorldSuccess bool) {
-				By("Checking ingress connectivity from k8s1 node to k8s1 pod (host)")
-				res := kubectl.ExecInHostNetNS(context.TODO(), k8s1Name,
-					helpers.CurlFail(k8s1PodIP))
-				ExpectWithOffset(1, res).To(getMatcher(expectHostSuccess),
-					"HTTP ingress connectivity to pod %q from local host", k8s1PodIP)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					By("Checking ingress connectivity from k8s1 node to k8s1 pod (host)")
+					res := kubectl.ExecInHostNetNS(context.TODO(), k8s1Name,
+						helpers.CurlFail(k8s1PodIP))
+					ExpectWithOffset(1, res).To(getMatcher(expectHostSuccess),
+						"HTTP ingress connectivity to pod %q from local host", k8s1PodIP)
+				}()
 
-				By("Checking ingress connectivity from k8s1 node to k8s2 pod (remote-node)")
-				res = kubectl.ExecInHostNetNS(context.TODO(), k8s1Name,
-					helpers.CurlFail(k8s2PodIP))
-				ExpectWithOffset(1, res).To(getMatcher(expectRemoteNodeSuccess),
-					"HTTP ingress connectivity to pod %q from remote node", k8s2PodIP)
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					By("Checking ingress connectivity from k8s1 node to k8s2 pod (remote-node)")
+					res := kubectl.ExecInHostNetNS(context.TODO(), k8s1Name,
+						helpers.CurlFail(k8s2PodIP))
+					ExpectWithOffset(1, res).To(getMatcher(expectRemoteNodeSuccess),
+						"HTTP ingress connectivity to pod %q from remote node", k8s2PodIP)
+				}()
 
-				By("Checking ingress connectivity from k8s1 pod to k8s2 pod")
-				res = kubectl.ExecPodCmd(testNamespace, k8s1PodName, helpers.CurlFail(k8s2PodIP))
-				ExpectWithOffset(1, res).To(getMatcher(expectPodSuccess),
-					"HTTP ingress connectivity to pod %q from pod %q", k8s2PodIP, k8s1PodIP)
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					By("Checking ingress connectivity from k8s1 pod to k8s2 pod")
+					res := kubectl.ExecPodCmd(testNamespace, k8s1PodName, helpers.CurlFail(k8s2PodIP))
+					ExpectWithOffset(1, res).To(getMatcher(expectPodSuccess),
+						"HTTP ingress connectivity to pod %q from pod %q", k8s2PodIP, k8s1PodIP)
+				}()
 
-				By("Checking ingress connectivity from world to k8s1 pod")
 				if helpers.ExistNodeWithoutCilium() {
-					By("Adding a static route to %s on the %s node (outside)", k8s1PodIP, outsideNodeName)
-					res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, true)
-					Expect(res).To(getMatcher(true))
+					wg.Add(1)
+					go func() {
+						defer GinkgoRecover()
+						defer wg.Done()
+						By("Checking ingress connectivity from world to k8s1 pod")
+						By("Adding a static route to %s on the %s node (outside)", k8s1PodIP, outsideNodeName)
+						res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, true)
+						Expect(res).To(getMatcher(true))
 
-					testCurlFromOutside(k8s1PodIP, outsideNodeName, expectWorldSuccess)
+						testCurlFromOutside(k8s1PodIP, outsideNodeName, expectWorldSuccess)
+					}()
 				}
+				wg.Wait()
 			}
 
 			installDefaultDenyIngressPolicy := func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -640,6 +640,13 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		})
 
 		It("LRP connectivity", func() {
+			type lrpTestCase struct {
+				selector string
+				cmd      string
+				want     string
+				notWant  string
+			}
+
 			// Basic sanity check
 			ciliumPods, err := kubectl.GetCiliumPods()
 			Expect(err).To(BeNil(), "Cannot get cilium pods")
@@ -649,12 +656,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			}
 
 			By("Checking traffic goes to local backend")
-			testCases := []struct {
-				selector string
-				cmd      string
-				want     string
-				notWant  string
-			}{
+			testCases := []lrpTestCase{
 				{
 					selector: "id=app1",
 					cmd:      curl4TCP,
@@ -706,23 +708,37 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 					notWant:  be1Name,
 				},
 			}
-			for _, tc := range testCases {
-				Consistently(func() bool {
-					pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, tc.selector)
-					Expect(err).Should(BeNil(), "cannot retrieve pod names by filter %q", tc.selector)
-					Expect(len(pods)).Should(BeNumerically(">", 0), "no pod exists by filter %q", tc.selector)
-					ret := true
-					for _, pod := range pods {
-						res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, tc.cmd)
-						Expect(err).To(BeNil(), "%s failed in %s pod", tc.cmd, pod)
-						ret = ret && strings.Contains(res.Stdout(), tc.want) && !strings.Contains(res.Stdout(), tc.notWant)
-					}
-					return ret
-				}, 30*time.Second, 1*time.Second).Should(BeTrue(), "assertion fails for test case: %v", tc)
+
+			var wg sync.WaitGroup
+			wg.Add(len(testCases))
+			for _, testCase := range testCases {
+				go func(tc lrpTestCase) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					Consistently(func() bool {
+						pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, tc.selector)
+						Expect(err).Should(BeNil(), "cannot retrieve pod names by filter %q", tc.selector)
+						Expect(len(pods)).Should(BeNumerically(">", 0), "no pod exists by filter %q", tc.selector)
+						ret := true
+						for _, pod := range pods {
+							res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, tc.cmd)
+							Expect(err).To(BeNil(), "%s failed in %s pod", tc.cmd, pod)
+							ret = ret && strings.Contains(res.Stdout(), tc.want) && !strings.Contains(res.Stdout(), tc.notWant)
+						}
+						return ret
+					}, 30*time.Second, 1*time.Second).Should(BeTrue(), "assertion fails for test case: %v", tc)
+				}(testCase)
 			}
+			wg.Wait()
 		})
 
 		It("LRP restores service when removed", func() {
+			type lrpTestCase struct {
+				selector string
+				cmd      string
+				pod      string
+			}
+
 			_ = kubectl.Delete(lrpSvcYAML)
 			// Basic sanity check
 			ciliumPods, err := kubectl.GetCiliumPods()
@@ -733,11 +749,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			}
 
 			By("Checking traffic goes to both backends")
-			testCases := []struct {
-				selector string
-				cmd      string
-				pod      string
-			}{
+			testCases := []lrpTestCase{
 				{
 					selector: "id=app1",
 					cmd:      curl4TCP,
@@ -755,22 +767,30 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 					cmd:      curl4UDP,
 				},
 			}
-			for _, tc := range testCases {
-				for _, want := range []string{be1Name, be2Name} {
-					Eventually(func() bool {
-						pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, tc.selector)
-						Expect(err).Should(BeNil(), "cannot retrieve pod names by filter %q", tc.selector)
-						Expect(len(pods)).Should(BeNumerically(">", 0), "no pod exists by filter %q", tc.selector)
-						ret := true
-						for _, pod := range pods {
-							res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, tc.cmd)
-							Expect(err).To(BeNil(), "%s failed in %s pod", tc.cmd, pod)
-							ret = ret && strings.Contains(res.Stdout(), want)
-						}
-						return ret
-					}, 30*time.Second, 1*time.Second).Should(BeTrue(), "assertion fails for test case: %v", tc)
+
+			var wg sync.WaitGroup
+			wg.Add(len(testCases) * 2)
+			for _, testCase := range testCases {
+				for _, name := range []string{be1Name, be2Name} {
+					go func(tc lrpTestCase, want string) {
+						defer GinkgoRecover()
+						defer wg.Done()
+						Eventually(func() bool {
+							pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, tc.selector)
+							Expect(err).Should(BeNil(), "cannot retrieve pod names by filter %q", tc.selector)
+							Expect(len(pods)).Should(BeNumerically(">", 0), "no pod exists by filter %q", tc.selector)
+							ret := true
+							for _, pod := range pods {
+								res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, tc.cmd)
+								Expect(err).To(BeNil(), "%s failed in %s pod", tc.cmd, pod)
+								ret = ret && strings.Contains(res.Stdout(), want)
+							}
+							return ret
+						}, 30*time.Second, 1*time.Second).Should(BeTrue(), "assertion fails for test case: %v", tc)
+					}(testCase, name)
 				}
 			}
+			wg.Wait()
 		})
 	})
 


### PR DESCRIPTION
 * #16030 -- Fix logging for expired FQDN IPs (@youssefazrak)
 * #16064 -- test: Misc improvements (@pchaigno)
 * #16053 -- test: Fix incorrect uninstall in K8sBandwidth (@pchaigno)
 * #16069 -- docs: Improve wording around Helm values in OKD GSG (@errordeveloper)
 * #16085 -- daemon: require BPF masq to enable --install-no-conntrack-iptables-rules (@jibi)
 * #15828 -- eni: Support Instance Metadata Service Version 2 (IMDSv2) (@Smana)
 * #16169 -- docs, gsg: minor edits to kpr guide and note on hybrid use (@borkmann)
 * #16171 -- docs, gsg: add link to plumbers talk on service lb mechanisms (@borkmann)
 * #16153 -- pkg/k8s: ignore overwrite source "custom-resource" with "k8s" errors (@aanm)
 * #16141 -- docs: add information about ConfigMap updates (@aanm)
 * #16161 -- docs: Add caveat for OpenShift (@christarazi)
 * #16160 -- contrib: Make upstream commit check more generic (@joestringer)
 * #16178 -- wireguard: Fix traffic counters in `cilium debuginfo` (@gandro)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16030 16064 16053 16069 16085 15828 16169 16171 16153 16141 16161 16160 16178; do contrib/backporting/set-labels.py $pr done 1.10; done
```
