### PR TITLE
v1.9 backports 2021-05-27

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -267,8 +267,15 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		ip4Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv4Mask}
 	}
 
-	dpConfig := endpoint.NewDatapathConfiguration()
-	info.DatapathConfiguration = &dpConfig
+	if option.Config.EnableEndpointRoutes {
+		disabled := false
+		dpConfig := &models.EndpointDatapathConfiguration{
+			InstallEndpointRoute: true,
+			RequireEgressProg:    true,
+			RequireRouting:       &disabled,
+		}
+		info.DatapathConfiguration = dpConfig
+	}
 
 	netNS, err := netns.ReplaceNetNSWithName(netNSName)
 	if err != nil {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -306,19 +306,24 @@ func (m *endpointCreationManager) DebugStatus() (output string) {
 // createEndpoint attempts to create the endpoint corresponding to the change
 // request that was specified.
 func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, epTemplate *models.EndpointChangeRequest) (*endpoint.Endpoint, int, error) {
-	if epTemplate.DatapathConfiguration == nil {
-		dpConfig := endpoint.NewDatapathConfiguration()
-		epTemplate.DatapathConfiguration = &dpConfig
-	}
 	if option.Config.EnableEndpointRoutes {
+		if epTemplate.DatapathConfiguration == nil {
+			epTemplate.DatapathConfiguration = &models.EndpointDatapathConfiguration{}
+		}
+
+		// Indicate to insert a per endpoint route instead of routing
+		// via cilium_host interface
 		epTemplate.DatapathConfiguration.InstallEndpointRoute = true
+
+		// Since routing occurs via endpoint interface directly, BPF
+		// program is needed on that device at egress as BPF program on
+		// cilium_host interface is bypassed
 		epTemplate.DatapathConfiguration.RequireEgressProg = true
+
+		// Delegate routing to the Linux stack rather than tail-calling
+		// between BPF programs.
 		disabled := false
 		epTemplate.DatapathConfiguration.RequireRouting = &disabled
-	} else {
-		epTemplate.DatapathConfiguration.InstallEndpointRoute = false
-		epTemplate.DatapathConfiguration.RequireEgressProg = false
-		epTemplate.DatapathConfiguration.RequireRouting = nil
 	}
 
 	log.WithFields(logrus.Fields{

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -359,19 +359,19 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 		}
 	}
 
-	if ip := ep.IPv4Address(); ip.IsSet() {
-		if ep.RequireEndpointRoute() {
-			upsertEndpointRoute(ep, *ip.IPNet(32))
-		} else {
-			removeEndpointRoute(ep, *ip.IPNet(32))
+	if ep.RequireEndpointRoute() {
+		scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
+			logfields.Veth: ep.InterfaceName(),
+		})
+		if ip := ep.IPv4Address(); ip.IsSet() {
+			if err := upsertEndpointRoute(ep, *ip.IPNet(32)); err != nil {
+				scopedLog.WithError(err).Warn("Failed to upsert route")
+			}
 		}
-	}
-
-	if ip := ep.IPv6Address(); ip.IsSet() {
-		if ep.RequireEndpointRoute() {
-			upsertEndpointRoute(ep, *ip.IPNet(128))
-		} else {
-			removeEndpointRoute(ep, *ip.IPNet(128))
+		if ip := ep.IPv6Address(); ip.IsSet() {
+			if err := upsertEndpointRoute(ep, *ip.IPNet(128)); err != nil {
+				scopedLog.WithError(err).Warn("Failed to upsert route")
+			}
 		}
 	}
 

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -525,7 +525,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 
 	// If desired state is waiting-for-identity but identity is already
 	// known, bump it to ready state immediately to force re-generation
-	if e.getState() == StateWaitingForIdentity && e.SecurityIdentity != nil {
+	if newEp.state == StateWaitingForIdentity && e.SecurityIdentity != nil {
 		e.setState(StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
 		changed = true
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1426,12 +1426,14 @@ func (e *Endpoint) setState(toState, reason string) bool {
 		// transitioning to StateWaitingToRegenerate, as this means that a
 		// regeneration is already queued up. Callers would then queue up
 		// another unneeded regeneration, which is undesired.
-		case StateWaitingForIdentity, StateDisconnecting, StateRestoring:
+		// Transition to StateWaitingForIdentity is also not allowed as that
+		// will break the ensuing regeneration.
+		case StateDisconnecting, StateRestoring:
 			goto OKState
-		// Don't log this state transition being invalid below so that we don't
+		// Don't log these state transition being invalid below so that we don't
 		// put warnings in the logs for a case which does not result in incorrect
 		// behavior.
-		case StateWaitingToRegenerate:
+		case StateWaitingForIdentity, StateWaitingToRegenerate:
 			return false
 		}
 	case StateRegenerating:

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -819,8 +819,10 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, bEp []byte) (*
 	// If host label is present, it's the host endpoint.
 	ep.isHost = ep.HasLabels(labels.LabelHost)
 
-	// Overwrite datapath configuration with the current agent configuration.
-	ep.DatapathConfiguration = NewDatapathConfiguration()
+	if ep.isHost {
+		// Overwrite datapath configuration with the current agent configuration.
+		ep.DatapathConfiguration = NewDatapathConfiguration()
+	}
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -288,7 +288,7 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	assertStateTransition(c, e, e.setState, StateReady, StateDisconnecting, true)
 	assertStateTransition(c, e, e.setState, StateReady, StateDisconnected, false)
 
-	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingForIdentity, true)
+	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingForIdentity, false)
 	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateReady, false)
 	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateWaitingToRegenerate, false)
 	assertStateTransition(c, e, e.setState, StateWaitingToRegenerate, StateRegenerating, false)

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -92,6 +92,12 @@ func (k *K8sWatcher) updateK8sV1Namespace(oldNS, newNS *slim_corev1.Namespace) e
 	oldIdtyLabels, _ := labelsfilter.Filter(oldLabels)
 	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
 
+	// Do not perform any other operations the the old labels are the same as
+	// the new labels
+	if oldIdtyLabels.DeepEqual(&newIdtyLabels) {
+		return nil
+	}
+
 	eps := k.endpointManager.GetEndpoints()
 	failed := false
 	for _, ep := range eps {


### PR DESCRIPTION
* #16268 -- pkg/k8s: ignore namespace events that do not change labels (@aanm)
 * #16271 -- endpoint: Skip waiting-to-regenerate -> waiting-for-identity state transitions (@jrajahalme)
 * #16227 -- loader: Revert incorrect initialization of endpoints in chaining mode (@pchaigno)
    - Small conflict in first commit.
    - Skipped commit b21e109 ("test/K8sCustomCalls: Deploy pods after Cilium only") since that test was introduced in v1.10.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16268 16271 16227; do contrib/backporting/set-labels.py $pr done 1.9; done
```