### PR TITLE
test: Fix panic after 'jq' returns "null"

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -675,7 +675,7 @@ func (kub *Kubectl) labelNodes() error {
 // GetCiliumEndpoint returns the CiliumEndpoint for the specified pod.
 func (kub *Kubectl) GetCiliumEndpoint(namespace string, pod string) (*cnpv2.EndpointStatus, error) {
 	fullName := namespace + "/" + pod
-	cmd := fmt.Sprintf("%s -n %s get cep %s -o json | jq '.status'", KubectlCmd, namespace, pod)
+	cmd := fmt.Sprintf("%s -n %s get cep %s -o json | jq '.status | select (.!=null)'", KubectlCmd, namespace, pod)
 	res := kub.ExecShort(cmd)
 	if !res.WasSuccessful() {
 		return nil, fmt.Errorf("unable to run command '%s' to retrieve CiliumEndpoint %s: %s",


### PR DESCRIPTION
jq can return "null" as in:

  $ echo "{}" | jq '.status'
  null
  $

Some of our test code expects stdout to be empty in this case, which
leads to panics like:

  Stacktrace
  /home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:465
  Test Panicked

In this case there was no other indication of what went wrong. Tracing
the test commands and output against the test source revealed that
this is caused by 'jq' returning "null" in stdout when the test code
expects stdout to be empty if nothing is found.

This can be fixed by adding " | select (.!=null)" to the end of the jq query:

  $ echo "{}" | jq '.status | select (.!=null)'
  $

After this the test for empty stdout after the jq query functions as expected.

Fixes: #16480
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
