### PR TITLE
ci: Mark GKE as running 5.4 kernel

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
                         returnStdout: true,
                         script: 'echo ${ghprbCommentBody} | sed -r "s/([^ ]* |^[^ ]*$)//" | sed "s/^$/K8s*/" | tr -d \'\n\''
                         )}"""
-                KERNEL="419"
+                KERNEL="54"
                 NATIVE_CIDR= """${sh(
                         returnStdout: true,
                         script: 'cat ${TESTDIR}/gke/cluster-cidr | tr -d \'\n\''


### PR DESCRIPTION
As spotted by André, GKE is [now running with Linux 5.4](https://cloud.google.com/container-optimized-os/docs/release-notes#cos-85-13310-1041-9). We can therefore reflect that in the Jenkins configuration for the GKE job, to be sure to run any test that requires 5.4+.