### PR TITLE
pkg/k8s: ignore namespace events that do not change labels

### DIFF
--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -92,6 +92,12 @@ func (k *K8sWatcher) updateK8sV1Namespace(oldNS, newNS *slim_corev1.Namespace) e
 	oldIdtyLabels, _ := labelsfilter.Filter(oldLabels)
 	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
 
+	// Do not perform any other operations the the old labels are the same as
+	// the new labels
+	if oldIdtyLabels.DeepEqual(&newIdtyLabels) {
+		return nil
+	}
+
 	eps := k.endpointManager.GetEndpoints()
 	failed := false
 	for _, ep := range eps {


### PR DESCRIPTION
As we can receive different type of namespace events, like difference in
the annotations. We can ignore all of these events unless the labels are
different.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Ignore K8s namespace events that have the same labels
```
