### PR TITLE
Add test for return path for fragmented packets

### DIFF
--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -23,7 +23,8 @@ spec:
             path: /
             port: 80
       - name: udp
-        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        # image: docker.io/cilium/echoserver-udp:v2020.01.30
+        image: anfernee/echoserver-udp:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 69
@@ -83,7 +84,8 @@ spec:
             path: /
             port: 80
       - name: udp
-        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        # image: docker.io/cilium/echoserver-udp:v2020.01.30
+        image: anfernee/echoserver-udp:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 69


### PR DESCRIPTION
This PR add tests for return path for fragmented packets. 

It has dependency on: https://github.com/cilium/echoserver-udp/pull/1