### PR TITLE
docs: use `.. code-block:: shell-session` wherever relevant

### DIFF
--- a/Documentation/api.rst
+++ b/Documentation/api.rst
@@ -37,7 +37,7 @@ can be pointed to an arbitrary API address.
 Example
 -------
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ cilium -H unix:///var/run/cilium/cilium.sock
     [...]
@@ -61,7 +61,7 @@ Example
 
 The full example can be found in the `cilium/client-example`_ repository.
 
-.. code:: go
+.. code-block:: go
 
     import (
             "fmt"

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -298,7 +298,7 @@ tc and XDP programs.
 Each helper function is implemented with a commonly shared function signature
 similar to system calls. The signature is defined as:
 
-::
+.. code-block:: c
 
     u64 fn(u64 r1, u64 r2, u64 r3, u64 r4, u64 r5)
 
@@ -310,7 +310,7 @@ which are similar to those of system calls. The following example is an extract
 from a helper function which updates map elements by calling into the
 corresponding map implementation callbacks:
 
-::
+.. code-block:: c
 
     BPF_CALL_4(bpf_map_update_elem, struct bpf_map *, map, void *, key,
                void *, value, u64, flags)
@@ -482,7 +482,7 @@ such that when LLVM compiles and generates the BPF object file all these
 functions were inlined and therefore duplicated many times in the resulting
 object file, artificially inflating its code size:
 
-  ::
+.. code-block:: c
 
     #include <linux/bpf.h>
 
@@ -515,7 +515,7 @@ with Linux kernel 4.16 and LLVM 6.0 this restriction got lifted and BPF programs
 no longer need to use ``always_inline`` everywhere. Thus, the prior shown BPF
 example code can then be rewritten more naturally as:
 
-  ::
+.. code-block:: c
 
     #include <linux/bpf.h>
 
@@ -599,7 +599,7 @@ and 32 bit ``arm``, ``x86_32`` architectures are all shipped with an in-kernel
 eBPF JIT compiler, also all of them are feature equivalent and can be enabled
 through:
 
-::
+.. code-block:: shell-session
 
     # echo 1 > /proc/sys/net/core/bpf_jit_enable
 
@@ -611,7 +611,7 @@ compiler at all need to run eBPF programs through the in-kernel interpreter.
 In the kernel's source tree, eBPF JIT support can be easily determined through
 issuing a grep for ``HAVE_EBPF_JIT``:
 
-::
+.. code-block:: shell-session
 
     # git grep HAVE_EBPF_JIT arch/
     arch/arm/Kconfig:       select HAVE_EBPF_JIT   if !CPU_ENDIAN_BE32
@@ -644,7 +644,7 @@ crash the kernel instead of allowing the corruption to happen silently.
 Architectures that support setting the image memory as read-only can be
 determined through:
 
-::
+.. code-block:: shell-session
 
     $ git grep ARCH_HAS_SET_MEMORY | grep select
     arch/arm/Kconfig:    select ARCH_HAS_SET_MEMORY
@@ -686,7 +686,7 @@ operation, but really all generic operations are blinded.
 
 Example of JITing a program with hardening disabled:
 
-::
+.. code-block:: shell-session
 
     # echo 0 > /proc/sys/net/core/bpf_jit_harden
 
@@ -705,7 +705,7 @@ Example of JITing a program with hardening disabled:
 The same program gets constant blinded when loaded through BPF
 as an unprivileged user in the case hardening is enabled:
 
-::
+.. code-block:: shell-session
 
     # echo 1 > /proc/sys/net/core/bpf_jit_harden
 
@@ -760,7 +760,7 @@ set only ``CAP_SYS_ADMIN`` privileged processes out of the initial
 namespace are allowed to use the ``bpf(2)`` system call from that
 point onwards. Upon start, Cilium sets this knob to ``1`` as well.
 
-::
+.. code-block:: shell-session
 
     # echo 1 > /proc/sys/kernel/unprivileged_bpf_disabled
 
@@ -806,7 +806,7 @@ Fedora
 
 The following applies to Fedora 25 or later:
 
-::
+.. code-block:: shell-session
 
     $ sudo dnf install -y git gcc ncurses-devel elfutils-libelf-devel bc \
       openssl-devel libcap-devel clang llvm graphviz bison flex glibc-static
@@ -819,7 +819,7 @@ Ubuntu
 
 The following applies to Ubuntu 17.04 or later:
 
-::
+.. code-block:: shell-session
 
     $ sudo apt-get install -y make gcc libssl-dev bc libelf-dev libcap-dev \
       clang gcc-multilib llvm libncurses5-dev git pkg-config libmnl-dev bison flex \
@@ -830,9 +830,9 @@ openSUSE Tumbleweed
 
 The following applies to openSUSE Tumbleweed and openSUSE Leap 15.0 or later:
 
-::
+.. code-block:: shell-session
 
-   $ sudo  zypper install -y git gcc ncurses-devel libelf-devel bc libopenssl-devel \
+   $ sudo zypper install -y git gcc ncurses-devel libelf-devel bc libopenssl-devel \
    libcap-devel clang llvm graphviz bison flex glibc-devel-static
 
 Compiling the Kernel
@@ -842,7 +842,7 @@ Development of new BPF features for the Linux kernel happens inside the ``net-ne
 git tree, latest BPF fixes in the ``net`` tree. The following command will obtain
 the kernel source for the ``net-next`` tree through git:
 
-::
+.. code-block:: shell-session
 
     $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git
 
@@ -851,7 +851,7 @@ tree much faster by truncating the git history only to the most recent commit.
 
 In case the ``net`` tree is of interest, it can be cloned from this url:
 
-::
+.. code-block:: shell-session
 
     $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git
 
@@ -890,7 +890,7 @@ After you have booted into the newly compiled kernel, navigate to the BPF selfte
 suite in order to test BPF functionality (current working directory points to
 the root of the cloned git tree):
 
-::
+.. code-block:: shell-session
 
     $ cd tools/testing/selftests/bpf/
     $ make
@@ -915,7 +915,7 @@ failures:
 
 In order to run through all BPF selftests, the following command is needed:
 
-::
+.. code-block:: shell-session
 
     $ sudo make run_tests
 
@@ -933,20 +933,20 @@ in header files can be synchronized in the iproute2 tree.
 In order to clone the iproute2 ``master`` branch, the following command can
 be used:
 
-::
+.. code-block:: shell-session
 
     $ git clone https://git.kernel.org/pub/scm/network/iproute2/iproute2.git
 
 Similarly, to clone into mentioned ``net-next`` branch of iproute2, run the
 following:
 
-::
+.. code-block:: shell-session
 
     $ git clone -b net-next https://git.kernel.org/pub/scm/network/iproute2/iproute2.git
 
 After that, proceed with the build and installation:
 
-::
+.. code-block:: shell-session
 
     $ cd iproute2/
     $ ./configure --prefix=/usr
@@ -980,7 +980,7 @@ and maps. It is part of the kernel tree and available under ``tools/bpf/bpftool/
 Make sure to have cloned either the ``net`` or ``net-next`` kernel tree as described
 earlier. In order to build and install bpftool, the following steps are required:
 
-::
+.. code-block:: shell-session
 
     $ cd <kernel-tree>/tools/bpf/bpftool/
     $ make
@@ -1036,7 +1036,7 @@ program to hardware (e.g. NIC).
 
 For LLVM, BPF target support can be checked, for example, through the following:
 
-::
+.. code-block:: shell-session
 
     $ llc --version
     LLVM (http://llvm.org/):
@@ -1073,7 +1073,7 @@ scripts triggering a compilation also do not have to be endian aware.
 A minimal, stand-alone XDP drop program might look like the following example
 (``xdp-example.c``):
 
-::
+.. code-block:: c
 
     #include <linux/bpf.h>
 
@@ -1092,7 +1092,7 @@ A minimal, stand-alone XDP drop program might look like the following example
 
 It can then be compiled and loaded into the kernel as follows:
 
-::
+.. code-block:: shell-session
 
     $ clang -O2 -Wall -target bpf -c xdp-example.c -o xdp-example.o
     # ip link set dev em1 xdp obj xdp-example.o
@@ -1105,7 +1105,7 @@ that is, ``EM_BPF`` (decimal: ``247`` / hex: ``0xf7``). In this example, the pro
 has been compiled with ``bpf`` target under ``x86_64``, therefore ``LSB`` (as opposed
 to ``MSB``) is shown regarding endianness:
 
-::
+.. code-block:: shell-session
 
     $ file xdp-example.o
     xdp-example.o: ELF 64-bit LSB relocatable, *unknown arch 0xf7* version 1 (SYSV), not stripped
@@ -1117,7 +1117,7 @@ and the symbol table.
 In the unlikely case where clang and LLVM need to be compiled from scratch, the
 following commands can be used:
 
-::
+.. code-block:: shell-session
 
     $ git clone https://github.com/llvm/llvm-project.git
     $ cd llvm-project
@@ -1147,7 +1147,7 @@ significantly increase (e.g. by 10x or more).
 
 For debugging, clang can generate the assembler output as follows:
 
-::
+.. code-block:: shell-session
 
     $ clang -O2 -S -Wall -target bpf -c xdp-example.c -o xdp-example.S
     $ cat xdp-example.S
@@ -1170,7 +1170,7 @@ program using BPF assembler directly, then use llvm-mc to assemble it into an
 object file. For example, you can assemble the xdp-example.S listed above back
 into object file using:
 
-::
+.. code-block:: shell-session
 
     $ llvm-mc -triple bpf -filetype=obj -o xdp-example.o xdp-example.S
 
@@ -1178,7 +1178,7 @@ Furthermore, more recent LLVM versions (>= 4.0) can also store debugging
 information in dwarf format into the object file. This can be done through
 the usual workflow by adding ``-g`` for compilation.
 
-::
+.. code-block:: shell-session
 
     $ clang -O2 -g -Wall -target bpf -c xdp-example.c -o xdp-example.o
     $ llvm-objdump -S -no-show-raw-insn xdp-example.o
@@ -1201,7 +1201,7 @@ This means that in case BPF programs get rejected by the verifier, ``llvm-objdum
 can help to correlate the instructions back to the original C code, which is
 highly useful for analysis.
 
-::
+.. code-block:: shell-session
 
     # ip link set dev em1 xdp obj xdp-example.o verb
 
@@ -1222,7 +1222,7 @@ the same BPF assembler code as the kernel.
 Leaving out the ``-no-show-raw-insn`` option will also dump the raw
 ``struct bpf_insn`` as hex in front of the assembly:
 
-::
+.. code-block:: shell-session
 
     $ llvm-objdump -S xdp-example.o
 
@@ -1239,14 +1239,14 @@ For LLVM IR debugging, the compilation process for BPF can be split into
 two steps, generating a binary LLVM IR intermediate file ``xdp-example.bc``, which
 can later on be passed to llc:
 
-::
+.. code-block:: shell-session
 
     $ clang -O2 -Wall -target bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
     $ llc xdp-example.bc -march=bpf -filetype=obj -o xdp-example.o
 
 The generated LLVM IR can also be dumped in human readable format through:
 
-::
+.. code-block:: shell-session
 
     $ clang -O2 -Wall -emit-llvm -S -c xdp-example.c -o -
 
@@ -1271,7 +1271,7 @@ In order to generate BTF from DWARF debugging information, elfutils (>= 0.173)
 is needed. If that is not available, then adding the ``-mattr=dwarfris`` option
 to the ``llc`` command is required during compilation:
 
-::
+.. code-block:: shell-session
 
     $ llc -march=bpf -mattr=help |& grep dwarfris
       dwarfris - Disable MCAsmInfo DwarfUsesRelocationsAcrossSections.
@@ -1293,7 +1293,7 @@ For converting DWARF into BTF, a recent pahole version (>= 1.12) is required.
 A recent pahole version can also be obtained from its official git repository
 if not available from one of the distribution packages:
 
-::
+.. code-block:: shell-session
 
     $ git clone https://git.kernel.org/pub/scm/devel/pahole/pahole.git
 
@@ -1302,7 +1302,7 @@ object file. ``pahole`` can be probed for BTF support as follows (note that
 the ``llvm-objcopy`` tool is required for ``pahole`` as well, so check its
 presence, too):
 
-::
+.. code-block:: shell-session
 
     $ pahole --help | grep BTF
     -J, --btf_encode           Encode as BTF
@@ -1312,7 +1312,7 @@ source level debug information by passing ``-g`` to the ``clang`` command
 line. Note that ``-g`` is needed independently of whether ``llc``'s
 ``dwarfris`` option is used. Full example for generating the object file:
 
-::
+.. code-block:: shell-session
 
     $ clang -O2 -g -Wall -target bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
     $ llc xdp-example.bc -march=bpf -mattr=dwarfris -filetype=obj -o xdp-example.o
@@ -1321,14 +1321,14 @@ Alternatively, by using clang only to build a BPF program with debugging
 information (again, the dwarfris flag can be omitted when having proper
 elfutils version):
 
-::
+.. code-block:: shell-session
 
     $ clang -target bpf -O2 -g -c -Xclang -target-feature -Xclang +dwarfris -c xdp-example.c -o xdp-example.o
 
 After successful compilation ``pahole`` can be used to properly dump structures
 of the BPF program based on the DWARF information:
 
-::
+.. code-block:: shell-session
 
     $ pahole xdp-example.o
     struct xdp_md {
@@ -1344,14 +1344,14 @@ Through the option ``-J`` ``pahole`` can eventually generate the BTF from
 DWARF. In the object file DWARF data will still be retained alongside the
 newly added BTF data. Full ``clang`` and ``pahole`` example combined:
 
-::
+.. code-block:: shell-session
 
     $ clang -target bpf -O2 -Wall -g -c -Xclang -target-feature -Xclang +dwarfris -c xdp-example.c -o xdp-example.o
     $ pahole -J xdp-example.o
 
 The presence of a ``.BTF`` section can be seen through ``readelf`` tool:
 
-::
+.. code-block:: shell-session
 
     $ readelf -a xdp-example.o
     [...]
@@ -1372,7 +1372,7 @@ more efficient and smaller code.
 
 Available ``-mcpu`` options can be queried through:
 
-::
+.. code-block:: shell-session
 
     $ llc -march bpf -mcpu=help
     Available CPUs for this target:
@@ -1397,7 +1397,7 @@ them for compiling the BPF program whenever appropriate.
 
 A full command line example with llc's ``-mcpu=probe``:
 
-::
+.. code-block:: shell-session
 
     $ clang -O2 -Wall -target bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
     $ llc xdp-example.bc -march=bpf -mcpu=probe -filetype=obj -o xdp-example.o
@@ -1447,7 +1447,7 @@ when there are operations on 32-bit types. The associated ALU instructions with
 32-bit subregisters will become ALU32 instructions. For example, for the
 following sample code:
 
-::
+.. code-block:: shell-session
 
     $ cat 32-bit-example.c
         void cal(unsigned int *a, unsigned int *b, unsigned int *c)
@@ -1458,7 +1458,7 @@ following sample code:
 
 At default code generation, the assembler will looks like:
 
-::
+.. code-block:: shell-session
 
     $ clang -target bpf -emit-llvm -S 32-bit-example.c
     $ llc -march=bpf 32-bit-example.ll
@@ -1474,7 +1474,7 @@ At default code generation, the assembler will looks like:
 enable the new 32-bit subregisters support by specifying ``-mattr=+alu32``, then
 the assembler will looks like:
 
-::
+.. code-block:: shell-session
 
     $ llc -march=bpf -mattr=+alu32 32-bit-example.ll
     $ cat 32-bit-example.s
@@ -1524,7 +1524,7 @@ describe some of the differences for the BPF model:
    will thus produce an error since only BPF maps are valid relocation entries
    which loaders can process.
 
-   ::
+   .. code-block:: c
 
     #include <linux/bpf.h>
 
@@ -1575,7 +1575,7 @@ describe some of the differences for the BPF model:
    ``acc_map``, which has two map slots, one for traffic accounted on the
    ingress hook, one on the egress hook.
 
-   ::
+   .. code-block:: c
 
     #include <linux/bpf.h>
     #include <linux/pkt_cls.h>
@@ -1705,7 +1705,7 @@ describe some of the differences for the BPF model:
 
   The code can be compiled and loaded via iproute2 as follows:
 
-  ::
+  .. code-block:: shell-session
 
     $ clang -O2 -Wall -target bpf -c tc-example.c -o tc-example.o
 
@@ -1767,7 +1767,7 @@ describe some of the differences for the BPF model:
 
   Helper functions such as ``trace_printk()`` can be worked around as follows:
 
-  ::
+  .. code-block:: c
 
     static void BPF_FUNC(trace_printk, const char *fmt, int fmt_size, ...);
 
@@ -1806,7 +1806,7 @@ describe some of the differences for the BPF model:
   addition, also LLVM provides some built-ins that the programs can use for
   constant sizes (here: ``n``) which will then always get inlined:
 
-  ::
+  .. code-block:: c
 
     #ifndef memset
     # define memset(dest, chr, n)   __builtin_memset((dest), (chr), (n))
@@ -1834,7 +1834,7 @@ describe some of the differences for the BPF model:
   A very limited form of looping is available for constant upper loop bounds
   by using ``#pragma unroll`` directive. Example code that is compiled to BPF:
 
-  ::
+  .. code-block:: c
 
     #pragma unroll
         for (i = 0; i < IPV6_MAX_HEADERS; i++) {
@@ -1902,7 +1902,7 @@ describe some of the differences for the BPF model:
 
   Minimal example extract of using tail calls:
 
-  ::
+  .. code-block:: c
 
     [...]
 
@@ -1971,7 +1971,7 @@ describe some of the differences for the BPF model:
   The generated elf contains section headers describing the map id and the
   entry within that map:
 
-  ::
+  .. code-block:: shell-session
 
     $ llvm-objdump -S --no-show-raw-insn prog_array.o | less
     prog_array.o:   file format ELF64-BPF
@@ -2011,7 +2011,7 @@ describe some of the differences for the BPF model:
 
   Example for tc to perform tail call map updates:
 
-  ::
+  .. code-block:: shell-session
 
     # tc exec bpf graft m:globals/jmp_map key 0 obj new.o sec foo
 
@@ -2035,7 +2035,7 @@ describe some of the differences for the BPF model:
   as well as ``test/CodeGen/BPF/`` might be helpful for providing some additional
   examples. Test code:
 
-  ::
+  .. code-block:: c
 
     #include <linux/bpf.h>
 
@@ -2079,7 +2079,7 @@ describe some of the differences for the BPF model:
   size, and padding is added for the proper alignment. Because of this, the size
   of struct may often grow larger than expected.
 
-  ::
+  .. code-block:: c
 
     struct called_info {
         u64 start;  // 8-byte
@@ -2106,7 +2106,7 @@ describe some of the differences for the BPF model:
 
   Example code:
 
-  ::
+  .. code-block:: c
 
     struct called_info {
         u64 start;
@@ -2156,7 +2156,7 @@ describe some of the differences for the BPF model:
   and the message says reading a data from +20 is an invalid indirect read.
   And as we discussed earlier, the address 0x14(20) is the place where PADDING is.
 
-  ::
+  .. code-block:: c
 
     // Actual compiled composition of struct called_info
     // 0x10(16)    0x14(20)    0x18(24)
@@ -2172,7 +2172,7 @@ describe some of the differences for the BPF model:
 
   Removing the padding by using ``#pragma pack(n)`` directive:
 
-  ::
+  .. code-block:: c
 
     #pragma pack(4)
     struct called_info {
@@ -2207,7 +2207,7 @@ describe some of the differences for the BPF model:
   explicit padding ``u32 pad`` member at the end will resolve the same problem without
   packing of the structure.
 
-  ::
+  .. code-block:: c
 
     struct called_info {
         u64 start;  // 8-byte
@@ -2238,7 +2238,7 @@ describe some of the differences for the BPF model:
 
   To illustrate this, consider the following snippet:
 
-  ::
+  .. code-block:: c
 
     struct iphdr *ip4 = (struct iphdr *) skb->data + ETH_HLEN;
 
@@ -2266,7 +2266,7 @@ describe some of the differences for the BPF model:
 
   To fix this, the reference to ``ip4`` has to be updated:
 
-  ::
+  .. code-block:: c
 
     struct iphdr *ip4 = (struct iphdr *) skb->data + ETH_HLEN;
 
@@ -2315,7 +2315,7 @@ of all details, but enough for getting started.
   through ``ip`` to a XDP-supported netdevice called ``em1`` with the following
   command:
 
-  ::
+  .. code-block:: shell-session
 
     # ip link set dev em1 xdp obj prog.o
 
@@ -2324,7 +2324,7 @@ of all details, but enough for getting started.
   section is named differently, for example, ``foobar``, then the program needs
   to be loaded as:
 
-  ::
+  .. code-block:: shell-session
 
     # ip link set dev em1 xdp obj prog.o sec foobar
 
@@ -2332,7 +2332,7 @@ of all details, but enough for getting started.
   Changing the minimal, stand-alone XDP drop program by removing the ``__section()``
   annotation from the ``xdp_drop`` entry point would look like the following:
 
-  ::
+  .. code-block:: c
 
     #include <linux/bpf.h>
 
@@ -2350,7 +2350,7 @@ of all details, but enough for getting started.
 
   And can be loaded as follows:
 
-  ::
+  .. code-block:: shell-session
 
     # ip link set dev em1 xdp obj prog.o sec .text
 
@@ -2359,7 +2359,7 @@ of all details, but enough for getting started.
   order to replace the currently running XDP program with a new one, the ``-force``
   option must be used:
 
-  ::
+  .. code-block:: shell-session
 
     # ip -force link set dev em1 xdp obj prog.o
 
@@ -2380,7 +2380,7 @@ of all details, but enough for getting started.
   In order to remove the existing XDP program from the interface, the following
   command must be issued:
 
-  ::
+  .. code-block:: shell-session
 
     # ip link set dev em1 xdp off
 
@@ -2428,7 +2428,7 @@ of all details, but enough for getting started.
   Example for enforcing a BPF/XDP program to be loaded in native XDP mode,
   dumping the link details and unloading the program again:
 
-  ::
+  .. code-block:: shell-session
 
      # ip -force link set dev em1 xdpdrv obj prog.o
      # ip link show
@@ -2443,7 +2443,7 @@ of all details, but enough for getting started.
   native XDP, and additionally dumping the BPF instructions of the attached
   dummy program through bpftool:
 
-  ::
+  .. code-block:: shell-session
 
     # ip -force link set dev em1 xdpgeneric obj prog.o
     # ip link show
@@ -2460,7 +2460,7 @@ of all details, but enough for getting started.
   And last but not least offloaded XDP, where we additionally dump program
   information via bpftool for retrieving general metadata:
 
-  ::
+  .. code-block:: shell-session
 
      # ip -force link set dev em1 xdpoffload obj prog.o
      # ip link show
@@ -2483,7 +2483,7 @@ of all details, but enough for getting started.
   versa is not atomically possible. Only switching programs within a specific
   operation mode is:
 
-  ::
+  .. code-block:: shell-session
 
      # ip -force link set dev em1 xdpgeneric obj prog.o
      # ip -force link set dev em1 xdpoffload obj prog.o
@@ -2496,7 +2496,7 @@ of all details, but enough for getting started.
   Switching between modes requires to first leave the current operation mode
   in order to then enter the new one:
 
-  ::
+  .. code-block:: shell-session
 
      # ip -force link set dev em1 xdpgeneric obj prog.o
      # ip -force link set dev em1 xdpgeneric off
@@ -2517,7 +2517,7 @@ of all details, but enough for getting started.
   ``em1``, and with the following command the program can be attached to the networking
   ``ingress`` path of ``em1``:
 
-  ::
+  .. code-block:: shell-session
 
     # tc qdisc add dev em1 clsact
     # tc filter add dev em1 ingress bpf da obj prog.o
@@ -2534,7 +2534,7 @@ of all details, but enough for getting started.
 
   The equivalent for attaching the program to the ``egress`` hook looks as follows:
 
-  ::
+  .. code-block:: shell-session
 
     # tc filter add dev em1 egress bpf da obj prog.o
 
@@ -2554,7 +2554,7 @@ of all details, but enough for getting started.
   the device. Like in XDP, should the default section name not be used, then it
   can be specified during load, for example, in case of section ``foobar``:
 
-  ::
+  .. code-block:: shell-session
 
     # tc filter add dev em1 egress bpf da obj prog.o sec foobar
 
@@ -2564,7 +2564,7 @@ of all details, but enough for getting started.
 
   The attached programs can be listed through the following commands:
 
-  ::
+  .. code-block:: shell-session
 
     # tc filter show dev em1 ingress
     filter protocol all pref 49152 bpf
@@ -2603,7 +2603,7 @@ of all details, but enough for getting started.
   a priori on initial load, so that they do not have to be queried at a later
   point in time for the ``replace`` operation. Thus, creation becomes:
 
-  ::
+  .. code-block:: shell-session
 
     # tc filter add dev em1 ingress pref 1 handle 1 bpf da obj prog.o sec foobar
 
@@ -2615,14 +2615,14 @@ of all details, but enough for getting started.
   existing program at ``ingress`` hook with the new BPF program from the file
   ``prog.o`` in section ``foobar``:
 
-  ::
+  .. code-block:: shell-session
 
     # tc filter replace dev em1 ingress pref 1 handle 1 bpf da obj prog.o sec foobar
 
   Last but not least, in order to remove all attached programs from the ``ingress``
   respectively ``egress`` hook, the following can be used:
 
-  ::
+  .. code-block:: shell-session
 
     # tc filter del dev em1 ingress
     # tc filter del dev em1 egress
@@ -2631,7 +2631,7 @@ of all details, but enough for getting started.
   removes all attached programs from the ``ingress`` and ``egress`` hooks, the
   below command is provided:
 
-  ::
+  .. code-block:: shell-session
 
     # tc qdisc del dev em1 clsact
 
@@ -2639,7 +2639,7 @@ of all details, but enough for getting started.
   similarly as with XDP BPF programs. Netronome's nfp supported NICs offer both
   types of BPF offload.
 
-  ::
+  .. code-block:: shell-session
 
     # tc qdisc add dev em1 clsact
     # tc filter replace dev em1 ingress pref 1 handle 1 bpf skip_sw da obj prog.o
@@ -2649,7 +2649,7 @@ of all details, but enough for getting started.
   If the above error is shown, then tc hardware offload first needs to be enabled
   for the device through ethtool's ``hw-tc-offload`` setting:
 
-  ::
+  .. code-block:: shell-session
 
     # ethtool -K em1 hw-tc-offload on
     # tc qdisc add dev em1 clsact
@@ -2672,7 +2672,7 @@ of all details, but enough for getting started.
 
   A netdevsim device can be created as follows:
 
-  ::
+  .. code-block:: shell-session
 
     # modprobe netdevsim
     // [ID] [PORT_COUNT]
@@ -2689,7 +2689,7 @@ of all details, but enough for getting started.
   After that step, XDP BPF or tc BPF programs can be test loaded as shown
   in the various examples earlier:
 
-  ::
+  .. code-block:: shell-session
 
     # ip -force link set dev eth0 xdpoffload obj prog.o
     # ip l
@@ -2710,7 +2710,7 @@ simplicity.
   The option ``verb`` can be appended for loading programs in order to dump the
   verifier log, even if no error occurred:
 
-  ::
+  .. code-block:: shell-session
 
     # ip link set dev em1 xdp obj xdp-example.o verb
 
@@ -2731,14 +2731,14 @@ simplicity.
   the program from the BPF file system in case some external entity pinned it
   there and attach it to the device:
 
-  ::
+  .. code-block:: shell-session
 
   # ip link set dev em1 xdp pinned /sys/fs/bpf/prog
 
   iproute2 can also use the short form that is relative to the detected mount
   point of the BPF file system:
 
-  ::
+  .. code-block:: shell-session
 
   # ip link set dev em1 xdp pinned m:prog
 
@@ -2750,7 +2750,7 @@ to the default location under ``/sys/fs/bpf/``.
 In case an instance has already been found, then it will be used and no additional
 mount will be performed:
 
-  ::
+.. code-block:: shell-session
 
     # mkdir /var/run/bpf
     # mount --bind /var/run/bpf /var/run/bpf
@@ -2778,7 +2778,7 @@ As briefly covered in the previous LLVM section, iproute2 will install a
 header file upon installation which can be included through the standard
 include path by BPF programs:
 
-  ::
+.. code-block:: c
 
     #include <iproute2/bpf_elf.h>
 
@@ -2821,7 +2821,7 @@ into the BPF file system.
 For a quick overview of all BPF programs currently loaded on the host
 invoke the following command:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog
      398: sched_cls  tag 56207908be8ad877
@@ -2840,7 +2840,7 @@ invoke the following command:
 
 Similarly, to get an overview of all active maps:
 
-  ::
+.. code-block:: shell-session
 
     # bpftool map
     5: hash  flags 0x0
@@ -2859,7 +2859,7 @@ Note that for each command, bpftool also supports json based output by
 appending ``--json`` at the end of the command line. An additional
 ``--pretty`` improves the output to be more human readable.
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog --json --pretty
 
@@ -2867,7 +2867,7 @@ For dumping the post-verifier BPF instruction image of a specific BPF
 program, one starting point could be to inspect a specific program, e.g.
 attached to the tc ingress hook:
 
-  ::
+.. code-block:: shell-session
 
      # tc filter show dev cilium_host egress
      filter protocol all pref 1 bpf chain 0
@@ -2878,7 +2878,7 @@ The program from the object file ``bpf_host.o``, section ``from-netdev`` has
 a BPF program ID of ``406`` as denoted in ``id 406``. Based on this information
 bpftool can provide some high-level metadata specific to the program:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog show id 406
      406: sched_cls  tag e0362f5bd9163a0a
@@ -2897,7 +2897,7 @@ be used to get information or dump the map themselves.
 Additionally, bpftool can issue a dump request of the BPF instructions the
 program runs:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump xlated id 406
       0: (b7) r7 = 0
@@ -2923,7 +2923,7 @@ verifier. Since the program was JITed and therefore the actual JIT image
 that was generated out of above ``xlated`` instructions is executed, it
 can be dumped as well through bpftool:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump jited id 406
       0:        push   %rbp
@@ -2942,7 +2942,7 @@ can be dumped as well through bpftool:
 Mainly for BPF JIT developers, the option also exists to interleave the
 disassembly with the actual native opcodes:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump jited id 406 opcodes
       0:        push   %rbp
@@ -2966,7 +2966,7 @@ disassembly with the actual native opcodes:
 The same interleaving can be done for the normal BPF instructions which
 can sometimes be useful for debugging in the kernel:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump xlated id 406 opcodes
       0: (b7) r7 = 0
@@ -2988,7 +2988,7 @@ The basic blocks of a program can also be visualized with the help of
 generates a dot file instead of the plain BPF ``xlated`` instruction
 dump that can later be converted to a png file:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump xlated id 406 visual &> output.dot
      $ dot -Tpng output.dot -o output.png
@@ -3010,7 +3010,7 @@ One example of rewrites is the inlining of helper functions in order to
 improve runtime performance, here in the case of a map lookup for hash
 tables:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump xlated id 3
       0: (b7) r1 = 2
@@ -3032,7 +3032,7 @@ kallsyms. Therefore, make sure that JITed BPF programs are exposed to
 kallsyms (``bpf_jit_kallsyms``) and that kallsyms addresses are not
 obfuscated (calls are otherwise shown as ``call bpf_unspec#0``):
 
-  ::
+.. code-block:: shell-session
 
      # echo 0 > /proc/sys/kernel/kptr_restrict
      # echo 1 > /proc/sys/net/core/bpf_jit_kallsyms
@@ -3042,7 +3042,7 @@ as JIT case. In the latter, the tag of the subprogram is shown as
 call target. In each case, the ``pc+2`` is the pc-relative offset of
 the call target, which denotes the subprogram.
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump xlated id 1
      0: (85) call pc+2#__bpf_prog_run_args32
@@ -3053,7 +3053,7 @@ the call target, which denotes the subprogram.
 
 JITed variant of the dump:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump xlated id 1
      0: (85) call pc+2#bpf_prog_3b185187f1855c4c_F
@@ -3066,7 +3066,7 @@ In the case of tail calls, the kernel maps them into a single instruction
 internally, bpftool will still correlate them as a helper call for ease
 of debugging:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog dump xlated id 2
      [...]
@@ -3092,7 +3092,7 @@ value pairs.
 If no BTF (BPF Type Format) data is available for a given map, then
 the key / value pairs are dumped as hex:
 
-  ::
+.. code-block:: shell-session
 
      # bpftool map dump id 5
      key:
@@ -3121,7 +3121,7 @@ BPF maps and the BPF_ANNOTATE_KV_PAIR() macro from iproute2 will
 result in the following dump (``test_xdp_noinline.o`` from kernel
 selftests):
 
-  ::
+.. code-block:: shell-session
 
      # cat tools/testing/selftests/bpf/test_xdp_noinline.c
        [...]
@@ -3152,7 +3152,7 @@ corresponding types out of the BTF for loading the map.
 Compiling through LLVM and generating BTF through debugging information
 by ``pahole``:
 
-  ::
+.. code-block:: shell-session
 
      # clang [...] -O2 -target bpf -g -emit-llvm -c test_xdp_noinline.c -o - |
        llc -march=bpf -mcpu=probe -mattr=dwarfris -filetype=obj -o test_xdp_noinline.o
@@ -3160,7 +3160,7 @@ by ``pahole``:
 
 Now loading into kernel and dumping the map via bpftool:
 
-  ::
+.. code-block:: shell-session
 
      # ip -force link set dev lo xdp obj test_xdp_noinline.o sec xdp-test
      # ip a
@@ -3203,7 +3203,7 @@ keys can be performed through bpftool as well.
 If the BPF program has been successfully loaded with BTF debugging information,
 the BTF ID will be shown in ``prog show`` command result denoted in ``btf_id``.
 
-  ::
+.. code-block:: shell-session
 
      # bpftool prog show id 72
      72: xdp  name balancer_ingres  tag acf44cabb48385ed  gpl
@@ -3214,7 +3214,7 @@ the BTF ID will be shown in ``prog show`` command result denoted in ``btf_id``.
 This can also be confirmed with ``btf show`` command which dumps all BTF
 objects loaded on a system.
 
-  ::
+.. code-block:: shell-session
 
      # bpftool btf show
      60: size 12243B  prog_ids 72  map_ids 126,130,131,127,129,128
@@ -3223,7 +3223,7 @@ And the subcommand ``btf dump`` can be used to check which debugging information
 is included in the BTF. With this command, BTF dump can be formatted either
 'raw' or 'c', the one that is used in C code.
 
-  ::
+.. code-block:: shell-session
 
      # bpftool btf dump id 60 format c
        [...]
@@ -3311,7 +3311,7 @@ Kernel Testing
 The Linux kernel ships a BPF selftest suite, which can be found in the kernel
 source tree under ``tools/testing/selftests/bpf/``.
 
-::
+.. code-block:: shell-session
 
     $ cd tools/testing/selftests/bpf/
     $ make
@@ -3328,7 +3328,7 @@ JIT Debugging
 For JIT developers performing audits or writing extensions, each compile run
 can output the generated JIT image into the kernel log through:
 
-::
+.. code-block:: shell-session
 
     # echo 2 > /proc/sys/net/core/bpf_jit_enable
 
@@ -3355,7 +3355,7 @@ compilation process. The dump output for eBPF and cBPF JITs is the same format.
 In the kernel tree under ``tools/bpf/``, there is a tool called ``bpf_jit_disasm``. It
 reads out the latest dump and prints the disassembly for further inspection:
 
-::
+.. code-block:: shell-session
 
     # ./bpf_jit_disasm
     70 bytes emitted from JIT compiler (pass:3, flen:6)
@@ -3383,7 +3383,7 @@ reads out the latest dump and prints the disassembly for further inspection:
 
 Alternatively, the tool can also dump related opcodes along with the disassembly.
 
-::
+.. code-block:: shell-session
 
     # ./bpf_jit_disasm -o
     70 bytes emitted from JIT compiler (pass:3, flen:6)
@@ -3437,7 +3437,7 @@ For performance analysis of JITed BPF programs, ``perf`` can be used as
 usual. As a prerequisite, JITed programs need to be exported through kallsyms
 infrastructure.
 
-::
+.. code-block:: shell-session
 
     # echo 1 > /proc/sys/net/core/bpf_jit_enable
     # echo 1 > /proc/sys/net/core/bpf_jit_kallsyms
@@ -3450,7 +3450,7 @@ Due to the use of direct write, ``bpf_try_make_head_writable()`` failed, which
 would then release the cloned ``skb`` again and return with an error message.
 ``perf`` thus records all ``kfree_skb`` events.
 
-::
+.. code-block:: shell-session
 
     # tc qdisc add dev em1 clsact
     # tc filter add dev em1 ingress bpf da obj prog.o sec main
@@ -3498,7 +3498,7 @@ of user space programs with the bpf system call.
 
 Tracepoints for BPF:
 
-::
+.. code-block:: shell-session
 
     # perf list | grep bpf:
     bpf:bpf_map_create                                 [Tracepoint event]
@@ -3517,7 +3517,7 @@ Tracepoints for BPF:
 Example usage with ``perf`` (alternatively to ``sleep`` example used here,
 a specific application like ``tc`` could be used here instead, of course):
 
-::
+.. code-block:: shell-session
 
     # perf record -a -e bpf:* sleep 10
     # perf script
@@ -3533,7 +3533,7 @@ For the BPF programs, their individual program tag is displayed.
 
 For debugging, XDP also has a tracepoint that is triggered when exceptions are raised:
 
-::
+.. code-block:: shell-session
 
     # perf list | grep xdp:
     xdp:xdp_exception                                  [Tracepoint event]
@@ -3558,7 +3558,7 @@ When a BPF program makes a call to ``bpf_trace_printk()``, the output is sent
 to the kernel tracing pipe. Users may read from this file to consume events
 that are traced to this buffer:
 
-::
+.. code-block:: shell-session
 
    # tail -f /sys/kernel/debug/tracing/trace_pipe
    ...
@@ -3658,7 +3658,7 @@ writes from there into the packet.
 The packet representation in XDP that is passed to the BPF program as
 the BPF context looks as follows:
 
-::
+.. code-block:: c
 
     struct xdp_buff {
         void *data;
@@ -3692,7 +3692,7 @@ packet pointers: ``data_hard_start`` <= ``data_meta`` <= ``data`` < ``data_end``
 The ``rxq`` field points to some additional per receive queue metadata which
 is populated at ring setup time (not at XDP runtime):
 
-::
+.. code-block:: c
 
     struct xdp_rxq_info {
         struct net_device *dev;
@@ -3709,7 +3709,7 @@ After running the XDP BPF program, a verdict is returned from the program in
 order to tell the driver how to process the packet next. In the ``linux/bpf.h``
 system header file all available return verdicts are enumerated:
 
-::
+.. code-block:: c
 
     enum xdp_action {
         XDP_ABORTED = 0,
@@ -4124,7 +4124,7 @@ Both the tc ingress and egress hook share the same action return verdicts
 that tc BPF programs can use. They are defined in the ``linux/pkt_cls.h``
 system header:
 
-::
+.. code-block:: c
 
     #define TC_ACT_UNSPEC         (-1)
     #define TC_ACT_OK               0

--- a/Documentation/cheatsheet.rst
+++ b/Documentation/cheatsheet.rst
@@ -12,7 +12,7 @@ Cilium is controlled via an easy command-line interface. This CLI is a single
 application that takes subcommands that you can find in the command reference
 guide.
 
-::
+.. code-block:: shell-session
 
     $ cilium
     CLI for interacting with the local Cilium Agent
@@ -57,7 +57,7 @@ All the list commands will return a pretty printed list with the information
 retrieved from Cilium Daemon. If you need something more detailed you can use JSON
 output, to get the JSON output you can use the global option ``-o json``
 
-::
+.. code-block:: shell-session
 
     $ cilium endpoint list -o json
 
@@ -66,7 +66,7 @@ Moreover, Cilium also provides a `JSONPath
 be extracted. JSONPath template reference can be found in `Kubernetes
 documentation <https://kubernetes.io/docs/reference/kubectl/jsonpath/>`_
 
-::
+.. code-block:: shell-session
 
     $ cilium endpoint list -o jsonpath='{[*].id}'
     29898 38939 56326
@@ -83,14 +83,14 @@ If you use bash or zsh, Cilium CLI can provide tab completion for subcommands.
 If you want to install tab completion, you should run the following command in
 your terminal.
 
-::
+.. code-block:: shell-session
 
    $ source <(cilium completion)
 
 If you want to have Cilium completion always loaded, you can install using the
 following:
 
-::
+.. code-block:: shell-session
 
     $ echo "source <(cilium completion)" >> ~/.bashrc
 
@@ -102,7 +102,8 @@ Basics
 ------
 
 Check the status of the agent
-::
+
+.. code-block:: shell-session
 
     $ cilium status
     KVStore:                Ok         Consul: 172.17.0.3:8300
@@ -117,7 +118,8 @@ Check the status of the agent
     $
 
 Get a detailed status of the agent:
-::
+
+.. code-block:: shell-session
 
     $ cilium status --all-controllers --all-health --all-redirects
     KVStore:                Ok         Consul: 172.17.0.3:8300
@@ -141,7 +143,8 @@ Get a detailed status of the agent:
     $
 
 Get the current agent configuration
-::
+
+.. code-block:: shell-session
 
     cilium config
 
@@ -150,20 +153,23 @@ Policy management
 
 
 Importing a Cilium Network Policy
-::
+
+.. code-block:: shell-session
 
     cilium policy import my-policy.json
 
 
 Get list of all imported policy rules
-::
 
-	cilium policy get
+.. code-block:: shell-session
+
+    cilium policy get
 
 Remove all policies
-::
 
-	cilium policy delete --all
+.. code-block:: shell-session
+
+    cilium policy delete --all
 
 
 Tracing
@@ -171,18 +177,21 @@ Tracing
 
 
 Check policy enforcement between two labels on port 80:
-::
 
-	cilium policy trace -s <app.from> -d <app.to> --dport 80
+.. code-block:: shell-session
+
+    cilium policy trace -s <app.from> -d <app.to> --dport 80
 
 
 Check policy enforcement between two identities
-::
+
+.. code-block:: shell-session
 
     cilium policy trace --src-identity <from-id> --dst-identity <to-id>
 
 Check policy enforcement between two pods:
-::
+
+.. code-block:: shell-session
 
     cilium policy trace --src-k8s-pod <namespace>:<pod.from> --dst-k8s-pod <namespace>:<pod.to>
 
@@ -192,42 +201,49 @@ Monitoring
 
 
 Monitor cilium datapath notifications
-::
+
+.. code-block:: shell-session
 
     cilium monitor
 
 
 Verbose output (including debug if enabled)
-::
+
+.. code-block:: shell-session
 
     cilium monitor -v
 
 Extra verbose output (including packet dissection)
-::
+
+.. code-block:: shell-session
 
     cilium monitor -v -v
 
 
 Filter for only the events related to endpoint
-::
+
+.. code-block:: shell-session
 
     cilium monitor --related-to=<id>
 
 
 Filter for only events on layer 7
-::
+
+.. code-block:: shell-session
 
     cilium monitor -t L7
 
 
 Show notifications only for dropped packet events
-::
+
+.. code-block:: shell-session
 
     cilium monitor --type drop
 
 
 Don't dissect packet payload, display payload in hex information
-::
+
+.. code-block:: shell-session
 
     cilium monitor -v -v --hex
 
@@ -237,9 +253,10 @@ Connectivity
 ------------
 
 Check cluster Connectivity
-::
 
-	cilium-health status
+.. code-block:: shell-session
+
+    cilium-health status
 
 There is also a `blog post
 <https://cilium.io/blog/2018/2/6/cilium-troubleshooting-cluster-health-monitor/>`_
@@ -249,22 +266,26 @@ Endpoints
 ---------
 
 Get list of all local endpoints
-::
+
+.. code-block:: shell-session
 
     cilium endpoint list
 
 Get detailed view of endpoint properties and state
-::
+
+.. code-block:: shell-session
 
     cilium endpoint get <id>
 
 Show recent endpoint specific log entries
-::
+
+.. code-block:: shell-session
 
     cilium endpoint log <id>
 
 Enable debugging output on the cilium monitor for this endpoint
-::
+
+.. code-block:: shell-session
 
     cilium endpoint config <id> Debug=true
 
@@ -273,19 +294,22 @@ Loadbalancing
 -------------
 
 Get list of loadbalancer services
-::
+
+.. code-block:: shell-session
 
     cilium service list
 
 
 Or you can get the loadbalancer information using bpf list
-:::
+
+.. code-block:: shell-session
 
     cilium bpf lb list
 
 
 Add a new loadbalancer
-::
+
+.. code-block:: shell-session
 
     cilium service update --frontend 127.0.0.1:80 \
         --backends 127.0.0.2:90,127.0.0.3:90 \
@@ -295,22 +319,26 @@ eBPF
 ----
 
 List node tunneling mapping information
-::
+
+.. code-block:: shell-session
 
     cilium bpf tunnel list
 
 Checking logs for verifier issue
-::
+
+.. code-block:: shell-session
 
     journalctl -u cilium | grep -B20 -F10 Verifier
 
 List connection tracking entries:
-::
+
+.. code-block:: shell-session
 
     sudo cilium bpf ct list global
 
 Flush connection tracking entries:
-::
+
+.. code-block:: shell-session
 
     sudo cilium bpf ct flush
 
@@ -328,13 +356,13 @@ Policies
 In Kubernetes you can use two kinds of policies, Kubernetes Network Policies or
 Cilium Network Policies. Both can be retrieved from the ``kubectl`` command:
 
-.. code-block:: bash
+.. code-block:: shell-session
    :name: Kubernetes Network Policies
    :caption: Kubernetes Network Policies
 
     kubectl get netpol
 
-.. code-block:: bash
+.. code-block:: shell-session
    :name: Kubernetes Cilium Policies
    :caption: Kubernetes Cilium Policies
 
@@ -353,7 +381,7 @@ Endpoints
 To retrieve a list of all endpoints managed by cilium, ``Cilium Endpoint``
 resource can be used.
 
-::
+.. code-block:: shell-session
 
     $ kubectl get cep
     NAME                AGE

--- a/Documentation/cmdref/kvstore.rst
+++ b/Documentation/cmdref/kvstore.rst
@@ -36,7 +36,7 @@ for TLS authentication:
 
 Example of the consul configuration file:
 
-.. code:: yaml
+.. code-block:: yaml
 
     ---
     cafile: '/var/lib/cilium/consul-ca.pem'
@@ -64,7 +64,7 @@ etcd endpoints:
 
 Example of the etcd configuration file:
 
-.. code:: yaml
+.. code-block:: yaml
 
     ---
     endpoints:

--- a/Documentation/concepts/kubernetes/ciliumendpoint.rst
+++ b/Documentation/concepts/kubernetes/ciliumendpoint.rst
@@ -21,9 +21,9 @@ the policy in effect on it.
 
 For example:
 
-::
+.. code-block:: shell-session
 
-    kubectl get ciliumendpoints --all-namespaces
+    $ kubectl get ciliumendpoints --all-namespaces
     NAMESPACE     NAME                     AGE
     default       app1-55d7944bdd-l7c8j    1h
     default       app1-55d7944bdd-sn9xj    1h

--- a/Documentation/concepts/kubernetes/concepts.rst
+++ b/Documentation/concepts/kubernetes/concepts.rst
@@ -48,7 +48,7 @@ pod started immediately after will have networking managed by Cilium.  In a
 production deployment, this step could be performed as a rolling update of
 kube-dns pods to avoid downtime of the DNS service.
 
-::
+.. code-block:: shell-session
 
         $ kubectl --namespace kube-system delete pods -l k8s-app=kube-dns
         pod "kube-dns-268032401-t57r2" deleted
@@ -56,7 +56,7 @@ kube-dns pods to avoid downtime of the DNS service.
 Running ``kubectl get pods`` will show you that Kubernetes started a new set of
 ``kube-dns`` pods while at the same time terminating the old pods:
 
-::
+.. code-block:: shell-session
 
         $ kubectl --namespace kube-system get pods
         NAME                          READY     STATUS        RESTARTS   AGE

--- a/Documentation/concepts/kubernetes/configuration.rst
+++ b/Documentation/concepts/kubernetes/configuration.rst
@@ -68,7 +68,7 @@ The following `ConfigMap` is an example where the etcd cluster is running in 2
 nodes, ``node-1`` and ``node-2`` with TLS, and client to server authentication
 enabled.
 
-.. code:: yaml
+.. code-block:: yaml
 
     apiVersion: v1
     kind: ConfigMap
@@ -148,7 +148,7 @@ Manually installing CNI
 This step is typically already included in all Kubernetes distributions or
 Kubernetes installers but can be performed manually:
 
-.. code:: bash
+.. code-block:: shell-session
 
     sudo mkdir -p /opt/cni
     wget https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
@@ -168,7 +168,7 @@ If you want to provide your own custom CNI configuration file, set the
 configuration file by adding the following to the ``env:`` section of the
 ``cilium`` DaemonSet:
 
-.. code:: bash
+.. code-block:: yaml
 
         - name: CILIUM_CUSTOM_CNI_CONF
           value: "true"
@@ -176,7 +176,7 @@ configuration file by adding the following to the ``env:`` section of the
 The CNI installation can be configured with environment variables. These
 environment variables can be specified in the `DaemonSet` file like this:
 
-.. code:: bash
+.. code-block:: yaml
 
     env:
       - name: "CNI_CONF_NAME"
@@ -197,7 +197,7 @@ The following variables are supported:
 If you want to further adjust the CNI configuration you may do so by creating
 the CNI configuration ``/etc/cni/net.d/05-cilium.conf`` manually:
 
-.. code:: bash
+.. code-block:: shell-session
 
     sudo mkdir -p /etc/cni/net.d
     sudo sh -c 'echo "{
@@ -239,9 +239,9 @@ the following command:
 
 ``kubectl get crd ciliumnetworkpolicies.cilium.io -o json``
 
-.. code:: bash
+.. code-block:: shell-session
 
-	kubectl get crd ciliumnetworkpolicies.cilium.io -o json | grep -A 12 openAPIV3Schema
+    $ kubectl get crd ciliumnetworkpolicies.cilium.io -o json | grep -A 12 openAPIV3Schema
             "openAPIV3Schema": {
                 "oneOf": [
                     {
@@ -259,7 +259,7 @@ the following command:
 In case the user writes a policy that does not conform to the schema, Kubernetes
 will return an error, e.g.:
 
-.. code:: bash
+.. code-block:: shell-session
 
 	cat <<EOF > ./bad-cnp.yaml
 	apiVersion: "cilium.io/v2"
@@ -305,7 +305,7 @@ Due to how systemd `mounts
 <https://unix.stackexchange.com/questions/283442/systemd-mount-fails-where-setting-doesnt-match-unit-name>`__
 filesystems, the mount point path must be reflected in the unit filename.
 
-.. code:: bash
+.. code-block:: shell-session
 
         cat <<EOF | sudo tee /etc/systemd/system/sys-fs-bpf.mount
         [Unit]
@@ -354,15 +354,15 @@ Cilium CNI configuration.
 
 First make sure cilium is running:
 
-::
+.. code-block:: shell-session
 
-    kubectl get pods -n kube-system -o wide
+    $ kubectl get pods -n kube-system -o wide
     NAME               READY     STATUS    RESTARTS   AGE       IP          NODE
     cilium-mqtdz       1/1       Running   0          3m       10.0.2.15   minikube
 
 After that you can restart CRI-O:
 
-::
+.. code-block:: shell-session
 
     minikube ssh -- sudo systemctl restart crio
 
@@ -375,9 +375,7 @@ Some CRI-O environments automatically mount the bpf filesystem in the pods,
 which is something that Cilium avoids doing when
 ``--set containerRuntime.integration=crio`` is set. However, some
 CRI-O environments do not mount the bpf filesystem automatically which causes
-Cilium to print the follow message:
-
-.. parsed-literal::
+Cilium to print the following message::
 
         level=warning msg="BPF system config check: NOT OK." error="CONFIG_BPF kernel parameter is required" subsys=linux-datapath
         level=warning msg="================================= WARNING ==========================================" subsys=bpf

--- a/Documentation/concepts/kubernetes/requirements.rst
+++ b/Documentation/concepts/kubernetes/requirements.rst
@@ -49,7 +49,7 @@ easiest method to handle IP allocation in a Kubernetes cluster. To enable this
 feature, simply add the following flag when starting
 ``kube-controller-manager``:
 
-.. code:: bash
+.. code-block:: shell-session
 
         --allocate-node-cidrs
 

--- a/Documentation/concepts/kubernetes/troubleshooting.rst
+++ b/Documentation/concepts/kubernetes/troubleshooting.rst
@@ -16,7 +16,7 @@ Verifying the installation
 Check the status of the `DaemonSet` and verify that all desired instances are in
 "ready" state:
 
-.. code:: bash
+.. code-block:: shell-session
 
         $ kubectl --namespace kube-system get ds
         NAME      DESIRED   CURRENT   READY     NODE-SELECTOR   AGE
@@ -27,7 +27,7 @@ a problem. The next step is to list all cilium pods by matching on the label
 ``k8s-app=cilium`` and also sort the list by the restart count of each pod to
 easily identify the failing pods:
 
-.. code:: bash
+.. code-block:: shell-session
 
         $ kubectl --namespace kube-system get pods --selector k8s-app=cilium \
                   --sort-by='.status.containerStatuses[0].restartCount'
@@ -37,7 +37,7 @@ easily identify the failing pods:
 Pod ``cilium-813gf`` is failing and has already been restarted 2 times. Let's
 print the logfile of that pod to investigate the cause:
 
-.. code:: bash
+.. code-block:: shell-session
 
         $ kubectl --namespace kube-system logs cilium-813gf
         INFO      _ _ _

--- a/Documentation/concepts/networking/ipam/cluster-pool.rst
+++ b/Documentation/concepts/networking/ipam/cluster-pool.rst
@@ -54,6 +54,6 @@ Look for allocation errors
 
 Check the ``Error`` field in the ``Status.Operator`` field:
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl get ciliumnodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.operator.error}{"\n"}{end}'

--- a/Documentation/concepts/networking/ipam/gke.rst
+++ b/Documentation/concepts/networking/ipam/gke.rst
@@ -48,9 +48,9 @@ Validate the exposed PodCIDR field
 
 Check if the Kubernetes nodes contain a value in the ``podCIDR`` field:
 
-.. code:: bash
+.. code-block:: shell-session
 
-    kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.podCIDR}{"\n"}{end}'
+    $ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.podCIDR}{"\n"}{end}'
     gke-cluster4-default-pool-b195a3f3-k431	10.4.0.0/24
     gke-cluster4-default-pool-b195a3f3-zv3p	10.4.1.0/24
 
@@ -60,12 +60,12 @@ Check the Cilium status
 Run ``cilium status`` on the node in question and validate that the CIDR used
 for IPAM matches the PodCIDR announced in the Kubernetes node:
 
-.. code:: bash
+.. code-block:: shell-session
 
-    kubectl -n kube-system get pods -o wide | grep gke-cluster4-default-pool-b195a3f3-k431
+    $ kubectl -n kube-system get pods -o wide | grep gke-cluster4-default-pool-b195a3f3-k431
     cilium-lv4xd                       1/1     Running   0          3h8m   10.164.0.112   gke-cluster4-default-pool-b195a3f3-k431   <none>           <none>
 
-    kubectl -n kube-system exec -ti cilium-lv4xd -- cilium status
+    $ kubectl -n kube-system exec -ti cilium-lv4xd -- cilium status
     KVStore:                Ok   Disabled
     Kubernetes:             Ok   1.14+ (v1.14.10-gke.27) [linux/amd64]
     Kubernetes APIs:        ["CustomResourceDefinition", "cilium/v2::CiliumClusterwideNetworkPolicy", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "core/v1::Endpoint", "core/v1::Namespace", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -60,9 +60,9 @@ specified, the program will be automatically attached to the devices selected by
 To manually change this, use the ``devices`` helm option. Use ``cilium status``
 to determine which devices the program is running on:
 
-::
+.. code-block:: shell-session
 
-    kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep Masquerading
+    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep Masquerading
     Masquerading:   BPF (ip-masq-agent)   [eth0, eth1]  10.0.0.0/16
 
 From the output above, the program is running on the ``eth0`` and ``eth1`` devices.
@@ -106,20 +106,20 @@ The agent uses Fsnotify to track updates to the configuration file, so the origi
 
 The example below shows how to configure the agent via `ConfigMap` and to verify it:
 
-::
+.. code-block:: shell-session
 
-    cat agent-config/config
+    $ cat agent-config/config
     nonMasqueradeCIDRs:
     - 10.0.0.0/8
     - 172.16.0.0/12
     - 192.168.0.0/16
     masqLinkLocal: false
 
-    kubectl create configmap ip-masq-agent --from-file=agent-config --namespace=kube-system
+    $ kubectl create configmap ip-masq-agent --from-file=agent-config --namespace=kube-system
 
-    # Wait ~60s until the ConfigMap is mounted into a cilium pod
+    $ # Wait ~60s until the ConfigMap is mounted into a cilium pod
 
-    kubectl -n kube-system exec -ti cilium-xxxxx -- cilium bpf ipmasq list
+    $ kubectl -n kube-system exec -ti cilium-xxxxx -- cilium bpf ipmasq list
     IP PREFIX/ADDRESS
     10.0.0.0/8
     169.254.0.0/16

--- a/Documentation/concepts/networking/routing.rst
+++ b/Documentation/concepts/networking/routing.rst
@@ -177,16 +177,12 @@ Ingress
    represented on the node as interface ``ethN``.
 
 2. An IP routing rule ensures that traffic to all local pod IPs is done using
-   the main routing table:
-
-   .. code-block:: bash
+   the main routing table::
 
        20:	from all to 192.168.105.44 lookup main
 
 3. The main routing table contains an exact match route to steer traffic into a
-   veth pair which is hooked into the pod:
-
-   .. code-block:: bash
+   veth pair which is hooked into the pod::
 
        192.168.105.44 dev lxc5a4def8d96c5
 
@@ -209,16 +205,12 @@ Egress
 
 3. An IP routing rule ensures that traffic from individual endpoints are using
    a routing table specific to the ENI from which the endpoint IP was
-   allocated:
-
-   .. code-block:: bash
+   allocated::
 
        30:	from 192.168.105.44 to 192.168.0.0/16 lookup 92
 
 4. The ENI specific routing table contains a default route which redirects
-   to the router of the VPC via the ENI interface:
-
-   .. code-block:: bash
+   to the router of the VPC via the ENI interface::
 
        default via 192.168.0.1 dev eth2
        192.168.0.1 dev eth2

--- a/Documentation/concepts/observability/hubble-configuration.rst
+++ b/Documentation/concepts/observability/hubble-configuration.rst
@@ -47,9 +47,8 @@ specific certificate authority (CA) is required.
 In order to use custom TLS certificates ``hubble.tls.auto.enabled`` must
 be set to ``false`` and TLS certificates manually provided.
 
-This can be done by specifying the options below to Helm at install or upgrade time:
+This can be done by specifying the options below to Helm at install or upgrade time::
 
-.. parsed-literal::
     --set hubble.tls.auto.enabled=false                          # disable automatic TLS certificate generation
     --set-file hubble.tls.ca.cert=ca.crt.b64                     # certificate of the CA that signs all certificates
     --set-file hubble.tls.server.cert=server.crt.b64             # certificate for Hubble server

--- a/Documentation/concepts/security/proxy/envoy.rst
+++ b/Documentation/concepts/security/proxy/envoy.rst
@@ -121,7 +121,7 @@ It is easiest to start Cilium development by following the :ref:`dev_guide`
 
 After cloning Cilium: 
 
-::
+.. code-block:: shell-session
 
     $ cd cilium 
     $ contrib/vagrant/start.sh 
@@ -137,7 +137,7 @@ Step 5: Create New Proxy Skeleton
 From inside the proxylib directory, copy the rd2d directory and rename the files. 
 Replace ''newproto'' with your protocol: 
 
-:: 
+.. code-block:: shell-session
 
     $ mkdir newproto
     $ cd newproto
@@ -252,7 +252,7 @@ cassandra/cassandraparser_test.go for an example of this).
 
 To run the unit tests, go to proxylib/newproto and run: 
 
-:: 
+.. code-block:: shell-session
 
   $ go test
 
@@ -289,12 +289,12 @@ First, create a Go object that will represent a single rule in the policy langua
 this is the rule for the r2d2 protocol, which performs exact match on the command string, and a regex
 on the filename:  
 
-:: 
+.. code-block:: go
 
- type R2d2Rule struct {
-    cmdExact   string
-    fileRegexCompiled *regexp.Regexp
- }
+    type R2d2Rule struct {
+       cmdExact   string
+       fileRegexCompiled *regexp.Regexp
+    }
 
 There are two key methods to update: 
 
@@ -318,7 +318,7 @@ Once you add the logic to call Matches() and return DROP in OnData, you will nee
 unit tests to have policies that allow the traffic you expect to be passed.   The following 
 is an example of how r2d2/r2d2parser_test.go adds an allow-all policy for a given test: 
 
-:: 
+.. code-block:: go
 
     s.ins.CheckInsertPolicyText(c, "1", []string{`
         name: "cp1"
@@ -334,7 +334,7 @@ is an example of how r2d2/r2d2parser_test.go adds an allow-all policy for a give
 The following is an example of a policy that would allow READ commands with a file 
 regex of ".*": 
 
-:: 
+.. code-block:: go
 
     s.ins.CheckInsertPolicyText(c, "1", []string{`
         name: "cp2"
@@ -370,7 +370,7 @@ an HTTP proxy would return a ''403 Access Denied'' error.  Look back at the prot
 understand what an access denied message looks like for this protocol, and use the p.connection.Inject() method 
 to send this error reply back to the client.   See r2d2/r2d2parser.go for an example. 
 
-:: 
+.. code-block:: go
 
     p.connection.Inject(true, []byte("ERROR\r\n"))
 
@@ -392,7 +392,7 @@ and indicates whether the request was allowed or denied.
 A call to ''p.connection.Log()'' implements access logging. See the OnData function in r2d2/r2d2parser.go 
 as an example: 
 
-:: 
+.. code-block:: go
 
       p.connection.Log(access_log_entry_type,
         &cilium.LogEntry_GenericL7{
@@ -412,7 +412,7 @@ Find the standard docker container for running the protocol server.  Often the s
 
 Start both a server and client container running in the cilium dev VM, and attach them to the already created “cilium-net”.  For example, with Cassandra, we run:
 
-:: 
+.. code-block:: shell-session
 
     docker run --name cass-server -l id=cass-server -d --net cilium-net cassandra
 
@@ -425,7 +425,7 @@ access the client CLI.
 
 Use ''cilium endpoint list'' to identify the IP address of the protocol server.  
 
-:: 
+.. code-block:: shell-session
 
   $ cilium endpoint list
   ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])   IPv6                 IPv4            STATUS   
@@ -436,15 +436,15 @@ Use ''cilium endpoint list'' to identify the IP address of the protocol server.
 
 One can then invoke the client CLI using that server IP address (10.11.51.247 in the above example):
 
-:: 
+.. code-block:: shell-session
 
- docker exec -it cass-client sh -c 'cqlsh 10.11.51.247 -e "select * from system.local"'
+    docker exec -it cass-client sh -c 'cqlsh 10.11.51.247 -e "select * from system.local"'
 
 Note that in the above example, ingress policy is not enforced for the Cassandra server endpoint, so no data will flow through the
 Cassandra parser.  A simple ''allow all'' L7 Cassandra policy can be used to send all data to the Cassandra server through the 
 Go Cassandra parser.  This policy has a single empty rule, which matches all requests.  An allow all policy looks like: 
 
-:: 
+.. code-block:: json
 
   [ { 
     "endpointSelector": {"matchLabels":{"id":"cass-server"}}, 
@@ -464,7 +464,7 @@ A policy can be imported into cilium using ''cilium policy import'', after which
 confirms that ingress policy is now in place on the server.  If the above policy was saved to a file cass-allow-all.json, 
 one would run: 
 
-:: 
+.. code-block:: shell-session
 
     $ cilium policy import cass-allow-all.json
     Revision: 1
@@ -479,14 +479,14 @@ Note that policy is now showing as ''Enabled'' for the Cassandra server on ingre
 
 To remove this or any other policy, run: 
 
-:: 
+.. code-block:: shell-session
 
     $ cilium policy delete --all 
 
 To install a new policy, first delete, and then run ''cilium policy import'' again.  For example, the following policy would allow
 select statements on a specific set of tables to this Cassandra server, but deny all other queries. 
 
-:: 
+.. code-block:: json
 
   [ {
     "endpointSelector": {"matchLabels":{"id":"cass-server"}},
@@ -505,12 +505,12 @@ select statements on a specific set of tables to this Cassandra server, but deny
   } ]
 
 When performing manual testing, remember that each time you change your Go proxy code, you must
-re-run ''make'' and ''sudo make install'' and then restart the cilium-agent process.  If the only changes
+re-run ``make`` and ``sudo make install`` and then restart the cilium-agent process.  If the only changes
 you have made since last compiling cilium are in your cilium/proxylib directory, you can safely 
-just run ''make'' and ''sudo make install''  in that directory, which saves time.  
+just run ``make`` and ``sudo make install``  in that directory, which saves time.  
 For example: 
 
-:: 
+.. code-block:: shell-session
 
   $ cd proxylib  // only safe is this is the only directory that has changed
   $ make  
@@ -525,7 +525,7 @@ the ''--debug-verbose=flow'' flag, which is critical to getting visibility in tr
 So it is easiest to stop the cilium service and run the cilium-agent directly as a command in a terminal window, 
 and adding the ''--debug-verbose=flow'' flag. 
 
-:: 
+.. code-block:: shell-session
 
   $ sudo service cilium stop 
   

--- a/Documentation/concepts/terminology.rst
+++ b/Documentation/concepts/terminology.rst
@@ -134,7 +134,7 @@ which is then associated with the endpoint. The label is prefixed with
 ``container:`` to indicate that the label was derived from the container
 runtime.
 
-::
+.. code-block:: shell-session
 
     $ docker run --net cilium -d -l app=benchmark tgraf/netperf
     aaff7190f47d071325e7af06577f672beff64ccc91d2b53c42262635c063cf1c

--- a/Documentation/configuration/api-rate-limiting.rst
+++ b/Documentation/configuration/api-rate-limiting.rst
@@ -41,9 +41,7 @@ Configuration
 =============
 
 The ``api-rate-limit`` option can be used to overwrite individual settings of the
-default configuration:
-
-.. code::
+default configuration::
 
    --api-rate-limit endpoint-create=rate-limit:2/s,rate-burst:4
 
@@ -132,9 +130,7 @@ values should typically adjust slower than ``rate-limit``:
 Metrics
 =======
 
-All API calls subject to rate limiting will expose :ref:`metrics_api_rate_limiting`. Example:
-
-.. code::
+All API calls subject to rate limiting will expose :ref:`metrics_api_rate_limiting`. Example::
 
     cilium_api_limiter_adjustment_factor                  api_call="endpoint-create"                               0.695787
     cilium_api_limiter_processed_requests_total           api_call="endpoint-create" outcome="success"             7.000000
@@ -152,15 +148,13 @@ Understanding the log output
 ============================
 
 The API rate limiter logs under the ``rate`` subsystem. An example message can
-be seen below:
-
-.. code::
+be seen below::
 
    level=info msg="API call has been processed" name=endpoint-create processingDuration=772.847247ms subsys=rate totalDuration=14.923958916s uuid=d34a2e1f-1ac9-11eb-8663-42010a8a0fe1 waitDurationTotal=14.151023084s
 
 The following is an explanation for all the API rate limiting messages:
 
-.. code::
+::
 
    "Processing API request with rate limiter"
 
@@ -169,7 +163,7 @@ The request was admitted into the rate limiter. The associated HTTP context
 according to the configuration of the rate limiter. It will enter the waiting
 stage according to the computed waiting duration.
 
-.. code::
+::
 
    "API request released by rate limiter"
 
@@ -182,7 +176,7 @@ code.
 This is a common message when the requests are being processed within the
 configured bounds of the rate limiter.
 
-.. code::
+::
 
    "API call has been processed":
 
@@ -191,7 +185,7 @@ action has finished. This means the request is no longer actively waiting or in
 other words, no longer being rate-limited. This does not mean the underlying
 HTTP action has succeeded; only that this request has been dealt with.
 
-.. code::
+::
 
    "Not processing API request due to cancelled context"
 
@@ -200,7 +194,7 @@ has given up on the request. This most likely means that the HTTP request timed
 out. A 429 HTTP response status code is returned to the caller, which may or
 may not receive it anyway.
 
-.. code::
+::
 
    "Not processing API request. Wait duration for maximum parallel requests exceeds maximum"
 
@@ -211,7 +205,7 @@ response.
 This is a common message when the rate limiter is doing its job of preventing
 too many parallel requests at once.
 
-.. code::
+::
 
    "Not processing API request. Wait duration exceeds maximum"
 
@@ -224,7 +218,7 @@ thrown out. A 429 HTTP response status code would be returned to the caller.
 This is the most common message when the rate limiter is doing its job of
 pacing the incoming requests into Cilium.
 
-.. code::
+::
 
    "Not processing API request due to cancelled context while waiting"
 

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -17,7 +17,7 @@ Clone and Provision Environment
 #. Fork the Cilium repository to your GitHub user or organization.
 #. Clone your ``${YOUR_GITHUB_USERNAME_OR_ORG}/cilium`` fork into your ``GOPATH``, and setup the base repository as ``upstream`` remote:
 
-   ::
+   .. code-block:: shell-session
 
       mkdir -p "${GOPATH}/src/github.com/cilium"
       cd "${GOPATH}/src/github.com/cilium"
@@ -416,7 +416,7 @@ steps 1 to 2 times per day. Works best if done first thing in the working day.
 
 #. If the PR is a backport PR, update the labels of cherry-picked PRs with the command included at the end of the original post. For example:
 
-   .. code-block:: bash
+   .. code-block:: shell-session
    
        $ for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done
 

--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -54,7 +54,7 @@ toFQDNs rules and events relating to those rules are also relevant.
 
     Be sure to run cilium monitor on the same node as the pod being debugged!
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl exec pod/cilium-sbp8v -n kube-system -- cilium monitor --related-to 3459
     Listening for events on 4 CPUs with 64x4096 of shared memory
@@ -111,7 +111,7 @@ the issue. This can be verified with ``cilium fqdn cache list``. The IPs in the
 response should appear in the cache for the appropriate endpoint. The lookup
 time is included in the json output of the command.
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl exec pod/cilium-sbp8v -n kube-system -- cilium fqdn cache list
     Endpoint   Source   FQDN         TTL    ExpirationTime             IPs
@@ -190,7 +190,7 @@ If an IP exists in the FQDN cache (check with ``cilium fqdn cache list``) then
 ``matchName`` or via ``matchPattern``, should cause IPs for that domain to have
 allocated Security Identities. These can be listed with:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl exec pod/cilium-sbp8v -n kube-system -- cilium identity list
     ID         LABELS
@@ -218,7 +218,7 @@ represents each ``toFQDNs:`` rule with a ``FQDNSelector`` instance. These
 receive updates from a global ``NameManage`` in the daemon.
 They can be listed along with other selectors (roughly corresponding to any L3 rule):
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl exec pod/cilium-sbp8v -n kube-system -- cilium policy selectors
     SELECTOR                                                                                                         USERS   IDENTITIES
@@ -243,7 +243,7 @@ They can be listed along with other selectors (roughly corresponding to any L3 r
 In this example 16777217 is used by two selectors, one with ``matchPattern: "*"``
 and another empty one. This is because of the policy in use:
 
-.. code:: yaml
+.. code-block:: yaml
 
     apiVersion: cilium.io/v2
     kind: CiliumNetworkPolicy
@@ -303,7 +303,7 @@ propagate from the selectors to the Endpoint specific policy. Unless a new
 policy is being added, this often only involves updating the Policy Map of the
 Endpoint with the new CIDR Identity of the IP. This can be verified:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl exec pod/cilium-sbp8v -n kube-system -- cilium bpf policy get 3459
     DIRECTION   LABELS (source:key[=value])   PORT/PROTO   PROXY PORT   BYTES   PACKETS
@@ -317,7 +317,7 @@ Endpoint with the new CIDR Identity of the IP. This can be verified:
 Note that the labels for identities are resolved here. This can be skipped, or
 there may be cases where this doesn't occur:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl exec pod/cilium-sbp8v -n kube-system -- cilium bpf policy get -n 3459
     DIRECTION   IDENTITY   PORT/PROTO   PROXY PORT   BYTES   PACKETS
@@ -370,7 +370,7 @@ Race detection
 
 To compile a Cilium binary with race detection, you can do:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ make RACE=1
 
@@ -382,7 +382,7 @@ To compile a Cilium binary with race detection, you can do:
 
 To run unit tests with race detection, you can do:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ make RACE=1 unit-tests
 
@@ -397,7 +397,7 @@ action is required, besides building the binary with this tag.
 
 For example:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ make LOCKDEBUG=1
     $ # Deadlock detection during unit tests:

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -15,7 +15,7 @@ Verifying Your Development Setup
 Assuming you have Go installed, you can quickly verify many elements of your
 development setup by running:
 
-::
+.. code-block:: shell-session
 
     $ make dev-doctor
 
@@ -81,7 +81,7 @@ Option 1 - Using the Provided Vagrantfiles (Recommended)
 
 To bring up a Vagrant VM with Cilium plus dependencies installed, run:
 
-::
+.. code-block:: shell-session
 
     $ contrib/vagrant/start.sh [vm_name]
 
@@ -89,7 +89,7 @@ This will create and run a vagrant VM based on the base box ``cilium/ubuntu``.
 The ``vm_name`` argument is optional and allows you to add new nodes to an
 existing cluster. For example, to add a net-next VM to a one-node cluster:
 
-::
+.. code-block:: shell-session
 
     $ K8S=1 NWORKERS=1 NETNEXT=1 ./contrib/vagrant/start.sh k8s2+
 
@@ -103,7 +103,7 @@ etc.
 
 For example, you could have something like this in your ``.devvmrc``:
 
-::
+.. code-block:: bash
 
     #!/usr/bin/env bash
 
@@ -181,20 +181,21 @@ brought up by vagrant:
 If you want to start the VM with cilium enabled with ``containerd``, with
 kubernetes installed and plus a worker, run:
 
-::
+.. code-block:: shell-session
 
-	$ RUNTIME=containerd K8S=1 NWORKERS=1 contrib/vagrant/start.sh
+    $ RUNTIME=containerd K8S=1 NWORKERS=1 contrib/vagrant/start.sh
 
 If you want to get VM status, run:
-::
 
-  $ RUNTIME=containerd K8S=1 NWORKERS=1 vagrant status
+.. code-block:: shell-session
+
+    $ RUNTIME=containerd K8S=1 NWORKERS=1 vagrant status
 
 If you want to connect to the Kubernetes cluster running inside the developer VM via ``kubectl`` from your host machine, set ``KUBECONFIG`` environment variable to include new kubeconfig file:
 
-::
+.. code-block:: shell-session
 
-$ export KUBECONFIG=$KUBECONFIG:$GOPATH/src/github.com/cilium/cilium/vagrant.kubeconfig
+    $ export KUBECONFIG=$KUBECONFIG:$GOPATH/src/github.com/cilium/cilium/vagrant.kubeconfig
 
 and add ``127.0.0.1 k8s1`` to your hosts file.
 
@@ -217,7 +218,7 @@ from the main Vagrantfile, for example:
 
 To start a local k8s 1.18 cluster with one CI VM locally, run:
 
-::
+.. code-block:: shell-session
 
     $ cd test
     $ K8S_VERSION=1.18 K8S_NODES=1 ./vagrant-local-start.sh
@@ -231,7 +232,7 @@ can run ``make clean`` in ``tests`` to delete the cached vagrant box.
 
 To start the CI runtime VM locally, run:
 
-::
+.. code-block:: shell-session
 
     $ cd test
     $ ./vagrant-local-start-runtime.sh
@@ -248,7 +249,7 @@ Option 2 - Manual Installation
 Alternatively you can import the vagrant box ``cilium/ubuntu``
 directly and manually install Cilium:
 
-::
+.. code-block:: shell-session
 
         $ vagrant init cilium/ubuntu
         $ vagrant up
@@ -314,7 +315,7 @@ to enable NFS.
 
 If for some reason, running of the provisioning script fails, you should bring the VM down before trying again:
 
-::
+.. code-block:: shell-session
 
     $ vagrant halt
 
@@ -335,7 +336,7 @@ Build Cilium
 When you make changes, the tree is automatically kept in sync via NFS.
 You can issue a build as follows:
 
-::
+.. code-block:: shell-session
 
     $ make
 
@@ -344,7 +345,7 @@ Install to dev environment
 
 After a successful build and test you can re-install Cilium by:
 
-::
+.. code-block:: shell-session
 
     $ sudo -E make install
 
@@ -353,14 +354,14 @@ Restart Cilium service
 
 To run the newly installed version of Cilium, restart the service:
 
-::
+.. code-block:: shell-session
 
     $ sudo systemctl restart cilium
 
 You can verify the service and cilium-agent status by the following
 commands, respectively:
 
-::
+.. code-block:: shell-session
 
     $ sudo systemctl status cilium
     $ cilium status
@@ -372,7 +373,7 @@ After Cilium daemon has been restarted, you may want to verify that it
 boots up properly and integration with Envoy still works. To do this,
 run this bash test script:
 
-::
+.. code-block:: shell-session
 
     $ tests/envoy-smoke-test.sh
 
@@ -388,13 +389,13 @@ Making Changes
 
 #. Make sure the ``master`` branch of your fork is up-to-date:
 
-   ::
+   .. code-block:: shell-session
 
       git fetch upstream master:master
 
 #. Create a PR branch with a descriptive name, branching from ``master``:
 
-   ::
+   .. code-block:: shell-session
 
       git switch -c pr/changes-to-something master
 
@@ -437,7 +438,7 @@ Add/update a golang dependency
 
 Let's assume we want to add ``github.com/containernetworking/cni`` version ``v0.5.2``:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ go get github.com/containernetworking/cni@v0.5.2
     $ go mod tidy
@@ -450,7 +451,7 @@ your local cache but the remaining runs will be faster.
 Updating k8s is a special case which requires updating k8s libraries in a single
 change:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ # get the tag we are updating (for example ``v0.17.3`` corresponds to k8s ``v1.17.3``)
     $ # open go.mod and search and replace all ``v0.17.3`` with the version
@@ -534,28 +535,28 @@ If you'd like IPv6 addresses, you will need to follow these steps:
 
 1) Edit ``/etc/docker/daemon.json`` and set the ``ipv6`` key to ``true``.
 
-::
+   .. code-block:: json
 
-    {
-      "ipv6": true
-    }
-
-
-If that doesn't work alone, try assigning a fixed range. Many people have
-reported trouble with IPv6 and Docker. `Source here.
-<https://github.com/moby/moby/issues/29443#issuecomment-495808871>`_
-
-::
-
-    {
-      "ipv6": true,
-      "fixed-cidr-v6": "2001:db8:1::/64"
-    }
+      {
+        "ipv6": true
+      }
 
 
-And then:
+   If that doesn't work alone, try assigning a fixed range. Many people have
+   reported trouble with IPv6 and Docker. `Source here.
+   <https://github.com/moby/moby/issues/29443#issuecomment-495808871>`_
 
-::
+   .. code-block:: json
+
+      {
+        "ipv6": true,
+        "fixed-cidr-v6": "2001:db8:1::/64"
+      }
+
+
+   And then:
+
+   .. code-block:: shell-session
 
     ip -6 route add 2001:db8:1::/64 dev docker0
     sysctl net.ipv6.conf.default.forwarding=1
@@ -566,9 +567,9 @@ And then:
 
 3) The new command for creating a network managed by Cilium:
 
-::
+   .. code-block:: shell-session
 
-    $ docker network create --ipv6 --driver cilium --ipam-driver cilium cilium-net
+      $ docker network create --ipv6 --driver cilium --ipam-driver cilium cilium-net
 
 
 Now new containers will have an IPv6 address assigned to them.
@@ -673,7 +674,7 @@ One of the most common issues when developing datapath code is that the eBPF
 code cannot be loaded into the kernel. This frequently manifests as the
 endpoints appearing in the "not-ready" state and never switching out of it:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ cilium endpoint list
     ENDPOINT   POLICY        IDENTITY   LABELS (source:key[=value])   IPv6                     IPv4            STATUS
@@ -693,7 +694,7 @@ Current eBPF map state for particular programs is held under ``/sys/fs/bpf/``,
 and the `bpf-map <https://github.com/cilium/bpf-map>`_ utility can be useful
 for debugging what is going on inside them, for example:
 
-.. code:: bash
+.. code-block:: shell-session
 
     # ls /sys/fs/bpf/tc/globals/
     cilium_calls_15124  cilium_calls_48896        cilium_ct4_global       cilium_lb4_rr_seq       cilium_lb6_services  cilium_policy_25729  cilium_policy_60670       cilium_proxy6

--- a/Documentation/contributing/development/hubble.rst
+++ b/Documentation/contributing/development/hubble.rst
@@ -18,7 +18,7 @@ Bumping the vendored Cilium dependency
 Hubble vendors Cilium using Go modules. You can bump the dependency by first
 running:
 
-    ::
+.. code-block:: shell-session
 
         go get github.com/cilium/cilium@master
 
@@ -28,7 +28,7 @@ by ``go get`` and ``go mod``. Therefore you must also manually copy any updated
 
 Once you have done this you can tidy up, vendor the modules, and verify them:
 
-    ::
+.. code-block:: shell-session
 
         go mod tidy
         go mod vendor

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -18,7 +18,7 @@ Developer images
 Run ``make dev-docker-image`` to build a cilium-agent Docker image that
 contains your local changes.
 
-::
+.. code-block:: shell-session
 
     ARCH=amd64 DOCKER_DEV_ACCOUNT=quay.io/myaccount DOCKER_IMAGE_TAG=jane-developer-my-fix make dev-docker-image
 
@@ -26,7 +26,7 @@ Run ``make docker-operator-generic-image`` (respectively,
 ``docker-operator-aws-image`` or ``docker-operator-azure-image``) to build the
 cilium-operator Docker image:
 
-::
+.. code-block:: shell-session
 
     ARCH=amd64 DOCKER_DEV_ACCOUNT=quay.io/myaccount DOCKER_IMAGE_TAG=jane-developer-my-fix make docker-operator-generic-image
 
@@ -44,7 +44,7 @@ Official release images
 
 Anyone can build official release images using the make target below.
 
-::
+.. code-block:: shell-session
 
     DOCKER_IMAGE_TAG=v1.4.0 make docker-images-all
 
@@ -55,14 +55,14 @@ Docker BuildKit allows build artifact caching between builds and
 generally results in faster builds for the developer. Support can be
 enabled by:
 
-::
+.. code-block:: shell-session
 
     export DOCKER_BUILDKIT=1
 
 Multi-arch image build support for arm64 (aka aarch64) and amd64 (aka
 x86-64) can be enabled by defining:
 
-::
+.. code-block:: shell-session
 
     export DOCKER_BUILDX=1
 
@@ -76,7 +76,7 @@ is "default".
 Buildx targets push images automatically, so you must also have
 DOCKER_REGISTRY and DOCKER_DEV_ACCOUNT defined, e.g.:
 
-::
+.. code-block:: shell-session
 
     export DOCKER_REGISTRY=docker.io
     export DOCKER_DEV_ACCOUNT=your-account
@@ -85,7 +85,7 @@ Currently the cilium-runtime and cilium-builder images are released
 for amd64 only (see the table below). This means that you have to
 build your own cilium-runtime and cilium-builder images:
 
-::
+.. code-block:: shell-session
 
     make docker-image-runtime
 
@@ -93,7 +93,7 @@ After the build finishes update the runtime image references in other
 Dockerfiles (``docker buildx imagetools inspect`` is useful for finding
 image information). Then proceed to build the cilium-builder:
 
-::
+.. code-block:: shell-session
 
     make docker-image-builder
 
@@ -103,7 +103,7 @@ github.com/cilium/hubble. Hubble builds via buildx QEMU based
 emulation, unless you have an ARM machine added to your buildx
 builder:
 
-::
+.. code-block:: shell-session
 
     export IMAGE_REPOSITORY=${DOCKER_REGISTRY}/${DOCKER_DEV_ACCOUNT}/hubble
     CONTAINER_ENGINE="docker buildx" DOCKER_FLAGS="--push --platform=linux/arm64,linux/amd64" make image
@@ -111,7 +111,7 @@ builder:
 Update the main Cilium Dockerfile with the new Hubble reference and
 build the multi-arch versions of the Cilium images:
 
-::
+.. code-block:: shell-session
 
     make docker-images-all
 

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -82,14 +82,14 @@ One-time Setup
    you have a machine ready, you need to configure git to have your name and
    email address to be used in the commit messages:
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
       $ git config --global user.name "John Doe"
       $ git config --global user.email johndoe@example.com
 
 #. Add remotes for the Cilium upstream repository and your Cilium repository fork.
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
       $ git remote add johndoe git@github.com:johndoe/cilium.git
       $ git remote add upstream https://github.com/cilium/cilium.git
@@ -122,7 +122,7 @@ One-time Setup
 
    Verify your machine is correctly configured by running
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
       $ go run ./tools/dev-doctor --backporting
 
@@ -151,7 +151,7 @@ Creating the Backports Branch
    a new branch, and runs the ``contrib/backporting/check-stable`` script to
    fetch the full set of PRs to backport.
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
       $ GITHUB_TOKEN=xxx contrib/backporting/start-backport 1.0
 
@@ -171,7 +171,7 @@ Creating the Backports Branch
    specified on the command line until one cherry pick fails or every
    commit is cherry-picked.
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
       $ contrib/backporting/cherry-pick <oldest-commit-sha>
       ...
@@ -209,13 +209,11 @@ section above. It pushes the git tree, creates the pull request and updates
 the labels for the PRs that are backported, based on the
 ``vRELEASE-backport-YYYY-MM-DD.txt`` file in the current directory.
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
       $ GITHUB_TOKEN=xxx contrib/backporting/submit-backport
 
-The script takes up to three positional arguments:
-
-   .. code-block:: bash
+The script takes up to three positional arguments::
 
       usage: submit-backport [branch version] [pr-summary] [your remote]
 
@@ -232,7 +230,7 @@ Via GitHub Web Interface
 
 #. Push your backports branch to your fork of the Cilium repo.
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
       $ git push -u <remote_for_your_fork> HEAD
 
@@ -286,7 +284,7 @@ and clear the ``backport-pending/X.Y`` label(s). If the backport pull request
 description was generated using the scripts above, then the full command is
 listed in the pull request description.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
    $ GITHUB_TOKEN=xxx for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done
 
@@ -313,6 +311,6 @@ Merger
 When merging a backport PR, set the labels of the backported PRs to
 ``done``. Typically, backport PRs include a line on how do that. E.g.,:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ GITHUB_TOKEN=xxx for pr in 12894 12621 12973 12977 12952; do contrib/backporting/set-labels.py $pr done 1.8; done

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -17,7 +17,7 @@ On Freeze date
 
 #. Fork a new release branch from master:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout master; git pull origin master
        git checkout -b v1.2
@@ -55,7 +55,7 @@ On Freeze date
 #. Commit changes, open a pull request against the new ``v1.2`` branch, and get
    the pull request merged
 
-   ::
+   .. code-block:: shell-session
 
        git checkout -b pr/prepare-v1.2
        git add [...]
@@ -78,13 +78,13 @@ On Freeze date
    * A new section is added for the upcoming release that is being prepared, and
    * The section for the oldest release is removed.
 
-   ::
+   .. code-block:: shell-session
 
-       git checkout -b pr/master-cilium-actions-update origin/master
-       # modify .github/cilium-actions.yml
-       git add .github/cilium-actions.yml
-       git commit
-       git push
+       $ git checkout -b pr/master-cilium-actions-update origin/master
+       $ # modify .github/cilium-actions.yml
+       $ git add .github/cilium-actions.yml
+       $ git commit
+       $ git push
 
 #. Continue with the next step only after the previous steps are merged into
    master.
@@ -107,7 +107,7 @@ On Freeze date
 
 #. Prepare the master branch for the next development cycle:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout master; git pull
 

--- a/Documentation/contributing/release/rc.rst
+++ b/Documentation/contributing/release/rc.rst
@@ -28,19 +28,19 @@ If you intent to release a new feature release, see the
 #. Checkout the desired stable branch (can be master branch if stable branch was
    not created) and pull it:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout v1.0; git pull
 
 #. Create a branch for the release pull request:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout -b pr/prepare-v1.0.3
 
 #. Update the ``AUTHORS file``
 
-   ::
+   .. code-block:: shell-session
 
        make update-authors
 
@@ -98,13 +98,13 @@ If you intent to release a new feature release, see the
 
 #. Checkout out the stable branch and pull your merged changes:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout v1.0; git pull
 
 #. Create release tags:
 
-   ::
+   .. code-block:: shell-session
 
        git tag -a v1.0.3 -m 'Release v1.0.3'
        git tag -a 1.0.3 -m 'Release 1.0.3'
@@ -119,7 +119,7 @@ If you intent to release a new feature release, see the
 
 #. Push the git release tag
 
-   ::
+   .. code-block:: shell-session
 
        git push --tags
 
@@ -164,7 +164,7 @@ If you intent to release a new feature release, see the
 
 #. Checkout out the stable branch and pull your merged changes:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout v1.0; git pull
 

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -43,17 +43,17 @@ Reference steps for the template
 
 #. Checkout the desired stable branch and pull it:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout v1.0; git pull
 
 #. Run the release preparation script:
 
-   ::
+   .. code-block:: shell-session
 
        contrib/release/start-release.sh
 
-  .. note::
+   .. note::
 
        Check to see if the ``AUTHORS`` file has any formatting errors (for
        instance, indentation mismatches) as well as duplicate contributor
@@ -69,7 +69,7 @@ Reference steps for the template
 
 #. Prepare a pull request for the changes:
 
-   ::
+   .. code-block:: shell-session
 
       contrib/release/submit-release.sh
 
@@ -79,13 +79,13 @@ Reference steps for the template
 
 #. Checkout out the stable branch and pull your merged changes:
 
-   ::
+   .. code-block:: shell-session
 
        git checkout v1.0; git pull
 
 #. Create and push release tags to GitHub:
 
-   ::
+   .. code-block:: shell-session
 
       contrib/release/tag-release.sh
 
@@ -101,7 +101,7 @@ Reference steps for the template
 
 #. Once the release images are pushed, pull the image digests and prepare a PR with the official release image digests:
 
-   ::
+   .. code-block:: shell-session
 
       contrib/release/post-release.sh <URL of workflow run from the release link above>
 
@@ -119,7 +119,7 @@ Reference steps for the template
 #. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`_
    and push the changes into that repository (not the main cilium repository):
 
-   ::
+   .. code-block:: shell-session
 
       ./prepare_artifacts.sh /path/to/cilium/repository/checked/out/to/release/commit
       git push
@@ -135,7 +135,7 @@ Reference steps for the template
 
    In the ``cilium/charts`` repository:
 
-   ::
+   .. code-block:: shell-session
 
       ./prepare_artifacts.sh /path/to/cilium/repository/checked/out/to/release/commit
       git push
@@ -156,11 +156,11 @@ Reference steps for the template
 
 #. Create a new git branch based on the master branch to update ``README.rst``:
 
-   ::
+   .. code-block:: shell-session
 
-      git checkout -b pr/bump-readme-vX.Y.Z origin/master
-      contrib/release/bump-readme.sh
-      # (Commit changes & submit PR)
+      $ git checkout -b pr/bump-readme-vX.Y.Z origin/master
+      $ contrib/release/bump-readme.sh
+      $ # (Commit changes & submit PR)
 
 #. Bump the version of Cilium used in the Cilium upgrade tests to use the new release
 
@@ -175,13 +175,13 @@ Reference steps for the template
    on the ``1.8`` line, this step should be performed. Once ``1.9`` is out for
    example, then this is no longer required for ``1.8`` or earlier releases.
 
-   ::
+   .. code-block:: shell-session
 
        contrib/release/bump-docker-stable.sh X.Y.Z
 
 #. Check if all docker images are available before announcing the release:
 
-   ::
+   .. code-block:: shell-session
 
       make -C install/kubernetes/ check-docker-images
 

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -325,7 +325,7 @@ Triage process
    setting the SINCE environment variable (it is a unix timestamp). The script
    checks the various test pipelines that need triage.
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
        $ contrib/scripts/jenkins-failures.sh
 
@@ -446,7 +446,7 @@ Logging into VM running tests
 1. If you have access to credentials for Jenkins, log into the Jenkins slave running the test workload
 2. Identify the vagrant box running the specific test
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ vagrant global-status
     id       name                          provider   state   directory
@@ -459,7 +459,7 @@ Logging into VM running tests
 
 3. Log into the specific VM
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ JOB_BASE_NAME=PR-1588 BUILD_NUMBER=6 vagrant ssh 6e68c6c
 

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -10,7 +10,7 @@ Documentation
 First, start a local document server that automatically refreshes when you save files for
 real-time preview. It relies on the ``cilium/docs-builder`` Docker container.
 
-::
+.. code-block:: shell-session
 
     $ make render-docs-live-preview
 
@@ -19,7 +19,7 @@ Cilium documentation you should check that you did not introduce any new warning
 check that your changes look as you intended one last time before opening a pull request. To do this
 you can build the docs:
 
-::
+.. code-block:: shell-session
 
     $ make render-docs
 
@@ -34,5 +34,6 @@ http://localhost:9081 in a browser.
    not been released) regardless of which Cilium branch you are in. You can target a specific
    branch by specifying ``READTHEDOCS_VERSION`` environment variable:
 
-   .. parsed-literal::
+   .. code-block:: shell-session
+
       READTHEDOCS_VERSION=v1.7 make render-docs-live-preview

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -48,7 +48,7 @@ Running all of the Ginkgo tests may take an hour or longer. To run all the
 ginkgo tests, invoke the make command as follows from the root of the cilium
 repository:
 
-::
+.. code-block:: shell-session
 
     $ sudo make -C test/ test
 
@@ -62,7 +62,7 @@ Running Runtime Tests
 
 To run all of the runtime tests, execute the following command from the ``test`` directory:
 
-::
+.. code-block:: shell-session
 
     ginkgo --focus="Runtime"
 
@@ -70,7 +70,7 @@ Ginkgo searches for all tests in all subdirectories that are "named" beginning
 with the string "Runtime" and contain any characters after it. For instance,
 here is an example showing what tests will be ran using Ginkgo's dryRun option:
 
-::
+.. code-block:: shell-session
 
     $ ginkgo --focus="Runtime" -dryRun
     Running Suite: runtime
@@ -113,14 +113,14 @@ Running Kubernetes Tests
 
 To run all of the Kubernetes tests, run the following command from the ``test`` directory:
 
-::
+.. code-block:: shell-session
 
     ginkgo --focus="K8s"
 
 To run a specific test from the Kubernetes tests suite, run the following command
 from the ``test`` directory:
 
-::
+.. code-block:: shell-session
 
     ginkgo --focus="K8s.*Check iptables masquerading with random-fully"
 
@@ -140,7 +140,7 @@ The Kubernetes tests support the following Kubernetes versions:
 By default, the Vagrant VMs are provisioned with Kubernetes 1.20. To run with any other
 supported version of Kubernetes, run the test suite with the following format:
 
-::
+.. code-block:: shell-session
 
     K8S_VERSION=<version> ginkgo --focus="K8s"
 
@@ -156,16 +156,16 @@ supported version of Kubernetes, run the test suite with the following format:
    To avoid this, one can prevent Vagrant from installing the Additions by
    putting the following into ``$HOME/.vagrant.d/Vagrantfile``:
 
-   .. code:: ruby
+   .. code-block:: ruby
 
       Vagrant.configure('2') do |config|
-	if Vagrant.has_plugin?("vagrant-vbguest") then
-	  config.vbguest.auto_update = false
-	end
+        if Vagrant.has_plugin?("vagrant-vbguest") then
+          config.vbguest.auto_update = false
+        end
 
-	config.vm.provider :virtualbox do |vbox|
-	  vbox.check_guest_additions = false
-	end
+        config.vm.provider :virtualbox do |vbox|
+          vbox.check_guest_additions = false
+        end
       end
 
 Running Nightly Tests
@@ -173,7 +173,7 @@ Running Nightly Tests
 
 To run all of the Nightly tests, run the following command from the ``test`` directory:
 
-::
+.. code-block:: shell-session
 
     ginkgo --focus="Nightly"
 
@@ -188,7 +188,7 @@ Available CLI Options
 For more advanced workflows, check the list of available custom options for the Cilium
 framework in the ``test/`` directory and interact with ginkgo directly:
 
-::
+.. code-block:: shell-session
 
     $ cd test/
     $ ginkgo . -- -cilium.help
@@ -251,22 +251,22 @@ If you want to run one specified test, there are a few options:
   "focused" test. For more information, consult the `Focused Specs`_
   documentation from Ginkgo.
 
-::
+  .. code-block:: go
 
-    It("Example test", func(){
-        Expect(true).Should(BeTrue())
-    })
+      It("Example test", func(){
+          Expect(true).Should(BeTrue())
+      })
 
-    FIt("Example focused test", func(){
-        Expect(true).Should(BeTrue())
-    })
+      FIt("Example focused test", func(){
+          Expect(true).Should(BeTrue())
+      })
 
 
 * From the command line: specify a more granular focus if you want to focus on, say, Runtime L7 tests:
 
-::
+  .. code-block:: shell-session
 
-    ginkgo --focus "Runtime.*L7"
+      ginkgo --focus "Runtime.*L7"
 
 
 This will focus on tests that contain "Runtime", followed by any
@@ -282,9 +282,9 @@ Compiling the tests without running them
 To validate that the Go code you've written for testing is correct without
 needing to run the full test, you can build the test directory:
 
-::
+.. code-block:: shell-session
 
-	make -C test/ build
+    make -C test/ build
 
 Test Reports
 ~~~~~~~~~~~~
@@ -302,7 +302,7 @@ Best Practices for Writing Tests
 * Leave the testing environment in the same state that it was in when the test started by deleting resources, resetting configuration, etc.
 * Gather logs in the case that a test fails. If a test fails while running on Jenkins, a postmortem needs to be done to analyze why. So, dumping logs to a location where Jenkins can pick them up is of the highest imperative. Use the following code in an ``AfterFailed`` method:
 
-::
+.. code-block:: go
 
 	AfterFailed(func() {
 		vm.ReportFailed()
@@ -362,8 +362,7 @@ Example Test Layout
 Here is an example layout of how a test may be written with the aforementioned
 constructs:
 
-Test description diagram:
-::
+Test description diagram::
 
     Describe
         BeforeAll(A)
@@ -385,8 +384,7 @@ Test description diagram:
             TESTB3
 
 
-Test execution flow:
-::
+Test execution flow::
 
     Describe
         BeforeAll
@@ -418,7 +416,7 @@ You can retrieve all run commands and their output in the report directory
 a file called log where all information is saved, in case of a failing
 test an exhaustive data will be added.
 
-::
+.. code-block:: shell-session
 
 	$ head test/test_results/RuntimeKafkaKafkaPolicyIngress/logs
 	level=info msg=Starting testName=RuntimeKafka
@@ -444,7 +442,7 @@ code, and run ginkgo using ``dlv``.
 
 Example how to run ginkgo using ``dlv``:
 
-::
+.. code-block:: shell-session
 
 	dlv test . -- --ginkgo.focus="Runtime" -ginkgo.v=true --cilium.provision=false
 
@@ -479,7 +477,7 @@ This mode expects:
 
 An example invocation is
 
-::
+.. code-block:: shell-session
 
   CNI_INTEGRATION=eks K8S_VERSION=1.16 ginkgo --focus="K8s" -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.passCLIEnvironment=true
 
@@ -503,7 +501,7 @@ cluster.
           the value of the cluster IPv4 CIDR returned by the ``gcloud container
           clusters describe`` command.
 
-::
+.. code-block:: shell-session
 
   export CLUSTER_NAME=cluster1
   export CLUSTER_ZONE=us-west2-a
@@ -522,17 +520,17 @@ Not all tests can succeed on EKS. Many do, however and may be useful.
 :gh-issue:`9678#issuecomment-749350425` contains a list of tests that are still
 failing.
 
-1- Setup a cluster as in :ref:`k8s_install_quick` or utilize an existing
-cluster.
+1. Setup a cluster as in :ref:`k8s_install_quick` or utilize an existing
+   cluster.
 
-2- Source the testing integration script from ``cilium/contrib/testing/integrations.sh``.
+2. Source the testing integration script from ``cilium/contrib/testing/integrations.sh``.
 
-3- Invoke the ``gks`` function by passing which ``cilium`` docker image to run and the test focus. The command also
-accepts additional ginkgo arguments.
+3. Invoke the ``gks`` function by passing which ``cilium`` docker image to run
+   and the test focus. The command also accepts additional ginkgo arguments.
 
-::
+.. code-block:: shell-session
 
-  gks quay.io/cilium/cilium:latest K8sDemo
+    gks quay.io/cilium/cilium:latest K8sDemo
 
 
 Adding new Managed Kubernetes providers
@@ -543,22 +541,23 @@ file.  This isn't always adequate, however, and adding defaults specific to
 each provider is possible. The `commit adding GKE <https://github.com/cilium/cilium/commit/c2d8445fd725c515a635c8c3ad3be901a08084eb>`_
 support is a good reference.
 
-1- Add a map of helm settings to act as an override for this provider in
-`test/helpers/kubectl.go <https://github.com/cilium/cilium/blob/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers/kubectl.go#L80-L102>`_.
-These should be the helm settings used when generating cilium specs for this provider.
+1. Add a map of helm settings to act as an override for this provider in
+   `test/helpers/kubectl.go <https://github.com/cilium/cilium/blob/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers/kubectl.go#L80-L102>`_.
+   These should be the helm settings used when generating cilium specs for this
+   provider.
 
-2- Add a unique `CI Integration constant <https://github.com/cilium/cilium/blob/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers/kubectl.go#L66-L67>`_.
-This value is passed in when invoking ginkgo via the ``CNI_INTEGRATON``
-environment variable.
+2. Add a unique `CI Integration constant <https://github.com/cilium/cilium/blob/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers/kubectl.go#L66-L67>`_.
+   This value is passed in when invoking ginkgo via the ``CNI_INTEGRATON``
+   environment variable.
 
-3- Update the `helm overrides <https://github.com/cilium/cilium/blob/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers/kubectl.go#L138-L147>`_
-mapping with the constant and the helm settings.
+3. Update the `helm overrides <https://github.com/cilium/cilium/blob/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers/kubectl.go#L138-L147>`_
+   mapping with the constant and the helm settings.
 
-4- For cases where a test should be skipped use the ``SkipIfIntegration``. To
-skip whole contexts, use ``SkipContextIf``. More complex logic can be expressed
-with functions like ``IsIntegration``. These functions are all part of the
-`test/helpers <https://github.com/cilium/cilium/tree/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers>`_
-package.
+4. For cases where a test should be skipped use the ``SkipIfIntegration``. To
+   skip whole contexts, use ``SkipContextIf``. More complex logic can be
+   expressed with functions like ``IsIntegration``. These functions are all
+   part of the `test/helpers <https://github.com/cilium/cilium/tree/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers>`_
+   package.
 
 Running End-To-End Tests In Other Environments via SSH
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -595,7 +594,7 @@ An example ``ssh-config`` can be the following:
 
 To run this you can use the following command:
 
-::
+.. code-block:: shell-session
 
     ginkgo -- --cilium.provision=false --cilium.SSHConfig="cat ssh-config"
 

--- a/Documentation/contributing/testing/unit.rst
+++ b/Documentation/contributing/testing/unit.rst
@@ -21,7 +21,7 @@ Prerequisites
 Some tests interact with the kvstore and depend on a local kvstore instances of
 both etcd and consul. To start the local instances, run:
 
-::
+.. code-block:: shell-session
 
      $ make start-kvstores
 
@@ -31,7 +31,7 @@ Running all tests
 To run unit tests over the entire repository, run the following command in the
 project root directory:
 
-::
+.. code-block:: shell-session
 
     $ make unit-tests
 
@@ -41,7 +41,7 @@ Testing individual packages
 It is possible to test individual packages by invoking ``go test`` directly.
 You can then ``cd`` into the package subject to testing and invoke go test:
 
-::
+.. code-block:: shell-session
 
     $ cd pkg/kvstore
     $ go test
@@ -50,7 +50,7 @@ You can then ``cd`` into the package subject to testing and invoke go test:
 If you need more verbose output, you can pass in the ``-check.v`` and
 ``-check.vv`` arguments:
 
-::
+.. code-block:: shell-session
 
     $ cd pkg/kvstore
     $ go test -check.v -check.vv
@@ -59,7 +59,7 @@ If the unit tests have some prerequisites like :ref:`unit_testing_prerequisites`
 you can use the following command to automatically set up the prerequisites,
 run the unit tests and tear down the prerequisites:
 
-::
+.. code-block:: shell-session
 
     $ make unit-tests TESTPKGS=pkg/kvstore
 
@@ -75,16 +75,16 @@ There are two ways that you can run the 'privileged' tests.
 
 1. To run all the 'privileged' tests for cilium follow the instructions below.
 
-::
+    .. code-block:: shell-session
 
-    $ sudo -E make tests-privileged
+        $ sudo -E make tests-privileged
 
 2. To run a specific package 'privileged' test, follow the instructions below.
    Here for example we are trying to run the tests for 'routing' package.
 
-::
+    .. code-block:: shell-session
 
-    $ TESTPKGS="pkg/aws/eni/routing" sudo -E make tests-privileged
+        $ TESTPKGS="pkg/aws/eni/routing" sudo -E make tests-privileged
 
 Running individual tests
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ Running individual tests
 Due to the use of gocheck, the standard ``go test -run`` will not work,
 instead, the ``-check.f`` argument has to be specified:
 
-::
+.. code-block:: shell-session
 
     $ go test -check.f TestParallelAllocation
 
@@ -106,7 +106,7 @@ will watch for changes in a directory and run the unit tests for that package
 any time the files change. For example, if writing unit tests in ``pkg/policy``,
 run this in a terminal next to your editor:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ . contrib/shell/test.sh
     $ watchtest pkg/policy

--- a/Documentation/gettingstarted/aws.rst
+++ b/Documentation/gettingstarted/aws.rst
@@ -71,7 +71,7 @@ with each empty string replaced by the associated value as a base64-encoded stri
 
 The base64 command line utility can be used to generate each value, for example:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ echo -n "eu-west-1"  | base64
     ZXUtd2VzdC0x
@@ -79,7 +79,7 @@ The base64 command line utility can be used to generate each value, for example:
 This secret stores the AWS credentials, which will be used to connect the AWS
 API.
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl create -f cilium-secret.yaml
 
@@ -120,7 +120,7 @@ for debugging purposes:
 
 To list all of the available AWS instances, the following command can be used:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
    $ kubectl  -n kube-system exec -ti testing-aws-pod -- aws ec2 describe-instances
 
@@ -129,7 +129,7 @@ restarted in order to pick up the credentials in the secret.
 To do this, identify and delete the existing cilium-operator pod, which will be
 recreated automatically:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl get pods -l name=cilium-operator -n kube-system
     NAME                              READY   STATUS    RESTARTS   AGE
@@ -141,7 +141,8 @@ recreated automatically:
 
 It is important for this demo that ``coredns`` is working correctly. To know the
 status of ``coredns`` you can run the following command:
-::
+
+.. code-block:: shell-session
 
     $ kubectl get deployment kube-dns -n kube-system
     NAME       DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
@@ -194,7 +195,7 @@ get pods,svc`` will inform you about the progress of the operation.  Each pod
 will go through several states until it reaches ``Running`` at which point the
 pod is ready.
 
-::
+.. code-block:: shell-session
 
     $ kubectl get pods,svc
     NAME                             READY     STATUS    RESTARTS   AGE
@@ -247,7 +248,7 @@ set of CIDRs that correspond to the specification in ToGroups, e.g., the IPs of
 all instances that are part of a specified security group. The list of IPs will
 be updated periodically.
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl get cnp
     NAME                                                             AGE
@@ -256,7 +257,7 @@ be updated periodically.
 
 Eventually, the derivative policy will contain IPs in the ToCIDR section:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
    $ kubectl get cnp to-groups-sample-togroups-044ba7d1-f491-11e8-ad2e-080027d2d952
 
@@ -331,7 +332,7 @@ The derivative rule should contain the following information:
 The Cilium Endpoint status for the *xwing* should have policy enforcement
 enabled only for egress connectivity:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl get cep xwing
     NAME    ENDPOINT ID   IDENTITY ID   POLICY ENFORCEMENT   ENDPOINT STATE   IPV4         IPV6

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -62,9 +62,9 @@ on all Cilium managed nodes.
 
 Verify that the Cilium Pod has come up correctly:
 
-.. code:: bash
+.. code-block:: shell-session
 
-    kubectl -n kube-system get pods -l k8s-app=cilium
+    $ kubectl -n kube-system get pods -l k8s-app=cilium
     NAME                READY     STATUS    RESTARTS   AGE
     cilium-crf7f        1/1       Running   0          10m
 
@@ -73,16 +73,16 @@ the ``cilium status`` CLI command provides visibility through the ``BandwidthMan
 info line. It also dumps a list of devices on which the egress bandwidth limitation
 is enforced:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
-    kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep BandwidthManager
+    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep BandwidthManager
     BandwidthManager:       EDT with BPF   [eth0]
 
 Assuming we have a multi-node cluster, in the next step, we deploy a netperf Pod on
 the node named foobar. The following example deployment yaml limits the egress
 bandwidth of the netperf Pod on the node's physical device:
 
-.. parsed-literal::
+.. code-block:: yaml
 
     apiVersion: apps/v1
     kind: Deployment
@@ -111,9 +111,9 @@ Once up and running, ``netperf`` client can be invoked from a different node in 
 cluster using the Pod's IP (in this case ``10.217.0.254``) directly. The test streaming
 direction is from the netperf deployment towards the client, hence ``TCP_MAERTS``:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
-  netperf -t TCP_MAERTS -H 10.217.0.254
+  $ netperf -t TCP_MAERTS -H 10.217.0.254
   MIGRATED TCP MAERTS TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.217.0.254 () port 0 AF_INET
   Recv   Send    Send
   Socket Socket  Message  Elapsed
@@ -127,9 +127,9 @@ As can be seen, egress traffic of the netperf Pod has been limited to 10Mbit per
 In order to introspect current endpoint bandwidth settings from BPF side, the following
 command can be run:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
-    kubectl exec -it -n kube-system cilium-xxxxx -- cilium bpf bandwidth list
+    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium bpf bandwidth list
     IDENTITY   EGRESS BANDWIDTH (BitsPerSec)
     491        10M
 

--- a/Documentation/gettingstarted/cassandra.rst
+++ b/Documentation/gettingstarted/cassandra.rst
@@ -77,7 +77,7 @@ Running ``kubectl get svc,pods`` will inform you about the progress of the opera
 Each pod will go through several states until it reaches ``Running`` at which
 point the setup is ready.
 
-::
+.. code-block:: shell-session
 
     $ kubectl get svc,pods
     NAME                    TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
@@ -101,7 +101,7 @@ First, we'll create the keyspaces and tables mentioned above, and populate them 
 
 Next, create two environment variables that refer to the *empire-hq* and *empire-outpost* pods:
 
-::
+.. code-block:: shell-session
 
    $ HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}')
    $ OUTPOST_POD=$(kubectl get pods -l app=empire-outpost -o jsonpath='{.items[0].metadata.name}')
@@ -110,7 +110,7 @@ Next, create two environment variables that refer to the *empire-hq* and *empire
 Now we will run the 'cqlsh' Cassandra client in the *empire-outpost* pod, telling it to access
 the Cassandra cluster identified by the 'cassandra-svc' DNS name:
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec -it $OUTPOST_POD -- cqlsh cassandra-svc
     Connected to Test Cluster at cassandra-svc:9042.
@@ -121,7 +121,7 @@ the Cassandra cluster identified by the 'cassandra-svc' DNS name:
 Next, using the cqlsh prompt, we'll show that the outpost can add records to the "daily_records" table
 in the "attendance" keyspace:
 
-::
+.. code-block:: shell-session
 
     cqlsh> INSERT INTO attendance.daily_records (creation, loc_id, present, empire_member_id) values (now(), 074AD3B9-A47D-4EBC-83D3-CAD75B1911CE, true, 6AD3139F-EBFC-4E0C-9F79-8F997BA01D90);
 
@@ -137,7 +137,7 @@ but it could read all entries as well.
 
 To see this, we can run the following command:
 
-::
+.. code-block:: shell-session
 
   $ cqlsh> SELECT * FROM attendance.daily_records;
 
@@ -163,7 +163,7 @@ Uh oh!  The rebels now has strategic information about empire troop strengths at
 But even more nasty from a security perspective is that the outpost container can also access information in any keyspace,
 including the deathstar keyspace.  For example, run:
 
-::
+.. code-block:: shell-session
 
  $ cqlsh> SELECT * FROM deathstar.scrum_notes;
 
@@ -221,7 +221,7 @@ Apply this Cassandra-aware network security policy using ``kubectl`` in a new wi
 
 If we then again try to perform the attacks from the *empire-outpost* pod, we'll see that they are denied:
 
-::
+.. code-block:: shell-session
 
   $ cqlsh> SELECT * FROM attendance.daily_records;
   Unauthorized: Error from server: code=2100 [Unauthorized] message="Request Unauthorized"
@@ -235,7 +235,7 @@ could easily be confused with a network error), but rather we respond with the C
 Likewise, if the outpost pod ever tries to access a table in another keyspace, like deathstar, this request will also be
 denied:
 
-::
+.. code-block:: shell-session
 
   $ cqlsh> SELECT * FROM deathstar.scrum_notes;
   Unauthorized: Error from server: code=2100 [Unauthorized] message="Request Unauthorized"
@@ -244,7 +244,7 @@ This is blocked as well, thanks to the Cilium network policy.
 
 Use another window to confirm that the *empire-hq* pod still has full access to the cassandra cluster:
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec -it $HQ_POD -- cqlsh cassandra-svc
     Connected to Test Cluster at cassandra-svc:9042.
@@ -255,7 +255,7 @@ Use another window to confirm that the *empire-hq* pod still has full access to 
 The power of Cilium's identity-based security allows *empire-hq* to still have full access
 to both tables:
 
-::
+.. code-block:: shell-session
 
 
   $ cqlsh> SELECT * FROM attendance.daily_records;
@@ -270,7 +270,7 @@ to both tables:
 
 Similarly, the deathstar can still access the scrum notes:
 
-::
+.. code-block:: shell-session
 
   $ cqlsh> SELECT * FROM deathstar.scrum_notes;
 
@@ -284,7 +284,7 @@ Cassandra-Aware Visibility (Bonus)
 As a bonus, you can re-run the above queries with policy enforced and view how Cilium provides Cassandra-aware visibility, including
 whether requests are forwarded or denied.   First, use "kubectl exec" to access the cilium pod.
 
-::
+.. code-block:: shell-session
 
   $ CILIUM_POD=$(kubectl get pods -n kube-system -l k8s-app=cilium -o jsonpath='{.items[0].metadata.name}')
   $ kubectl exec -it -n kube-system $CILIUM_POD -- /bin/bash

--- a/Documentation/gettingstarted/clustermesh/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh/clustermesh.rst
@@ -240,14 +240,14 @@ Use the following list of steps to troubleshoot issues with ClusterMesh:
  #. Validate that the ``cilium-xxx`` as well as the ``cilium-operator-xxx`` pods
     are healthy and ready. 
 
-    .. code:: bash
+    .. code-block:: shell-session
 
        cilium status --context $CLUSTER1
        cilium status --context $CLUSTER2
 
  #. Validate the Cluster Mesh is enabled correctly and operational:
 
-    .. code:: bash
+    .. code-block:: shell-session
 
        cilium clustermesh status --context $CLUSTER1
        cilium clustermesh status --context $CLUSTER2

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -35,7 +35,7 @@ desired CNI chaining configuration. This ConfigMap will be installed as the CNI
 configuration file on all nodes and defines the chaining configuration. In the
 example below, the Azure CNI, portmap, and Cilium are chained together.
 
-.. code:: yaml
+.. code-block:: yaml
 
     apiVersion: v1
     kind: ConfigMap
@@ -69,7 +69,7 @@ example below, the Azure CNI, portmap, and Cilium are chained together.
 
 Deploy the `ConfigMap`:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl apply -f chaining.yaml
 

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -20,7 +20,7 @@ Create a ``chaining.yaml`` file based on the following template to specify the
 desired CNI chaining configuration:
 
 
-.. code:: yaml
+.. code-block:: yaml
 
     apiVersion: v1
     kind: ConfigMap
@@ -61,7 +61,7 @@ desired CNI chaining configuration:
 
 Deploy the `ConfigMap`:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl apply -f chaining.yaml
 

--- a/Documentation/gettingstarted/cni-chaining-generic-veth.rst
+++ b/Documentation/gettingstarted/cni-chaining-generic-veth.rst
@@ -24,7 +24,7 @@ Validate that the current CNI plugin is using veth
    able spot network devices representing the pods running on that node.
 3. A network device might look something like this:
 
-   .. code:: bash
+   .. code-block:: shell-session
 
        103: lxcb3901b7f9c02@if102: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
            link/ether 3a:39:92:17:75:6f brd ff:ff:ff:ff:ff:ff link-netnsid 18 promiscuity 0
@@ -43,7 +43,7 @@ Create a ``chaining.yaml`` file based on the following template to specify the
 desired CNI chaining configuration:
 
 
-.. code:: yaml
+.. code-block:: yaml
 
     apiVersion: v1
     kind: ConfigMap
@@ -68,7 +68,7 @@ desired CNI chaining configuration:
 
 Deploy the `ConfigMap`:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl apply -f chaining.yaml
 

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -20,7 +20,7 @@ Create a ``chaining.yaml`` file based on the following template to specify the
 desired CNI chaining configuration:
 
 
-.. code:: yaml
+.. code-block:: yaml
 
     apiVersion: v1
     kind: ConfigMap
@@ -51,7 +51,7 @@ desired CNI chaining configuration:
 
 Deploy the `ConfigMap`:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl apply -f chaining.yaml
 

--- a/Documentation/gettingstarted/elasticsearch.rst
+++ b/Documentation/gettingstarted/elasticsearch.rst
@@ -42,7 +42,7 @@ Deploy the app using command below, which will create
     pod "empire-hq" created
     pod "spaceship" created
 
-::
+.. code-block:: shell-session
 
     $ kubectl get svc,pods
     NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                           AGE
@@ -65,7 +65,7 @@ For Elasticsearch clusters the **least privilege security** challenge is to give
 
 ``outpost`` client uploading troop logs 
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec outpost -- python upload_logs.py 
     Uploading Stormtroopers Performance Logs
@@ -73,7 +73,7 @@ For Elasticsearch clusters the **least privilege security** challenge is to give
 
 ``spaceship`` uploading diagnostics
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec spaceship -- python upload_diagnostics.py 
     Uploading Spaceship Diagnostics
@@ -81,7 +81,7 @@ For Elasticsearch clusters the **least privilege security** challenge is to give
 
 ``empire-hq`` running search queries for logs and diagnostics
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec empire-hq -- python search.py 
     Searching for Spaceship Diagnostics
@@ -98,7 +98,7 @@ For Elasticsearch clusters the **least privilege security** challenge is to give
 
 Now imagine an outpost captured by the rebels. In the commands below, the rebels first search all the indices and then manipulate the diagnostics data from a compromised outpost. 
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec outpost -- python search.py 
     Searching for Spaceship Diagnostics
@@ -115,7 +115,7 @@ Now imagine an outpost captured by the rebels. In the commands below, the rebels
 Rebels manipulate spaceship diagnostics data so that the spaceship defects are not known to the empire-hq! (Hint: Rebels have changed the ``stats`` for the tiefighter spaceship, a change hard to detect but with adverse impact!)
 
 
-:: 
+.. code-block:: shell-session
 
     $ kubectl exec outpost -- python update.py 
     Uploading Spaceship Diagnostics
@@ -158,7 +158,7 @@ Apply this Elasticsearch-aware network security policy using ``kubectl``:
 
 Let's test the security policies. Firstly, the search access is blocked for both outpost and spaceship. So from a compromised outpost, rebels will not be able to search and obtain knowledge about troops and spaceship diagnostics. Secondly, the outpost clients don't have access to create or update the ``index: spaceship_diagnostics``. 
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec outpost -- python search.py 
     GET http://elasticsearch:9200/spaceship_diagnostics/_search [status:403 request:0.008s]
@@ -167,7 +167,7 @@ Let's test the security policies. Firstly, the search access is blocked for both
     elasticsearch.exceptions.AuthorizationException: TransportError(403, 'Access denied\r\n')
     command terminated with exit code 1
 
-:: 
+.. code-block:: shell-session
 
     $ kubectl exec outpost -- python update.py 
     PUT http://elasticsearch:9200/spaceship_diagnostics/stats/1 [status:403 request:0.006s]
@@ -178,7 +178,7 @@ Let's test the security policies. Firstly, the search access is blocked for both
 
 We can re-run any of the below commands to show that the security policy still allows all legitimate requests (i.e., no 403 errors are returned).
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec outpost -- python upload_logs.py 
     ...

--- a/Documentation/gettingstarted/external-workloads.rst
+++ b/Documentation/gettingstarted/external-workloads.rst
@@ -234,7 +234,7 @@ From the external workload, ping the backend IP of ``clustermesh-apiserver`` ser
 
 The ping should keep running also when the following CCNP is applied in your cluster:
 
-.. parsed-literal::
+.. code-block:: yaml
 
     apiVersion: cilium.io/v2
     kind: CiliumClusterwideNetworkPolicy
@@ -256,7 +256,7 @@ The ping should keep running also when the following CCNP is applied in your clu
 
 The ping should stop if you delete these lines from the policy (e.g., ``kubectl edit ccnp test-ccnp``):
 
-.. parsed-literal::
+.. code-block:: yaml
 
       - fromEndpoints:
         - matchLabels:

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -87,7 +87,7 @@ How to access Grafana
 
 Expose the port on your local machine
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl -n cilium-monitoring port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000
 
@@ -98,7 +98,7 @@ How to access Prometheus
 
 Expose the port on your local machine
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl -n cilium-monitoring port-forward service/prometheus --address 0.0.0.0 --address :: 9090:9090
 

--- a/Documentation/gettingstarted/grpc.rst
+++ b/Documentation/gettingstarted/grpc.rst
@@ -17,7 +17,8 @@ minutes.
 
 It is important for this demo that ``kube-dns`` is working correctly. To know the
 status of ``kube-dns`` you can run the following command:
-::
+
+.. code-block:: shell-session
 
     $ kubectl get deployment kube-dns -n kube-system
     NAME       DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
@@ -106,7 +107,7 @@ Kubernetes will deploy the pods and service in the background. Running
 Each pod will go through several states until it reaches ``Running`` at which
 point the setup is ready.
 
-::
+.. code-block:: shell-session
 
     $ kubectl get pods,svc
     NAME                                 READY     STATUS    RESTARTS   AGE
@@ -127,7 +128,7 @@ exists in the *terminal-87* container.
 We'll invoke the 'cc_door_client' with the name of the gRPC method to call, and any
 parameters (in this case, the door-id):
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec terminal-87 -- python3 /cloudcity/cc_door_client.py GetName 1
     Door name is: Spaceport Door #1
@@ -146,7 +147,8 @@ the fine-grained nature of gRPC calls that R2-D2 exploited to override the secur
 and help the rebels escape.
 
 To see this, run:
-::
+
+.. code-block:: shell-session
 
     $ kubectl exec terminal-87 -- python3 /cloudcity/cc_door_client.py SetAccessCode 1 999
     Successfully set AccessCode to 999
@@ -196,7 +198,7 @@ Apply this gRPC-aware network security policy using ``kubectl`` in the main wind
 After this security policy is in place, access to the innocuous calls like ``GetLocation``
 still works as intended:
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec terminal-87 -- python3 /cloudcity/cc_door_client.py GetLocation 1
     Door location is lat = 10.222200393676758 long = 68.87879943847656
@@ -204,7 +206,7 @@ still works as intended:
 
 However, if we then again try to invoke ``SetAccessCode``, it is denied:
 
-::
+.. code-block:: shell-session
 
     $ kubectl exec terminal-87 -- python3 /cloudcity/cc_door_client.py SetAccessCode 1 999
 

--- a/Documentation/gettingstarted/gsg_sw_demo.rst
+++ b/Documentation/gettingstarted/gsg_sw_demo.rst
@@ -29,7 +29,7 @@ Kubernetes will deploy the pods and service in the background.  Running
 Each pod will go through several states until it reaches ``Running`` at which
 point the pod is ready.
 
-::
+.. code-block:: shell-session
 
     $ kubectl get pods,svc
     NAME                             READY   STATUS    RESTARTS   AGE
@@ -45,7 +45,7 @@ point the pod is ready.
 Each pod will be represented in Cilium as an :ref:`endpoint`. We can invoke the
 ``cilium`` tool inside the Cilium pod to list them:
 
-::
+.. code-block:: shell-session
 
     $ kubectl -n kube-system get pods -l k8s-app=cilium
     NAME           READY   STATUS    RESTARTS   AGE

--- a/Documentation/gettingstarted/host-services.rst
+++ b/Documentation/gettingstarted/host-services.rst
@@ -52,9 +52,9 @@ and therefore no additional lower layer NAT is required.
 
 Verify that it has come up correctly:
 
-.. code:: bash
+.. code-block:: shell-session
 
-    kubectl -n kube-system get pods -l k8s-app=cilium
+    $ kubectl -n kube-system get pods -l k8s-app=cilium
     NAME                READY     STATUS    RESTARTS   AGE
     cilium-crf7f        1/1       Running   0          10m
 

--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -4,7 +4,7 @@
 
       Download the latest hubble release:
 
-      .. parsed-literal::
+      .. code-block:: shell-session
 
          export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
          curl -L --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-amd64.tar.gz{,.sha256sum}
@@ -16,7 +16,7 @@
 
       Download the latest hubble release:
 
-      .. parsed-literal::
+      .. code-block:: shell-session
 
          export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
          curl -L --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-amd64.tar.gz{,.sha256sum}
@@ -28,7 +28,7 @@
 
       Download the latest hubble release:
 
-      .. parsed-literal::
+      .. code-block:: shell-session
 
          curl -LO "https://raw.githubusercontent.com/cilium/hubble/master/stable.txt"
          set /p HUBBLE_VERSION=<stable.txt

--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -87,11 +87,11 @@ application of any type.
 Once the deployment is ready, issue a request from both spaceships to emulate
 some traffic.
 
-.. parsed-literal::
+.. code-block:: shell-session
 
-    kubectl exec xwing -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec xwing -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
     Ship landed
-    kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
     Ship landed
 
 These requests will then be displayed in the UI as service dependencies between

--- a/Documentation/gettingstarted/hubble_setup.rst
+++ b/Documentation/gettingstarted/hubble_setup.rst
@@ -34,7 +34,7 @@ Enable Hubble in Cilium
 
         .. code-block:: shell-session
 
-            cilium hubble enable
+            $ cilium hubble enable
             🔑 Found existing CA in secret cilium-ca
             ✨ Patching ConfigMap cilium-config to enable Hubble...
             ♻️  Restarted Cilium pods
@@ -61,7 +61,7 @@ Enable Hubble in Cilium
 
         .. code-block:: shell-session
 
-            cilium status
+            $ cilium status
                 /¯¯\
              /¯¯\__/¯¯\    Cilium:         OK
              \__/¯¯\__/    Operator:       OK
@@ -111,15 +111,15 @@ cluster. For more information on this method, see `Use Port Forwarding to Access
 
 .. code-block:: shell-session
 
-    cilium hubble port-forward&
+    $ cilium hubble port-forward&
     Forwarding from 0.0.0.0:4245 -> 4245
     Forwarding from [::]:4245 -> 4245
 
 Now you can validate that you can access the Hubble API via the installed CLI:
 
-.. code:: shell-session
+.. code-block:: shell-session
 
-    hubble status
+    $ hubble status
     Healthcheck (via localhost:4245): Ok
     Current/Max Flows: 11917/12288 (96.98%)
     Flows/s: 11.74
@@ -127,9 +127,9 @@ Now you can validate that you can access the Hubble API via the installed CLI:
 
 You can also query the flow API and look for flows:
 
-.. code:: bash
+.. code-block:: shell-session
 
-   hubble observe
+   $ hubble observe
 
 .. note::
 

--- a/Documentation/gettingstarted/ipam-cluster-pool.rst
+++ b/Documentation/gettingstarted/ipam-cluster-pool.rst
@@ -42,9 +42,9 @@ Validate installation
 
 #. Validate that Cilium has started up correctly
 
-   ::
+   .. code-block:: shell-session
 
-           cilium status --all-addresses
+           $ cilium status --all-addresses
            KVStore:                Ok   etcd: 1/1 connected, has-quorum=true: https://192.168.33.11:2379 - 3.3.12 (Leader)
            [...]
            IPAM:                   IPv4: 2/256 allocated,
@@ -54,9 +54,9 @@ Validate installation
 
 #. Validate the ``spec.ipam.podCIDRs`` section:
 
-   ::
+   .. code-block:: shell-session
 
-       kubectl get cn k8s1 -o yaml
+       $ kubectl get cn k8s1 -o yaml
        apiVersion: cilium.io/v2
        kind: CiliumNode
        metadata:

--- a/Documentation/gettingstarted/ipam-crd.rst
+++ b/Documentation/gettingstarted/ipam-crd.rst
@@ -30,9 +30,9 @@ Enable CRD IPAM mode
 
 #. Validate that the CRD has been registered:
 
-   ::
+   .. code-block:: shell-session
 
-	   kubectl get crds
+	   $ kubectl get crds
 	   NAME                              CREATED AT
 	   [...]
 	   ciliumnodes.cilium.io             2019-06-08T12:26:41Z
@@ -58,9 +58,9 @@ Create a CiliumNode CR
 
 #. Validate that Cilium has started up correctly
 
-   ::
+   .. code-block:: shell-session
 
-           cilium status --all-addresses
+           $ cilium status --all-addresses
            KVStore:                Ok   etcd: 1/1 connected, has-quorum=true: https://192.168.33.11:2379 - 3.3.12 (Leader)
            [...]
            IPAM:                   IPv4: 2/4 allocated,
@@ -70,9 +70,9 @@ Create a CiliumNode CR
 
 #. Validate the ``status.IPAM.used`` section:
 
-   ::
+   .. code-block:: shell-session
 
-       kubectl get cn k8s1 -o yaml
+       $ kubectl get cn k8s1 -o yaml
        apiVersion: cilium.io/v2
        kind: CiliumNode
        metadata:

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -105,9 +105,9 @@ masquerading all traffic leaving the node:
 
 Verify that it has come up correctly:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
-    kubectl -n kube-system get pods -l k8s-app=cilium
+    $ kubectl -n kube-system get pods -l k8s-app=cilium
     NAME                READY     STATUS    RESTARTS   AGE
     cilium-crf7f        1/1       Running   0          10m
 

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -43,15 +43,15 @@ Download the `cilium enhanced istioctl version 1.8.2 <https://github.com/cilium/
 .. tabs::
   .. group-tab:: Linux
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
-     curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-linux-amd64.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-linux-amd64.tar.gz | tar xz
 
   .. group-tab:: OSX
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
-     curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-osx.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-osx.tar.gz | tar xz
 
 .. note::
 
@@ -60,13 +60,13 @@ Download the `cilium enhanced istioctl version 1.8.2 <https://github.com/cilium/
 
 Deploy the default Istio configuration profile onto Kubernetes:
 
-::
+.. code-block:: shell-session
 
     ./cilium-istioctl install -y
 
 Add a namespace label to instruct Istio to automatically inject Envoy sidecar proxies when you deploy your application later:
 
-::
+.. code-block:: shell-session
 
     kubectl label namespace default istio-injection=enabled
 
@@ -115,9 +115,9 @@ To deploy the application with manual sidecar injection, run:
 Check the progress of the deployment (every service should have an
 ``AVAILABLE`` count of ``1``):
 
-::
+.. code-block:: shell-session
 
-    watch "kubectl get deployments"
+    $ watch "kubectl get deployments"
     NAME             READY   UP-TO-DATE   AVAILABLE   AGE
     details-v1       1/1     1            1           12s
     productpage-v1   1/1     1            1           13s
@@ -145,7 +145,7 @@ Create an Istio ingress gateway for the productpage service:
 
 To obtain the URL to the frontend productpage service, run:
 
-::
+.. code-block:: shell-session
 
     export GATEWAY_URL=http://$(minikube ip):$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
     export PRODUCTPAGE_URL=${GATEWAY_URL}/productpage
@@ -194,9 +194,9 @@ Deploy the ``ratings v1`` and ``reviews v2`` services:
 Check the progress of the deployment (every service should have an
 ``AVAILABLE`` count of ``1``):
 
-::
+.. code-block:: shell-session
 
-    watch "kubectl get deployments"
+    $ watch "kubectl get deployments"
     NAME             READY   UP-TO-DATE   AVAILABLE   AGE
     details-v1       1/1     1            1           17m
     productpage-v1   1/1     1            1           17m
@@ -227,10 +227,10 @@ running ``curl`` from within the pod:
    All traffic from ``reviews v1`` to ``ratings`` is blocked, so the
    connection attempt fails after the connection timeout.
 
-::
+.. code-block:: shell-session
 
-    export POD_REVIEWS_V1=`kubectl get pods -l app=reviews,version=v1 -o jsonpath='{.items[0].metadata.name}'`
-    kubectl exec ${POD_REVIEWS_V1} -c istio-proxy -ti -- curl --connect-timeout 5 --fail http://ratings:9080/ratings/0
+    $ export POD_REVIEWS_V1=`kubectl get pods -l app=reviews,version=v1 -o jsonpath='{.items[0].metadata.name}'`
+    $ kubectl exec ${POD_REVIEWS_V1} -c istio-proxy -ti -- curl --connect-timeout 5 --fail http://ratings:9080/ratings/0
     curl: (28) Connection timed out after 5001 milliseconds
     command terminated with exit code 28
 
@@ -305,14 +305,14 @@ REST API, under the ``/api/v1`` HTTP URI path:
 Check that the full REST API is currently accessible in ``v1`` and
 returns valid JSON data:
 
-::
+.. code-block:: shell-session
 
     for APIPATH in /api/v1/products /api/v1/products/0 /api/v1/products/0/reviews /api/v1/products/0/ratings; do echo ; curl -s -S "${GATEWAY_URL}${APIPATH}" ; echo ; done
 
 
 The output will be similar to this:
 
-::
+.. code-block:: json
 
     [{"descriptionHtml": "<a href=\"https://en.wikipedia.org/wiki/The_Comedy_of_Errors\">Wikipedia Summary</a>: The Comedy of Errors is one of <b>William Shakespeare's</b> early plays. It is his shortest and one of his most farcical comedies, with a major part of the humour coming from slapstick and mistaken identity, in addition to puns and word play.", "id": 0, "title": "The Comedy of Errors"}]
 
@@ -345,16 +345,16 @@ deploy a Kafka broker:
 Wait until the ``kafka-v1-0`` pod is ready, i.e. until it has a
 ``READY`` count of ``1/1``:
 
-::
+.. code-block:: shell-session
 
-    watch "kubectl get pods -l app=kafka"
+    $ watch "kubectl get pods -l app=kafka"
     NAME         READY     STATUS    RESTARTS   AGE
     kafka-v1-0   1/1       Running   0          21m
 
 Create the ``authaudit`` Kafka topic, which will be used by
 ``productpage v2``:
 
-::
+.. code-block:: shell-session
 
     kubectl exec kafka-v1-0 -c kafka -- bash -c '/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --zookeeper localhost:2181/kafka --create --topic authaudit --partitions 1 --replication-factor 1'
 
@@ -392,9 +392,9 @@ this service:
 Check the progress of the deployment (every service should have an
 ``AVAILABLE`` count of ``1``):
 
-::
+.. code-block:: shell-session
 
-    watch "kubectl get deployments"
+    $ watch "kubectl get deployments"
     NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
     authaudit-logger-v1   1/1     1            1           41s
     details-v1            1/1     1            1           37m
@@ -406,13 +406,13 @@ Check the progress of the deployment (every service should have an
 Check that the product REST API is still accessible, and that Cilium
 now denies at Layer-7 any access to the reviews and ratings REST API:
 
-::
+.. code-block:: shell-session
 
     for APIPATH in /api/v1/products /api/v1/products/0 /api/v1/products/0/reviews /api/v1/products/0/ratings; do echo ; curl -s -S "${GATEWAY_URL}${APIPATH}" ; echo ; done
 
 The output will be similar to this:
 
-::
+.. code-block:: json
 
     [{"descriptionHtml": "<a href=\"https://en.wikipedia.org/wiki/The_Comedy_of_Errors\">Wikipedia Summary</a>: The Comedy of Errors is one of <b>William Shakespeare's</b> early plays. It is his shortest and one of his most farcical comedies, with a major part of the humour coming from slapstick and mistaken identity, in addition to puns and word play.", "id": 0, "title": "The Comedy of Errors"}]
 
@@ -433,13 +433,13 @@ this service's log. Note that you need to log in/out using the ``sign
 in``/``sign out`` element on the bookinfo web page. When you do, you
 can observe these kind of audit logs:
 
-::
+.. code-block:: shell-session
 
     export POD_LOGGER_V1=`kubectl get pods -l app=authaudit-logger,version=v1 -o jsonpath='{.items[0].metadata.name}'`
 
-::
+.. code-block:: shell-session
 
-    kubectl logs ${POD_LOGGER_V1} -c authaudit-logger
+    $ kubectl logs ${POD_LOGGER_V1} -c authaudit-logger
     ...
     {"timestamp": "2017-12-04T09:34:24.341668", "remote_addr": "10.15.28.238", "event": "login", "user": "richard"}
     {"timestamp": "2017-12-04T09:34:40.943772", "remote_addr": "10.15.28.238", "event": "logout", "user": "richard"}
@@ -470,9 +470,9 @@ ENTER, e.g. ``test message``)
 
    You can terminate the command with a single ``<CTRL>-d``.
 
-::
+.. code-block:: shell-session
 
-    kubectl exec ${POD_LOGGER_V1} -c authaudit-logger -ti -- /opt/kafka_2.11-0.10.1.0/bin/kafka-console-producer.sh --broker-list=kafka:9092 --topic=authaudit
+    $ kubectl exec ${POD_LOGGER_V1} -c authaudit-logger -ti -- /opt/kafka_2.11-0.10.1.0/bin/kafka-console-producer.sh --broker-list=kafka:9092 --topic=authaudit
     test message
     [2017-12-07 02:13:47,020] ERROR Error when sending message to topic authaudit with key: null, value: 12 bytes with error: (org.apache.kafka.clients.producer.internals.ErrorLoggingCallback)
     org.apache.kafka.common.errors.TopicAuthorizationException: Not authorized to access topics: [authaudit]
@@ -483,16 +483,16 @@ error for any ``Produce`` request from this service.
 Create another topic named ``credit-card-payments``, meant to transmit
 highly-sensitive credit card payment requests:
 
-::
+.. code-block:: shell-session
 
-    kubectl exec kafka-v1-0 -c kafka -- bash -c '/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --zookeeper localhost:2181/kafka --create --topic credit-card-payments --partitions 1 --replication-factor 1'
+    $ kubectl exec kafka-v1-0 -c kafka -- bash -c '/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --zookeeper localhost:2181/kafka --create --topic credit-card-payments --partitions 1 --replication-factor 1'
 
 Check that Cilium prevents the ``authaudit-logger`` service from
 fetching messages from this topic:
 
-::
+.. code-block:: shell-session
 
-    kubectl exec ${POD_LOGGER_V1} -c authaudit-logger -ti -- /opt/kafka_2.11-0.10.1.0/bin/kafka-console-consumer.sh --bootstrap-server=kafka:9092 --topic=credit-card-payments
+    $ kubectl exec ${POD_LOGGER_V1} -c authaudit-logger -ti -- /opt/kafka_2.11-0.10.1.0/bin/kafka-console-consumer.sh --bootstrap-server=kafka:9092 --topic=credit-card-payments
     [2017-12-07 03:08:54,513] WARN Not authorized to read from topic credit-card-payments. (org.apache.kafka.clients.consumer.internals.Fetcher)
     [2017-12-07 03:08:54,517] ERROR Error processing message, terminating consumer process:  (kafka.tools.ConsoleConsumer$)
     org.apache.kafka.common.errors.TopicAuthorizationException: Not authorized to access topics: [credit-card-payments]
@@ -513,7 +513,7 @@ You have now installed Cilium and Istio, deployed a demo app, and
 tested both Cilium's L3-L7 network security policies and Istio's
 service route rules.  To clean up, run:
 
-::
+.. code-block:: shell-session
 
     minikube delete
 

--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -23,7 +23,7 @@ Install a Master Node
 The first step is to install a K3s master node making sure to disable support
 for the default CNI plugin:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none' sh -
 
@@ -38,7 +38,7 @@ node using a node-token which can be found on the master node at
 Install K3s on agent nodes and join them to the master node making sure to
 replace the variables with values from your environment:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     curl -sfL https://get.k3s.io | K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
 
@@ -51,7 +51,8 @@ you need to configure your Kubernetes cluster to operate with Cilium.
 Mount the eBPF Filesystem
 =========================
 On each node, run the following to mount the eBPF Filesystem:
-::
+
+.. code-block:: shell-session
 
      sudo mount bpffs -t bpf /sys/fs/bpf
 

--- a/Documentation/gettingstarted/k8s-install-download-release.rst
+++ b/Documentation/gettingstarted/k8s-install-download-release.rst
@@ -13,7 +13,7 @@
 
    Setup Helm repository:
 
-   .. code:: bash
+   .. code-block:: shell-session
 
       helm repo add cilium https://helm.cilium.io/
 

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -59,9 +59,7 @@ Deploy Cilium release via Helm:
       --set "etcd.endpoints[2]=http://etcd-endpoint3:2379"
 
 If you do not want Cilium to store state in Kubernetes custom resources (CRDs),
-consider setting ``identityAllocationMode``:
-
-.. parsed-literal::
+consider setting ``identityAllocationMode``::
 
     --set identityAllocationMode=kvstore
 
@@ -72,7 +70,7 @@ Optional: Configure the SSL certificates
 Create a Kubernetes secret with the root certificate authority, and client-side
 key and certificate of etcd:
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl create secret generic -n kube-system cilium-etcd-secrets \
         --from-file=etcd-client-ca.crt=ca.crt \

--- a/Documentation/gettingstarted/k8s-install-kops.rst
+++ b/Documentation/gettingstarted/k8s-install-kops.rst
@@ -40,7 +40,7 @@ Installing kops
 .. tabs::
   .. group-tab:: Linux
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
         curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
         chmod +x kops-linux-amd64
@@ -48,7 +48,7 @@ Installing kops
 
   .. group-tab:: MacOS
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
         brew update && brew install kops
 
@@ -59,18 +59,18 @@ Setting up IAM Group and User
 Assuming you have all the prerequisites, run the following commands to create
 the kops user and group:
 
-.. code:: bash
+.. code-block:: shell-session
 
-        # Create IAM group named kops and grant access
-        aws iam create-group --group-name kops
-        aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess --group-name kops
-        aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonRoute53FullAccess --group-name kops
-        aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess --group-name kops
-        aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/IAMFullAccess --group-name kops
-        aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonVPCFullAccess --group-name kops
-        aws iam create-user --user-name kops
-        aws iam add-user-to-group --user-name kops --group-name kops
-        aws iam create-access-key --user-name kops
+        $ # Create IAM group named kops and grant access
+        $ aws iam create-group --group-name kops
+        $ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess --group-name kops
+        $ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonRoute53FullAccess --group-name kops
+        $ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess --group-name kops
+        $ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/IAMFullAccess --group-name kops
+        $ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AmazonVPCFullAccess --group-name kops
+        $ aws iam create-user --user-name kops
+        $ aws iam add-user-to-group --user-name kops --group-name kops
+        $ aws iam create-access-key --user-name kops
 
 
 kops requires the creation of a dedicated S3 bucket in order to store the
@@ -79,10 +79,10 @@ name and provide your unique bucket name (for example a reverse of FQDN added
 with short description of the cluster). Also make sure to use the region where
 you will be deploying the cluster.
 
-.. code:: bash
+.. code-block:: shell-session
 
-        aws s3api create-bucket --bucket prefix-example-com-state-store --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2
-        export KOPS_STATE_STORE=s3://prefix-example-com-state-store
+        $ aws s3api create-bucket --bucket prefix-example-com-state-store --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2
+        $ export KOPS_STATE_STORE=s3://prefix-example-com-state-store
 
 The above steps are sufficient for getting a working cluster installed. Please
 consult `kops aws documentation
@@ -113,17 +113,17 @@ Creating a Cluster
   ``com-company-emailid-``.
 
 
-.. code:: bash
+.. code-block:: shell-session
 
-        export NAME=com-company-emailid-cilium.k8s.local
-        kops create cluster --state=${KOPS_STATE_STORE} --node-count 3 --topology private --master-zones us-west-2a,us-west-2b,us-west-2c --zones us-west-2a,us-west-2b,us-west-2c --networking cilium --cloud-labels "Team=Dev,Owner=Admin" ${NAME} --yes
+        $ export NAME=com-company-emailid-cilium.k8s.local
+        $ kops create cluster --state=${KOPS_STATE_STORE} --node-count 3 --topology private --master-zones us-west-2a,us-west-2b,us-west-2c --zones us-west-2a,us-west-2b,us-west-2c --networking cilium --cloud-labels "Team=Dev,Owner=Admin" ${NAME} --yes
 
 
 You may be prompted to create a ssh public-private key pair.
 
-.. code:: bash
+.. code-block:: shell-session
 
-        ssh-keygen
+        $ ssh-keygen
 
 
 (Please see :ref:`appendix_kops`)
@@ -140,9 +140,9 @@ To undo the dependencies and other deployment features in AWS from the kops
 cluster creation, use kops to destroy a cluster *immediately* with the
 parameter ``--yes``:
 
-.. code:: bash
+.. code-block:: shell-session
 
-        kops delete cluster ${NAME} --yes
+        $ kops delete cluster ${NAME} --yes
 
 
 Further reading on using Cilium with Kops

--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -25,7 +25,7 @@ Create the cluster
 
 Initialize the control plane via executing on it:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubeadm init
 
@@ -34,7 +34,7 @@ Initialize the control plane via executing on it:
    the kube-proxy deployment phase, so it has to be executed with the
    ``--skip-phases=addon/kube-proxy`` option:
 
-   .. code:: bash
+   .. code-block:: shell-session
 
       kubeadm init --skip-phases=addon/kube-proxy
 
@@ -43,7 +43,7 @@ Initialize the control plane via executing on it:
 Afterwards, join worker nodes by specifying the control-plane node IP address
 and the token returned by ``kubeadm init``:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubeadm join <..>
 

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -23,13 +23,13 @@ Please consult `Kubespray Prerequisites <https://github.com/kubernetes-sigs/kube
 Installing Kubespray
 ====================
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ git clone --branch v2.6.0 https://github.com/kubernetes-sigs/kubespray
 
 Install dependencies from ``requirements.txt``
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ cd kubespray
   $ sudo pip install -r requirements.txt
@@ -45,7 +45,7 @@ Configure AWS credentials
 
 Export the variables for your AWS credentials 
 
-.. code:: bash
+.. code-block:: shell-session
 
   export AWS_ACCESS_KEY_ID="www"
   export AWS_SECRET_ACCESS_KEY ="xxx"
@@ -57,7 +57,7 @@ Configure Terraform Variables
 
 We will start by specifying the infrastructure needed for the Kubernetes cluster.
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ cd contrib/terraform/aws
   $ cp contrib/terraform/aws/terraform.tfvars.example terraform.tfvars`
@@ -75,7 +75,7 @@ By default, this tutorial will create:
 
 Example ``terraform.tfvars`` file:
 
-.. code:: bash
+.. code-block:: bash
 
   #Global Vars
   aws_cluster_name = "kubespray"
@@ -116,20 +116,20 @@ Apply the configuration
   - ``module.aws-elb``
   - ``module.aws-iam``
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ terraform init
 
 Once initialized , execute:
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ terraform plan -out=aws_kubespray_plan
 
 This will generate a file, ``aws_kubespray_plan``, depicting an execution
 plan of the infrastructure that will be created on AWS. To apply, execute:
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ terraform init
   $ terraform apply "aws_kubespray_plan"
@@ -144,7 +144,7 @@ Kubespray uses Ansible as its substrate for provisioning and orchestration. Once
 We recommend using the `latest released Cilium version`_ by editing ``roles/download/defaults/main.yml``. Open the file, search for ``cilium_version``, and replace the version with the latest released. As an example, the updated version entry will look like: ``cilium_version: "v1.2.0"``.
 
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache  -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
@@ -155,11 +155,11 @@ Validate Cluster
 
 To check if cluster is created successfully, ssh into the bastion host with the user ``core``. 
 
-.. code:: bash
+.. code-block:: shell-session
 
-  # Get information about the basiton host 
-  $ cat ssh-bastion.conf    
-  $ ssh -i ~/path/to/ec2-key-file.pem core@public_ip_of_bastion_host 
+  $ # Get information about the basiton host
+  $ cat ssh-bastion.conf
+  $ ssh -i ~/path/to/ec2-key-file.pem core@public_ip_of_bastion_host
 
 Execute the commands below from the bastion host. If ``kubectl`` isn't installed on the bastion host, you can login to the master node to test the below commands. You may need to copy the private key to the bastion host to access the master node.
 
@@ -168,7 +168,7 @@ Execute the commands below from the bastion host. If ``kubectl`` isn't installed
 Delete Cluster
 ==============
 
-.. code:: bash
+.. code-block:: shell-session
 
   $ cd contrib/terraform/aws
   $ terraform destroy

--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -73,7 +73,7 @@ And set ``networkType: Cilium``:
 
 The resulting configuration will look like this:
 
-.. code:: yaml
+.. code-block:: yaml
 
    apiVersion: v1
    baseDomain: ilya-openshift-test-1.cilium.rocks

--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -8,9 +8,9 @@ ensure that Cilium starts managing them. This is required to ensure that all
 pods which have been running before Cilium was deployed have network
 connectivity provided by Cilium and NetworkPolicy applies to them:
 
-::
+.. code-block:: shell-session
 
-    kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -L 1 -r kubectl delete pod
+    $ kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{print "-n "$1" "$2}' | xargs -L 1 -r kubectl delete pod
     pod "event-exporter-v0.2.3-f9c896d75-cbvcz" deleted
     pod "fluentd-gcp-scaler-69d79984cb-nfwwk" deleted
     pod "heapster-v1.6.0-beta.1-56d5d5d87f-qw8pv" deleted

--- a/Documentation/gettingstarted/kafka.rst
+++ b/Documentation/gettingstarted/kafka.rst
@@ -78,7 +78,7 @@ Running ``kubectl get svc,pods`` will inform you about the progress of the opera
 Each pod will go through several states until it reaches ``Running`` at which
 point the setup is ready.
 
-::
+.. code-block:: shell-session
 
     $ kubectl get svc,pods
     NAME            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
@@ -105,22 +105,26 @@ For consistency, we recommend opening them in the pattern shown in the image bel
 In each window, use copy-paste to have each terminal provide a shell inside each pod.
 
 empire-hq terminal:
-::
+
+.. code-block:: shell-session
 
    $ HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}') && kubectl exec -it $HQ_POD -- sh -c "PS1=\"empire-hq $\" /bin/bash"
 
 empire-backup terminal:
-::
+
+.. code-block:: shell-session
 
    $ BACKUP_POD=$(kubectl get pods -l app=empire-backup -o jsonpath='{.items[0].metadata.name}') && kubectl exec -it $BACKUP_POD -- sh -c "PS1=\"empire-backup $\" /bin/bash"
 
 outpost-8888 terminal:
-::
+
+.. code-block:: shell-session
 
    $ OUTPOST_8888_POD=$(kubectl get pods -l outpostid=8888 -o jsonpath='{.items[0].metadata.name}') && kubectl exec -it $OUTPOST_8888_POD -- sh -c "PS1=\"outpost-8888 $\" /bin/bash"
 
 outpost-9999 terminal:
-::
+
+.. code-block:: shell-session
 
    $ OUTPOST_9999_POD=$(kubectl get pods -l outpostid=9999 -o jsonpath='{.items[0].metadata.name}') && kubectl exec -it $OUTPOST_9999_POD -- sh -c "PS1=\"outpost-9999 $\" /bin/bash"
 
@@ -133,25 +137,25 @@ commands below will hang intentionally, waiting to print data they consume from 
 
 In the *empire-backup* window, start listening on the top-secret *deathstar-plans* topic:
 
-::
+.. code-block:: shell-session
 
     $ ./kafka-consume.sh --topic deathstar-plans
 
 In the *outpost-8888* window, start listening to *empire-announcement*:
 
-::
+.. code-block:: shell-session
 
     $ ./kafka-consume.sh --topic empire-announce
 
 Do the same in the *outpost-9999* window:
 
-::
+.. code-block:: shell-session
 
     $ ./kafka-consume.sh --topic empire-announce
 
 Now from the *empire-hq*, first produce a message to the *empire-announce* topic:
 
-::
+.. code-block:: shell-session
 
    $ echo "Happy 40th Birthday to General Tagge" | ./kafka-produce.sh --topic empire-announce
 
@@ -160,7 +164,7 @@ This message will be posted to the *empire-announce* topic, and shows up in both
 
 *empire-hq* can also post a version of the top-secret deathstar plans to the *deathstar-plans* topic:
 
-::
+.. code-block:: shell-session
 
    $ echo "deathstar reactor design v3" | ./kafka-produce.sh --topic deathstar-plans
 
@@ -179,7 +183,7 @@ sending "malicious" data to all other consumers on the topic.
 To prove this, kill the existing ``kafka-consume.sh`` command in the outpost-9999 window
 by typing control-C and instead run:
 
-::
+.. code-block:: shell-session
 
   $ echo "Vader Booed at Empire Karaoke Party" | ./kafka-produce.sh --topic empire-announce
 
@@ -190,7 +194,7 @@ on the kafka-broker.
 
 In the outpost-9999 container, run:
 
-::
+.. code-block:: shell-session
 
   $ ./kafka-consume.sh --topic deathstar-plans
   "deathstar reactor design v3"
@@ -244,7 +248,7 @@ Apply this Kafka-aware network security policy using ``kubectl`` in the main win
 If we then again try to produce a message from outpost-9999 to *empire-annnounce*, it is denied.
 Type control-c and then run:
 
-::
+.. code-block:: shell-session
 
   $ echo "Vader Trips on His Own Cape" | ./kafka-produce.sh --topic empire-announce
   >>[2018-04-10 23:50:34,638] ERROR Error when sending message to topic empire-announce with key: null, value: 27 bytes with error: (org.apache.kafka.clients.producer.internals.ErrorLoggingCallback)
@@ -260,7 +264,7 @@ role = consume is only allowed for topic *empire-announce*.
 
 To test, from the outpost-9999 terminal, run:
 
-::
+.. code-block:: shell-session
 
   $./kafka-consume.sh --topic deathstar-plans
   [2018-04-10 23:51:12,956] WARN Error while fetching metadata with correlation id 2 : {deathstar-plans=TOPIC_AUTHORIZATION_FAILED} (org.apache.kafka.clients.NetworkClient)

--- a/Documentation/gettingstarted/kind-configure.rst
+++ b/Documentation/gettingstarted/kind-configure.rst
@@ -18,9 +18,8 @@ each node. See the
 documentation for more information.
 
 .. tip::
-    By default, kind uses the following pod and service subnets:
+    By default, kind uses the following pod and service subnets::
 
-    .. parsed-literal::
         Networking.PodSubnet     = "10.244.0.0/16"
         Networking.ServiceSubnet = "10.96.0.0/12"
 

--- a/Documentation/gettingstarted/kind-create-cluster.rst
+++ b/Documentation/gettingstarted/kind-create-cluster.rst
@@ -1,7 +1,7 @@
 To create a cluster with the configuration defined above, pass the
 ``kind-config.yaml`` you created with the ``--config`` flag of kind.
 
-.. code:: bash
+.. code-block:: shell-session
 
     kind create cluster --config=kind-config.yaml
 
@@ -10,7 +10,7 @@ After a couple of seconds or minutes, a 4 nodes cluster should be created.
 A new ``kubectl`` context (``kind-kind``) should be added to ``KUBECONFIG`` or, if unset,
 to ``${HOME}/.kube/config``:
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl cluster-info --context kind-kind
 

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -97,7 +97,7 @@ We will explicitly configure their ``pod-network-cidr`` and ``service-cidr`` to 
 
 Example ``kind-cluster1.yaml``:
 
-.. code:: yaml
+.. code-block:: yaml
 
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
@@ -113,7 +113,7 @@ Example ``kind-cluster1.yaml``:
 
 Example ``kind-cluster2.yaml``:
 
-.. code:: yaml
+.. code-block:: yaml
 
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
@@ -132,7 +132,7 @@ Create Kind Clusters
 
 We can now create the respective clusters:
 
-.. code:: bash
+.. code-block:: shell-session
 
     kind create cluster --name=cluster1 --config=kind-cluster1.yaml
     kind create cluster --name=cluster2 --config=kind-cluster2.yaml
@@ -146,7 +146,7 @@ we're enabling managed etcd and setting both ``cluster-name`` and
 
 Make sure context is set to ``kind-cluster2`` cluster.
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl config use-context kind-cluster2
 
@@ -165,7 +165,7 @@ Make sure context is set to ``kind-cluster2`` cluster.
 
 Change the kubectl context to ``kind-cluster1`` cluster:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl config use-context kind-cluster1
 

--- a/Documentation/gettingstarted/kube-router.rst
+++ b/Documentation/gettingstarted/kube-router.rst
@@ -21,15 +21,15 @@ Deploy kube-router
 
 Download the kube-router DaemonSet template:
 
-.. code:: bash
+.. code-block:: shell-session
 
     curl -LO https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.2/daemonset/generic-kuberouter-only-advertise-routes.yaml
 
 Open the file ``generic-kuberouter-only-advertise-routes.yaml`` and edit the
-``args:`` section. The following arguments are **requried** to be set to
+``args:`` section. The following arguments are **required** to be set to
 exactly these values:
 
-.. code:: bash
+.. code-block:: yaml
 
     - "--run-router=true"
     - "--run-firewall=false"
@@ -44,7 +44,7 @@ being used which require the least preparations in your cluster. Please see the
 <https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md>`_
 for more information.
 
-.. code:: bash
+.. code-block:: yaml
 
     - "--enable-ibgp=true"
     - "--enable-overlay=true"
@@ -57,7 +57,7 @@ with an external router. This is useful if you want externally routable Kubernet
 Pod and Service IPs. Note the values used here should be changed to
 whatever IPs and ASNs are configured on your external router.
 
-.. code:: bash
+.. code-block:: yaml
 
     - "--cluster-asn=65001"
     - "--peer-router-ips=10.0.0.1,10.0.2"
@@ -66,7 +66,7 @@ whatever IPs and ASNs are configured on your external router.
 Apply the DaemonSet file to deploy kube-router and verify it has come up
 correctly:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl apply -f generic-kuberouter-only-advertise-routes.yaml
     $ kubectl -n kube-system get pods -l k8s-app=kube-router
@@ -86,7 +86,7 @@ ConfigMap ``cilium-config`` or by adjusting the DaemonSet to run the
 same ConfigMap, we must explicitly set ``ipam: kubernetes`` since kube-router
 pulls the pod CIDRs directly from K8s:
 
-.. code:: bash
+.. code-block:: yaml
 
     # Encapsulation mode for communication between nodes
     # Possible values:
@@ -101,7 +101,7 @@ You can then install Cilium according to the instructions in section
 
 Ensure that Cilium is up and running:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl -n kube-system get pods -l k8s-app=cilium
     NAME           READY     STATUS    RESTARTS   AGE
@@ -115,7 +115,7 @@ Verify Installation
 
 Verify that kube-router has installed routes:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ kubectl -n kube-system exec -ti cilium-fhpk2 -- ip route list scope global
     default via 172.0.32.1 dev eth0 proto dhcp src 172.0.50.227 metric 1024

--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -52,7 +52,7 @@ Enable the feature by setting the ``localRedirectPolicy`` value to ``true``.
 
 Verify that Cilium agent pod is running.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl -n kube-system get pods -l k8s-app=cilium
     NAME           READY   STATUS    RESTARTS   AGE
@@ -61,7 +61,7 @@ Verify that Cilium agent pod is running.
 
 Validate that the Cilium Local Redirect Policy CRD has been registered.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
 	   $ kubectl get crds
 	   NAME                              CREATED AT
@@ -85,7 +85,7 @@ resources that will be created in the next step.
 
 Verify that the pod is running.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl get pods | grep lrp-pod
     lrp-pod                      1/1     Running   0          46s
@@ -134,7 +134,7 @@ configuration.
 
 Verify that the custom resource is created.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl get ciliumlocalredirectpolicies | grep lrp-addr
     NAME           AGE
@@ -145,12 +145,12 @@ service entry with the backend IP address of that of the ``lrp-pod`` that was
 selected by the policy. Make sure that ``cilium service list`` is run
 in Cilium pod running on the same node as ``lrp-pod``.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl describe pod lrp-pod  | grep 'IP:'
     IP:           10.16.70.187
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system cilium-5ngzd -- cilium service list
     ID   Frontend               Service Type   Backend
@@ -160,7 +160,7 @@ in Cilium pod running on the same node as ``lrp-pod``.
 Invoke a curl command from the client pod to the IP address and port
 configuration specified in the ``lrp-addr`` custom resource above.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl exec mediabot -- curl -I -s http://169.254.169.254:8080/index.html
     HTTP/1.1 200 OK
@@ -176,7 +176,7 @@ configuration specified in the ``lrp-addr`` custom resource above.
 Verify that the traffic was redirected to the ``lrp-pod`` that was deployed.
 ``tcpdump`` should be run on the same node that ``lrp-pod`` is running on.
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ sudo tcpdump -i any -n port 80
     tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
@@ -224,7 +224,7 @@ Deploy the Kubernetes service for which traffic needs to be redirected.
 
 Verify that the service is created.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl get service | grep 'my-service'
     my-service   ClusterIP   172.20.0.51   <none>        80/TCP     2d7h
@@ -232,7 +232,7 @@ Verify that the service is created.
 Verify that Cilium's eBPF kube-proxy replacement created a ``ClusterIP``
 service entry.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system ds/cilium -- cilium service list
     ID   Frontend               Service Type   Backend
@@ -250,7 +250,7 @@ configuration.
 
 Verify that the custom resource is created.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl get ciliumlocalredirectpolicies | grep svc
     NAME               AGE
@@ -261,7 +261,7 @@ service entry with type ``LocalRedirect`` and the node-local backend
 selected by the policy. Make sure to run ``cilium service list`` in Cilium pod
 running on the same node as ``lrp-pod``.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system cilium-5ngzd -- cilium service list
     ID   Frontend               Service Type       Backend
@@ -271,7 +271,7 @@ running on the same node as ``lrp-pod``.
 Invoke a curl command from the client pod to the Cluster IP address and port of
 ``my-service`` specified in the ``lrp-svc`` custom resource above.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl exec mediabot -- curl -I -s http://172.20.0.51/index.html
     HTTP/1.1 200 OK
@@ -287,12 +287,12 @@ Invoke a curl command from the client pod to the Cluster IP address and port of
 Verify that the traffic was redirected to the ``lrp-pod`` that was deployed.
 ``tcpdump`` should be run on the same node that ``lrp-pod`` is running on.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     $ kubectl describe pod lrp-pod  | grep 'IP:'
     IP:           10.16.70.187
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ sudo tcpdump -i any -n port 80
     tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
@@ -415,7 +415,7 @@ security credentials for pods.
 
 - Deploy `kiam <https://github.com/uswitch/kiam>`_ using helm charts.
 
-  .. code-block:: bash
+  .. code-block:: shell-session
 
       $ helm repo add uswitch https://uswitch.github.io/kiam-helm-charts/charts/
       $ helm repo update
@@ -465,7 +465,7 @@ security credentials for pods.
       identity-credentials/
       (...)
 
-  .. code-block:: bash
+  .. code-block:: shell-session
 
       $ sudo tcpdump -i any -enn "(port 8181) and (host 192.168.33.99 and 192.168.98.118)"
       tcpdump: verbose output suppressed, use -v or -vv for full protocol decode

--- a/Documentation/gettingstarted/memcached.rst
+++ b/Documentation/gettingstarted/memcached.rst
@@ -72,7 +72,7 @@ Running ``kubectl get svc,pods`` will inform you about the progress of the opera
 Each pod will go through several states until it reaches ``Running`` at which
 point the setup is ready.
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl get svc,pods
     NAME                       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)     AGE
@@ -97,7 +97,7 @@ In **all three** terminal windows, set some handy environment variables for the 
 
 In the terminal window dedicated for the A-wing pod, exec in, use python to import the binary memcached library and set the client connection to the memcached server:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl exec -ti $AWING_POD -- sh
     # python
@@ -109,7 +109,7 @@ In the terminal window dedicated for the A-wing pod, exec in, use python to impo
 
 In the terminal window dedicated for the Alliance-Tracker, exec in, use python to import the binary memcached library and set the client connection to the memcached server:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl exec -ti $TRACKER_POD -- sh
     # python
@@ -128,7 +128,7 @@ Let's show that each client is able to access the memcached server. Execute the 
 
 A-wing will access the memcached-server using the *binary protocol*. In your terminal window for A-Wing, set A-wing's coordinates:
 
-.. parsed-literal::
+.. code-block:: python
 
     >>> client.set("awing-coord","4309.432,918.980",time=2400)
     True
@@ -138,7 +138,7 @@ A-wing will access the memcached-server using the *binary protocol*. In your ter
 
 In your main terminal window, have X-wing starfighter set their coordinates using the text-based protocol to the memcached server.
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl exec $XWING_POD -- sh -c "echo -en \\"$SETXC\\" | nc memcached-server 11211"
     STORED
@@ -149,7 +149,7 @@ In your main terminal window, have X-wing starfighter set their coordinates usin
 
 Check that the Alliance Fleet Tracker is able to get all starfighters' coordinates in your terminal window for the Alliance-Tracker:
 
-.. parsed-literal::
+.. code-block:: python
 
     >>> client.get("awing-coord")
     '4309.432,918.980'
@@ -165,7 +165,7 @@ If every client has access to the Memcached API on port 11211, all have over-pri
 
 With L4 port access to the memcached server, all starfighters could write to any key/ship and read all ship coordinates. In your main terminal, execute:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl exec $XWING_POD sh -- -c "echo -en \\"$GETAC\\" | nc memcached-server 11211"
     VALUE awing-coord 0 16
@@ -174,7 +174,7 @@ With L4 port access to the memcached server, all starfighters could write to any
 
 In your A-Wing terminal window, confirm the over-privileged access:
 
-.. parsed-literal::
+.. code-block:: python
 
     >>> client.get("xwing-coord")
     '8893.34,234.3290'
@@ -185,7 +185,7 @@ In your A-Wing terminal window, confirm the over-privileged access:
 
 From A-Wing, set the X-Wing coordinates back to their proper position:
 
-.. parsed-literal::
+.. code-block:: python
 
     >>> client.set("xwing-coord","8893.34,234.3290",time=2400)
     True
@@ -226,14 +226,14 @@ Apply this Memcached-aware network security policy using ``kubectl`` in your mai
 
 If we then try to perform the attacks from the *X-wing* pod from the main terminal window, we'll see that they are denied:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
     $ kubectl exec $XWING_POD -- sh -c "echo -en \\"$GETAC\\" | nc memcached-server 11211"
     CLIENT_ERROR access denied
 
 From the A-Wing terminal window, we can confirm that if *A-wing* goes outside of the bounds of its allowed calls. You may need to run the ``client.get`` command twice for the python call:
 
-.. parsed-literal::
+.. code-block:: python
 
     >>> client.get("awing-coord")
     '4309.432,918.980'
@@ -248,7 +248,7 @@ From the A-Wing terminal window, we can confirm that if *A-wing* goes outside of
 
 Similarly, the Alliance-Tracker cannot set any coordinates, which you can attempt from the Alliance-Tracker terminal window:
 
-.. parsed-literal::
+.. code-block:: python
 
     >>> client.get("xwing-coord")
     '8893.34,234.3290'
@@ -269,7 +269,7 @@ With the CiliumNetworkPolicy in place, the allowed Memcached calls are still all
 
 In the main terminal window, execute:
 
-.. parsed-literal::
+.. code-block:: shell-session
 
   $ kubectl exec $XWING_POD -- sh -c "echo -en \\"$GETXC\\" | nc memcached-server 11211"
   VALUE xwing-coord 0 16
@@ -285,7 +285,7 @@ In the main terminal window, execute:
 
 In the A-Wing terminal window, execute:
 
-.. parsed-literal::
+.. code-block:: python
 
   >>> client.set("awing-coord","9852.542,892.1318",time=1200)
   True
@@ -296,7 +296,7 @@ In the A-Wing terminal window, execute:
 
 In the Alliance-Tracker terminal window, execute:
 
-.. parsed-literal::
+.. code-block:: python
 
   >>> client.get("awing-coord")
   '9852.542,892.1318'

--- a/Documentation/gettingstarted/microk8s.rst
+++ b/Documentation/gettingstarted/microk8s.rst
@@ -23,7 +23,7 @@ Install microk8s
 
 #. Enable the microk8s Cilium service
 
-   ::
+   .. code-block:: shell-session
 
       microk8s enable cilium
 

--- a/Documentation/kvstore.rst
+++ b/Documentation/kvstore.rst
@@ -158,7 +158,7 @@ The contents stored in the kvstore can be queued and manipulate using the
 
 Example:
 
-.. code:: bash
+.. code-block:: shell-session
 
-        $ cilium kvstore get --recursive cilium/state/nodes/
-        cilium/state/nodes/v1/default/runtime1 => {"Name":"runtime1","IPAddresses":[{"AddressType":"InternalIP","IP":"10.0.2.15"}],"IPv4AllocCIDR":{"IP":"10.11.0.0","Mask":"//8AAA=="},"IPv6AllocCIDR":{"IP":"f00d::a0f:0:0:0","Mask":"//////////////////8AAA=="},"IPv4HealthIP":"","IPv6HealthIP":""}
+    $ cilium kvstore get --recursive cilium/state/nodes/
+    cilium/state/nodes/v1/default/runtime1 => {"Name":"runtime1","IPAddresses":[{"AddressType":"InternalIP","IP":"10.0.2.15"}],"IPv4AllocCIDR":{"IP":"10.11.0.0","Mask":"//8AAA=="},"IPv6AllocCIDR":{"IP":"f00d::a0f:0:0:0","Mask":"//////////////////8AAA=="},"IPv4HealthIP":"","IPv6HealthIP":""}

--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -164,7 +164,7 @@ It will run Prometheus and Grafana in the ``cilium-monitoring`` namespace. If
 you have either enabled Cilium or Hubble metrics, they will automatically
 be scraped by Prometheus. You can then expose Grafana to access it via your browser.
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl -n cilium-monitoring port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000
 

--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -81,7 +81,7 @@ Upon defining a custom list of labels in the ConfigMap, Cilium add the provided
 list of labels to the default list of labels. After saving the ConfigMap,
 restart the Cilium Agents to pickup the new labels setting.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
     kubectl delete pods -n kube-system -l k8s-app=cilium
 
@@ -100,7 +100,7 @@ Including Labels
 Labels can be defined as a list of labels to include. Only the labels specified
 and the default inclusive labels will be used to evaluate Cilium identities:
 
-.. code-block:: bash
+.. code-block:: yaml
 
     labels: "k8s:io.kubernetes.pod.namespace k8s:k8s-app k8s:app k8s:name"
 
@@ -139,7 +139,7 @@ an exclamation mark after colon separating the prefix and label. When defined as
 list of exclusions, Cilium will include the set of default labels, but will
 exclude any matches in the provided list when evaluating Cilium identities:
 
-.. code-block:: bash
+.. code-block:: yaml
 
     labels: "k8s:!controller-uid k8s:!job-name"
 

--- a/Documentation/operations/performance/scalability/report.rst
+++ b/Documentation/operations/performance/scalability/report.rst
@@ -19,7 +19,8 @@ were suitable for our testing:
 Setup
 =====
 
-.. parsed-literal::
+.. code-block:: shell-session
+
  helm template cilium \\
      --namespace kube-system \\
      --set endpointHealthChecking.enabled=false \\
@@ -223,7 +224,7 @@ selected all pods on this namespace and was allowed to send traffic to another
 pod on this namespace. Each of the 250 policies allows access to a disjoint set
 of ports. In the end we will have 250 different policies selecting 10000 pods.
 
-::
+.. code-block:: yaml
 
     apiVersion: "cilium.io/v2"
     kind: CiliumNetworkPolicy

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -94,7 +94,7 @@ RancherOS_                 >= 1.5.5
           (see :gh-issue:`10645` for details). To avoid that, configure
           ``rp_filter`` in systemd using the following commands:
 
-          .. code:: bash
+          .. code-block:: shell-session
 
               echo 'net.ipv4.conf.lxc*.rp_filter = 0' > /etc/sysctl.d/99-override_cilium_rp_filter.conf
               systemctl restart systemd-sysctl
@@ -115,7 +115,7 @@ configuration options must be enabled. This is typically the case  with
 distribution kernels. When an option can be built as a module or statically
 linked, either choice is valid.
 
-.. code:: bash
+::
 
         CONFIG_BPF=y
         CONFIG_BPF_SYSCALL=y
@@ -137,7 +137,7 @@ L7 proxy redirection currently uses ``TPROXY`` iptables actions as well
 as ``socket`` matches. For L7 redirection to work as intended kernel
 configuration must include the following modules:
 
-.. code:: bash
+::
 
         CONFIG_NETFILTER_XT_TARGET_TPROXY=m
         CONFIG_NETFILTER_XT_MATCH_MARK=m
@@ -344,8 +344,8 @@ Mounted eBPF filesystem
 
         .. code-block:: shell-session
 
-                  mount | grep /sys/fs/bpf
-                  # if present should output, e.g. "none on /sys/fs/bpf type bpf"...
+            # mount | grep /sys/fs/bpf
+            $ # if present should output, e.g. "none on /sys/fs/bpf type bpf"...
 
 This step is **required for production** environments but optional for testing
 and development. It allows the ``cilium-agent`` to pin eBPF resources to a
@@ -362,15 +362,15 @@ In order to mount the eBPF filesystem, the following command must be run in the
 host mount namespace. The command must only be run once during the boot process
 of the machine.
 
-.. code:: bash
+   code-block:: shell-session
 
-	mount bpffs /sys/fs/bpf -t bpf
+	# mount bpffs /sys/fs/bpf -t bpf
 
 A portable way to achieve this with persistence is to add the following line to
 ``/etc/fstab`` and then run ``mount /sys/fs/bpf``. This will cause the
 filesystem to be automatically mounted when the node boots.
 
-.. code:: bash
+::
 
      bpffs			/sys/fs/bpf		bpf	defaults 0 0
 

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -71,7 +71,7 @@ Alternatively, the ``k8s-cilium-exec.sh`` script can be used to run ``cilium
 status`` on all nodes. This will provide detailed status and health information
 of all nodes in the cluster:
 
-.. code:: bash
+.. code-block:: shell-session
 
    curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-cilium-exec.sh
    chmod +x ./k8s-cilium-exec.sh
@@ -105,7 +105,7 @@ Logs
 To retrieve log files of a cilium pod, run (replace ``cilium-1234`` with a pod
 name returned by ``kubectl -n kube-system get pods -l k8s-app=cilium``)
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl -n kube-system logs --timestamps cilium-1234
 
@@ -113,7 +113,7 @@ If the cilium pod was already restarted due to the liveness problem after
 encountering an issue, it can be useful to retrieve the logs of the pod before
 the last restart:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl -n kube-system logs --timestamps -p cilium-1234
 
@@ -255,7 +255,7 @@ machine.
 
 You may access the Hubble Relay service by port-forwarding it locally:
 
-.. code:: bash
+.. code-block:: shell-session
 
    kubectl -n kube-system port-forward service/hubble-relay --address 0.0.0.0 --address :: 4245:80
 
@@ -265,13 +265,13 @@ on port ``4245`` on all of it's IP addresses.
 You can verify that Hubble Relay can be reached by using the Hubble CLI and
 running the following command from your local machine:
 
-.. code:: bash
+.. code-block:: shell-session
 
    hubble status
 
 This command should return an output similar to the following:
 
-.. code-block:: shell-session
+::
 
    Healthcheck (via localhost:4245): Ok
    Current/Max Flows: 16380/16380 (100.00%)
@@ -281,7 +281,7 @@ This command should return an output similar to the following:
 You may see details about nodes that Hubble Relay is connected to by running
 the following command:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
    hubble list nodes
 
@@ -499,14 +499,14 @@ Start by finding the endpoint you are debugging from the following list. There
 are several cross references for you to use in this list, including the IP
 address and pod labels:
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl -n kube-system exec -ti cilium-q8wvt -- cilium endpoint list
 
 When you find the correct endpoint, the first column of every row is the
 endpoint ID. Use that to dump the full endpoint information:
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl -n kube-system exec -ti cilium-q8wvt -- cilium endpoint get 59084
 
@@ -584,9 +584,7 @@ Understanding etcd status
 -------------------------
 
 The etcd status is reported when running ``cilium status``. The following line
-represents the status of etcd:
-
-.. code:: bash
+represents the status of etcd::
 
    KVStore:  Ok  etcd: 1/1 connected, lease-ID=29c6732d5d580cb5, lock lease-ID=29c6732d5d580cb7, has-quorum=true: https://192.168.33.11:2379 - 3.4.9 (Leader)
 
@@ -644,15 +642,11 @@ cluster size. The larger the cluster, the longer the `interval
    more consecutive failures.
 
 Example of a status with a quorum failure which has not yet reached the
-threshold:
-
-.. code:: bash
+threshold::
 
     KVStore: Ok   etcd: 1/1 connected, lease-ID=29c6732d5d580cb5, lock lease-ID=29c6732d5d580cb7, has-quorum=2m2.778966915s since last heartbeat update has been received, consecutive-errors=1: https://192.168.33.11:2379 - 3.4.9 (Leader)
 
-Example of a status with the number of quorum failures exceeding the threshold:
-
-.. code:: bash
+Example of a status with the number of quorum failures exceeding the threshold::
 
     KVStore: Failure   Err: quorum check failed 8 times in a row: 4m28.446600949s since last heartbeat update has been received
 
@@ -688,9 +682,7 @@ Manual Verification of Setup
 ----------------------------
 
  #. Validate that the ClusterMesh subsystem is initialized by looking for a
-    ``cilium-agent`` log message like this:
-
-    .. code-block:: shell-session
+    ``cilium-agent`` log message like this::
 
        level=info msg="Initializing ClusterMesh routing" path=/var/lib/cilium/clustermesh/ subsys=daemon
 
@@ -721,15 +713,11 @@ Manual Verification of Setup
 
  #. Validate that the connection to the remote cluster could be established.
     You will see a log message like this in the ``cilium-agent`` logs for each
-    remote cluster:
-
-    .. code-block:: shell-session
+    remote cluster::
 
        level=info msg="Connection to remote cluster established"
 
-    If the connection failed, you will see a warning like this:
-
-    .. code-block:: shell-session
+    If the connection failed, you will see a warning like this::
 
        level=warning msg="Unable to establish etcd connection to remote cluster"
 
@@ -842,7 +830,7 @@ State Propagation
       cluster.  It will also have a section ``externalEndpoints`` which must
       list all endpoints of remote clusters.
 
-      .. code-block:: shell-session
+      ::
 
           #### k8s-service-cache
 
@@ -923,13 +911,13 @@ Retrieve Cilium pod managing a particular pod
 
 Identifies the Cilium pod that is managing a particular pod in a namespace:
 
-.. code:: bash
+.. code-block:: shell-session
 
     k8s-get-cilium-pod.sh <pod> <namespace>
 
 **Example:**
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-get-cilium-pod.sh
     $ chmod +x k8s-get-cilium-pod.sh
@@ -943,13 +931,13 @@ Execute a command in all Kubernetes Cilium pods
 
 Run a command within all Cilium pods of a cluster
 
-.. code:: bash
+.. code-block:: shell-session
 
     k8s-cilium-exec.sh <command>
 
 **Example:**
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ curl -sLO https://raw.githubusercontent.com/cilium/cilium/master/contrib/k8s/k8s-cilium-exec.sh
     $ chmod +x k8s-cilium-exec.sh
@@ -966,7 +954,7 @@ Lists all Kubernetes pods in the cluster for which Cilium does *not* provide
 networking. This includes pods running in host-networking mode and pods that
 were started before Cilium was deployed.
 
-.. code:: bash
+.. code-block:: shell-session
 
    k8s-unmanaged.sh
 
@@ -1003,7 +991,7 @@ The script has the following list of prerequisites:
 You can download the latest version of the ``cilium-sysdump`` tool using the
 following command:
 
-.. code:: bash
+.. code-block:: shell-session
 
    curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
    python cilium-sysdump.zip
@@ -1012,7 +1000,7 @@ You can specify from which nodes to collect the system dumps by passing
 node IP addresses via the ``--nodes`` argument and the duration of the time
 window for collecting logs via the ``--since`` argument (e.g. ``2m``, ``3h``).
 
-.. code:: bash
+.. code-block:: shell-session
 
    python cilium-sysdump.zip --nodes $NODE1_IP,$NODE2_IP2 --since $LOG_DURATION
 
@@ -1040,7 +1028,7 @@ large, consider ``--size-limit``.
 
 Use ``--help`` to see more options:
 
-.. code:: bash
+.. code-block:: shell-session
 
    python cilium-sysdump.zip --help
 
@@ -1059,7 +1047,7 @@ default, it writes to the ``tmp`` directory.
 
 Note that the command needs to be run from inside the Cilium pod/container.
 
-.. code:: bash
+.. code-block:: shell-session
 
    cilium-bugtool
 
@@ -1073,7 +1061,7 @@ bit different
 
 .. code-block:: shell-session
 
-   # First we need to get the Cilium pod
+   $ # First we need to get the Cilium pod
    $ kubectl get pods --namespace kube-system
    NAME                          READY     STATUS    RESTARTS   AGE
    cilium-kg8lv                  1/1       Running   0          13m
@@ -1081,11 +1069,11 @@ bit different
    kube-dns-6fc954457d-sf2nk     3/3       Running   0          1h
    kubernetes-dashboard-6xvc7    1/1       Running   0          1h
 
-   # Run the bugtool from this pod
+   $ # Run the bugtool from this pod
    $ kubectl -n kube-system exec cilium-kg8lv -- cilium-bugtool
    [...]
 
-   # Copy the archive from the pod
+   $ # Copy the archive from the pod
    $ kubectl cp kube-system/cilium-kg8lv:/tmp/cilium-bugtool-20180411-155146.166+0000-UTC-266836983.tar /tmp/cilium-bugtool-20180411-155146.166+0000-UTC-266836983.tar
    [...]
 
@@ -1134,7 +1122,7 @@ format is in Markdown format so this can be used when reporting a bug on the
 `issue tracker`_.  Running without arguments will print to standard output, but
 you can also redirect to a file like
 
-.. code:: bash
+.. code-block:: shell-session
 
    cilium debuginfo -f debuginfo.md
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -113,13 +113,13 @@ you can delete the cilium-preflight and proceed with the upgrade.
 .. tabs::
   .. group-tab:: kubectl
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       kubectl delete -f cilium-preflight.yaml
 
   .. group-tab:: Helm
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm delete cilium-preflight --namespace=kube-system
 
@@ -249,13 +249,13 @@ or something went wrong during upgrade. To undo the rollout run:
 .. tabs::
   .. group-tab:: kubectl
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       kubectl rollout undo daemonset/cilium -n kube-system
 
   .. group-tab:: Helm
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm history cilium --namespace=kube-system
       helm rollback cilium [REVISION] --namespace=kube-system
@@ -957,7 +957,7 @@ IMPORTANT: Changes required before upgrading to 1.8.0
 .. tabs::
   .. group-tab:: kubectl
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm template cilium \
       --namespace=kube-system \
@@ -969,7 +969,7 @@ IMPORTANT: Changes required before upgrading to 1.8.0
 
   .. group-tab:: Helm
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm upgrade cilium --namespace=kube-system \
       --set agent.keepDeprecatedProbes=true
@@ -1053,7 +1053,7 @@ Upgrading from >=1.7.0 to 1.8.y
   To check whether any action is required the following command can be used to
   check the currently configured maximum number of TCP conntrack entries:
 
-  .. code:: bash
+  .. code-block:: shell-session
 
      sudo grep -R CT_MAP_SIZE_TCP /var/run/cilium/state/templates/
 
@@ -1064,7 +1064,7 @@ Upgrading from >=1.7.0 to 1.8.y
 .. tabs::
   .. group-tab:: kubectl
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm template cilium \\
       --namespace=kube-system \\
@@ -1076,7 +1076,7 @@ Upgrading from >=1.7.0 to 1.8.y
 
   .. group-tab:: Helm
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm upgrade cilium --namespace=kube-system \\
       --set global.bpf.ctTcpMax=100000
@@ -1097,7 +1097,7 @@ Upgrading from >=1.7.0 to 1.8.y
   To check whether any adjustment is required the following command can be used
   to check the currently configured maximum number of NAT table entries:
 
-  .. code:: bash
+  .. code-block:: shell-session
 
      sudo grep -R SNAT_MAPPING_IPV[46]_SIZE /var/run/cilium/state/globals/
 
@@ -1109,7 +1109,7 @@ Upgrading from >=1.7.0 to 1.8.y
 .. tabs::
   .. group-tab:: kubectl
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm template cilium \\
       --namespace=kube-system \\
@@ -1121,7 +1121,7 @@ Upgrading from >=1.7.0 to 1.8.y
 
   .. group-tab:: Helm
 
-    .. parsed-literal::
+    .. code-block:: shell-session
 
       helm upgrade cilium --namespace=kube-system \\
       --set global.bpf.natMax=841429
@@ -1333,7 +1333,7 @@ and the etcd is set up to have `client to server authentication <https://etcd.io
 Generate the latest ConfigMap
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: bash
+.. code-block:: shell-session
 
     helm template cilium \
       --namespace=kube-system \
@@ -1392,7 +1392,7 @@ Apply new ConfigMap
 After adding the options, manually save the file with your changes and install
 the `ConfigMap` in the ``kube-system`` namespace of your cluster.
 
-::
+.. code-block:: shell-session
 
         $ kubectl apply -n kube-system -f ./cilium-cm-old.yaml
 
@@ -1517,7 +1517,7 @@ allocating identities in a way that conflicts with older ones in the kvstore.
 
 The cilium preflight manifest requires etcd support and can be built with:
 
-.. code:: bash
+.. code-block:: shell-session
 
     helm template cilium \
       --namespace=kube-system \
@@ -1569,7 +1569,7 @@ Example migration
     ``cilium`` CLI options with the preflight command. The default is to derive the
     configuration as cilium-agent does.
 
-  .. parsed-literal::
+  .. code-block:: shell-session
 
         cilium preflight migrate-identity --k8s-kubeconfig-path /var/lib/cilium/cilium.kubeconfig --kvstore etcd --kvstore-opt etcd.config=/var/lib/cilium/etcd-config.yml
 

--- a/Documentation/policy/intro.rst
+++ b/Documentation/policy/intro.rst
@@ -43,20 +43,20 @@ never
 
 To configure the policy enforcement mode at runtime for all endpoints managed by a Cilium agent, use:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ cilium config PolicyEnforcement={default,always,never}
 
 If you want to configure the policy enforcement mode at start-time for a particular agent, provide the following flag when launching the Cilium
 daemon:
 
-.. code:: bash
+.. code-block:: shell-session
 
     $ cilium-agent --enable-policy={default,always,never} [...]
 
 Similarly, you can enable the policy enforcement mode across a Kubernetes cluster by including the parameter above in the Cilium DaemonSet.
 
-.. code:: yaml
+.. code-block:: yaml
 
     - name: CILIUM_ENABLE_POLICY
       value: always

--- a/Documentation/policy/kubernetes.rst
+++ b/Documentation/policy/kubernetes.rst
@@ -127,7 +127,7 @@ admission controller
 or can be directly specified in the Pod, Deployment, ReplicationController
 resource like this:
 
-.. code:: bash
+.. code-block:: yaml
 
         apiVersion: v1
         kind: Pod

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -36,7 +36,7 @@ An L3/L4 policy is enforced on the ``deathstar`` service to allow access to all 
 
     Currently, there is no support for tracing L7 policies via this tool.
 
-.. code:: bash
+.. code-block:: shell-session
 
     # Policy trace using pod name and service labels
 
@@ -55,10 +55,10 @@ An L3/L4 policy is enforced on the ``deathstar`` service to allow access to all 
     Ingress verdict: denied
 
     Final verdict: DENIED
-    
-.. code:: bash
-    
-    # Get the Cilium security id
+
+.. code-block:: shell-session
+
+    $ # Get the Cilium security id
 
     $ kubectl exec -ti cilium-88k78 -n kube-system -- cilium endpoint list | egrep  'deathstar|xwing|tiefighter'
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                              IPv6                 IPv4            STATUS   
@@ -68,7 +68,7 @@ An L3/L4 policy is enforced on the ``deathstar`` service to allow access to all 
     33633      Disabled           Disabled          53208      k8s:class=xwing                                          f00d::a0f:0:0:8361   10.15.151.230   ready   
     38654      Disabled           Disabled          22962      k8s:class=tiefighter                                     f00d::a0f:0:0:96fe   10.15.88.156    ready   
 
-    # Policy trace using Cilium security ids
+    $ # Policy trace using Cilium security ids
 
     $ kubectl exec -ti cilium-88k78 -n kube-system -- cilium policy trace --src-identity 53208 --dst-identity 22133  --dport 80
     ----------------------------------------------------------------
@@ -99,16 +99,16 @@ be returned together.
 
 In the above example, for one of the ``deathstar`` pods the endpoint id is 568. We can print all policies applied to it with:
 
-.. code:: bash
+.. code-block:: shell-session
 
-    # Get a shell on the Cilium pod
+    $ # Get a shell on the Cilium pod
 
     $ kubectl exec -ti cilium-88k78 -n kube-system -- /bin/bash
 
-    # print out the ingress labels
-    # clean up the data
-    # fetch each policy via each set of labels
-    # (Note that while the structure is "...l4.ingress...", it reflects all L3, L4 and L7 policy.
+    $ # print out the ingress labels
+    $ # clean up the data
+    $ # fetch each policy via each set of labels
+    $ # (Note that while the structure is "...l4.ingress...", it reflects all L3, L4 and L7 policy.
 
     $ cilium endpoint get 568 -o jsonpath='{range ..status.policy.realized.l4.ingress[*].derived-from-rules}{@}{"\n"}{end}'|tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
     Labels: k8s:io.cilium.k8s.policy.name=rule1 k8s:io.cilium.k8s.policy.namespace=default
@@ -168,7 +168,7 @@ In the above example, for one of the ``deathstar`` pods the endpoint id is 568. 
     Revision: 217
 
 
-    # repeat for egress
+    $ # repeat for egress
     $ cilium endpoint get 568 -o jsonpath='{range ..status.policy.realized.l4.egress[*].derived-from-rules}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
 
 Troubleshooting ``toFQDNs`` rules

--- a/Documentation/policy/visibility.rst
+++ b/Documentation/policy/visibility.rst
@@ -33,7 +33,7 @@ For example:
 To do this, you can provide the annotation in your Kubernetes YAMLs, or via the
 command line, e.g.:
 
-.. code:: bash
+.. code-block:: shell-session
 
     kubectl annotate pod foo -n bar io.cilium.proxy-visibility="<Egress/53/UDP/DNS>,<Egress/80/TCP/HTTP>"
 
@@ -49,18 +49,18 @@ transparently redirect traffic to the proxy such that the output of
 You can check the status of the visibility policy by checking the Cilium
 endpoint of that pod, for example:
 
-::
+.. code-block:: shell-session
 
-        $ kubectl get cep -n kube-system
-        NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4           IPV6
-        coredns-7d7f5b7685-wvzwb   1959          104           false                 false                                    ready            10.16.75.193   f00d::a10:0:0:2c77
-        $
-        $ kubectl annotate pod -n kube-system coredns-7d7f5b7685-wvzwb io.cilium.proxy-visibility="<Egress/53/UDP/DNS>,<Egress/80/TCP/HTTP>" --overwrite
-        pod/coredns-7d7f5b7685-wvzwb annotated
-        $
-        $ kubectl get cep -n kube-system
-        NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4           IPV6
-        coredns-7d7f5b7685-wvzwb   1959          104           false                 false                OK                  ready            10.16.75.193   f00d::a10:0:0:2c7
+    $ kubectl get cep -n kube-system
+    NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4           IPV6
+    coredns-7d7f5b7685-wvzwb   1959          104           false                 false                                    ready            10.16.75.193   f00d::a10:0:0:2c77
+    $
+    $ kubectl annotate pod -n kube-system coredns-7d7f5b7685-wvzwb io.cilium.proxy-visibility="<Egress/53/UDP/DNS>,<Egress/80/TCP/HTTP>" --overwrite
+    pod/coredns-7d7f5b7685-wvzwb annotated
+    $
+    $ kubectl get cep -n kube-system
+    NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4           IPV6
+    coredns-7d7f5b7685-wvzwb   1959          104           false                 false                OK                  ready            10.16.75.193   f00d::a10:0:0:2c7
 
 Troubleshooting
 ---------------
@@ -78,14 +78,14 @@ The following example deliberately misconfigures the annotation to demonstrate
 that the CiliumEndpoint for the pod presents an error when the visibility
 annotation cannot be implemented:
 
-::
+.. code-block:: shell-session
 
-        $ kubectl annotate pod -n kube-system coredns-7d7f5b7685-wvzwb io.cilium.proxy-visibility="<Ingress/53/UDP/DNS>,<Egress/80/TCP/HTTP>"
-        pod/coredns-7d7f5b7685-wvzwb annotated
-        $
-        $ kubectl get cep -n kube-system
-        NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY                        ENDPOINT STATE   IPV4           IPV6
-        coredns-7d7f5b7685-wvzwb   1959          104           false                 false                dns not allowed with direction Ingress   ready            10.16.75.193   f00d::a10:0:0:2c77
+    $ kubectl annotate pod -n kube-system coredns-7d7f5b7685-wvzwb io.cilium.proxy-visibility="<Ingress/53/UDP/DNS>,<Egress/80/TCP/HTTP>"
+    pod/coredns-7d7f5b7685-wvzwb annotated
+    $
+    $ kubectl get cep -n kube-system
+    NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY                        ENDPOINT STATE   IPV4           IPV6
+    coredns-7d7f5b7685-wvzwb   1959          104           false                 false                dns not allowed with direction Ingress   ready            10.16.75.193   f00d::a10:0:0:2c77
 
 Limitations
 -----------

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -681,6 +681,7 @@ priori
 priorityClassName
 productpage
 profiler
+prog
 programmability
 prometheus
 protobuf


### PR DESCRIPTION
The `.. code-block::` directive defined by Sphinx is more flexible, and we have tried to enforce its use over `.. code::` for some time. Similarly, the `bash` language passed as an argument to that directive is often incorrect, as it should be used for bash scripts. For commands to type in the console, `shell-session` should be preferred.

One issue is that contributors keep copy-pasting the existing incorrect directives. Following the discussion at https://github.com/cilium/cilium/pull/16431#discussion_r645686380, in this PR:

- Replace `.. code::` with `.. code-block::` everywhere.

- Replace `bash` with `shell-session` everywhere relevant (most of the occurrences).

- Fix the use of `::` (literal block, for raw output) versus the `code-block` directive (for code snippets). However, I have not checked all existing occurrences of `.. code-block::`.

- Fix the use of the `parsed-literal` directive, which should be used only when there are RST elements to parse in the block (typically some RST substitutions).

- Fix a small number of minor formatting issues met when updating the directives.

_[Apologies for the large number of review requests triggered -- This is all about formatting for the documentation, really]_