### PR TITLE
loader: Revert incorrect initialization of endpoints in chaining mode

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -266,8 +266,15 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		ip4Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv4Mask}
 	}
 
-	dpConfig := endpoint.NewDatapathConfiguration()
-	info.DatapathConfiguration = &dpConfig
+	if option.Config.EnableEndpointRoutes {
+		disabled := false
+		dpConfig := &models.EndpointDatapathConfiguration{
+			InstallEndpointRoute: true,
+			RequireEgressProg:    true,
+			RequireRouting:       &disabled,
+		}
+		info.DatapathConfiguration = dpConfig
+	}
 
 	netNS, err := netns.ReplaceNetNSWithName(netNSName)
 	if err != nil {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -306,19 +306,24 @@ func (m *endpointCreationManager) DebugStatus() (output string) {
 // createEndpoint attempts to create the endpoint corresponding to the change
 // request that was specified.
 func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, epTemplate *models.EndpointChangeRequest) (*endpoint.Endpoint, int, error) {
-	if epTemplate.DatapathConfiguration == nil {
-		dpConfig := endpoint.NewDatapathConfiguration()
-		epTemplate.DatapathConfiguration = &dpConfig
-	}
 	if option.Config.EnableEndpointRoutes {
+		if epTemplate.DatapathConfiguration == nil {
+			epTemplate.DatapathConfiguration = &models.EndpointDatapathConfiguration{}
+		}
+
+		// Indicate to insert a per endpoint route instead of routing
+		// via cilium_host interface
 		epTemplate.DatapathConfiguration.InstallEndpointRoute = true
+
+		// Since routing occurs via endpoint interface directly, BPF
+		// program is needed on that device at egress as BPF program on
+		// cilium_host interface is bypassed
 		epTemplate.DatapathConfiguration.RequireEgressProg = true
+
+		// Delegate routing to the Linux stack rather than tail-calling
+		// between BPF programs.
 		disabled := false
 		epTemplate.DatapathConfiguration.RequireRouting = &disabled
-	} else {
-		epTemplate.DatapathConfiguration.InstallEndpointRoute = false
-		epTemplate.DatapathConfiguration.RequireEgressProg = false
-		epTemplate.DatapathConfiguration.RequireRouting = nil
 	}
 
 	log.WithFields(logrus.Fields{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -851,8 +851,10 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, bEp []byte) (*
 	// If host label is present, it's the host endpoint.
 	ep.isHost = ep.HasLabels(labels.LabelHost)
 
-	// Overwrite datapath configuration with the current agent configuration.
-	ep.DatapathConfiguration = NewDatapathConfiguration()
+	if ep.isHost {
+		// Overwrite datapath configuration with the current agent configuration.
+		ep.DatapathConfiguration = NewDatapathConfiguration()
+	}
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -110,7 +110,12 @@ var _ = Describe("K8sCustomCalls", func() {
 			pingBytes       uint   = 98 * helpers.PingCount
 		)
 
-		BeforeAll(func() {
+		AfterEach(func() {
+			_ = kubectl.Delete(yaml)
+			ExpectAllPodsTerminated(kubectl)
+		})
+
+		installPods := func() {
 			// Initialize all paths. This cannot be done at
 			// variable declaration because kubectl is not set when
 			// the Context is initialized.
@@ -143,12 +148,7 @@ var _ = Describe("K8sCustomCalls", func() {
 			cmd = fmt.Sprintf("make -C %s V=0", "cilium")
 			res = kubectl.ExecPodCmd(helpers.DefaultNamespace, compilerPodName, cmd)
 			res.ExpectSuccess("Failed to build cilium CLI")
-		})
-
-		AfterAll(func() {
-			_ = kubectl.Delete(yaml)
-			ExpectAllPodsTerminated(kubectl)
-		})
+		}
 
 		getPodsInfo := func() {
 			By("Retrieving pods information")
@@ -318,6 +318,8 @@ var _ = Describe("K8sCustomCalls", func() {
 			ExpectWithOffset(1, err).ShouldNot(HaveOccurred(), "Cannot get cilium pod on k8s1")
 			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 			ExpectWithOffset(1, err).ShouldNot(HaveOccurred(), "Cannot get cilium pod on k8s2")
+
+			installPods()
 
 			copyAndLoadObjectFile(ciliumPodK8s2)
 			defer cleanupLoadedObjects(ciliumPodK8s2)


### PR DESCRIPTION
This pull request is a partial revert of https://github.com/cilium/cilium/pull/15228.

Commit 72e6238 started removing existing endpoint routes when `enable-endpoint-routes` is disabled in the agent. In chaining mode however, if Cilium isn't the primary CNI, it isn't responsible for the endpoint's networking. In that case, the primary CNI may install and rely on those endpoint routes and we shouldn't remove them. Commit 0875453afda841d3bba50fb16ed0929e72c08ddf, from the same PR, overwrote the `RequireEgressProg` datapath attribute, breaking reverse NAT in chaining mode.

This pull request reverts incorrect changes. We'll provide a proper solution to remove only endpoint routes Cilium "owns" in a subsequent pull request, after more end-to-end tests have been added for chaining mode.

See commit descriptions for details.

Fixes: https://github.com/cilium/cilium/issues/16007.
Fixes: https://github.com/cilium/cilium/pull/15228.