### PR TITLE
contrib: Identify upstream commits by author and date

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -141,9 +141,9 @@ generate_commit_list_for_pr () {
   # Use GitHub to determine the number of commits to list, but then query
   # the branch directly to determine the canonical order of the commits.
   for commit in $(git rev-list --reverse -$n_commits $branch); do
-    patchid="$(git show $commit | git patch-id)"
+    patchid="$(git log -n1 --pretty=format:"%ae%at" $commit)"
     subject="$(git show -s --pretty="%s" $commit)"
-    echo "$patchid $subject" >> $tmp_file
+    echo "$patchid $commit $subject" >> $tmp_file
   done
   git branch -q -D $branch
   echo "   Merge with $n_commits commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
@@ -156,11 +156,10 @@ generate_commit_list_for_pr () {
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
     entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
-    upstream="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
-    upstream="$(git show $upstream | git patch-id)"
-    upstream=($upstream)
-    if [ "$entry_id" == "${upstream[0]}" ]; then
-      echo -e "     |  ${upstream[1]} via $entry_sha (\"$entry_sub\")"
+    upstream_commit="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
+    upstream_id="$(git log -n1 --pretty=format:"%ae%at" $upstream_commit)"
+    if [ "$entry_id" == "${upstream_id}" ]; then
+      echo -e "     |  ${upstream_commit} via $entry_sha (\"$entry_sub\")"
     else
       echo -e "     |  Warning: No commit correlation found!    via $entry_sha (\"$entry_sub\")"
     fi


### PR DESCRIPTION
When listing the commits of pull requests to backport, GitHub doesn't offer a way to find the corresponding commits merged in master. We therefore have to do it manually. To that end, we first retrieve a candidate commit by matching on the exact commit title. Several commits can have the same title however, so we need another check to confirm the candidate commit is the same commit as the pull request's.

We currently use `git patch-id` for the second check. That command computes a unique ID for a patch. It can however have false negatives. For example, 9515d1e ("docs: add a reference of helm values") and de62fa3 ("docs: add a reference of helm values") refer to the same patch, the first being from the pull request and the second from master (i.e., once merged). Nevertheless, when we run `git patch-id`, we get two different IDs:

    $ git show 9515d1e | git patch-id
    5d928411d72fcdb5c9c24ab2138896e6709e578c 9515d1ea37f1d1122ece73cf061cf47590e90f9e
    $ git show de62fa3 | git patch-id
    de14f63774d0f56ecc1e22db615987bedffe1e4b de62fa37c9ac679fd45bb617e8759dd7a4918ccb

Comparing the two commits shows that the difference is actually due to changes not introduced by this commit:

    $ diff <(git show 9515d1e) <(git show de62fa3)
    [...]
    1997,1998c1997,1998
    < @@ -118,7 +118,7 @@ contributors across the globe, there is almost always someone available to help.
    <  | debug.enabled | bool | `false` | Enable debug logging |
    ---
    > @@ -119,7 +119,7 @@ contributors across the globe, there is almost always someone available to help.
    >  | disableEndpointCRD | string | `"false"` | Disable the usage of CiliumEndpoint CRD |
    [...]

We however don't need to use `git patch-id`. Using the author's email address and date (+ commit title) is usually enough to uniquely identify commits on master. If someone sends two commits with the same title and author date (to the second), then they are definitely trying to game the system. In that unlikely event, we have two rounds of reviews (original pull request and backport pull request) to catch it.

This pull request implements that change. `%ae%at` (author email followed by author date without spaces) is used as the commit ID instead of the ID generated by `git patch-id`.