### PR TITLE
[config] Add validation rule for combination of BPFMasquerade/IPtable…

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1313,6 +1313,10 @@ func initEnv(cmd *cobra.Command) {
 		log.Fatal("L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
 	}
 
+	if option.Config.EnableNodePort && !option.Config.InstallIptRules && !option.Config.EnableBPFMasquerade {
+		log.Fatal("NodePort enabled requires either BPF Masquerade or iptables rules enabled (\"--enable-bpf-masquerade=true\", \"--install-iptables-rules=true\")")
+	}
+
 	if option.Config.EnableIPSec && option.Config.Tunnel != option.TunnelDisabled {
 		if err := ipsec.ProbeXfrmStateOutputMask(); err != nil {
 			log.WithError(err).Fatal("IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later).")


### PR DESCRIPTION
Disabling `InstallIptRules` option will instruct Cilium to not create
any iptables rules to mess with pod traffic. But in order to carry
this setting, Cilium also needs eBPF masquerade enabled.

Otherwise, Cilium will fallback to absent iptables rules/chains and eventually
network nodes will gradually be totally unreachable, without any sign of failure
as Cilium pods will continue to operate normally.

In this commit, we add a validation rule to prevent users from applying configuration
that may break their network layer.