### PR TITLE
node: Add WireguardPubKey to ToCiliumNode

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -202,6 +202,7 @@ Jenkinsfile.nightly @cilium/ci-structure
 /pkg/mountinfo @cilium/bpf
 /pkg/mtu @cilium/bpf
 /pkg/multicast @cilium/bpf
+/pkg/node @cilium/agent
 /pkg/option @cilium/agent @cilium/cli
 /pkg/pidfile @cilium/agent
 /pkg/policy @cilium/policy

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -92,6 +92,7 @@ func (n *Node) ToCiliumNode() *ciliumv2.CiliumNode {
 		podCIDRs               []string
 		ipAddrs                []ciliumv2.NodeAddress
 		healthIPv4, healthIPv6 string
+		annotations            = map[string]string{}
 	)
 
 	if n.IPv4AllocCIDR != nil {
@@ -114,10 +115,15 @@ func (n *Node) ToCiliumNode() *ciliumv2.CiliumNode {
 		})
 	}
 
+	if n.WireguardPubKey != "" {
+		annotations[annotation.WireguardPubKey] = n.WireguardPubKey
+	}
+
 	return &ciliumv2.CiliumNode{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   n.Name,
-			Labels: n.Labels,
+			Name:        n.Name,
+			Labels:      n.Labels,
+			Annotations: annotations,
 		},
 		Spec: ciliumv2.NodeSpec{
 			Addresses: ipAddrs,
@@ -196,6 +202,7 @@ type Node struct {
 	// NodeIdentity is the numeric identity allocated for the node
 	NodeIdentity uint32
 
+	// WireguardPubKey is the WireGuard public key of this node
 	WireguardPubKey string
 }
 

--- a/pkg/node/types/node_test.go
+++ b/pkg/node/types/node_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -188,17 +189,24 @@ func (s *NodeSuite) TestNode_ToCiliumNode(c *C) {
 			{Type: addressing.NodeInternalIP, IP: net.ParseIP("c0de::1")},
 			{Type: addressing.NodeExternalIP, IP: net.ParseIP("c0de::2")},
 		},
-		EncryptionKey: uint8(10),
-		IPv4AllocCIDR: cidr.MustParseCIDR("10.10.0.0/16"),
-		IPv6AllocCIDR: cidr.MustParseCIDR("c0de::/96"),
-		IPv4HealthIP:  net.ParseIP("1.1.1.1"),
-		IPv6HealthIP:  net.ParseIP("c0de::1"),
-		NodeIdentity:  uint32(12345),
+		EncryptionKey:   uint8(10),
+		IPv4AllocCIDR:   cidr.MustParseCIDR("10.10.0.0/16"),
+		IPv6AllocCIDR:   cidr.MustParseCIDR("c0de::/96"),
+		IPv4HealthIP:    net.ParseIP("1.1.1.1"),
+		IPv6HealthIP:    net.ParseIP("c0de::1"),
+		NodeIdentity:    uint32(12345),
+		WireguardPubKey: "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
 	}
 
 	n := nodeResource.ToCiliumNode()
 	c.Assert(n, checker.DeepEquals, &ciliumv2.CiliumNode{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ""},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "",
+			Annotations: map[string]string{
+				annotation.WireguardPubKey: "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
+			},
+		},
 		Spec: ciliumv2.NodeSpec{
 			Addresses: []ciliumv2.NodeAddress{
 				{Type: addressing.NodeInternalIP, IP: "2.2.2.2"},


### PR DESCRIPTION
This ensures the WireGuard public key is preserved when converting a
`nodeTypes.Node` object to a `CiliumNode` CRD. This conversion is currently
is only used for attaching external workloads (which has no support for
WireGuard at the moment anyways), but it might be used in other places in the
future, therefore we should ensure that it propagates all information
correctly.

I discovered this while validating WireGuard support in Clustermesh.
This PR does not fix any outstanding bugs.
