### PR TITLE
Refactor logging package to split syslog functionality into separate file

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"log/syslog"
 	"os"
 	"regexp"
 	"strings"
@@ -28,19 +27,12 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
-	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 	"k8s.io/klog/v2"
 )
 
 type LogFormat string
 
 const (
-	SLevel    = "syslog.level"
-	SNetwork  = "syslog.network"
-	SAddress  = "syslog.address"
-	SSeverity = "syslog.severity"
-	SFacility = "syslog.facility"
-	STag      = "syslog.tag"
 	Syslog    = "syslog"
 	LevelOpt  = "level"
 	FormatOpt = "format"
@@ -56,71 +48,9 @@ const (
 	DefaultLogLevel logrus.Level = logrus.InfoLevel
 )
 
-var (
-	// DefaultLogger is the base logrus logger. It is different from the logrus
-	// default to avoid external dependencies from writing out unexpectedly
-	DefaultLogger = InitializeDefaultLogger()
-
-	// syslogOpts is the set of supported options for syslog configuration.
-	syslogOpts = map[string]bool{
-		SLevel:    true,
-		SNetwork:  true,
-		SAddress:  true,
-		SSeverity: true,
-		SFacility: true,
-		STag:      true,
-	}
-
-	// From /usr/include/sys/syslog.h.
-	syslogSeverityMap = map[string]syslog.Priority{
-		"emerg":   syslog.LOG_EMERG,
-		"panic":   syslog.LOG_EMERG,
-		"alert":   syslog.LOG_ALERT,
-		"crit":    syslog.LOG_CRIT,
-		"err":     syslog.LOG_ERR,
-		"error":   syslog.LOG_ERR,
-		"warn":    syslog.LOG_WARNING,
-		"warning": syslog.LOG_WARNING,
-		"notice":  syslog.LOG_NOTICE,
-		"info":    syslog.LOG_INFO,
-		"debug":   syslog.LOG_DEBUG,
-	}
-
-	// From /usr/include/sys/syslog.h.
-	syslogFacilityMap = map[string]syslog.Priority{
-		"kern":     syslog.LOG_KERN,
-		"user":     syslog.LOG_USER,
-		"mail":     syslog.LOG_MAIL,
-		"daemon":   syslog.LOG_DAEMON,
-		"auth":     syslog.LOG_AUTH,
-		"syslog":   syslog.LOG_SYSLOG,
-		"lpr":      syslog.LOG_LPR,
-		"news":     syslog.LOG_NEWS,
-		"uucp":     syslog.LOG_UUCP,
-		"cron":     syslog.LOG_CRON,
-		"authpriv": syslog.LOG_AUTHPRIV,
-		"ftp":      syslog.LOG_FTP,
-		"local0":   syslog.LOG_LOCAL0,
-		"local1":   syslog.LOG_LOCAL1,
-		"local2":   syslog.LOG_LOCAL2,
-		"local3":   syslog.LOG_LOCAL3,
-		"local4":   syslog.LOG_LOCAL4,
-		"local5":   syslog.LOG_LOCAL5,
-		"local6":   syslog.LOG_LOCAL6,
-		"local7":   syslog.LOG_LOCAL7,
-	}
-
-	// syslogLevelMap maps logrus.Level values to syslog.Priority levels.
-	syslogLevelMap = map[logrus.Level]syslog.Priority{
-		logrus.PanicLevel: syslog.LOG_ALERT,
-		logrus.FatalLevel: syslog.LOG_CRIT,
-		logrus.ErrorLevel: syslog.LOG_ERR,
-		logrus.WarnLevel:  syslog.LOG_WARNING,
-		logrus.InfoLevel:  syslog.LOG_INFO,
-		logrus.DebugLevel: syslog.LOG_DEBUG,
-		logrus.TraceLevel: syslog.LOG_DEBUG,
-	}
-)
+// DefaultLogger is the base logrus logger. It is different from the logrus
+// default to avoid external dependencies from writing out unexpectedly
+var DefaultLogger = InitializeDefaultLogger()
 
 func init() {
 	log := DefaultLogger.WithField(logfields.LogSubsys, "klog")
@@ -260,68 +190,6 @@ func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) 
 	return nil
 }
 
-// setupSyslog sets up and configures syslog with the provided options in
-// logOpts. If some options are not provided, sensible defaults are used.
-func setupSyslog(logOpts LogOptions, tag string, debug bool) error {
-	opts := getLogDriverConfig(Syslog, logOpts)
-	syslogOptValues := make(map[string][]string)
-	syslogOptValues[SSeverity] = mapStringPriorityToSlice(syslogSeverityMap)
-	syslogOptValues[SFacility] = mapStringPriorityToSlice(syslogFacilityMap)
-	if err := opts.validateOpts(Syslog, syslogOpts, syslogOptValues); err != nil {
-		return err
-	}
-	if stag, ok := opts[STag]; ok {
-		tag = stag
-	}
-
-	logLevel, ok := opts[SLevel]
-	if !ok {
-		if debug {
-			logLevel = "debug"
-		} else {
-			logLevel = "info"
-		}
-	}
-
-	// Validate provided log level.
-	level, err := logrus.ParseLevel(logLevel)
-	if err != nil {
-		DefaultLogger.Fatal(err)
-	}
-
-	SetLogLevel(level)
-
-	network := ""
-	address := ""
-	// Inherit severity from log level if syslog.severity is not specified explicitly
-	severity := syslogLevelMap[level]
-	// Default values for facility if not specified
-	facility := syslog.LOG_KERN
-	if networkStr, ok := opts[SNetwork]; ok {
-		network = networkStr
-	}
-	if addressStr, ok := opts[SAddress]; ok {
-		address = addressStr
-	}
-	if severityStr, ok := opts[SSeverity]; ok {
-		severity = syslogSeverityMap[severityStr]
-	}
-	if facilityStr, ok := opts[SFacility]; ok {
-		facility = syslogFacilityMap[facilityStr]
-	}
-
-	// Create syslog hook.
-	h, err := logrus_syslog.NewSyslogHook(network, address, severity|facility, tag)
-	if err != nil {
-		DefaultLogger.Fatal(err)
-	}
-	// TODO: switch to a per-logger version when we upgrade to logrus >1.0.3
-	logrus.AddHook(h)
-	DefaultLogger.AddHook(h)
-
-	return nil
-}
-
 // GetFormatter returns a configured logrus.Formatter with some specific values
 // we want to have
 func GetFormatter(format LogFormat) logrus.Formatter {
@@ -399,12 +267,4 @@ func CanLogAt(logger *logrus.Logger, level logrus.Level) bool {
 // GetLevel returns the log level of the given logger.
 func GetLevel(logger *logrus.Logger) logrus.Level {
 	return logrus.Level(atomic.LoadUint32((*uint32)(&logger.Level)))
-}
-
-func mapStringPriorityToSlice(m map[string]syslog.Priority) []string {
-	s := make([]string, 0, len(m))
-	for k := range m {
-		s = append(s, k)
-	}
-	return s
 }

--- a/pkg/logging/logging_nosyslog.go
+++ b/pkg/logging/logging_nosyslog.go
@@ -1,0 +1,21 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package logging
+
+func setupSyslog(logOpts LogOptions, tag string, debug bool) error {
+	return nil
+}

--- a/pkg/logging/logging_syslog.go
+++ b/pkg/logging/logging_syslog.go
@@ -1,0 +1,165 @@
+// Copyright 2016-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package logging
+
+import (
+	"log/syslog"
+
+	"github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+const (
+	SLevel    = "syslog.level"
+	SNetwork  = "syslog.network"
+	SAddress  = "syslog.address"
+	SSeverity = "syslog.severity"
+	SFacility = "syslog.facility"
+	STag      = "syslog.tag"
+)
+
+var (
+	// syslogOpts is the set of supported options for syslog configuration.
+	syslogOpts = map[string]bool{
+		SLevel:    true,
+		SNetwork:  true,
+		SAddress:  true,
+		SSeverity: true,
+		SFacility: true,
+		STag:      true,
+	}
+
+	// From /usr/include/sys/syslog.h.
+	syslogSeverityMap = map[string]syslog.Priority{
+		"emerg":   syslog.LOG_EMERG,
+		"panic":   syslog.LOG_EMERG,
+		"alert":   syslog.LOG_ALERT,
+		"crit":    syslog.LOG_CRIT,
+		"err":     syslog.LOG_ERR,
+		"error":   syslog.LOG_ERR,
+		"warn":    syslog.LOG_WARNING,
+		"warning": syslog.LOG_WARNING,
+		"notice":  syslog.LOG_NOTICE,
+		"info":    syslog.LOG_INFO,
+		"debug":   syslog.LOG_DEBUG,
+	}
+
+	// From /usr/include/sys/syslog.h.
+	syslogFacilityMap = map[string]syslog.Priority{
+		"kern":     syslog.LOG_KERN,
+		"user":     syslog.LOG_USER,
+		"mail":     syslog.LOG_MAIL,
+		"daemon":   syslog.LOG_DAEMON,
+		"auth":     syslog.LOG_AUTH,
+		"syslog":   syslog.LOG_SYSLOG,
+		"lpr":      syslog.LOG_LPR,
+		"news":     syslog.LOG_NEWS,
+		"uucp":     syslog.LOG_UUCP,
+		"cron":     syslog.LOG_CRON,
+		"authpriv": syslog.LOG_AUTHPRIV,
+		"ftp":      syslog.LOG_FTP,
+		"local0":   syslog.LOG_LOCAL0,
+		"local1":   syslog.LOG_LOCAL1,
+		"local2":   syslog.LOG_LOCAL2,
+		"local3":   syslog.LOG_LOCAL3,
+		"local4":   syslog.LOG_LOCAL4,
+		"local5":   syslog.LOG_LOCAL5,
+		"local6":   syslog.LOG_LOCAL6,
+		"local7":   syslog.LOG_LOCAL7,
+	}
+
+	// syslogLevelMap maps logrus.Level values to syslog.Priority levels.
+	syslogLevelMap = map[logrus.Level]syslog.Priority{
+		logrus.PanicLevel: syslog.LOG_ALERT,
+		logrus.FatalLevel: syslog.LOG_CRIT,
+		logrus.ErrorLevel: syslog.LOG_ERR,
+		logrus.WarnLevel:  syslog.LOG_WARNING,
+		logrus.InfoLevel:  syslog.LOG_INFO,
+		logrus.DebugLevel: syslog.LOG_DEBUG,
+		logrus.TraceLevel: syslog.LOG_DEBUG,
+	}
+)
+
+func mapStringPriorityToSlice(m map[string]syslog.Priority) []string {
+	s := make([]string, 0, len(m))
+	for k := range m {
+		s = append(s, k)
+	}
+	return s
+}
+
+// setupSyslog sets up and configures syslog with the provided options in
+// logOpts. If some options are not provided, sensible defaults are used.
+func setupSyslog(logOpts LogOptions, tag string, debug bool) error {
+	opts := getLogDriverConfig(Syslog, logOpts)
+	syslogOptValues := make(map[string][]string)
+	syslogOptValues[SSeverity] = mapStringPriorityToSlice(syslogSeverityMap)
+	syslogOptValues[SFacility] = mapStringPriorityToSlice(syslogFacilityMap)
+	if err := opts.validateOpts(Syslog, syslogOpts, syslogOptValues); err != nil {
+		return err
+	}
+	if stag, ok := opts[STag]; ok {
+		tag = stag
+	}
+
+	logLevel, ok := opts[SLevel]
+	if !ok {
+		if debug {
+			logLevel = "debug"
+		} else {
+			logLevel = "info"
+		}
+	}
+
+	// Validate provided log level.
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		DefaultLogger.Fatal(err)
+	}
+
+	SetLogLevel(level)
+
+	network := ""
+	address := ""
+	// Inherit severity from log level if syslog.severity is not specified explicitly
+	severity := syslogLevelMap[level]
+	// Default values for facility if not specified
+	facility := syslog.LOG_KERN
+	if networkStr, ok := opts[SNetwork]; ok {
+		network = networkStr
+	}
+	if addressStr, ok := opts[SAddress]; ok {
+		address = addressStr
+	}
+	if severityStr, ok := opts[SSeverity]; ok {
+		severity = syslogSeverityMap[severityStr]
+	}
+	if facilityStr, ok := opts[SFacility]; ok {
+		facility = syslogFacilityMap[facilityStr]
+	}
+
+	// Create syslog hook.
+	h, err := logrus_syslog.NewSyslogHook(network, address, severity|facility, tag)
+	if err != nil {
+		DefaultLogger.Fatal(err)
+	}
+	// TODO: switch to a per-logger version when we upgrade to logrus >1.0.3
+	logrus.AddHook(h)
+	DefaultLogger.AddHook(h)
+
+	return nil
+}


### PR DESCRIPTION
This will allow to build `pkg/logging` on platforms not supporting syslog for `cilium-cli`, see https://github.com/cilium/cilium-cli/issues/231. Thus also marking for backports to 1.10 since we vendor a stable `cilium/cilium` release into `cilium-cli` (currently `v1.9.8`, but eventually switching to `v1.10`).

See individual commits for details.