### PR TITLE
.github: add instructions when releasing a new minor version

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -30,6 +30,8 @@ assignees: ''
         instructions.
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
+  - [ ] For a new minor version, add the 'stable' tag as part of the GitHub
+        workflow and remove the 'stable' tag from the last stable branch.
 - [ ] Merge PR
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
   - Pull latest branch locally and run `contrib/release/tag-release.sh`


### PR DESCRIPTION
The 'stable' tag needs to point to the last stable version released so
we should be updated whenever a new minor version is released.

Signed-off-by: André Martins <andre@cilium.io>
