### PR TITLE
docs: Hubble UI does not show HTTP endpoints anymore

### DIFF
--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -102,10 +102,6 @@ the different pods:
 In the bottom of the interface, you may also inspect each recent Hubble flow
 event in your current namespace individually.
 
-.. note::
-    If you enable :ref:`proxy_visibility` on your pods, the Hubble UI service
-    map will display the HTTP endpoints which are being accessed by the requests.
-
 Inspecting a wide variety of network traffic
 ============================================
 


### PR DESCRIPTION
This removes a note in the Hubble getting started guide that recommends
turning on L7 visibility to see what HTTP endpoints are being used by
the captured flows. This feature has been removed in Hubble UI 0.7 (Cilium
1.9), making the note obsolete.
