### PR TITLE
Minikube guide updates

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -99,6 +99,12 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
           minikube start --network-plugin=cni
 
+    .. note::
+
+       From minikube v1.12.1+, cilium networking plugin can be enabled directly with
+       ``--cni=cilium`` parameter in ``minikube start`` command. However, this may not
+       install the latest version of cilium.
+
 Install the Cilium CLI
 ======================
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -98,7 +98,6 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        .. code-block:: shell-session
 
           minikube start --network-plugin=cni
-          minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf
 
 Install the Cilium CLI
 ======================


### PR DESCRIPTION
Add a note about `--cni=cilium` flag that can automatically install Cilium. However, it installs v1.8 by default so add a note regarding this.

Cilium init script mounts the BPF fs if not already mounted so the manual step to mount BPF fs isn't required. Let's double check - 

```
$ minikube start --network-plugin=cni
$ cilium install
$ minikube ssh -- mount | grep bpf
none on /sys/fs/bpf type bpf (rw,relatime)

ks logs cilium-zp2st -c ebpf-mount
Mounting eBPF filesystem...
```

`ebpf-mount` is the init container that mounts the BPF fs. Here is the relevant code in cilium/cli - https://github.com/cilium/cilium-cli/blob/master/install/install.go#L685

Fixes: #16324 
