### PR TITLE
Add an IPAM backend: external

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -456,6 +456,9 @@ func init() {
 	flags.String(option.IPAM, ipamOption.IPAMClusterPool, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
+	flags.String(option.ExternalIPAMAddress, "", "External IPAM address")
+	option.BindEnv(option.ExternalIPAMAddress)
+
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(option.IPv4Range)
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -215,7 +215,7 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 	var result *ipam.AllocationResult
 	routerIP = family.Router()
 	if routerIP != nil {
-		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router")
+		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, ipam.IPOwnerHost)
 		if err != nil {
 			log.Warn("Router IP could not be re-allocated. Need to re-allocate. This will cause brief network disruption")
 
@@ -230,7 +230,7 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 
 	if routerIP == nil {
 		family := ipam.DeriveFamily(family.PrimaryExternal())
-		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, "router")
+		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, ipam.IPOwnerHost)
 		if err != nil {
 			err = fmt.Errorf("Unable to allocate router IP for family %s: %s", family, err)
 			return
@@ -255,7 +255,7 @@ func (d *Daemon) allocateHealthIPs() error {
 	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking && option.Config.EnableEndpointHealthChecking {
 		if option.Config.EnableIPv4 {
-			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health")
+			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, ipam.IPOwnerHealth)
 			if err != nil {
 				return fmt.Errorf("unable to allocate health IPs: %s,see https://cilium.link/ipam-range-full", err)
 			}
@@ -274,7 +274,7 @@ func (d *Daemon) allocateHealthIPs() error {
 		}
 
 		if option.Config.EnableIPv6 {
-			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health")
+			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, ipam.IPOwnerHealth)
 			if err != nil {
 				if d.nodeDiscovery.LocalNode.IPv4HealthIP != nil {
 					d.ipam.ReleaseIP(d.nodeDiscovery.LocalNode.IPv4HealthIP)

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
@@ -93,7 +94,9 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 		return false, err
 	}
 
-	if !ep.DatapathConfiguration.ExternalIpam {
+	// If IPAM is external, skip check IP with IPAM as the external IPAM may unavailable for a short time.
+	// TODO: ensure the external IPAM is healthy then allocateIPsLocked.
+	if !ep.DatapathConfiguration.ExternalIpam || option.Config.IPAMMode() != ipamOption.IPAMExternal {
 		if err := d.allocateIPsLocked(ep); err != nil {
 			return false, fmt.Errorf("Failed to re-allocate IP of endpoint: %s", err)
 		}

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -137,7 +137,7 @@ func init() {
 				return "cilium-operator-azure"
 			case ipamOption.IPAMAlibabaCloud:
 				return "cilium-operator-alibabacloud"
-			case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool, ipamOption.IPAMCRD:
+			case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool, ipamOption.IPAMCRD, ipamOption.IPAMExternal:
 				return "cilium-operator-generic"
 			default:
 				return ""

--- a/pkg/ipam/external.go
+++ b/pkg/ipam/external.go
@@ -1,0 +1,107 @@
+// Copyright 2019-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"fmt"
+	"net"
+
+	ipamapi "github.com/cilium/cilium/api/v1/client/ipam"
+	"github.com/cilium/cilium/pkg/client"
+
+	"github.com/go-openapi/strfmt"
+)
+
+var _ Allocator = &External{}
+
+func newExternal(address string, family Family) (Allocator, error) {
+	tr, err := client.NewTransport(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &External{
+		family: string(family),
+		client: ipamapi.New(tr, strfmt.Default),
+	}, nil
+}
+
+type External struct {
+	family string
+	client ipamapi.ClientService
+}
+
+func (e *External) Allocate(ip net.IP, owner string) (*AllocationResult, error) {
+	body := ipamapi.NewPostIpamIPParams()
+	body.SetIP(ip.String())
+	body.SetOwner(&owner)
+
+	_, err := e.client.PostIpamIP(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AllocationResult{IP: ip}, nil
+}
+
+func (e *External) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*AllocationResult, error) {
+	return e.Allocate(ip, owner)
+}
+
+func (e *External) Release(ip net.IP) error {
+	body := ipamapi.NewDeleteIpamIPParams()
+	body.SetIP(ip.String())
+
+	_, err := e.client.DeleteIpamIP(body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *External) AllocateNext(owner string) (*AllocationResult, error) {
+	body := ipamapi.NewPostIpamParams()
+	body.SetFamily(&e.family)
+	body.SetOwner(&owner)
+
+	resp, err := e.client.PostIpam(body)
+	if err != nil {
+		return nil, err
+	}
+
+	if e.family == string(IPv4) {
+		return &AllocationResult{IP: net.ParseIP(resp.GetPayload().IPV4.IP)}, nil
+	}
+
+	if e.family == string(IPv6) {
+		return &AllocationResult{IP: net.ParseIP(resp.GetPayload().IPV6.IP)}, nil
+	}
+
+	panic(fmt.Errorf("unreachable, unsupported ip family: %s", e.family))
+}
+
+func (e *External) AllocateNextWithoutSyncUpstream(owner string) (*AllocationResult, error) {
+	return e.AllocateNext(owner)
+}
+
+func (e *External) Dump() (map[string]string, string) {
+	// TODO
+	return nil, ""
+}
+
+func (e *External) RestoreFinished() {
+	return
+}

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -56,6 +56,7 @@ func (t *testConfiguration) HealthCheckingEnabled() bool              { return t
 func (t *testConfiguration) IPAMMode() string                         { return ipamOption.IPAMClusterPool }
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
 func (t *testConfiguration) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }
+func (t *testConfiguration) ExternalIPAMAddress() string              { return "" }
 
 func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -36,4 +36,8 @@ const (
 
 	// IPAMAlibabaCloud is the value to select the AlibabaCloud ENI IPAM plugin for option.IPAM
 	IPAMAlibabaCloud = "alibabacloud"
+
+	// IPAMExternal is the value to external IPAM.
+	// option.IPAM
+	IPAMExternal = "external"
 )

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -23,6 +23,14 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+const (
+	// IPOwnerHost is the IP owner key of cilium_host device.
+	IPOwnerHost = "router"
+
+	// IPOwnerHealth is the IP owner key of lxc_health(cilium health) device.
+	IPOwnerHealth = "health"
+)
+
 // AllocationResult is the result of an allocation
 type AllocationResult struct {
 	// IP is the allocated IP

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -752,6 +752,9 @@ const (
 	// IPAM is the IPAM method to use
 	IPAM = "ipam"
 
+	// ExternalIPAMAddress is the external IPAM address
+	ExternalIPAMAddress = "external-ipam-address"
+
 	// XDPModeNative for loading progs with XDPModeLinkDriver
 	XDPModeNative = "native"
 
@@ -1770,6 +1773,9 @@ type DaemonConfig struct {
 	// IPAM is the IPAM method to use
 	IPAM string
 
+	// ExternalIPAMAddressStr is the external IPAM address
+	ExternalIPAMAddressStr string
+
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource bool
@@ -2122,6 +2128,11 @@ func (c *DaemonConfig) IPAMMode() string {
 	return strings.ToLower(c.IPAM)
 }
 
+// ExternalIPAMAddress returns the external IPAM address
+func (c *DaemonConfig) ExternalIPAMAddress() string {
+	return c.ExternalIPAMAddressStr
+}
+
 // TracingEnabled returns if tracing policy (outlining which rules apply to a
 // specific set of labels) is enabled.
 func (c *DaemonConfig) TracingEnabled() bool {
@@ -2436,6 +2447,7 @@ func (c *DaemonConfig) Populate() {
 	c.HTTPRetryTimeout = viper.GetInt(HTTPRetryTimeout)
 	c.IdentityChangeGracePeriod = viper.GetDuration(IdentityChangeGracePeriod)
 	c.IPAM = viper.GetString(IPAM)
+	c.ExternalIPAMAddressStr = viper.GetString(ExternalIPAMAddress)
 	c.IPv4Range = viper.GetString(IPv4Range)
 	c.IPv4NodeAddr = viper.GetString(IPv4NodeAddr)
 	c.IPv4ServiceRange = viper.GetString(IPv4ServiceRange)


### PR DESCRIPTION
# External IPAM

1. Add an IPAMD backend: external. Which enable ipamd run as a sidecar container with cilium-agent. When allocate/release IP, the socket call chain like: kubelet(cni) -> cilium-agent -> ipamd.
2. cilium-agent use [ipam API Client](https://github.com/cilium/cilium/blob/master/api/v1/client/ipam/ipam_client.go) to allocate/release IP.

# What's Next

1. Decouple ipamd with cilium-agent, which means migrate the kubernetes, crd, cluster-pool, eni, azure and etc IPAM backend to external IPAM backend, external IPAM backend(ipamd) run as a sidecar container or a separate goroutine. And change [Daemon.ipam](https://github.com/cilium/cilium/blob/master/daemon/cmd/daemon.go#L153) hold a [ipam API Client](https://github.com/cilium/cilium/blob/master/api/v1/client/ipam/ipam_client.go)  instance.
2. Simplify socket call chain to: kubelet(cni) -> ipamd, and cilium-agent -> ipamd.
2. If `--enable-endpoint-routes` disabled, we may set cilium-agent config `--k8s-require-ipv4-pod-cidr` to be true, if we must set the Pod CIDR route to the cilium-host device. And ipamd is responsible for setting the Node annotation `io.cilium.network.ipv4-pod-cidr`. And Node annotation `io.cilium.network.ipv4-pod-cidr` value support multi CIDR as a string combine with `','` will be better.