### PR TITLE
test: Remove uptime reporting

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1209,41 +1209,6 @@ func (kub *Kubectl) MonitorEndpointStart(pod string, epID int64) (res *CmdRes, c
 	return kub.ExecInBackground(ctx, cmd, ExecOptions{SkipLog: true}), cancel
 }
 
-// BackgroundReport dumps the result of the given commands on cilium pods each
-// five seconds.
-func (kub *Kubectl) BackgroundReport(commands ...string) (context.CancelFunc, error) {
-	backgroundCtx, cancel := context.WithCancel(context.Background())
-	retrieveInfo := func() {
-		pods, err := kub.GetCiliumPods()
-		if err != nil {
-			kub.Logger().Infof("failed to retrieve cilium pods: %s", err)
-			return
-		}
-		if len(pods) == 0 {
-			kub.Logger().Infof("no cilium pods found")
-			return
-		}
-		for _, pod := range pods {
-			for _, cmd := range commands {
-				kub.CiliumExecContext(context.TODO(), pod, cmd)
-			}
-		}
-	}
-	go func(ctx context.Context) {
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				retrieveInfo()
-			}
-		}
-	}(backgroundCtx)
-	return cancel, nil
-}
-
 // PprofReport runs pprof on cilium nodes each 5 minutes and saves the data
 // into the test folder saved with pprof suffix.
 func (kub *Kubectl) PprofReport() {

--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -15,7 +15,6 @@
 package k8sTest
 
 import (
-	"context"
 	"fmt"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -59,10 +58,6 @@ var _ = Describe("K8sBandwidthTest", func() {
 		)
 
 		var (
-			backgroundCancel       context.CancelFunc = func() {}
-			backgroundError        error
-			enableBackgroundReport = true
-
 			podLabels = []string{
 				testDS10,
 				testDS25,
@@ -73,16 +68,8 @@ var _ = Describe("K8sBandwidthTest", func() {
 			kubectl.CiliumReport("cilium bpf bandwidth list", "cilium endpoint list")
 		})
 
-		JustBeforeEach(func() {
-			if enableBackgroundReport {
-				backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
-				Expect(backgroundError).To(BeNil(), "Cannot start background report process")
-			}
-		})
-
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-			backgroundCancel()
 		})
 
 		AfterAll(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -15,7 +15,6 @@
 package k8sTest
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -30,9 +29,7 @@ import (
 var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 
 	var (
-		kubectl          *helpers.Kubectl
-		backgroundCancel context.CancelFunc = func() {}
-		backgroundError  error
+		kubectl *helpers.Kubectl
 
 		// these two are set in BeforeAll
 		l7Policy       string
@@ -106,14 +103,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 			return err
 		}
 
-		JustBeforeEach(func() {
-			backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
-			Expect(backgroundError).To(BeNil(), "Cannot start background report process")
-		})
-
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-			backgroundCancel()
 		})
 
 		AfterEach(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -75,11 +75,9 @@ var _ = SkipDescribeIf(func() bool {
 		cnpMatchExpressionDeny   string
 		connectivityCheckYml     string
 
-		app1Service                         = "app1-service"
-		backgroundCancel context.CancelFunc = func() {}
-		backgroundError  error
-		apps             = []string{helpers.App1, helpers.App2, helpers.App3}
-		daemonCfg        map[string]string
+		app1Service = "app1-service"
+		apps        = []string{helpers.App1, helpers.App2, helpers.App3}
+		daemonCfg   map[string]string
 	)
 
 	BeforeAll(func() {
@@ -135,14 +133,8 @@ var _ = SkipDescribeIf(func() bool {
 		kubectl.CloseSSHClient()
 	})
 
-	JustBeforeEach(func() {
-		backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
-		Expect(backgroundError).To(BeNil(), "Cannot start background report process")
-	})
-
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-		backgroundCancel()
 	})
 
 	// getMatcher returns a helper.CMDSucess() matcher for success or

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -43,10 +43,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
 
-		backgroundCancel       context.CancelFunc = func() {}
-		backgroundError        error
-		enableBackgroundReport = true
-
 		k8s1NodeName    string
 		k8s2NodeName    string
 		outsideNodeName string
@@ -115,16 +111,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
 
-	JustBeforeEach(func() {
-		if enableBackgroundReport {
-			backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
-			Expect(backgroundError).To(BeNil(), "Cannot start background report process")
-		}
-	})
-
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-		backgroundCancel()
 	})
 
 	AfterEach(func() {
@@ -2273,14 +2261,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Tests NodePort BPF",
 			func() {
-				BeforeAll(func() {
-					enableBackgroundReport = false
-				})
-
-				AfterAll(func() {
-					enableBackgroundReport = true
-				})
-
 				Context("Tests with vxlan", func() {
 					It("Tests NodePort", func() {
 						testNodePort(true, false, helpers.ExistNodeWithoutCilium(), 0)

--- a/test/k8sT/StressPolicy.go
+++ b/test/k8sT/StressPolicy.go
@@ -26,25 +26,15 @@ import (
 
 var _ = Describe("NightlyPolicyStress", func() {
 
-	var (
-		kubectl          *helpers.Kubectl
-		backgroundCancel context.CancelFunc = func() {}
-		backgroundError  error
-	)
+	var kubectl *helpers.Kubectl
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		deploymentManager.SetKubectl(kubectl)
 	})
 
-	JustBeforeEach(func() {
-		backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
-		Expect(backgroundError).To(BeNil(), "Cannot start background report process")
-	})
-
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-		backgroundCancel()
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -15,7 +15,6 @@
 package k8sTest
 
 import (
-	"context"
 	"fmt"
 	"net"
 
@@ -29,9 +28,7 @@ import (
 // doesn't need to execute this test suite.
 var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 	var (
-		kubectl          *helpers.Kubectl
-		backgroundCancel context.CancelFunc = func() {}
-		backgroundError  error
+		kubectl *helpers.Kubectl
 
 		demoManifest   = ""
 		ciliumFilename string
@@ -98,16 +95,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
-	})
-
-	JustBeforeEach(func() {
-		backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
-		Expect(backgroundError).To(BeNil(), "Cannot start background report process")
-	})
-
-	JustAfterEach(func() {
-		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-		backgroundCancel()
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -15,7 +15,6 @@
 package k8sTest
 
 import (
-	"context"
 	"fmt"
 	"runtime"
 	"time"
@@ -77,8 +76,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 		wgetCommand = fmt.Sprintf("wget --tries=2 --connect-timeout %d", helpers.CurlConnectTimeout)
 		curlCommand = fmt.Sprintf("curl --retry 2 --retry-connrefused --connect-timeout %d", helpers.CurlConnectTimeout)
 
-		kubectl      *helpers.Kubectl
-		uptimeCancel context.CancelFunc
+		kubectl *helpers.Kubectl
 
 		teardownTimeout = 10 * time.Minute
 
@@ -133,15 +131,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 		kubectl.CloseSSHClient()
 	})
 
-	JustBeforeEach(func() {
-		var err error
-		uptimeCancel, err = kubectl.BackgroundReport("uptime")
-		Expect(err).To(BeNil(), "Cannot start background report process")
-	})
-
 	JustAfterEach(func() {
-		uptimeCancel()
-
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 

--- a/test/k8sT/l7_demos.go
+++ b/test/k8sT/l7_demos.go
@@ -15,7 +15,6 @@
 package k8sTest
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 
@@ -32,9 +31,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDemosTest", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
-
-		backgroundCancel context.CancelFunc = func() {}
-		backgroundError  error
 
 		deathStarYAMLLink, xwingYAMLLink, l7PolicyYAMLLink string
 	)
@@ -54,14 +50,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDemosTest", func() {
 		kubectl.CiliumReport("cilium endpoint list", "cilium service list")
 	})
 
-	JustBeforeEach(func() {
-		backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
-		Expect(backgroundError).To(BeNil(), "Cannot start background report process")
-	})
-
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
-		backgroundCancel()
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Based on the sparse PR description which introduced the uptime reporting
\[1\], it used to detect any CPU discrepancies.

It's been awhile since we had any. Also, we have "lscpu" to detect such.
So, let's remove this unnecessary noise from the tests.

\[1\]: https://github.com/cilium/cilium/pull/4901