### PR TITLE
daemon: fix ConntrackLocal broken

### DIFF
--- a/bpf/lib/conntrack_map.h
+++ b/bpf/lib/conntrack_map.h
@@ -7,7 +7,8 @@
 #include "common.h"
 #include "config.h"
 
-#if defined(CT_MAP_TCP4) && defined(CT_MAP_TCP6)
+#if defined(CT_MAP_TCP4) || defined(CT_MAP_TCP6)
+
 #ifdef HAVE_LRU_HASH_MAP_TYPE
 #define CT_MAP_TYPE BPF_MAP_TYPE_LRU_HASH
 #else
@@ -79,5 +80,5 @@ get_ct_map4(const struct ipv4_ct_tuple *tuple)
 	return &CT_MAP_ANY4;
 }
 #endif
-#endif
+#endif /* #if defined(CT_MAP_TCP4) || defined(CT_MAP_TCP6) */
 #endif /* __LIB_CONNTRACK_MAP_H_ */

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -509,8 +509,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapName
 			}
 		}
-
-		ctmap.WriteBPFMacros(fw, nil)
 	}
 
 	if option.Config.AllowICMPFragNeeded {

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -37,12 +37,6 @@ var (
 		callsmap.MapName,
 		callsmap.CustomCallsMapName,
 	}
-	elfCtMapPrefixes = []string{
-		ctmap.MapNameTCP4,
-		ctmap.MapNameAny4,
-		ctmap.MapNameTCP6,
-		ctmap.MapNameAny6,
-	}
 )
 
 // templateCfg wraps a real configuration from an endpoint to pass through its
@@ -160,6 +154,16 @@ func elfMapSubstitutions(ep datapath.Endpoint) map[string]string {
 		result[templateStr] = desiredStr
 	}
 	if ep.ConntrackLocalLocked() {
+		elfCtMapPrefixes := []string{}
+		if option.Config.EnableIPv4 {
+			elfCtMapPrefixes = append(elfCtMapPrefixes, ctmap.MapNameTCP4)
+			elfCtMapPrefixes = append(elfCtMapPrefixes, ctmap.MapNameAny4)
+		}
+		if option.Config.EnableIPv6 {
+			elfCtMapPrefixes = append(elfCtMapPrefixes, ctmap.MapNameTCP6)
+			elfCtMapPrefixes = append(elfCtMapPrefixes, ctmap.MapNameAny6)
+		}
+
 		for _, name := range elfCtMapPrefixes {
 			templateStr := bpf.LocalMapName(name, templateLxcID)
 			desiredStr := bpf.LocalMapName(name, epID)


### PR DESCRIPTION
When enable per-endpoint CT with:

$ cilium config ConntrackLocal=true

the agent complains that some macros such as CT_MAP_TCP4, CT_MAP_TCP6 are
re-defined, which in turn leads to BPF regenration failed. The reason is
that these macros are currently both defined in node_config.h and
ep_config.h, and with ConntrackLocal=false, the values are the same
respectively; but when ConntrackLocal=true, the values will be different.

This patch fixes the problem by removing the duplicated macros from
node_config.h, and also respecting EnableIPv4/EnableIPv6 configurations
when performing ELF substitutions.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>