### PR TITLE
Add Bidirectional mount in Cilium DaemonSet

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -48,14 +48,6 @@ Should you encounter any issues during the installation, please refer to the
 Please consult the Kubernetes :ref:`k8s_requirements` for information on  how
 you need to configure your Kubernetes cluster to operate with Cilium.
 
-Mount the eBPF Filesystem
-=========================
-On each node, run the following to mount the eBPF Filesystem:
-
-.. code-block:: shell-session
-
-     sudo mount bpffs -t bpf /sys/fs/bpf
-
 Install Cilium
 ==============
 

--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -217,14 +217,6 @@ Install Cilium
 
        .. include:: requirements-k3s.rst
 
-       **Mount the eBPF Filesystem:**
-
-       On each node, run the following to mount the eBPF Filesystem:
-
-       .. code-block:: shell-session
-
-          sudo mount bpffs -t bpf /sys/fs/bpf
-      
        **Install Cilium:**
 
        .. parsed-literal::

--- a/Documentation/gettingstarted/k8s-install-rancher-existing-nodes.rst
+++ b/Documentation/gettingstarted/k8s-install-rancher-existing-nodes.rst
@@ -50,15 +50,6 @@ cluster:
 
 .. image:: images/rancher_add_nodes.png
 
-Before adding nodes to the cluster, ensure the BPF filesystem is mounted.
-You can persist the configuration using the following commands:
-
-.. code-block:: shell-session
-
-  sudo mount bpffs -t bpf /sys/fs/bpf
-  sudo bash -c "echo 'none /sys/fs/bpf bpf rw,relatime 0 0' >> /etc/fstab"
-
-
 Next, add nodes to the cluster using the Rancher-provided Docker commands. Be
 sure to add the appropriate number of nodes required for your cluster. After
 a few minutes, you will see that the Nodes overview will show an error message

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -347,20 +347,17 @@ Mounted eBPF filesystem
             # mount | grep /sys/fs/bpf
             $ # if present should output, e.g. "none on /sys/fs/bpf type bpf"...
 
-This step is **required for production** environments but optional for testing
-and development. It allows the ``cilium-agent`` to pin eBPF resources to a
-persistent filesystem and make them persistent across restarts of the agent.
 If the eBPF filesystem is not mounted in the host filesystem, Cilium will
-automatically mount the filesystem but it will be unmounted and re-mounted when
-the Cilium pod is restarted. This in turn will cause eBPF resources to be
-re-created which will cause network connectivity to be disrupted while Cilium
-is not running. Mounting the eBPF filesystem in the host mount namespace will
-ensure that the agent can be restarted without affecting connectivity of any
-pods.
+automatically mount the filesystem.
 
-In order to mount the eBPF filesystem, the following command must be run in the
-host mount namespace. The command must only be run once during the boot process
-of the machine.
+Mounting this BPF filesystem allows the ``cilium-agent`` to persist eBPF
+resources across restarts of the agent so that the datapath can continue to
+operate while the agent is subsequently restarted or upgraded.
+
+Optionally it is also possible to mount the eBPF filesystem before Cilium is
+deployed in the cluster, the following command must be run in the host mount
+namespace. The command must only be run once during the boot process of the
+machine.
 
    .. code-block:: shell-session
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1188,7 +1188,7 @@ func initEnv(cmd *cobra.Command) {
 	// the path to an already mounted filesystem instead. This is
 	// useful if the daemon is being round inside a namespace and the
 	// BPF filesystem is mapped into the slave namespace.
-	bpf.CheckOrMountFS(option.Config.BPFRoot, k8s.IsEnabled())
+	bpf.CheckOrMountFS(option.Config.BPFRoot)
 	cgroups.CheckOrMountCgrpFS(option.Config.CGroupRoot)
 
 	option.Config.Opts.SetBool(option.Debug, debugDatapath)

--- a/images/cilium/init-container.sh
+++ b/images/cilium/init-container.sh
@@ -13,7 +13,3 @@ if [ "${CILIUM_ALL_STATE}" = "true" ] \
     || [ "${CLEAN_CILIUM_STATE}" = "true" ]; then
 	cilium cleanup -f --all-state
 fi
-
-if [ "${CILIUM_WAIT_BPF_MOUNT}" = "true" ]; then
-	until mount | grep "/sys/fs/bpf type bpf"; do echo "BPF filesystem is not mounted yet"; sleep 1; done
-fi;

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -70,7 +70,6 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
-| bpf.waitForMount | bool | `false` | Force the cilium-agent DaemonSet to wait in an initContainer until the eBPF filesystem has been mounted. |
 | certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.4"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |
 | certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |

--- a/install/kubernetes/cilium/files/nodeinit/prestop.bash
+++ b/install/kubernetes/cilium/files/nodeinit/prestop.bash
@@ -17,9 +17,6 @@ else
   while PATH="${PATH}:/home/kubernetes/bin" crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
 fi
 
-systemctl disable sys-fs-bpf.mount || true
-systemctl stop sys-fs-bpf.mount || true
-
 if ip link show cilium_host; then
   echo "Deleting cilium_host interface..."
   ip link del cilium_host

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -251,6 +251,7 @@ spec:
         {{- if not (eq .Values.containerRuntime.integration "crio") }}
         - name: bpf-maps
           mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
         {{- end }}
         {{- if not (contains "/run/cilium/cgroupv2" .Values.cgroup.hostRoot) }}
         # Check for duplicate mounts before mounting
@@ -412,12 +413,7 @@ spec:
               name: cilium-config
               key: clean-cilium-bpf-state
               optional: true
-        - name: CILIUM_WAIT_BPF_MOUNT
-          valueFrom:
-            configMapKeyRef:
-              name: cilium-config
               key: wait-bpf-mount
-              optional: true
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}
@@ -439,8 +435,6 @@ spec:
         {{- if not (eq .Values.containerRuntime.integration "crio") }}
         - name: bpf-maps
           mountPath: /sys/fs/bpf
-          {{- /* Required for wait-bpf-mount to work */}}
-          mountPropagation: HostToContainer
         {{- end }}
           # Required to mount cgroup filesystem from the host to cilium agent pod
         - name: cilium-cgroup

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -386,9 +386,6 @@ data:
   enable-l7-proxy: {{ .Values.l7Proxy | quote }}
 {{- end }}
 
-  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
-  wait-bpf-mount: "{{ .Values.bpf.waitForMount }}"
-
 {{- if ne .Values.cni.chainingMode "none" }}
   # Enable chaining with another CNI plugin
   #

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -230,10 +230,6 @@ bpf:
   # -- Enable BPF clock source probing for more efficient tick retrieval.
   clockProbe: false
 
-  # -- Force the cilium-agent DaemonSet to wait in an initContainer until the
-  # eBPF filesystem has been mounted.
-  waitForMount: false
-
   # -- Enables pre-allocation of eBPF map values. This increases
   # memory usage but can reduce latency.
   preallocateMaps: false

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -60,7 +60,7 @@ var (
 )
 
 func runTests(m *testing.M) (int, error) {
-	CheckOrMountFS("", false)
+	CheckOrMountFS("")
 	if err := ConfigureResourceLimits(); err != nil {
 		return 1, fmt.Errorf("Failed to configure rlimit")
 	}

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -33,7 +33,7 @@ func Test(t *testing.T) {
 }
 
 func (k *CTMapTestSuite) SetUpSuite(c *C) {
-	bpf.CheckOrMountFS("", false)
+	bpf.CheckOrMountFS("")
 	err := bpf.ConfigureResourceLimits()
 	c.Assert(err, IsNil)
 }

--- a/pkg/maps/eppolicymap/eppolicymap_test.go
+++ b/pkg/maps/eppolicymap/eppolicymap_test.go
@@ -42,13 +42,13 @@ func (e *EPPolicyMapTestSuite) TearDownTest(c *C) {
 }
 
 func (e *EPPolicyMapTestSuite) TestCreateEPPolicy(c *C) {
-	bpf.CheckOrMountFS("", false)
+	bpf.CheckOrMountFS("")
 	CreateEPPolicyMap()
 }
 
 func (e *EPPolicyMapTestSuite) TestWriteEndpoint(c *C) {
 	option.Config.SockopsEnable = true
-	bpf.CheckOrMountFS("", false)
+	bpf.CheckOrMountFS("")
 	keys := make([]*lxcmap.EndpointKey, 1)
 	many := make([]*lxcmap.EndpointKey, 256)
 	fd, err := bpf.CreateMap(bpf.MapTypeHash,
@@ -75,7 +75,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpoint(c *C) {
 // in invalid fd in if its disabled.
 func (e *EPPolicyMapTestSuite) TestWriteEndpointFails(c *C) {
 	option.Config.SockopsEnable = true
-	bpf.CheckOrMountFS("", false)
+	bpf.CheckOrMountFS("")
 	keys := make([]*lxcmap.EndpointKey, 1)
 	_, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
@@ -91,7 +91,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointFails(c *C) {
 
 func (e *EPPolicyMapTestSuite) TestWriteEndpointDisabled(c *C) {
 	option.Config.SockopsEnable = false
-	bpf.CheckOrMountFS("", false)
+	bpf.CheckOrMountFS("")
 	keys := make([]*lxcmap.EndpointKey, 1)
 	fd, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func runTests(m *testing.M) (int, error) {
-	bpf.CheckOrMountFS("", false)
+	bpf.CheckOrMountFS("")
 	if err := bpf.ConfigureResourceLimits(); err != nil {
 		return 1, fmt.Errorf("Failed to configure rlimit")
 	}

--- a/tools/maptool/main.go
+++ b/tools/maptool/main.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
 package main
 
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/maps/eppolicymap"
 	"github.com/cilium/cilium/pkg/maps/sockmap"
 )
@@ -48,7 +47,7 @@ func main() {
 	if err := bpf.ConfigureResourceLimits(); err != nil {
 		fmt.Fprintf(os.Stdout, "Failed to configure resource limits: %s\n", err)
 	}
-	bpf.CheckOrMountFS(defaults.DefaultMapRoot, true)
+	bpf.CheckOrMountFS("")
 
 	bpfObjPath := os.Args[2]
 	if err := createMap(bpfObjPath); err != nil {


### PR DESCRIPTION
install/kubernetes: use bidirectional mounts to mount bpf fs

Bidirectional mounts are available in Kubernetes since 1.4 [1].
This allows Cilium container to mount the bpf fs automatically
and propagate the mount into the host.

This will improve Cilium's UX as it will remove the requirement of
mounting the BPF fs in the host.

[1] https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation

```release-note
Auto-mount bpf file-system from within Cilium DaemonSet and remove the requirement of having it mounted in the host. 
```
