### PR TITLE
ipsec: Fix off-by-one error on max keyID

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -518,10 +518,10 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 			offset = -1
 		}
 		if spiI > linux_defaults.IPsecMaxKeyVersion {
-			return 0, 0, fmt.Errorf("encryption Key space exhausted, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion, s[0])
+			return 0, 0, fmt.Errorf("encryption Key space exhausted, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, s[0])
 		}
 		if spiI == 0 {
-			return 0, 0, fmt.Errorf("zero is not a valid key to disable encryption use `--enable-ipsec=false`, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion, s[0])
+			return 0, 0, fmt.Errorf("zero is not a valid key to disable encryption use `--enable-ipsec=false`, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, s[0])
 		}
 		spi = uint8(spiI)
 

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -96,7 +96,7 @@ const (
 	TunnelDeviceName = "cilium_vxlan"
 
 	// IPSec offset value for node rules
-	IPsecMaxKeyVersion = 16
+	IPsecMaxKeyVersion = 15
 
 	// IPsecMarkMask is the mask required for the IPsec SPI and encrypt/decrypt bits
 	IPsecMarkMask = 0xFF00


### PR DESCRIPTION
We encoded the SPI (aka keyID) [on 4 bits](https://github.com/cilium/cilium/blob/v1.10.1/pkg/datapath/linux/ipsec/ipsec_linux.go#L147-L150) in the xfrm and packet marks. The maximum value is therefore 15 and not 16. This pull request fixes the check on the maximum keyID value.

Note [the documentation for IPsec key rotation](https://docs.cilium.io/en/v1.10/gettingstarted/encryption-ipsec/#key-rotation) already has the correct value so there shouldn't be any users with an incorrect keyID.

Fixes: https://github.com/cilium/cilium/pull/7450