### PR TITLE
.github: Fix error triggered by large comments

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -15,7 +15,13 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
+  # In case of PR comment, we can't simply append the comment to the group name
+  # as that is too long and results in an error. Instead we check if it's a
+  # trigger phrase and append a simple 'trigger-phrase'.
+  group: |
+    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
+     ${{ (startsWith(github.event.comment.body, 'ci-aks') ||
+          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -15,7 +15,13 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
+  # In case of PR comment, we can't simply append the comment to the group name
+  # as that is too long and results in an error. Instead we check if it's a
+  # trigger phrase and append a simple 'trigger-phrase'.
+  group: |
+    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
+     ${{ (startsWith(github.event.comment.body, 'ci-eks') ||
+          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -15,7 +15,13 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
+  # In case of PR comment, we can't simply append the comment to the group name
+  # as that is too long and results in an error. Instead we check if it's a
+  # trigger phrase and append a simple 'trigger-phrase'.
+  group: |
+    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
+     ${{ (startsWith(github.event.comment.body, 'ci-gke') ||
+          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -15,7 +15,13 @@ on:
   ###
 
 concurrency:
-  group: "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }} ${{ github.event.comment.body }}"
+  # In case of PR comment, we can't simply append the comment to the group name
+  # as that is too long and results in an error. Instead we check if it's a
+  # trigger phrase and append a simple 'trigger-phrase'.
+  group: |
+    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
+     ${{ (startsWith(github.event.comment.body, 'ci-multicluster') ||
+          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
To ensure random pull request comments don't cancel ongoing workflows, commit c569ead (".github: Fix concurrency group for comment-triggered workflows") appended the comment message to the concurrency group name. Unfortunately, that results in an error when the comment is too large:

    The maximum allowed memory size was exceeded while evaluating the following expression

This pull request fixes that error by simply appending `trigger-phrase` if the comment is one of the allowed trigger phrases and appending nothing otherwise. That way we avoid appending the whole comment to the concurrency group name, but still get a different concurrency group name for random comments and trigger comments.

This change was tested on a toy repository with both trigger phrases and a large comment.

Fixes: https://github.com/cilium/cilium/pull/16310.