### PR TITLE
pkg/k8s: set right logic to ignore ipcache errors

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -765,10 +765,10 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 			if !errors.Is(err, &ipcache.ErrOverwrite{
 				ExistingSrc: source.KVStore,
 				NewSrc:      source.Kubernetes,
-			}) || !errors.Is(err, &ipcache.ErrOverwrite{
+			}) && !errors.Is(err, &ipcache.ErrOverwrite{
 				ExistingSrc: source.Local,
 				NewSrc:      source.Kubernetes,
-			}) || !errors.Is(err, &ipcache.ErrOverwrite{
+			}) && !errors.Is(err, &ipcache.ErrOverwrite{
 				ExistingSrc: source.CustomResource,
 				NewSrc:      source.Kubernetes,
 			}) {


### PR DESCRIPTION
The logic to ignore errors is inverted and the errors are still being
printed as warnings. This commit inverts the logic so that only relevant
warnings are printed.

Fixes: 0ab4fa184d3a ("pkg/k8s: ignore certain ipcache errors")
Fixes: 465cac1b740b ("pkg/k8s: ignore overwrite source "custom-resource" with "k8s" errors")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix "unable to update ipcache map entry on pod add" harmless log warnings
```
