### PR TITLE
.github: Don't run CodeQL for every master push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,6 @@ name: codeql
 on:
   push:
     branches:
-    - master
     - v1.10
     - v1.9
     - v1.8
@@ -17,8 +16,6 @@ jobs:
   analyze:
     if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2


### PR DESCRIPTION
We are limited to 20 concurrent GitHub jobs and that limit is frequently reached, leading to long queues. The CodeQL job takes between 17 and 25 minutes so it has a non-negligible impact.

We already run that job on every pull request and once a day. CodeQL performs a static analysis so it's not hard to figure out where the bug is when a bug is reported (vs. end-to-end tests where it may be useful to run on every single commit). This commit therefore removes the CodeQL trigger for every master push.

The `fail-fast` strategy is also removed as it seems to only apply to matrix jobs anyway [1]. In any case, the jobs in the CodeQL workflow each depend on previous jobs succeeding.

1 - https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
