### PR TITLE
ipsec: Fix logging of SPI after key rotations

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -486,9 +486,7 @@ func LoadIPSecKeysFile(path string) (int, uint8, error) {
 func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 	var spi uint8
 	var keyLen int
-	scopedLog := log.WithFields(logrus.Fields{
-		"spi": spi,
-	})
+	scopedLog := log
 
 	if err := encrypt.MapCreate(); err != nil {
 		return 0, 0, fmt.Errorf("Encrypt map create failed: %v", err)
@@ -580,6 +578,11 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 			}
 			ipSecKeysGlobal[""] = ipSecKey
 		}
+
+		scopedLog := log.WithFields(logrus.Fields{
+			"oldSPI": oldSpi,
+			"SPI":    spi,
+		})
 
 		// Detect a version change and call cleanup routine to remove old
 		// keys after a timeout period. We also want to ensure on restart


### PR DESCRIPTION
Five minutes after IPsec key rotations, we cleanup the old IPsec state and print the following message:

    level=info msg="New encryption keys reclaiming SPI" spi=0 subsys=ipsec

Unfortunately, due to a bug the SPI was always 0 in that log message. This pull request changes it and also logs the old SPI value if we have it:

    level=info msg="New encryption keys reclaiming SPI" SPI=7 oldSPI=0 subsys=ipsec

Fixes: https://github.com/cilium/cilium/pull/7450.