### PR TITLE
.github/workflows: verify that each commit builds for test suite changes

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -58,7 +58,7 @@ jobs:
           PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
           git rebase --exec "make build -j $(nproc)" $PR_PARENT_SHA
 
-      - name: Check code changes
+      - name: Check bpf code changes
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: bpf-tree
         with:
@@ -77,6 +77,26 @@ jobs:
           PR_FIRST_SHA=$(echo "$PR_COMMITS_API_JSON" | jq -r ".[0].sha")
           PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
           git rebase --exec "make -C bpf build_all -j $(nproc)" $PR_PARENT_SHA
+
+      - name: Check test code changes
+        uses: dorny/paths-filter@78ab00f87740f82aec8ed8826eb4c3c851044126
+        id: test-tree
+        with:
+          filters: |
+            src:
+              - 'test/**'
+
+      # Runs only if code under test/ is changed.
+      - name: Check if ginkgo test suite build works for every commit
+        if: steps.test-tree.outputs.src == 'true'
+        run: |
+         PR_COMMITS_API_JSON=$(curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            ${{ github.event.pull_request.commits_url }})
+          PR_FIRST_SHA=$(echo "$PR_COMMITS_API_JSON" | jq -r ".[0].sha")
+          PR_PARENT_SHA=$(git rev-parse "${PR_FIRST_SHA}^")
+          git rebase --exec "make -C test build -j $(nproc)" $PR_PARENT_SHA
 
       - name: Failed commit during the build
         if: ${{ failure() }}


### PR DESCRIPTION
Make sure the individual commits of a PR build without errors for test
suite changes as well.

Noticed during review of #16470, see https://github.com/cilium/cilium/pull/16470#discussion_r651638453