### PR TITLE
test/helpers: Fix incorrect count of endpoints

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -206,7 +206,7 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsReady"})
 	desiredState := string(models.EndpointStateReady)
 	body := func() bool {
-		filter := `{range [*]}{@.status.external-identifiers.container-name}{"="}{@.status.state},{@.status.identity.id}{"\n"}{end}`
+		filter := `{range [*]}{@.id}{"="}{@.status.state},{@.status.identity.id}{"\n"}{end}`
 		cmd := fmt.Sprintf(`cilium endpoint list -o jsonpath='%s'`, filter)
 
 		res := s.Exec(cmd)


### PR DESCRIPTION
The test helper `WaitEndpointsReady()` waits for all endpoints on the node to be in `ready` state with a non-`init` security identity.

To that end it lists all endpoints in the format `[container-name]=[state],[identity]`, transforms that into a Go map m1, and iterates through the map to construct a new map `m2` with `state => counter`. If it counts as many values (endpoints) in m1 as in state `m2[ready]`, then all endpoints are ready.

However, the number of values in `m1` isn't actually equal to the number of endpoints. The container name, used as the key, may be empty for several endpoints, including the host endpoint and endpoints in `init` state. The last endpoint with an empty container name will therefore overwrite previous entries in the map. That leads the function to such conclusions as:

    =ready,5
    httpd3=ready,31837
    app2=ready,28159
    =ready,1
    httpd2=ready,4632
    app1=ready,49770
    httpd1=ready,14980
    cilium-health=ready,4

    '7' containers are in a 'ready' state of a total of '7' containers."

It counts 7 containers in ready state, when there are 8 containers. Here the difference matters because the first container, which got overwritten in the map, shouldn't be considered `ready` by this function since it has the `init` (5) identity.

As a fix, we can use the Cilium endpoint ID as the key to the map, as it is guaranteed to be unique per endpoint, contrary to the container name.

Fixes: https://github.com/cilium/cilium/issues/16433.