### PR TITLE
endpoint: trigger k8s sync controller on identity update

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -149,6 +149,7 @@ type Controller struct {
 	uuid              string
 	stop              chan struct{}
 	update            chan struct{}
+	trigger           chan struct{}
 	ctxDoFunc         context.Context
 	cancelDoFunc      context.CancelFunc
 
@@ -178,6 +179,14 @@ func (c *Controller) GetLastError() error {
 	defer c.mutex.RUnlock()
 
 	return c.lastError
+}
+
+// Trigger triggers the controller
+func (c *Controller) Trigger() {
+	select {
+	case c.trigger <- struct{}{}:
+	default:
+	}
 }
 
 // GetLastErrorTimestamp returns the last error returned
@@ -283,6 +292,7 @@ func (c *Controller) runController() {
 			runFunc = true
 
 		case <-runTimer.After(interval):
+		case <-c.trigger:
 		}
 
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -352,6 +352,12 @@ type Endpoint struct {
 	noTrackPort uint16
 }
 
+// EndpointSyncControllerName returns the controller name to synchronize
+// endpoint in to kubernetes.
+func EndpointSyncControllerName(epID uint16) string {
+	return fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", epID)
+}
+
 // SetAllocator sets the identity allocator for this endpoint.
 func (e *Endpoint) SetAllocator(allocator cache.IdentityAllocator) {
 	e.unconditionalLock()
@@ -1960,6 +1966,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	// Unconditionally force policy recomputation after a new identity has been
 	// assigned.
 	e.forcePolicyComputation()
+
+	// Trigger the sync-to-k8s-ciliumendpoint controller to sync the new
+	// endpoint's identity.
+	e.controllers.TriggerController(EndpointSyncControllerName(e.ID))
 
 	e.unlock()
 

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -43,12 +43,6 @@ const (
 	subsysEndpointSync = "endpointsynchronizer"
 )
 
-// controllerNameOf returns the controller name to synchronize endpoint in to
-// kubernetes.
-func controllerNameOf(epID uint16) string {
-	return fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", epID)
-}
-
 // EndpointSynchronizer currently is an empty type, which wraps around syncing
 // of CiliumEndpoint resources.
 type EndpointSynchronizer struct{}
@@ -61,7 +55,7 @@ type EndpointSynchronizer struct{}
 func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 	var (
 		endpointID     = e.ID
-		controllerName = controllerNameOf(endpointID)
+		controllerName = endpoint.EndpointSyncControllerName(endpointID)
 		scopedLog      = e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 	)
 
@@ -332,7 +326,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 // CEP from Kubernetes once the endpoint is stopped / removed from the
 // Cilium agent.
 func (epSync *EndpointSynchronizer) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
-	controllerName := controllerNameOf(e.ID)
+	controllerName := endpoint.EndpointSyncControllerName(e.ID)
 
 	scopedLog := e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 


### PR DESCRIPTION
When an endpoint's identity is updated, Cilium does not sync immediately
the new state with k8s, but rather waits up to 10 seconds for the
sync-to-k8s-ciliumendpoint controller to run, meaning that the the new
identity can remain unannounced for up to 10 seconds.

This commit fixes this by explicitly triggering the k8s sync controller
whenever an endpoint's identity is updated.

Fixes https://github.com/cilium/cilium/issues/15097