### PR TITLE
helm: Allow configuration of probe timers

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -254,6 +254,8 @@ contributors across the globe, there is almost always someone available to help.
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
+| livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
+| livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
@@ -336,6 +338,8 @@ contributors across the globe, there is almost always someone available to help.
 | proxy | object | `{"prometheus":{"enabled":true,"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
 | proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
+| readinessProbe.failureThreshold | int | `3` | failure threshold of readiness probe |
+| readinessProbe.periodSeconds | int | `30` | interval between checks of the readiness probe |
 | remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
@@ -346,6 +350,8 @@ contributors across the globe, there is almost always someone available to help.
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | sockops | object | `{"enabled":false}` | Configure BPF socket operations configuration |
+| startupProbe.failureThreshold | int | `105` | failure threshold of startup probe. 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s) |
+| startupProbe.periodSeconds | int | `2` | interval between checks of the startup probe |
 | tls | object | `{"enabled":true,"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | tunnel | string | `"vxlan"` | Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -121,8 +121,8 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
-          failureThreshold: 24
-          periodSeconds: 2
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           successThreshold: 1
 {{- end }}
         livenessProbe:
@@ -146,7 +146,7 @@ spec:
             - name: "brief"
               value: "true"
 {{- end }}
-          failureThreshold: 10
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
 {{- if semverCompare "<1.20-0" $k8sVersion }}
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -155,7 +155,7 @@ spec:
           # of this field.
           initialDelaySeconds: 120
 {{- end }}
-          periodSeconds: 30
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
@@ -179,11 +179,11 @@ spec:
             - name: "brief"
               value: "true"
 {{- end }}
-          failureThreshold: 3
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if semverCompare "<1.20-0" $k8sVersion }}
           initialDelaySeconds: 5
 {{- end }}
-          periodSeconds: 30
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: 1
           timeoutSeconds: 5
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -901,6 +901,23 @@ keepDeprecatedLabels: false
 # -- Keep the deprecated probes when deploying Cilium DaemonSet
 keepDeprecatedProbes: false
 
+startupProbe:
+  # -- failure threshold of startup probe.
+  # 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s)
+  failureThreshold: 105
+  # -- interval between checks of the startup probe
+  periodSeconds: 2
+livenessProbe:
+  # -- failure threshold of liveness probe
+  failureThreshold: 10
+  # -- interval between checks of the liveness probe
+  periodSeconds: 30
+readinessProbe:
+  # -- failure threshold of readiness probe
+  failureThreshold: 3
+  # -- interval between checks of the readiness probe
+  periodSeconds: 30
+
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
 # Valid options are "disabled", "probe", "partial", "strict".
 # ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/


### PR DESCRIPTION
This PR makes the period and threshold of the startup, readiness and liveness probe configurable. It also makes the tolerance of the `startupProbe` roughly equivalent to the `initialDelay` construction.

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

```release-note
Allow configuration of probe timers in Helm chart
```
