### PR TITLE
docs: Fix Helm instructions for BGP

### DIFF
--- a/Documentation/gettingstarted/bgp.rst
+++ b/Documentation/gettingstarted/bgp.rst
@@ -60,7 +60,7 @@ Here are the required Helm values:
 
 .. parsed-literal::
 
-   helm install cilium |CHART_RELEASE| --set bgp.enabled=true --set bgp.announce.lbIP=true
+   helm install cilium |CHART_RELEASE| --set bgp.enabled=true --set bgp.announce.loadbalancerIP=true
 
 Verify that Cilium Agent pod is running.
 


### PR DESCRIPTION
Helm value "bgp.announce.lbIP" is invalid, it should be "bgp.announce.loadbalancerIP".
(Source: https://github.com/cilium/cilium/tree/v1.10.0/install/kubernetes/cilium#values)

Signed-off-by: Tobias Mose <tobias.mose@xentom.com>