### PR TITLE
v1.8 backports 2021-06-25

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -141,9 +141,9 @@ generate_commit_list_for_pr () {
   # Use GitHub to determine the number of commits to list, but then query
   # the branch directly to determine the canonical order of the commits.
   for commit in $(git rev-list --reverse -$n_commits $branch); do
-    patchid="$(git show $commit | git patch-id)"
+    patchid="$(git log -n1 --pretty=format:"%ae%at" $commit)"
     subject="$(git show -s --pretty="%s" $commit)"
-    echo "$patchid $subject" >> $tmp_file
+    echo "$patchid $commit $subject" >> $tmp_file
   done
   git branch -q -D $branch
   echo "   Merge with $n_commits commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
@@ -156,11 +156,10 @@ generate_commit_list_for_pr () {
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
     entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
-    upstream="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
-    upstream="$(git show $upstream | git patch-id)"
-    upstream=($upstream)
-    if [ "$entry_id" == "${upstream[0]}" ]; then
-      echo -e "     |  ${upstream[1]} via $entry_sha (\"$entry_sub\")"
+    upstream_commit="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
+    upstream_id="$(git log -n1 --pretty=format:"%ae%at" $upstream_commit)"
+    if [ "$entry_id" == "${upstream_id}" ]; then
+      echo -e "     |  ${upstream_commit} via $entry_sha (\"$entry_sub\")"
     else
       echo -e "     |  Warning: No commit correlation found!    via $entry_sha (\"$entry_sub\")"
     fi

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -780,7 +780,7 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 			// issued arping after us, as it might have a more recent hwAddr value.
 			return
 		}
-		n.neighLastPingByNextHop[nextHopStr] = time.Now()
+		n.neighLastPingByNextHop[nextHopStr] = now
 		if prevHwAddr, found := n.neighByNextHop[nextHopStr]; found && prevHwAddr.String() == hwAddr.String() {
 			// Nothing to update, return early to avoid calling to netlink. This
 			// is based on the assumption that n.neighByNextHop gets populated

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1188,23 +1188,28 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 			c.Assert(err, check.IsNil)
 			return nil
 		})
-		// Check that MAC has been changed in the neigh table
-		time.Sleep(500 * time.Millisecond)
-		neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
-		c.Assert(err, check.IsNil)
-		found = false
-		for _, n := range neighs {
-			if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT {
-				c.Assert(n.HardwareAddr.String(), check.Equals, mac.String())
-				c.Assert(neighHwAddr(ip1.String()), check.Equals, mac.String())
-				c.Assert(neighRefCount(ip1.String()), check.Equals, 1)
-				found = true
-				break
-			}
-		}
-		c.Assert(found, check.Equals, true)
 
+		// Check that MAC has been changed in the neigh table
+		var found bool
+		err := testutils.WaitUntilWithSleep(func() bool {
+			neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
+			c.Assert(err, check.IsNil)
+			found = false
+			for _, n := range neighs {
+				if n.IP.Equal(ip1) && n.State == netlink.NUD_PERMANENT &&
+					n.HardwareAddr.String() == mac.String() &&
+					neighHwAddr(ip1.String()) == mac.String() &&
+					neighRefCount(ip1.String()) == 1 {
+					found = true
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second, 200*time.Millisecond)
+		c.Assert(err, check.IsNil)
+		c.Assert(found, check.Equals, true)
 	}
+
 	// Cleanup
 	close(done)
 	wg.Wait()

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -203,7 +203,7 @@ func (k *K8sWatcher) addK8sPodV1(pod *slim_corev1.Pod) error {
 		logfields.K8sNamespace: pod.ObjectMeta.Namespace,
 		"podIP":                pod.Status.PodIP,
 		"podIPs":               pod.Status.PodIPs,
-		"hostIP":               pod.Status.PodIP,
+		"hostIP":               pod.Status.HostIP,
 	})
 
 	if pod.Spec.HostNetwork {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2015,7 +2015,7 @@ var (
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
 		IdentityAllocationMode:       IdentityAllocationModeKVstore,
 		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
-		EnableWellKnownIdentities:    defaults.EnableEndpointRoutes,
+		EnableWellKnownIdentities:    defaults.EnableWellKnownIdentities,
 		K8sEnableK8sEndpointSlice:    defaults.K8sEnableEndpointSlice,
 		k8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 

--- a/pkg/testutils/condition.go
+++ b/pkg/testutils/condition.go
@@ -26,7 +26,14 @@ type ConditionFunc func() bool
 // WaitUntil evaluates the condition every 10 milliseconds and waits for the
 // condition to be met. The function will time out and return an error after
 // timeout
+
 func WaitUntil(condition ConditionFunc, timeout time.Duration) error {
+	return WaitUntilWithSleep(condition, timeout, 10*time.Millisecond)
+}
+
+// WaitUntilWithSleep does the same as WaitUntil except that the sleep time
+// between the condition checks is given.
+func WaitUntilWithSleep(condition ConditionFunc, timeout, sleep time.Duration) error {
 	now := time.Now()
 	for {
 		if time.Since(now) > timeout {
@@ -37,6 +44,6 @@ func WaitUntil(condition ConditionFunc, timeout time.Duration) error {
 			return nil
 		}
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(sleep)
 	}
 }

--- a/test/vagrant-ci-start.sh
+++ b/test/vagrant-ci-start.sh
@@ -4,6 +4,10 @@ set -e
 
 K8S_NODES=${K8S_NODES:-2}
 
+echo "restarting portmap and nfs-kernel-server services to combat nfs server issues"
+systemctl restart portmap.service || true
+systemctl restart nfs-kernel-server.service || true
+
 echo "destroying vms in case this is a retry"
 for i in $(seq 1 $K8S_NODES); do
     vagrant destroy k8s${i}-${K8S_VERSION} --force


### PR DESCRIPTION
* #16506 -- ci: restart portmap service on CI nodes (@nebril)
 * #16434 -- pkg/option: Fix default assignment of EnableWellKnownIdentities (@mauriciovasquezbernal)
 * #16530 -- k8s: Fix logging (@jrajahalme)
 * #16604 -- bpf: fix hw_csum issue for icmp probe packets (@borkmann)
 * #16578 -- node-neigh: Fix concurrent arping update unit test flake (@brb)
 * #16572 -- contrib: Identify upstream commits by author and date (@pchaigno)

Skipped due to conflicts:
 * #16190 -- pkg/k8s: add pod IP event change (@aanm)
 * #16529 -- policy: Make selectorcache callbacks lock-free (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16506 16434 16530 16604 16578 16572; do contrib/backporting/set-labels.py $pr done 1.8; done
```