### PR TITLE
Fix "Egress for destination CIDR 0.0.0.0/0 blocks all network connections"

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -793,6 +793,21 @@ ct_recreate4:
 		struct egress_info *info;
 		struct endpoint_key key = {};
 
+#ifdef IPV4_SNAT_EXCLUSION_DST_CIDR
+		/* If destination is in cluster, skip egress gateway.
+		 */
+		if (ipv4_is_in_subnet(ip4->daddr, IPV4_SNAT_EXCLUSION_DST_CIDR,
+				      IPV4_SNAT_EXCLUSION_DST_CIDR_LEN))
+			goto skip_egress_gateway;
+#endif
+
+		/* If tunnel endpoint is found in ipcache, it means the remote endpoint is
+		 * in cluster. In this case, we should skip egress gateway. If destination
+		 * is either remote node or host node, also skip egress gateway.
+		 */
+		if (tunnel_endpoint != 0 || *dstID == REMOTE_NODE_ID || *dstID == HOST_ID)
+			goto skip_egress_gateway;
+
 		info = lookup_ip4_egress_endpoint(ip4->saddr, ip4->daddr);
 		if (!info)
 			goto skip_egress_gateway;

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4116,6 +4116,24 @@ func (kub *Kubectl) WaitForIPCacheEntry(node, ipAddr string) error {
 		&TimeoutConfig{Timeout: HelperTimeout})
 }
 
+func (kub *Kubectl) WaitForEgressPolicyEntry(node, ipAddr string) error {
+	ciliumPod, err := kub.GetCiliumPodOnNode(node)
+	if err != nil {
+		return err
+	}
+
+	body := func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+		defer cancel()
+		cmd := fmt.Sprintf(`cilium bpf egress list | grep -q %s`, ipAddr)
+		return kub.CiliumExecContext(ctx, ciliumPod, cmd).WasSuccessful()
+	}
+
+	return WithTimeout(body,
+		fmt.Sprintf("egress policy entry for %s was not found in time", ipAddr),
+		&TimeoutConfig{Timeout: HelperTimeout})
+}
+
 // RepeatCommandInBackground runs command on repeat in goroutine until quit channel
 // is closed and closes run channel when command is first run
 func (kub *Kubectl) RepeatCommandInBackground(cmd string) (quit, run chan struct{}) {
@@ -4263,6 +4281,7 @@ func GenerateNamespaceForTest(seed string) string {
 	replaced := strings.Replace(lowered, " ", "", -1)
 	replaced = strings.Replace(replaced, "_", "", -1)
 	replaced = strings.Replace(replaced, "/", "", -1)
+	replaced = strings.Replace(replaced, "-", "", -1)
 
 	timestamped := time.Now().Format("200601021504") + seed + replaced
 

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -1,0 +1,298 @@
+// Copyright 2017-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+	. "github.com/onsi/gomega"
+)
+
+var _ = SkipDescribeIf(func() bool {
+	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || !helpers.RunsOn419OrLaterKernel() || helpers.DoesNotExistNodeWithoutCilium()
+}, "K8sEgressGatewayTest", func() {
+	var (
+		kubectl         *helpers.Kubectl
+		ciliumFilename  string
+		randomNamespace string
+
+		egressIP  string
+		k8s1IP    string
+		k8s2IP    string
+		outsideIP string
+
+		assignIPYAML string
+		echoPodYAML  string
+		policyYAML   string
+
+		namespaceSelector string = "ns=cilium-test"
+	)
+
+	// TODO(anfernee): Check a better way to deduplicate it with similar snippet in DatapathConfiguration.go
+	runEchoServer := func() {
+		// Run echo server on outside node
+		originalEchoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-hostnetns.yaml")
+		res := kubectl.ExecMiddle("mktemp")
+		res.ExpectSuccess()
+		echoPodYAML = strings.Trim(res.Stdout(), "\n")
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/NODE_WITHOUT_CILIUM/%s/' %s > %s",
+			helpers.GetNodeWithoutCilium(), originalEchoPodPath, echoPodYAML)).ExpectSuccess()
+		kubectl.ApplyDefault(echoPodYAML).ExpectSuccess("Cannot install echoserver application")
+		Expect(kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=echoserver-hostnetns",
+			helpers.HelperTimeout)).Should(BeNil())
+	}
+
+	assignEgressIP := func() {
+		// Assign egress IP address to k8s2
+		originalAssignIPYAML := helpers.ManifestGet(kubectl.BasePath(), "egress-ip-deployment.yaml")
+		res := kubectl.ExecMiddle("mktemp")
+		res.ExpectSuccess()
+		assignIPYAML = strings.Trim(res.Stdout(), "\n")
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_EGRESS_IP/%s/' %s > %s",
+			egressIP, originalAssignIPYAML, assignIPYAML)).ExpectSuccess()
+		res = kubectl.ApplyDefault(assignIPYAML)
+		Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", assignIPYAML)
+		Expect(kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=egress-ip-assign",
+			helpers.HelperTimeout)).Should(BeNil())
+
+		// Wait egressIP online
+		srcPod, _ := fetchPodsWithOffset(kubectl, helpers.DefaultNamespace, "", "name=egress-ip-assign", "", false, 0)
+		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, srcPod, helpers.PingWithCount(egressIP, 5))
+		res.ExpectSuccess()
+	}
+
+	BeforeAll(func() {
+		if helpers.DoesNotRunWithKubeProxyReplacement() {
+			Skip("EgressGatewayTest requires KubeProxyReplacement")
+		}
+
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		_, k8s1IP = kubectl.GetNodeInfo(helpers.K8s1)
+		_, k8s2IP = kubectl.GetNodeInfo(helpers.K8s2)
+		_, outsideIP = kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+
+		egressIP = getEgressIP(k8s1IP)
+
+		deploymentManager.SetKubectl(kubectl)
+
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
+
+		runEchoServer()
+		assignEgressIP()
+	})
+
+	AfterAll(func() {
+		_ = kubectl.Delete(echoPodYAML)
+		_ = kubectl.Delete(assignIPYAML)
+
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
+	})
+
+	AfterFailed(func() {
+		// Especially check if there are duplicated address allocated on cilium_host
+		kubectl.CiliumReport("ip addr")
+	})
+
+	testEgressGateway := func(fromGateway bool) {
+		if fromGateway {
+			By("Check egress policy from gateway node")
+		} else {
+			By("Check egress policy from non-gateway node")
+		}
+
+		hostIP := k8s1IP
+		if fromGateway {
+			hostIP = k8s2IP
+		}
+		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", "zgroup=testDSClient", hostIP, false, 1)
+
+		res := kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.CurlFail("http://%s:80", outsideIP))
+		res.ExpectSuccess()
+		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", egressIP))
+	}
+
+	testConnectivity := func(fromGateway bool) {
+		if fromGateway {
+			By("Check connectivity from gateway node")
+		} else {
+			By("Check connectivity from non-gateway node")
+		}
+		hostIP := k8s1IP
+		if fromGateway {
+			hostIP = k8s2IP
+		}
+		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", "zgroup=testDSClient", hostIP, false, 1)
+
+		// Pod-to-node connectivity should work
+		res := kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.PingWithCount(k8s1IP, 1))
+		res.ExpectSuccess()
+
+		res = kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.PingWithCount(k8s2IP, 1))
+		res.ExpectSuccess()
+
+		// DNS query should work (pod-to-pod connectivity)
+		res = kubectl.ExecPodCmd(randomNamespace, srcPod, "dig kubernetes +time=2")
+		res.ExpectSuccess()
+	}
+
+	applyEgressPolicy := func() {
+		// Apply egress policy yaml
+		originalPolicyYAML := helpers.ManifestGet(kubectl.BasePath(), "egress-nat-policy.yaml")
+		res := kubectl.ExecMiddle("mktemp")
+		res.ExpectSuccess()
+		policyYAML = strings.Trim(res.Stdout(), "\n")
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_EGRESS_IP/%s/' %s > %s",
+			egressIP, originalPolicyYAML, policyYAML)).ExpectSuccess()
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_OUTSIDE_NODE_IP/%s/' -i %s",
+			outsideIP, policyYAML)).ExpectSuccess()
+		res = kubectl.ApplyDefault(policyYAML)
+		Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", policyYAML)
+	}
+
+	Context("tunnel disabled with endpoint routes enabled", func() {
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"egressGateway.enabled":  "true",
+				"tunnel":                 "disabled",
+				"autoDirectNodeRoutes":   "true",
+				"bpf.masquerade":         "true",
+				"endpointRoutes.enabled": "true",
+			})
+
+			randomNamespace = deploymentManager.DeployRandomNamespaceShared(DemoDaemonSet)
+			kubectl.NamespaceLabel(randomNamespace, namespaceSelector)
+			deploymentManager.WaitUntilReady()
+
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteAll()
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+		})
+
+		It("Checks connectivity works without policy", func() {
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+		It("Checks egress policy and basic connectivity both work", func() {
+			applyEgressPolicy()
+			kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
+			kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+			defer kubectl.Delete(policyYAML)
+
+			testEgressGateway(true)
+			testEgressGateway(false)
+			testConnectivity(true)
+			testConnectivity(false)
+		})
+
+	})
+
+	Context("tunnel disabled with endpoint routes disabled", func() {
+
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"egressGateway.enabled":  "true",
+				"tunnel":                 "disabled",
+				"autoDirectNodeRoutes":   "true",
+				"bpf.masquerade":         "true",
+				"endpointRoutes.enabled": "false",
+			})
+
+			randomNamespace = deploymentManager.DeployRandomNamespaceShared(DemoDaemonSet)
+			kubectl.NamespaceLabel(randomNamespace, namespaceSelector)
+			deploymentManager.WaitUntilReady()
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteAll()
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+		})
+
+		It("Checks connectivity works without policy", func() {
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+		It("Checks egress policy and basic connectivity both work", func() {
+			applyEgressPolicy()
+			kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
+			kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+			defer kubectl.Delete(policyYAML)
+
+			testEgressGateway(false)
+			testEgressGateway(true)
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+	})
+
+	Context("tunnel vxlan", func() {
+
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"egressGateway.enabled": "true",
+				"bpf.masquerade":        "true",
+				"tunnel":                "vxlan",
+			})
+
+			randomNamespace = deploymentManager.DeployRandomNamespaceShared(DemoDaemonSet)
+			kubectl.NamespaceLabel(randomNamespace, namespaceSelector)
+			deploymentManager.WaitUntilReady()
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteAll()
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+		})
+
+		It("Checks connectivity works without policy", func() {
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+		It("Checks egress policy and basic connectivity both work", func() {
+			applyEgressPolicy()
+			kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
+			kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+			defer kubectl.Delete(policyYAML)
+
+			testEgressGateway(false)
+			testEgressGateway(true)
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+	})
+
+})
+
+// Use x.x.x.100 as the egress IP
+func getEgressIP(nodeIP string) string {
+	ip := net.ParseIP(nodeIP).To4()
+	ip[3] = 100
+	return ip.String()
+}

--- a/test/k8sT/manifests/egress-ip-deployment.yaml
+++ b/test/k8sT/manifests/egress-ip-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "egress-ip-assign"
+  labels:
+    name: "egress-ip-assign"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: "egress-ip-assign"
+  template:
+    metadata:
+      labels:
+        name: "egress-ip-assign"
+    spec:
+      # Pin it on k8s2 so it becomes the gateway node
+      nodeSelector:
+        cilium.io/ci-node: k8s2
+      hostNetwork: true
+      containers:
+      - name: egress-ip
+        image: docker.io/library/busybox:1.31.1
+        command: ["/bin/sh","-c"]
+        securityContext:
+          privileged: true
+        env:
+        - name: EGRESS_IPS
+          value: "INPUT_EGRESS_IP/24"
+        args:
+        - "for i in $EGRESS_IPS; do ip address add $i dev enp0s8; done; sleep 10000000"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - "for i in $EGRESS_IPS; do ip address del $i dev enp0s8; done"

--- a/test/k8sT/manifests/egress-nat-policy.yaml
+++ b/test/k8sT/manifests/egress-nat-policy.yaml
@@ -1,0 +1,33 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEgressNATPolicy
+metadata:
+  name: egress-sample
+spec:
+  egress:
+  - podSelector:
+      matchLabels:
+        zgroup: testDSClient
+    namespaceSelector:
+      matchLabels:
+        ns: cilium-test
+  destinationCIDRs:
+  - INPUT_OUTSIDE_NODE_IP/32
+  egressSourceIP: INPUT_EGRESS_IP
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEgressNATPolicy
+metadata:
+  name: egress-to-black-hole
+spec:
+  egress:
+  - podSelector:
+      matchLabels:
+        zgroup: testDSClient
+    namespaceSelector:
+      matchLabels:
+        ns: cilium-test
+  # Route everything to a black hole.
+  # It shouldn't affect in-cluster traffic.
+  destinationCIDRs:
+  - 0.0.0.0/0
+  egressSourceIP: 1.1.1.1 # It's a black hole


### PR DESCRIPTION
    datapath: Fix egress gateway to exclude in-cluster traffic
    
    Egress gateway uses destination CIDR to decide whether or not to
    
    (1) forwarding a packet to egress gateway
    (2) SNAT with egressIP
    
    In-cluster traffic should be excluded from the destination CIDR because
    it's not "egress" traffic. In-cluster traffic includes both pod-to-pod
    and pod-to-node.
    
    For both cases, we check ipcache and IPV4_SNAT_EXCLUSION_DST_CIDR to see
    if the destination is in pod CIDR range or it's ID belongs to node ID.
    If it matches, we treat it as in-cluster traffic and skip both (1) and (2).

It also includes a refactor: 

    datapath: Use IS_BPF_OVERLAY as overlay check
    
    To check if the current interface is overlay or not is a static check.
    It doesn't need to perform runtime check, with something like:
    
            ctx->ifindex != ENCAP_IFINDEX

Fixes: ##16147

A set of e2e tests that can reproduce this issue are also included in the PR. 