### PR TITLE
Docs: Changed parameters for minikube start

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -155,10 +155,11 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
        Install minikube >= v1.5.2 as per minikube documentation: 
        `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
+       The following command will bring up a single node minikube cluster prepared for installing cilium.
 
        .. code-block:: shell-session
 
-          minikube start --network-plugin=cni
+          minikube start --network-plugin=cni --cni=false
 
     .. note::
 


### PR DESCRIPTION
When minikube is started with `--network-plugin=cni --cni=false`
the minikube cluster is started with the cni plugin configured and no
cni installed. This is a better prepared cluster when the next step is
to install cilium.