### PR TITLE
v1.9 backports 2021-06-22

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -486,9 +486,7 @@ func LoadIPSecKeysFile(path string) (int, uint8, error) {
 func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 	var spi uint8
 	var keyLen int
-	scopedLog := log.WithFields(logrus.Fields{
-		"spi": spi,
-	})
+	scopedLog := log
 
 	if err := encrypt.MapCreate(); err != nil {
 		return 0, 0, fmt.Errorf("Encrypt map create failed: %v", err)
@@ -580,6 +578,11 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 			}
 			ipSecKeysGlobal[""] = ipSecKey
 		}
+
+		scopedLog := log.WithFields(logrus.Fields{
+			"oldSPI": oldSpi,
+			"SPI":    spi,
+		})
 
 		// Detect a version change and call cleanup routine to remove old
 		// keys after a timeout period. We also want to ensure on restart

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -785,7 +785,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 			// issued arping after us, as it might have a more recent hwAddr value.
 			return
 		}
-		n.neighLastPingByNextHop[nextHopStr] = time.Now()
+		n.neighLastPingByNextHop[nextHopStr] = now
 		if prevHwAddr, found := n.neighByNextHop[nextHopStr]; found && prevHwAddr.String() == hwAddr.String() {
 			// Nothing to update, return early to avoid calling to netlink. This
 			// is based on the assumption that n.neighByNextHop gets populated

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1188,23 +1188,28 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 			c.Assert(err, check.IsNil)
 			return nil
 		})
-		// Check that MAC has been changed in the neigh table
-		time.Sleep(500 * time.Millisecond)
-		neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-		c.Assert(err, check.IsNil)
-		found = false
-		for _, n := range neighs {
-			if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
-				c.Assert(n.HardwareAddr.String(), check.Equals, mac.String())
-				c.Assert(neighHwAddr(ip1.String()), check.Equals, mac.String())
-				c.Assert(neighRefCount(ip1.String()), check.Equals, 1)
-				found = true
-				break
-			}
-		}
-		c.Assert(found, check.Equals, true)
 
+		// Check that MAC has been changed in the neigh table
+		var found bool
+		err := testutils.WaitUntilWithSleep(func() bool {
+			neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+			c.Assert(err, check.IsNil)
+			found = false
+			for _, n := range neighs {
+				if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT &&
+					n.HardwareAddr.String() == mac.String() &&
+					neighHwAddr(ip1.String()) == mac.String() &&
+					neighRefCount(ip1.String()) == 1 {
+					found = true
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second, 200*time.Millisecond)
+		c.Assert(err, check.IsNil)
+		c.Assert(found, check.Equals, true)
 	}
+
 	// Cleanup
 	close(done)
 	wg.Wait()

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -210,7 +210,7 @@ func (k *K8sWatcher) addK8sPodV1(pod *slim_corev1.Pod) error {
 		logfields.K8sNamespace: pod.ObjectMeta.Namespace,
 		"podIP":                pod.Status.PodIP,
 		"podIPs":               pod.Status.PodIPs,
-		"hostIP":               pod.Status.PodIP,
+		"hostIP":               pod.Status.HostIP,
 	})
 
 	// In Kubernetes Jobs, Pods can be left in Kubernetes until the Job

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2121,7 +2121,7 @@ var (
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
 		IdentityAllocationMode:       IdentityAllocationModeKVstore,
 		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
-		EnableWellKnownIdentities:    defaults.EnableEndpointRoutes,
+		EnableWellKnownIdentities:    defaults.EnableWellKnownIdentities,
 		K8sEnableK8sEndpointSlice:    defaults.K8sEnableEndpointSlice,
 		k8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 
 	"github.com/sirupsen/logrus"
 )
@@ -426,8 +426,8 @@ func (l4Filter *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficd
 }
 
 // IdentitySelectionUpdated implements CachedSelectionUser interface
-// This call is made while holding name manager and selector cache
-// locks, must beware of deadlocking!
+// This call is made from a single goroutine in FIFO order to keep add
+// and delete events ordered properly. No locks are held.
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -17,6 +17,8 @@
 package policy
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -356,6 +358,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDenyWildcard(c *C) {
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -433,12 +436,14 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	testSelectorCache.UpdateIdentities(added1, nil)
 	// Cleanup the identities from the testSelectorCache
 	defer testSelectorCache.UpdateIdentities(nil, added1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	testSelectorCache.UpdateIdentities(nil, deleted1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
@@ -521,6 +522,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -600,12 +602,14 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	testSelectorCache.UpdateIdentities(added1, nil)
 	// Cleanup the identities from the testSelectorCache
 	defer testSelectorCache.UpdateIdentities(nil, added1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	testSelectorCache.UpdateIdentities(nil, deleted1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -193,7 +193,7 @@ func (rpm *Manager) DeleteRedirectPolicy(config LRPConfig) error {
 
 	switch storedConfig.lrpType {
 	case lrpConfigTypeSvc:
-		rpm.deletePolicyService(*storedConfig.serviceID)
+		rpm.deletePolicyService(storedConfig)
 	case lrpConfigTypeAddr:
 		for _, feM := range storedConfig.frontendMappings {
 			rpm.deletePolicyFrontend(storedConfig, feM.feAddr)
@@ -480,30 +480,27 @@ func (rpm *Manager) notifyPolicyBackendDelete(config *LRPConfig, frontendMapping
 }
 
 // deletePolicyService deletes internal state associated with the specified service.
-func (rpm *Manager) deletePolicyService(svcID k8s.ServiceID) {
-	if rp, ok := rpm.policyServices[svcID]; ok {
-		// Get the policy config that selects this service.
-		config := rpm.policyConfigs[rp]
-		for _, m := range config.frontendMappings {
-			rpm.deletePolicyFrontend(config, m.feAddr)
+func (rpm *Manager) deletePolicyService(config *LRPConfig) {
+	for _, m := range config.frontendMappings {
+		rpm.deletePolicyFrontend(config, m.feAddr)
+	}
+	switch config.frontendType {
+	case svcFrontendAll:
+		config.frontendMappings = nil
+	case svcFrontendSinglePort:
+		fallthrough
+	case svcFrontendNamedPorts:
+		for _, feM := range config.frontendMappings {
+			feM.feAddr.IP = net.IP{}
 		}
-		switch config.frontendType {
-		case svcFrontendAll:
-			config.frontendMappings = nil
-		case svcFrontendSinglePort:
-			fallthrough
-		case svcFrontendNamedPorts:
-			for _, feM := range config.frontendMappings {
-				feM.feAddr.IP = net.IP{}
-			}
-		}
-		// Retores the svc backends if there's still such a k8s svc.
-		swg := lock.NewStoppableWaitGroup()
-		if restored := rpm.svcCache.EnsureService(svcID, swg); restored {
-			log.WithFields(logrus.Fields{
-				logfields.K8sSvcID: svcID,
-			}).Debug("Restored service")
-		}
+	}
+	// Retores the svc backends if there's still such a k8s svc.
+	swg := lock.NewStoppableWaitGroup()
+	svcID := *config.serviceID
+	if restored := rpm.svcCache.EnsureService(svcID, swg); restored {
+		log.WithFields(logrus.Fields{
+			logfields.K8sSvcID: svcID,
+		}).Debug("Restored service")
 	}
 }
 

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -246,7 +246,7 @@ func (rpm *Manager) OnDeleteService(svcID k8s.ServiceID) {
 		return
 	}
 
-	rpm.deletePolicyService(svcID)
+	rpm.deleteService(svcID)
 }
 
 func (rpm *Manager) OnAddPod(pod *slimcorev1.Pod) {
@@ -503,6 +503,31 @@ func (rpm *Manager) deletePolicyService(svcID k8s.ServiceID) {
 			log.WithFields(logrus.Fields{
 				logfields.K8sSvcID: svcID,
 			}).Debug("Restored service")
+		}
+	}
+}
+
+func (rpm *Manager) deleteService(svcID k8s.ServiceID) {
+	var (
+		rp policyID
+		ok bool
+	)
+	if rp, ok = rpm.policyServices[svcID]; !ok {
+		return
+	}
+	// Get the policy config that selects this service.
+	config := rpm.policyConfigs[rp]
+	for _, m := range config.frontendMappings {
+		rpm.deletePolicyFrontend(config, m.feAddr)
+	}
+	switch config.frontendType {
+	case svcFrontendAll:
+		config.frontendMappings = nil
+	case svcFrontendSinglePort:
+		fallthrough
+	case svcFrontendNamedPorts:
+		for _, feM := range config.frontendMappings {
+			feM.feAddr.IP = net.IP{}
 		}
 	}
 }

--- a/pkg/testutils/condition.go
+++ b/pkg/testutils/condition.go
@@ -26,7 +26,14 @@ type ConditionFunc func() bool
 // WaitUntil evaluates the condition every 10 milliseconds and waits for the
 // condition to be met. The function will time out and return an error after
 // timeout
+
 func WaitUntil(condition ConditionFunc, timeout time.Duration) error {
+	return WaitUntilWithSleep(condition, timeout, 10*time.Millisecond)
+}
+
+// WaitUntilWithSleep does the same as WaitUntil except that the sleep time
+// between the condition checks is given.
+func WaitUntilWithSleep(condition ConditionFunc, timeout, sleep time.Duration) error {
 	now := time.Now()
 	for {
 		if time.Since(now) > timeout {
@@ -37,6 +44,6 @@ func WaitUntil(condition ConditionFunc, timeout time.Duration) error {
 			return nil
 		}
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(sleep)
 	}
 }


### PR DESCRIPTION
 * #16434 -- pkg/option: Fix default assignment of EnableWellKnownIdentities (@mauriciovasquezbernal)
 * #16530 -- k8s: Fix logging (@jrajahalme)
 * #16604 -- bpf: fix hw_csum issue for icmp probe packets (@borkmann)
 * #16578 -- node-neigh: Fix concurrent arping update unit test flake (@brb)
 * #16557 -- ipsec: Fix logging of SPI after key rotations (@pchaigno)
 * #16548 -- lrp: Skip clusterIP service restore in service delete callback (@aditighag)
 * #16529 -- policy: Make selectorcache callbacks lock-free (@jrajahalme)

Skipped due to conflicts - 

 * #16238 -- docs: add a reference of helm values (@bmcustodio)
 * #16470 -- test: Spring cleaning of K8sServicesTest (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16434 16530 16604 16578 16557 16548 16529; do contrib/backporting/set-labels.py $pr done 1.9; done
```