### PR TITLE
install: Allow setting enable-health-check-nodeport to 'false'

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -526,7 +526,7 @@ data:
 {{- if hasKey .Values.nodePort "directRoutingDevice" }}
   direct-routing-device: {{ .Values.nodePort.directRoutingDevice | quote }}
 {{- end }}
-{{- if .Values.nodePort.enableHealthCheck }}
+{{- if hasKey .Values.nodePort "enableHealthCheck" }}
   enable-health-check-nodeport: {{ .Values.nodePort.enableHealthCheck | quote}}
 {{- end }}
   node-port-bind-protection: {{ .Values.nodePort.bindProtection | quote }}


### PR DESCRIPTION
Per https://docs.cilium.io/en/v1.10/gettingstarted/kubeproxy-free/#kube-proxy-hybrid-modes , when `kubeProxyReplacement=partial`, `enableHealthCheckNodeport` should be `false`. However, the current helm template only allows using the default of `true` or explicitly settings to `true`.
