### PR TITLE
fix warning log for list IPV6 address: move IPV4 to IPv6.

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -207,7 +207,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 	if option.Config.EnableIPv6 {
 		addrs, err := d.datapath.LocalNodeAddressing().IPv6().LocalAddresses()
 		if err != nil {
-			log.WithError(err).Warning("Unable to list local IPv4 addresses")
+			log.WithError(err).Warning("Unable to list local IPv6 addresses")
 		}
 
 		addrs = append(addrs, node.GetIPv6Router())


### PR DESCRIPTION
fix a small error for a log.
to list IPV6 address, but print the log is list IPv4.