### PR TITLE
test: Fix artifact collection for bad log failures

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -315,7 +315,7 @@ var _ = AfterEach(func() {
 	}
 
 	// This piece of code is to enable zip attachments on Junit Output.
-	if ginkgo.CurrentGinkgoTestDescription().Failed && helpers.IsRunningOnJenkins() {
+	if TestFailed() && helpers.IsRunningOnJenkins() {
 		// ReportDirectory is already created. No check the error
 		path, _ := helpers.CreateReportDirectory()
 		zipFileName := fmt.Sprintf("%s_%s.zip", helpers.MakeUID(), GetTestName())
@@ -331,7 +331,7 @@ var _ = AfterEach(func() {
 		GinkgoPrint("[[ATTACHMENT|%s]]", zipFileName)
 	}
 
-	if !ginkgo.CurrentGinkgoTestDescription().Failed && helpers.IsRunningOnJenkins() {
+	if !TestFailed() && helpers.IsRunningOnJenkins() {
 		// If the test success delete the monitor.log filename to not store all
 		// the data in Jenkins
 		testPath, err := helpers.CreateReportDirectory()


### PR DESCRIPTION
When a test fails because a [bad log message](https://github.com/cilium/cilium/blob/v1.10.0/test/helpers/cons.go#L291) is found, the per-test artifacts are not collected and exposed in the Jenkins UI.

We only collect per-test artifacts for failing tests, which we detect with `ginkgo.CurrentGinkgoTestDescription().Failed`. Unfortunately, this variable is not updated when the test fails in a `JustAfterEach` block. That's the case for the bad log messages, which are almost always checked from a `JustAfterEach` block.

This pull request fixes that issue by using the dedicated function `TestFailed()` instead of `ginkgo.CurrentGinkgoTestDescription().Failed`.

This issue was discovered by @joestringer before in da25f94 ("k8sT: Clean up services in JustAfterEach"), but the fix was not extended to the existing code at the time.

[Before](https://jenkins.cilium.io/job/Cilium-PR-Runtime-4.9/4917/testReport/junit/(root)/Suite-runtime/RuntimeFQDNPolicies_toFQDNs_populates_toCIDRSet__data_from_proxy__L3_dependent_L7_HTTP_with_toFQDN_updates_proxy_policy/):
![image](https://user-images.githubusercontent.com/1764210/121401774-6d6c0480-c959-11eb-97f1-540d716012a1.png)

[After](https://jenkins.cilium.io/job/Cilium-PR-K8s-1.20-kernel-4.19/637/testReport/junit/Suite-k8s-1/20/K8sServicesTest_Checks_service_across_nodes_Supports_IPv4_fragments/):
![image](https://user-images.githubusercontent.com/1764210/121401810-7a88f380-c959-11eb-84ef-ffd58127d87f.png) 