### PR TITLE
.github: Don't wait for GKE cluster cleanup

### DIFF
--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -282,7 +282,7 @@ jobs:
       - name: Clean up GKE
         if: ${{ always() }}
         run: |
-          gcloud container clusters delete ${{ env.clusterName }} --zone ${{ env.zone }} --quiet
+          gcloud container clusters delete ${{ env.clusterName }} --zone ${{ env.zone }} --quiet --async
 
       - name: Upload artifacts
         if: ${{ failure() }}

--- a/.github/workflows/multicluster.yaml
+++ b/.github/workflows/multicluster.yaml
@@ -244,16 +244,8 @@ jobs:
       - name: Clean up GKE
         if: ${{ always() }}
         run: |
-          i=0
-          for e in ${{ env.clusterName1 }} ${{ env.clusterName2 }}; do
-            gcloud container clusters delete $e --zone ${{ env.zone }} --quiet &
-            pids[$i]=$!
-            ((i++))
-          done
-          # Wait for all cluster-cleanup processes.
-          for pid in ${pids[*]}; do
-            wait $pid
-          done
+          gcloud container clusters delete ${{ env.clusterName1 }} --zone ${{ env.zone }} --quiet --async
+          gcloud container clusters delete ${{ env.clusterName2 }} --zone ${{ env.zone }} --quiet --async
         shell: bash {0}
 
       - name: Upload artifacts


### PR DESCRIPTION
In commit ba737f3 (".github: Parallelize cleanup of multicluster setup"), I missed that `gcloud` can also take an `--async` flag to not  wait for the actual cluster deletion to happen and return immediately (similarly to AKS' `--no-wait`).

This pull request therefore reverts ba737f3 (".github: Parallelize cleanup of multicluster setup") and makes use of `--async` instead.

Related: https://github.com/cilium/cilium/pull/16207.