### PR TITLE
daemon: skip overwriting external-ipam datapath configuration when restoring endpoints

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -851,8 +851,17 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, bEp []byte) (*
 	// If host label is present, it's the host endpoint.
 	ep.isHost = ep.HasLabels(labels.LabelHost)
 
-	// Overwrite datapath configuration with the current agent configuration.
-	ep.DatapathConfiguration = NewDatapathConfiguration()
+	// Only overwrite datapath configuration related with enable-endpoint-routes
+	if option.Config.EnableEndpointRoutes {
+		ep.DatapathConfiguration.InstallEndpointRoute = true
+		ep.DatapathConfiguration.RequireEgressProg = true
+		disabled := false
+		ep.DatapathConfiguration.RequireRouting = &disabled
+	} else {
+		ep.DatapathConfiguration.InstallEndpointRoute = false
+		ep.DatapathConfiguration.RequireEgressProg = false
+		ep.DatapathConfiguration.RequireRouting = nil
+	}
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually


### PR DESCRIPTION
Previously, endpoints were restored with a new default datapath configuration. It would
overwrite some of endpoints datapath configurations, such as 'externalIPAM'.

Cilium running on generic-veth mode creates endpoints with 'externalIPAM' setting true,
which means that cilium endpoints ips are not managed by cilium. But the configuration
would be overwritted with false when restoring endpoints, and it made endpoints unable
to be restored and bpf programs unable to be reloaded.

This patch skips overwriting external-ipam datapath configuration when restoring endpoints,
and only overwrites the configurations related to 'enable-endpoint-routes' to fix the
problem.

Fixes: #16281

Signed-off-by: Firmly Zhu <firmlyzhu@gmail.com>


