### PR TITLE
test: Pass container to ExecPodCmdBackground()

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -822,7 +822,10 @@ func (kub *Kubectl) ExecPodCmdContext(ctx context.Context, namespace string, pod
 // To receive the output of this function, the caller must invoke either
 // kub.WaitUntilFinish() or kub.WaitUntilMatch() then subsequently fetch the
 // output out of the result.
-func (kub *Kubectl) ExecPodCmdBackground(ctx context.Context, namespace string, pod string, cmd string, options ...ExecOptions) *CmdRes {
+func (kub *Kubectl) ExecPodCmdBackground(ctx context.Context, namespace string, pod, container string, cmd string, options ...ExecOptions) *CmdRes {
+	if container != "" {
+		pod += " -c " + container
+	}
 	command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
 	return kub.ExecInBackground(ctx, command, options...)
 }
@@ -3246,7 +3249,7 @@ func (kub *Kubectl) CiliumReport(commands ...string) {
 	ginkgoext.GinkgoPrint("Fetching command output from pods %s", pods)
 	for _, pod := range pods {
 		for _, cmd := range commands {
-			res = kub.ExecPodCmdBackground(ctx, CiliumNamespace, pod, cmd, ExecOptions{SkipLog: true})
+			res = kub.ExecPodCmdBackground(ctx, CiliumNamespace, pod, "cilium-agent", cmd, ExecOptions{SkipLog: true})
 			results = append(results, res)
 		}
 	}
@@ -3566,7 +3569,7 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 				continue
 			}
 			//Remove bugtool artifact, so it'll be not used if any other fail test
-			_ = kub.ExecPodCmdBackground(ctx, namespace, pod, fmt.Sprintf("rm /tmp/%s", line))
+			_ = kub.ExecPodCmdBackground(ctx, namespace, pod, "cilium-agent", fmt.Sprintf("rm /tmp/%s", line))
 		}
 
 	}
@@ -4204,9 +4207,9 @@ func (kub *Kubectl) HubbleObserve(pod string, args string) *CmdRes {
 }
 
 // HubbleObserveFollow runs `hubble observe --follow --output=json <args>` on
-// 'ns/pod' in the background. The process is stopped when ctx is cancelled.
+// the Cilium pod 'ns/pod' in the background. The process is stopped when ctx is cancelled.
 func (kub *Kubectl) HubbleObserveFollow(ctx context.Context, pod string, args string) *CmdRes {
-	return kub.ExecPodCmdBackground(ctx, CiliumNamespace, pod, fmt.Sprintf("hubble observe --follow --output=json %s", args))
+	return kub.ExecPodCmdBackground(ctx, CiliumNamespace, pod, "cilium-agent", fmt.Sprintf("hubble observe --follow --output=json %s", args))
 }
 
 // WaitForIPCacheEntry waits until the given ipAddr appears in "cilium bpf ipcache list"

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -233,7 +233,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
 			res := kubectl.ExecPodCmdBackground(
 				ctx,
 				helpers.DefaultNamespace,
-				netperfClient,
+				netperfClient, "",
 				fmt.Sprintf("netperf -l 60 -t TCP_STREAM -H %s", podsIps[netperfServer]))
 
 			restartCilium()
@@ -250,7 +250,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
 			res := kubectl.ExecPodCmdBackground(
 				ctx,
 				helpers.DefaultNamespace,
-				netperfClient,
+				netperfClient, "",
 				fmt.Sprintf("netperf -l 60 -t TCP_STREAM -H %s", podsIps[netperfServer]))
 
 			By("Installing the L3-L4 Policy")


### PR DESCRIPTION
Add container option to kubectl exec to avoid test failures due to unexpected output like this:

            s: "could not parse \"Defaulted container \\\"cilium-agent\\\" out of: cilium-agent, clean-cilium-state (init)\" as JSON (line 0 of \"kubectl exec -n kube-system cilium-fsfdb -- hubble observe --follow --output=json --last 1 --type l7 --from-pod 202106040737k8shubbletesthubbleobservetestl7flow/app2-58757b7dd5-4fvh7 --to-namespace 202106040737k8shubbletesthubbleobservetestl7flow --to-label id=app1,zgroup=testapp --protocol http\")",

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
