### PR TITLE
operator: remove deprecated options

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -353,8 +353,6 @@ data:
   auto-create-cilium-node-resource: "true"
 {{- if .Values.eni.updateEC2AdapterLimitViaAPI }}
   update-ec2-adapter-limit-via-api: "true"
-  # The below value is deprecated and will be removed in a future release, see https://github.com/cilium/cilium/issues/12396
-  update-ec2-apdater-limit-via-api: "true"
 {{- end }}
 {{- if .Values.eni.awsReleaseExcessIPs }}
   aws-release-excess-ips: "true"

--- a/operator/main.go
+++ b/operator/main.go
@@ -91,8 +91,6 @@ var (
 		},
 	}
 
-	// Deprecated: remove in 1.9
-	apiServerPort  uint16
 	shutdownSignal = make(chan struct{})
 
 	ciliumK8sClient clientset.Interface
@@ -205,7 +203,7 @@ func kvstoreEnabled() bool {
 
 func getAPIServerAddr() []string {
 	if operatorOption.Config.OperatorAPIServeAddr == "" {
-		return []string{fmt.Sprintf("127.0.0.1:%d", apiServerPort), fmt.Sprintf("[::1]:%d", apiServerPort)}
+		return []string{"127.0.0.1:0", "[::1]:0"}
 	}
 	return []string{operatorOption.Config.OperatorAPIServeAddr}
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -149,10 +149,6 @@ const (
 	// ParallelAllocWorkers specifies the number of parallel workers to be used for IPAM allocation
 	ParallelAllocWorkers = "parallel-alloc-workers"
 
-	// UpdateEC2AdapterLimitViaAPIDeprecated configures the operator to use the EC2
-	// API to fill out the instancetype to adapter limit mapping.
-	UpdateEC2AdapterLimitViaAPIDeprecated = "update-ec2-apdater-limit-via-api"
-
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2
 	// API to fill out the instancetype to adapter limit mapping.
 	UpdateEC2AdapterLimitViaAPI = "update-ec2-adapter-limit-via-api"
@@ -404,8 +400,7 @@ func (c *OperatorConfig) Populate() {
 	// AWS options
 
 	c.AWSReleaseExcessIPs = viper.GetBool(AWSReleaseExcessIPs)
-	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPIDeprecated) ||
-		viper.GetBool(UpdateEC2AdapterLimitViaAPI)
+	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.EC2APIEndpoint = viper.GetString(EC2APIEndpoint)
 
 	// Azure options

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"fmt"
-
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/spf13/viper"
 
@@ -45,9 +43,6 @@ func init() {
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(operatorOption.ENITags)
 
-	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPIDeprecated, false, fmt.Sprintf("Use the EC2 API to update the instance type to adapter limits. Deprecated in favor of %s", operatorOption.UpdateEC2AdapterLimitViaAPI))
-	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPIDeprecated)
-	flags.MarkDeprecated(operatorOption.UpdateEC2AdapterLimitViaAPIDeprecated, "This option will be removed in v1.10")
 	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
 	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPI)
 


### PR DESCRIPTION
Drive-by cleanup: these were scheduled to be removed in 1.10 or earlier.

```release-note
Remove deprecated --update-ec2-apdater-limit-via-api option
```
