### PR TITLE
pkg/kvstore: fix concurrent access of var in testing

### DIFF
--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -167,7 +168,7 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 	}
 
 	// short timeout for tests
-	versionCheckTimeout = time.Second
+	atomic.StoreInt64(&versionCheckTimeout, int64(time.Second))
 
 	c.Assert(client.checkMinVersion(context.TODO()), IsNil)
 


### PR DESCRIPTION
This variable can be accessed with the atomic library and will prevent
the race detector from complaining about concurrent access of this
variable.

Fixes https://github.com/cilium/cilium/issues/16370