### PR TITLE
fix: conditionally change hubble-relay port in hubble-ui

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -61,7 +61,11 @@ spec:
             - name: EVENTS_SERVER_PORT
               value: "8090"
             - name: FLOWS_API_ADDR
+{{- if .Values.hubble.relay.tls.server.enabled }}
+              value: "hubble-relay:443"
+{{- else }}
               value: "hubble-relay:80"
+{{- end }}
           ports:
             - containerPort: 8090
               name: grpc


### PR DESCRIPTION
In case of enabled TLS for Hubble Relay the hubble-ui
shall follow the service port change

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #16510

```release-note
conditionally change hubble relay port in hubble-ui
```
