### PR TITLE
test: align filter for kubectl.GetPodsNodes() on kubectl.GetPodsIPs()

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -892,7 +892,7 @@ func (kub *Kubectl) GetPods(namespace string, filter string) *CmdRes {
 // returns an error if pods cannot be retrieved correctly
 func (kub *Kubectl) GetPodsNodes(namespace string, filter string) (map[string]string, error) {
 	jsonFilter := `{range .items[*]}{@.metadata.name}{"="}{@.spec.nodeName}{"\n"}{end}`
-	res := kub.Exec(fmt.Sprintf("%s -n %s get pods %s -o jsonpath='%s'",
+	res := kub.Exec(fmt.Sprintf("%s -n %s get pods -l '%s' -o jsonpath='%s'",
 		KubectlCmd, namespace, filter, jsonFilter))
 	if !res.WasSuccessful() {
 		return nil, fmt.Errorf("cannot retrieve pods: %s", res.CombineOutput())
@@ -910,7 +910,7 @@ func (kub *Kubectl) GetPodOnNodeLabeledWithOffset(label string, podFilter string
 
 	var podName string
 
-	podsNodes, err := kub.GetPodsNodes(DefaultNamespace, fmt.Sprintf("-l %s", podFilter))
+	podsNodes, err := kub.GetPodsNodes(DefaultNamespace, fmt.Sprintf("%s", podFilter))
 	gomega.ExpectWithOffset(callOffset, err).Should(gomega.BeNil(), "Cannot retrieve pods nodes with filter %q", podFilter)
 	gomega.Expect(podsNodes).ShouldNot(gomega.BeEmpty(), "No pod found in namespace %s with filter %q", DefaultNamespace, podFilter)
 	for pod, node := range podsNodes {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1111,7 +1111,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			BeforeAll(func() {
 				appPods = helpers.GetAppPods(apps, namespaceForTest, kubectl, "id")
-				podsNodes, err := kubectl.GetPodsNodes(namespaceForTest, "-l id=app1")
+				podsNodes, err := kubectl.GetPodsNodes(namespaceForTest, "id=app1")
 				Expect(err).To(BeNil(), "error getting pod->node mapping")
 				Expect(len(podsNodes)).To(Equal(2))
 				// Just grab the first one.
@@ -1121,7 +1121,7 @@ var _ = SkipDescribeIf(func() bool {
 					break
 				}
 
-				podsNodes, err = kubectl.GetPodsNodes(namespaceForTest, "-l id=app2")
+				podsNodes, err = kubectl.GetPodsNodes(namespaceForTest, "id=app2")
 				Expect(err).To(BeNil(), "error getting pod->node mapping")
 				Expect(len(podsNodes)).To(Equal(1))
 				for k := range podsNodes {
@@ -1894,7 +1894,7 @@ var _ = SkipDescribeIf(func() bool {
 		}
 
 		testConnectivitytoRedis := func() {
-			webPods, err := kubectl.GetPodsNodes(helpers.DefaultNamespace, "-l app=guestbook")
+			webPods, err := kubectl.GetPodsNodes(helpers.DefaultNamespace, "app=guestbook")
 			ExpectWithOffset(1, err).To(BeNil(), "Error retrieving web pods")
 			ExpectWithOffset(1, webPods).ShouldNot(BeEmpty(), "Cannot retrieve web pods")
 

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -120,8 +120,8 @@ var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 
 		podNode1 = getPodName("id=app1")
 		podNode2 = getPodName("id=app3")
-		hostNetworkPodNode1 = getPodNodeName(helpers.K8s1, "-l id=host-client")
-		hostNetworkPodNode2 = getPodNodeName(helpers.K8s2, "-l id=host-client")
+		hostNetworkPodNode1 = getPodNodeName(helpers.K8s1, "id=host-client")
+		hostNetworkPodNode2 = getPodNodeName(helpers.K8s2, "id=host-client")
 
 		// map the public and private ip addresses of k8s1. We need to do this
 		// since the public and private IP addresses are also ephemeral across


### PR DESCRIPTION
`kubectl.GetPodsNodes()`'s usage is very similar to `kubectl.GetPodsIPs()`'s, but the latter always adds a `-l ` option to the generated kubectl command, avoiding the caller to pass it through as part of the filter argument.

Let's align `kubectl.GetPodsNodes()`, for consistency. Having the `-l ` in the function makes the calls more readable. It prevents the use of other selectors (e.g. `--field-selector`), but the helper is only used with label queries at the moment.
