### PR TITLE
watchers: Fix BGP subscriber potentially getting skipped

### DIFF
--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -79,6 +79,10 @@ func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) e
 	}
 	newNodeLabels := newK8sNode.GetLabels()
 
+	if option.Config.BGPAnnounceLBIP {
+		k.bgpSpeakerManager.OnUpdateNode(newK8sNode)
+	}
+
 	nodeEP := k.endpointManager.GetHostEndpoint()
 	if nodeEP == nil {
 		log.Debug("Host endpoint not found, updating node labels")
@@ -90,10 +94,5 @@ func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) e
 	if err != nil {
 		return err
 	}
-
-	if option.Config.BGPAnnounceLBIP {
-		k.bgpSpeakerManager.OnUpdateNode(newK8sNode)
-	}
-
 	return nil
 }


### PR DESCRIPTION
It is possible for the BGP speaker subscriber to be skipped in a K8s
node event if the host endpoint is not yet created. This can happen at
the very early stages of Cilium startup, as a K8s node add event is sent
to the K8s watchers as one of the first events It is also often sent
before any endpoints have been generated. If that happends, then the
consequence is that the MetalLB integration is not seeded with the node
labels, which can prevent peering with the BGP routers if the user has
node-selectors defined in their BGP configuration. In other words, the
MetalLB integration would try to match the selectors against empty
labels, which will always fail.

The short term fix is to move the BGP speaker logic slightly above where
the host endpoint logic can return so that it is guaranteed to always be
executed. Longer term, we have an issue
https://github.com/cilium/cilium/issues/15471 to refactor the
subscribers so that they are executed separately, rather than bundled
into one function like (*K8sWatcher).updateK8sNodeV1(). That would have
prevented this bug.

Fixes: d8dbb82bc1 ("daemon, bgp, watchers: Implement LB IP announcement via
BGP")
Fixes: https://github.com/cilium/cilium/issues/16340

Signed-off-by: Chris Tarazi <chris@isovalent.com>

```release-note
Fix bug where users were unable to use node-selectors in the BGP configuration when using BGP support
```