### PR TITLE
.github: Disable flow validation in flaky tests

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Clean up Cilium
         run: |
@@ -224,7 +224,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Post-test information gathering
         if: ${{ failure() }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Clean up Cilium
         run: |
@@ -211,7 +211,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Clean up Cilium
         run: |
@@ -244,7 +244,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Clean up Cilium
         run: |
@@ -277,7 +277,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Post-test information gathering
         if: ${{ failure() }}

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Clean up Cilium
         run: |
@@ -123,7 +123,7 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test
+          cilium connectivity test --flow-validation=disabled
 
       - name: Post-test information gathering
         if: ${{ always() }}

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -236,7 +236,8 @@ jobs:
             --context ${{ steps.contexts.outputs.context1 }} \
             --multi-cluster ${{ steps.contexts.outputs.context2 }} \
             --test '!pod-to-nodeport' \
-            --test '!pod-to-local-nodeport'
+            --test '!pod-to-local-nodeport' \
+             --flow-validation=disabled
 
       - name: Post-test information gathering
         if: ${{ failure() }}


### PR DESCRIPTION
The flow validation of cilium connectivity test has been reported to be flaky in several of the `ci-xxx` tests [1, 2, 3, 4]. To reduce CI noise, we can disable flow validation until the flakes are fixed.

1 - https://github.com/cilium/cilium/issues/16292.
2 - https://github.com/cilium/cilium/issues/16291.
3 - https://github.com/cilium/cilium/issues/16096.
4 - https://github.com/cilium/cilium/issues/16392.