### PR TITLE
.github/workflows: install ginkgo for test suite build test

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -41,6 +41,10 @@ jobs:
         run: |
           sudo apt-get install libelf-dev
 
+      - name: Install ginkgo
+        run: |
+          go get github.com/onsi/ginkgo/ginkgo@v1.12.1
+
       - name: Checkout code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:


### PR DESCRIPTION
The test suite build check for the individual commits of a PR currently
fails due to missing ginkgo binary. Install ginkgo v1.12.1 (as per
go.mod).

Fixes: e260ba9a08cf (".github/workflows: verify that each commit builds for test suite changes")