### PR TITLE
v1.9 backports 2021-05-21

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -17,6 +17,14 @@ jobs:
           fetch-depth: 0
       - name: Run checkpatch.pl
         uses: docker://quay.io/cilium/cilium-checkpatch:cc7e6b5811f46d7b040dedfe2f6b0010c2c51a12@sha256:9160b6ca58eb99a3ed5d567a494b2e2001325ebad32029c5bd17a8ae4df01044
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   coccicheck:
     name: coccicheck
     runs-on: ubuntu-latest
@@ -25,6 +33,14 @@ jobs:
       - uses: docker://cilium/coccicheck:1.0
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_all:
     name: build datapath
     runs-on: ubuntu-latest
@@ -50,3 +66,11 @@ jobs:
           V: 0
         run: |
           make --quiet -C bpf build_all || (echo "Run 'make -C bpf build_all' locally to investigate build breakages"; exit 1)
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,3 +16,11 @@ jobs:
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -21,6 +21,14 @@ jobs:
           go mod tidy
           go mod vendor
           git diff --exit-code || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   golangci:
     name: lint
@@ -31,6 +39,14 @@ jobs:
         uses: golangci/golangci-lint-action@v2.5.2
         with:
           version: v1.31
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   precheck:
     runs-on: ubuntu-latest
@@ -48,6 +64,14 @@ jobs:
         run: |
           cd src/github.com/cilium/cilium
           make precheck
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   generate-api:
     runs-on: ubuntu-latest
@@ -65,6 +89,14 @@ jobs:
         run: |
           cd src/github.com/cilium/cilium
           contrib/scripts/check-api-code-gen.sh
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   generate-k8s-api:
     runs-on: ubuntu-latest
@@ -93,3 +125,12 @@ jobs:
         run: |
           cd src/github.com/cilium/cilium
           contrib/scripts/check-k8s-code-gen.sh
+
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/images-legacy-hotfix-releases.yaml
+++ b/.github/workflows/images-legacy-hotfix-releases.yaml
@@ -86,6 +86,15 @@ jobs:
           path: image-digest
           retention-days: 1
 
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   image-digests:
     if: ${{ github.repository == 'cilium/cilium' }}
     name: Display Digests

--- a/.github/workflows/images-legacy-releases.yaml
+++ b/.github/workflows/images-legacy-releases.yaml
@@ -102,6 +102,15 @@ jobs:
           path: image-digest
           retention-days: 1
 
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   image-digests:
     if: ${{ github.repository == 'cilium/cilium' }}
     name: Display Digests

--- a/.github/workflows/images-legacy.yaml
+++ b/.github/workflows/images-legacy.yaml
@@ -96,6 +96,16 @@ jobs:
           name: image-digest ${{ matrix.name }}
           path: image-digest
           retention-days: 1
+
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   image-digests:
     if: ${{ github.repository == 'cilium/cilium' }}
     name: Display Digests

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -94,3 +94,12 @@ jobs:
         with:
           entrypoint: make
           args: -C images hubble-relay-image PUSH=true
+
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -56,3 +56,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: --namespace=test-clusters --init-manifest=cilium.yaml --image=cilium/hubble-perf-test:8cfdbfe "/usr/local/bin/run_in_test_cluster.sh" "--prom-name=prom" "--prom-ns=prom" "--duration=30m"
+
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -90,3 +90,12 @@ jobs:
         with:
           name: cilium-sysdump-out.zip
           path: cilium-sysdump-out.zip
+
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -151,3 +151,12 @@ jobs:
         with:
           name: cilium-sysdump-out.zip
           path: cilium-sysdump-out.zip
+
+      - name: Send slack notification
+        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -453,6 +453,35 @@ Follow the :ref:`backport_process` guide to know how to perform this task.
 
 .. _dev_coo:
 
+Coordination
+++++++++++++
+
+In general, coordinating in the #launchpad Slack channel with the other hat
+owner for the week is encouraged. It can reduce your workload and it will avoid
+backporting conflicts such as opening a PR with the same backports. Such
+discussions will typically revolve around which branches to tackle and which
+day of the week.
+
+An example interaction in #launchpad:
+
+::
+
+    Starting backport round for v1.7 and v1.8 now
+    cc @other-hat-wearer
+
+The other hat owner can then handle v1.9 and v1.10 backports the next day, for
+example.
+
+If there are many backports to be done, then splitting up the rounds can be
+beneficial. Typically, backporters opt to start a round in the beginning of the
+week and then another near the end of the week.
+
+By the start / end of the week, if there are other backport PRs that haven't
+been merged, then please coordinate with the previous / next backporter to
+check what the status is and establish who will work on getting the backports
+into the tree (for instance by investigating CI failures and addressing review
+feedback). There's leeway to negotiate depending on who has time available.
+
 Developer's Certificate of Origin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -464,8 +464,19 @@ func detectDevices(detectNodePortDevs, detectDirectRoutingDev bool) error {
 			"Cannot retrieve host IP addrs for BPF NodePort device detection")
 	} else {
 		for _, a := range addrs {
-			if hasHardwareAddress(a.LinkIndex) {
-				ifidxByAddr[a.IP.String()] = a.LinkIndex
+			// Any cilium_* interface will never be a valid NodePort or Direct Routing
+			// interface. Skip interface if we cannot resolve it from Netlink via its
+			// ifIndex or if its name begins with cilium_.
+			if link, err := netlink.LinkByIndex(a.LinkIndex); err != nil {
+				log.WithError(err).WithField(logfields.LinkIndex, a.LinkIndex).Warn(
+					"Unable to resolve link from ifIndex, skipping interface for device detection")
+			} else if strings.HasPrefix(link.Attrs().Name, "cilium_") {
+				log.WithField(logfields.Device, link.Attrs().Name).Debug(
+					"Skipping Cilium-generated interface for device detection")
+			} else {
+				if hasHardwareAddress(a.LinkIndex) {
+					ifidxByAddr[a.IP.String()] = a.LinkIndex
+				}
 			}
 		}
 	}

--- a/daemon/cmd/kubeproxy_replacement_test.go
+++ b/daemon/cmd/kubeproxy_replacement_test.go
@@ -109,6 +109,15 @@ func (s *KubeProxySuite) TestDetectDevices(c *C) {
 	c.Assert(detectDevices(true, true), IsNil)
 	c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy1"})
 	c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy1")
+
+	// 7. With IPv6 node address on dummy3, set cilium_foo interface to node IP,
+	// only dummy3 should be detected matching node IP (no IPv6 default route present)
+	option.Config.EnableIPv6 = true
+	c.Assert(createDummy("dummy3", "2001:db8::face/64"), IsNil)
+	c.Assert(createDummy("cilium_foo", "2001:db8::face/128"), IsNil)
+	node.SetK8sNodeIP(net.ParseIP("2001:db8::face"))
+	c.Assert(detectDevices(true, true), IsNil)
+	c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy3"})
 }
 
 func createDummy(iface, ipAddr string) error {

--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -1478,7 +1478,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1490,7 +1490,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1544,7 +1544,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1556,7 +1556,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1606,7 +1606,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -638,7 +638,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -650,7 +650,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -704,7 +704,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -716,7 +716,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -766,7 +766,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -1002,7 +1002,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -786,7 +786,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -484,7 +484,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -496,7 +496,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -546,7 +546,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -750,7 +750,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -762,7 +762,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -816,7 +816,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -828,7 +828,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -878,7 +878,7 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -26,7 +26,7 @@ deployment: "echo-b": _echoDeployment & {
 	_serverPort:     "8080"
 	_exposeNodePort: true
 	_exposeHeadless: true
-	_nodePort:       31313
+	_nodePort:       31414
 
 	metadata: labels: component: "services-check"
 	spec: template: spec: containers: [{ports: [{_expose: true, containerPort: 8080, _portName: "http", hostPort: 40000}]}]

--- a/examples/kubernetes/connectivity-check/services.cue
+++ b/examples/kubernetes/connectivity-check/services.cue
@@ -40,7 +40,7 @@ deployment: "pod-to-b-intra-node-hostport": _hostPortDeployment
 // NodePort checks
 _nodePortDeployment: {
 	metadata: labels: component: "nodeport-check"
-	_probeTarget: "echo-b-host-headless:31313"
+	_probeTarget: "echo-b-host-headless:31414"
 }
 deployment: "pod-to-b-multi-node-nodeport": _nodePortDeployment
 deployment: "pod-to-b-intra-node-nodeport": _nodePortDeployment

--- a/examples/policies/host/lock-down-dev-vms.yaml
+++ b/examples/policies/host/lock-down-dev-vms.yaml
@@ -89,14 +89,14 @@ spec:
         name: pod-to-b-intra-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
   - fromEndpoints:
     - matchLabels:
         name: pod-to-b-multi-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
 
 

--- a/examples/policies/host/lock-down-gke.yaml
+++ b/examples/policies/host/lock-down-gke.yaml
@@ -77,14 +77,14 @@ spec:
         name: pod-to-b-intra-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
   - fromEndpoints:
     - matchLabels:
         name: pod-to-b-multi-node-nodeport
     toPorts:
     - ports:
-      - port: "31313"
+      - port: "31414"
         protocol: TCP
 
 

--- a/test/k8sT/manifests/policy-stress-test.yaml
+++ b/test/k8sT/manifests/policy-stress-test.yaml
@@ -734,7 +734,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           exec:
             command:
@@ -745,7 +745,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -798,7 +798,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
         livenessProbe:
           exec:
             command:
@@ -809,7 +809,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31313/public
+            - echo-b-host-headless:31414/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -883,7 +883,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    nodePort: 31313
+    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b


### PR DESCRIPTION
* #16104 -- daemon: Ignore cilium_* interfaces when deriving NodePort device (@eyanulis)
 * #16218 -- ci: add slack notification to GH actions (@nebril)
 * #16158 -- examples, connectivity-check, test: Use even-numbered nodePort (@christarazi)
 * #15989 -- docs: Clarify coordination for backporting process (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16104 16218 16158 15989; do contrib/backporting/set-labels.py $pr done 1.9; done
```