### PR TITLE
version, metrics: allow to build on non-unix platforms

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -1457,15 +1456,6 @@ func DumpMetrics() ([]*models.Metric, error) {
 // Error2Outcome converts an error to LabelOutcome
 func Error2Outcome(err error) string {
 	if err != nil {
-		return LabelValueOutcomeFail
-	}
-
-	return LabelValueOutcomeSuccess
-}
-
-// Errno2Outcome converts a unix.Errno to LabelOutcome
-func Errno2Outcome(errno unix.Errno) string {
-	if errno != 0 {
 		return LabelValueOutcomeFail
 	}
 

--- a/pkg/metrics/metrics_unix.go
+++ b/pkg/metrics/metrics_unix.go
@@ -1,0 +1,28 @@
+// Copyright 2017-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package metrics
+
+import "golang.org/x/sys/unix"
+
+// Errno2Outcome converts a unix.Errno to LabelOutcome
+func Errno2Outcome(errno unix.Errno) string {
+	if errno != 0 {
+		return LabelValueOutcomeFail
+	}
+
+	return LabelValueOutcomeSuccess
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,14 +18,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"runtime"
 	"strings"
-
-	"github.com/cilium/cilium/pkg/versioncheck"
-
-	"github.com/blang/semver/v4"
-	"golang.org/x/sys/unix"
 )
 
 // CiliumVersion provides a minimal structure to the version string
@@ -85,35 +79,4 @@ func Base64() (string, error) {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(jsonBytes), nil
-}
-
-func parseKernelVersion(ver string) (semver.Version, error) {
-	verStrs := strings.Split(ver, ".")
-	switch {
-	case len(verStrs) < 2:
-		return semver.Version{}, fmt.Errorf("unable to get kernel version from %q", ver)
-	case len(verStrs) < 3:
-		verStrs = append(verStrs, "0")
-	}
-	// We are assuming the kernel version will be something as:
-	// 4.9.17-040917-generic
-
-	// If verStrs is []string{ "4", "9", "17-040917-generic" }
-	// then we need to retrieve patch number.
-	patch := regexp.MustCompilePOSIX(`^[0-9]+`).FindString(verStrs[2])
-	if patch == "" {
-		verStrs[2] = "0"
-	} else {
-		verStrs[2] = patch
-	}
-	return versioncheck.Version(strings.Join(verStrs[:3], "."))
-}
-
-// GetKernelVersion returns the version of the Linux kernel running on this host.
-func GetKernelVersion() (semver.Version, error) {
-	var unameBuf unix.Utsname
-	if err := unix.Uname(&unameBuf); err != nil {
-		return semver.Version{}, err
-	}
-	return parseKernelVersion(string(unameBuf.Release[:]))
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -20,17 +20,13 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/cilium/cilium/pkg/versioncheck"
-
-	"github.com/blang/semver/v4"
 	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) { TestingT(t) }
 
-type VersionSuite struct {
-}
+type VersionSuite struct{}
 
 var _ = Suite(&VersionSuite{})
 
@@ -106,30 +102,4 @@ func (vs *VersionSuite) TestVersionArchMatchesGOARCH(c *C) {
 	// var ciliumVersion is not set in tests, thus Version does not contain the cilium version,
 	// just check that GOOS/GOARCH are reported correctly, see #13122.
 	c.Assert(Version, Matches, ".* "+runtime.GOOS+"/"+runtime.GOARCH)
-}
-
-func (vs *VersionSuite) TestParseKernelVersion(c *C) {
-	mustHaveVersion := func(v string) semver.Version {
-		ver, err := versioncheck.Version(v)
-		c.Assert(err, IsNil)
-		return ver
-	}
-
-	var flagtests = []struct {
-		in  string
-		out semver.Version
-	}{
-		{"4.10.0", mustHaveVersion("4.10.0")},
-		{"4.10", mustHaveVersion("4.10.0")},
-		{"4.12.0+", mustHaveVersion("4.12.0")},
-		{"4.12.8", mustHaveVersion("4.12.8")},
-		{"4.14.0-rc7+", mustHaveVersion("4.14.0")},
-		{"4.9.17-040917-generic", mustHaveVersion("4.9.17")},
-		{"4.9.generic", mustHaveVersion("4.9.0")},
-	}
-	for _, tt := range flagtests {
-		s, err := parseKernelVersion(tt.in)
-		c.Assert(err, IsNil)
-		c.Assert(tt.out.Equals(s), Equals, true)
-	}
 }

--- a/pkg/version/version_unix.go
+++ b/pkg/version/version_unix.go
@@ -1,0 +1,58 @@
+// Copyright 2017-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package version
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/cilium/cilium/pkg/versioncheck"
+	"golang.org/x/sys/unix"
+)
+
+func parseKernelVersion(ver string) (semver.Version, error) {
+	verStrs := strings.Split(ver, ".")
+	switch {
+	case len(verStrs) < 2:
+		return semver.Version{}, fmt.Errorf("unable to get kernel version from %q", ver)
+	case len(verStrs) < 3:
+		verStrs = append(verStrs, "0")
+	}
+	// We are assuming the kernel version will be something as:
+	// 4.9.17-040917-generic
+
+	// If verStrs is []string{ "4", "9", "17-040917-generic" }
+	// then we need to retrieve patch number.
+	patch := regexp.MustCompilePOSIX(`^[0-9]+`).FindString(verStrs[2])
+	if patch == "" {
+		verStrs[2] = "0"
+	} else {
+		verStrs[2] = patch
+	}
+	return versioncheck.Version(strings.Join(verStrs[:3], "."))
+}
+
+// GetKernelVersion returns the version of the Linux kernel running on this host.
+func GetKernelVersion() (semver.Version, error) {
+	var unameBuf unix.Utsname
+	if err := unix.Uname(&unameBuf); err != nil {
+		return semver.Version{}, err
+	}
+	return parseKernelVersion(string(unameBuf.Release[:]))
+}

--- a/pkg/version/version_unix_test.go
+++ b/pkg/version/version_unix_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+// +build !privileged_tests
+
+package version
+
+import (
+	"github.com/cilium/cilium/pkg/versioncheck"
+
+	"github.com/blang/semver/v4"
+	. "gopkg.in/check.v1"
+)
+
+func (vs *VersionSuite) TestParseKernelVersion(c *C) {
+	mustHaveVersion := func(v string) semver.Version {
+		ver, err := versioncheck.Version(v)
+		c.Assert(err, IsNil)
+		return ver
+	}
+
+	var flagtests = []struct {
+		in  string
+		out semver.Version
+	}{
+		{"4.10.0", mustHaveVersion("4.10.0")},
+		{"4.10", mustHaveVersion("4.10.0")},
+		{"4.12.0+", mustHaveVersion("4.12.0")},
+		{"4.12.8", mustHaveVersion("4.12.8")},
+		{"4.14.0-rc7+", mustHaveVersion("4.14.0")},
+		{"4.9.17-040917-generic", mustHaveVersion("4.9.17")},
+		{"4.9.generic", mustHaveVersion("4.9.0")},
+	}
+	for _, tt := range flagtests {
+		s, err := parseKernelVersion(tt.in)
+		c.Assert(err, IsNil)
+		c.Assert(tt.out.Equals(s), Equals, true)
+	}
+}


### PR DESCRIPTION
These packages are transitive dependencies in cilium-cli, but currently they
fails to build on non-unix platforms (e.g. windows) due to their use of
golang.org/x/sys/unix.

However, we want still to be able to build it for some these platforms,
see e.g. https://github.com/cilium/cilium-cli/issues/231. Fix the build
by moving all unix-specific functionality (i.e. the Uname call) to
separate files, protected by build tags.

Also marking for backports to 1.10 since we vendor a stable cilium/cilium release into cilium-cli (currently v1.9.8, but switching to v1.10 with cilium/cilium-cli#358 once all necessary fixes have been backported).