### PR TITLE
docs: update requirements (urllib3 1.26.5, requests 2.25.1)

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -13,7 +13,7 @@ Pygments==2.7.4
 pytz==2018.7
 PyYAML==5.4
 recommonmark==0.4.0
-requests==2.20.0
+requests==2.25.1
 semver==2.9.0
 six==1.15.0
 snowballstemmer==1.2.1
@@ -29,5 +29,5 @@ sphinxcontrib-websupport==1.1.0
 sphinx-tabs==1.1.13
 sphinx-version-warning==1.1.2
 typing==3.6.6
-urllib3==1.24.2
+urllib3==1.26.5
 yamllint==1.22.0


### PR DESCRIPTION
In #16390, dependabot says:

    build(deps): bump urllib3 from 1.24.2 to 1.26.5 in /Documentation

    - [Release notes](https://github.com/urllib3/urllib3/releases)
    - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
    - [Commits](urllib3/urllib3@1.24.2...1.26.5)

    ---
    updated-dependencies:
    - dependency-name: urllib3
      dependency-type: direct:production
    ...

However, this breaks the build for the documentation, because:

    requests 2.20.0 depends on urllib3<1.25 and >=1.21.1

Let's update the version for `urllib3`, but let's also update `requests` to its latest version.
