### PR TITLE
Consider "used" or "unused" CNPs / CCNPs as a new metric

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -255,6 +255,7 @@ func (e *Endpoint) regeneratePolicy() (retErr error) {
 		e.getLogger().Debug("Forced policy recalculation")
 	}
 
+	repo.UpdatePolicyMetrics(e.SecurityIdentity, true)
 	// Set the revision of this endpoint to the current revision of the policy
 	// repository.
 	e.setNextPolicyRevision(revision)

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -52,7 +52,7 @@ type Identity struct {
 
 	// ReferenceCount counts the number of references pointing to this
 	// identity. This field is used by the owning cache of the identity.
-	ReferenceCount int `json:"-"`
+	ReferenceCount uint `json:"-"`
 }
 
 // IPIdentityPair is a pairing of an IP and the security identity to which that

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -93,12 +93,14 @@ func (idm *IdentityManager) add(identity *identity.Identity) {
 			identity: identity,
 			refCount: 1,
 		}
+		identity.ReferenceCount = 1
 		for o := range idm.observers {
 			o.LocalEndpointIdentityAdded(identity)
 		}
 
 	} else {
 		idMeta.refCount++
+		identity.ReferenceCount = idMeta.refCount
 	}
 }
 
@@ -172,6 +174,7 @@ func (idm *IdentityManager) remove(identity *identity.Identity) {
 		return
 	}
 	idMeta.refCount--
+	identity.ReferenceCount = idMeta.refCount
 	if idMeta.refCount == 0 {
 		delete(idm.identities, identity.ID)
 		for o := range idm.observers {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -210,6 +210,14 @@ var (
 	// Policy is the number of policies loaded into the agent
 	Policy = NoOpGauge
 
+	// PolicyUsed
+	// PolicyUsed is the number of used policies loaded into the agent
+	PolicyUsed = NoOpGauge
+
+	// PolicyUnused
+	// PolicyUnused is the number of unused policies loaded into the agent
+	PolicyUnused = NoOpGauge
+
 	// PolicyRegenerationCount is the total number of successful policy
 	// regenerations.
 	PolicyRegenerationCount = NoOpCounter
@@ -454,6 +462,8 @@ type Configuration struct {
 	EndpointStateCountEnabled               bool
 	EndpointRegenerationTimeStatsEnabled    bool
 	PolicyCountEnabled                      bool
+	PolicyUsedCountEnabled                  bool
+	PolicyUnusedCountEnabled                bool
 	PolicyRegenerationCountEnabled          bool
 	PolicyRegenerationTimeStatsEnabled      bool
 	PolicyRevisionEnabled                   bool
@@ -521,6 +531,8 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_endpoint_state":                                                {},
 		Namespace + "_endpoint_regeneration_time_stats_seconds":                      {},
 		Namespace + "_policy":                                                        {},
+		Namespace + "_policy_used":                                                   {},
+		Namespace + "_policy_unused":                                                 {},
 		Namespace + "_policy_regeneration_total":                                     {},
 		Namespace + "_policy_regeneration_time_stats_seconds":                        {},
 		Namespace + "_policy_max_revision":                                           {},
@@ -639,6 +651,26 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, Policy)
 			c.PolicyCountEnabled = true
+
+		case Namespace + "_policy_used":
+			PolicyUsed = prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Name:      "policy_used",
+				Help:      "Number of policies used currently loaded",
+			})
+
+			collectors = append(collectors, PolicyUsed)
+			c.PolicyUsedCountEnabled = true
+
+		case Namespace + "_policy_unused":
+			PolicyUnused = prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Name:      "policy_unused",
+				Help:      "Number of policies unused currently loaded",
+			})
+
+			collectors = append(collectors, PolicyUnused)
+			c.PolicyUnusedCountEnabled = true
 
 		case Namespace + "_policy_regeneration_total":
 			PolicyRegenerationCount = prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -70,6 +70,7 @@ func (cache *PolicyCache) lookupOrCreate(identity *identityPkg.Identity, create 
 	if create && !ok {
 		cip = newCachedSelectorPolicy(identity, cache.repo.GetSelectorCache())
 		cache.policies[identity.ID] = cip
+
 	}
 	return cip
 }
@@ -88,6 +89,7 @@ func (cache *PolicyCache) delete(identity *identityPkg.Identity) bool {
 	defer cache.Unlock()
 	cip, ok := cache.policies[identity.ID]
 	if ok {
+		cache.repo.UpdatePolicyMetrics(identity, false)
 		delete(cache.policies, identity.ID)
 		cip.getPolicy().Detach()
 	}
@@ -131,7 +133,6 @@ func (cache *PolicyCache) updateSelectorPolicy(identity *identityPkg.Identity) (
 	if err != nil {
 		return false, err
 	}
-
 	cip.setPolicy(selPolicy)
 
 	return true, nil

--- a/test/k8sT/manifests/sw_l3_l4_dummy.yaml
+++ b/test/k8sT/manifests/sw_l3_l4_dummy.yaml
@@ -1,0 +1,18 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "dummy"
+spec:
+  description: "L3-L4 dummy policy only"
+  endpointSelector:
+    matchLabels:
+      org: frontend 
+      class: eng 
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        org: backend
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP


### PR DESCRIPTION
Added "used" policy and "unused" policy per-node metrics

Fixes: #13338

Signed-off-by: Venkata Reddy <venkata.reddy@accuknox.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
