### PR TITLE
bpf: ct: use union to hide the rx_bytes hack

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -677,7 +677,14 @@ struct ipv4_ct_tuple {
 
 struct ct_entry {
 	__u64 rx_packets;
-	__u64 rx_bytes;
+	/* Previously, the rx_bytes field was not used for entries with
+	 * the dir=CT_SERVICE (see GH#7060). Therefore, we can safely abuse
+	 * this field to save the backend_id.
+	 */
+	union {
+		__u64 rx_bytes;
+		__u64 backend_id;
+	};
 	__u64 tx_packets;
 	__u64 tx_bytes;
 	__u32 lifetime;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -231,9 +231,8 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 			ct_state->ifindex = entry->ifindex;
 			ct_state->dsr = entry->dsr;
 			ct_state->proxy_redirect = entry->proxy_redirect;
-			/* See the ct_create4 comments re the rx_bytes hack */
 			if (dir == CT_SERVICE)
-				ct_state->backend_id = entry->rx_bytes;
+				ct_state->backend_id = entry->backend_id;
 		}
 
 #ifdef ENABLE_NAT46
@@ -714,8 +713,7 @@ ct_update6_backend_id(const void *map, const struct ipv6_ct_tuple *tuple,
 	if (!entry)
 		return;
 
-	/* See the ct_create4 comments re the rx_bytes hack */
-	entry->rx_bytes = state->backend_id;
+	entry->backend_id = state->backend_id;
 }
 
 static __always_inline void
@@ -748,9 +746,8 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 	 */
 	entry.proxy_redirect = proxy_redirect;
 
-	/* See the ct_create4 comments re the rx_bytes hack */
 	if (dir == CT_SERVICE)
-		entry.rx_bytes = ct_state->backend_id;
+		entry.backend_id = ct_state->backend_id;
 
 	entry.lb_loopback = ct_state->loopback;
 	entry.node_port = ct_state->node_port;
@@ -810,8 +807,7 @@ static __always_inline void ct_update4_backend_id(const void *map,
 	if (!entry)
 		return;
 
-	/* See the ct_create4 comments re the rx_bytes hack */
-	entry->rx_bytes = state->backend_id;
+	entry->backend_id = state->backend_id;
 }
 
 static __always_inline void
@@ -850,12 +846,8 @@ static __always_inline int ct_create4(const void *map_main,
 	entry.dsr = ct_state->dsr;
 	entry.ifindex = ct_state->ifindex;
 
-	/* Previously, the rx_bytes field was not used for entries with
-	 * the dir=CT_SERVICE (see GH#7060). Therefore, we can safely abuse
-	 * this field to save the backend_id.
-	 */
 	if (dir == CT_SERVICE)
-		entry.rx_bytes = ct_state->backend_id;
+		entry.backend_id = ct_state->backend_id;
 	entry.rev_nat_index = ct_state->rev_nat_index;
 	seen_flags.value |= is_tcp ? TCP_FLAG_SYN : 0;
 	ct_update_timeout(&entry, is_tcp, dir, seen_flags);

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -501,7 +501,7 @@ func (k *CtKey6Global) GetTupleKey() tuple.TupleKey {
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type CtEntry struct {
 	RxPackets uint64 `align:"rx_packets"`
-	RxBytes   uint64 `align:"rx_bytes"`
+	RxBytes   uint64 `align:"$union0"`
 	TxPackets uint64 `align:"tx_packets"`
 	TxBytes   uint64 `align:"tx_bytes"`
 	Lifetime  uint32 `align:"lifetime"`


### PR DESCRIPTION
For CT entries with a CT_SERVICE direction the rx_bytes field is not
used and because of this it has been repurposed to store the backend ID.

This commit defines a union with rx_bytes and backend_id in order to
make accessing the backend ID less confusing.