### PR TITLE
endpoint: Skip waiting-to-regenerate -> waiting-for-identity state transitions

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -525,7 +525,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 
 	// If desired state is waiting-for-identity but identity is already
 	// known, bump it to ready state immediately to force re-generation
-	if e.getState() == StateWaitingForIdentity && e.SecurityIdentity != nil {
+	if newEp.state == StateWaitingForIdentity && e.SecurityIdentity != nil {
 		e.setState(StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
 		changed = true
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1328,12 +1328,14 @@ func (e *Endpoint) setState(toState State, reason string) bool {
 		// transitioning to StateWaitingToRegenerate, as this means that a
 		// regeneration is already queued up. Callers would then queue up
 		// another unneeded regeneration, which is undesired.
-		case StateWaitingForIdentity, StateDisconnecting, StateRestoring:
+		// Transition to StateWaitingForIdentity is also not allowed as that
+		// will break the ensuing regeneration.
+		case StateDisconnecting, StateRestoring:
 			goto OKState
-		// Don't log this state transition being invalid below so that we don't
+		// Don't log these state transition being invalid below so that we don't
 		// put warnings in the logs for a case which does not result in incorrect
 		// behavior.
-		case StateWaitingToRegenerate:
+		case StateWaitingForIdentity, StateWaitingToRegenerate:
 			return false
 		}
 	case StateRegenerating:

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -286,7 +286,7 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	assertStateTransition(c, e, e.setState, StateReady, StateDisconnecting, true)
 	assertStateTransition(c, e, e.setState, StateReady, StateDisconnected, false)
 
-	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingForIdentity, true)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingForIdentity, false)
 	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateReady, false)
 	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingToRegenerate, false)
 	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateRegenerating, false)


### PR DESCRIPTION
Regeneration logic fails if waiting-for-identity changes to ready state in a scenario like this:

  builder: ready -> waiting-to-regenerate
  ..
  label change etc: waiting-to-regenerate -> waiting-for-identity
  ..
  labels resolved: waiting-for-identity -> ready
  ..
  builder: (ready) -> regenerating (FAILS as this is not expected)

Resolve this by giving precedence to the waiting-to-regenerate state
over the waiting-for-identity state.  Compensate for possibly blocking
this state change in Cilium endpoint PATCH API.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
Fixed bug causing policy realization being skipped in some scenarios with endpoint identity churn.
```
