### PR TITLE
test: Wait for kube-dns before starting test

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4560,3 +4560,19 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 	}
 	return nil
 }
+
+// NslookupInPod executes 'nslookup' in the given pod until it succeeds or times out.
+func (kub *Kubectl) NslookupInPod(namespace, pod string, target string) (err error) {
+	err2 := WithTimeout(func() bool {
+		res := kub.ExecPodCmd(namespace, pod, fmt.Sprintf("nslookup %s", target))
+		if res.WasSuccessful() {
+			return true
+		}
+		err = fmt.Errorf("error looking up %s from %s/%s: %s", target, namespace, pod, res.CombineOutput().String())
+		return false
+	}, "Could not resolve target name", &TimeoutConfig{Timeout: HelperTimeout})
+	if err2 != nil {
+		return err
+	}
+	return nil
+}

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -86,6 +86,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 		Expect(err).Should(BeNil(), "Testapp is not ready after timeout")
 
 		appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
+
+		// Validate that coredns is reachable from test pods
+		err = kubectl.NslookupInPod(helpers.DefaultNamespace, appPods[helpers.App2], "kube-dns.kube-system.svc.cluster.local")
+		Expect(err).Should(BeNil(), "Error reaching kube-dns before test: %s", err)
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
Wait for kube-dns to become reachable from test pod before running test in fqdn.go.

Fixes: #16409
