### PR TITLE
docs: Fix command for overwriting iptables on kube-proxy replacement install

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -67,8 +67,8 @@ Cilium replacement has been installed:
     $ kubectl -n kube-system delete ds kube-proxy
     $ # Delete the configmap as well to avoid kube-proxy being reinstalled during a kubeadm upgrade (works only for K8s 1.19 and newer)
     $ kubectl -n kube-system delete cm kube-proxy
-    $ # Run on each node:
-    $ iptables-restore <(iptables-save | grep -v KUBE)
+    $ # Run on each node with root permissions:
+    $ iptables-save | grep -v KUBE | iptables-restore
 
 .. include:: k8s-install-download-release.rst
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->
Updated the restore iptables command because this command wasn't working on Ubuntu 20.10 arm64.
