### PR TITLE
k8s, node: Restore router IPs (cilium_host) from K8s resource 

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -386,12 +386,12 @@ func (d *Daemon) configureIPAM() {
 	}
 
 	if option.Config.IPv6Range != AutoCIDR {
-		_, net, err := net.ParseCIDR(option.Config.IPv6Range)
+		allocCIDR, err := cidr.ParseCIDR(option.Config.IPv6Range)
 		if err != nil {
 			log.WithError(err).WithField(logfields.V6Prefix, option.Config.IPv6Range).Fatal("Invalid IPv6 allocation prefix")
 		}
 
-		node.SetIPv6NodeRange(net)
+		node.SetIPv6NodeRange(allocCIDR)
 	}
 
 	if err := node.AutoComplete(); err != nil {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -139,7 +139,7 @@ func useNodeCIDR(n *nodeTypes.Node) {
 		node.SetIPv4AllocRange(n.IPv4AllocCIDR)
 	}
 	if n.IPv6AllocCIDR != nil && option.Config.EnableIPv6 {
-		node.SetIPv6NodeRange(n.IPv6AllocCIDR.IPNet)
+		node.SetIPv6NodeRange(n.IPv6AllocCIDR)
 	}
 }
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -341,9 +341,8 @@ func GetMasqIPv4AddrsWithDevices() map[string]net.IP {
 }
 
 // SetIPv6NodeRange sets the IPv6 address pool to be used on this node
-func SetIPv6NodeRange(net *net.IPNet) {
-	copy := *net
-	ipv6AllocRange = cidr.NewCIDR(&copy)
+func SetIPv6NodeRange(net *cidr.CIDR) {
+	ipv6AllocRange = net
 }
 
 // AutoComplete completes the parts of addressing that can be auto derived

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -305,6 +305,7 @@ func SetIPv4AllocRange(net *cidr.CIDR) {
 func Uninitialize() {
 	ipv4AllocRange = nil
 	ipv6AllocRange = nil
+	ipv4RouterAddress, ipv6RouterAddress = nil, nil
 }
 
 // GetNodePortIPv4Addrs returns the node-port IPv4 address for NAT

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -162,7 +162,7 @@ func (n *NodeDiscovery) JoinCluster(nodeName string) {
 		node.SetIPv4AllocRange(resp.IPv4AllocCIDR)
 	}
 	if resp.IPv6AllocCIDR != nil {
-		node.SetIPv6NodeRange(resp.IPv6AllocCIDR.IPNet)
+		node.SetIPv6NodeRange(resp.IPv6AllocCIDR)
 	}
 	identity.SetLocalNodeID(resp.NodeIdentity)
 }

--- a/pkg/policy/l3_test.go
+++ b/pkg/policy/l3_test.go
@@ -17,8 +17,6 @@
 package policy
 
 import (
-	"net"
-
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/labels"
@@ -28,8 +26,7 @@ import (
 )
 
 func (ds *PolicyTestSuite) SetUpTest(c *C) {
-	_, v6node, err := net.ParseCIDR("2001:DB8::/96")
-	c.Assert(err, IsNil)
+	v6node := cidr.MustParseCIDR("2001:DB8::/96")
 	v4node := cidr.MustParseCIDR("192.0.2.3/24")
 	node.SetIPv6NodeRange(v6node)
 	node.SetIPv4AllocRange(v4node)


### PR DESCRIPTION
Previously, after a node reboot, Cilium would allocate a new router IP
and append it slice of node IPs. Since the node IPs have already been
synced to the K8s resource, meaning there are already IPs present (from
the previous Cilium instance), the router IP is appended to the slice.
In other parts of Cilium, it is assumed that the router IP is the first
node IP (first element of the slice). Since the new router IP has been
appended to the end, it is no longer where it is expected, aka no longer
the first element. This causes a mismatch of which router IP is to be
used. There should only ever be one router IP (one IPv4 or one IPv6).

In case of a node reboot, the router IPs cannot be restored because they
are wiped away due to the Cilium state dir being mounted as a tmpfs [1].
This commit fixes this to restore the router IPs from the K8s resource
(Node or CiliumNode) if they are present in the annotations. This
prevents the possibility of having more than one router IP, as described
above. Note that router IPs from the K8s resource are only restored if
no router IP was found on the filesystem, which is considered the source
of truth. In other words, the filesystem takes precedence over the K8s
resource. The user is warned in cases of a mismatch between the two
different sources. We also check that the IP to be restored is within
the pod / node CIDR range, otherwise we ignore it from restoration.

[1]: Linux distributions mount /run as tmpfs and Cilium's default state
	 directory is created under /run. (It's worth mentioning that it's
	 also common for /var/run to be symlinked to /run.)

Fixes: https://github.com/cilium/cilium/issues/16279

```release-note
Fix bug where Cilium allocates a new router (`cilium_host`) IP upon node reboot, breaking connectivity especially with IPsec
```