### PR TITLE
test/helpers: Fix panic due to missing CEP status

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -692,6 +692,10 @@ func (kub *Kubectl) GetCiliumEndpoint(namespace string, pod string) (*cnpv2.Endp
 		return nil, fmt.Errorf("unable to unmarshal CiliumEndpoint %s: %s", fullName, err)
 	}
 
+	if data == nil {
+		return nil, fmt.Errorf("CiliumEndpoint does not have a status yet")
+	}
+
 	return data, nil
 }
 


### PR DESCRIPTION
One of our test failed with:

    panic(0x1d477a0, 0x3142660)
    	/usr/local/go/src/runtime/panic.go:965 +0x1b9
    github.com/cilium/cilium/test/helpers.(*Kubectl).RestartUnmanagedPodsInNamespace(0xc000252648, 0x2009c80, 0xb, 0x0, 0x0, 0x0)
    	/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/helpers/kubectl.go:2057 +0x8a5
    github.com/cilium/cilium/test/k8sT.DeployCiliumOptionsAndDNS(0xc000252648, 0xc0000526c0, 0x1c, 0xc001b8ed20)
    	/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/k8sT/assertionHelpers.go:175 +0xa5
    github.com/cilium/cilium/test/k8sT.glob..func19.1.4()
    	/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/k8sT/hubble.go:138 +0x3cf
    github.com/cilium/cilium/test/ginkgo-ext.BeforeAll.func1()
    	/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:207 +0x9d
    github.com/cilium/cilium/test/ginkgo-ext.beforeEach.func1()
    	/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:459 +0x94
    github.com/cilium/cilium/test/ginkgo-ext.applyAdvice.func1(0x31c0f40, 0x0, 0x0, 0x0, 0x0, 0x0)
    	/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:561 +0x112
    github.com/cilium/cilium/test.TestTest(0xc000103e00)
    	/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/test_suite_test.go:109 +0x347
    testing.tRunner(0xc000103e00, 0x2103118)
    	/usr/local/go/src/testing/testing.go:1194 +0xef
    created by testing.(*T).Run
    	/usr/local/go/src/testing/testing.go:1239 +0x2b3

The nil pointer dereference happens in `RestartUnmanagedPodsInNamespace` because `GetCiliumEndpoint` returns a nil `EndpointStatus` object and no error. The test logs reveal that the `GetCiliumEndpoint` command simply returned null:

    $ kubectl -n kube-system get cep hubble-relay-694856fdb8-6ddr7 -o json | jq '.status'
    null

This new error is likely caused by 4ffa55f delaying the addition of the status to the `CiliumEndpoints`.

Fixes: https://github.com/cilium/cilium/pull/15230.
Fixes: https://github.com/cilium/cilium/issues/16441.