### PR TITLE
test: Fix missing artifacts for tests with parentheses 

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -323,7 +323,7 @@ var _ = AfterEach(func() {
 
 		_, err := exec.Command(
 			"/bin/bash", "-c",
-			fmt.Sprintf("zip -qr %s %s", zipFilePath, path)).CombinedOutput()
+			fmt.Sprintf("zip -qr \"%s\" \"%s\"", zipFilePath, path)).CombinedOutput()
 		if err != nil {
 			log.WithError(err).Errorf("cannot create zip file '%s'", zipFilePath)
 		}


### PR DESCRIPTION
When tests with parentheses in their name fail, the artifacts are missing. This is happening because we run:

    bash -c "zip -qr test_name.zip test_directory"

That therefore fails with:

    /bin/bash: -c: line 0: syntax error near unexpected token `('

We need to add double quotes for this command to work properly with parentheses.

I tested this change with a previous version of this pull request where one test was made to fail on purpose.

[Before](https://jenkins.cilium.io/job/Cilium-PR-K8s-1.20-kernel-4.19/712/testReport/junit/Suite-k8s-1/20/K8sServicesTest_Checks_service_across_nodes_Tests_NodePort__kube_proxy__with_IPSec_and_externalTrafficPolicy_Local/):
![image](https://user-images.githubusercontent.com/1764210/122203787-b0b8fc80-ce9e-11eb-891b-30b177a0a43a.png)

[After](https://jenkins.cilium.io/job/Cilium-PR-K8s-1.20-kernel-4.19/716/testReport/junit/Suite-k8s-1/20/K8sServicesTest_Checks_service_across_nodes_Tests_NodePort__kube_proxy__with_IPSec_and_externalTrafficPolicy_Local/):
![image](https://user-images.githubusercontent.com/1764210/122203764-aa2a8500-ce9e-11eb-8bbd-8d64eb8f8196.png)


Fixes: https://github.com/cilium/cilium/issues/15128.
Fixes: https://github.com/cilium/cilium/pull/4176.