### PR TITLE
node: fix arpping test

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1201,6 +1201,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	}
 	// Cleanup
 	close(done)
+	wg.Wait()
 	now = time.Now()
 	err = linuxNodeHandler.NodeDelete(nodev1)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
In TestArpPingHandling, wait for all goroutines that are inserting the
new neighbors to finish before deleting the node.

Fixes: #16221