### PR TITLE
docs: fix warnings for documentation build, use a linter

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -2138,7 +2138,8 @@ describe some of the differences for the BPF model:
         return 0;
     }
 
-    // On bpf_load_program
+  Corresponding output on ``bpf_load_program()``::
+
     bpf_load_program() err=13
     0: (bf) r6 = r1
     ...

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -85,4 +85,11 @@ fi
 # fi
 
 echo "Building documentation (${target})..."
-exec sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@
+sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@ -q 2> >(tee "${warnings}" >&2)
+
+# We can have warnings but no errors here, or sphinx-build would return non-0
+# and we would have exited because of "set -o errexit".
+if [ -s "${warnings}" ] ; then
+    echo "Please fix the above documentation warnings"
+    exit 1
+fi

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -55,6 +55,24 @@ hint_about_wordlist_update() {
 if [ -n "${SKIP_LINT-}" ]; then
   echo "Skipping syntax and spelling validations..."
 else
+  echo "Running linter..."
+  CONF_PY_ROLES=$(sed -n "/^extlinks = {$/,/^}$/ s/^ *'\([^']\+\)':.*/\1/p" conf.py | tr '\n' ',')
+  CONF_PY_SUBSTITUTIONS=$(sed -n 's/^\.\. |\([^|]\+\)|.*/\1/p' conf.py | tr '\n' ',')
+  ignored_messages="("
+  ignored_messages="${ignored_messages}bpf.rst:.*: \(INFO/1\) Enumerated list start value not ordinal"
+  ignored_messages="${ignored_messages}|Hyperlink target .*is not referenced\."
+  ignored_messages="${ignored_messages}|Duplicate implicit target name:"
+  ignored_messages="${ignored_messages}|Malformed table\."
+  ignored_messages="${ignored_messages})"
+  rstcheck \
+      --report info \
+      --ignore-language bash \
+      --ignore-message "${ignored_messages}" \
+      --ignore-directives tabs \
+      --ignore-roles ${CONF_PY_ROLES}\
+      --ignore-substitutions ${CONF_PY_SUBSTITUTIONS} \
+      -r .
+
   echo "Validating documentation (syntax, spelling)..."
   if build_with_spellchecker ; then
     status_ok=0

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -207,8 +207,8 @@ Update cilium-builder and cilium-runtime images
 
        $ git commit -s -a -m "update cilium-{runtime,builder}"
 
-#. Ping one of the members of `team/build <https://github.com/orgs/cilium/teams/build/members>`_
-   to approve the build that was created by GitHub Actions `here <https://github.com/cilium/cilium/actions?query=workflow:%22Base+Image+Release+Build%22>`_.
+#. Ping one of the members of `team/build <https://github.com/orgs/cilium/teams/build/members>`__
+   to approve the build that was created by GitHub Actions `here <https://github.com/cilium/cilium/actions?query=workflow:%22Base+Image+Release+Build%22>`__.
    Note that at this step cilium-builder build failure is expected since we have yet to update the runtime digest.
 
 #. Wait for cilium-runtime build to complete. Only after the image is available run:
@@ -223,8 +223,8 @@ Update cilium-builder and cilium-runtime images
 
        $ git commit --amend -s -a
 
-#. Ping one of the members of `team/build <https://github.com/orgs/cilium/teams/build/members>`_
-   to approve the build that was created by GitHub Actions `here <https://github.com/cilium/cilium/actions?query=workflow:%22Base+Image+Release+Build%22>`_.
+#. Ping one of the members of `team/build <https://github.com/orgs/cilium/teams/build/members>`__
+   to approve the build that was created by GitHub Actions `here <https://github.com/cilium/cilium/actions?query=workflow:%22Base+Image+Release+Build%22>`__.
 
 #. Wait for the build to complete. Only after the image is available run:
 

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -116,7 +116,7 @@ Reference steps for the template
    #. Copy the official docker manifests for the release from the previous step
       into the end of the Github release announcement.
 
-#. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
+#. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`__
    and push the changes into that repository (not the main cilium repository):
 
    .. code-block:: shell-session
@@ -124,7 +124,7 @@ Reference steps for the template
       ./prepare_artifacts.sh /path/to/cilium/repository/checked/out/to/release/commit
       git push
 
-#. Prepare Helm changes for the dev version of the branch using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
+#. Prepare Helm changes for the dev version of the branch using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`__
    for the vX.Y helm charts, and push the changes into that repository (not the main cilium repository):
 
    In the ``cilium/cilium`` repository:

--- a/Documentation/gettingstarted/alibabacloud-eni.rst
+++ b/Documentation/gettingstarted/alibabacloud-eni.rst
@@ -117,7 +117,7 @@ These keys need to have certain `RAM Permissions
         {
           "Action": [
             "vpc:DescribeVSwitches",
-            "vpc:ListTagResources",
+            "vpc:ListTagResources"
           ],
           "Resource": [
             "*"

--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -165,28 +165,28 @@ commands:
 
 1. Install tcpdump
 
-.. code-block:: shell-session
+   .. code-block:: shell-session
 
-    $ apt-get update
-    $ apt-get -y install tcpdump
+       $ apt-get update
+       $ apt-get -y install tcpdump
 
 2. Check that traffic is encrypted. In the example below, this can be verified
    by the fact that packets carry the IP Encapsulating Security Payload (ESP).
    In the example below, ``eth0`` is the interface used for pod-to-pod
    communication. Replace this interface with ``cilium_vxlan`` if tunneling is enabled.
 
-.. code-block:: shell-session
+   .. code-block:: shell-session
 
-    tcpdump -n -i eth0 esp
-    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-    listening on cilium_vxlan, link-type EN10MB (Ethernet), capture size 262144 bytes
-    15:16:21.626416 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e2), length 180
-    15:16:21.626473 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e3), length 180
-    15:16:21.627167 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579d), length 100
-    15:16:21.627296 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579e), length 100
-    15:16:21.627523 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579f), length 180
-    15:16:21.627699 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e4), length 100
-    15:16:21.628408 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e5), length 100
+       tcpdump -n -i eth0 esp
+       tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+       listening on cilium_vxlan, link-type EN10MB (Ethernet), capture size 262144 bytes
+       15:16:21.626416 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e2), length 180
+       15:16:21.626473 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e3), length 180
+       15:16:21.627167 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579d), length 100
+       15:16:21.627296 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579e), length 100
+       15:16:21.627523 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579f), length 180
+       15:16:21.627699 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e4), length 100
+       15:16:21.628408 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e5), length 100
 
 Key Rotation
 ============

--- a/Documentation/gettingstarted/encryption-wireguard.rst
+++ b/Documentation/gettingstarted/encryption-wireguard.rst
@@ -83,39 +83,39 @@ commands:
 1. Check that WireGuard has been enabled (number of peers should correspond to
    a number of nodes subtracted by one):
 
-.. code-block:: shell-session
+   .. code-block:: shell-session
 
-   cilium status | grep Encryption
+      cilium status | grep Encryption
 
-   Encryption: Wireguard [cilium_wg0 (Pubkey: <..>, Port: 51871, Peers: 2)]
+      Encryption: Wireguard [cilium_wg0 (Pubkey: <..>, Port: 51871, Peers: 2)]
 
 2. Install tcpdump
 
-.. code-block:: shell-session
+   .. code-block:: shell-session
 
-    apt-get update
-    apt-get -y install tcpdump
+      apt-get update
+      apt-get -y install tcpdump
 
 3. Check that traffic is sent via the ``cilium_wg0`` tunnel device:
 
-.. code-block:: shell-session
+   .. code-block:: shell-session
 
-    tcpdump -n -i cilium_wg0
+      tcpdump -n -i cilium_wg0
 
-    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-    listening on cilium_wg0, link-type RAW (Raw IP), capture size 262144 bytes
-    15:05:24.643427 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [S], seq 476474887, win 64860, options [mss 1410,sackOK,TS val 648097391 ecr 0,nop,wscale 7], length 0
-    15:05:24.644185 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [S.], seq 4032860634, ack 476474888, win 64308, options [mss 1410,sackOK,TS val 4004186138 ecr 648097391,nop,wscale 7], length 0
-    15:05:24.644238 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 1, win 507, options [nop,nop,TS val 648097391 ecr 4004186138], length 0
-    15:05:24.644277 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [P.], seq 1:81, ack 1, win 507, options [nop,nop,TS val 648097392 ecr 4004186138], length 80: HTTP: GET / HTTP/1.1
-    15:05:24.644370 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [.], ack 81, win 502, options [nop,nop,TS val 4004186139 ecr 648097392], length 0
-    15:05:24.645536 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [.], seq 1:1369, ack 81, win 502, options [nop,nop,TS val 4004186140 ecr 648097392], length 1368: HTTP: HTTP/1.1 200 OK
-    15:05:24.645569 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 1369, win 502, options [nop,nop,TS val 648097393 ecr 4004186140], length 0
-    15:05:24.645578 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [P.], seq 1369:2422, ack 81, win 502, options [nop,nop,TS val 4004186140 ecr 648097392], length 1053: HTTP
-    15:05:24.645644 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 2422, win 494, options [nop,nop,TS val 648097393 ecr 4004186140], length 0
-    15:05:24.645752 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [F.], seq 81, ack 2422, win 502, options [nop,nop,TS val 648097393 ecr 4004186140], length 0
-    15:05:24.646431 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [F.], seq 2422, ack 82, win 502, options [nop,nop,TS val 4004186141 ecr 648097393], length 0
-    15:05:24.646484 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 2423, win 502, options [nop,nop,TS val 648097394 ecr 4004186141], length 0
+      tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+      listening on cilium_wg0, link-type RAW (Raw IP), capture size 262144 bytes
+      15:05:24.643427 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [S], seq 476474887, win 64860, options [mss 1410,sackOK,TS val 648097391 ecr 0,nop,wscale 7], length 0
+      15:05:24.644185 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [S.], seq 4032860634, ack 476474888, win 64308, options [mss 1410,sackOK,TS val 4004186138 ecr 648097391,nop,wscale 7], length 0
+      15:05:24.644238 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 1, win 507, options [nop,nop,TS val 648097391 ecr 4004186138], length 0
+      15:05:24.644277 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [P.], seq 1:81, ack 1, win 507, options [nop,nop,TS val 648097392 ecr 4004186138], length 80: HTTP: GET / HTTP/1.1
+      15:05:24.644370 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [.], ack 81, win 502, options [nop,nop,TS val 4004186139 ecr 648097392], length 0
+      15:05:24.645536 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [.], seq 1:1369, ack 81, win 502, options [nop,nop,TS val 4004186140 ecr 648097392], length 1368: HTTP: HTTP/1.1 200 OK
+      15:05:24.645569 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 1369, win 502, options [nop,nop,TS val 648097393 ecr 4004186140], length 0
+      15:05:24.645578 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [P.], seq 1369:2422, ack 81, win 502, options [nop,nop,TS val 4004186140 ecr 648097392], length 1053: HTTP
+      15:05:24.645644 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 2422, win 494, options [nop,nop,TS val 648097393 ecr 4004186140], length 0
+      15:05:24.645752 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [F.], seq 81, ack 2422, win 502, options [nop,nop,TS val 648097393 ecr 4004186140], length 0
+      15:05:24.646431 IP 10.244.3.78.8080 > 10.244.1.35.51116: Flags [F.], seq 2422, ack 82, win 502, options [nop,nop,TS val 4004186141 ecr 648097393], length 0
+      15:05:24.646484 IP 10.244.1.35.51116 > 10.244.3.78.8080: Flags [.], ack 2423, win 502, options [nop,nop,TS val 648097394 ecr 4004186141], length 0
 
 Troubleshooting
 ===============

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -310,9 +310,7 @@ returns valid JSON data:
     for APIPATH in /api/v1/products /api/v1/products/0 /api/v1/products/0/reviews /api/v1/products/0/ratings; do echo ; curl -s -S "${GATEWAY_URL}${APIPATH}" ; echo ; done
 
 
-The output will be similar to this:
-
-.. code-block:: json
+The output will be similar to this::
 
     [{"descriptionHtml": "<a href=\"https://en.wikipedia.org/wiki/The_Comedy_of_Errors\">Wikipedia Summary</a>: The Comedy of Errors is one of <b>William Shakespeare's</b> early plays. It is his shortest and one of his most farcical comedies, with a major part of the humour coming from slapstick and mistaken identity, in addition to puns and word play.", "id": 0, "title": "The Comedy of Errors"}]
 
@@ -410,9 +408,7 @@ now denies at Layer-7 any access to the reviews and ratings REST API:
 
     for APIPATH in /api/v1/products /api/v1/products/0 /api/v1/products/0/reviews /api/v1/products/0/ratings; do echo ; curl -s -S "${GATEWAY_URL}${APIPATH}" ; echo ; done
 
-The output will be similar to this:
-
-.. code-block:: json
+The output will be similar to this::
 
     [{"descriptionHtml": "<a href=\"https://en.wikipedia.org/wiki/The_Comedy_of_Errors\">Wikipedia Summary</a>: The Comedy of Errors is one of <b>William Shakespeare's</b> early plays. It is his shortest and one of his most farcical comedies, with a major part of the humour coming from slapstick and mistaken identity, in addition to puns and word play.", "id": 0, "title": "The Comedy of Errors"}]
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -193,9 +193,7 @@ version which was installed in this cluster. Valid options are:
    `1.9_helm_options` to determine the 1.9 equivalent options for options you
    previously specified when initially installing Cilium.
 
-   For example, an 1.8 installation with the following options:
-
-   .. code-block:: txt
+   For example, an 1.8 installation with the following options::
 
       --namespace=kube-system \\
       --set global.k8sServiceHost=API_SERVER_IP \\
@@ -204,9 +202,7 @@ version which was installed in this cluster. Valid options are:
       --set global.kubeProxyReplacement=strict
 
 
-   Can be upgraded using the options below:
-
-   .. code-block:: txt
+   Can be upgraded using the options below::
 
       --namespace=kube-system \\
       --set upgradeCompatibility=1.8 \\

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -31,3 +31,4 @@ sphinx-version-warning==1.1.2
 typing==3.6.6
 urllib3==1.26.5
 yamllint==1.22.0
+rstcheck==3.3.1


### PR DESCRIPTION
Four big steps in the PR:

1. Fix the checks for warnings on builds for the documentation (1st commit).
2. Address build warnings (2nd commit).
3. Introduce a linter, rstcheck, for the RST documentation files (3rd commit).
4. Fix issues reported by linters in the documentation (remaining commits).

Please refer to individual commit logs for details.