### PR TITLE
monitor: print error message on failure to decode layer

### DIFF
--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -207,7 +207,7 @@ func Dissect(dissect bool, data []byte) {
 		defer dissectLock.Unlock()
 
 		initParser()
-		parser.DecodeLayers(data, &cache.decoded)
+		err := parser.DecodeLayers(data, &cache.decoded)
 
 		for _, typ := range cache.decoded {
 			switch typ {
@@ -231,6 +231,9 @@ func Dissect(dissect bool, data []byte) {
 		}
 		if parser.Truncated {
 			fmt.Println("  Packet has been truncated")
+		}
+		if err != nil {
+			fmt.Println("  Failed to decode layer:", err)
 		}
 
 	} else {


### PR DESCRIPTION
Print an error message as part of the monitor verbose output when the packet parser fails to decode a layer properly. This allows to better understand how some packets are formed. For example, it provides more information for UDP fragments that do not have a UDP header.
