### PR TITLE
policy: Adjust existing policy for visibility annotations

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -46,8 +46,8 @@ func (e *Endpoint) getPolicyLogger() *logrus.Entry {
 	return (*logrus.Entry)(v)
 }
 
-// policyDebug logs the 'msg' with 'fields' if policy debug logging is enabled.
-func (e *Endpoint) policyDebug(fields logrus.Fields, msg string) {
+// PolicyDebug logs the 'msg' with 'fields' if policy debug logging is enabled.
+func (e *Endpoint) PolicyDebug(fields logrus.Fields, msg string) {
 	if dbgLog := e.getPolicyLogger(); dbgLog != nil {
 		dbgLog.WithFields(fields).Debug(msg)
 	}

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -41,8 +41,8 @@ func (s *EndpointSuite) TestPolicyLog(c *C) {
 	policyLogger.Info("testing policy logging")
 
 	// Test logging with integrated nil check, no fields
-	ep.policyDebug(nil, "testing policyDebug")
-	ep.policyDebug(logrus.Fields{"testField": "Test Value"}, "policyDebug with fields")
+	ep.PolicyDebug(nil, "testing PolicyDebug")
+	ep.PolicyDebug(logrus.Fields{"testField": "Test Value"}, "PolicyDebug with fields")
 
 	// Disable option
 	ep.Options.SetValidated(option.DebugPolicy, option.OptionDisabled)
@@ -55,6 +55,6 @@ func (s *EndpointSuite) TestPolicyLog(c *C) {
 	buf, err := os.ReadFile(filepath.Join(option.Config.StateDir, "endpoint-policy.log"))
 	c.Assert(err, IsNil)
 	c.Assert(bytes.Contains(buf, []byte("testing policy logging")), Equals, true)
-	c.Assert(bytes.Contains(buf, []byte("testing policyDebug")), Equals, true)
+	c.Assert(bytes.Contains(buf, []byte("testing PolicyDebug")), Equals, true)
 	c.Assert(bytes.Contains(buf, []byte("Test Value")), Equals, true)
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -195,6 +195,8 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return secondAnno, nil
 	})
+	err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
@@ -213,6 +215,8 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return thirdAnno, nil
 	})
+	err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
@@ -258,6 +262,8 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return noAnno, nil
 	})
+	err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
 	d, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	ep.removeOldRedirects(d, cmp)

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -315,13 +315,13 @@ var (
 	mapKeyAllowAll__ = Key{0, 0, 0, dirIngress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithoutOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithOwners()
 	}
 	mapEntryL7Deny_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithoutOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithOwners()
 	}
 	mapEntryL7Proxy = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithoutOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithOwners()
 	}
 )
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -589,6 +589,13 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 		}
 	}
 
+	// Add dependency deny-L3->deny-L3L4 if allow-L4 exists
+	denyL3, denyL3exists := m[mapKeyDeny_Foo__]
+	denyL3L4, denyL3L4exists := m[mapKeyDeny_FooL4]
+	allowL4, allowL4exists := m[mapKeyAllow___L4]
+	if allowL4exists && !allowL4.IsDeny && denyL3exists && denyL3.IsDeny && denyL3L4exists && denyL3L4.IsDeny {
+		mapKeyDeny_Foo__.AddDependent(m, mapKeyDeny_FooL4)
+	}
 	return m
 }
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -315,13 +315,13 @@ var (
 	mapKeyAllowAll__ = Key{0, 0, 0, dirIngress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithoutSelectors()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithoutOwners()
 	}
 	mapEntryL7Deny_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithoutSelectors()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithoutOwners()
 	}
 	mapEntryL7Proxy = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithoutSelectors()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithoutOwners()
 	}
 )
 
@@ -371,7 +371,7 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 		allowAllIngress := true
 		allowAllEgress := false // Skip egress
 		result.AllowAllIdentities(allowAllIngress, allowAllEgress)
-		result.clearCachedSelectors()
+		result.clearOwners()
 		return result, nil
 	}
 
@@ -403,18 +403,18 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 		}
 	}
 	l4IngressPolicy.Detach(d.Repository.GetSelectorCache())
-	result.clearCachedSelectors()
+	result.clearOwners()
 	return result, nil
 }
 
-// clearCachedSelectors removes CachedSelectors from MapStateEntries
+// clearOwners removes CachedSelectors from MapStateEntries
 // for testing purposes.  Table-driven testing pattern used for these
 // tests does not allow expected MapStateEntries to contain actual
 // CachedSelectors as those have not been inserted to the selector
 // cache at the time when the expectations are created.
-func (m MapState) clearCachedSelectors() {
+func (m MapState) clearOwners() {
 	for k, v := range m {
-		v.selectors = make(map[CachedSelector]struct{})
+		v.owners = make(map[MapStateOwner]struct{})
 		m[k] = v
 	}
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -318,8 +318,8 @@ func (l4 *L4Filter) GetPort() uint16 {
 //                                caller must replace the ProxyPort with the actual
 //                                listening port number.
 // Note: It is possible for two selectors to select the same security ID.
-// To give priority for L7 redirection (e.g., for visibility purposes), we use
-// RedirectPreferredInsert() instead of directly inserting the value to the map.
+// To give priority for deny and L7 redirection (e.g., for visibility purposes), we use
+// DenyPreferredInsert() instead of directly inserting the value to the map.
 // PolicyOwner (aka Endpoint) is locked during this call.
 func (l4Filter *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficdirection.TrafficDirection) MapState {
 	port := uint16(l4Filter.Port)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -176,6 +176,8 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 	// Record an incremental Add if desired and entry is new or changed
 	if adds != nil && (!exists || !oldEntry.DatapathEqual(&entry)) {
+		// Do not leak internal maps to callers
+		updatedEntry.owners = nil
 		adds[key] = updatedEntry
 		// Key add overrides any previous delete of the same key
 		if deletes != nil {
@@ -203,6 +205,8 @@ func (keys MapState) deleteKeyWithChanges(key Key, cs MapStateOwner, adds, delet
 			}
 		}
 		if deletes != nil {
+			// Do not leak internal maps to callers
+			entry.owners = nil
 			deletes[key] = entry
 			// Remove a potential previously added key
 			if adds != nil {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/u8proto"
 
 	"gopkg.in/check.v1"
 )
@@ -772,6 +773,14 @@ func HttpEgressKey(id int) Key {
 	return testEgressKey(id, 80, 6)
 }
 
+func allowEntry(proxyPort uint16, owners ...MapStateOwner) MapStateEntry {
+	return testEntry(proxyPort, false, owners...)
+}
+
+func denyEntry(proxyPort uint16, owners ...MapStateOwner) MapStateEntry {
+	return testEntry(proxyPort, true, owners...)
+}
+
 func testEntry(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEntry {
 	entry := MapStateEntry{
 		ProxyPort: proxyPort,
@@ -784,6 +793,14 @@ func testEntry(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEnt
 		entry.owners[owner] = struct{}{}
 	}
 	return entry
+}
+
+func allowEntryD(proxyPort uint16, derivedFrom labels.LabelArrayList, owners ...MapStateOwner) MapStateEntry {
+	return testEntryD(proxyPort, false, derivedFrom, owners...)
+}
+
+func denyEntryD(proxyPort uint16, derivedFrom labels.LabelArrayList, owners ...MapStateOwner) MapStateEntry {
+	return testEntryD(proxyPort, true, derivedFrom, owners...)
 }
 
 func testEntryD(proxyPort uint16, deny bool, derivedFrom labels.LabelArrayList, owners ...MapStateOwner) MapStateEntry {
@@ -815,23 +832,23 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		adds      MapState
 		deletes   MapState
 	}{{
-		name: "test-1a - Adding identity to an existing state",
+		name: "test-1a - Adding L3-deny to an existing allow-all with L4-only allow redirect map state entries",
 		setup: MapState{
-			AnyIngressKey():   testEntry(0, false),
-			HttpIngressKey(0): testEntry(12345, false, nil),
+			AnyIngressKey():   allowEntry(0),
+			HttpIngressKey(0): allowEntry(12345, nil),
 		},
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			AnyIngressKey():          testEntry(0, false),
-			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
-			HttpIngressKey(0):        testEntry(12345, false, nil),
-			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+			AnyIngressKey():          allowEntry(0),
+			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):        allowEntry(12345, nil),
+			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
 		},
 		adds: MapState{
-			testIngressKey(41, 0, 0): testEntry(0, true),
-			HttpIngressKey(41):       testEntry(0, true),
+			testIngressKey(41, 0, 0): denyEntry(0),
+			HttpIngressKey(41):       denyEntry(0),
 		},
 		deletes: MapState{},
 	}, {
@@ -841,16 +858,16 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			AnyIngressKey():          testEntry(0, false),
-			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
-			testIngressKey(42, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(42)),
-			HttpIngressKey(0):        testEntry(12345, false, nil),
-			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
-			HttpIngressKey(42):       testEntry(0, true).WithOwners(testIngressKey(42, 0, 0)),
+			AnyIngressKey():          allowEntry(0),
+			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
+			testIngressKey(42, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(42)),
+			HttpIngressKey(0):        allowEntry(12345, nil),
+			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
+			HttpIngressKey(42):       denyEntry(0).WithOwners(testIngressKey(42, 0, 0)),
 		},
 		adds: MapState{
-			testIngressKey(42, 0, 0): testEntry(0, true),
-			HttpIngressKey(42):       testEntry(0, true),
+			testIngressKey(42, 0, 0): denyEntry(0),
+			HttpIngressKey(42):       denyEntry(0),
 		},
 		deletes: MapState{},
 	}, {
@@ -860,15 +877,15 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csFoo, adds: nil, deletes: []int{42}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			AnyIngressKey():          testEntry(0, false),
-			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
-			HttpIngressKey(0):        testEntry(12345, false, nil),
-			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+			AnyIngressKey():          allowEntry(0),
+			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):        allowEntry(12345, nil),
+			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
 		},
 		adds: MapState{},
 		deletes: MapState{
-			testIngressKey(42, 0, 0): testEntry(0, true), // removed key
-			HttpIngressKey(42):       testEntry(0, true), // removed dependent key
+			testIngressKey(42, 0, 0): denyEntry(0), // removed key
+			HttpIngressKey(42):       denyEntry(0), // removed dependent key
 		},
 	}, {
 		name: "test-2a - Adding 2 identities, and deleting a nonexisting key on an empty state",
@@ -876,12 +893,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, true, csFoo),
-			HttpIngressKey(43): testEntry(0, true, csFoo),
+			HttpIngressKey(42): denyEntry(0, csFoo),
+			HttpIngressKey(43): denyEntry(0, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): testEntry(0, true),
-			HttpIngressKey(43): testEntry(0, true),
+			HttpIngressKey(42): denyEntry(0),
+			HttpIngressKey(43): denyEntry(0),
 		},
 		deletes: MapState{},
 	}, {
@@ -891,12 +908,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, true, csFoo, csBar),
-			HttpIngressKey(43): testEntry(0, true, csFoo),
-			HttpIngressKey(44): testEntry(0, true, csBar),
+			HttpIngressKey(42): denyEntry(0, csFoo, csBar),
+			HttpIngressKey(43): denyEntry(0, csFoo),
+			HttpIngressKey(44): denyEntry(0, csBar),
 		},
 		adds: MapState{
-			HttpIngressKey(44): testEntry(0, true),
+			HttpIngressKey(44): denyEntry(0),
 		},
 		deletes: MapState{},
 	}, {
@@ -906,9 +923,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, true, csBar),
-			HttpIngressKey(43): testEntry(0, true, csFoo),
-			HttpIngressKey(44): testEntry(0, true, csBar),
+			HttpIngressKey(42): denyEntry(0, csBar),
+			HttpIngressKey(43): denyEntry(0, csFoo),
+			HttpIngressKey(44): denyEntry(0, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -919,9 +936,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, true, csBar),
-			HttpIngressKey(43): testEntry(0, true, csFoo),
-			HttpIngressKey(44): testEntry(0, true, csBar),
+			HttpIngressKey(42): denyEntry(0, csBar),
+			HttpIngressKey(43): denyEntry(0, csFoo),
+			HttpIngressKey(44): denyEntry(0, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -932,12 +949,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			HttpIngressKey(43): testEntry(0, true, csFoo),
-			HttpIngressKey(44): testEntry(0, true, csBar),
+			HttpIngressKey(43): denyEntry(0, csFoo),
+			HttpIngressKey(44): denyEntry(0, csBar),
 		},
 		adds: MapState{},
 		deletes: MapState{
-			HttpIngressKey(42): testEntry(0, true),
+			HttpIngressKey(42): denyEntry(0),
 		},
 	}, {
 		continued: true,
@@ -946,8 +963,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
 		state: MapState{
-			HttpIngressKey(43): testEntry(0, true, csFoo),
-			HttpIngressKey(44): testEntry(0, true, csBar),
+			HttpIngressKey(43): denyEntry(0, csFoo),
+			HttpIngressKey(44): denyEntry(0, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -955,18 +972,18 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		continued: false,
 		name:      "test-3a - egress allow with deny-L3",
 		setup: MapState{
-			AnyIngressKey():         testEntry(0, false),
-			HostIngressKey():        testEntry(0, false),
-			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
+			AnyIngressKey():         allowEntry(0),
+			HostIngressKey():        allowEntry(0),
+			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
 		},
 		args: []args{
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():         testEntry(0, false),
-			HostIngressKey():        testEntry(0, false),
-			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
+			AnyIngressKey():         allowEntry(0),
+			HostIngressKey():        allowEntry(0),
+			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -978,15 +995,15 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():         testEntry(0, false),
-			HostIngressKey():        testEntry(0, false),
-			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
-			DNSUDPEgressKey(43):     testEntry(0, false, csBar),
-			DNSTCPEgressKey(43):     testEntry(0, false, csBar),
+			AnyIngressKey():         allowEntry(0),
+			HostIngressKey():        allowEntry(0),
+			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
+			DNSUDPEgressKey(43):     allowEntry(0, csBar),
+			DNSTCPEgressKey(43):     allowEntry(0, csBar),
 		},
 		adds: MapState{
-			DNSUDPEgressKey(43): testEntry(0, false),
-			DNSTCPEgressKey(43): testEntry(0, false),
+			DNSUDPEgressKey(43): allowEntry(0),
+			DNSTCPEgressKey(43): allowEntry(0),
 		},
 		deletes: MapState{},
 	}, {
@@ -996,15 +1013,55 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():         testEntry(0, false),
-			HostIngressKey():        testEntry(0, false),
-			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
-			DNSUDPEgressKey(43):     testEntry(0, false, csBar),
-			DNSTCPEgressKey(43):     testEntry(0, false, csBar),
-			HttpEgressKey(43):       testEntry(1, false, csFoo),
+			AnyIngressKey():         allowEntry(0),
+			HostIngressKey():        allowEntry(0),
+			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
+			DNSUDPEgressKey(43):     allowEntry(0, csBar),
+			DNSTCPEgressKey(43):     allowEntry(0, csBar),
+			HttpEgressKey(43):       allowEntry(1, csFoo),
 		},
 		adds: MapState{
-			HttpEgressKey(43): testEntry(1, false),
+			HttpEgressKey(43): allowEntry(1),
+		},
+		deletes: MapState{},
+	}, {
+		name: "test-4 - Adding L3-deny to an existing allow-all",
+		setup: MapState{
+			AnyIngressKey(): allowEntry(0),
+		},
+		args: []args{
+			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():          allowEntry(0),
+			testIngressKey(41, 0, 0): denyEntry(0, csFoo),
+		},
+		adds: MapState{
+			testIngressKey(41, 0, 0): denyEntry(0),
+		},
+		deletes: MapState{},
+	}, {
+		name: "test-5 - Multiple dependent entries",
+		setup: MapState{
+			AnyEgressKey():     allowEntry(0),
+			HttpEgressKey(0):   allowEntry(12345, nil),
+			DNSUDPEgressKey(0): allowEntry(12346, nil),
+		},
+		args: []args{
+			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: false, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyEgressKey():          allowEntry(0),
+			testEgressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpEgressKey(41), DNSUDPEgressKey(41)),
+			HttpEgressKey(0):        allowEntry(12345, nil),
+			HttpEgressKey(41):       denyEntry(0).WithOwners(testEgressKey(41, 0, 0)),
+			DNSUDPEgressKey(0):      allowEntry(12346, nil),
+			DNSUDPEgressKey(41):     denyEntry(0).WithOwners(testEgressKey(41, 0, 0)),
+		},
+		adds: MapState{
+			testEgressKey(41, 0, 0): denyEntry(0),
+			HttpEgressKey(41):       denyEntry(0),
+			DNSUDPEgressKey(41):     denyEntry(0),
 		},
 		deletes: MapState{},
 	}, {
@@ -1014,13 +1071,13 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			//HttpIngressKey(42): testEntry(0, false, csFoo),
+			//HttpIngressKey(42): allowEntry(0, csFoo),
 		},
 		adds: MapState{
-			//HttpIngressKey(42): testEntry(0, false),
+			//HttpIngressKey(42): allowEntry(0),
 		},
 		deletes: MapState{
-			//HttpIngressKey(43): testEntry(0, false),
+			//HttpIngressKey(43): allowEntry(0),
 		},
 	},
 	}
@@ -1078,112 +1135,112 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		adds      MapState
 		deletes   MapState
 	}{{
-		name: "test-1 - Adding identity to an empty state",
+		name: "test-1a - Adding identity to an empty state",
 		args: []args{
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, false, csFoo),
+			HttpIngressKey(42): allowEntry(0, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): testEntry(0, false),
+			HttpIngressKey(42): allowEntry(0),
 		},
 		deletes: MapState{},
 	}, {
 		continued: true,
-		name:      "test-2 - Removing the sole key",
+		name:      "test-1b - Removing the sole key",
 		args: []args{
 			{cs: csFoo, adds: nil, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{},
 		adds:  MapState{},
 		deletes: MapState{
-			HttpIngressKey(42): testEntry(0, false),
+			HttpIngressKey(42): allowEntry(0),
 		},
 	}, {
-		name: "test-3 - Adding 2 identities, and deleting a nonexisting key on an empty state",
+		name: "test-2a - Adding 2 identities, and deleting a nonexisting key on an empty state",
 		args: []args{
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, false, csFoo),
-			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(42): allowEntry(0, csFoo),
+			HttpIngressKey(43): allowEntry(0, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): testEntry(0, false),
-			HttpIngressKey(43): testEntry(0, false),
+			HttpIngressKey(42): allowEntry(0),
+			HttpIngressKey(43): allowEntry(0),
 		},
 		deletes: MapState{},
 	}, {
 		continued: true,
-		name:      "test-4 - Adding Bar also selecting 42",
+		name:      "test-2b - Adding Bar also selecting 42",
 		args: []args{
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, false, csFoo, csBar),
-			HttpIngressKey(43): testEntry(0, false, csFoo),
-			HttpIngressKey(44): testEntry(0, false, csBar),
+			HttpIngressKey(42): allowEntry(0, csFoo, csBar),
+			HttpIngressKey(43): allowEntry(0, csFoo),
+			HttpIngressKey(44): allowEntry(0, csBar),
 		},
 		adds: MapState{
-			HttpIngressKey(44): testEntry(0, false),
+			HttpIngressKey(44): allowEntry(0),
 		},
 		deletes: MapState{},
 	}, {
 		continued: true,
-		name:      "test-5 - Deleting 42 from Foo, remains on Bar and no deletes",
+		name:      "test-2c - Deleting 42 from Foo, remains on Bar and no deletes",
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, false, csBar),
-			HttpIngressKey(43): testEntry(0, false, csFoo),
-			HttpIngressKey(44): testEntry(0, false, csBar),
+			HttpIngressKey(42): allowEntry(0, csBar),
+			HttpIngressKey(43): allowEntry(0, csFoo),
+			HttpIngressKey(44): allowEntry(0, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
 	}, {
 		continued: true,
-		name:      "test-5b - Deleting 42 from Foo again, not deleted",
+		name:      "test-2d - Deleting 42 from Foo again, not deleted",
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): testEntry(0, false, csBar),
-			HttpIngressKey(43): testEntry(0, false, csFoo),
-			HttpIngressKey(44): testEntry(0, false, csBar),
+			HttpIngressKey(42): allowEntry(0, csBar),
+			HttpIngressKey(43): allowEntry(0, csFoo),
+			HttpIngressKey(44): allowEntry(0, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
 	}, {
 		continued: true,
-		name:      "test-6 - Deleting 42 from Bar, deleted",
+		name:      "test-2e - Deleting 42 from Bar, deleted",
 		args: []args{
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(43): testEntry(0, false, csFoo),
-			HttpIngressKey(44): testEntry(0, false, csBar),
+			HttpIngressKey(43): allowEntry(0, csFoo),
+			HttpIngressKey(44): allowEntry(0, csBar),
 		},
 		adds: MapState{},
 		deletes: MapState{
-			HttpIngressKey(42): testEntry(0, false),
+			HttpIngressKey(42): allowEntry(0),
 		},
 	}, {
 		continued: true,
-		name:      "test-6b - Adding an entry that already exists, no adds",
+		name:      "test-2f - Adding an entry that already exists, no adds",
 		args: []args{
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(43): testEntry(0, false, csFoo),
-			HttpIngressKey(44): testEntry(0, false, csBar),
+			HttpIngressKey(43): allowEntry(0, csFoo),
+			HttpIngressKey(44): allowEntry(0, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
 	}, {
 		continued: false,
-		name:      "test-7a - egress HTTP proxy (setup)",
+		name:      "test-3a - egress HTTP proxy (setup)",
 		args: []args{
 			{cs: nil, adds: []int{0}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
 			{cs: nil, adds: []int{1}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
@@ -1191,33 +1248,33 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():     testEntry(0, false, nil),
-			HostIngressKey():    testEntry(0, false, nil),
-			DNSUDPEgressKey(42): testEntry(0, false, csBar),
-			DNSTCPEgressKey(42): testEntry(0, false, csBar),
+			AnyIngressKey():     allowEntry(0, nil),
+			HostIngressKey():    allowEntry(0, nil),
+			DNSUDPEgressKey(42): allowEntry(0, csBar),
+			DNSTCPEgressKey(42): allowEntry(0, csBar),
 		},
 		adds: MapState{
-			AnyIngressKey():     testEntry(0, false),
-			HostIngressKey():    testEntry(0, false),
-			DNSUDPEgressKey(42): testEntry(0, false),
-			DNSTCPEgressKey(42): testEntry(0, false),
+			AnyIngressKey():     allowEntry(0),
+			HostIngressKey():    allowEntry(0),
+			DNSUDPEgressKey(42): allowEntry(0),
+			DNSTCPEgressKey(42): allowEntry(0),
 		},
 		deletes: MapState{},
 	}, {
 		continued: true,
-		name:      "test-7b - egress HTTP proxy (incremental update)",
+		name:      "test-3b - egress HTTP proxy (incremental update)",
 		args: []args{
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():     testEntry(0, false, nil),
-			HostIngressKey():    testEntry(0, false, nil),
-			DNSUDPEgressKey(42): testEntry(0, false, csBar),
-			DNSTCPEgressKey(42): testEntry(0, false, csBar),
-			HttpEgressKey(43):   testEntry(1, false, csFoo),
+			AnyIngressKey():     allowEntry(0, nil),
+			HostIngressKey():    allowEntry(0, nil),
+			DNSUDPEgressKey(42): allowEntry(0, csBar),
+			DNSTCPEgressKey(42): allowEntry(0, csBar),
+			HttpEgressKey(43):   allowEntry(1, csFoo),
 		},
 		adds: MapState{
-			HttpEgressKey(43): testEntry(1, false),
+			HttpEgressKey(43): allowEntry(1),
 		},
 		deletes: MapState{},
 	}, {
@@ -1227,13 +1284,13 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			//HttpIngressKey(42): testEntry(0, false, csFoo),
+			//HttpIngressKey(42): allowEntry(0, csFoo),
 		},
 		adds: MapState{
-			//HttpIngressKey(42): testEntry(0, false),
+			//HttpIngressKey(42): allowEntry(0),
 		},
 		deletes: MapState{
-			//HttpIngressKey(43): testEntry(0, false),
+			//HttpIngressKey(43): allowEntry(0),
 		},
 	},
 	}
@@ -1259,6 +1316,555 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, nil)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(policyMapState)
+		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
+		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
+		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))
+	}
+}
+
+var testLabels = labels.LabelArray{
+	labels.NewLabel("test", "ing", labels.LabelSourceReserved),
+}
+
+func (ds *PolicyTestSuite) TestMapState_AddVisibilityKeys(c *check.C) {
+	csFoo := newTestCachedSelector("Foo", false)
+	csBar := newTestCachedSelector("Bar", false)
+
+	type args struct {
+		redirectPort uint16
+		visMeta      VisibilityMetadata
+	}
+	tests := []struct {
+		name       string
+		keys, want MapState
+		args       args
+	}{
+		{
+			name: "test-1 - Add HTTP ingress visibility - allow-all",
+			keys: MapState{
+				AnyIngressKey(): allowEntry(0),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				AnyIngressKey():   allowEntry(0),
+				HttpIngressKey(0): allowEntryD(12345, visibilityDerivedFrom, nil),
+			},
+		},
+		{
+			name: "test-2 - Add HTTP ingress visibility - no allow-all",
+			keys: MapState{},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{},
+		},
+		{
+			name: "test-3 - Add HTTP ingress visibility - L4-allow",
+			keys: MapState{
+				HttpIngressKey(0): allowEntryD(0, labels.LabelArrayList{testLabels}),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				HttpIngressKey(0): allowEntryD(12345, labels.LabelArrayList{testLabels, visibilityDerivedFromLabels}),
+			},
+		},
+		{
+			name: "test-4 - Add HTTP ingress visibility - L3/L4-allow",
+			keys: MapState{
+				HttpIngressKey(123): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				HttpIngressKey(123): allowEntryD(12345, labels.LabelArrayList{testLabels, visibilityDerivedFromLabels}, csBar),
+			},
+		},
+		{
+			name: "test-5 - Add HTTP ingress visibility - L3-allow (host)",
+			keys: MapState{
+				HostIngressKey(): allowEntry(0),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				HostIngressKey():  allowEntry(0).WithDependents(HttpIngressKey(1)),
+				HttpIngressKey(1): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels}).WithOwners(HostIngressKey()),
+			},
+		},
+		{
+			name: "test-6 - Add HTTP ingress visibility - L3/L4-allow on different port",
+			keys: MapState{
+				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
+			},
+		},
+		{
+			name: "test-7 - Add HTTP ingress visibility - allow-all + L4-deny (no change)",
+			keys: MapState{
+				AnyIngressKey():   allowEntry(0),
+				HttpIngressKey(0): denyEntry(0),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				AnyIngressKey():   allowEntry(0),
+				HttpIngressKey(0): denyEntry(0),
+			},
+		},
+		{
+			name: "test-8 - Add HTTP ingress visibility - allow-all + L3-deny",
+			keys: MapState{
+				AnyIngressKey():           allowEntry(0),
+				testIngressKey(234, 0, 0): denyEntry(0, csFoo),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				AnyIngressKey():           allowEntry(0),
+				testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
+				HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
+				HttpIngressKey(234):       denyEntry(0, csFoo).WithOwners(testIngressKey(234, 0, 0)),
+			},
+		},
+		{
+			name: "test-9 - Add HTTP ingress visibility - allow-all + L3/L4-deny",
+			keys: MapState{
+				AnyIngressKey():     allowEntry(0),
+				HttpIngressKey(132): denyEntry(0, csBar),
+			},
+			args: args{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				AnyIngressKey():     allowEntry(0),
+				HttpIngressKey(132): denyEntry(0, csBar),
+				HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom, nil),
+			},
+		},
+		{
+			name: "test-10 - Add HTTP egress visibility",
+			keys: MapState{
+				AnyEgressKey(): allowEntry(0),
+			},
+			args: args{
+				redirectPort: 12346,
+				visMeta:      VisibilityMetadata{Ingress: false, Port: 80, Proto: u8proto.TCP},
+			},
+			want: MapState{
+				AnyEgressKey():   allowEntry(0),
+				HttpEgressKey(0): allowEntryD(12346, visibilityDerivedFrom, nil),
+			},
+		},
+	}
+	for _, tt := range tests {
+		old := make(MapState, len(tt.keys))
+		for k, v := range tt.keys {
+			old[k] = v
+		}
+		adds := make(MapState)
+		deletes := make(MapState)
+		tt.keys.AddVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, adds, deletes)
+		c.Assert(tt.keys, checker.DeepEquals, tt.want, check.Commentf(tt.name))
+		// Find new and updated entries
+		wantAdds := make(MapState)
+		wantDeletes := make(MapState)
+		for k, v := range old {
+			if _, ok := tt.keys[k]; !ok {
+				wantDeletes[k] = v.export()
+			}
+		}
+		for k, v := range tt.keys {
+			if v2, ok := old[k]; ok {
+				v = v.export()
+				v2 = v2.export()
+				if equals, _ := checker.DeepEqual(v2, v); !equals {
+					wantAdds[k] = v
+					wantDeletes[k] = v2
+				}
+			} else {
+				wantAdds[k] = v.export()
+			}
+		}
+		c.Assert(adds, checker.DeepEquals, wantAdds, check.Commentf(tt.name))
+		c.Assert(deletes, checker.DeepEquals, wantDeletes, check.Commentf(tt.name))
+	}
+}
+
+func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *check.C) {
+	csFoo := newTestCachedSelector("Foo", false)
+	csBar := newTestCachedSelector("Bar", false)
+
+	type args struct {
+		cs       *testCachedSelector
+		adds     []int
+		deletes  []int
+		port     uint16
+		proto    uint8
+		ingress  bool
+		redirect bool
+		deny     bool
+	}
+	type visArgs struct {
+		redirectPort uint16
+		visMeta      VisibilityMetadata
+	}
+	tests := []struct {
+		continued  bool // Start from the end state of the previous test
+		name       string
+		setup      MapState
+		visArgs    []visArgs
+		visAdds    MapState
+		visDeletes MapState
+		args       []args // changes applied, in order
+		state      MapState
+		adds       MapState
+		deletes    MapState
+	}{{
+		name: "test-1a - Adding identity to deny with visibilty",
+		setup: MapState{
+			AnyIngressKey():           allowEntry(0),
+			testIngressKey(234, 0, 0): denyEntry(0, csFoo),
+		},
+		visArgs: []visArgs{{
+			redirectPort: 12345,
+			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+		}},
+		visAdds: MapState{
+			HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom),
+			HttpIngressKey(234): denyEntry(0),
+		},
+		args: []args{
+			{cs: csFoo, adds: []int{235}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():           allowEntry(0),
+			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
+			testIngressKey(235, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
+			HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
+			HttpIngressKey(234):       denyEntry(0).WithOwners(testIngressKey(234, 0, 0)),
+			HttpIngressKey(235):       denyEntry(0).WithOwners(testIngressKey(235, 0, 0)),
+		},
+		adds: MapState{
+			testIngressKey(235, 0, 0): denyEntry(0),
+			HttpIngressKey(235):       denyEntry(0),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-1b - Removing the sole key",
+		args: []args{
+			{cs: csFoo, adds: nil, deletes: []int{235}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():           allowEntry(0),
+			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
+			HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
+			HttpIngressKey(234):       denyEntry(0).WithOwners(testIngressKey(234, 0, 0)),
+		},
+		adds: MapState{},
+		deletes: MapState{
+			testIngressKey(235, 0, 0): denyEntry(0),
+			HttpIngressKey(235):       denyEntry(0),
+		},
+	}, {
+		name: "test-2a - Adding 2 identities, and deleting a nonexisting key on an empty state",
+		args: []args{
+			{cs: csFoo, adds: []int{235, 236}, deletes: []int{50}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
+		},
+		visArgs: []visArgs{{
+			redirectPort: 12345,
+			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+		}},
+		state: MapState{
+			testIngressKey(235, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
+			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
+			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
+		},
+		adds: MapState{
+			testIngressKey(235, 0, 0): allowEntry(0),
+			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom),
+			testIngressKey(236, 0, 0): allowEntry(0),
+			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2b - Adding Bar also selecting 235",
+		args: []args{
+			{cs: csBar, adds: []int{235, 237}, deletes: []int{50}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
+		},
+		visArgs: []visArgs{{
+			redirectPort: 12345,
+			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+		}},
+		state: MapState{
+			testIngressKey(235, 0, 0): allowEntry(0, csFoo, csBar).WithDependents(HttpIngressKey(235)),
+			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
+			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
+			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		},
+		adds: MapState{
+			testIngressKey(237, 0, 0): allowEntry(0),
+			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2c - Deleting 235 from Foo, remains on Bar and no deletes",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{235}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		visArgs: []visArgs{{
+			redirectPort: 12345,
+			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+		}},
+		state: MapState{
+			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
+			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
+			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
+			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2d - Deleting 235 from Foo again, not deleted",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{235}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		visArgs: []visArgs{{
+			redirectPort: 12345,
+			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+		}},
+		state: MapState{
+			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
+			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
+			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
+			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2e - Deleting 235 from Bar, deleted",
+		args: []args{
+			{cs: csBar, adds: []int{}, deletes: []int{235}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		visArgs: []visArgs{{
+			redirectPort: 12345,
+			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+		}},
+		state: MapState{
+			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
+			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		},
+		adds: MapState{},
+		deletes: MapState{
+			testIngressKey(235, 0, 0): allowEntry(0),
+			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom),
+		},
+	}, {
+		continued: true,
+		name:      "test-2f - Adding an entry that already exists, no adds",
+		args: []args{
+			{cs: csBar, adds: []int{237}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
+		},
+		visArgs: []visArgs{{
+			redirectPort: 12345,
+			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+		}},
+		state: MapState{
+			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
+			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-3a - egress HTTP proxy (setup)",
+		setup: MapState{
+			AnyIngressKey():  allowEntry(0),
+			HostIngressKey(): allowEntry(0),
+			HttpEgressKey(0): allowEntry(0),
+		},
+		visArgs: []visArgs{
+			{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			{
+				redirectPort: 12346,
+				visMeta:      VisibilityMetadata{Ingress: false, Port: 80, Proto: u8proto.TCP},
+			},
+			{
+				redirectPort: 12347,
+				visMeta:      VisibilityMetadata{Ingress: false, Port: 53, Proto: u8proto.UDP},
+			},
+		},
+		visAdds: MapState{
+			HttpIngressKey(0): allowEntryD(12345, visibilityDerivedFrom),
+			HttpEgressKey(0):  allowEntryD(12346, visibilityDerivedFrom),
+		},
+		visDeletes: MapState{
+			// Old value for the modified entry
+			HttpEgressKey(0): allowEntry(0),
+		},
+		args: []args{
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
+		},
+		state: MapState{
+			AnyIngressKey():  allowEntry(0),
+			HostIngressKey(): allowEntry(0),
+			// Entry added solely due to visibility annotation has a 'nil' owner
+			HttpIngressKey(0): allowEntryD(12345, visibilityDerivedFrom).WithOwners(nil),
+			// Entries modified due to visibility annotation keep their existing owners (here none)
+			HttpEgressKey(0):    allowEntryD(12346, visibilityDerivedFrom),
+			DNSUDPEgressKey(42): allowEntryD(12347, visibilityDerivedFrom, csBar),
+			DNSTCPEgressKey(42): allowEntry(0, csBar),
+		},
+		adds: MapState{
+			DNSUDPEgressKey(42): allowEntryD(12347, visibilityDerivedFrom),
+			DNSTCPEgressKey(42): allowEntry(0),
+		},
+		deletes: MapState{
+			// AddVisibilityKeys() returns overwritten entries in 'deletes'
+			DNSUDPEgressKey(42): allowEntry(0),
+		},
+	}, {
+		continued: true,
+		name:      "test-3b - egress HTTP proxy (incremental update)",
+		args: []args{
+			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
+		},
+		visArgs: []visArgs{
+			{
+				redirectPort: 12345,
+				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
+			},
+			{
+				redirectPort: 12346,
+				visMeta:      VisibilityMetadata{Ingress: false, Port: 80, Proto: u8proto.TCP},
+			},
+			{
+				redirectPort: 12347,
+				visMeta:      VisibilityMetadata{Ingress: false, Port: 53, Proto: u8proto.UDP},
+			},
+		},
+		state: MapState{
+			AnyIngressKey():     allowEntry(0),
+			HostIngressKey():    allowEntry(0),
+			HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(nil),
+			HttpEgressKey(0):    allowEntryD(12346, visibilityDerivedFrom),
+			DNSUDPEgressKey(42): allowEntryD(12347, visibilityDerivedFrom, csBar),
+			DNSTCPEgressKey(42): allowEntry(0, csBar),
+			// Redirect entries are not modified by visibility annotations
+			HttpEgressKey(43): allowEntry(1, csFoo),
+		},
+		adds: MapState{
+			HttpEgressKey(43): allowEntry(1),
+		},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-n - title",
+		args:      []args{
+			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			//HttpIngressKey(42): allowEntry(0, csFoo),
+		},
+		adds: MapState{
+			//HttpIngressKey(42): allowEntry(0),
+		},
+		deletes: MapState{
+			//HttpIngressKey(43): allowEntry(0),
+		},
+	},
+	}
+
+	policyMapState := MapState{}
+
+	for _, tt := range tests {
+		// Allow omit empty maps
+		if tt.visAdds == nil {
+			tt.visAdds = make(MapState)
+		}
+		if tt.visDeletes == nil {
+			tt.visDeletes = make(MapState)
+		}
+		if tt.adds == nil {
+			tt.adds = make(MapState)
+		}
+		if tt.deletes == nil {
+			tt.deletes = make(MapState)
+		}
+		policyMaps := MapChanges{}
+		if !tt.continued {
+			if tt.setup != nil {
+				policyMapState = tt.setup
+			} else {
+				policyMapState = MapState{}
+			}
+		}
+		adds := make(MapState)
+		deletes := make(MapState)
+		for _, arg := range tt.visArgs {
+			policyMapState.AddVisibilityKeys(DummyOwner{}, arg.redirectPort, &arg.visMeta, adds, deletes)
+		}
+		c.Assert(adds, checker.DeepEquals, tt.visAdds, check.Commentf(tt.name+" (visAdds)"))
+		c.Assert(deletes, checker.DeepEquals, tt.visDeletes, check.Commentf(tt.name+" (visDeletes)"))
+		for _, x := range tt.args {
+			dir := trafficdirection.Egress
+			if x.ingress {
+				dir = trafficdirection.Ingress
+			}
+			adds := x.cs.addSelections(x.adds...)
+			deletes := x.cs.deleteSelections(x.deletes...)
+			var cs CachedSelector
+			if x.cs != nil {
+				cs = x.cs
+			}
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, nil)
+		}
+		adds, deletes = policyMaps.consumeMapChanges(policyMapState)
+		// Visibilty redirects need to be re-applied after consumeMapChanges()
+		for _, arg := range tt.visArgs {
+			policyMapState.AddVisibilityKeys(DummyOwner{}, arg.redirectPort, &arg.visMeta, adds, deletes)
+		}
 		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
 		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
 		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -26,7 +26,8 @@ func (e MapStateEntry) WithOwners(owners ...MapStateOwner) MapStateEntry {
 // WithoutOwners returns a copy of 'e', but owners replaced with 'nil'. 'e' is not modified.
 // Note: This is used only in unit tests and helps test readability.
 func (e MapStateEntry) WithoutOwners() MapStateEntry {
-	return e.WithOwners()
+	e.owners = nil
+	return e
 }
 
 func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
@@ -761,7 +762,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			ProxyPort: proxyPort,
 			IsDeny:    deny,
 		}
-		entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		if len(owners) > 0 {
+			entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		}
 		for _, cs := range owners {
 			entry.owners[cs] = struct{}{}
 		}
@@ -794,7 +797,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpIngressKey(42): TestEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -818,8 +821,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpIngressKey(43): TestEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(43): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -834,7 +837,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpIngressKey(44): TestEntry(0, false, csBar),
 		},
 		adds: MapState{
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(44): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -905,10 +908,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
 		},
 		adds: MapState{
-			AnyIngressKey():     TestEntry(0, false, nil),
-			HostIngressKey():    TestEntry(0, false, nil),
-			DNSUDPEgressKey(42): TestEntry(0, false, csBar),
-			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
+			AnyIngressKey():     TestEntry(0, false),
+			HostIngressKey():    TestEntry(0, false),
+			DNSUDPEgressKey(42): TestEntry(0, false),
+			DNSTCPEgressKey(42): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -925,7 +928,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpEgressKey(43):   TestEntry(1, false, csFoo),
 		},
 		adds: MapState{
-			HttpEgressKey(43): TestEntry(1, false, csFoo),
+			HttpEgressKey(43): TestEntry(1, false),
 		},
 		deletes: MapState{},
 	}, {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -12,21 +12,21 @@ import (
 	"gopkg.in/check.v1"
 )
 
-// WithSelectors returns a copy of 'e', but selectors replaced with 'selectors'. 'e' is not modified.
-// No selectors is represented with a 'nil' map.
-func (e MapStateEntry) WithSelectors(selectors ...CachedSelector) MapStateEntry {
+// WithOwners returns a copy of 'e', but owners replaced with 'owners'. 'e' is not modified.
+// No owners is represented with a 'nil' map.
+func (e MapStateEntry) WithOwners(owners ...MapStateOwner) MapStateEntry {
 	mse := e
-	mse.selectors = make(map[CachedSelector]struct{}, len(selectors))
-	for _, cs := range selectors {
-		mse.selectors[cs] = struct{}{}
+	mse.owners = make(map[MapStateOwner]struct{}, len(owners))
+	for _, cs := range owners {
+		mse.owners[cs] = struct{}{}
 	}
 	return mse
 }
 
-// WithoutSelectors returns a copy of 'e', but selectors replaced with 'nil'. 'e' is not modified.
+// WithoutOwners returns a copy of 'e', but owners replaced with 'nil'. 'e' is not modified.
 // Note: This is used only in unit tests and helps test readability.
-func (e MapStateEntry) WithoutSelectors() MapStateEntry {
-	return e.WithSelectors()
+func (e MapStateEntry) WithoutOwners() MapStateEntry {
+	return e.WithOwners()
 }
 
 func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
@@ -756,14 +756,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		return TestEgressKey(id, 80, 6)
 	}
 
-	TestEntry := func(proxyPort uint16, deny bool, selectors ...CachedSelector) MapStateEntry {
+	TestEntry := func(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEntry {
 		entry := MapStateEntry{
 			ProxyPort: proxyPort,
 			IsDeny:    deny,
 		}
-		entry.selectors = make(map[CachedSelector]struct{}, len(selectors))
-		for _, cs := range selectors {
-			entry.selectors[cs] = struct{}{}
+		entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		for _, cs := range owners {
+			entry.owners[cs] = struct{}{}
 		}
 		return entry
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -7,26 +7,36 @@ package policy
 
 import (
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 
 	"gopkg.in/check.v1"
 )
 
-// WithOwners returns a copy of 'e', but owners replaced with 'owners'. 'e' is not modified.
+// WithOwners replaces owners of 'e' with 'owners'.
 // No owners is represented with a 'nil' map.
 func (e MapStateEntry) WithOwners(owners ...MapStateOwner) MapStateEntry {
-	mse := e
-	mse.owners = make(map[MapStateOwner]struct{}, len(owners))
+	e.owners = make(map[MapStateOwner]struct{}, len(owners))
 	for _, cs := range owners {
-		mse.owners[cs] = struct{}{}
+		e.owners[cs] = struct{}{}
 	}
-	return mse
+	return e
 }
 
-// WithoutOwners returns a copy of 'e', but owners replaced with 'nil'. 'e' is not modified.
+// WithoutOwners clears the 'owners' of 'e'.
 // Note: This is used only in unit tests and helps test readability.
 func (e MapStateEntry) WithoutOwners() MapStateEntry {
 	e.owners = nil
+	return e
+}
+
+// WithDependents 'e' adds 'keys' to 'e.dependents'.
+func (e MapStateEntry) WithDependents(keys ...Key) MapStateEntry {
+	if len(keys) > 0 {
+		for _, key := range keys {
+			e.AddDependent(key)
+		}
+	}
 	return e
 }
 
@@ -717,59 +727,338 @@ func (ds *PolicyTestSuite) TestMapState_DenyPreferredInsert(c *check.C) {
 	}
 }
 
-func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
+func testKey(id int, port uint16, proto uint8, direction trafficdirection.TrafficDirection) Key {
+	return Key{
+		Identity:         uint32(id),
+		DestPort:         port,
+		Nexthdr:          proto,
+		TrafficDirection: direction.Uint8(),
+	}
+}
+
+func testIngressKey(id int, port uint16, proto uint8) Key {
+	return testKey(id, port, proto, trafficdirection.Ingress)
+}
+
+func testEgressKey(id int, port uint16, proto uint8) Key {
+	return testKey(id, port, proto, trafficdirection.Egress)
+}
+
+func DNSUDPEgressKey(id int) Key {
+	return testEgressKey(id, 53, 17)
+}
+
+func DNSTCPEgressKey(id int) Key {
+	return testEgressKey(id, 53, 6)
+}
+
+func HostIngressKey() Key {
+	return testIngressKey(1, 0, 0)
+}
+
+func AnyIngressKey() Key {
+	return testIngressKey(0, 0, 0)
+}
+
+func AnyEgressKey() Key {
+	return testEgressKey(0, 0, 0)
+}
+
+func HttpIngressKey(id int) Key {
+	return testIngressKey(id, 80, 6)
+}
+
+func HttpEgressKey(id int) Key {
+	return testEgressKey(id, 80, 6)
+}
+
+func testEntry(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEntry {
+	entry := MapStateEntry{
+		ProxyPort: proxyPort,
+		IsDeny:    deny,
+	}
+	if len(owners) > 0 {
+		entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+	}
+	for _, owner := range owners {
+		entry.owners[owner] = struct{}{}
+	}
+	return entry
+}
+
+func testEntryD(proxyPort uint16, deny bool, derivedFrom labels.LabelArrayList, owners ...MapStateOwner) MapStateEntry {
+	entry := testEntry(proxyPort, deny, owners...)
+	entry.DerivedFromRules = derivedFrom
+	return entry
+}
+
+func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 	csFoo := newTestCachedSelector("Foo", false)
 	csBar := newTestCachedSelector("Bar", false)
 
-	TestKey := func(id int, port uint16, proto uint8, direction trafficdirection.TrafficDirection) Key {
-		return Key{
-			Identity:         uint32(id),
-			DestPort:         port,
-			Nexthdr:          proto,
-			TrafficDirection: direction.Uint8(),
-		}
+	type args struct {
+		cs       *testCachedSelector
+		adds     []int
+		deletes  []int
+		port     uint16
+		proto    uint8
+		ingress  bool
+		redirect bool
+		deny     bool
 	}
-	TestIngressKey := func(id int, port uint16, proto uint8) Key {
-		return TestKey(id, port, proto, trafficdirection.Ingress)
-	}
-	TestEgressKey := func(id int, port uint16, proto uint8) Key {
-		return TestKey(id, port, proto, trafficdirection.Egress)
-	}
-	DNSUDPEgressKey := func(id int) Key {
-		return TestEgressKey(id, 53, 17)
-	}
-	DNSTCPEgressKey := func(id int) Key {
-		return TestEgressKey(id, 53, 6)
-	}
-	HostIngressKey := func() Key {
-		return TestIngressKey(1, 0, 0)
-	}
-	AnyIngressKey := func() Key {
-		return TestIngressKey(0, 0, 0)
-	}
-	//AnyEgressKey := func() Key {
-	//	return TestEgressKey(0, 0, 0)
-	//}
-	HttpIngressKey := func(id int) Key {
-		return TestIngressKey(id, 80, 6)
-	}
-	HttpEgressKey := func(id int) Key {
-		return TestEgressKey(id, 80, 6)
+	tests := []struct {
+		continued bool // Start from the end state of the previous test
+		name      string
+		setup     MapState
+		args      []args // changes applied, in order
+		state     MapState
+		adds      MapState
+		deletes   MapState
+	}{{
+		name: "test-1a - Adding identity to an existing state",
+		setup: MapState{
+			AnyIngressKey():   testEntry(0, false),
+			HttpIngressKey(0): testEntry(12345, false, nil),
+		},
+		args: []args{
+			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():          testEntry(0, false),
+			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):        testEntry(12345, false, nil),
+			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+		},
+		adds: MapState{
+			testIngressKey(41, 0, 0): testEntry(0, true),
+			HttpIngressKey(41):       testEntry(0, true),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-1b - Adding 2nd identity",
+		args: []args{
+			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():          testEntry(0, false),
+			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
+			testIngressKey(42, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(42)),
+			HttpIngressKey(0):        testEntry(12345, false, nil),
+			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+			HttpIngressKey(42):       testEntry(0, true).WithOwners(testIngressKey(42, 0, 0)),
+		},
+		adds: MapState{
+			testIngressKey(42, 0, 0): testEntry(0, true),
+			HttpIngressKey(42):       testEntry(0, true),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-1c - Removing the same key",
+		args: []args{
+			{cs: csFoo, adds: nil, deletes: []int{42}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():          testEntry(0, false),
+			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):        testEntry(12345, false, nil),
+			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+		},
+		adds: MapState{},
+		deletes: MapState{
+			testIngressKey(42, 0, 0): testEntry(0, true), // removed key
+			HttpIngressKey(42):       testEntry(0, true), // removed dependent key
+		},
+	}, {
+		name: "test-2a - Adding 2 identities, and deleting a nonexisting key on an empty state",
+		args: []args{
+			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, true, csFoo),
+			HttpIngressKey(43): testEntry(0, true, csFoo),
+		},
+		adds: MapState{
+			HttpIngressKey(42): testEntry(0, true),
+			HttpIngressKey(43): testEntry(0, true),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2b - Adding Bar also selecting 42",
+		args: []args{
+			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, true, csFoo, csBar),
+			HttpIngressKey(43): testEntry(0, true, csFoo),
+			HttpIngressKey(44): testEntry(0, true, csBar),
+		},
+		adds: MapState{
+			HttpIngressKey(44): testEntry(0, true),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2c - Deleting 42 from Foo, remains on Bar and no deletes",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, true, csBar),
+			HttpIngressKey(43): testEntry(0, true, csFoo),
+			HttpIngressKey(44): testEntry(0, true, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2d - Deleting 42 from Foo again, not deleted",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, true, csBar),
+			HttpIngressKey(43): testEntry(0, true, csFoo),
+			HttpIngressKey(44): testEntry(0, true, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2e - Deleting 42 from Bar, deleted",
+		args: []args{
+			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			HttpIngressKey(43): testEntry(0, true, csFoo),
+			HttpIngressKey(44): testEntry(0, true, csBar),
+		},
+		adds: MapState{},
+		deletes: MapState{
+			HttpIngressKey(42): testEntry(0, true),
+		},
+	}, {
+		continued: true,
+		name:      "test-2f - Adding an entry that already exists, no adds",
+		args: []args{
+			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			HttpIngressKey(43): testEntry(0, true, csFoo),
+			HttpIngressKey(44): testEntry(0, true, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-3a - egress allow with deny-L3",
+		setup: MapState{
+			AnyIngressKey():         testEntry(0, false),
+			HostIngressKey():        testEntry(0, false),
+			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
+		},
+		args: []args{
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
+		},
+		state: MapState{
+			AnyIngressKey():         testEntry(0, false),
+			HostIngressKey():        testEntry(0, false),
+			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-3b - egress allow DNS on another ID with deny-L3",
+		args: []args{
+			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
+			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
+		},
+		state: MapState{
+			AnyIngressKey():         testEntry(0, false),
+			HostIngressKey():        testEntry(0, false),
+			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
+			DNSUDPEgressKey(43):     testEntry(0, false, csBar),
+			DNSTCPEgressKey(43):     testEntry(0, false, csBar),
+		},
+		adds: MapState{
+			DNSUDPEgressKey(43): testEntry(0, false),
+			DNSTCPEgressKey(43): testEntry(0, false),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-3c - egress allow HTTP proxy with deny-L3",
+		args: []args{
+			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
+		},
+		state: MapState{
+			AnyIngressKey():         testEntry(0, false),
+			HostIngressKey():        testEntry(0, false),
+			testEgressKey(42, 0, 0): testEntry(0, true, csFoo),
+			DNSUDPEgressKey(43):     testEntry(0, false, csBar),
+			DNSTCPEgressKey(43):     testEntry(0, false, csBar),
+			HttpEgressKey(43):       testEntry(1, false, csFoo),
+		},
+		adds: MapState{
+			HttpEgressKey(43): testEntry(1, false),
+		},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-n - title",
+		args:      []args{
+			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			//HttpIngressKey(42): testEntry(0, false, csFoo),
+		},
+		adds: MapState{
+			//HttpIngressKey(42): testEntry(0, false),
+		},
+		deletes: MapState{
+			//HttpIngressKey(43): testEntry(0, false),
+		},
+	},
 	}
 
-	TestEntry := func(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEntry {
-		entry := MapStateEntry{
-			ProxyPort: proxyPort,
-			IsDeny:    deny,
+	policyMapState := MapState{}
+
+	for _, tt := range tests {
+		policyMaps := MapChanges{}
+		if !tt.continued {
+			if tt.setup != nil {
+				policyMapState = tt.setup
+			} else {
+				policyMapState = MapState{}
+			}
 		}
-		if len(owners) > 0 {
-			entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		for _, x := range tt.args {
+			dir := trafficdirection.Egress
+			if x.ingress {
+				dir = trafficdirection.Ingress
+			}
+			adds := x.cs.addSelections(x.adds...)
+			deletes := x.cs.deleteSelections(x.deletes...)
+			var cs CachedSelector
+			if x.cs != nil {
+				cs = x.cs
+			}
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, nil)
 		}
-		for _, cs := range owners {
-			entry.owners[cs] = struct{}{}
-		}
-		return entry
+		adds, deletes := policyMaps.consumeMapChanges(policyMapState)
+		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
+		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
+		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))
 	}
+}
+
+func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
+	csFoo := newTestCachedSelector("Foo", false)
+	csBar := newTestCachedSelector("Bar", false)
 
 	type args struct {
 		cs       *testCachedSelector
@@ -794,10 +1083,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): testEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -809,7 +1098,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		state: MapState{},
 		adds:  MapState{},
 		deletes: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
 		},
 	}, {
 		name: "test-3 - Adding 2 identities, and deleting a nonexisting key on an empty state",
@@ -817,12 +1106,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): testEntry(0, false, csFoo),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
-			HttpIngressKey(43): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
+			HttpIngressKey(43): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -832,12 +1121,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo, csBar),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(42): testEntry(0, false, csFoo, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds: MapState{
-			HttpIngressKey(44): TestEntry(0, false),
+			HttpIngressKey(44): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -847,9 +1136,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csBar),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(42): testEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -860,9 +1149,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csBar),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(42): testEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -873,12 +1162,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds: MapState{},
 		deletes: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
 		},
 	}, {
 		continued: true,
@@ -887,8 +1176,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -902,16 +1191,16 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():     TestEntry(0, false, nil),
-			HostIngressKey():    TestEntry(0, false, nil),
-			DNSUDPEgressKey(42): TestEntry(0, false, csBar),
-			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
+			AnyIngressKey():     testEntry(0, false, nil),
+			HostIngressKey():    testEntry(0, false, nil),
+			DNSUDPEgressKey(42): testEntry(0, false, csBar),
+			DNSTCPEgressKey(42): testEntry(0, false, csBar),
 		},
 		adds: MapState{
-			AnyIngressKey():     TestEntry(0, false),
-			HostIngressKey():    TestEntry(0, false),
-			DNSUDPEgressKey(42): TestEntry(0, false),
-			DNSTCPEgressKey(42): TestEntry(0, false),
+			AnyIngressKey():     testEntry(0, false),
+			HostIngressKey():    testEntry(0, false),
+			DNSUDPEgressKey(42): testEntry(0, false),
+			DNSTCPEgressKey(42): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -921,14 +1210,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():     TestEntry(0, false, nil),
-			HostIngressKey():    TestEntry(0, false, nil),
-			DNSUDPEgressKey(42): TestEntry(0, false, csBar),
-			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
-			HttpEgressKey(43):   TestEntry(1, false, csFoo),
+			AnyIngressKey():     testEntry(0, false, nil),
+			HostIngressKey():    testEntry(0, false, nil),
+			DNSUDPEgressKey(42): testEntry(0, false, csBar),
+			DNSTCPEgressKey(42): testEntry(0, false, csBar),
+			HttpEgressKey(43):   testEntry(1, false, csFoo),
 		},
 		adds: MapState{
-			HttpEgressKey(43): TestEntry(1, false),
+			HttpEgressKey(43): testEntry(1, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -938,13 +1227,13 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			//HttpIngressKey(42): TestEntry(0, false, csFoo),
+			//HttpIngressKey(42): testEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			//HttpIngressKey(42): TestEntry(0, false),
+			//HttpIngressKey(42): testEntry(0, false),
 		},
 		deletes: MapState{
-			//HttpIngressKey(43): TestEntry(0, false),
+			//HttpIngressKey(43): testEntry(0, false),
 		},
 	},
 	}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -6,6 +6,8 @@ package policy
 import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+
+	"github.com/sirupsen/logrus"
 )
 
 // selectorPolicy is a structure which contains the resolved policy for a
@@ -70,6 +72,7 @@ type PolicyOwner interface {
 	LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
 	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
+	PolicyDebug(fields logrus.Fields, msg string)
 }
 
 // newSelectorPolicy returns an empty selectorPolicy stub.

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -477,7 +477,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                          allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithSelectors(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 		},
@@ -491,7 +491,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -487,8 +487,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	// maps on the policy got cleared
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -641,7 +641,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		PolicyOwner: DummyOwner{},
 		PolicyMapState: MapState{
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                          allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithSelectors(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 		},
@@ -663,7 +663,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 
 	// Assign an empty mutex so that checker.Equal does not complain about the

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/testutils/allocator"
 
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -184,6 +185,10 @@ func (d DummyOwner) GetNamedPortLocked(ingress bool, name string, proto uint8) u
 
 func (d DummyOwner) GetID() uint64 {
 	return 1234
+}
+
+func (d DummyOwner) PolicyDebug(fields logrus.Fields, msg string) {
+	log.WithFields(fields).Info(msg)
 }
 
 func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Repository {

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -659,8 +659,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	c.Assert(policy.policyMapChanges.changes, IsNil)
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1265,40 +1265,40 @@ var _ = SkipDescribeIf(func() bool {
 
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
-				By("Importing policy which selects app1; proxy-visibility annotation should be removed")
+				By("Importing policy which selects app1")
 
 				_, err := kubectl.CiliumPolicyAction(
 					namespaceForTest, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be applied in %q namespace", l3Policy, namespaceForTest)
 
-				By("Checking that proxy visibility annotation is removed due to policy being added")
-				checkProxyRedirection(app1PodIP, false, policy.ParserTypeHTTP, false)
+				By("Checking that proxy visibility annotation is still applied even while a policy was imported")
+				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
 				_, err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3Policy, helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be deleted in %q namespace", l3Policy, namespaceForTest)
 
-				By("Checking that proxy visibility annotation is re-added after policy is removed")
+				By("Checking that proxy visibility annotation is still applied after policy is removed")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
-				By("Importing policy using named ports which selects app1; proxy-visibility annotation should be removed")
+				By("Importing policy using named ports which selects app1; proxy-visibility annotation should remain")
 
 				_, err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3NamedPortPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be applied in %q namespace", l3NamedPortPolicy, namespaceForTest)
 
-				By("Checking that proxy visibility annotation is removed due to policy being added")
-				checkProxyRedirection(app1PodIP, false, policy.ParserTypeHTTP, false)
+				By("Checking that proxy visibility annotation is still applied to policy being added")
+				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
 				_, err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3NamedPortPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be deleted in %q namespace", l3NamedPortPolicy, namespaceForTest)
 
-				By("Checking that proxy visibility annotation is re-added after policy is removed")
+				By("Checking that proxy visibility annotation is still applied after policy is removed")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 			})
 		})


### PR DESCRIPTION
Adjust and expand eBPF policy map keys and values to redirect for
visibility on the port of the visibility annotation while still
denying traffic on this port for identities for which the traffic is
denied.

Datapath lookup order is, from highest to lowest precedence:
1. L3/L4
2. L4-only (wildcard L3)
3. L3-only (wildcard L4)
4. Allow-all

This means that the L4-only allow visibility key can only be added if
there is an allow-all key, and all L3-only deny keys are expanded to
L3/L4 keys. If no L4-only key is added then also the L3-only allow
keys need to be expanded to L3/L4 keys for visibility redirection. In
addition the existing L3/L4 and L4-only allow keys need to be
redirected to the proxy port, if not already redirected.

The above can be accomplished by:

1. Change existing L4-only ALLOW key on matching port that does not already
   redirect to redirect.
   - e.g., 0:80=allow,0 -> 0:80=allow,<proxyport>
2. If allow-all key exists, add L4-only visibility redirect key if the L4-only
   key does not already exist.
   - e.g., 0:0=allow,0 -> add 0:80=allow,<proxyport> if 0:80 key does not exist
     - this allows all traffic on port 80, but see step 5 below.
3. Change all L3/L4 ALLOW keys on matching port that do not already redirect to
   redirect.
   - e.g, <ID1>:80=allow,0 -> <ID1>:80=allow,<proxyport>
4. For each L3-only ALLOW key add the corresponding L3/L4 ALLOW redirect if no
   L3/L4 key already exists and no L4-only key already exists and one is not added.
   - e.g., <ID2>:0=allow,0 -> add <ID2>:80=allow,<proxyport> if <ID2>:80
     and 0:80 do not exist and 0:80 was not added
5. If a new L4-only key was added: For each L3-only DENY key add the
   corresponding L3/L4 DENY key if no L3/L4 key already exists
   - e.g., <ID3>:0=deny,0 -> add <ID3>:80=deny,0 if <ID3>:80 does not exist.

With the above we only change/expand existing allow keys to redirect, and
expand existing drop keys to also drop on the port of interest, if a new
L4-only key allowing the port is added.

Adjust the unit test to mimic the real behavior a bit better by
regenerating endpoint policy after updating visibility policy. This is
needed due to the test using same port for HTTP and Kafka, and without
regenerating visibility redirects no longer overwrite existing
redirects.

Visibility redirects need to be re-applied after applying incremental
policy map changes. This is due to incremental changes possibly adding
keys for new identities that need visibility redirections or
additional deny keys as defined above.

Testing: New unit tests in policy package cover all the cases
described above.

Fixes: #9088

```release-note
Pod L7 visibility annotations are now supported also when policy enforcement is enabled.
```
