### PR TITLE
.github: Fix scheduled end-to-end tests

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -31,6 +31,7 @@ jobs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
       - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
           curl ${{ github.event.issue.pull_request.url }} > pr.json
@@ -39,10 +40,12 @@ jobs:
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
       - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: tested-tree
         with:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -31,6 +31,7 @@ jobs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
       - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
           curl ${{ github.event.issue.pull_request.url }} > pr.json
@@ -39,10 +40,12 @@ jobs:
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
       - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: tested-tree
         with:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -31,6 +31,7 @@ jobs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
       - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
           curl ${{ github.event.issue.pull_request.url }} > pr.json
@@ -39,10 +40,12 @@ jobs:
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
       - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: tested-tree
         with:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -32,6 +32,7 @@ jobs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
       - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
           curl ${{ github.event.issue.pull_request.url }} > pr.json
@@ -40,10 +41,12 @@ jobs:
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
       - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: tested-tree
         with:


### PR DESCRIPTION
Commit 50df544 added a new job in the end-to-end workflows to checkout the tested code and run paths-filter on it. That first job fails when the workflows are scheduled (vs. triggered by PR comment) because we try to grab the pull request URL, which doesn't exist:

    curl ${{ github.event.issue.pull_request.url }} > pr.json

results in error:

    Run curl  > pr.json
    curl: try 'curl --help' or 'curl --manual' for more information

We can avoid this by skipping steps in the first job when triggered by schedule. We can't skip the entire first job because the second job has a dependency on the first and would fail if we skipped the first.

Fix tested at https://github.com/pchaigno/cilium/actions/runs/865244530 by pushing to the default branch of my fork.

Fixes: https://github.com/cilium/cilium/pull/16157.