### PR TITLE
tests: re-enable Host Firewall for AutoDirectNodeRoutes test and encryption + direct routing

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -338,9 +338,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// Needed to bypass bug with masquerading when devices are set. See #12141.
 			if helpers.DoesNotRunWithKubeProxyReplacement() {
 				options["masquerade"] = "false"
-				// This test fails if the hostfw is enabled (and devices specified).
-				// See #12205 for details.
-				options["hostFirewall"] = "false"
 			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -716,10 +716,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 
-		// This test is broken because of #12205. In short, when bpf_host is
-		// loading on the native device, the source identity of packet on the
-		// destination node is resolved to WORLD and policy enforcement fails.
-		XIt("Check connectivity with transparent encryption and direct routing with bpf_host", func() {
+		SkipItIf(helpers.RunsWithoutKubeProxy, "Check connectivity with transparent encryption and direct routing with bpf_host", func() {
 			privateIface, err := kubectl.GetPrivateIface()
 			Expect(err).Should(BeNil(), "Unable to determine the private interface")
 			defaultIface, err := kubectl.GetDefaultIface()
@@ -734,6 +731,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"encryption.ipsec.interface": privateIface,
 				"devices":                    devices,
 				"hostFirewall":               "false",
+				"kubeProxyReplacement":       "disabled",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})


### PR DESCRIPTION
Issue #12205 has been fixed via #16136, and the Host Firewall can be used again in the tests. Renable those tests that we had disabled because of the issue.
