### PR TITLE
.github: Fix concurrency group comment triggers

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -26,6 +26,13 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
+    if: |
+      (github.event.issue.pull_request && (
+        startsWith(github.event.comment.body, 'ci-aks') ||
+        (startsWith(github.event.comment.body, 'test-me-please'))
+      )) ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
+      github.event.label.name == 'ci-run/aks'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -15,7 +15,7 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -15,7 +15,7 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -26,6 +26,13 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
+    if: |
+      (github.event.issue.pull_request && (
+        startsWith(github.event.comment.body, 'ci-eks') ||
+        (startsWith(github.event.comment.body, 'test-me-please'))
+      )) ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
+      github.event.label.name == 'ci-run/eks'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -26,6 +26,13 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
+    if: |
+      (github.event.issue.pull_request && (
+        startsWith(github.event.comment.body, 'ci-gke') ||
+        (startsWith(github.event.comment.body, 'test-me-please'))
+      )) ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
+      github.event.label.name == 'ci-run/gke'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -15,7 +15,7 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -27,6 +27,13 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
+    if: |
+      (github.event.issue.pull_request && (
+        startsWith(github.event.comment.body, 'ci-multicluster') ||
+        (startsWith(github.event.comment.body, 'test-me-please'))
+      )) ||
+      (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
+      github.event.label.name == 'ci-run/multicluster'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -15,7 +15,7 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}"
+  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
The first commit fixes the concurrency groups to avoid random PR comments cancelling ongoing end-to-end tests. The second commit enables skipping the `paths-filter` job when possible. See commit descriptions for details.

Fixes: https://github.com/cilium/cilium/pull/16199.