### PR TITLE
bpf: rename variables with camel-case names

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -451,7 +451,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 	    __u32 ipcache_srcid __maybe_unused, const bool from_host)
 {
 	struct remote_endpoint_info *info = NULL;
-	__u32 __maybe_unused remoteID = 0;
+	__u32 __maybe_unused remote_id = 0;
 	__u32 __maybe_unused monitor = 0;
 	struct ipv4_ct_tuple tuple = {};
 	bool skip_redirect = false;
@@ -508,7 +508,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			return ret;
 	} else if (!ctx_skip_host_fw(ctx)) {
 		/* We're on the ingress path of the native device. */
-		ret = ipv4_host_policy_ingress(ctx, &remoteID);
+		ret = ipv4_host_policy_ingress(ctx, &remote_id);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -1084,12 +1084,12 @@ int to_host(struct __ctx_buff *ctx)
 	__u16 __maybe_unused proto = 0;
 	int ret = CTX_ACT_OK;
 	bool traced = false;
-	__u32 srcID = 0;
+	__u32 src_id = 0;
 
 	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
 		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
-		srcID = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
-		set_identity_mark(ctx, srcID);
+		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+		set_identity_mark(ctx, src_id);
 	} else if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
@@ -1114,7 +1114,7 @@ int to_host(struct __ctx_buff *ctx)
 #endif
 
 	if (!traced)
-		send_trace_notify(ctx, TRACE_TO_STACK, srcID, 0, 0,
+		send_trace_notify(ctx, TRACE_TO_STACK, src_id, 0, 0,
 				  CILIUM_IFINDEX, ret, 0);
 
 #ifdef ENABLE_HOST_FIREWALL
@@ -1133,12 +1133,12 @@ int to_host(struct __ctx_buff *ctx)
 # endif
 # ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		ret = ipv6_host_policy_ingress(ctx, &srcID);
+		ret = ipv6_host_policy_ingress(ctx, &src_id);
 		break;
 # endif
 # ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		ret = ipv4_host_policy_ingress(ctx, &srcID);
+		ret = ipv4_host_policy_ingress(ctx, &src_id);
 		break;
 # endif
 	default:
@@ -1151,7 +1151,7 @@ int to_host(struct __ctx_buff *ctx)
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, srcID, ret, CTX_ACT_DROP,
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
 					      METRIC_INGRESS);
 
 	return ret;
@@ -1163,12 +1163,12 @@ declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6))
 			 is_defined(DEBUG)), CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY)
 int tail_ipv6_host_policy_ingress(struct __ctx_buff *ctx)
 {
-	__u32 srcID = 0;
+	__u32 src_id = 0;
 	int ret;
 
-	ret = ipv6_host_policy_ingress(ctx, &srcID);
+	ret = ipv6_host_policy_ingress(ctx, &src_id);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, srcID, ret, CTX_ACT_DROP,
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
 					      METRIC_INGRESS);
 	return ret;
 }
@@ -1179,12 +1179,12 @@ declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6))
 			 is_defined(DEBUG)), CILIUM_CALL_IPV4_TO_HOST_POLICY_ONLY)
 int tail_ipv4_host_policy_ingress(struct __ctx_buff *ctx)
 {
-	__u32 srcID = 0;
+	__u32 src_id = 0;
 	int ret;
 
-	ret = ipv4_host_policy_ingress(ctx, &srcID);
+	ret = ipv4_host_policy_ingress(ctx, &src_id);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, srcID, ret, CTX_ACT_DROP,
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
 					      METRIC_INGRESS);
 	return ret;
 }

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -24,7 +24,7 @@
 static __always_inline void update_metrics(__u64 bytes, __u8 direction,
 					   __u8 reason)
 {
-	struct metrics_value *entry, newEntry = {};
+	struct metrics_value *entry, new_entry = {};
 	struct metrics_key key = {};
 
 	key.reason = reason;
@@ -36,9 +36,9 @@ static __always_inline void update_metrics(__u64 bytes, __u8 direction,
 		entry->count += 1;
 		entry->bytes += bytes;
 	} else {
-		newEntry.count = 1;
-		newEntry.bytes = bytes;
-		map_update_elem(&METRICS_MAP, &key, &newEntry, 0);
+		new_entry.count = 1;
+		new_entry.bytes = bytes;
+		map_update_elem(&METRICS_MAP, &key, &new_entry, 0);
 	}
 }
 

--- a/bpf/sockops/bpf_redir.c
+++ b/bpf/sockops/bpf_redir.c
@@ -44,7 +44,7 @@ int bpf_redir_proxy(struct sk_msg_md *msg)
 	struct remote_endpoint_info *info;
 	__u64 flags = BPF_F_INGRESS;
 	struct sock_key key = {};
-	__u32 dstID = 0;
+	__u32 dst_id = 0;
 	int verdict;
 
 	sk_msg_extract4_key(msg, &key);
@@ -56,11 +56,11 @@ int bpf_redir_proxy(struct sk_msg_md *msg)
 	 */
 	info = lookup_ip4_remote_endpoint(key.dip4);
 	if (info != NULL && info->sec_label)
-		dstID = info->sec_label;
+		dst_id = info->sec_label;
 	else
-		dstID = WORLD_ID;
+		dst_id = WORLD_ID;
 
-	verdict = policy_sk_egress(dstID, key.sip4, key.dport);
+	verdict = policy_sk_egress(dst_id, key.sip4, key.dport);
 	if (verdict >= 0)
 		msg_redirect_hash(msg, &SOCK_OPS_MAP, &key, flags);
 	return SK_PASS;

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -55,7 +55,7 @@ static __always_inline bool redirect_to_proxy(int verdict)
 static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 {
 	struct lb4_key lb4_key = {};
-	__u32 dip4, dport, dstID = 0;
+	__u32 dip4, dport, dst_id = 0;
 	struct endpoint_info *exists;
 	struct lb4_service *svc;
 	struct sock_key key = {};
@@ -77,12 +77,12 @@ static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 
 		info = lookup_ip4_remote_endpoint(key.dip4);
 		if (info != NULL && info->sec_label)
-			dstID = info->sec_label;
+			dst_id = info->sec_label;
 		else
-			dstID = WORLD_ID;
+			dst_id = WORLD_ID;
 	}
 
-	verdict = policy_sk_egress(dstID, key.sip4, key.dport);
+	verdict = policy_sk_egress(dst_id, key.sip4, key.dport);
 	if (redirect_to_proxy(verdict)) {
 		__be32 host_ip = IPV4_GATEWAY;
 


### PR DESCRIPTION
We run checkpatch.pl on the commits touching the bpf/ code, and it complains when edits contain camel-case variable names -- even if they were not introduced by the commit. We could disable this report in the script we use to call checkpatch.pl, but at the same time we _do_ want it to catch the introduction of new camel-case names.

As suggested in https://github.com/cilium/cilium/pull/16447#discussion_r646556442, let's fix the existing variable names once and for all, to avoid contributors to get surprised by the reports.

The number of variables is rather low: `srcID`, `dstID`, `localID`, `remoteID`, and `newEntries`.
