### PR TITLE
ipcache: Use cluster-name in KVStore endpoints key prefix

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -425,7 +425,7 @@ func updateEndpoint(oldEp, newEp *types.CiliumEndpoint) {
 					continue
 				}
 
-				keyPath := path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace, ip)
+				keyPath := path.Join(ipcache.IPIdentitiesPath, ipcache.GetAddressSpace(), ip)
 				entry := identity.IPIdentityPair{
 					IP:           net.ParseIP(ip),
 					Metadata:     "",
@@ -479,7 +479,7 @@ func updateEndpoint(oldEp, newEp *types.CiliumEndpoint) {
 			}
 			if !found {
 				// Delete the old IPs from the kvstore:
-				keyPath := path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace, oldIP)
+				keyPath := path.Join(ipcache.IPIdentitiesPath, ipcache.GetAddressSpace(), oldIP)
 				if err := kvstore.Client().Delete(context.Background(), keyPath); err != nil {
 					log.WithError(err).
 						WithFields(logrus.Fields{
@@ -505,7 +505,7 @@ func deleteEndpoint(obj interface{}) {
 					continue
 				}
 
-				keyPath := path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace, ip)
+				keyPath := path.Join(ipcache.IPIdentitiesPath, ipcache.GetAddressSpace(), ip)
 				if err := kvstore.Client().Delete(context.Background(), keyPath); err != nil {
 					log.WithError(err).Warningf("Unable to delete endpoint %s in etcd", keyPath)
 				}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -706,7 +706,7 @@ func (e *Endpoint) notifyEndpointRegeneration(err error) {
 // / <global ID Prefix>:<cluster name>:<node name>:<endpoint ID> as a string.
 func (e *Endpoint) FormatGlobalEndpointID() string {
 	localNodeName := nodeTypes.GetName()
-	metadata := []string{endpointid.CiliumGlobalIdPrefix.String(), ipcache.AddressSpace, localNodeName, strconv.Itoa(int(e.ID))}
+	metadata := []string{endpointid.CiliumGlobalIdPrefix.String(), ipcache.GetAddressSpace(), localNodeName, strconv.Itoa(int(e.ID))}
 	return strings.Join(metadata, ":")
 }
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -194,11 +194,12 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
 	// Valid IPv6.
 	validIPv6Key := "cilium/state/ip/v1/default/f00d::a00:0:0:c164"
+	prefix := "cilium/state/ip/v1/default/"
 
 	_, expectedIPv6, err := net.ParseCIDR("f00d::a00:0:0:c164/128")
 	c.Assert(err, IsNil)
 
-	ipv6, isHost, err := keyToIPNet(validIPv6Key)
+	ipv6, isHost, err := keyToIPNet(validIPv6Key, prefix)
 	c.Assert(ipv6, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isHost, Equals, true)
@@ -210,7 +211,7 @@ func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
 	_, expectedIPv6, err = net.ParseCIDR("f00d::a00:0:0:0/64")
 	c.Assert(err, IsNil)
 
-	ipv6, isHost, err = keyToIPNet(validIPv6Key)
+	ipv6, isHost, err = keyToIPNet(validIPv6Key, prefix)
 	c.Assert(ipv6, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isHost, Equals, false)
@@ -220,7 +221,7 @@ func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
 	validIPv4Key := "cilium/state/ip/v1/default/10.0.114.197"
 	_, expectedIPv4, err := net.ParseCIDR("10.0.114.197/32")
 	c.Assert(err, IsNil)
-	ipv4, isHost, err := keyToIPNet(validIPv4Key)
+	ipv4, isHost, err := keyToIPNet(validIPv4Key, prefix)
 	c.Assert(ipv4, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isHost, Equals, true)
@@ -230,29 +231,22 @@ func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
 	validIPv4Key = "cilium/state/ip/v1/default/10.0.114.0/24"
 	_, expectedIPv4, err = net.ParseCIDR("10.0.114.0/24")
 	c.Assert(err, IsNil)
-	ipv4, isHost, err = keyToIPNet(validIPv4Key)
+	ipv4, isHost, err = keyToIPNet(validIPv4Key, prefix)
 	c.Assert(ipv4, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isHost, Equals, false)
 	c.Assert(ipv4, checker.DeepEquals, expectedIPv4)
 
-	// Invalid prefix.
-	invalidPrefixKey := "cilium/state/foobar/v1/default/f00d::a00:0:0:c164"
-	nilIP, isHost, err := keyToIPNet(invalidPrefixKey)
-	c.Assert(nilIP, IsNil)
-	c.Assert(err, Not(IsNil))
-	c.Assert(isHost, Equals, false)
-
 	// Invalid IP in key.
 	invalidIPKey := "cilium/state/ip/v1/default/10.abfd.114.197"
-	nilIP, isHost, err = keyToIPNet(invalidIPKey)
+	nilIP, isHost, err := keyToIPNet(invalidIPKey, prefix)
 	c.Assert(nilIP, IsNil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(isHost, Equals, false)
 
 	// Invalid CIDR.
 	invalidIPKey = "cilium/state/ip/v1/default/192.0.2.3/54"
-	nilIP, isHost, err = keyToIPNet(invalidIPKey)
+	nilIP, isHost, err = keyToIPNet(invalidIPKey, prefix)
 	c.Assert(nilIP, IsNil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(isHost, Equals, false)


### PR DESCRIPTION
Currently, we use `default` as `<cluster>` in KVStore endpoints
key prefix `cilium/state/ip/v1/<cluster>/<ip>`, this should be
`cluster-name` if it is configured.

Existing agents in a cluster that have a name different than `default`
will create new endpoint entries with key `cilium/state/ip/v1/<cluster>/<ip>`,
and the old `cilium/state/ip/v1/default/<ip>` entries will exist harmlessly
until it is finally deleted after `kvstore-lease-ttl`.

Also handle the cases when endpoints key prefix becomes inconsistent when
rolling out agents.

Fixes: #16378
Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>


```release-note
Use cluster-name in KVStore endpoints key prefix
```
