### PR TITLE
workflows: Fix use of paths-filter on master pushes

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,6 +18,11 @@ jobs:
     outputs:
       docs-tree: ${{ steps.docs-tree.outputs.src }}
     steps:
+      - name: Checkout code
+        if: ${{ !github.event.pull_request }}
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
       - name: Check code changes
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: docs-tree

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -19,6 +19,11 @@ jobs:
       bpf-tree: ${{ steps.changes.outputs.bpf-tree }}
       coccinelle: ${{ steps.changes.outputs.coccinelle }}
     steps:
+      - name: Checkout code
+        if: ${{ !github.event.pull_request }}
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
       - name: Check code changes
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: changes

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -13,6 +13,11 @@ jobs:
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
     steps:
+      - name: Checkout code
+        if: ${{ !github.event.pull_request }}
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
       - name: Check code changes
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: go-changes

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -26,6 +26,11 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
+      - name: Checkout code
+        if: ${{ !github.event.pull_request }}
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
       - name: Check code changes
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: tested-tree

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -25,6 +25,11 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
+      - name: Checkout code
+        if: ${{ !github.event.pull_request }}
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          persist-credentials: false
       - name: Check code changes
         uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
         id: tested-tree


### PR DESCRIPTION
For pull requests, paths-filter retrieves the list of changed files via the GitHub API, but for pushes it needs access to the code. When a workflow is triggered by a push to master, we therefore need to checkout the source code before using paths-filter.

This change fixes the errors:

    Run dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
    Get current git ref
      /usr/bin/git branch --show-current
      fatal: not a git repository (or any of the parent directories): .git
    Error: The process '/usr/bin/git' failed with exit code 128

I tested it by pushing to my fork's default branch. The result can be seen at: https://github.com/pchaigno/cilium/runs/2801208965?check_suite_focus=true.

Reported-by: André Martins <andre@cilium.io>