### PR TITLE
workflows: Do not fail if nothing to kill

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -196,7 +196,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
+          pkill -9 -e -f "kubectl port-forward" || echo "nothing killed" # kill background port forwards
 
       - name: Install Cilium with encryption
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -189,7 +189,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
+          pkill -9 -e -f "kubectl port-forward" || echo "nothing killed" # kill background port forwards
 
       - name: Install Cilium with encryption
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -184,7 +184,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
+          pkill -9 -e -f "kubectl port-forward" || echo "nothing killed" # kill background port forwards
 
       - name: Install Cilium with tunnel datapath
         run: |
@@ -216,7 +216,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
+          pkill -9 -e -f "kubectl port-forward" || echo "nothing killed" # kill background port forwards
 
       - name: Install Cilium with encryption
         run: |
@@ -249,7 +249,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
+          pkill -9 -e -f "kubectl port-forward" || echo "nothing killed" # kill background port forwards
 
       - name: Install Cilium with encryption and tunnel datapath
         run: |

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pgrep -f "kubectl port-forward" | xargs kill -9 # kill background port forwards
+          pkill -9 -e -f "kubectl port-forward" || echo "nothing killed" # kill background port forwards
 
       - name: Install Cilium with encryption
         run: |


### PR DESCRIPTION
When using `xargs` to pass pids to `kill`, there might no be any pids,
thus causing `kill` to fail due to missing arguments. This can happen in
CI when `kubectl port-forward` already exited on its own due to the pods
getting deleted.

This commit replaces `pgrep | xargs kill` with `pkill` (which is
functionally identical), and ignores any non-zero exit codes from
`pkill` in case no processes are found. To aid in troubleshooting, this
commit also adds the `-e` (echo) flag to the `pkill` command, to display
the kubectl processes getting killed:

```console
$ pkill -9 -e -f "kubectl port-forward" || echo "nothing killed"
kubectl killed (pid 1155795)
kubectl killed (pid 1156193)
$ pkill -9 -e -f "kubectl port-forward" || echo "nothing killed"
nothing killed
```

Fixes: #16636
