### PR TITLE
.github: Limit CodeQL workflow to .go files

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -1,14 +1,8 @@
 name: codeql
 
 on:
-  push:
-    branches:
-    - v1.10
-    - v1.9
-    - v1.8
-  pull_request:
-    branches:
-    - master
+  push: {}
+  pull_request: {}
   schedule:
     - cron: "45 6 * * 3"
 

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -1,8 +1,16 @@
 name: codeql
 
 on:
-  push: {}
-  pull_request: {}
+  push:
+    paths:
+      - '*.go'
+      - 'go.mod'
+      - 'go.sum'
+  pull_request:
+    paths:
+      - '*.go'
+      - 'go.mod'
+      - 'go.sum'
   schedule:
     - cron: "45 6 * * 3"
 


### PR DESCRIPTION
See commits for details.

This pull request could be extended to `lint-go.yaml` but I'm not sure it's worth it currently, given that test is very fast.