### PR TITLE
helm: Improve the Helm chart documentation.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ go.sum linguist-generated
 examples/kubernetes/connectivity-check/connectivity-*.yaml linguist-generated
 pkg/k8s/apis/cilium.io/v2/client/crds/*.yaml linguist-generated
 Documentation/cmdref/** linguist-generated
+Documentation/helm-values.rst linguist-generated

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -59,13 +59,14 @@ M2R_IMAGE := docker.io/bmcustodio/m2r:$(M2R_VERSION)@sha256:$(M2R_SHA)
 M2R := $(DOCKER_CTR) $(M2R_IMAGE) m2r
 
 .PHONY: $(HELM_VALUES)
-$(HELM_VALUES): TMP_FILE := helm-values.tmp
-$(HELM_VALUES): AWK_FILE := helm-values.awk
+$(HELM_VALUES): TMP_FILE_1 := helm-values.tmp
+$(HELM_VALUES): TMP_FILE_2 := helm-values.awk
 $(HELM_VALUES):
-	$(QUIET)$(HELM_DOCS) -d -c $(HELM_DOCS_CHARTS_DIR) -t $(HELM_DOCS_OUTPUT_DIR)/$(TMP_FILE).tmpl > $(TMP_FILE)
-	$(QUIET)awk -F'|' '{print "|"$$2"|"$$5"|"$$3"|"$$4"|"}' $(TMP_FILE) > $(AWK_FILE)
-	$(QUIET)$(M2R) --overwrite $(AWK_FILE)
-	$(QUIET)$(RM) -- $(TMP_FILE) $(AWK_FILE)
+	$(QUIET)$(HELM_DOCS) -d -c $(HELM_DOCS_CHARTS_DIR) -t $(HELM_DOCS_OUTPUT_DIR)/$(TMP_FILE_1).tmpl > $(TMP_FILE_1)
+	$(QUIET)awk -F'|' '{print "|"$$2"|"$$5"|"$$3"|"$$4"|"}' $(TMP_FILE_1) > $(TMP_FILE_2)
+	$(QUIET)$(M2R) --overwrite $(TMP_FILE_2)
+	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $@)" > $@
+	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2)
 
 epub latex html: builder-image copy-api $(HELM_VALUES)
 	@$(ECHO_GEN)_build/$@

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -19,7 +19,7 @@
      - bool
      - ``false``
    * - autoDirectNodeRoutes
-     - 
+     - Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment.
      - bool
      - ``false``
    * - azure.enabled
@@ -29,7 +29,7 @@
    * - bandwidthManager
      - Optimize TCP and UDP workloads and enable rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.
      - bool
-     - ``true``
+     - ``false``
    * - bgp
      - Configure BGP
      - object
@@ -51,11 +51,11 @@
      - bool
      - ``false``
    * - bpf.lbMapMax
-     - Configure the maximum number of entries in the TCP connection tracking table. ctTcpMax: '524288' -- Configure the maximum number of entries for the non-TCP connection tracking table. ctAnyMax: '262144' -- Configure the maximum number of service entries in the load balancer maps.
+     - Configure the maximum number of service entries in the load balancer maps.
      - int
      - ``65536``
    * - bpf.monitorAggregation
-     - Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/v1.9/concepts/ebpf/maps/#ebpf-maps -- Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum
+     - Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum
      - string
      - ``"medium"``
    * - bpf.monitorFlags
@@ -67,7 +67,7 @@
      - string
      - ``"5s"``
    * - bpf.policyMapMax
-     - Configure the maximum number of entries for the NAT table. natMax: 524288 -- Configure the maximum number of entries for the neighbor table. neighMax: 524288 -- Configure the maximum number of entries in endpoint policy map. (per endpoint)
+     - Configure the maximum number of entries in endpoint policy map. (per endpoint)
      - int
      - ``16384``
    * - bpf.preallocateMaps
@@ -215,7 +215,7 @@
      - string
      - ``"/etc/cni/net.d"``
    * - cni.configMapKey
-     - Specify the path to a CNI config to read from on agent start. This can be useful if you want to manage your CNI configuration outside of a Kubernetes environment. This parameter is mutually exclusive with the 'cni.configMap' parameter. readCniConf: /host/etc/cni/net.d/05-cilium.conf -- When defined, configMap will mount the provided value as ConfigMap and interpret the cniConf variable as CNI configuration file and write it when the agent starts up configMap: cni-configuration -- Configure the key in the CNI ConfigMap to read the contents of the CNI configuration from.
+     - Configure the key in the CNI ConfigMap to read the contents of the CNI configuration from.
      - string
      - ``"cni-config"``
    * - cni.customConf
@@ -235,13 +235,17 @@
      - bool
      - ``true``
    * - containerRuntime
-     - Configure how frequently garbage collection should occur for the datapath connection tracking table. conntrackGCInterval: "0s" -- Configure container runtime specific integration.
+     - Configure container runtime specific integration.
      - object
      - ``{"integration":"none"}``
    * - containerRuntime.integration
      - Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime)
      - string
      - ``"none"``
+   * - customCalls
+     - Tail call hooks for custom eBPF programs.
+     - object
+     - ``{"enabled":false}``
    * - customCalls.enabled
      - Enable tail call hooks for custom eBPF programs.
      - bool
@@ -258,6 +262,10 @@
      - Enable debug logging
      - bool
      - ``false``
+   * - disableEndpointCRD
+     - Disable the usage of CiliumEndpoint CRD
+     - string
+     - ``"false"``
    * - egressGateway
      - Enables egress gateway (beta) to redirect and SNAT the traffic that leaves the cluster.
      - object
@@ -271,7 +279,7 @@
      - bool
      - ``true``
    * - enableIPv4Masquerade
-     - hashSeed is the cluster-wide base64 encoded seed for the hashing hashSeed: -- Enables masquerading of IPv4 traffic leaving the node from endpoints.
+     - Enables masquerading of IPv4 traffic leaving the node from endpoints.
      - bool
      - ``true``
    * - enableIPv6Masquerade
@@ -283,7 +291,7 @@
      - bool
      - ``false``
    * - enableXTSocketFallback
-     - 
+     - Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: http://docs.cilium.io/en/stable/install/system_requirements/#admin-kernel-version.
      - bool
      - ``true``
    * - encryption.enabled
@@ -527,7 +535,7 @@
      - string
      - ``":4244"``
    * - hubble.metrics
-     - Buffer size of the channel Hubble uses to receive monitor events. If this value is not set, the queue size is set to the default monitor queue size. eventQueueSize: "" -- Number of recent flows for Hubble to cache. Defaults to 4095. Possible values are:   1, 3, 7, 15, 31, 63, 127, 255, 511, 1023,   2047, 4095, 8191, 16383, 32767, 65535 eventBufferCapacity: "4095" -- Hubble metrics configuration. See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics.
+     - Hubble metrics configuration. See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics.
      - object
      - ``{"enabled":null,"port":9091,"serviceMonitor":{"enabled":false}}``
    * - hubble.metrics.enabled
@@ -743,7 +751,7 @@
      - string
      - ``nil``
    * - installIptablesRules
-     - 
+     - Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy.
      - bool
      - ``true``
    * - installNoConntrackIptablesRules
@@ -791,7 +799,7 @@
      - object
      - ``{}``
    * - keepDeprecatedLabels
-     - requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR range via the Kubernetes node resource requireIPv6PodCIDR: false -- Keep the deprecated selector labels when deploying Cilium DaemonSet
+     - Keep the deprecated selector labels when deploying Cilium DaemonSet
      - bool
      - ``false``
    * - keepDeprecatedProbes
@@ -799,7 +807,7 @@
      - bool
      - ``false``
    * - kubeProxyReplacementHealthzBindAddr
-     - Configure the kube-proxy replacement in Cilium BPF datapath Valid options are "disabled", "probe", "partial", "strict". ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/ -- healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled.
+     - healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled.
      - string
      - ``""``
    * - l7Proxy
@@ -811,7 +819,7 @@
      - bool
      - ``false``
    * - logSystemLoad
-     - 
+     - Enables periodic logging of system load
      - bool
      - ``false``
    * - maglev
@@ -819,7 +827,7 @@
      - object
      - ``{}``
    * - monitor
-     - Specify the CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. nativeRoutingCIDR: -- Configure cilium-monitor sidecar
+     - Configure cilium-monitor sidecar
      - object
      - ``{"enabled":false}``
    * - name
@@ -827,7 +835,7 @@
      - string
      - ``"cilium"``
    * - nodePort
-     - Configure service load balancing loadBalancer: algorithm is the name of the load balancing algorithm for backend selection e.g. random or maglev algorithm: "random" mode is the operation mode of load balancing for remote backends e.g. snat, dsr, hybrid mode: snat acceleration is the option to accelerate service handling via XDP e.g. native, disabled acceleration: disabled
+     - Configure N-S k8s service loadbalancing
      - object
      - ``{"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enabled":false}``
    * - nodePort.autoProtectPortRange
@@ -835,7 +843,7 @@
      - bool
      - ``true``
    * - nodePort.bindProtection
-     - Port range to use for NodePort services. range: "30000,32767" -- Set to true to prevent applications binding to service ports.
+     - Set to true to prevent applications binding to service ports.
      - bool
      - ``true``
    * - nodePort.enableHealthCheck
@@ -1002,6 +1010,10 @@
      - For using with an existing serviceAccount.
      - string
      - ``"cilium-operator"``
+   * - operator.skipCRDCreation
+     - Skip CRDs creation for cilium-operator
+     - bool
+     - ``false``
    * - operator.tolerations
      - Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
      - list
@@ -1023,7 +1035,7 @@
      - object
      - ``{}``
    * - policyEnforcementMode
-     - 
+     - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
      - string
      - ``"default"``
    * - pprof.enabled
@@ -1159,21 +1171,17 @@
      - object
      - ``{"annotations":{},"create":true,"name":"hubble-generate-certs"}``
    * - sleepAfterInit
-     - 
+     - Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node.
      - bool
      - ``false``
    * - sockops
      - Configure BPF socket operations configuration
      - object
      - ``{"enabled":false}``
-   * - tls.enabled
-     - 
-     - bool
-     - ``true``
-   * - tls.secretsBackend
-     - 
-     - string
-     - ``"local"``
+   * - tls
+     - Configure TLS configuration in the agent.
+     - object
+     - ``{"enabled":true,"secretsBackend":"local"}``
    * - tolerations
      - Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
      - list

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1,3 +1,6 @@
+..
+  AUTO-GENERATED. Please DO NOT edit manually.
+
 
 .. list-table::
    :header-rows: 1
@@ -1198,4 +1201,3 @@
      - Enable the use of well-known identities.
      - bool
      - ``false``
-

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -46,7 +46,7 @@
      - bool
      - ``false``
    * - bpf.clockProbe
-     - 
+     - Enable BPF clock source probing for more efficient tick retrieval.
      - bool
      - ``false``
    * - bpf.lbExternalClusterIP
@@ -58,7 +58,7 @@
      - int
      - ``65536``
    * - bpf.monitorAggregation
-     - Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum
+     - Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum.
      - string
      - ``"medium"``
    * - bpf.monitorFlags
@@ -70,7 +70,7 @@
      - string
      - ``"5s"``
    * - bpf.policyMapMax
-     - Configure the maximum number of entries in endpoint policy map. (per endpoint)
+     - Configure the maximum number of entries in endpoint policy map (per endpoint).
      - int
      - ``16384``
    * - bpf.preallocateMaps
@@ -146,11 +146,11 @@
      - int
      - ``32379``
    * - clustermesh.apiserver.service.type
-     - 
+     - The type of service used for apiserver access.
      - string
      - ``"NodePort"``
    * - clustermesh.apiserver.tls.admin
-     - base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key Used if 'auto' is not enabled.
+     - base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key. Used if 'auto' is not enabled.
      - object
      - ``{"cert":"","key":""}``
    * - clustermesh.apiserver.tls.auto
@@ -178,15 +178,15 @@
      - string
      - ``""``
    * - clustermesh.apiserver.tls.client
-     - base64 encoded PEM values for the clustermesh-apiserver client certificate and private key Used if 'auto' is not enabled.
+     - base64 encoded PEM values for the clustermesh-apiserver client certificate and private key. Used if 'auto' is not enabled.
      - object
      - ``{"cert":"","key":""}``
    * - clustermesh.apiserver.tls.remote
-     - base64 encoded PEM values for the clustermesh-apiserver remote cluster certificate and private key Used if 'auto' is not enabled.
+     - base64 encoded PEM values for the clustermesh-apiserver remote cluster certificate and private key. Used if 'auto' is not enabled.
      - object
      - ``{"cert":"","key":""}``
    * - clustermesh.apiserver.tls.server
-     - base64 encoded PEM values for the clustermesh-apiserver server certificate and private key Used if 'auto' is not enabled.
+     - base64 encoded PEM values for the clustermesh-apiserver server certificate and private key. Used if 'auto' is not enabled.
      - object
      - ``{"cert":"","key":""}``
    * - clustermesh.apiserver.tolerations
@@ -266,7 +266,7 @@
      - bool
      - ``false``
    * - disableEndpointCRD
-     - Disable the usage of CiliumEndpoint CRD
+     - Disable the usage of CiliumEndpoint CRD.
      - string
      - ``"false"``
    * - egressGateway
@@ -274,7 +274,7 @@
      - object
      - ``{"enabled":false}``
    * - enableCnpStatusUpdates
-     - Specify which network interfaces can run the eBPF datapath. This means that a packet sent from a pod to a destination outside the cluster will be masqueraded (to an output device IPv4 address), if the output device runs the program. When not specified, probing will automatically detect devices. devices: "" TODO: Add documentation disableIptablesFeederRules: "" TODO: Add documentation egressMasqueradeInterfaces: ""
+     - Whether to enable CNP status updates.
      - bool
      - ``false``
    * - enableCriticalPriorityClass
@@ -342,7 +342,7 @@
      - string
      - ``"ipsec"``
    * - endpointHealthChecking.enabled
-     - 
+     - Enable connectivity health checking between virtual endpoints.
      - bool
      - ``true``
    * - endpointRoutes.enabled
@@ -398,19 +398,19 @@
      - list
      - ``["https://CHANGE-ME:2379"]``
    * - etcd.extraArgs
-     - Additional cilium-etcd-operator container arguments
+     - Additional cilium-etcd-operator container arguments.
      - list
      - ``[]``
    * - etcd.extraConfigmapMounts
-     - Additional cilium-etcd-operator ConfigMap mounts
+     - Additional cilium-etcd-operator ConfigMap mounts.
      - list
      - ``[]``
    * - etcd.extraHostPathMounts
-     - Additional cilium-etcd-operator hostPath mounts
+     - Additional cilium-etcd-operator hostPath mounts.
      - list
      - ``[]``
    * - etcd.extraInitContainers
-     - Additional InitContainers to initialize the pod
+     - Additional InitContainers to initialize the pod.
      - list
      - ``[]``
    * - etcd.image
@@ -474,7 +474,7 @@
      - bool
      - ``false``
    * - extraArgs
-     - Additional agent container arguments
+     - Additional agent container arguments.
      - list
      - ``[]``
    * - extraConfig
@@ -482,19 +482,19 @@
      - object
      - ``{}``
    * - extraConfigmapMounts
-     - Additional agent ConfigMap mounts
+     - Additional agent ConfigMap mounts.
      - list
      - ``[]``
    * - extraEnv
-     - Additional agent container environment variables
+     - Additional agent container environment variables.
      - object
      - ``{}``
    * - extraHostPathMounts
-     - Additional agent hostPath mounts
+     - Additional agent hostPath mounts.
      - list
      - ``[]``
    * - extraInitContainers
-     - Additional InitContainers to initialize the pod
+     - Additional InitContainers to initialize the pod.
      - list
      - ``[]``
    * - gke.enabled
@@ -502,7 +502,7 @@
      - bool
      - ``false``
    * - healthChecking
-     - 
+     - Enable connectivity health checking.
      - bool
      - ``true``
    * - healthPort
@@ -553,10 +553,6 @@
      - Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
      - bool
      - ``false``
-   * - hubble.metricsServer
-     - 
-     - string
-     - ``""``
    * - hubble.relay.dialTimeout
      - Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
      - string
@@ -682,11 +678,11 @@
      - object
      - ``{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"latest"}``
    * - hubble.ui.backend.resources
-     - 
+     - Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
      - object
      - ``{}``
    * - hubble.ui.enabled
-     - 
+     - Whether to enable the Hubble UI.
      - bool
      - ``false``
    * - hubble.ui.frontend.image
@@ -694,7 +690,7 @@
      - object
      - ``{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"latest"}``
    * - hubble.ui.frontend.resources
-     - 
+     - Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
      - object
      - ``{}``
    * - hubble.ui.ingress
@@ -718,11 +714,11 @@
      - object
      - ``{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.18.2@sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7"}``
    * - hubble.ui.proxy.resources
-     - 
+     - Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment.
      - object
      - ``{}``
    * - hubble.ui.replicas
-     - 
+     - The number of replicas of Hubble UI to deploy.
      - int
      - ``1``
    * - hubble.ui.rollOutPods
@@ -730,7 +726,7 @@
      - bool
      - ``false``
    * - hubble.ui.securityContext.enabled
-     - 
+     - Whether to set the security context on the Hubble UI pods.
      - bool
      - ``true``
    * - hubble.ui.tolerations
@@ -742,7 +738,7 @@
      - object
      - ``{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}``
    * - identityAllocationMode
-     - 
+     - Method to use for identity allocation (\ ``crd`` or ``kvstore``\ ).
      - string
      - ``"crd"``
    * - image
@@ -802,7 +798,7 @@
      - object
      - ``{}``
    * - keepDeprecatedLabels
-     - Keep the deprecated selector labels when deploying Cilium DaemonSet
+     - Keep the deprecated selector labels when deploying Cilium DaemonSet.
      - bool
      - ``false``
    * - keepDeprecatedProbes
@@ -818,7 +814,7 @@
      - bool
      - ``true``
    * - localRedirectPolicy
-     - 
+     - Enable Local Redirect Policy.
      - bool
      - ``false``
    * - logSystemLoad
@@ -830,9 +826,13 @@
      - object
      - ``{}``
    * - monitor
-     - Configure cilium-monitor sidecar
+     - Specify the CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. nativeRoutingCIDR:
      - object
      - ``{"enabled":false}``
+   * - monitor.enabled
+     - Enable the cilium-monitor sidecar.
+     - bool
+     - ``false``
    * - name
      - Agent container name.
      - string
@@ -866,19 +866,19 @@
      - bool
      - ``false``
    * - nodeinit.extraConfigmapMounts
-     - 
+     - Additional nodeinit ConfigMap mounts.
      - list
      - ``[]``
    * - nodeinit.extraEnv
-     - 
+     - Additional nodeinit environment variables.
      - object
      - ``{}``
    * - nodeinit.extraHostPathMounts
-     - 
+     - Additional nodeinit host path mounts.
      - list
      - ``[]``
    * - nodeinit.extraInitContainers
-     - 
+     - Additional nodeinit init containers.
      - list
      - ``[]``
    * - nodeinit.image
@@ -890,7 +890,7 @@
      - object
      - ``{}``
    * - nodeinit.podAnnotations
-     - Annotations to be added to node-init pods
+     - Annotations to be added to node-init pods.
      - object
      - ``{}``
    * - nodeinit.podDisruptionBudget
@@ -898,11 +898,11 @@
      - object
      - ``{"enabled":true,"maxUnavailable":2}``
    * - nodeinit.podLabels
-     - Labels to be added to node-init pods
+     - Labels to be added to node-init pods.
      - object
      - ``{}``
    * - nodeinit.priorityClassName
-     - 
+     - The priority class to use for the nodeinit pod.
      - string
      - ``""``
    * - nodeinit.resources
@@ -910,7 +910,7 @@
      - object
      - ``{"requests":{"cpu":"100m","memory":"100Mi"}}``
    * - nodeinit.securityContext
-     - Security context to be added to nodeinit pods
+     - Security context to be added to nodeinit pods.
      - object
      - ``{}``
    * - nodeinit.tolerations
@@ -930,35 +930,35 @@
      - bool
      - ``true``
    * - operator.endpointGCInterval
-     - 
+     - Interval for endpoint garbage collection.
      - string
      - ``"5m0s"``
    * - operator.extraArgs
-     - Additional cilium-operator container arguments
+     - Additional cilium-operator container arguments.
      - list
      - ``[]``
    * - operator.extraConfigmapMounts
-     - 
+     - Additional cilium-operator ConfigMap mounts.
      - list
      - ``[]``
    * - operator.extraEnv
-     - 
+     - Additional cilium-operator environment variables.
      - object
      - ``{}``
    * - operator.extraHostPathMounts
-     - Additional cilium-operator hostPath mounts
+     - Additional cilium-operator hostPath mounts.
      - list
      - ``[]``
    * - operator.extraInitContainers
-     - Additional InitContainers to initialize the pod
+     - Additional InitContainers to initialize the pod.
      - list
      - ``[]``
    * - operator.identityGCInterval
-     - 
+     - Interval for identity garbage collection.
      - string
      - ``"15m0s"``
    * - operator.identityHeartbeatTimeout
-     - 
+     - Timeout for identity heartbeats.
      - string
      - ``"30m0s"``
    * - operator.image
@@ -1050,19 +1050,19 @@
      - bool
      - ``false``
    * - preflight.extraConfigmapMounts
-     - 
+     - Additional preflight ConfigMap mounts.
      - list
      - ``[]``
    * - preflight.extraEnv
-     - 
+     - Additional preflight environment variables.
      - object
      - ``{}``
    * - preflight.extraHostPathMounts
-     - 
+     - Additional preflight host path mounts.
      - list
      - ``[]``
    * - preflight.extraInitContainers
-     - 
+     - Additional preflight init containers.
      - list
      - ``[]``
    * - preflight.image
@@ -1082,11 +1082,11 @@
      - object
      - ``{"enabled":true,"maxUnavailable":2}``
    * - preflight.podLabels
-     - 
+     - Labels to be added to thee preflight pod.
      - object
      - ``{}``
    * - preflight.priorityClassName
-     - 
+     - The priority class to use for the preflight pod.
      - string
      - ``""``
    * - preflight.resources
@@ -1098,7 +1098,7 @@
      - object
      - ``{}``
    * - preflight.tofqdnsPreCache
-     - 
+     - Path to write the ``--tofqdns-pre-cache`` file to.
      - string
      - ``""``
    * - preflight.tolerations
@@ -1114,7 +1114,7 @@
      - bool
      - ``true``
    * - priorityClassName
-     - 
+     - The priority class to use for cilium-agent.
      - string
      - ``""``
    * - prometheus

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1082,7 +1082,7 @@
      - object
      - ``{"enabled":true,"maxUnavailable":2}``
    * - preflight.podLabels
-     - Labels to be added to thee preflight pod.
+     - Labels to be added to the preflight pod.
      - object
      - ``{}``
    * - preflight.priorityClassName

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -297,6 +297,7 @@ dev
 devel
 dialTimeout
 diff
+disableEndpointCRD
 disableEnvoyVersionCheck
 disableIptablesFeederRules
 disassembly
@@ -764,6 +765,7 @@ sha
 sidecarImageRegex
 sig
 skb
+skipCRDCreation
 skipteardown
 sleepAfterInit
 snat
@@ -908,6 +910,7 @@ xfrm
 xml
 xor
 xoring
+xt
 xwing
 xxxxx
 yaml

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -170,6 +170,6 @@ ifeq ($(BASE_IMAGE),)
     BASE_IMAGE=scratch
 endif
 
-HELM_DOCS_VERSION ?= "v1.3.0"
-HELM_DOCS_SHA ?= "12f065115654c9a1d6819b938487d327f1fdb5c32bdc2a5c74afef22ed68f5ca"
-HELM_DOCS_IMAGE ?= "docker.io/jnorwood/helm-docs:$(HELM_DOCS_VERSION)@sha256:$(HELM_DOCS_SHA)"
+HELM_DOCS_VERSION ?= "5ddabba"
+HELM_DOCS_SHA ?= "c4a91daac6bf9c181fac79e09712fcf1f9102fcab1bbacbc733883965f5fd244"
+HELM_DOCS_IMAGE ?= "docker.io/bmcustodio/helm-docs:$(HELM_DOCS_VERSION)@sha256:$(HELM_DOCS_SHA)"

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -56,7 +56,7 @@ contributors across the globe, there is almost always someone available to help.
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]},{"matchExpressions":[{"key":"beta.kubernetes.io/os","operator":"In","values":["linux"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"k8s-app","operator":"In","values":["cilium"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Pod affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
-| autoDirectNodeRoutes | bool | `false` |  |
+| autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
 | azure.enabled | bool | `false` | Enable Azure integration |
 | bandwidthManager | bool | `false` | Optimize TCP and UDP workloads and enable rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
 | bgp | object | `{"announce":{"loadbalancerIP":false},"enabled":false}` | Configure BGP |
@@ -64,11 +64,11 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
 | bpf.clockProbe | bool | `false` |  |
 | bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
-| bpf.lbMapMax | int | `65536` | Configure the maximum number of entries in the TCP connection tracking table. ctTcpMax: '524288' -- Configure the maximum number of entries for the non-TCP connection tracking table. ctAnyMax: '262144' -- Configure the maximum number of service entries in the load balancer maps. |
-| bpf.monitorAggregation | string | `"medium"` | Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/v1.9/concepts/ebpf/maps/#ebpf-maps -- Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum |
+| bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
+| bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum |
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
-| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries for the NAT table. natMax: 524288 -- Configure the maximum number of entries for the neighbor table. neighMax: 524288 -- Configure the maximum number of entries in endpoint policy map. (per endpoint) |
+| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map. (per endpoint) |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.waitForMount | bool | `false` | Force the cilium-agent DaemonSet to wait in an initContainer until the eBPF filesystem has been mounted. |
 | certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.4"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
@@ -105,13 +105,14 @@ contributors across the globe, there is almost always someone available to help.
 | cni.chainingMode | string | `"none"` | Configure chaining on top of other CNI plugins. Possible values:  - none  - generic-veth  - aws-cni  - portmap |
 | cni.confFileMountPath | string | `"/tmp/cni-configuration"` | Configure the path to where to mount the ConfigMap inside the agent pod. |
 | cni.confPath | string | `"/etc/cni/net.d"` | Configure the path to the CNI configuration directory on the host. |
-| cni.configMapKey | string | `"cni-config"` | Specify the path to a CNI config to read from on agent start. This can be useful if you want to manage your CNI configuration outside of a Kubernetes environment. This parameter is mutually exclusive with the 'cni.configMap' parameter. readCniConf: /host/etc/cni/net.d/05-cilium.conf -- When defined, configMap will mount the provided value as ConfigMap and interpret the cniConf variable as CNI configuration file and write it when the agent starts up configMap: cni-configuration -- Configure the key in the CNI ConfigMap to read the contents of the CNI configuration from. |
+| cni.configMapKey | string | `"cni-config"` | Configure the key in the CNI ConfigMap to read the contents of the CNI configuration from. |
 | cni.customConf | bool | `false` | Skip writing of the CNI configuration. This can be used if writing of the CNI configuration is performed by external automation. |
 | cni.exclusive | bool | `true` | Make Cilium take ownership over the `/etc/cni/net.d` directory on the node, renaming all non-Cilium CNI configurations to `*.cilium_bak`. This ensures no Pods can be scheduled using other CNI plugins during Cilium agent downtime. |
 | cni.hostConfDirMountPath | string | `"/host/etc/cni/net.d"` | Configure the path to where the CNI configuration directory is mounted inside the agent pod. |
 | cni.install | bool | `true` | Install the CNI configuration and binary files into the filesystem. |
-| containerRuntime | object | `{"integration":"none"}` | Configure how frequently garbage collection should occur for the datapath connection tracking table. conntrackGCInterval: "0s" -- Configure container runtime specific integration. |
+| containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. |
 | containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime) |
+| customCalls | object | `{"enabled":false}` | Tail call hooks for custom eBPF programs. |
 | customCalls.enabled | bool | `false` | Enable tail call hooks for custom eBPF programs. |
 | daemon.runPath | string | `"/var/run/cilium"` | Configure where Cilium runtime state should be stored. |
 | datapathMode | string | `"veth"` | Configure which datapath mode should be used for configuring container connectivity. Valid options are "veth" or "ipvlan". |
@@ -120,10 +121,10 @@ contributors across the globe, there is almost always someone available to help.
 | egressGateway | object | `{"enabled":false}` | Enables egress gateway (beta) to redirect and SNAT the traffic that leaves the cluster. |
 | enableCnpStatusUpdates | bool | `false` | Specify which network interfaces can run the eBPF datapath. This means that a packet sent from a pod to a destination outside the cluster will be masqueraded (to an output device IPv4 address), if the output device runs the program. When not specified, probing will automatically detect devices. devices: "" TODO: Add documentation disableIptablesFeederRules: "" TODO: Add documentation egressMasqueradeInterfaces: "" |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
-| enableIPv4Masquerade | bool | `true` | hashSeed is the cluster-wide base64 encoded seed for the hashing hashSeed: -- Enables masquerading of IPv4 traffic leaving the node from endpoints. |
+| enableIPv4Masquerade | bool | `true` | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters. |
-| enableXTSocketFallback | bool | `true` |  |
+| enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: http://docs.cilium.io/en/stable/install/system_requirements/#admin-kernel-version. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.interface | string | `""` | Deprecated in favor of encryption.ipsec.interface. The interface to use for encrypted traffic. This option is only effective when encryption.type is set to ipsec. |
 | encryption.ipsec.interface | string | `""` | The interface to use for encrypted traffic. |
@@ -184,7 +185,7 @@ contributors across the globe, there is almost always someone available to help.
 | hostServices.protocols | string | `"tcp,udp"` | Supported list of protocols to apply ClusterIP translation to. |
 | hubble.enabled | bool | `true` | Enable Hubble (true by default). |
 | hubble.listenAddress | string | `":4244"` | An additional address for Hubble to listen to. Set this field ":4244" if you are enabling Hubble Relay, as it assumes that Hubble is listening on port 4244. |
-| hubble.metrics | object | `{"enabled":null,"port":9091,"serviceMonitor":{"enabled":false}}` | Buffer size of the channel Hubble uses to receive monitor events. If this value is not set, the queue size is set to the default monitor queue size. eventQueueSize: "" -- Number of recent flows for Hubble to cache. Defaults to 4095. Possible values are:   1, 3, 7, 15, 31, 63, 127, 255, 511, 1023,   2047, 4095, 8191, 16383, 32767, 65535 eventBufferCapacity: "4095" -- Hubble metrics configuration. See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
+| hubble.metrics | object | `{"enabled":null,"port":9091,"serviceMonitor":{"enabled":false}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
 | hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:   enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http You can specify the list of metrics from the helm CLI:   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}" |
 | hubble.metrics.port | int | `9091` | Configure the port the hubble metric server listens on. |
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
@@ -238,7 +239,7 @@ contributors across the globe, there is almost always someone available to help.
 | identityAllocationMode | string | `"crd"` |  |
 | image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Agent container image. |
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
-| installIptablesRules | bool | `true` |  |
+| installIptablesRules | bool | `true` | Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy. |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
 | ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/ |
@@ -250,18 +251,18 @@ contributors across the globe, there is almost always someone available to help.
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | ipvlan.enabled | bool | `false` | Enable the IPVLAN datapath |
 | k8s | object | `{}` | Configure Kubernetes specific configuration |
-| keepDeprecatedLabels | bool | `false` | requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR range via the Kubernetes node resource requireIPv6PodCIDR: false -- Keep the deprecated selector labels when deploying Cilium DaemonSet |
+| keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
-| kubeProxyReplacementHealthzBindAddr | string | `""` | Configure the kube-proxy replacement in Cilium BPF datapath Valid options are "disabled", "probe", "partial", "strict". ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/ -- healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
+| kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | localRedirectPolicy | bool | `false` |  |
-| logSystemLoad | bool | `false` |  |
+| logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
-| monitor | object | `{"enabled":false}` | Specify the CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. nativeRoutingCIDR: -- Configure cilium-monitor sidecar |
+| monitor | object | `{"enabled":false}` | Configure cilium-monitor sidecar |
 | name | string | `"cilium"` | Agent container name. |
-| nodePort | object | `{"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enabled":false}` | Configure service load balancing loadBalancer: -- standalone enables the standalone L4LB which does not connect to kube-apiserver. standalone: false -- algorithm is the name of the load balancing algorithm for backend selection e.g. random or maglev algorithm: random -- mode is the operation mode of load balancing for remote backends e.g. snat, dsr, hybrid mode: snat -- acceleration is the option to accelerate service handling via XDP e.g. native, disabled acceleration: disabled -- dsrDispatch configures whether IP option or IPIP encapsulation is used to pass a service IP and port to remote backend dsrDispatch: opt -- Configure N-S k8s service loadbalancing |
+| nodePort | object | `{"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enabled":false}` | Configure N-S k8s service loadbalancing |
 | nodePort.autoProtectPortRange | bool | `true` | Append NodePort range to ip_local_reserved_ports if clash with ephemeral ports is detected. |
-| nodePort.bindProtection | bool | `true` | Port range to use for NodePort services. range: "30000,32767" -- Set to true to prevent applications binding to service ports. |
+| nodePort.bindProtection | bool | `true` | Set to true to prevent applications binding to service ports. |
 | nodePort.enableHealthCheck | bool | `true` | Enable healthcheck nodePort server for NodePort services |
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
@@ -309,7 +310,7 @@ contributors across the globe, there is almost always someone available to help.
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | podLabels | object | `{}` | Labels to be added to agent pods |
-| policyEnforcementMode | string | `"default"` |  |
+| policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraConfigmapMounts | list | `[]` |  |
@@ -343,10 +344,9 @@ contributors across the globe, there is almost always someone available to help.
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
-| sleepAfterInit | bool | `false` |  |
+| sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | sockops | object | `{"enabled":false}` | Configure BPF socket operations configuration |
-| tls.enabled | bool | `true` |  |
-| tls.secretsBackend | string | `"local"` |  |
+| tls | object | `{"enabled":true,"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | tunnel | string | `"vxlan"` | Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | Cilium agent update strategy |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -321,7 +321,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| preflight.podLabels | object | `{}` | Labels to be added to thee preflight pod. |
+| preflight.podLabels | object | `{}` | Labels to be added to the preflight pod. |
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
 | preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | preflight.securityContext | object | `{}` | Security context to be added to preflight pods |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -62,13 +62,13 @@ contributors across the globe, there is almost always someone available to help.
 | bgp | object | `{"announce":{"loadbalancerIP":false},"enabled":false}` | Configure BGP |
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
-| bpf.clockProbe | bool | `false` |  |
+| bpf.clockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
 | bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
-| bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum |
+| bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
-| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map. (per endpoint) |
+| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.waitForMount | bool | `false` | Force the cilium-agent DaemonSet to wait in an initContainer until the eBPF filesystem has been mounted. |
 | certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.4"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
@@ -87,17 +87,17 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as     resources:       limits:         cpu: 1000m         memory: 1024M       requests:         cpu: 100m         memory: 64Mi |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
 | clustermesh.apiserver.service.nodePort | int | `32379` | Optional port to use as the node port for apiserver access. |
-| clustermesh.apiserver.service.type | string | `"NodePort"` |  |
-| clustermesh.apiserver.tls.admin | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key Used if 'auto' is not enabled. |
+| clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |
+| clustermesh.apiserver.tls.admin | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key. Used if 'auto' is not enabled. |
 | clustermesh.apiserver.tls.auto | object | `{"certValidityDuration":1095,"enabled":true,"method":"helm"}` | Configure automatic TLS certificates generation. A Kubernetes CronJob is used the generate any certificates not provided by the user at installation time. |
 | clustermesh.apiserver.tls.auto.certValidityDuration | int | `1095` | Generated certificates validity duration in days. |
 | clustermesh.apiserver.tls.auto.enabled | bool | `true` | When set to true, automatically generate a CA and certificates to enable mTLS between clustermesh-apiserver and external workload instances. If set to false, the certs to be provided by setting appropriate values below. |
 | clustermesh.apiserver.tls.ca | object | `{"cert":"","key":""}` | base64 encoded PEM values for the ExternalWorkload CA certificate and private key. |
 | clustermesh.apiserver.tls.ca.cert | string | `""` | Optional CA cert. If it is provided, it will be used by the 'cronJob' method to generate all other certificates. Otherwise, an ephemeral CA is generated. |
 | clustermesh.apiserver.tls.ca.key | string | `""` | Optional CA private key. If it is provided, it will be used by the 'cronJob' method to generate all other certificates. Otherwise, an ephemeral CA is generated. |
-| clustermesh.apiserver.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver client certificate and private key Used if 'auto' is not enabled. |
-| clustermesh.apiserver.tls.remote | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver remote cluster certificate and private key Used if 'auto' is not enabled. |
-| clustermesh.apiserver.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver server certificate and private key Used if 'auto' is not enabled. |
+| clustermesh.apiserver.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver client certificate and private key. Used if 'auto' is not enabled. |
+| clustermesh.apiserver.tls.remote | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver remote cluster certificate and private key. Used if 'auto' is not enabled. |
+| clustermesh.apiserver.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver server certificate and private key. Used if 'auto' is not enabled. |
 | clustermesh.apiserver.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | clustermesh.apiserver.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | clustermesh-apiserver update strategy |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
@@ -117,9 +117,9 @@ contributors across the globe, there is almost always someone available to help.
 | daemon.runPath | string | `"/var/run/cilium"` | Configure where Cilium runtime state should be stored. |
 | datapathMode | string | `"veth"` | Configure which datapath mode should be used for configuring container connectivity. Valid options are "veth" or "ipvlan". |
 | debug.enabled | bool | `false` | Enable debug logging |
-| disableEndpointCRD | string | `"false"` | Disable the usage of CiliumEndpoint CRD |
+| disableEndpointCRD | string | `"false"` | Disable the usage of CiliumEndpoint CRD. |
 | egressGateway | object | `{"enabled":false}` | Enables egress gateway (beta) to redirect and SNAT the traffic that leaves the cluster. |
-| enableCnpStatusUpdates | bool | `false` | Specify which network interfaces can run the eBPF datapath. This means that a packet sent from a pod to a destination outside the cluster will be masqueraded (to an output device IPv4 address), if the output device runs the program. When not specified, probing will automatically detect devices. devices: "" TODO: Add documentation disableIptablesFeederRules: "" TODO: Add documentation egressMasqueradeInterfaces: "" |
+| enableCnpStatusUpdates | bool | `false` | Whether to enable CNP status updates. |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
 | enableIPv4Masquerade | bool | `true` | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
@@ -136,7 +136,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to ipsec. |
 | encryption.secretName | string | `"cilium-ipsec-keys"` | Deprecated in favor of encryption.ipsec.secretName. Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec. |
 | encryption.type | string | `"ipsec"` | Encryption method. Can be either ipsec or wireguard. |
-| endpointHealthChecking.enabled | bool | `true` |  |
+| endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | endpointStatus | object | `{"enabled":false,"status":""}` | Enable endpoint status. Status can be: policy, health, controllers, logs and / or state. For 2 or more options use a comma. |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |
@@ -150,10 +150,10 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.clusterDomain | string | `"cluster.local"` | Cluster domain for cilium-etcd-operator. |
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |
 | etcd.endpoints | list | `["https://CHANGE-ME:2379"]` | List of etcd endpoints (not needed when using managed=true). |
-| etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments |
-| etcd.extraConfigmapMounts | list | `[]` | Additional cilium-etcd-operator ConfigMap mounts |
-| etcd.extraHostPathMounts | list | `[]` | Additional cilium-etcd-operator hostPath mounts |
-| etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod |
+| etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
+| etcd.extraConfigmapMounts | list | `[]` | Additional cilium-etcd-operator ConfigMap mounts. |
+| etcd.extraHostPathMounts | list | `[]` | Additional cilium-etcd-operator hostPath mounts. |
+| etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7"}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.nodeSelector | object | `{}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -169,14 +169,14 @@ contributors across the globe, there is almost always someone available to help.
 | externalIPs.enabled | bool | `false` | Enable ExternalIPs service support. |
 | externalWorkloads | object | `{"enabled":false}` | Configure external workloads support |
 | externalWorkloads.enabled | bool | `false` | Enable support for external workloads, such as VMs (false by default). |
-| extraArgs | list | `[]` | Additional agent container arguments |
+| extraArgs | list | `[]` | Additional agent container arguments. |
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
-| extraConfigmapMounts | list | `[]` | Additional agent ConfigMap mounts |
-| extraEnv | object | `{}` | Additional agent container environment variables |
-| extraHostPathMounts | list | `[]` | Additional agent hostPath mounts |
-| extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod |
+| extraConfigmapMounts | list | `[]` | Additional agent ConfigMap mounts. |
+| extraEnv | object | `{}` | Additional agent container environment variables. |
+| extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
+| extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
-| healthChecking | bool | `true` |  |
+| healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9876` | TCP port for the agent health API. This is not the port for cilium-health. |
 | hostFirewall | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |
@@ -189,7 +189,6 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:   enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http You can specify the list of metrics from the helm CLI:   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}" |
 | hubble.metrics.port | int | `9091` | Configure the port the hubble metric server listens on. |
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
-| hubble.metricsServer | string | `""` |  |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay","tag":"latest","useDigest":false}` | Hubble-relay container image. |
@@ -221,22 +220,22 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.enabled | bool | `true` | Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network. |
 | hubble.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
 | hubble.ui.backend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"latest"}` | Hubble-ui backend image. |
-| hubble.ui.backend.resources | object | `{}` |  |
-| hubble.ui.enabled | bool | `false` |  |
+| hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
+| hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
 | hubble.ui.frontend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"latest"}` | Hubble-ui frontend image. |
-| hubble.ui.frontend.resources | object | `{}` |  |
+| hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
 | hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.18.2@sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7"}` | Hubble-ui ingress proxy image. |
-| hubble.ui.proxy.resources | object | `{}` |  |
-| hubble.ui.replicas | int | `1` |  |
+| hubble.ui.proxy.resources | object | `{}` | Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment. |
+| hubble.ui.replicas | int | `1` | The number of replicas of Hubble UI to deploy. |
 | hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
-| hubble.ui.securityContext.enabled | bool | `true` |  |
+| hubble.ui.securityContext.enabled | bool | `true` | Whether to set the security context on the Hubble UI pods. |
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
-| identityAllocationMode | string | `"crd"` |  |
+| identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd` or `kvstore`). |
 | image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Agent container image. |
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
 | installIptablesRules | bool | `true` | Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy. |
@@ -251,14 +250,15 @@ contributors across the globe, there is almost always someone available to help.
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | ipvlan.enabled | bool | `false` | Enable the IPVLAN datapath |
 | k8s | object | `{}` | Configure Kubernetes specific configuration |
-| keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet |
+| keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
-| localRedirectPolicy | bool | `false` |  |
+| localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
-| monitor | object | `{"enabled":false}` | Configure cilium-monitor sidecar |
+| monitor | object | `{"enabled":false}` | Specify the CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. nativeRoutingCIDR: |
+| monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent container name. |
 | nodePort | object | `{"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enabled":false}` | Configure N-S k8s service loadbalancing |
 | nodePort.autoProtectPortRange | bool | `true` | Append NodePort range to ip_local_reserved_ports if clash with ephemeral ports is detected. |
@@ -267,30 +267,30 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
-| nodeinit.extraConfigmapMounts | list | `[]` |  |
-| nodeinit.extraEnv | object | `{}` |  |
-| nodeinit.extraHostPathMounts | list | `[]` |  |
-| nodeinit.extraInitContainers | list | `[]` |  |
+| nodeinit.extraConfigmapMounts | list | `[]` | Additional nodeinit ConfigMap mounts. |
+| nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |
+| nodeinit.extraHostPathMounts | list | `[]` | Additional nodeinit host path mounts. |
+| nodeinit.extraInitContainers | list | `[]` | Additional nodeinit init containers. |
 | nodeinit.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
-| nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods |
+| nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods |
-| nodeinit.priorityClassName | string | `""` |  |
+| nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
+| nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
 | nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| nodeinit.securityContext | object | `{}` | Security context to be added to nodeinit pods |
+| nodeinit.securityContext | object | `{}` | Security context to be added to nodeinit pods. |
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"io.cilium/app","operator":"In","values":["operator"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | cilium-operator affinity |
 | operator.enabled | bool | `true` | Enable the cilium-operator component (required). |
-| operator.endpointGCInterval | string | `"5m0s"` |  |
-| operator.extraArgs | list | `[]` | Additional cilium-operator container arguments |
-| operator.extraConfigmapMounts | list | `[]` |  |
-| operator.extraEnv | object | `{}` |  |
-| operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts |
-| operator.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod |
-| operator.identityGCInterval | string | `"15m0s"` |  |
-| operator.identityHeartbeatTimeout | string | `"30m0s"` |  |
+| operator.endpointGCInterval | string | `"5m0s"` | Interval for endpoint garbage collection. |
+| operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
+| operator.extraConfigmapMounts | list | `[]` | Additional cilium-operator ConfigMap mounts. |
+| operator.extraEnv | object | `{}` | Additional cilium-operator environment variables. |
+| operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
+| operator.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
+| operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
+| operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest","useDigest":false}` | cilium-operator image. |
 | operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
@@ -313,23 +313,23 @@ contributors across the globe, there is almost always someone available to help.
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
-| preflight.extraConfigmapMounts | list | `[]` |  |
-| preflight.extraEnv | object | `{}` |  |
-| preflight.extraHostPathMounts | list | `[]` |  |
-| preflight.extraInitContainers | list | `[]` |  |
+| preflight.extraConfigmapMounts | list | `[]` | Additional preflight ConfigMap mounts. |
+| preflight.extraEnv | object | `{}` | Additional preflight environment variables. |
+| preflight.extraHostPathMounts | list | `[]` | Additional preflight host path mounts. |
+| preflight.extraInitContainers | list | `[]` | Additional preflight init containers. |
 | preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| preflight.podLabels | object | `{}` |  |
-| preflight.priorityClassName | string | `""` |  |
+| preflight.podLabels | object | `{}` | Labels to be added to thee preflight pod. |
+| preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
 | preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | preflight.securityContext | object | `{}` | Security context to be added to preflight pods |
-| preflight.tofqdnsPreCache | string | `""` |  |
+| preflight.tofqdnsPreCache | string | `""` | Path to write the `--tofqdns-pre-cache` file to. |
 | preflight.tolerations | list | `[{"effect":"NoSchedule","key":"node.kubernetes.io/not-ready"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true"},{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Node tolerations for preflight scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | preflight.updateStrategy | object | `{"type":"RollingUpdate"}` | preflight update strategy |
 | preflight.validateCNPs | bool | `true` | By default we should always validate the installed CNPs before upgrading Cilium. This will make sure the user will have the policies deployed in the cluster with the right schema. |
-| priorityClassName | string | `""` |  |
+| priorityClassName | string | `""` | The priority class to use for cilium-agent. |
 | prometheus | object | `{"enabled":false,"metrics":null,"port":9090,"serviceMonitor":{"enabled":false}}` | Configure prometheus metrics on the configured port at /metrics |
 | prometheus.metrics | string | `nil` | Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics |
 | prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1483,7 +1483,7 @@ preflight:
   # -- Annotations to be added to preflight pods
   podAnnotations: {}
 
-  # -- Labels to be added to thee preflight pod.
+  # -- Labels to be added to the preflight pod.
   podLabels: {}
 
   # -- PodDisruptionBudget settings

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -114,18 +114,19 @@ affinity:
           - cilium
       topologyKey: kubernetes.io/hostname
 
+# -- The priority class to use for cilium-agent.
 priorityClassName: ""
 
-# -- Additional agent container arguments
+# -- Additional agent container arguments.
 extraArgs: []
 
-# -- Additional agent container environment variables
+# -- Additional agent container environment variables.
 extraEnv: {}
 
-# -- Additional InitContainers to initialize the pod
+# -- Additional InitContainers to initialize the pod.
 extraInitContainers: []
 
-# -- Additional agent hostPath mounts
+# -- Additional agent hostPath mounts.
 extraHostPathMounts: []
   # - name: host-mnt-data
   #   mountPath: /host/mnt/data
@@ -134,7 +135,7 @@ extraHostPathMounts: []
   #   readOnly: true
   #   mountPropagation: HostToContainer
 
-# -- Additional agent ConfigMap mounts
+# -- Additional agent ConfigMap mounts.
 extraConfigmapMounts: []
   # - name: certs-configmap
   #   mountPath: /certs
@@ -226,6 +227,7 @@ bgp:
     loadbalancerIP: false
 
 bpf:
+  # -- Enable BPF clock source probing for more efficient tick retrieval.
   clockProbe: false
 
   # -- Force the cilium-agent DaemonSet to wait in an initContainer until the
@@ -254,8 +256,7 @@ bpf:
   # -- Configure the maximum number of entries for the neighbor table.
   # neighMax: 524288
 
-  # -- Configure the maximum number of entries in endpoint policy map.
-  # (per endpoint)
+  # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384
 
   # -- Configure auto-sizing for all BPF maps based on available memory.
@@ -263,7 +264,7 @@ bpf:
   #mapDynamicSizeRatio: 0.0025
 
   # -- Configure the level of aggregation for monitor notifications.
-  # Valid options are none, low, medium, maximum
+  # Valid options are none, low, medium, maximum.
   monitorAggregation: medium
 
   # -- Configure the typical time between monitor notifications for
@@ -393,12 +394,13 @@ daemon:
 # program. When not specified, probing will automatically detect devices.
 # devices: ""
 
-# TODO: Add documentation
+# -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 
-# TODO: Add documentation
+# -- Limit egress masquerading to interface selector.
 # egressMasqueradeInterfaces: ""
 
+# -- Whether to enable CNP status updates.
 enableCnpStatusUpdates: false
 
 # -- Configures the use of the KVStore to optimize Kubernetes event handling by
@@ -460,8 +462,8 @@ encryption:
   # This option is only effective when encryption.type is set to ipsec.
   interface: ""
 
-# TODO: Add documentation
 endpointHealthChecking:
+  # -- Enable connectivity health checking between virtual endpoints.
   enabled: true
 
 # -- Enable endpoint status.
@@ -507,7 +509,7 @@ gke:
   # -- Enable Google Kubernetes Engine integration
   enabled: false
 
-# TODO: Add documentation
+# -- Enable connectivity health checking.
 healthChecking: true
 
 # -- TCP port for the agent health API. This is not the port for cilium-health.
@@ -585,8 +587,6 @@ hubble:
       # This requires the prometheus CRDs to be available.
       # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
       enabled: false
-
-  metricsServer: ""
 
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
@@ -725,6 +725,7 @@ hubble:
     # servicePort: 80
 
   ui:
+    # -- Whether to enable the Hubble UI.
     enabled: false
 
     # -- Roll out Hubble-ui pods automatically when configmap is updated.
@@ -736,14 +737,15 @@ hubble:
         repository: quay.io/cilium/hubble-ui-backend
         tag: latest
         pullPolicy: Always
-      # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
-      #     resources:
-      #       limits:
-      #         cpu: 1000m
-      #         memory: 1024M
-      #       requests:
-      #         cpu: 100m
-      #         memory: 64Mi
+      # [Example]
+      # resources:
+      #   limits:
+      #     cpu: 1000m
+      #     memory: 1024M
+      #   requests:
+      #     cpu: 100m
+      #     memory: 64Mi
+      # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
       resources: {}
 
     frontend:
@@ -752,14 +754,15 @@ hubble:
         repository: quay.io/cilium/hubble-ui
         tag: latest
         pullPolicy: Always
-      # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
-      #     resources:
-      #       limits:
-      #         cpu: 1000m
-      #         memory: 1024M
-      #       requests:
-      #         cpu: 100m
-      #         memory: 64Mi
+      # [Example]
+      # resources:
+      #   limits:
+      #     cpu: 1000m
+      #     memory: 1024M
+      #   requests:
+      #     cpu: 100m
+      #     memory: 64Mi
+      # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
       resources: {}
 
     proxy:
@@ -768,16 +771,18 @@ hubble:
         repository: docker.io/envoyproxy/envoy
         tag: v1.18.2@sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7
         pullPolicy: Always
-      # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as
-      #     resources:
-      #       limits:
-      #         cpu: 1000m
-      #         memory: 1024M
-      #       requests:
-      #         cpu: 100m
-      #         memory: 64Mi
+      # [Example]
+      # resources:
+      #   limits:
+      #     cpu: 1000m
+      #     memory: 1024M
+      #   requests:
+      #     cpu: 100m
+      #     memory: 64Mi
+      # -- Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment.
       resources: {}
 
+    # -- The number of replicas of Hubble UI to deploy.
     replicas: 1
 
     # -- Annotations to be added to hubble-ui pods
@@ -802,6 +807,7 @@ hubble:
       type: RollingUpdate
 
     securityContext:
+      # -- Whether to set the security context on the Hubble UI pods.
       enabled: true
 
     # -- hubble-ui ingress configuration.
@@ -818,7 +824,7 @@ hubble:
       #      - chart-example.local
 
 
-# TODO: Add documentation
+# -- Method to use for identity allocation (`crd` or `kvstore`).
 identityAllocationMode: "crd"
 
 # TODO: Add documentation
@@ -889,7 +895,7 @@ k8s: {}
   # range via the Kubernetes node resource
   # requireIPv6PodCIDR: false
 
-# -- Keep the deprecated selector labels when deploying Cilium DaemonSet
+# -- Keep the deprecated selector labels when deploying Cilium DaemonSet.
 keepDeprecatedLabels: false
 
 # -- Keep the deprecated probes when deploying Cilium DaemonSet
@@ -909,6 +915,7 @@ kubeProxyReplacementHealthzBindAddr: ""
 # -- Enable Layer 7 network policy.
 l7Proxy: true
 
+# -- Enable Local Redirect Policy.
 localRedirectPolicy: false
 
 # To include or exclude matched resources from cilium identity evaluation
@@ -946,8 +953,8 @@ egressGateway:
 # This value corresponds to the configured cluster-cidr.
 # nativeRoutingCIDR:
 
-# -- Configure cilium-monitor sidecar
 monitor:
+  # -- Enable the cilium-monitor sidecar.
   enabled: false
 
 # -- Configure service load balancing
@@ -1075,7 +1082,7 @@ tls:
 #   - geneve
 tunnel: "vxlan"
 
-# -- Disable the usage of CiliumEndpoint CRD
+# -- Disable the usage of CiliumEndpoint CRD.
 disableEndpointCRD: "false"
 
 wellKnownIdentities:
@@ -1094,19 +1101,15 @@ etcd:
     pullPolicy: Always
 
   # -- cilium-etcd-operator priorityClassName
-  #
   priorityClassName: ""
 
-  # -- Additional cilium-etcd-operator container arguments
-  #
+  # -- Additional cilium-etcd-operator container arguments.
   extraArgs: []
 
-  # -- Additional InitContainers to initialize the pod
-  #
+  # -- Additional InitContainers to initialize the pod.
   extraInitContainers: []
 
-  # -- Additional cilium-etcd-operator hostPath mounts
-  #
+  # -- Additional cilium-etcd-operator hostPath mounts.
   extraHostPathMounts: []
     # - name: textfile-dir
     #   mountPath: /srv/txt_collector
@@ -1114,8 +1117,7 @@ etcd:
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
-  # -- Additional cilium-etcd-operator ConfigMap mounts
-  #
+  # -- Additional cilium-etcd-operator ConfigMap mounts.
   extraConfigmapMounts: []
     # - name: certs-configmap
     #   mountPath: /certs
@@ -1124,7 +1126,6 @@ etcd:
 
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  #
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -1134,7 +1135,6 @@ etcd:
 
   # -- Node labels for cilium-etcd-operator pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
   nodeSelector: {}
 
   # -- Annotations to be added to cilium-etcd-operator pods
@@ -1241,17 +1241,16 @@ operator:
         topologyKey: kubernetes.io/hostname
 
 
-  # -- Additional cilium-operator container arguments
-  #
+  # -- Additional cilium-operator container arguments.
   extraArgs: []
 
+  # -- Additional cilium-operator environment variables.
   extraEnv: {}
 
-  # -- Additional InitContainers to initialize the pod
-  #
+  # -- Additional InitContainers to initialize the pod.
   extraInitContainers: []
 
-  # -- Additional cilium-operator hostPath mounts
+  # -- Additional cilium-operator hostPath mounts.
   extraHostPathMounts: []
     # - name: host-mnt-data
     #   mountPath: /host/mnt/data
@@ -1260,6 +1259,7 @@ operator:
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
+  # -- Additional cilium-operator ConfigMap mounts.
   extraConfigmapMounts: []
     # - name: certs-configmap
     #   mountPath: /certs
@@ -1268,7 +1268,6 @@ operator:
 
   # -- Node tolerations for cilium-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  #
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -1310,8 +1309,13 @@ operator:
   securityContext: {}
     # runAsUser: 0
 
+  # -- Interval for endpoint garbage collection.
   endpointGCInterval: "5m0s"
+
+  # -- Interval for identity garbage collection.
   identityGCInterval: "15m0s"
+
+  # -- Timeout for identity heartbeats.
   identityHeartbeatTimeout: "30m0s"
 
   # -- Enable prometheus metrics for cilium-operator on the configured port at
@@ -1339,16 +1343,20 @@ nodeinit:
     tag: 62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
     pullPolicy: Always
 
+  # -- The priority class to use for the nodeinit pod.
   priorityClassName: ""
 
   # -- node-init update strategy
   updateStrategy:
     type: RollingUpdate
 
+  # -- Additional nodeinit environment variables.
   extraEnv: {}
 
+  # -- Additional nodeinit init containers.
   extraInitContainers: []
 
+  # -- Additional nodeinit host path mounts.
   extraHostPathMounts: []
     # - name: textfile-dir
     #   mountPath: /srv/txt_collector
@@ -1356,6 +1364,7 @@ nodeinit:
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
+  # -- Additional nodeinit ConfigMap mounts.
   extraConfigmapMounts: []
     # - name: certs-configmap
     #   mountPath: /certs
@@ -1377,10 +1386,10 @@ nodeinit:
   #
   nodeSelector: {}
 
-  # -- Annotations to be added to node-init pods
+  # -- Annotations to be added to node-init pods.
   podAnnotations: {}
 
-  # -- Labels to be added to node-init pods
+  # -- Labels to be added to node-init pods.
   podLabels: {}
 
   # -- PodDisruptionBudget settings
@@ -1398,7 +1407,7 @@ nodeinit:
       cpu: 100m
       memory: 100Mi
 
-  # -- Security context to be added to nodeinit pods
+  # -- Security context to be added to nodeinit pods.
   #
   securityContext: {}
     # runAsUser: 0
@@ -1420,16 +1429,20 @@ preflight:
     useDigest: false
     pullPolicy: Always
 
+  # -- The priority class to use for the preflight pod.
   priorityClassName: ""
 
   # -- preflight update strategy
   updateStrategy:
     type: RollingUpdate
 
+  # -- Additional preflight environment variables.
   extraEnv: {}
 
+  # -- Additional preflight init containers.
   extraInitContainers: []
 
+  # -- Additional preflight host path mounts.
   extraHostPathMounts: []
     # - name: textfile-dir
     #   mountPath: /srv/txt_collector
@@ -1437,6 +1450,7 @@ preflight:
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
+  # -- Additional preflight ConfigMap mounts.
   extraConfigmapMounts: []
     # - name: certs-configmap
     #   mountPath: /certs
@@ -1469,7 +1483,7 @@ preflight:
   # -- Annotations to be added to preflight pods
   podAnnotations: {}
 
-  # Labels to be added to preflight pods
+  # -- Labels to be added to thee preflight pod.
   podLabels: {}
 
   # -- PodDisruptionBudget settings
@@ -1495,7 +1509,7 @@ preflight:
   securityContext: {}
     # runAsUser: 0
 
-  # -- Path to write the --tofqdns-pre-cache file to.
+  # -- Path to write the `--tofqdns-pre-cache` file to.
   tofqdnsPreCache: ""
   # -- By default we should always validate the installed CNPs before upgrading
   # Cilium. This will make sure the user will have the policies deployed in the
@@ -1535,6 +1549,7 @@ clustermesh:
         pullPolicy: Always
 
     service:
+      # -- The type of service used for apiserver access.
       type: NodePort
       # -- Optional port to use as the node port for apiserver access.
       nodePort: 32379
@@ -1618,22 +1633,22 @@ clustermesh:
         # -- Optional CA private key. If it is provided, it will be used by the 'cronJob' method to
         # generate all other certificates. Otherwise, an ephemeral CA is generated.
         key: ""
-      # -- base64 encoded PEM values for the clustermesh-apiserver server certificate and private key
+      # -- base64 encoded PEM values for the clustermesh-apiserver server certificate and private key.
       # Used if 'auto' is not enabled.
       server:
         cert: ""
         key: ""
-      # -- base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key
+      # -- base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key.
       # Used if 'auto' is not enabled.
       admin:
         cert: ""
         key: ""
-      # -- base64 encoded PEM values for the clustermesh-apiserver client certificate and private key
+      # -- base64 encoded PEM values for the clustermesh-apiserver client certificate and private key.
       # Used if 'auto' is not enabled.
       client:
         cert: ""
         key: ""
-      # -- base64 encoded PEM values for the clustermesh-apiserver remote cluster certificate and private key
+      # -- base64 encoded PEM values for the clustermesh-apiserver remote cluster certificate and private key.
       # Used if 'auto' is not enabled.
       remote:
         cert: ""


### PR DESCRIPTION
`helm-docs` has an issue that causes some of our fields to have wrong documentation associated with them (e.g. containing documentation belonging to other, commented-out fields). This PR attempts to fix them by using a fork of `helm-docs` containing the [proposed fix](https://github.com/norwoodj/helm-docs/pull/99) and adjusting what needs to be adjusted to have a minimally readable and correct reference.

**Goals:**

* Propose that we use the fork of `helm-docs` until https://github.com/norwoodj/helm-docs/pull/99 is merged.
* That all Helm chart fields present in the tables have a readable, correct and meaningful description.
  * I can definitely use a second pair of eyes on this one 🙂
* Include a comment on `helm-values.rst` indicating it is automatically generated.
* For the same reason, add `helm-values.rst` to `.gitattributes`.

**Non-goals:**

* That all Helm chart fields have an actual description.
* To fix all inconsistency issues (e.g. some descriptions end with a `.` and some don't, some descriptions use backticks for correct rendering of code, some don't).
* To make the tables extra-readable and actually eye-pleasant.

I think that these non-goals require a big effort and are only ever useful if the introduction of the fork is consensual, so I think we could cover them as part of a subsequent PR. Thoughts?

```release-note
Improve the Helm chart documentation.
```
