### PR TITLE
docs: add missing mount bpf fs on minikube GSG

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -98,6 +98,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        .. code-block:: shell-session
 
           minikube start --network-plugin=cni
+          minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf
 
 Install the Cilium CLI
 ======================


### PR DESCRIPTION
Fixes: 413191ba399e ("doc: New quick install guide")
Signed-off-by: André Martins <andre@cilium.io>