### PR TITLE
docs: run GitHub action when Charts are touched to check Helm values ref

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -35,6 +35,7 @@ jobs:
               - 'cilium-health/cmd/**'
               - 'daemon/cmd/**'
               - 'hubble-relay/cmd/**'
+              - 'install/kubernetes/**/'
               - 'operator/cmd/**'
 
   # Runs only if code under Documentation or */cmd/ is changed as the docs


### PR DESCRIPTION
PR #16238 added a reference for the Helm values in the Charts to the documentation. A number of these values are not common words from the dictionary, and need to be added to the list of acceptable words in the spelling list as we update the charts.

The GitHub action for documentation is supposed to help with the task, catching omitted keywords. But it is only run when a number of documentation-related files are run, and this does not currently include the Charts! Let's fix in order to catch spelling mistake (or omitted spelling list updates).

Fixes: #16238
