### PR TITLE
examples: add an example of a hubble-cli Deployment

### DIFF
--- a/examples/hubble/hubble-cli.yaml
+++ b/examples/hubble/hubble-cli.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubble-cli
+  labels:
+    app.kubernetes.io/name: hubble-cli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hubble-cli
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hubble-cli
+    spec:
+      containers:
+      - name: hubble-cli
+        image: quay.io/cilium/hubble:v0.8.0
+        imagePullPolicy: Always
+        command:
+          - tail
+        args:
+          - -f
+          - /dev/null
+        volumeMounts:
+          - mountPath: /var/run/cilium
+            name: hubble-sock-dir
+            readOnly: true
+          - mountPath: /var/lib/hubble-relay/tls
+            name: tls
+            readOnly: true
+      restartPolicy: Always
+      volumes:
+      - hostPath:
+          path: /var/run/cilium
+          type: Directory
+        name: hubble-sock-dir
+      - name: tls
+        projected:
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-server-ca.crt


### PR DESCRIPTION
_**NOTE**: This PR aim to replace both https://github.com/cilium/cilium/pull/14615 (which make little sense now that we don't have the auto-generated install.yaml stuff) and https://github.com/cilium/cilium-cli/pull/172 (which has its own limitations with respect to Huble TLS layout changes).There is a corresponding backport PR of this targeting v1.9 at https://github.com/cilium/cilium/pull/16460._

In order to debug Relay to Hubble connectivity issues, it is sometimes useful to have a Pod running with the Hubble CLI.

Because the Relay image is based on a scratch image, kubectl exec'ing into it is not possible. While the Hubble CLI can be found in the Cilium Pods, the Relay certificate needed to establish the mTLS handshake to the Hubble server is not mounted into the Cilium Pods.

This commit introduce a new hubble-cli Deployment example. When debugging Relay mTLS issues, it can be used to quickly run a hubble-cli Pod:

    kubectl apply -n kube-system -f url/to/hubble-cli.yaml

Since the Relay mTLS certificates are mounted into the hubble-cli Pods, one can connect to a Hubble server given it's IP address and ServerName:

    kubectl exec -it -n kube-system deployment/hubble-cli -- \
        hubble observe --server tls://${IP?}:4244 \
            --tls-server-name ${SERVERNAME?} \
            --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt \
            --tls-client-cert-file /var/lib/hubble-relay/tls/client.crt \
            --tls-client-key-file /var/lib/hubble-relay/tls/client.key

Both `${IP}` and `${SERVERNAME}` can be obtained by either looking at the Hubble Relay Pod logs or alternatively by running:

    kubectl exec -it -n kube-system deployment/hubble-cli -- \
        hubble watch peers --server unix:///var/run/cilium/hubble.sock