### PR TITLE
install: fix ordering of operator resource block

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -228,14 +228,14 @@ spec:
           mountPropagation: {{ .mountPropagation }}
 {{- end }}
 {{- end }}
-{{- if .Values.operator.resources }}
-        resources:
-          {{- toYaml .Values.operator.resources | trim | nindent 10 }}
-{{- end }}
 {{- if .Values.bgp.enabled }}
         - mountPath: /var/lib/cilium/bgp
           name: bgp-config-path
           readOnly: true
+{{- end }}
+{{- if .Values.operator.resources }}
+        resources:
+          {{- toYaml .Values.operator.resources | trim | nindent 10 }}
 {{- end }}
       hostNetwork: true
 {{- if (and .Values.etcd.managed (not .Values.etcd.k8sService)) }}


### PR DESCRIPTION
Signed-off-by: Nick M <4718+rkage@users.noreply.github.com>

Fixes: #16272

```release-note
Fix bug with Helm chart where a user could not enable BGP and set Operator resources.
```
