### PR TITLE
ci: use git status instead of git diff to check for a clean state

### DIFF
--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           make -C examples/kubernetes/connectivity-check fmt
           make -C examples/kubernetes/connectivity-check all
-          git diff --exit-code || (echo "please run 'make -C examples/kubernetes/connectivity-check all' and submit your changes"; exit 1)
+          test -z "$(git status --porcelain)" || (echo "please run 'make -C examples/kubernetes/connectivity-check fmt all' and submit your changes"; exit 1)
 
       - name: Set image tag
         id: vars

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           go mod tidy
           go mod vendor
-          git diff --exit-code || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
+          test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
       - name: Send slack notification
         if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
         uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           make -C examples/kubernetes/connectivity-check fmt
           make -C examples/kubernetes/connectivity-check all
-          git diff --exit-code || (echo "please run 'make -C examples/kubernetes/connectivity-check all' and submit your changes"; exit 1)
+          test -z "$(git status --porcelain)" || (echo "please run 'make -C examples/kubernetes/connectivity-check fmt all' and submit your changes"; exit 1)
 
       - name: Enable IPv6 in docker
         run: |

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Run helm-docs
         run: |
           make -C install/kubernetes docs
-          git diff --exit-code || (echo "please run 'make -C install/kubernetes docs' and submit your changes"; exit 1)
+          test -z "$(git status --porcelain)" || (echo "please run 'make -C install/kubernetes docs' and submit your changes"; exit 1)
 
   conformance-test:
     needs: check_changes
@@ -104,7 +104,7 @@ jobs:
         run: |
           make -C examples/kubernetes/connectivity-check fmt
           make -C examples/kubernetes/connectivity-check all
-          git diff --exit-code || (echo "please run 'make -C examples/kubernetes/connectivity-check all' and submit your changes"; exit 1)
+          test -z "$(git status --porcelain)" || (echo "please run 'make -C examples/kubernetes/connectivity-check fmt all' and submit your changes"; exit 1)
 
       - name: Create kind cluster
         uses: helm/kind-action@7a937c0fb648064a83b8b9354151e5e543d9fcec


### PR DESCRIPTION
Before this patch, git diff was used to ensure a clean state with respect to the git repository. While it could catch a modified or removed file, it would not fail when a file was not checked in git (i.e. untracked).

This patch use git status instead of git diff, effectively catching untracked files as well.