### PR TITLE
test: Specify node-selectors in BGP configmap

### DIFF
--- a/test/k8sT/manifests/bgp-configmap.yaml.tmpl
+++ b/test/k8sT/manifests/bgp-configmap.yaml.tmpl
@@ -9,6 +9,10 @@ data:
       - peer-address: {{ .RouterIP }}
         peer-asn: 64512
         my-asn: 64512
+        node-selectors:
+        - match-expressions:
+          - key: cilium.io/ci-node
+            operator: Exists
     address-pools:
       - name: default
         protocol: bgp


### PR DESCRIPTION
We recently had a regression
(https://github.com/cilium/cilium/issues/16340) that occurred when the
user specified node-selectors in their BGP configmap. The node-selectors
were not picked up due to the bug that was fixed in
https://github.com/cilium/cilium/pull/16341.

This commit is to add regression testing for the BGP integration.

Depends on https://github.com/cilium/cilium/pull/16341


