### PR TITLE
helm: Disable the bandwidth manager by default

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -58,7 +58,7 @@ contributors across the globe, there is almost always someone available to help.
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | autoDirectNodeRoutes | bool | `false` |  |
 | azure.enabled | bool | `false` | Enable Azure integration |
-| bandwidthManager | bool | `true` | Optimize TCP and UDP workloads and enable rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
+| bandwidthManager | bool | `false` | Optimize TCP and UDP workloads and enable rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
 | bgp | object | `{"announce":{"loadbalancerIP":false},"enabled":false}` | Configure BGP |
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -214,7 +214,7 @@ alibabacloud:
 # -- Optimize TCP and UDP workloads and enable rate-limiting traffic from
 # individual Pods with EDT (Earliest Departure Time)
 # through the "kubernetes.io/egress-bandwidth" Pod annotation.
-bandwidthManager: true
+bandwidthManager: false
 
 # -- Configure BGP
 bgp:


### PR DESCRIPTION
Commit 5412142 disabled our kube-proxy replacement (KPR) by default. If the bandwidth manager is enabled, we will still autodetect the devices. However, if we are running in native routing mode, since KPR is disabled, we will hit #12205 (connectivity issues when devices are set but KPR is disabled).

We therefore should disable the bandwidth manager by default to avoid running into this bug. The same will be done for the cilium-cli default installation.

The bandwidth manager is also still a beta feature, so probably best not to enable it by default.

Related: 5412142 ("install: Disable kube-proxy-replacement by default")
Related: https://github.com/cilium/cilium/issues/12205.