### PR TITLE
remove ARP entries left from previous Cilium run

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1697,6 +1697,11 @@ func runDaemon() {
 		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
 
+	// clean up all arp PERM entries that might have previously set by
+	// a Cilium instance
+	if !d.datapath.Node().NodeNeighDiscoveryEnabled() {
+		d.datapath.Node().NodeCleanNeighbors()
+	}
 	// Start periodical arping to refresh neighbor table
 	if d.datapath.Node().NodeNeighDiscoveryEnabled() && option.Config.ARPPingRefreshPeriod != 0 {
 		d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -492,6 +492,11 @@ func (c *clusterNodesClient) NodeNeighDiscoveryEnabled() bool {
 }
 
 func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	// no-op
+	return
+}
+
+func (c *clusterNodesClient) NodeCleanNeighbors() {
 	// no-op
 	return
 }

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,5 +53,9 @@ func (n *fakeNodeHandler) NodeNeighDiscoveryEnabled() bool {
 }
 
 func (n *fakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
+	return
+}
+
+func (n *fakeNodeHandler) NodeCleanNeighbors() {
 	return
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@ package linux
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -52,6 +54,15 @@ const (
 	success      = "success"
 	failed       = "failed"
 )
+
+const (
+	neighFileName = "neigh-link.json"
+)
+
+// NeighLink contains the details of a NeighLink
+type NeighLink struct {
+	Name string `json:"link-name"`
+}
 
 type linuxNodeHandler struct {
 	mutex                  lock.Mutex
@@ -1391,6 +1402,17 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 				return fmt.Errorf("cannot find link by name %s for neigh discovery: %w",
 					ifaceName, err)
 			}
+
+			// Store neighDiscoveryLink so that we can remove the ARP
+			// PERM entries when cilium-agent starts with neigh discovery
+			// disabled next time.
+			err = storeNeighLink(option.Config.StateDir, ifaceName)
+			if err != nil {
+				log.WithError(err).Warning("Unable to store neigh discovery iface." +
+					" Removing ARP PERM entries upon cilium-agent init when neigh" +
+					" discovery is disabled will not work.")
+			}
+
 			// neighDiscoveryLink can be accessed by a concurrent insertNeighbor
 			// goroutine.
 			n.neighLock.Lock()
@@ -1479,6 +1501,118 @@ func (n *linuxNodeHandler) NodeNeighborRefresh(ctx context.Context, nodeToRefres
 	case <-ctx.Done():
 	case <-refreshComplete:
 	}
+}
+
+// NodeCleanNeighbors cleans all neighbor entries of previously used neighbor
+// discovery link interfaces. It should be used when the agent changes the state
+// from `n.enableNeighDiscovery = true` to `n.enableNeighDiscovery = false`.
+func (n *linuxNodeHandler) NodeCleanNeighbors() {
+	linkName, err := loadNeighLink(option.Config.StateDir)
+	if err != nil {
+		log.WithError(err).Error("Unable to load neigh discovery iface name" +
+			" for removing ARP PERM entries")
+		return
+	}
+	if len(linkName) == 0 {
+		return
+	}
+
+	// Delete the file after cleaning up neighbor list if we were able to clean
+	// up all neighbors.
+	successClean := true
+	defer func() {
+		if successClean {
+			os.Remove(filepath.Join(option.Config.StateDir, neighFileName))
+		}
+	}()
+
+	l, err := netlink.LinkByName(linkName)
+	if err != nil {
+		// If the link is not found we don't need to keep retrying cleaning
+		// up the neihbor entries so we can keep successClean=true
+		if _, ok := err.(netlink.LinkNotFoundError); !ok {
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.Device: linkName,
+			}).Error("Unable to remove PERM ARP entries of network device")
+			successClean = false
+		}
+		return
+	}
+
+	neighList, err := netlink.NeighListExecute(netlink.Ndmsg{
+		Family: netlink.FAMILY_V4,
+		Index:  uint32(l.Attrs().Index),
+		State:  netlink.NUD_PERMANENT,
+	})
+	if err != nil {
+		log.WithError(err).WithFields(logrus.Fields{
+			logfields.Device:    linkName,
+			logfields.LinkIndex: l.Attrs().Index,
+		}).Error("Unable to list PERM ARP entries for removal of network device")
+		successClean = false
+		return
+	}
+
+	var successRemoval, errRemoval int
+	for _, neigh := range neighList {
+		err := netlink.NeighDel(&neigh)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.Device:    linkName,
+				logfields.LinkIndex: l.Attrs().Index,
+				"neighbor":          neigh.String(),
+			}).Errorf("Unable to remove PERM ARP entry of network device. "+
+				"Consider removing this entry manually with 'ip neigh del %s dev %s'", neigh.IP.String(), linkName)
+			errRemoval++
+			successClean = false
+		} else {
+			successRemoval++
+		}
+	}
+	if successRemoval != 0 {
+		log.WithFields(logrus.Fields{
+			logfields.Count: successRemoval,
+		}).Info("Removed PERM ARP entries previously installed by cilium-agent")
+	}
+	if errRemoval != 0 {
+		log.WithFields(logrus.Fields{
+			logfields.Count: errRemoval,
+		}).Warning("Unable to remove PERM ARP entries previously installed by cilium-agent")
+	}
+}
+
+func storeNeighLink(dir string, name string) error {
+	configFileName := filepath.Join(dir, neighFileName)
+	f, err := os.Create(configFileName)
+	if err != nil {
+		return fmt.Errorf("unable to create '%s': %w", configFileName, err)
+	}
+	defer f.Close()
+	nl := NeighLink{Name: name}
+	err = json.NewEncoder(f).Encode(nl)
+	if err != nil {
+		return fmt.Errorf("unable to encode '%+v': %w", nl, err)
+	}
+	return nil
+}
+
+func loadNeighLink(dir string) (string, error) {
+	configFileName := filepath.Join(dir, neighFileName)
+	f, err := os.Open(configFileName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("unable to open '%s': %w", configFileName, err)
+	}
+	defer f.Close()
+	var nl NeighLink
+
+	err = json.NewDecoder(f).Decode(&nl)
+	if err != nil {
+		return "", fmt.Errorf("unable to decode '%s': %w", configFileName, err)
+	}
+	return nl.Name, nil
 }
 
 // NodeDeviceNameWithDefaultRoute returns the node's device name which

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -957,6 +957,12 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
+	prevStateDir := option.Config.StateDir
+	defer func() { option.Config.StateDir = prevStateDir }()
+
+	tmpDir := c.MkDir()
+	option.Config.StateDir = tmpDir
+
 	// 1. Test whether another node in the same L2 subnet can be arpinged.
 	//    The other node is in the different netns reachable via the veth pair.
 	//
@@ -1402,6 +1408,39 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		}
 	}
 	c.Assert(found, check.Equals, false)
+
+	c.Assert(linuxNodeHandler.NodeAdd(nodev3), check.IsNil)
+	time.Sleep(100 * time.Millisecond) // insertNeighbor is invoked async
+
+	nextHop = net.ParseIP("9.9.9.250")
+	// Check that both node{2,3} are via nextHop (gw)
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found = false
+	for _, n := range neighs {
+		if n.IP.Equal(nextHop) && n.State == netlink.NUD_PERMANENT {
+			found = true
+		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
+			c.ExpectFailure("node{2,3} should not be in the same L2")
+		}
+	}
+	c.Assert(found, check.Equals, true)
+
+	// We have stored the devices in NodeConfigurationChanged
+	linuxNodeHandler.NodeCleanNeighbors()
+
+	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+	c.Assert(err, check.IsNil)
+	found = false
+	for _, n := range neighs {
+		if n.IP.Equal(nextHop) && n.State == netlink.NUD_PERMANENT {
+			found = true
+		} else if n.IP.Equal(node2IP) || n.IP.Equal(node3IP) {
+			c.ExpectFailure("node{2,3} should not be in the same L2")
+		}
+	}
+	c.Assert(found, check.Equals, false)
+
 }
 
 func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config datapath.LocalNodeConfiguration) {

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,4 +107,15 @@ func (s *linuxTestSuite) TestCreateNodeRouteSpecMtu(c *check.C) {
 
 	c.Assert(err, check.IsNil)
 	c.Assert(generatedRoute.MTU, check.Equals, 0)
+}
+
+func (s *linuxTestSuite) TestStoreLoadNeighLinks(c *check.C) {
+	tmpDir := c.MkDir()
+	devExpected := "dev1"
+	err := storeNeighLink(tmpDir, devExpected)
+	c.Assert(err, check.IsNil)
+
+	devsActual, err := loadNeighLink(tmpDir)
+	c.Assert(err, check.IsNil)
+	c.Assert(devExpected, checker.DeepEquals, devsActual)
 }

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -140,4 +140,8 @@ type NodeHandler interface {
 
 	// NodeNeighborRefresh is called to refresh node neighbor table
 	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node)
+
+	// NodeCleanNeighbors cleans all neighbor entries for the direct routing device
+	// and the encrypt interface.
+	NodeCleanNeighbors()
 }

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,6 +127,11 @@ func (h handler) NodeNeighDiscoveryEnabled() bool {
 // NodeNeighborRefresh implements
 // datapath.NodeHandler.NodeNeighborRefresh. It is a no-op.
 func (h handler) NodeNeighborRefresh(_ context.Context, _ types.Node) {
+	// no-op
+	return
+}
+
+func (h handler) NodeCleanNeighbors() {
 	// no-op
 	return
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -147,6 +147,10 @@ func (n *signalNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTy
 	return
 }
 
+func (n *signalNodeHandler) NodeCleanNeighbors() {
+	return
+}
+
 func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp := newSignalNodeHandler()
 	dp.EnableNodeAddEvent = true


### PR DESCRIPTION
In certain configurations, when node neighbor discovery is enabled [1],
the neighbor table is populated with PERMANENT entries. If the agent is
then configured to not use neighbor discovery, those entries are left
behind, without being garbage collected. This can cause connectivity
issues across nodes, where it's more likely to happen in the same L2
network, if a new node reuses an IP address from a previous node and its
MAC address changes. In a L3 network it is unlikely to happen since the
ARP entry will be associated with a L3 router and it is less likely to
change its MAC address.

[1]
```
n.enableNeighDiscovery = n.nodeConfig.EnableIPv4 &&
	(option.Config.EnableNodePort ||
		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled))
```

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Remove previous PERM ARP entries installed by Cilium when kube-proxy-replacement and IPSec are disabled.
```

v1.8 backport: https://github.com/cilium/cilium/pull/15993
v1.9 backport: https://github.com/cilium/cilium/pull/16358

:warning: **The review of this PR was already done in https://github.com/cilium/cilium/pull/15993 so no need to wait for reviews of CODEOWNERS as janitor's enough.**