### PR TITLE
test: Use new test-verifier image in K8sVerifier

### DIFF
--- a/images/scripts/update-cilium-builder-image.sh
+++ b/images/scripts/update-cilium-builder-image.sh
@@ -25,7 +25,7 @@ if [ -n "${sha256}" ]; then
 fi
 
 # shellcheck disable=SC2207
-used_by=($(git grep -l CILIUM_BUILDER_IMAGE= images/*/Dockerfile) "test/k8sT/manifests/test-verifier.yaml" "test/k8sT/manifests/demo-customcalls.yaml" "api/v1/Makefile")
+used_by=($(git grep -l CILIUM_BUILDER_IMAGE= images/*/Dockerfile) "test/k8sT/manifests/demo-customcalls.yaml" "api/v1/Makefile")
 
 for i in "${used_by[@]}" ; do
   sed -E "s#(CILIUM_BUILDER_IMAGE=|image: )${image}:.*\$#\1${image_full}#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:3e04d507e2f7a0b569490060ddc8b9423c9fc8f0@sha256:7949a297fd2f07a008ef8a163ed84bfb338a37f3b36b68c2c9c5fddb324d325f
+    image: quay.io/cilium/test-verifier:0f6647c542b71e89f310e437570b6d05dd9351bb@sha256:b21ee37daf5b533cc8457060800ac679c5b7bf48cc6f5070584cd59213fabc43
     workingDir: /cilium
     command: ["sleep"]
     args:


### PR DESCRIPTION
Until now, K8sVerifier was using the cilium-builder image to build the datapath and run verifier-test.sh. Having a K8sVerifier-specific image also allows us to include a patch for the tc binary, to increase the maximum size of the verifier log buffer. In the K8sVerifier test, we load all BPF programs in verbose mode, so the log buffer is always needed (vs. only in case of retry following a load error usually). A small log buffer can lead to a load failure that is actually a false positive (it's just the log buffer being too small and not an actual issue with the BPF program).