### PR TITLE
daemon: Warn on disabling iptables

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1267,6 +1267,10 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.Ipvlan.OperationMode = connector.OperationModeL3
 		if option.Config.InstallIptRules {
 			option.Config.Ipvlan.OperationMode = connector.OperationModeL3S
+		} else {
+			log.WithFields(logrus.Fields{
+				logfields.URL: "https://github.com/cilium/cilium/issues/12879",
+			}).Warn("IPtables rule configuration has been disabled. This may affect policy and forwarding, see the URL for more details.")
 		}
 	case datapathOption.DatapathModeLBOnly:
 		log.Info("Running in LB-only mode")


### PR DESCRIPTION
I'm looking forward to a time when we no longer need to configure
iptables. However, for the moment there's a couple of minor features we
use to handle policy and forwarding correctly which rely on iptables.
Furthermore, even if all of this is implemented in eBPF, the user's
environment may still have iptables configured and this can then
interfere with the Cilium traffic handling, depending on how Cilium is
configured.

For now, it likely makes sense to warn users that disabling this flag
could lead to unexpected policy and forwarding behaviour. Once we've
resolved the linked issue, maybe we can think about reverting this to an
info message to account for the compatibility case mentioned above.

Related: https://github.com/cilium/cilium/issues/12879
