### PR TITLE
    examples: add an example of a hubble-cli Deployment

### DIFF
--- a/examples/hubble/hubble-cli.yaml
+++ b/examples/hubble/hubble-cli.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubble-cli
+  labels:
+    app.kubernetes.io/name: hubble-cli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hubble-cli
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hubble-cli
+    spec:
+      containers:
+      - name: hubble-cli
+        image: quay.io/cilium/hubble:v0.8.0
+        imagePullPolicy: IfNotPresent
+        command:
+          - tail
+        args:
+          - -f
+          - /dev/null
+        volumeMounts:
+          - mountPath: /var/run/cilium
+            name: hubble-sock-dir
+            readOnly: true
+          - mountPath: /var/lib/hubble-relay/tls
+            name: tls
+            readOnly: true
+      restartPolicy: Always
+      volumes:
+      - hostPath:
+          path: /var/run/cilium
+          type: Directory
+        name: hubble-sock-dir
+      - name: tls
+        projected:
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+          - configMap:
+              name: hubble-ca-cert
+              items:
+                - key: ca.crt
+                  path: hubble-server-ca.crt


### PR DESCRIPTION
_**NOTE**: this is a backport PR of https://github.com/cilium/cilium/pull/16459 targeting the v1.9 branch._

There is a slight difference in how the TLS certificates are projected: this patch uses the `hubble-ca-cert` ConfigMap. This version is compatible with the way we deploy Hubble _via Helm_ in v1.9 and v1.10 (where the ConfigMap is still deployed for compatibility), while https://github.com/cilium/cilium/pull/16459 is compatible with cilium-cli and Helm starting v1.10.