### PR TITLE
Auto-detect Azure cloud name via IMDS

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -11,7 +11,6 @@ cilium-operator-azure [flags]
 ### Options
 
 ```
-      --azure-cloud-name string                   Name of the Azure cloud being used (default "AzurePublicCloud")
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
       --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -14,7 +14,6 @@ cilium-operator [flags]
       --alibaba-cloud-vpc-id string               Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
       --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
       --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
-      --azure-cloud-name string                   Name of the Azure cloud being used (default "AzurePublicCloud")
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
       --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)

--- a/operator/main.go
+++ b/operator/main.go
@@ -382,7 +382,7 @@ func onOperatorStartLeading(ctx context.Context) {
 			log.WithError(err).Fatalf("Unable to init %s allocator", ipamMode)
 		}
 
-		nm, err := alloc.Start(&ciliumNodeUpdateImplementation{})
+		nm, err := alloc.Start(ctx, &ciliumNodeUpdateImplementation{})
 		if err != nil {
 			log.WithError(err).Fatalf("Unable to start %s allocator", ipamMode)
 		}

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -28,6 +28,7 @@ func init() {
 
 	flags.String(operatorOption.AzureCloudName, "AzurePublicCloud", "Name of the Azure cloud being used")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureCloudName, "AZURE_CLOUD_NAME")
+	flags.MarkDeprecated(operatorOption.AzureCloudName, "This option will be removed in v1.11")
 
 	flags.String(operatorOption.AzureSubscriptionID, "", "Subscription ID to access Azure API")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")

--- a/pkg/azure/api/metadata.go
+++ b/pkg/azure/api/metadata.go
@@ -39,6 +39,12 @@ func GetResourceGroupName(ctx context.Context) (string, error) {
 	return getMetadataString(ctx, "instance/compute/resourceGroupName")
 }
 
+// GetAzureCloudName retrieves the current Azure cloud name in which the host running the Cilium Operator is located
+// This is retrieved via the Azure Instance Metadata Service
+func GetAzureCloudName(ctx context.Context) (string, error) {
+	return getMetadataString(ctx, "instance/compute/azEnvironment")
+}
+
 // getMetadataString returns the text representation of a field from the Azure IMS (instance metadata service)
 // more can be found at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service#instance-api
 func getMetadataString(ctx context.Context, path string) (string, error) {

--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -56,7 +56,7 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context) error {
 	var err error
 	vpcID := operatorOption.Config.AlibabaCloudVPCID
 	if vpcID == "" {
-		vpcID, err = metadata.GetVPCID(context.TODO())
+		vpcID, err = metadata.GetVPCID(ctx)
 		if err != nil {
 			return err
 		}
@@ -88,7 +88,7 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context) error {
 // Start kicks off ENI allocation, the initial connection to AlibabaCloud
 // APIs is done in a blocking manner. Provided this is successful, a controller is
 // started to manage allocation based on CiliumNode custom resources
-func (a *AllocatorAlibabaCloud) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *AllocatorAlibabaCloud) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
 	var iMetrics ipam.MetricsAPI
 
 	log.Info("Starting AlibabaCloud ENI allocator...")
@@ -105,7 +105,7 @@ func (a *AllocatorAlibabaCloud) Start(getterUpdater ipam.CiliumNodeGetterUpdater
 		return nil, fmt.Errorf("unable to initialize AlibabaCloud node manager: %w", err)
 	}
 
-	if err := nodeManager.Start(context.TODO()); err != nil {
+	if err := nodeManager.Start(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -71,7 +71,7 @@ func (a *AllocatorAWS) Init(ctx context.Context) error {
 // Start kicks of ENI allocation, the initial connection to AWS
 // APIs is done in a blocking manner, given that is successful, a controller is
 // started to manage allocation based on CiliumNode custom resources
-func (a *AllocatorAWS) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
 	var iMetrics ipam.MetricsAPI
 
 	log.Info("Starting ENI allocator...")
@@ -88,7 +88,7 @@ func (a *AllocatorAWS) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 		return nil, fmt.Errorf("unable to initialize ENI node manager: %w", err)
 	}
 
-	if err := nodeManager.Start(context.TODO()); err != nil {
+	if err := nodeManager.Start(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -39,7 +39,7 @@ type AllocatorAzure struct{}
 func (*AllocatorAzure) Init(ctx context.Context) error { return nil }
 
 // Start kicks of the Azure IP allocation
-func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (*AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
 
 	var (
 		azMetrics azureAPI.MetricsAPI
@@ -51,7 +51,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 	subscriptionID := operatorOption.Config.AzureSubscriptionID
 	if subscriptionID == "" {
 		log.Debug("SubscriptionID was not specified via CLI, retrieving it via Azure IMS")
-		subID, err := azureAPI.GetSubscriptionID(context.TODO())
+		subID, err := azureAPI.GetSubscriptionID(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("Azure subscription ID was not specified via CLI and retrieving it from the Azure IMS was not possible: %w", err)
 		}
@@ -62,7 +62,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 	resourceGroupName := operatorOption.Config.AzureResourceGroup
 	if resourceGroupName == "" {
 		log.Debug("ResourceGroupName was not specified via CLI, retrieving it via Azure IMS")
-		rgName, err := azureAPI.GetResourceGroupName(context.TODO())
+		rgName, err := azureAPI.GetResourceGroupName(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("Azure resource group name was not specified via CLI and retrieving it from the Azure IMS was not possible: %w", err)
 		}
@@ -88,7 +88,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (alloca
 		return nil, fmt.Errorf("unable to initialize Azure node manager: %w", err)
 	}
 
-	if err := nodeManager.Start(context.TODO()); err != nil {
+	if err := nodeManager.Start(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -94,7 +94,7 @@ func (a *AllocatorOperator) Init(ctx context.Context) error {
 }
 
 // Start kicks of Operator allocation.
-func (a *AllocatorOperator) Start(updater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
 	log.WithFields(logrus.Fields{
 		logfields.IPv4CIDRs: operatorOption.Config.ClusterPoolIPv4CIDR,
 		logfields.IPv6CIDRs: operatorOption.Config.ClusterPoolIPv6CIDR,

--- a/pkg/ipam/allocator/provider.go
+++ b/pkg/ipam/allocator/provider.go
@@ -26,7 +26,7 @@ import (
 // these are implemented by e.g. pkg/ipam/allocator/{aws,azure}.
 type AllocatorProvider interface {
 	Init(ctx context.Context) error
-	Start(getterUpdater ipam.CiliumNodeGetterUpdater) (NodeEventHandler, error)
+	Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (NodeEventHandler, error)
 }
 
 // NodeEventHandler should implement the behavior to handle CiliumNode


### PR DESCRIPTION
Via the instance metadata service we can query in which Azure cloud the
operator is running.

Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

```release-note
Auto-detect Azure cloud name via IMDS
```
