### PR TITLE
Switch ginkgo upgrade testing to upgrade from v1.10->latest

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -187,9 +187,9 @@ const (
 
 	// CiliumStableHelmChartVersion should be the chart version that points
 	// to the v1.X branch
-	CiliumStableHelmChartVersion = "1.9-dev"
-	CiliumStableVersion          = "v1.9"
-	CiliumLatestHelmChartVersion = "1.9.90"
+	CiliumStableHelmChartVersion = "1.10"
+	CiliumStableVersion          = "v" + CiliumStableHelmChartVersion
+	CiliumLatestHelmChartVersion = "1.10.90"
 
 	MonitorLogFileName = "monitor.log"
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2545,89 +2545,6 @@ func (kub *Kubectl) CiliumInstall(filename string, options map[string]string) er
 	return nil
 }
 
-// convertOptionsToLegacyOptions maps current helm values to old helm Values
-// TODO: When Cilium 1.10 branch is created, remove this function
-func (kub *Kubectl) convertOptionsToLegacyOptions(options map[string]string) map[string]string {
-
-	result := make(map[string]string)
-
-	legacyMappings := map[string]string{
-		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key":       "global.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key",
-		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator":  "global.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator",
-		"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]": "global.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]",
-		"bpf.preallocateMaps":           "global.bpf.preallocateMaps",
-		"bpf.masquerade":                "config.bpfMasquerade",
-		"cleanState":                    "global.cleanState",
-		"cni.binPath":                   "global.cni.binPath",
-		"cni.chainingMode":              "global.cni.chainingMode",
-		"cni.confPath":                  "global.cni.confPath",
-		"cni.customConf":                "global.cni.customConf",
-		"daemon.runPath":                "global.daemon.runPath",
-		"debug.enabled":                 "global.debug.enabled",
-		"devices":                       "global.devices", // Override "eth0 eth0\neth0"
-		"enableCnpStatusUpdates":        "config.enableCnpStatusUpdates",
-		"etcd.leaseTTL":                 "global.etcd.leaseTTL",
-		"externalIPs.enabled":           "global.externalIPs.enabled",
-		"gke.enabled":                   "global.gke.enabled",
-		"hostFirewall":                  "global.hostFirewall",
-		"hostPort.enabled":              "global.hostPort.enabled",
-		"hostServices.enabled":          "global.hostServices.enabled",
-		"hubble.enabled":                "global.hubble.enabled",
-		"hubble.listenAddress":          "global.hubble.listenAddress",
-		"hubble.relay.image.repository": "hubble-relay.image.repository",
-		"hubble.relay.image.tag":        "hubble-relay.image.tag",
-		"image.tag":                     "global.tag",
-		"ipam.mode":                     "config.ipam",
-		"ipv4.enabled":                  "global.ipv4.enabled",
-		"ipv6.enabled":                  "global.ipv6.enabled",
-		"k8s.requireIPv4PodCIDR":        "global.k8s.requireIPv4PodCIDR",
-		"k8sServiceHost":                "global.k8sServiceHost",
-		"k8sServicePort":                "global.k8sServicePort",
-		"kubeProxyReplacement":          "global.kubeProxyReplacement",
-		"loadBalancer.mode":             "global.nodePort.mode",
-		"logSystemLoad":                 "global.logSystemLoad",
-		"masquerade":                    "global.masquerade",
-		"nativeRoutingCIDR":             "global.nativeRoutingCIDR",
-		"nodeinit.enabled":              "global.nodeinit.enabled",
-		"nodeinit.reconfigureKubelet":   "global.nodeinit.reconfigureKubelet",
-		"nodeinit.removeCbrBridge":      "global.nodeinit.removeCbrBridge",
-		"nodeinit.restartPods":          "globalnodeinit.restartPods",
-		"nodePort.enabled":              "global.nodePort.enabled",
-		"operator.enabled":              "operator.enabled",
-		"pprof.enabled":                 "global.pprof.enabled",
-		"sessionAffinity":               "config.sessionAffinity",
-		"sleepAfterInit":                "agent.sleepAfterInit",
-		"tunnel":                        "global.tunnel",
-	}
-
-	for newKey, v := range options {
-		if oldKey, ok := legacyMappings[newKey]; ok {
-			result[oldKey] = v
-		} else if !ok {
-			if newKey == "image.repository" {
-				result["agent.image"] = v + ":" + options["image.tag"]
-			} else if newKey == "operator.image.repository" {
-				if options["eni.enabled"] == "true" {
-					result["operator.image"] = v + "-aws:" + options["image.tag"]
-				} else if options["azure.enabled"] == "true" {
-					result["operator.image"] = v + "-azure:" + options["image.tag"]
-				} else {
-					result["operator.image"] = v + "-generic:" + options["image.tag"]
-				}
-			} else if newKey == "preflight.image.repository" {
-				result["preflight.image"] = v + ":" + options["image.tag"]
-			} else if strings.HasSuffix(newKey, ".tag") {
-				// Already handled in the if statement above
-				continue
-			} else {
-				log.Warningf("Skipping option %s", newKey)
-			}
-		}
-	}
-	result["ci.kubeCacheMutationDetector"] = "true"
-	return result
-}
-
 // RunHelm runs the helm command with the given options.
 func (kub *Kubectl) RunHelm(action, repo, helmName, version, namespace string, options map[string]string) (*CmdRes, error) {
 	err := kub.overwriteHelmOptions(options)
@@ -2635,11 +2552,6 @@ func (kub *Kubectl) RunHelm(action, repo, helmName, version, namespace string, o
 		return nil, err
 	}
 	optionsString := ""
-
-	//TODO: In 1.10 dev cycle, remove this
-	if version == "1.8-dev" {
-		options = kub.convertOptionsToLegacyOptions(options)
-	}
 
 	for k, v := range options {
 		optionsString += fmt.Sprintf(" --set %s=%s ", k, v)

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cilium/cilium/pkg/versioncheck"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
@@ -403,12 +402,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			"operator.enabled":    "false ",
 			"preflight.image.tag": newImageVersion,
 			"nodeinit.enabled":    "false",
-		}
-		hasNewHelmValues := versioncheck.MustCompile(">=1.8.90")
-		if hasNewHelmValues(versioncheck.MustVersion(newHelmChartVersion)) {
-			opts["agent"] = "false "
-		} else {
-			opts["agent.enabled"] = "false "
+			"agent":               "false ",
 		}
 
 		EventuallyWithOffset(1, func() (*helpers.CmdRes, error) {
@@ -437,18 +431,6 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			"image.tag":              newImageVersion,
 			"operator.image.tag":     newImageVersion,
 			"hubble.relay.image.tag": newImageVersion,
-		}
-		// We have removed the labels since >= 1.7 and we are only testing
-		// starting from 1.6.
-		if oldHelmChartVersion == "1.6-dev" {
-			opts["agent.keepDeprecatedLabels"] = "true"
-		}
-		// We have replaced the liveness and readiness probes since >= 1.8 and
-		// we need to keep those deprecated probes from <1.8-dev to >=1.8
-		// upgrades since kubernetes does not do `kubectl apply -f` correctly.
-		switch oldHelmChartVersion {
-		case "1.6-dev", "1.7-dev":
-			opts["agent.keepDeprecatedProbes"] = "true"
 		}
 
 		upgradeCompatibilityVer := strings.TrimSuffix(oldHelmChartVersion, "-dev")

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -235,17 +235,19 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		cleanupCiliumState(filepath.Join(kubectl.BasePath(), helpers.HelmTemplate), newHelmChartVersion, "", newImageVersion, "")
 
 		By("Cleaning Cilium state (%s)", oldImageVersion)
-		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "quay.io/cilium/cilium", oldImageVersion, "")
+		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "quay.io/cilium/cilium-ci", oldImageVersion, "")
 
 		By("Deploying Cilium %s", oldHelmChartVersion)
 
 		opts := map[string]string{
-			"image.tag":                     oldImageVersion,
-			"operator.image.tag":            oldImageVersion,
-			"hubble.relay.image.tag":        oldImageVersion,
-			"image.repository":              "quay.io/cilium/cilium",
-			"operator.image.repository":     "quay.io/cilium/operator",
-			"hubble.relay.image.repository": "quay.io/cilium/hubble-relay",
+			"image.tag":                              oldImageVersion,
+			"operator.image.tag":                     oldImageVersion,
+			"hubble.relay.image.tag":                 oldImageVersion,
+			"clustermesh.apiserver.image.tag":        oldImageVersion,
+			"image.repository":                       "quay.io/cilium/cilium-ci",
+			"operator.image.repository":              "quay.io/cilium/operator",
+			"hubble.relay.image.repository":          "quay.io/cilium/hubble-relay-ci",
+			"clustermesh.apiserver.image.repository": "quay.io/cilium/clustermesh-apiserver-ci",
 		}
 
 		// Eventually allows multiple return values, and performs the assertion


### PR DESCRIPTION
- test: Bump Cilium upgrade for v1.11 development
- test: Remove deprecated upgrade test logic

For more details, see the individual commits.
