### PR TITLE
fix: missing update verb in hubble-generate-certs

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-generate-certs-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-generate-certs-clusterrole.yaml
@@ -37,4 +37,5 @@ rules:
       - hubble-ca-secret
     verbs:
       - get
+      - update
 {{- end }}


### PR DESCRIPTION
If hubble-ca-secret already exists, then certgen is
going to update it.

To let certgen do its job, we need to configure update
verb in the binded ClusterRole, otherwise it will fail
with cannot update resource \"secrets\" in API group
message.

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #16508

```release-note
Fix issue where generating Hubble certs were broken
```
