### PR TITLE
images: Remove trailing newlines before computing SHA256

### DIFF
--- a/images/scripts/get-image-digest.sh
+++ b/images/scripts/get-image-digest.sh
@@ -16,7 +16,7 @@ if [ "$(uname)" != "Linux" ]; then
   function sha256sum() { openssl sha256; }
 fi
 
-inspect=$(docker buildx imagetools inspect "${1}" --raw 2>/dev/null | sha256sum | cut -d " " -f 1 )
+inspect=$(docker buildx imagetools inspect "${1}" --raw 2>/dev/null | awk 'NR>1 { print p } { p = $0 } END { printf("%s", $0) }' | sha256sum | cut -d " " -f 1 )
 # shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
   echo "sha256:${inspect}"


### PR DESCRIPTION
Some versions of buildx may add a newline at the end of the output for `buildx imagetools inspect`. That additional newline leads to a different SHA256 hash:

    $ docker buildx version
    github.com/docker/buildx v0.3.1-tp-docker 6db68d029599c6710a32aa7adcba8e5a344795a7
    $ docker buildx imagetools inspect "quay.io/cilium/cilium-runtime:e5902a650726387b39d080ce77a9ef6ccb89eabc" --raw 2>/dev/null | sha256sum | cut -d " " -f 1
    7b0efa641ec89ee9860abfcce9a699765fee0f6f6337d4fe2d5cef09f60eb88c
    $ docker buildx imagetools inspect "quay.io/cilium/cilium-runtime:e5902a650726387b39d080ce77a9ef6ccb89eabc" --raw 2>/dev/null | perl -0pe 's/\n\Z//' | sha256sum | cut -d " " -f 1
    38995ce0cf801983fb3706ed76fa3df03572d4cd7c0d2c4281fe622e7cd77e51

This is turn means the local and CI/CD runs of the `update-xxx-image` make targets may lead to different image tags.

This pull request fixes it by removing any trailing newline from the output.