### PR TITLE
NodePort health checks should be disabled when kube-proxy is installed

### DIFF
--- a/pkg/service/healthserver/healthserver.go
+++ b/pkg/service/healthserver/healthserver.go
@@ -196,7 +196,7 @@ func (h *httpHealthHTTPServerFactory) newHTTPHealthServer(port uint16, svc *Serv
 					logfields.ServiceName:                svc.Service.Name,
 					logfields.ServiceNamespace:           svc.Service.Namespace,
 					logfields.ServiceHealthCheckNodePort: port,
-				}).Errorf("ListenAndServe failed for service health server, since the user might be running with kube-proxy. Please ensure that '--%s' option is set to false if '--%s' is set to '%s'", option.EnableHealthCheckNodePort, option.KubeProxyReplacement, option.KubeProxyReplacementPartial)
+				}).Errorf("ListenAndServe failed for service health server, since the user might be running with kube-proxy. Please ensure that '--%s' option is set to false if kube-proxy is running.", option.EnableHealthCheckNodePort)
 			}
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.ServiceName:                svc.Service.Name,

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2360,6 +2360,12 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 			"kubeProxyReplacement": "strict",
 		}
 
+		if RunsWithKubeProxy() {
+			// If kube-proxy is running, we need to disable NodePort health
+			// checks to avoid an error message.
+			opts["nodePort.enableHealthCheck"] = "false"
+		}
+
 		if DoesNotRunOnGKE() {
 			nodeIP, err := kub.GetNodeIPByLabel(K8s1, false)
 			if err != nil {


### PR DESCRIPTION
See commit descriptions.