### PR TITLE
Extends backend id to 32 bits

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -875,7 +875,7 @@ struct ct_state {
 	__be32 svc_addr;
 	__u32 src_sec_id;
 	__u16 ifindex;
-	__u16 backend_id;	/* Backend ID in lb4_backends */
+	__u32 backend_id;	/* Backend ID in lb4_backends */
 };
 
 #define SRC_RANGE_STATIC_PREFIX(STRUCT)		\

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -38,6 +38,15 @@ struct bpf_elf_map __section_maps LB6_BACKEND_MAP = {
 	.flags          = CONDITIONAL_PREALLOC,
 };
 
+struct bpf_elf_map __section_maps LB6_BACKEND_MAP_V2 = {
+	.type           = BPF_MAP_TYPE_HASH,
+	.size_key       = sizeof(__u32),
+	.size_value     = sizeof(struct lb6_backend),
+	.pinning        = PIN_GLOBAL_NS,
+	.max_elem       = CILIUM_LB_MAP_MAX_ENTRIES,
+	.flags          = CONDITIONAL_PREALLOC,
+};
+
 #ifdef ENABLE_SESSION_AFFINITY
 struct bpf_elf_map __section_maps LB6_AFFINITY_MAP = {
 	.type		= BPF_MAP_TYPE_LRU_HASH,
@@ -114,6 +123,15 @@ struct bpf_elf_map __section_maps LB4_SERVICES_MAP_V2 = {
 struct bpf_elf_map __section_maps LB4_BACKEND_MAP = {
 	.type           = BPF_MAP_TYPE_HASH,
 	.size_key       = sizeof(__u16),
+	.size_value     = sizeof(struct lb4_backend),
+	.pinning        = PIN_GLOBAL_NS,
+	.max_elem       = CILIUM_LB_MAP_MAX_ENTRIES,
+	.flags          = CONDITIONAL_PREALLOC,
+};
+
+struct bpf_elf_map __section_maps LB4_BACKEND_MAP_V2 = {
+	.type           = BPF_MAP_TYPE_HASH,
+	.size_key       = sizeof(__u32),
 	.size_value     = sizeof(struct lb4_backend),
 	.pinning        = PIN_GLOBAL_NS,
 	.max_elem       = CILIUM_LB_MAP_MAX_ENTRIES,
@@ -548,13 +566,13 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 	return NULL;
 }
 
-static __always_inline struct lb6_backend *__lb6_lookup_backend(__u16 backend_id)
+static __always_inline struct lb6_backend *__lb6_lookup_backend(__u32 backend_id)
 {
-	return map_lookup_elem(&LB6_BACKEND_MAP, &backend_id);
+	return map_lookup_elem(&LB6_BACKEND_MAP_V2, &backend_id);
 }
 
 static __always_inline struct lb6_backend *
-lb6_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u16 backend_id)
+lb6_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u32 backend_id)
 {
 	struct lb6_backend *backend;
 
@@ -1076,13 +1094,13 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 	return NULL;
 }
 
-static __always_inline struct lb4_backend *__lb4_lookup_backend(__u16 backend_id)
+static __always_inline struct lb4_backend *__lb4_lookup_backend(__u32 backend_id)
 {
-	return map_lookup_elem(&LB4_BACKEND_MAP, &backend_id);
+	return map_lookup_elem(&LB4_BACKEND_MAP_V2, &backend_id);
 }
 
 static __always_inline struct lb4_backend *
-lb4_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u16 backend_id)
+lb4_lookup_backend(struct __ctx_buff *ctx __maybe_unused, __u32 backend_id)
 {
 	struct lb4_backend *backend;
 

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -160,6 +160,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_services_v2", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_services", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_backends", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_backends_v2", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lb4_reverse_nat", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct4_global", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_ct_any4_global", bpffsMountpoint),

--- a/pkg/datapath/alignchecker/alignchecker.go
+++ b/pkg/datapath/alignchecker/alignchecker.go
@@ -89,12 +89,12 @@ func CheckStructAlignments(path string) error {
 	}
 	toCheckSizes := map[string][]reflect.Type{
 		"__u16": {
-			reflect.TypeOf(lbmap.Backend4Key{}),
-			reflect.TypeOf(lbmap.Backend6Key{}),
 			reflect.TypeOf(lbmap.RevNat4Key{}),
 			reflect.TypeOf(lbmap.RevNat6Key{}),
 		},
 		"__u32": {
+			reflect.TypeOf(lbmap.Backend4Key{}),
+			reflect.TypeOf(lbmap.Backend6Key{}),
 			reflect.TypeOf(signalmap.Key{}),
 			reflect.TypeOf(signalmap.Value{}),
 			reflect.TypeOf(eventsmap.Key{}),

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -179,6 +179,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["LB4_REVERSE_NAT_MAP"] = "cilium_lb4_reverse_nat"
 	cDefinesMap["LB4_SERVICES_MAP_V2"] = "cilium_lb4_services_v2"
 	cDefinesMap["LB4_BACKEND_MAP"] = "cilium_lb4_backends"
+	cDefinesMap["LB4_BACKEND_MAP_V2"] = "cilium_lb4_backends_v2"
 	cDefinesMap["LB4_REVERSE_NAT_SK_MAP"] = lbmap.SockRevNat4MapName
 	cDefinesMap["LB4_REVERSE_NAT_SK_MAP_SIZE"] = fmt.Sprintf("%d", lbmap.MaxSockRevNat4MapEntries)
 

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -159,6 +159,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			"cilium_lb4_services_v2",
 			"cilium_lb4_rr_seq_v2",
 			"cilium_lb4_backends",
+			"cilium_lb4_backends_v2",
 			"cilium_lb4_reverse_sk",
 			"cilium_snat_v4_external",
 			"cilium_proxy4",

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -177,7 +177,7 @@ type FEPortName string
 type ServiceID uint16
 
 // BackendID is the backend's ID.
-type BackendID uint16
+type BackendID = uint32
 
 // ID is the ID of L3n4Addr endpoint (either service or backend).
 type ID uint32

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/types"
 )
 
@@ -85,7 +86,7 @@ type AffinityMatchValue struct {
 }
 
 // NewAffinityMatchKey creates the AffinityMatch key
-func NewAffinityMatchKey(revNATID uint16, backendID uint32) *AffinityMatchKey {
+func NewAffinityMatchKey(revNATID uint16, backendID loadbalancer.BackendID) *AffinityMatchKey {
 	return &AffinityMatchKey{
 		BackendID: backendID,
 		RevNATID:  revNATID,

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -36,7 +36,7 @@ type LBBPFMap struct {
 	// Buffer used to avoid excessive allocations to temporarily store backend
 	// IDs. Concurrent access is protected by the
 	// pkg/service.go:(Service).UpsertService() lock.
-	maglevBackendIDsBuffer []uint16
+	maglevBackendIDsBuffer []loadbalancer.BackendID
 	maglevTableSize        uint64
 }
 
@@ -44,7 +44,7 @@ func New(maglev bool, maglevTableSize int) *LBBPFMap {
 	m := &LBBPFMap{}
 
 	if maglev {
-		m.maglevBackendIDsBuffer = make([]uint16, maglevTableSize)
+		m.maglevBackendIDsBuffer = make([]loadbalancer.BackendID, maglevTableSize)
 		m.maglevTableSize = uint64(maglevTableSize)
 	}
 
@@ -55,7 +55,7 @@ type UpsertServiceParams struct {
 	ID                        uint16
 	IP                        net.IP
 	Port                      uint16
-	Backends                  map[string]uint16
+	Backends                  map[string]loadbalancer.BackendID
 	PrevBackendCount          int
 	IPv6                      bool
 	Type                      loadbalancer.SVCType
@@ -96,7 +96,7 @@ func (lbmap *LBBPFMap) UpsertService(p *UpsertServiceParams) error {
 		}
 	}
 
-	backendIDs := make([]uint16, 0, len(p.Backends))
+	backendIDs := make([]loadbalancer.BackendID, 0, len(p.Backends))
 	for _, id := range p.Backends {
 		backendIDs = append(backendIDs, id)
 	}
@@ -151,7 +151,7 @@ func (lbmap *LBBPFMap) UpsertService(p *UpsertServiceParams) error {
 
 // UpsertMaglevLookupTable calculates Maglev lookup table for given backends, and
 // inserts into the Maglev BPF map.
-func (lbmap *LBBPFMap) UpsertMaglevLookupTable(svcID uint16, backends map[string]uint16, ipv6 bool) error {
+func (lbmap *LBBPFMap) UpsertMaglevLookupTable(svcID uint16, backends map[string]loadbalancer.BackendID, ipv6 bool) error {
 	backendNames := make([]string, 0, len(backends))
 	for name := range backends {
 		backendNames = append(backendNames, name)
@@ -214,7 +214,7 @@ func (*LBBPFMap) DeleteService(svc loadbalancer.L3n4AddrID, backendCount int, us
 }
 
 // AddBackend adds a backend into a BPF map.
-func (*LBBPFMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error {
+func (*LBBPFMap) AddBackend(id loadbalancer.BackendID, ip net.IP, port uint16, ipv6 bool) error {
 	var (
 		backend Backend
 		err     error
@@ -225,9 +225,9 @@ func (*LBBPFMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error 
 	}
 
 	if ipv6 {
-		backend, err = NewBackend6(loadbalancer.BackendID(id), ip, port, u8proto.ANY)
+		backend, err = NewBackend6(id, ip, port, u8proto.ANY)
 	} else {
-		backend, err = NewBackend4(loadbalancer.BackendID(id), ip, port, u8proto.ANY)
+		backend, err = NewBackend4(id, ip, port, u8proto.ANY)
 	}
 	if err != nil {
 		return fmt.Errorf("Unable to create backend (%d, %s, %d, %t): %s",
@@ -242,7 +242,7 @@ func (*LBBPFMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error 
 }
 
 // DeleteBackendByID removes a backend identified with the given ID from a BPF map.
-func (*LBBPFMap) DeleteBackendByID(id uint16, ipv6 bool) error {
+func (*LBBPFMap) DeleteBackendByID(id loadbalancer.BackendID, ipv6 bool) error {
 	var key BackendKey
 
 	if id == 0 {
@@ -250,9 +250,9 @@ func (*LBBPFMap) DeleteBackendByID(id uint16, ipv6 bool) error {
 	}
 
 	if ipv6 {
-		key = NewBackend6Key(loadbalancer.BackendID(id))
+		key = NewBackend6Key(id)
 	} else {
-		key = NewBackend4Key(loadbalancer.BackendID(id))
+		key = NewBackend4Key(id)
 	}
 
 	if err := deleteBackendLocked(key); err != nil {
@@ -264,15 +264,15 @@ func (*LBBPFMap) DeleteBackendByID(id uint16, ipv6 bool) error {
 
 // DeleteAffinityMatch removes the affinity match for the given svc and backend ID
 // tuple from the BPF map
-func (*LBBPFMap) DeleteAffinityMatch(revNATID uint16, backendID uint16) error {
+func (*LBBPFMap) DeleteAffinityMatch(revNATID uint16, backendID loadbalancer.BackendID) error {
 	return AffinityMatchMap.Delete(
-		NewAffinityMatchKey(revNATID, uint32(backendID)).ToNetwork())
+		NewAffinityMatchKey(revNATID, backendID).ToNetwork())
 }
 
 // AddAffinityMatch adds the given affinity match to the BPF map.
-func (*LBBPFMap) AddAffinityMatch(revNATID uint16, backendID uint16) error {
+func (*LBBPFMap) AddAffinityMatch(revNATID uint16, backendID loadbalancer.BackendID) error {
 	return AffinityMatchMap.Update(
-		NewAffinityMatchKey(revNATID, uint32(backendID)).ToNetwork(),
+		NewAffinityMatchKey(revNATID, backendID).ToNetwork(),
 		&AffinityMatchValue{})
 }
 
@@ -284,10 +284,10 @@ func (*LBBPFMap) DumpAffinityMatches() (BackendIDByServiceIDSet, error) {
 	parse := func(key bpf.MapKey, value bpf.MapValue) {
 		matchKey := key.DeepCopyMapKey().(*AffinityMatchKey).ToHost()
 		svcID := matchKey.RevNATID
-		backendID := uint16(matchKey.BackendID) // currently backend_id is u16
+		backendID := matchKey.BackendID
 
 		if _, ok := matches[svcID]; !ok {
-			matches[svcID] = map[uint16]struct{}{}
+			matches[svcID] = map[loadbalancer.BackendID]struct{}{}
 		}
 		matches[svcID][backendID] = struct{}{}
 	}

--- a/pkg/maps/lbmap/maglev.go
+++ b/pkg/maps/lbmap/maglev.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
 const (
@@ -151,7 +152,7 @@ func deleteMapIfMNotMatch(mapName string, tableSize uint32) (bool, error) {
 	return true, nil
 }
 
-func updateMaglevTable(ipv6 bool, revNATID uint16, backendIDs []uint16) error {
+func updateMaglevTable(ipv6 bool, revNATID uint16, backendIDs []loadbalancer.BackendID) error {
 	outerMap := maglevOuter4Map
 	innerMapName := MaglevInner4MapName
 	if ipv6 {

--- a/pkg/maps/lbmap/maglev_inner_map.go
+++ b/pkg/maps/lbmap/maglev_inner_map.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
 // maglevInnerMap is the internal representation of a maglev inner map.
@@ -22,7 +23,7 @@ type MaglevInnerKey struct {
 
 // MaglevInnerVal is the value of a maglev inner map.
 type MaglevInnerVal struct {
-	BackendIDs []uint16
+	BackendIDs []loadbalancer.BackendID
 }
 
 // newMaglevInnerMapSpec returns the spec for a maglev inner map.
@@ -31,7 +32,7 @@ func newMaglevInnerMapSpec(name string, tableSize uint32) *ebpf.MapSpec {
 		Name:       name,
 		Type:       ebpf.Array,
 		KeySize:    uint32(unsafe.Sizeof(MaglevInnerKey{})),
-		ValueSize:  uint32(unsafe.Sizeof(uint16(0)) * uintptr(tableSize)),
+		ValueSize:  uint32(unsafe.Sizeof(uint32(0)) * uintptr(tableSize)),
 		MaxEntries: 1,
 	}
 }
@@ -68,7 +69,7 @@ func MaglevInnerMapFromID(id int, tableSize uint32) (*maglevInnerMap, error) {
 // Lookup returns the value associated with a given key for a maglev inner map.
 func (m *maglevInnerMap) Lookup(key *MaglevInnerKey) (*MaglevInnerVal, error) {
 	value := &MaglevInnerVal{
-		BackendIDs: make([]uint16, m.tableSize),
+		BackendIDs: make([]uint32, m.tableSize),
 	}
 
 	if err := m.Map.Lookup(key, &value.BackendIDs); err != nil {

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -167,7 +167,7 @@ type RevNatValue interface {
 
 // BackendIDByServiceIDSet is the type of a set for checking whether a backend
 // belongs to a given service
-type BackendIDByServiceIDSet map[uint16]map[uint16]struct{} // svc ID => backend ID
+type BackendIDByServiceIDSet map[uint16]map[loadbalancer.BackendID]struct{} // svc ID => backend ID
 
 type SourceRangeSetByServiceID map[uint16][]*cidr.CIDR // svc ID => src range CIDRs
 

--- a/pkg/service/const.go
+++ b/pkg/service/const.go
@@ -17,5 +17,5 @@ const (
 
 	// MaxSetOfBackendID is maximum number of set of backendIDs IDs that can be
 	// stored in the local ID allocator.
-	MaxSetOfBackendID = uint32(0xFFFF)
+	MaxSetOfBackendID = uint32(0xFFFFFFFF)
 )

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -35,13 +35,13 @@ var (
 // LBMap is the interface describing methods for manipulating service maps.
 type LBMap interface {
 	UpsertService(*lbmap.UpsertServiceParams) error
-	UpsertMaglevLookupTable(uint16, map[string]uint16, bool) error
+	UpsertMaglevLookupTable(uint16, map[string]lb.BackendID, bool) error
 	IsMaglevLookupTableRecreated(bool) bool
 	DeleteService(lb.L3n4AddrID, int, bool) error
-	AddBackend(uint16, net.IP, uint16, bool) error
-	DeleteBackendByID(uint16, bool) error
-	AddAffinityMatch(uint16, uint16) error
-	DeleteAffinityMatch(uint16, uint16) error
+	AddBackend(lb.BackendID, net.IP, uint16, bool) error
+	DeleteBackendByID(lb.BackendID, bool) error
+	AddAffinityMatch(uint16, lb.BackendID) error
+	DeleteAffinityMatch(uint16, lb.BackendID) error
 	UpdateSourceRanges(uint16, []*cidr.CIDR, []*cidr.CIDR, bool) error
 	DumpServiceMaps() ([]*lb.SVC, []error)
 	DumpBackendMaps() ([]*lb.Backend, error)
@@ -197,9 +197,9 @@ func (s *Service) InitMaps(ipv6, ipv4, sockMaps, restore bool) error {
 		}
 	}
 	if ipv4 {
-		toOpen = append(toOpen, lbmap.Service4MapV2, lbmap.Backend4Map, lbmap.RevNat4Map)
+		toOpen = append(toOpen, lbmap.Service4MapV2, lbmap.Backend4MapV2, lbmap.RevNat4Map)
 		if !restore {
-			toDelete = append(toDelete, lbmap.Service4MapV2, lbmap.Backend4Map, lbmap.RevNat4Map)
+			toDelete = append(toDelete, lbmap.Service4MapV2, lbmap.Backend4MapV2, lbmap.RevNat4Map)
 		}
 		if sockMaps {
 			if err := lbmap.CreateSockRevNat4Map(); err != nil {
@@ -610,7 +610,7 @@ func (s *Service) deleteBackendsFromAffinityMatchMap(svcID lb.ID, backendIDs []l
 	}).Debug("Deleting backends from session affinity match")
 
 	for _, bID := range backendIDs {
-		if err := s.lbmap.DeleteAffinityMatch(uint16(svcID), uint16(bID)); err != nil {
+		if err := s.lbmap.DeleteAffinityMatch(uint16(svcID), bID); err != nil {
 			log.WithFields(logrus.Fields{
 				logfields.BackendID: bID,
 				logfields.ServiceID: svcID,
@@ -626,7 +626,7 @@ func (s *Service) addBackendsToAffinityMatchMap(svcID lb.ID, backendIDs []lb.Bac
 	}).Debug("Adding backends to affinity match map")
 
 	for _, bID := range backendIDs {
-		if err := s.lbmap.AddAffinityMatch(uint16(svcID), uint16(bID)); err != nil {
+		if err := s.lbmap.AddAffinityMatch(uint16(svcID), bID); err != nil {
 			log.WithFields(logrus.Fields{
 				logfields.BackendID: bID,
 				logfields.ServiceID: svcID,
@@ -696,16 +696,16 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 			logfields.L3n4Addr:  b.L3n4Addr,
 		}).Debug("Adding new backend")
 
-		if err := s.lbmap.AddBackend(uint16(b.ID), b.L3n4Addr.IP,
+		if err := s.lbmap.AddBackend(b.ID, b.L3n4Addr.IP,
 			b.L3n4Addr.L4Addr.Port, ipv6); err != nil {
 			return err
 		}
 	}
 
 	// Upsert service entries into BPF maps
-	backends := make(map[string]uint16, len(svc.backends))
+	backends := make(map[string]lb.BackendID, len(svc.backends))
 	for _, b := range svc.backends {
-		backends[b.String()] = uint16(b.ID)
+		backends[b.String()] = b.ID
 	}
 
 	p := &lbmap.UpsertServiceParams{
@@ -736,7 +736,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 		scopedLog.WithField(logfields.BackendID, id).
 			Debug("Removing obsolete backend")
 
-		if err := s.lbmap.DeleteBackendByID(uint16(id), ipv6); err != nil {
+		if err := s.lbmap.DeleteBackendByID(id, ipv6); err != nil {
 			log.WithError(err).WithField(logfields.BackendID, id).
 				Warn("Failed to remove backend from maps")
 		}
@@ -775,7 +775,7 @@ func (s *Service) deleteOrphanBackends() error {
 				Debug("Removing orphan backend")
 
 			DeleteBackendID(b.ID)
-			if err := s.lbmap.DeleteBackendByID(uint16(b.ID), b.L3n4Addr.IsIPv6()); err != nil {
+			if err := s.lbmap.DeleteBackendByID(b.ID, b.L3n4Addr.IsIPv6()); err != nil {
 				return fmt.Errorf("Unable to remove backend %d from map: %s", b.ID, err)
 			}
 			delete(s.backendByHash, hash)
@@ -835,9 +835,9 @@ func (s *Service) restoreServicesLocked() error {
 		if option.Config.DatapathMode == datapathOpt.DatapathModeLBOnly &&
 			newSVC.useMaglev() && s.lbmap.IsMaglevLookupTableRecreated(ipv6) {
 
-			backends := make(map[string]uint16, len(newSVC.backends))
+			backends := make(map[string]lb.BackendID, len(newSVC.backends))
 			for _, b := range newSVC.backends {
-				backends[b.String()] = uint16(b.ID)
+				backends[b.String()] = b.ID
 			}
 			if err := s.lbmap.UpsertMaglevLookupTable(uint16(newSVC.frontend.ID), backends, ipv6); err != nil {
 				return err
@@ -896,7 +896,7 @@ func (s *Service) deleteServiceLocked(svc *svcInfo) error {
 		scopedLog.WithField(logfields.BackendID, id).
 			Debug("Deleting obsolete backend")
 
-		if err := s.lbmap.DeleteBackendByID(uint16(id), ipv6); err != nil {
+		if err := s.lbmap.DeleteBackendByID(id, ipv6); err != nil {
 			return err
 		}
 	}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -338,7 +338,7 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 	c.Assert(len(matches), Equals, 1) // only the id2 svc has session affinity
 	c.Assert(len(matches[uint16(id2)]), Equals, 2)
 	for _, b := range lbmap.ServiceByID[uint16(id2)].Backends {
-		c.Assert(m.lbmap.AffinityMatch[uint16(id1)][uint16(b.ID)], Equals, struct{}{})
+		c.Assert(m.lbmap.AffinityMatch[uint16(id1)][b.ID], Equals, struct{}{})
 	}
 
 }

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -13,7 +13,7 @@ import (
 )
 
 type LBMockMap struct {
-	BackendByID      map[uint16]*lb.Backend
+	BackendByID      map[lb.BackendID]*lb.Backend
 	ServiceByID      map[uint16]*lb.SVC
 	AffinityMatch    lbmap.BackendIDByServiceIDSet
 	SourceRanges     lbmap.SourceRangeSetByServiceID
@@ -22,7 +22,7 @@ type LBMockMap struct {
 
 func NewLBMockMap() *LBMockMap {
 	return &LBMockMap{
-		BackendByID:      map[uint16]*lb.Backend{},
+		BackendByID:      map[lb.BackendID]*lb.Backend{},
 		ServiceByID:      map[uint16]*lb.SVC{},
 		AffinityMatch:    lbmap.BackendIDByServiceIDSet{},
 		SourceRanges:     lbmap.SourceRangeSetByServiceID{},
@@ -59,7 +59,7 @@ func (m *LBMockMap) UpsertService(p *lbmap.UpsertServiceParams) error {
 	return nil
 }
 
-func (m *LBMockMap) UpsertMaglevLookupTable(svcID uint16, backends map[string]uint16, ipv6 bool) error {
+func (m *LBMockMap) UpsertMaglevLookupTable(svcID uint16, backends map[string]lb.BackendID, ipv6 bool) error {
 	m.DummyMaglevTable[svcID] = len(backends)
 	return nil
 }
@@ -83,7 +83,7 @@ func (m *LBMockMap) DeleteService(addr lb.L3n4AddrID, backendCount int, maglev b
 	return nil
 }
 
-func (m *LBMockMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error {
+func (m *LBMockMap) AddBackend(id lb.BackendID, ip net.IP, port uint16, ipv6 bool) error {
 	if _, found := m.BackendByID[id]; found {
 		return fmt.Errorf("Backend %d already exists", id)
 	}
@@ -93,7 +93,7 @@ func (m *LBMockMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) err
 	return nil
 }
 
-func (m *LBMockMap) DeleteBackendByID(id uint16, ipv6 bool) error {
+func (m *LBMockMap) DeleteBackendByID(id lb.BackendID, ipv6 bool) error {
 	if _, found := m.BackendByID[id]; !found {
 		return fmt.Errorf("Backend %d does not exist", id)
 	}
@@ -119,9 +119,9 @@ func (m *LBMockMap) DumpBackendMaps() ([]*lb.Backend, error) {
 	return list, nil
 }
 
-func (m *LBMockMap) AddAffinityMatch(revNATID uint16, backendID uint16) error {
+func (m *LBMockMap) AddAffinityMatch(revNATID uint16, backendID lb.BackendID) error {
 	if _, ok := m.AffinityMatch[revNATID]; !ok {
-		m.AffinityMatch[revNATID] = map[uint16]struct{}{}
+		m.AffinityMatch[revNATID] = map[lb.BackendID]struct{}{}
 	}
 	if _, ok := m.AffinityMatch[revNATID][backendID]; ok {
 		return fmt.Errorf("Backend %d already exists in %d affinity map",
@@ -131,7 +131,7 @@ func (m *LBMockMap) AddAffinityMatch(revNATID uint16, backendID uint16) error {
 	return nil
 }
 
-func (m *LBMockMap) DeleteAffinityMatch(revNATID uint16, backendID uint16) error {
+func (m *LBMockMap) DeleteAffinityMatch(revNATID uint16, backendID lb.BackendID) error {
 	if _, ok := m.AffinityMatch[revNATID]; !ok {
 		return fmt.Errorf("Affinity map for %d does not exist", revNATID)
 	}


### PR DESCRIPTION
See commit msg.

This is not intended to be merged as is, the migrating/upgrading path is still missing. I would appreciate early feedbacks and will add migrating code later if needed.

This is sorta a stripped down version of PR #8041 to unblock us from running large-scale tests, we might as well bring back that original PR?
