### PR TITLE
docs: fix check-crd-compat-table script

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -15,7 +15,7 @@ export LC_ALL=C
 
 get_schema_of_tag(){
    tag="${1}"
-   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${tag} -- pkg/k8s | sed 's/.*=\ "//;s/"//'
+   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${tag} -- pkg/k8s | head -n1 | sed 's/.*=\ "//;s/"//'
 }
 
 get_line_of_schema_version(){


### PR DESCRIPTION
The script got broken with the introduction of CRD alphav1 which
contains another occurrence of the schema version. To handle this, the
script will take into account the first occurrence of the schema
version under 'pkg/k8s'.

Signed-off-by: André Martins <andre@cilium.io>