### PR TITLE
fqdn: Start DNS proxy earlier, block forwarding until rules have been restored

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -245,6 +245,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 		return DNSServerListenerAddr.IP, uint16(DNSServerListenerAddr.Port), DNSServerListenerAddr.String(), nil
 	}
 	dstPort = uint16(DNSServerListenerAddr.Port)
+	s.proxy.RestoreFinished()
 }
 
 func (s *DNSProxyTestSuite) TearDownTest(c *C) {


### PR DESCRIPTION
Split bootstrapFQDN() into proxy setup and rule restoration parts, and
setup proxy in the very beginning of the agent bootstrap to minimize
the time when the DNS proxy is not listening on the DNS proxy
port. Keep DNS proxy request forwarding blocked until DNS proxy rules
have been restored to minimize dropped requests due to missing rules.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
