### PR TITLE
cicd: skip codesql on forks

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
+    if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-18.04
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}


### PR DESCRIPTION
introduces an if statement into the codesql lint action
which skips the work if its taking place on a fork.

Signed-off-by: ldelossa <louis.delos@isovalent.com>