### PR TITLE
tests: rework custom calls's `AfterEach`/`AfterAll` blocks to skip if needed

### DIFF
--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -51,16 +51,11 @@ var _ = Describe("K8sCustomCalls", func() {
 		deploymentManager.SetKubectl(kubectl)
 	})
 
-	AfterEach(func() {
-		deploymentManager.DeleteAll()
-	})
-
 	AfterFailed(func() {
 		kubectl.CiliumReport("cilium status", "cilium endpoint list")
 	})
 
 	AfterAll(func() {
-		deploymentManager.DeleteCilium()
 		kubectl.CloseSSHClient()
 	})
 
@@ -113,6 +108,11 @@ var _ = Describe("K8sCustomCalls", func() {
 		AfterEach(func() {
 			_ = kubectl.Delete(yaml)
 			ExpectAllPodsTerminated(kubectl)
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteCilium()
+			deploymentManager.DeleteAll()
 		})
 
 		installPods := func() {


### PR DESCRIPTION
The `AfterAll()` and `AfterEach()` blocks in the test file for custom calls run everytime, even if the Context block for the actual tests is skipped. In that case, running the final blocks results in an attempt to remove deployments that have never been set up in the first place. This may lead to the blocks failing when the tests were in fact skipped, and may produce test artifacts even though Jenkins does not considered the test failed.

Fixes: 37f6192c9e77 ("test: add CI test for tail calls hooks for custom programs")
Fixes: #13191
Fixes: #16633
