### PR TITLE
Specify scrape interval for Hubble metrics

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -136,6 +136,7 @@ have it scrape all Hubble metrics from the endpoints automatically:
 
     scrape_configs:
       - job_name: 'kubernetes-endpoints'
+        scrape_interval: 30s
         kubernetes_sd_configs:
           - role: endpoints
         relabel_configs:


### PR DESCRIPTION

Fixes: #16148
I have checked that 30s (instead of 10s) works as well.

```release-note
Specify scrape interval for Hubble metrics
```

Signed-off-by: Christian Hörtnagl <christian2@univie.ac.at>