### PR TITLE
helm: Add support for disable-endpoint-crd option

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -116,6 +116,7 @@ contributors across the globe, there is almost always someone available to help.
 | daemon.runPath | string | `"/var/run/cilium"` | Configure where Cilium runtime state should be stored. |
 | datapathMode | string | `"veth"` | Configure which datapath mode should be used for configuring container connectivity. Valid options are "veth" or "ipvlan". |
 | debug.enabled | bool | `false` | Enable debug logging |
+| disableEndpointCRD | string | `"false"` | Disable the usage of CiliumEndpoint CRD |
 | egressGateway | object | `{"enabled":false}` | Enables egress gateway (beta) to redirect and SNAT the traffic that leaves the cluster. |
 | enableCnpStatusUpdates | bool | `false` | Specify which network interfaces can run the eBPF datapath. This means that a packet sent from a pod to a destination outside the cluster will be masqueraded (to an output device IPv4 address), if the output device runs the program. When not specified, probing will automatically detect devices. devices: "" TODO: Add documentation disableIptablesFeederRules: "" TODO: Add documentation egressMasqueradeInterfaces: "" |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libriaries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -107,6 +107,11 @@ data:
   cilium-endpoint-gc-interval: "{{ .Values.operator.endpointGCInterval }}"
 {{- end }}
 
+{{- if hasKey .Values "disableEndpointCRD" }}
+  # Disable the usage of CiliumEndpoint CRD
+  disable-endpoint-crd: "{{ .Values.disableEndpointCRD }}"
+{{- end }}
+
 {{- if hasKey .Values "identityChangeGracePeriod" }}
   # identity-change-grace-period is the grace period that needs to pass
   # before an endpoint that has changed its identity will start using

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -45,7 +45,7 @@ serviceAccounts:
     annotations: {}
   preflight:
     create: true
-    name: cilium-pre-flight 
+    name: cilium-pre-flight
     annotations: {}
   relay:
     create: true
@@ -1066,6 +1066,9 @@ tls:
 #   - geneve
 tunnel: "vxlan"
 
+# -- Disable the usage of CiliumEndpoint CRD
+disableEndpointCRD: "false"
+
 wellKnownIdentities:
   # -- Enable the use of well-known identities.
   enabled: false
@@ -1205,7 +1208,7 @@ operator:
 
   # -- For using with an existing serviceAccount.
   serviceAccountName: cilium-operator
- 
+
   # -- cilium-operator priorityClassName
   priorityClassName: ""
 


### PR DESCRIPTION
In this commit, we enable users that manage Cilium setup through Helm to
enable/disable the usage of CiliumEndpoint CRD.

```release-note
helm: Add support for disable-endpoint-crd option
```
