### PR TITLE
hubble/recorder: Refactor service implementation to fix multiple races

### DIFF
--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -339,11 +339,9 @@ func (s *Service) watchRecording(ctx context.Context, h *sink.Handle, stream rec
 		}
 
 		select {
-		case _, ok := <-h.StatsUpdated:
-			if !ok {
-				// sink closed
-				return
-			}
+		case <-h.StatsUpdated:
+		case <-h.Done:
+			return
 		case <-ctx.Done():
 			return
 		}

--- a/pkg/hubble/recorder/sink/dispatch.go
+++ b/pkg/hubble/recorder/sink/dispatch.go
@@ -45,11 +45,29 @@ type record struct {
 
 // Handle enables the owner to subscribe to sink statistics
 type Handle struct {
-	// C is a channel on which receives a new empty message whenever there
-	// was an update to the sink statistics. It is closed when the sink stops
-	// updating.
-	C    <-chan struct{}
+	// StatsUpdated is a channel on which receives a new empty message whenever
+	// there was an update to the sink statistics.
+	StatsUpdated <-chan struct{}
+	// Done is a channel which is closed when this sink has been shut down.
+	Done <-chan struct{}
+
 	sink *sink
+}
+
+// Stats returns the latest statistics for this sink.
+func (h *Handle) Stats() Statistics {
+	return h.sink.copyStats()
+}
+
+// Stop requests the underlying sink to stop. Handle.Done will be closed
+// once the sink has drained its queue and stopped.
+func (h *Handle) Stop() {
+	h.sink.stop()
+}
+
+// Err returns the last error on this sink once the channel has stopped
+func (h *Handle) Err() error {
+	return h.sink.err()
 }
 
 // Statistics contains the statistics for a pcap sink
@@ -58,6 +76,13 @@ type Statistics struct {
 	BytesWritten   uint64
 	PacketsLost    uint64
 	BytesLost      uint64
+}
+
+// PcapSink defines the parameters of a sink which writes to a pcap.RecordWriter
+type PcapSink struct {
+	RuleID uint16
+	Header pcap.Header
+	Writer pcap.RecordWriter
 }
 
 // Dispatch implements consumer.MonitorConsumer and dispatches incoming
@@ -90,50 +115,37 @@ func NewDispatch(sinkQueueSize int) (*Dispatch, error) {
 	}, nil
 }
 
-// RegisterSink registers a new sink for the given rule ID. Any captures with a
-// matching rule ID will be forwarded to the pcap sink w. The provided header
-// is written to the pcap sink w upon initialization.
-func (d *Dispatch) RegisterSink(ctx context.Context, ruleID uint16, w pcap.RecordWriter, header pcap.Header) (*Handle, error) {
+// StartSink starts a new sink for the pcap sink configuration p. Any
+// captures with a matching rule ID will be forwarded to the pcap sink p.Writer.
+// The provided p.Header is written to the pcap sink during initialization.
+// The sink is unregistered automatically when it stops. A sink is stopped for
+// one of the following four reasons. In all cases, Handle.Done will be closed.
+//  - Explicitly via Handle.Stop (Handle.Err() == nil)
+//  - When the context ctx is cancelled (Handle.Err() != nil)
+//  - When an error occurred (Handle.Err() != nil)
+func (d *Dispatch) StartSink(ctx context.Context, p PcapSink) (*Handle, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if _, ok := d.sinkByRuleID[ruleID]; ok {
-		return nil, fmt.Errorf("sink for rule id %d already registered", ruleID)
+	if _, ok := d.sinkByRuleID[p.RuleID]; ok {
+		return nil, fmt.Errorf("sink for rule id %d already registered", p.RuleID)
 	}
 
-	s := startSink(ctx, w, header, d.sinkQueueSize)
-	d.sinkByRuleID[ruleID] = s
+	s := startSink(ctx, p, d.sinkQueueSize)
+	d.sinkByRuleID[p.RuleID] = s
+
+	go func() {
+		<-s.done
+		d.mutex.Lock()
+		delete(d.sinkByRuleID, p.RuleID)
+		d.mutex.Unlock()
+	}()
+
 	return &Handle{
-		C:    s.trigger,
-		sink: s,
+		StatsUpdated: s.trigger,
+		Done:         s.done,
+		sink:         s,
 	}, nil
-}
-
-// UnregisterSink will stop and unregister the sink for the given ruleID.
-// It waits for any pending packets to be forwarded to the sink before closing
-// it and returns the final statistics or an error, if an error occurred.
-func (d *Dispatch) UnregisterSink(ctx context.Context, ruleID uint16) (stats Statistics, err error) {
-	d.mutex.Lock()
-	s, ok := d.sinkByRuleID[ruleID]
-	delete(d.sinkByRuleID, ruleID)
-	// unlock early to avoid holding the lock during s.close() which may block
-	d.mutex.Unlock()
-
-	if !ok {
-		return Statistics{}, fmt.Errorf("no sink found for rule id %d", ruleID)
-	}
-
-	s.stop()
-	select {
-	case <-s.done:
-		if err = s.err(); err != nil {
-			return Statistics{}, err
-		}
-	case <-ctx.Done():
-		return Statistics{}, fmt.Errorf("timed out waiting for sink to close: %w", ctx.Err())
-	}
-
-	return s.copyStats(), nil
 }
 
 func (d *Dispatch) decodeRecordCaptureLocked(data []byte) (rec record, err error) {
@@ -254,8 +266,4 @@ func (d *Dispatch) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
 // NotifyAgentEvent implements consumer.MonitorConsumer
 func (d *Dispatch) NotifyAgentEvent(typ int, message interface{}) {
 	// ignored
-}
-
-func (h *Handle) Stats() Statistics {
-	return h.sink.copyStats()
 }

--- a/pkg/hubble/recorder/sink/sink.go
+++ b/pkg/hubble/recorder/sink/sink.go
@@ -57,8 +57,6 @@ func startSink(ctx context.Context, p PcapSink, queueSize int) *sink {
 			closeErr := p.Writer.Close()
 
 			s.mutex.Lock()
-			close(s.trigger)
-			s.trigger = nil
 			if err == nil {
 				s.lastError = closeErr
 			} else {

--- a/pkg/hubble/recorder/sink/sink.go
+++ b/pkg/hubble/recorder/sink/sink.go
@@ -38,7 +38,7 @@ type sink struct {
 //  - sink.stop is called
 //  - ctx is cancelled
 //  - an error occurred
-func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueSize int) *sink {
+func startSink(ctx context.Context, p PcapSink, queueSize int) *sink {
 	s := &sink{
 		mutex:     lock.Mutex{},
 		queue:     make(chan record, queueSize),
@@ -54,7 +54,7 @@ func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueS
 		// close the channels when exiting.
 		var err error
 		defer func() {
-			closeErr := w.Close()
+			closeErr := p.Writer.Close()
 
 			s.mutex.Lock()
 			close(s.trigger)
@@ -68,7 +68,7 @@ func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueS
 			s.mutex.Unlock()
 		}()
 
-		if err = w.WriteHeader(hdr); err != nil {
+		if err = p.Writer.WriteHeader(p.Header); err != nil {
 			return
 		}
 
@@ -82,7 +82,7 @@ func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueS
 					OriginalLength: rec.origLen,
 				}
 
-				if err = w.WriteRecord(pcapRecord, rec.data); err != nil {
+				if err = p.Writer.WriteRecord(pcapRecord, rec.data); err != nil {
 					return
 				}
 


### PR DESCRIPTION
This PR fixes multiple concurrency issues in the implementation of the
Hubble Recorder API. The main one being that we were sending responses
to the client from both the main `Record` function, as well as the
`watchRecording` function which was spawned in a separate go routine.

However, sending to a grpc.ServerStream from multiple go routines is
_not_ safe: https://pkg.go.dev/google.golang.org/grpc#ServerStream
It is however safe to have one go routine receive from, and another go routine
send to the stream.

Therefore, this commit restructures the Hubble Recorder API in such a
way that only the `Record` stub ever sends back messages to the client.
Receiving is done in a separate go routine which forwards all received
messages into a channel, allowing us to select on incoming responses.

In addition, this commit hopefully also makes the logic a bit more
easier to read, as it tries to separate the cleanup of resources and
communicating with the client a bit more explicitly. It also drastically
simplifies the implementation of a follow-up PR which extends the
API with stop conditions (#16473).

I apologize for the size, but I had to restructure quite a bit to fix
the underlying issue. **I highly recommended to review per commit.**