### PR TITLE
workflows: Skip jobs instead of workflows

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -2,33 +2,41 @@ name: Documentation Updates
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request:
-    paths:
-      - 'Documentation/**'
-      - 'bugtool/cmd/**'
-      - 'cilium/cmd/**'
-      - 'cilium-health/cmd/**'
-      - 'daemon/cmd/**'
-      - 'hubble-relay/cmd/**'
-      - 'operator/cmd/**'
+  pull_request: {}
   push:
     branches:
       - master
-    paths:
-      - 'Documentation/**'
-      - 'bugtool/cmd/**'
-      - 'cilium/cmd/**'
-      - 'cilium-health/cmd/**'
-      - 'daemon/cmd/**'
-      - 'hubble-relay/cmd/**'
-      - 'operator/cmd/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-18.04
+    outputs:
+      docs-tree: ${{ steps.docs-tree.outputs.src }}
+    steps:
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: docs-tree
+        with:
+          filters: |
+            src:
+              - 'Documentation/**'
+              - 'bugtool/cmd/**'
+              - 'cilium/cmd/**'
+              - 'cilium-health/cmd/**'
+              - 'daemon/cmd/**'
+              - 'hubble-relay/cmd/**'
+              - 'operator/cmd/**'
+
+  # Runs only if code under Documentation or */cmd/ is changed as the docs
+  # should be unaffected otherwise.
   build-html:
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.docs-tree == 'true' }}
     name: Validate & Build HTML
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -1,22 +1,31 @@
 name: codeql
 
 on:
-  push:
-    paths:
-      - '*.go'
-      - 'go.mod'
-      - 'go.sum'
-  pull_request:
-    paths:
-      - '*.go'
-      - 'go.mod'
-      - 'go.sum'
+  push: {}
+  pull_request: {}
   schedule:
     - cron: "45 6 * * 3"
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-18.04
+    outputs:
+      go-changes: ${{ steps.go-changes.outputs.src }}
+    steps:
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: go-changes
+        with:
+          filters: |
+            src:
+              - '*.go'
+              - 'go.mod'
+              - 'go.sum'
+
   analyze:
-    if: github.repository == 'cilium/cilium'
+    needs: check_changes
+    if: github.repository == 'cilium/cilium' && needs.check_changes.outputs.go-changes == 'true'
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout repo

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -2,16 +2,10 @@ name: Smoke Test with IPv6
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request:
-    paths-ignore:
-      - 'Documentation/**'
-      - 'test/**'
+  pull_request: {}
   push:
     branches:
       - master
-    paths-ignore:
-      - 'Documentation/**'
-      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
@@ -26,8 +20,23 @@ env:
   LOG_TIME: 30m
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-18.04
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: tested-tree
+        with:
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
   conformance-test-ipv6:
-    if: ${{ github.repository == 'cilium/cilium' }}
+    needs: check_changes
+    if: ${{ github.repository == 'cilium/cilium' && needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -2,16 +2,10 @@ name: Smoke test
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request:
-    paths-ignore:
-      - 'Documentation/**'
-      - 'test/**'
+  pull_request: {}
   push:
     branches:
       - master
-    paths-ignore:
-      - 'Documentation/**'
-      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
@@ -25,6 +19,20 @@ env:
   LOG_TIME: 30m
 
 jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-18.04
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      - name: Check code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: tested-tree
+        with:
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
   preflight-clusterrole:
     runs-on: ubuntu-latest
     steps:
@@ -69,7 +77,8 @@ jobs:
           git diff --exit-code || (echo "please run 'make -C install/kubernetes docs' and submit your changes"; exit 1)
 
   conformance-test:
-    if: ${{ github.repository == 'cilium/cilium' }}
+    needs: check_changes
+    if: ${{ github.repository == 'cilium/cilium' && needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
In its initial version, commit 3ceb742 (".github: Skip unnecessary docs test") skipped the job instead of the whole workflow, based on changed code paths. After [discussion on the pull request](https://github.com/cilium/cilium/pull/16157#discussion_r635465752), we figured we could save some seconds by skipping the whole workflow instead of the job. Skipping the job requires adding a new job to check the code paths.

However, if we skip the whole workflow, the job status is never reported on GitHub. Since the documentation job is required to merge, that means maintainer's little helper will never mark the pull request as ready to merge.

Thus, this pull request reverts back to skipping the jobs instead of the whole workflows. To that end, we use `paths-filter` GitHub Action instead of the direct GitHub integration (since the GitHub path filters can only skip the whole workflow).