### PR TITLE
Improve Cilium integration with managed Kubernetes providers

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -143,21 +143,43 @@ jobs:
             az account show
 
       - name: Create AKS cluster
+        id: cluster-creation
         run: |
+          # Create group
           az group create \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
             --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
+
+          # Create cluster with a 1 node-count (we will remove this node pool
+          # afterwards)
+          # Details: Basic load balancers are not supported with multiple node
+          # pools. Create a cluster with standard load balancer selected to use
+          # multiple node pools, learn more at https://aka.ms/aks/nodepools.
           az aks create \
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
             --network-plugin azure \
+            --node-count 1 \
+            --load-balancer-sku standard \
+            --generate-ssh-keys
+
+          # Get the name of the node pool that we will delete afterwards
+          echo ::set-output name=nodepool_to_delete::$(az aks nodepool list --cluster-name ${{ env.name }} -g ${{ env.name }} -o json | jq -r '.[0].name')
+
+          # Create a node pool with the taint 'node.cilium.io/agent-not-ready=true:NoSchedule'
+          # and with 'mode=system' as it it the same mode used for the nodepool
+          # created with the cluster.
+          az aks nodepool add \
+            --name nodepool2 \
+            --cluster-name ${{ env.name }} \
+            --resource-group ${{ env.name }} \
             --node-count 2 \
             --node-vm-size Standard_B2s \
             --node-osdisk-size 30 \
-            --load-balancer-sku basic \
-            --generate-ssh-keys
+            --mode system \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule
 
       - name: Get cluster credentials
         run: |
@@ -175,6 +197,17 @@ jobs:
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+
+      - name: Delete the first node pool
+        run: |
+          # We can only delete the first node pool after Cilium is installed
+          # because some pods have Pod Disruption Budgets set. If we try to
+          # delete the first node pool without the second node pool being ready,
+          # AKS will not succeed with the pool deletion because some Deployments
+          # can't cease to exist in the cluster.
+          az aks nodepool delete --name ${{ steps.cluster-creation.outputs.nodepool_to_delete }} \
+            --cluster-name ${{ env.name }} \
+            --resource-group ${{ env.name }}
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -138,10 +138,34 @@ jobs:
 
       - name: Create EKS cluster without nodegroup
         run: |
-          eksctl create cluster \
-            --name ${{ env.clusterName }} \
-            --tags "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-            --without-nodegroup
+          cat <<EOF > eks-config.yaml
+            apiVersion: eksctl.io/v1alpha5
+            kind: ClusterConfig
+
+            metadata:
+              name: ${{ env.clusterName }}
+              region: ${{ env.region }}
+              tags:
+               usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+               owner: "${{ steps.vars.outputs.owner }}"
+
+            managedNodeGroups:
+            - name: ng-1
+              instanceTypes:
+               - t3.medium
+               - t3a.medium
+              desiredCapacity: 2
+              spot: true
+              privateNetworking: true
+              volumeType: "gp3"
+              volumeSize: 10
+              taints:
+               - key: "node.cilium.io/agent-not-ready"
+                 value: "true"
+                 effect: "NoSchedule"
+          EOF
+
+          eksctl create cluster -f ./eks-config.yaml
 
       - name: Update AWS VPC CNI plugin
         run: |
@@ -172,18 +196,6 @@ jobs:
             --set nodeinit.enabled=true \
             --set bpf.monitorAggregation=none \
             --set bandwidthManager=false
-
-      - name: Add managed spot nodegroup
-        run: |
-          eksctl create nodegroup \
-            --cluster ${{ env.clusterName }} \
-            --nodes 2 \
-            --instance-types "t3.medium,t3a.medium" \
-            --node-volume-type gp3 \
-            --node-volume-size 10 \
-            --managed \
-            --spot \
-            --node-private-networking
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -141,10 +141,34 @@ jobs:
 
       - name: Create EKS cluster without nodegroup
         run: |
-          eksctl create cluster \
-            --name ${{ env.clusterName }} \
-            --tags "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-            --without-nodegroup
+          cat <<EOF > eks-config.yaml
+          apiVersion: eksctl.io/v1alpha5
+          kind: ClusterConfig
+
+          metadata:
+            name: ${{ env.clusterName }}
+            region: ${{ env.region }}
+            tags:
+             usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+             owner: "${{ steps.vars.outputs.owner }}"
+
+          managedNodeGroups:
+          - name: ng-1
+            instanceTypes:
+             - t3.medium
+             - t3a.medium
+            desiredCapacity: 2
+            spot: true
+            privateNetworking: true
+            volumeType: "gp3"
+            volumeSize: 10
+            taints:
+             - key: "node.cilium.io/agent-not-ready"
+               value: "true"
+               effect: "NoSchedule"
+          EOF
+
+          eksctl create cluster -f ./eks-config.yaml
 
       - name: Wait for images to be available
         timeout-minutes: 10
@@ -156,18 +180,6 @@ jobs:
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
-
-      - name: Add managed spot nodegroup
-        run: |
-          eksctl create nodegroup \
-            --cluster ${{ env.clusterName }} \
-            --nodes 2 \
-            --instance-types "t3.medium,t3a.medium" \
-            --node-volume-type gp3 \
-            --node-volume-size 10 \
-            --managed \
-            --spot \
-            --node-private-networking
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -147,6 +147,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --preemptible
 
       - name: Get cluster credentials

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -147,6 +147,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --preemptible
 
       - name: Create GKE cluster 2
@@ -159,6 +160,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --preemptible
 
       - name: Get cluster credentials and setup contexts

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -39,10 +39,14 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        for instructions on how to install ``gcloud`` and prepare your
        account.
 
-       .. code-block:: shell-session
+       .. code-block:: bash
 
            export NAME="$(whoami)-$RANDOM"
-           gcloud container clusters create "${NAME}" --zone us-west2-a 
+           # Create the node pool with the following taint to guarantee that
+           # Pods are only scheduled in the node when Cilium is ready.
+           gcloud container clusters create "${NAME}" \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --zone us-west2-a
            gcloud container clusters get-credentials "${NAME}" --zone us-west2-a
 
     .. group-tab:: AKS
@@ -53,13 +57,51 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest>`_
        for instructions on how to install ``az`` and prepare your account.
 
-       .. code-block:: shell-session
+       .. code-block:: bash
 
            export NAME="$(whoami)-$RANDOM"
            export AZURE_RESOURCE_GROUP="aks-cilium-group"
            az group create --name "${AZURE_RESOURCE_GROUP}" -l westus2
-           az aks create --resource-group "${AZURE_RESOURCE_GROUP}" --name "${NAME}" --network-plugin azure
+
+           # Details: Basic load balancers are not supported with multiple node
+           # pools. Create a cluster with standard load balancer selected to use
+           # multiple node pools, learn more at aka.ms/aks/nodepools.
+           az aks create \
+           --resource-group "${AZURE_RESOURCE_GROUP}" \
+           --name "${NAME}" \
+           --network-plugin azure \
+           --load-balancer-sku standard
+
+           # Get the name of the node pool that was just created since it will
+           # be deleted after Cilium is installed.
+           nodepool_to_delete=$(az aks nodepool list --cluster-name "${NAME}" -g "${AZURE_RESOURCE_GROUP}" -o json | jq -r '.[0].name')
+
+           # Create a node pool with 'mode=system' as it is the same mode used
+           # for the default nodepool on cluster creation also this new node
+           # pool will have the taint 'node.cilium.io/agent-not-ready=true:NoSchedule'
+           # which will guarantee that pods will only be scheduled on that node
+           # once Cilium is ready.
+           az aks nodepool add \
+             --name "nodepool2" \
+             --cluster-name "${NAME}" \
+             --resource-group "${AZURE_RESOURCE_GROUP}" \
+             --node-count 2 \
+             --mode system \
+             --node-taints node.cilium.io/agent-not-ready=true:NoSchedule
+
+           # Get the credentials to access the cluster with kubectl
            az aks get-credentials --name "${NAME}" --resource-group "${AZURE_RESOURCE_GROUP}"
+
+           # We can only delete the first node pool after Cilium is installed
+           # because some pods have Pod Disruption Budgets set. If we try to
+           # delete the first node pool without the second node pool being ready,
+           # AKS will not succeed with the pool deletion because some Deployments
+           # can't cease to exist in the cluster.
+           #
+           # NOTE: Only delete the nodepool after deploying Cilium
+           az aks nodepool delete --name ${nodepool_to_delete} \
+             --cluster-name "${NAME}" \
+             --resource-group "${AZURE_RESOURCE_GROUP}"
 
        .. attention::
 
@@ -78,7 +120,26 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        .. code-block:: shell-session
 
            export NAME="$(whoami)-$RANDOM"
-           eksctl create cluster --name "${NAME}" --region eu-west-1 --without-nodegroup
+           cat <<EOF >eks-config.yaml
+           apiVersion: eksctl.io/v1alpha5
+           kind: ClusterConfig
+
+           metadata:
+             name: ${NAME}
+             region: eu-west-1
+
+           managedNodeGroups:
+           - name: ng-1
+             desiredCapacity: 2
+             privateNetworking: true
+             # taint nodes so that application pods are
+             # not scheduled until Cilium is deployed.
+             taints:
+              - key: "node.cilium.io/agent-not-ready"
+                value: "true"
+                effect: "NoSchedule"
+           EOF
+           eksctl create cluster -f ./eks-config.yaml
 
     .. group-tab:: kind
 
@@ -165,14 +226,11 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        **Install Cilium:**
 
-       Install Cilium into the EKS cluster. Set ``--wait=false`` as no nodes
-       exist yet. Then scale up the number of nodes and wait for Cilium to
-       bootstrap successfully.
+       Install Cilium into the EKS cluster.
 
        .. code-block:: shell-session
 
-           cilium install --wait=false
-           eksctl create nodegroup --cluster "${NAME}" --region eu-west-1 --nodes 2 
+           cilium install
            cilium status --wait
 
     .. group-tab:: OpenShift

--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -190,10 +190,6 @@ Install Cilium
 
        Cilium is now deployed and you are ready to scale-up the cluster:
 
-       .. code-block:: shell-session
-
-          eksctl create nodegroup --cluster test-cluster --nodes 2
-
     .. group-tab:: OpenShift
 
        .. include:: requirements-openshift.rst

--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -1,12 +1,13 @@
 Restart unmanaged Pods
 ======================
 
-If you did not use the ``nodeinit.restartPods=true`` in the Helm options when
-deploying Cilium, then unmanaged pods need to be restarted manually.  Restart
-all already running pods which are not running in host-networking mode to
-ensure that Cilium starts managing them. This is required to ensure that all
-pods which have been running before Cilium was deployed have network
-connectivity provided by Cilium and NetworkPolicy applies to them:
+If you did not create a cluster with the nodes tainted with the taint
+``node.cilium.io/agent-not-ready``, then unmanaged pods need to be restarted
+manually. Restart all already running pods which are not running in
+host-networking mode to ensure that Cilium starts managing them. This is
+required to ensure that all pods which have been running before Cilium was
+deployed have network connectivity provided by Cilium and NetworkPolicy applies
+to them:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -636,6 +636,12 @@ As an instance example, ``m5n.xlarge`` is used in the config ``nodegroup-config.
       desiredCapacity: 2
       ssh:
         allow: true
+      # taint nodes so that application pods are
+      # not scheduled until Cilium is deployed.
+      taints:
+        - key: "node.cilium.io/agent-not-ready"
+          value: "true"
+          effect: "NoSchedule"
 
 The nodegroup is created with:
 

--- a/Documentation/gettingstarted/requirements-aks.rst
+++ b/Documentation/gettingstarted/requirements-aks.rst
@@ -20,6 +20,9 @@ Direct Routing  Azure IPAM          Kubernetes CRD
   compatibility with Cilium. The Azure network plugin will be replaced with
   Cilium by the installer.
 
+* Node pools must also be created with the taint ``node.cilium.io/agent-not-ready=true:NoSchedule``
+  using ``--node-taints`` option.
+
 **Limitations:**
 
 * All VMs and VM scale sets used in a cluster must belong to the same resource

--- a/Documentation/gettingstarted/requirements-eks.rst
+++ b/Documentation/gettingstarted/requirements-eks.rst
@@ -16,10 +16,35 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
    If you want to chain Cilium on top of the AWS CNI, refer to the guide
    :ref:`chaining_aws_cni`.
 
-**Requirements:**
+The following command creates a Kubernetes cluster with ``eksctl``
+using `Amazon Elastic Kubernetes Service
+<https://aws.amazon.com/eks/>`_.  See `eksctl Installation
+<https://github.com/weaveworks/eksctl>`_ for instructions on how to
+install ``eksctl`` and prepare your account.
 
-* It is recommended to create an EKS cluster without any nodes, install
-  Cilium, and then scale up the number of nodes with Cilium already deployed.
+.. code-block:: shell-session
+
+   export NAME="$(whoami)-$RANDOM"
+   cat <<EOF >eks-config.yaml
+   apiVersion: eksctl.io/v1alpha5
+   kind: ClusterConfig
+
+   metadata:
+     name: ${NAME}
+     region: eu-west-1
+
+   managedNodeGroups:
+   - name: ng-1
+     desiredCapacity: 2
+     privateNetworking: true
+     # taint nodes so that application pods are
+     # not scheduled until Cilium is deployed.
+     taints:
+      - key: "node.cilium.io/agent-not-ready"
+        value: "true"
+        effect: "NoSchedule"
+   EOF
+   eksctl create cluster -f ./eks-config.yaml
 
 **Limitations:**
 

--- a/Documentation/gettingstarted/requirements-gke.rst
+++ b/Documentation/gettingstarted/requirements-gke.rst
@@ -11,5 +11,5 @@ Direct Routing  Kubernetes PodCIDR  Kubernetes CRD
 
 **Requirements:**
 
-* No special requirements. The Cilium installer will automatically
-  reconfigure your GKE cluster to use CNI mode.
+* The cluster must  be created with the taint ``node.cilium.io/agent-not-ready=true:NoSchedule``
+  using ``--node-taints`` option.

--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -198,7 +198,7 @@ func initK8s(ctx context.Context) (crdBackend allocator.Backend, crdAllocator *a
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 
-	if err := k8s.WaitForNodeInformation(); err != nil {
+	if err := k8s.WaitForNodeInformation(ctx, k8s.Client()); err != nil {
 		log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1722,7 +1722,7 @@ func runDaemon() {
 
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
-		k8s.Client().MarkNodeReady(nodeTypes.GetName())
+		k8s.Client().MarkNodeReady(d.k8sWatcher, nodeTypes.GetName())
 		bootstrapStats.k8sInit.End(true)
 	}
 

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -220,33 +220,6 @@ spec:
               date > {{ .Values.nodeinit.bootstrapFile }}
 {{- end }}
 
-{{- if .Values.nodeinit.restartPods }}
-              echo "Restarting kubenet managed pods"
-              if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
-                # Works for COS, ubuntu
-                # Note the first line is the containerID with a trailing \r
-                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f "$(sed 's/\r//;1q' $f)" || true; done
-              elif [ -n "$(docker ps --format '{{ "{{" }}.Image{{ "}}" }}' | grep ^[0-9]*\.dkr\.ecr\.[a-z]*-[a-z]*-[0-9]*\.amazonaws\.com/amazon-k8s-cni)" ]; then
-                timeout=1
-                for i in $(seq 1 7); do
-                  echo "Checking introspection API"
-                  curl localhost:61679 && retry=false || retry=true
-                  if [ $retry == false ]; then break ; fi
-                  sleep "$timeout"
-                  timeout=$(($timeout * 2))
-                done
-
-                for pod in $(curl "localhost:61679/v1/pods" 2> /dev/null | jq -r '. | keys[]'); do
-                  container_id=$(echo "$pod" | awk -F_ ' { print $3 } ' | cut -c1-12)
-                  echo "Restarting ${container_id}"
-                  docker kill "${container_id}" || true
-                done
-              else
-                # COS-beta (with containerd). Some versions of COS have crictl in /home/kubernetes/bin.
-                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do PATH="${PATH}:/home/kubernetes/bin" crictl stopp "$(sed 's/\r//;1q' $f)" || true; done
-              fi
-{{- end }}
-
               # AKS: If azure-vnet is installed on the node, and (still) configured in bridge mode,
               # configure it as 'transparent' to be consistent with Cilium's CNI chaining config.
               # If the azure-vnet CNI config is not removed, kubelet will execute CNI CHECK commands

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -144,7 +144,7 @@ func (s *Speaker) OnUpdateEndpoints(eps *slim_corev1.Endpoints) {
 }
 
 // OnUpdateNode notifies the Speaker of an update to a node.
-func (s *Speaker) OnUpdateNode(node *slim_corev1.Node) {
+func (s *Speaker) OnUpdateNode(node *v1.Node) {
 	s.queue.Add(nodeEvent(&node.Labels))
 }
 

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
+	core_v1 "k8s.io/api/core/v1"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -136,4 +137,13 @@ func (k8sCli K8sClient) GetSecrets(ctx context.Context, ns, name string) (map[st
 		return nil, err
 	}
 	return result.Data, nil
+}
+
+// GetK8sNode returns the node with the given nodeName.
+func (k8sCli K8sClient) GetK8sNode(ctx context.Context, nodeName string) (*core_v1.Node, error) {
+	if k8sCli.Interface == nil {
+		return nil, fmt.Errorf("GetK8sNode: No k8s, cannot access k8s nodes")
+	}
+
+	return k8sCli.CoreV1().Nodes().Get(ctx, nodeName, v1.GetOptions{})
 }

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,6 +64,12 @@ const (
 	CiliumK8sAnnotationPrefix = "cilium.io/"
 	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
 	CiliumIdentityAnnotationDeprecated = "cilium-identity"
+
+	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
+	// scheduled. Once cilium is setup it is removed from the node. Mostly
+	// used in cloud providers to prevent existing CNI plugins from managing
+	// pods.
+	AgentNotReadyNodeTaint = "node." + CiliumK8sAnnotationPrefix + "agent-not-ready"
 )
 
 const (

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -171,8 +171,8 @@ func ObjTov1Pod(obj interface{}) *slim_corev1.Pod {
 	return nil
 }
 
-func ObjToV1Node(obj interface{}) *slim_corev1.Node {
-	node, ok := obj.(*slim_corev1.Node)
+func ObjToV1Node(obj interface{}) *v1.Node {
+	node, ok := obj.(*v1.Node)
 	if ok {
 		return node
 	}
@@ -181,7 +181,7 @@ func ObjToV1Node(obj interface{}) *slim_corev1.Node {
 		// Delete was not observed by the watcher but is
 		// removed from kube-apiserver. This is the last
 		// known state and the object no longer exists.
-		node, ok := deletedObj.Obj.(*slim_corev1.Node)
+		node, ok := deletedObj.Obj.(*v1.Node)
 		if ok {
 			return node
 		}

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package benchmarks
 import (
 	"encoding/json"
 	"os"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -460,7 +461,7 @@ func (k *K8sIntegrationSuite) benchmarkInformer(nCycles int, newInformer bool, c
 				UpdateFunc: func(oldObj, newObj interface{}) {
 					if oldK8sNP := k8s.ObjToV1Node(oldObj); oldK8sNP != nil {
 						if newK8sNP := k8s.ObjToV1Node(newObj); newK8sNP != nil {
-							if oldK8sNP.DeepEqual(newK8sNP) {
+							if reflect.DeepEqual(oldK8sNP, newK8sNP) {
 								return
 							}
 						}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -209,13 +209,6 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 	return newNode
 }
 
-// GetNode returns the kubernetes nodeName's node information from the
-// kubernetes api server
-func GetNode(c kubernetes.Interface, nodeName string) (*corev1.Node, error) {
-	// Try to retrieve node's cidr and addresses from k8s's configuration
-	return c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-}
-
 // setNodeNetworkUnavailableFalse sets Kubernetes NodeNetworkUnavailable to
 // false as Cilium is managing the network connectivity.
 // https://kubernetes.io/docs/concepts/architecture/nodes/#condition

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node/addressing"
@@ -212,11 +213,29 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 // setNodeNetworkUnavailableFalse sets Kubernetes NodeNetworkUnavailable to
 // false as Cilium is managing the network connectivity.
 // https://kubernetes.io/docs/concepts/architecture/nodes/#condition
-func setNodeNetworkUnavailableFalse(c kubernetes.Interface, nodeName string) error {
+func setNodeNetworkUnavailableFalse(ctx context.Context, c kubernetes.Interface, nodeGetter nodeGetter, nodeName string) error {
+	n, err := nodeGetter.GetK8sNode(ctx, nodeName)
+	if err != nil {
+		return err
+	}
+
+	const reason = "CiliumIsUp"
+
+	for _, condition := range n.Status.Conditions {
+		if condition.Type == corev1.NodeNetworkUnavailable &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == reason {
+
+			// No need to update node condition as it is already available in
+			// the node status.
+			return nil
+		}
+	}
+
 	condition := corev1.NodeCondition{
 		Type:               corev1.NodeNetworkUnavailable,
 		Status:             corev1.ConditionFalse,
-		Reason:             "CiliumIsUp",
+		Reason:             reason,
 		Message:            "Cilium is running on this node",
 		LastTransitionTime: metav1.Now(),
 		LastHeartbeatTime:  metav1.Now(),
@@ -230,15 +249,68 @@ func setNodeNetworkUnavailableFalse(c kubernetes.Interface, nodeName string) err
 	return err
 }
 
+// removeNodeTaint removes the AgentNotReadyNodeTaint allowing for pods to be
+// scheduled once Cilium is setup. Mostly used in cloud providers to prevent
+// existing CNI plugins from managing pods.
+func removeNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter nodeGetter, nodeName string) error {
+	k8sNode, err := nodeGetter.GetK8sNode(ctx, nodeName)
+	if err != nil {
+		return err
+	}
+
+	var taintFound bool
+
+	var taints []corev1.Taint
+	for _, taint := range k8sNode.Spec.Taints {
+		if taint.Key != ciliumio.AgentNotReadyNodeTaint {
+			taints = append(taints, taint)
+		} else {
+			taintFound = true
+		}
+	}
+
+	// No cilium taints found
+	if !taintFound {
+		log.WithFields(logrus.Fields{
+			logfields.NodeName: nodeName,
+			"taint":            ciliumio.AgentNotReadyNodeTaint,
+		}).Debug("Taint not found in node")
+		return nil
+	}
+	log.WithFields(logrus.Fields{
+		logfields.NodeName: nodeName,
+		"taint":            ciliumio.AgentNotReadyNodeTaint,
+	}).Debug("Removing Node Taint")
+
+	k8sNode.Spec.Taints = taints
+
+	_, err = c.CoreV1().Nodes().Update(ctx, k8sNode, metav1.UpdateOptions{})
+	return err
+}
+
+const (
+	markK8sNodeReadyControllerName = "mark-k8s-node-as-available"
+)
+
 // MarkNodeReady marks the Kubernetes node resource as ready from a networking
 // perspective
-func (k8sCli K8sClient) MarkNodeReady(nodeName string) {
+func (k8sCli K8sClient) MarkNodeReady(nodeGetter nodeGetter, nodeName string) {
 	log.WithField(logfields.NodeName, nodeName).Debug("Setting NetworkUnavailable=false")
 
-	controller.NewManager().UpdateController("mark-k8s-node-as-available",
+	controller.NewManager().UpdateController(markK8sNodeReadyControllerName,
 		controller.ControllerParams{
-			DoFunc: func(_ context.Context) error {
-				return setNodeNetworkUnavailableFalse(k8sCli, nodeName)
+			DoFunc: func(ctx context.Context) error {
+				err := removeNodeTaint(ctx, k8sCli, nodeGetter, nodeName)
+				if err != nil {
+					return err
+				}
+				return setNodeNetworkUnavailableFalse(ctx, k8sCli, nodeGetter, nodeName)
 			},
 		})
+}
+
+// ReMarkNodeReady re-triggers the controller set by 'MarkNodeReady'. If
+// 'MarkNodeReady' has not been executed yet, calling this function be a no-op.
+func (k8sCli K8sClient) ReMarkNodeReady() {
+	controller.NewManager().TriggerController(markK8sNodeReadyControllerName)
 }

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/k8s"
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -31,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -43,7 +43,7 @@ var (
 
 // NodesInit initializes a k8s watcher for node events belonging to the node
 // where Cilium is running.
-func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
+func (k *K8sWatcher) NodesInit(k8sClient *k8s.K8sClient) {
 	onceNodeInitStart.Do(func() {
 		nodeStore, nodeController := informer.NewInformer(
 			cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
@@ -55,6 +55,9 @@ func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
 					var valid bool
 					if node := k8s.ObjToV1Node(obj); node != nil {
 						valid = true
+						if hasAgentNotReadyTaint(node) {
+							k8sClient.ReMarkNodeReady()
+						}
 						err := k.updateK8sNodeV1(nil, node)
 						k.K8sEventProcessed(metricNode, metricCreate, err == nil)
 					}
@@ -65,6 +68,10 @@ func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
 					if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
 						valid = true
 						if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
+							if hasAgentNotReadyTaint(newNode) {
+								k8sClient.ReMarkNodeReady()
+							}
+
 							oldNodeLabels := oldNode.GetLabels()
 							newNodeLabels := newNode.GetLabels()
 							if comparator.MapStringEquals(oldNodeLabels, newNodeLabels) {
@@ -87,6 +94,17 @@ func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
 		go nodeController.Run(wait.NeverStop)
 		k.k8sAPIGroups.AddAPI(k8sAPIGroupNodeV1Core)
 	})
+}
+
+// hasAgentNotReadyTaint returns true if the given node has the Cilium Agen
+// Not Ready Node Taint.
+func hasAgentNotReadyTaint(k8sNode *v1.Node) bool {
+	for _, taint := range k8sNode.Spec.Taints {
+		if taint.Key == ciliumio.AgentNotReadyNodeTaint {
+			return true
+		}
+	}
+	return false
 }
 
 func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *v1.Node) error {

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,64 +15,81 @@
 package watchers
 
 import (
+	"context"
+	"sync"
+
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
-	_, nodeController := informer.NewInformer(
-		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
-			"nodes", v1.NamespaceAll, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName())),
-		&slim_corev1.Node{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				var valid bool
-				if node := k8s.ObjToV1Node(obj); node != nil {
-					valid = true
-					err := k.updateK8sNodeV1(nil, node)
-					k.K8sEventProcessed(metricNode, metricCreate, err == nil)
-				}
-				k.K8sEventReceived(metricNode, metricCreate, valid, false)
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				var valid, equal bool
-				if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
-					valid = true
-					if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
-						oldNodeLabels := oldNode.GetLabels()
-						newNodeLabels := newNode.GetLabels()
-						if comparator.MapStringEquals(oldNodeLabels, newNodeLabels) {
-							equal = true
-						} else {
-							err := k.updateK8sNodeV1(oldNode, newNode)
-							k.K8sEventProcessed(metricNode, metricUpdate, err == nil)
+var (
+	// onceNodeInitStart is used to guarantee that only one function call of
+	// NodesInit is executed.
+	onceNodeInitStart sync.Once
+)
+
+// NodesInit initializes a k8s watcher for node events belonging to the node
+// where Cilium is running.
+func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
+	onceNodeInitStart.Do(func() {
+		nodeStore, nodeController := informer.NewInformer(
+			cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+				"nodes", v1.NamespaceAll, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName())),
+			&v1.Node{},
+			0,
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					var valid bool
+					if node := k8s.ObjToV1Node(obj); node != nil {
+						valid = true
+						err := k.updateK8sNodeV1(nil, node)
+						k.K8sEventProcessed(metricNode, metricCreate, err == nil)
+					}
+					k.K8sEventReceived(metricNode, metricCreate, valid, false)
+				},
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					var valid, equal bool
+					if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
+						valid = true
+						if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
+							oldNodeLabels := oldNode.GetLabels()
+							newNodeLabels := newNode.GetLabels()
+							if comparator.MapStringEquals(oldNodeLabels, newNodeLabels) {
+								equal = true
+							} else {
+								err := k.updateK8sNodeV1(oldNode, newNode)
+								k.K8sEventProcessed(metricNode, metricUpdate, err == nil)
+							}
 						}
 					}
-				}
-				k.K8sEventReceived(metricNode, metricUpdate, valid, equal)
+					k.K8sEventReceived(metricNode, metricUpdate, valid, equal)
+				},
 			},
-		},
-		nil,
-	)
+			nil,
+		)
 
-	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, nodeController.HasSynced, k8sAPIGroupNodeV1Core)
-	go nodeController.Run(wait.NeverStop)
-	k.k8sAPIGroups.AddAPI(k8sAPIGroupNodeV1Core)
+		k.nodeStore = nodeStore
+
+		k.blockWaitGroupToSyncResources(wait.NeverStop, nil, nodeController.HasSynced, k8sAPIGroupNodeV1Core)
+		go nodeController.Run(wait.NeverStop)
+		k.k8sAPIGroups.AddAPI(k8sAPIGroupNodeV1Core)
+	})
 }
 
-func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) error {
+func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *v1.Node) error {
 	var oldNodeLabels map[string]string
 	if oldK8sNode != nil {
 		oldNodeLabels = oldK8sNode.GetLabels()
@@ -95,4 +112,25 @@ func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) e
 		return err
 	}
 	return nil
+}
+
+// GetK8sNode returns the *local Node* from the local store.
+func (k *K8sWatcher) GetK8sNode(_ context.Context, nodeName string) (*v1.Node, error) {
+	k.WaitForCacheSync(k8sAPIGroupNodeV1Core)
+	pName := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}
+	nodeInterface, exists, err := k.nodeStore.Get(pName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, k8sErrors.NewNotFound(schema.GroupResource{
+			Group:    "core",
+			Resource: "Node",
+		}, nodeName)
+	}
+	return nodeInterface.(*v1.Node).DeepCopy(), nil
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import (
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -159,7 +160,7 @@ type bgpSpeakerManager interface {
 
 	OnUpdateEndpoints(eps *slim_corev1.Endpoints)
 
-	OnUpdateNode(node *slim_corev1.Node)
+	OnUpdateNode(node *corev1.Node)
 }
 type egressPolicyManager interface {
 	AddEgressPolicy(config egresspolicy.Config) (bool, error)
@@ -203,6 +204,8 @@ type K8sWatcher struct {
 	// variable is written for the first time.
 	podStoreSet  chan struct{}
 	podStoreOnce sync.Once
+
+	nodeStore cache.Store
 
 	namespaceStore cache.Store
 	datapath       datapath.Datapath
@@ -446,7 +449,7 @@ func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context) error {
 	go k.podsInit(k8s.WatcherClient(), asyncControllers)
 
 	// kubernetes nodes
-	k.nodesInit(k8s.WatcherClient())
+	k.NodesInit(k8s.Client())
 
 	// kubernetes namespaces
 	asyncControllers.Add(1)

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import (
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -62,6 +63,10 @@ const (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, nodeDiscoverySubsys)
 
+type k8sNodeGetter interface {
+	GetK8sNode(ctx context.Context, nodeName string) (*corev1.Node, error)
+}
+
 // NodeDiscovery represents a node discovery action
 type NodeDiscovery struct {
 	Manager               *nodemanager.Manager
@@ -71,6 +76,7 @@ type NodeDiscovery struct {
 	Registered            chan struct{}
 	LocalStateInitialized chan struct{}
 	NetConf               *cnitypes.NetConf
+	k8sNodeGetter         k8sNodeGetter
 }
 
 func enableLocalNodeRoute() bool {
@@ -354,7 +360,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 
 	// Tie the CiliumNode custom resource lifecycle to the lifecycle of the
 	// Kubernetes node
-	if k8sNode, err := k8s.GetNode(k8s.Client(), nodeTypes.GetName()); err != nil {
+	if k8sNode, err := n.k8sNodeGetter.GetK8sNode(context.TODO(), nodeTypes.GetName()); err != nil {
 		log.WithError(err).Warning("Kubernetes node resource representing own node is not available, cannot set OwnerReference")
 	} else {
 		nodeResource.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
@@ -590,6 +596,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	}
 
 	return nil
+}
+
+func (n *NodeDiscovery) RegisterK8sNodeGetter(k8sNodeGetter k8sNodeGetter) {
+	n.k8sNodeGetter = k8sNodeGetter
 }
 
 func getInt(i int) *int {


### PR DESCRIPTION
This PR introduces steps on how to install Cilium in cloud providers. The reason behind this PR is described in detail in https://github.com/cilium/cilium/issues/16602. Initially, the changes in this PR were supposed to be a few but the commit "pkg/k8s: replace GetNode instances with a k8s store" is necessary to make sure nodes that have the taint `node.cilium.io/agent-not-ready` set after Cilium started, will also have that taint removed without restart Cilium, by watching for Node events.

Marked this PR as needs-backport/1.10 as it tremendously improves the deployment of Cilium in cloud providers.

It should be easier to review the changes on a per-commit basis.

```release-note
Provide new installation steps to deploy Cilium in managed kubernetes providers (GKE, EKS, AKS) to allow scale up and down node pools.
```

Fixes https://github.com/cilium/cilium/issues/7404
Fixes https://github.com/cilium/cilium/issues/16602 
Fixes https://github.com/cilium/cilium/issues/15177
Fixes https://github.com/cilium/cilium/issues/16542

:warning: Note for reviewers, this PR was ran with a test commit to test the new changes into the conformance GH workflows. All of them have passed except multicluster which is currently broken on master.