### PR TITLE
envoy: Remove request headers from response access logs

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:07ea8061d047c1085f99916c0
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:82a70d56bf324287ced3129300db609eceb21d10@sha256:cc5221f9163b6806795d74844dff4fb2227e4fb70c4942171411f3d0d2d57316 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:e83275091139101e7ff29284ef35c56f4cd6bfc3@sha256:3ae9ae3ca32eb30816c9e6a655dcb36e7ba4183c8c0c93ad58b72ad6c064aa0b as cilium-envoy
 
 #
 # Hubble CLI

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -218,8 +218,10 @@ type LogRecordHTTP struct {
 	Protocol string
 
 	// Headers are all HTTP headers present in the request and response. Request records
-	// contain request headers, while response headers contain both request and response
-	// headers.
+	// contain request headers, while response headers contain response headers and the
+	// 'x-request-id' from the request headers, if any. If response headers already contain
+	// a 'x-request-id' with a different value then both will be included as two separate
+	// entries with the same key.
 	Headers http.Header
 
 	// MissingHeaders are HTTP request headers that were deemed missing from the request


### PR DESCRIPTION
Remove request headers from response access logs, except for
'x-request-id', which is retained for request/response correlation
purposes.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

Fixes: #16195

```release-note
HTTP response access logs no longer contain the request headers, except for 'x-request-id',
which is still included for request/response correlation purposes.
```
