### PR TITLE
.github: Fix image digest job printing

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -241,7 +241,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   image-digests:
-    if: ${{ github.repository == 'cilium/cilium' }}
+    if: ${{ always() && github.repository == 'cilium/cilium' &&
+      (needs.build-and-push-with-qemu.result == 'success' || needs.build-and-push-with-qemu.result == 'skipped') }}
     name: Display Digests
     runs-on: ubuntu-20.04
     needs: [build-and-push-prs, build-and-push-with-qemu]


### PR DESCRIPTION
Commit 044afab2ecf3 ("ci: Set up qemu in images workflow and build
cilium-test") introduced a new dependency for the "Display image digests"
job which provides a nice single page that developers can use to find
all of the CI image artifacts generated from the PR. Unfortunately the
new dependency is conditionally skipped, and when it is skipped, the
display digests job is also skipped because the dependency is skipped.

This is a known behaviour of GitHub actions/runner, issue 491.

This commit works around the issue by explicitly running the job if the
dependency was skipped, allowing the "display image digests" job to run
even when the qemu job is skipped.

This PR proposes the workaround listed on https://github.com/actions/runner/issues/491 .