### PR TITLE
docs: rename maintainers team to cilium-maintainers

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -273,7 +273,7 @@ Pull requests review process for committers
 #. Every committer in the `committers team <https://github.com/orgs/cilium/teams/committers/members>`_
    belongs to `one or more other teams in the Cilium organization <https://github.com/orgs/cilium/teams/team/teams>`_
    if you would like to be added or removed from any team, please contact any
-   of the `maintainers <https://github.com/orgs/cilium/teams/maintainers/members>`_.
+   of the `maintainers <https://github.com/orgs/cilium/teams/cilium-maintainers/members>`_.
 
 #. Once a PR is open, GitHub will automatically pick which `teams <https://github.com/orgs/cilium/teams/team/teams>`_
    should review the PR using the ``CODEOWNERS`` file. Each committer can see

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -32,7 +32,7 @@ On Freeze date
    ::
 
         * @cilium/janitors
-        .github/workflows/ @cilium/maintainers
+        .github/workflows/ @cilium/cilium-maintainers
         api/ @cilium/api
         pkg/apisocket/ @cilium/api
         pkg/monitor/payload @cilium/api


### PR DESCRIPTION
As there are going to to be more than one maintainers team we should
rename the current one. The remaining teams will have the following
format: '\<repository>-maintainers'

Signed-off-by: André Martins <andre@cilium.io>
