### PR TITLE
pkg/option: Fix default assignment of EnableWellKnownIdentities

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2010,7 +2010,7 @@ var (
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
 		IdentityAllocationMode:       IdentityAllocationModeKVstore,
 		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
-		EnableWellKnownIdentities:    defaults.EnableEndpointRoutes,
+		EnableWellKnownIdentities:    defaults.EnableWellKnownIdentities,
 		K8sEnableK8sEndpointSlice:    defaults.K8sEnableEndpointSlice,
 		k8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 		AllocatorListTimeout:         defaults.AllocatorListTimeout,


### PR DESCRIPTION
Fix a "typo" in the variable assignment. It wasn't causing any trouble because both `defaults.EnableEndpointRoutes` and `defaults.EnableWellKnownIdentities` are `true`. 