### PR TITLE
rate: fix TestStressRateLimiter when run with race detector

### DIFF
--- a/pkg/rate/api_limiter_norace_test.go
+++ b/pkg/rate/api_limiter_norace_test.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !race,!privileged_tests
+
+package rate
+
+import "gopkg.in/check.v1"
+
+func (b *ControllerSuite) TestStressRateLimiter(c *check.C) {
+	b.testStressRateLimiter(c, 1000)
+}

--- a/pkg/rate/api_limiter_race_test.go
+++ b/pkg/rate/api_limiter_race_test.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build race,!privileged_tests
+
+package rate
+
+import "gopkg.in/check.v1"
+
+func (b *ControllerSuite) TestStressRateLimiter(c *check.C) {
+	b.testStressRateLimiter(c, 72)
+}

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -721,7 +721,7 @@ func (b *ControllerSuite) TestAdjustedParallelRequests(c *check.C) {
 	c.Assert(a.adjustedParallelRequests(), check.Equals, 2)
 }
 
-func (b *ControllerSuite) TestStressRateLimiter(c *check.C) {
+func (b *ControllerSuite) testStressRateLimiter(c *check.C, nGoRoutines int) {
 	a := NewAPILimiter("foo", APILimiterParameters{
 		EstimatedProcessingDuration: 5 * time.Millisecond,
 		RateLimit:                   1000.0,
@@ -737,7 +737,7 @@ func (b *ControllerSuite) TestStressRateLimiter(c *check.C) {
 	)
 
 	go func() {
-		for i := 0; i < 1000; i++ {
+		for i := 0; i < nGoRoutines; i++ {
 			sem.Acquire(context.Background(), 1)
 			go func() {
 				var (
@@ -760,7 +760,7 @@ func (b *ControllerSuite) TestStressRateLimiter(c *check.C) {
 	}()
 
 	c.Assert(testutils.WaitUntil(func() bool {
-		return atomic.LoadInt32(&completed) == 1000
+		return atomic.LoadInt32(&completed) == int32(nGoRoutines)
 	}, 5*time.Second), check.IsNil)
 
 	log.Infof("%+v", a)


### PR DESCRIPTION
This test is currently failing consistently when run under the race
detector. Similar to TestAllocateID in pkg/idpool, decrease the number
of parallel goroutines when running the test under the race detector.

Fixes #13508
