### PR TITLE
sockops: Remove duplicate error logging

### DIFF
--- a/pkg/sockops/sockops.go
+++ b/pkg/sockops/sockops.go
@@ -306,13 +306,11 @@ func bpfLoadMapProg(object string, load string) error {
 func SkmsgEnable() error {
 	err := bpfCompileProg(cIPC, oIPC)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 
 	err = bpfLoadMapProg(oIPC, eIPC)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 	log.Info("Sockmsg Enabled, bpf_redir loaded")
@@ -360,12 +358,10 @@ func bpfLoadAttachProg(object string, load string, mapName string) (int, int, er
 func SockmapEnable() error {
 	err := bpfCompileProg(cSockops, oSockops)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 	progID, mapID, err := bpfLoadAttachProg(oSockops, eSockops, sockMap)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 	log.Infof("Sockmap Enabled: bpf_sockops prog_id %d and map_id %d loaded", progID, mapID)


### PR DESCRIPTION
If the compilation or loading of the sock_ops programs fail, we log the error twice, first in the `SockmapEnable` and `SkmsgEnable` functions, then in the calling function. This commit keeps only the error logging in `Daemon.init()`: https://github.com/cilium/cilium/blob/7a45cd409b8154e65818208c147976c5231e6187/daemon/cmd/daemon.go#L239-L242