### PR TITLE
vendor: Update go.universe.tf/metallb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ replace (
 	github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 
-	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210520171949-40d425d20241
+	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210607221240-b4c60b959dd7
 
 	// Using private fork of controller-tools. See commit msg for more context
 	// as to why we are using a private fork.

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/cilium/ipam v0.0.0-20201106170308-4184bc4bf9d6 h1:FhiaMJPUHPEw5pjoTfC
 github.com/cilium/ipam v0.0.0-20201106170308-4184bc4bf9d6/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
-github.com/cilium/metallb v0.1.1-0.20210520171949-40d425d20241 h1:6m6Nh2xOlmjaLacBUoOrs1SAGFygoDgyjNery9DOkpk=
-github.com/cilium/metallb v0.1.1-0.20210520171949-40d425d20241/go.mod h1:HTQ4n8ZdoOg8+j+txkXsFVKmHHc2PaXirzW5d4Sw7Qw=
+github.com/cilium/metallb v0.1.1-0.20210607221240-b4c60b959dd7 h1:HcvwigeOAXg+GJDAA7gKgpo8m0X+p/WL7wYdGIYIPuQ=
+github.com/cilium/metallb v0.1.1-0.20210607221240-b4c60b959dd7/go.mod h1:HTQ4n8ZdoOg8+j+txkXsFVKmHHc2PaXirzW5d4Sw7Qw=
 github.com/cilium/proxy v0.0.0-20210511221533-82a70d56bf32 h1:8imv/jHGU2g796+N6VEwSZcU8H6MQ0z33VTNeFeKMpQ=
 github.com/cilium/proxy v0.0.0-20210511221533-82a70d56bf32/go.mod h1:mvauc94lqkyJunRsU9Ef5FIsixi8vBeDoxuMYoGBemk=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -674,7 +674,7 @@ go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
-# go.universe.tf/metallb v0.9.6 => github.com/cilium/metallb v0.1.1-0.20210520171949-40d425d20241
+# go.universe.tf/metallb v0.9.6 => github.com/cilium/metallb v0.1.1-0.20210607221240-b4c60b959dd7
 ## explicit
 go.universe.tf/metallb/pkg/allocator
 go.universe.tf/metallb/pkg/allocator/k8salloc
@@ -1325,5 +1325,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 # github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
-# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210520171949-40d425d20241
+# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210607221240-b4c60b959dd7
 # sigs.k8s.io/controller-tools => github.com/christarazi/controller-tools v0.3.1-0.20200911184030-7e668c1fb4c2


### PR DESCRIPTION
Following https://github.com/cilium/metallb/pull/4, Cilium is now
tracking the code from the v0.9.6 branch of cilium/metallb:
https://github.com/cilium/metallb/tree/v0.9.6

This was done in a backwards-compatible way to ensure that older
versions of Cilium can still build by avoiding the invalidation of the
previous commit SHA (40d425d20241).

Signed-off-by: Chris Tarazi <chris@isovalent.com>
