### PR TITLE
pkgs/cgroups: warning <=1 procs in cgroup dir

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -87,4 +87,5 @@ The documentation is divided into the following sections:
    kvstore
    further_reading
    glossary
+   warnings
 

--- a/Documentation/warnings.rst
+++ b/Documentation/warnings.rst
@@ -1,0 +1,33 @@
+Cilium Warnings
+###############
+
+..
+   NOTES: each warning has an id (e.g., cgrouplowproccount) used in the code to
+   refer to specifics in this document. Code points to the latest version of the
+   docs, so text should be valid for all supported Cilium versions.
+
+.. _cgrouplowproccount:
+
+Low cgroup process count
+------------------------
+
+For :ref:`host-services`, Cilium attaches eBPF programs at cgroup hooks. For
+this to work properly, the cgroup that the programs are attached to needs to be
+at the proper level in the cgroup hierarchy so that all pods are created under
+it.
+
+The above warning indicates that something might be wrong since there is only
+one process running on the cgroup that the programs will be attached.  This, for
+example, might happen if the cilium pod runs on its own cgroup.
+
+For some environments (e.g., Kind) Cilium will try to avoid this issue by
+figuring out the proper path.
+
+You can provide an appropriate cgroup path to the agent via the
+``--cgroup-root`` option.
+
+Additional info
+***************
+
+* `Control Group v2 documentation <https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html>`_
+* ``bpftool cgroup tree`` provides an overview of the bpf cgroup-attached programs

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -124,6 +124,7 @@ func getCgroupRootForKind() (string, error) {
 // for details).
 func CheckOrMountCgrpFS(mapRoot string, runsOnKind bool) {
 	cgrpMountOnce.Do(func() {
+		defer cgrpSanityCheck()
 		if mapRoot == "" {
 			mapRoot = cgroupRoot
 		}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -477,6 +477,9 @@ const (
 	// Count is a measure being compared to the Limit
 	Count = "count"
 
+	// CgroupPath is where the cgroup fs is mounted
+	CgroupPath = "cgroupPath"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 

--- a/pkg/warnings/warnings.go
+++ b/pkg/warnings/warnings.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package warnings
+
+import "fmt"
+
+// GetUrl returns the warnings URL for a given warning id (see Documentation/warnings.html)
+func GetUrl(id string) string {
+	return fmt.Sprintf("https://docs.cilium.io/en/latest/warnings.html#%s", id)
+}


### PR DESCRIPTION
Having 1 or less processes in the cgroup directory we are attaching
programs is an indication that something is wrong. Issue a warning.

Since this is a nuanced warning, it would be good if we could provide
additional information to the user. This PR adds a warnings page to the
documentation. The warning points the user there so that they can get
additional context.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>

