### PR TITLE
Louis/podcidrs bgp

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -401,7 +401,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	d.redirectPolicyManager = redirectpolicy.NewRedirectPolicyManager(d.svc)
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
-		d.bgpSpeaker = speaker.New(speaker.Opts{
+		d.bgpSpeaker = speaker.New(ctx, speaker.Opts{
 			LoadBalancerIP: option.Config.BGPAnnounceLBIP,
 			PodCIDR:        option.Config.BGPAnnouncePodCIDR,
 		})

--- a/pkg/bgp/speaker/events.go
+++ b/pkg/bgp/speaker/events.go
@@ -16,6 +16,8 @@
 package speaker
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/k8s"
 
 	"go.universe.tf/metallb/pkg/k8s/types"
@@ -40,8 +42,13 @@ type nodeEvent struct {
 // loop is only stopped (implicitly) when the Agent is shutting down.
 //
 // Adapted from go.universe.tf/metallb/pkg/k8s/k8s.go.
-func (s *Speaker) run() {
+func (s *Speaker) run(ctx context.Context) {
 	for {
+		// only check ctx here, we'll allow any in-flight
+		// events to be processed completely.
+		if ctx.Err() != nil {
+			return
+		}
 		key, quit := s.queue.Get()
 		if quit {
 			return

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -155,10 +155,10 @@ type redirectPolicyManager interface {
 }
 
 type bgpSpeakerManager interface {
-	OnUpdateService(svc *slim_corev1.Service)
-	OnDeleteService(svc *slim_corev1.Service)
+	OnUpdateService(svc *slim_corev1.Service) error
+	OnDeleteService(svc *slim_corev1.Service) error
 
-	OnUpdateEndpoints(eps *slim_corev1.Endpoints)
+	OnUpdateEndpoints(eps *slim_corev1.Endpoints) error
 }
 type egressPolicyManager interface {
 	AddEgressPolicy(config egresspolicy.Config) (bool, error)


### PR DESCRIPTION
This pull adds the necessary commits to support BGP route withdrawal on a Node Delete event. 

After a Node Delete event is encountered an empty Advertisement will be plumbed to the BGP controller running inside the Cilium agent. 

After the event is received by our harness, we will flip a atomic to then shut the speaker down. When the BGP speaker is shut down it will no longer ingest concurrent events nor process any events that are still in its event queue. 