### PR TITLE
proxylib/test: fix data race between StartAccessLogServer and Close

### DIFF
--- a/proxylib/test/accesslog_server.go
+++ b/proxylib/test/accesslog_server.go
@@ -111,6 +111,11 @@ func StartAccessLogServer(accessLogName string, bufSize int) *AccessLogServer {
 				log.WithError(err).Warn("Failed to accept access log connection")
 				continue
 			}
+
+			if atomic.LoadUint32(&server.closing) != 0 {
+				break
+			}
+
 			log.Debug("Accepted access log connection")
 
 			server.conns = append(server.conns, uc)


### PR DESCRIPTION
Don't attempt to accept the connection if the server is closing.

Fixes #16296