### PR TITLE
docs: add custom spelling filter to check WireGuard spelling

### DIFF
--- a/Documentation/_exts/cilium_spellfilters.py
+++ b/Documentation/_exts/cilium_spellfilters.py
@@ -1,0 +1,9 @@
+from enchant.tokenize import Filter
+
+class WireGuardFilter(Filter):
+    """Accept either 'wireguard' (for documenting Helm values) or 'WireGuard',
+    but not 'Wireguard'.
+    """
+
+    def _skip(self, word):
+        return (word == 'wireguard' or word == 'WireGuard')

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -17,11 +17,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-# import sys
+import sys
 import re
 import subprocess
 import semver
-# sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.insert(0, os.path.abspath('_exts'))
+import cilium_spellfilters
 
 
 # -- General configuration ------------------------------------------------
@@ -150,6 +152,9 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
+
+# Add custom filters for spell checks.
+spelling_filters = [cilium_spellfilters.WireGuardFilter]
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -898,7 +898,6 @@ whitelists
 whitespace
 wildcard
 wildcards
-wireguard
 workflow
 workflows
 workspace


### PR DESCRIPTION
In the documentation, WireGuard should always be spelt with capital `W` and `G`. We also have a lowercase version coming from the documentation for Helm value, where `wireguard` is a value that one can pass to a dedicated option to select the encryption mode.

How to enforce correct spell checks for WireGuard, to avoid to introduce occurrences with erroneous capitalisation?

- If the spelling list contains `wireguard` or `Wireguard`, the check will be case-insensitive and `Wireguard` will not trigger an error (false negatives).

- If the spelling list contains `WireGuard` only, then the Helm value will trigger an error (false positive).

We want to allow both `WireGuard` and `wireguard`. This cannot be done via the spelling list, but can be implemented as a custom filter for Sphinx's spelling extension, in order to skip either of those spellings. Let's create this filter to make sure we capitalise the term correctly in the future.
