### PR TITLE
helm: Use `batch/v1` apiVersion for CronJob in K8s 1.21+ 

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -75,3 +75,14 @@ backend:
       name: http
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for cronjob.
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version -}}
+{{- print "batch/v1" -}}
+{{- else -}}
+{{- print "batch/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") .Values.clustermesh.apiserver.tls.auto.schedule }}
-apiVersion: batch/v1beta1
+apiVersion: {{ include "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: clustermesh-apiserver-generate-certs

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.hubble.tls.auto.schedule }}
-apiVersion: batch/v1beta1
+apiVersion: {{ include "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: hubble-generate-certs


### PR DESCRIPTION
The CronJob object reached GA in Kubernetes 1.2, thus bumping its api
version from `batch/v1beta1` to `batch/v1`. The old `batch/v1beta1` api
version will be removed in Kubernetes 1.25.

This fixes the following Helm warning on Kubernetes 1.21+:

```
W0623 11:06:59.097404 1094484 warnings.go:67] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```

The first commit is a drive-by fixup for 4cc699d  (see commit description).