### PR TITLE
CODEOWNERS: add entries for health, recorder and relay APIs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,9 +37,12 @@
 /.travis.yml @cilium/ci-structure
 /api/ @cilium/api
 /api/v1/flow/ @cilium/api @cilium/hubble
+/api/v1/health/ @cilium/api @cilium/health
 /api/v1/observer/ @cilium/api @cilium/hubble
 /api/v1/operator/ @cilium/api @cilium/operator
 /api/v1/peer/ @cilium/api @cilium/hubble
+/api/v1/recorder/ @cilium/api @cilium/hubble
+/api/v1/relay/ @cilium/api @cilium/hubble
 /bpf/ @cilium/bpf
 Makefile* @cilium/build
 /bpf/Makefile* @cilium/build @cilium/loader


### PR DESCRIPTION
Assign `api/v1/health` to @cilium/health in addition to @cilium/api and
`api/v1/{recorder,relay}` to @cilium/hubble in addition to @cilium/api.
