### PR TITLE
v1.10 backports 2021-06-29

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
+    if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-18.04
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -72,24 +72,12 @@ func (f *fakeDatapath) InstallProxyRules(uint16, bool, string) error {
 	return nil
 }
 
-func (f *fakeDatapath) RemoveProxyRules(uint16, bool, string) error {
-	return nil
-}
-
 func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *fakeDatapath) RemoveRules(quiet bool) {}
-
-func (f *fakeDatapath) InstallRules(ifName string) error {
+func (f *fakeDatapath) InstallRules(ifName string, quiet, install bool) error {
 	return nil
-}
-func (f *fakeDatapath) TransientRulesStart(ifName string) error {
-	return nil
-}
-func (f *fakeDatapath) TransientRulesEnd(quiet bool) {
-	return
 }
 
 func (m *fakeDatapath) GetProxyPort(name string) uint16 {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -44,20 +44,19 @@ import (
 )
 
 const (
-	ciliumPrefix                = "CILIUM_"
-	ciliumInputChain            = "CILIUM_INPUT"
-	ciliumOutputChain           = "CILIUM_OUTPUT"
-	ciliumOutputRawChain        = "CILIUM_OUTPUT_raw"
-	ciliumPostNatChain          = "CILIUM_POST_nat"
-	ciliumOutputNatChain        = "CILIUM_OUTPUT_nat"
-	ciliumPreNatChain           = "CILIUM_PRE_nat"
-	ciliumPostMangleChain       = "CILIUM_POST_mangle"
-	ciliumPreMangleChain        = "CILIUM_PRE_mangle"
-	ciliumPreRawChain           = "CILIUM_PRE_raw"
-	ciliumForwardChain          = "CILIUM_FORWARD"
-	ciliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
-	feederDescription           = "cilium-feeder:"
-	xfrmDescription             = "cilium-xfrm-notrack:"
+	oldCiliumPrefix       = "OLD_CILIUM_"
+	ciliumInputChain      = "CILIUM_INPUT"
+	ciliumOutputChain     = "CILIUM_OUTPUT"
+	ciliumOutputRawChain  = "CILIUM_OUTPUT_raw"
+	ciliumPostNatChain    = "CILIUM_POST_nat"
+	ciliumOutputNatChain  = "CILIUM_OUTPUT_nat"
+	ciliumPreNatChain     = "CILIUM_PRE_nat"
+	ciliumPostMangleChain = "CILIUM_POST_mangle"
+	ciliumPreMangleChain  = "CILIUM_PRE_mangle"
+	ciliumPreRawChain     = "CILIUM_PRE_raw"
+	ciliumForwardChain    = "CILIUM_FORWARD"
+	feederDescription     = "cilium-feeder:"
+	xfrmDescription       = "cilium-xfrm-notrack:"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -209,9 +208,6 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 	for scanner.Scan() {
 		rule := scanner.Text()
 		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering removing %s rule", prog)
-		if match != ciliumTransientForwardChain && strings.Contains(rule, ciliumTransientForwardChain) {
-			continue
-		}
 
 		// All rules installed by cilium either belong to a chain with
 		// the name CILIUM_ or call a chain with the name CILIUM_:
@@ -223,8 +219,7 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 			// disabled chains
 			skipFeeder := false
 			for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-				// we skip if the match is ciliumTransientForwardChain since we don't want to touch it
-				if match != ciliumTransientForwardChain && strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
+				if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
 					log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
 					skipFeeder = true
 					break
@@ -252,21 +247,29 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 	}
 }
 
+func (c *customChain) doRename(prog iptablesInterface, waitArgs []string, name string, quiet bool) {
+	args := append(waitArgs, "-t", c.table, "-E", c.name, name)
+	operation := "rename"
+	combinedOutput, err := prog.runProgCombinedOutput(args, true)
+	if err != nil && !quiet {
+		log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog, c.name, string(combinedOutput))
+	}
+}
+
+func (c *customChain) rename(waitArgs []string, name string, quiet bool) {
+	if option.Config.EnableIPv4 {
+		c.doRename(ip4tables, waitArgs, name, quiet)
+	}
+	if option.Config.EnableIPv6 && c.ipv6 {
+		c.doRename(ip6tables, waitArgs, name, quiet)
+	}
+}
+
 func (c *customChain) remove(waitArgs []string, quiet bool) {
 	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
 		combinedOutput, err := prog.runProgCombinedOutput(args, true)
-		if err != nil {
-			// If the chain is for transient rules and deletion
-			// fails for a reason other than the chain not being
-			// present, log the error.
-			// This is to help debug #11276.
-			msgChainNotFound := ": No chain/target/match by that name.\n"
-			debugTransientRules := c.name == ciliumTransientForwardChain &&
-				string(combinedOutput) != prog.getProg()+msgChainNotFound
-			if !quiet || debugTransientRules {
-				log.Warnf(string(combinedOutput))
-				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to process chain %s with %s (%s)", c.name, prog, operation)
-			}
+		if err != nil && !quiet {
+			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog.getProg(), c.name, string(combinedOutput))
 		}
 	}
 	doRemove := func(c *customChain, prog iptablesInterface, waitArgs []string, quiet bool) {
@@ -382,13 +385,6 @@ var ciliumChains = []customChain{
 	},
 }
 
-var transientChain = customChain{
-	name:       ciliumTransientForwardChain,
-	table:      "filter",
-	hook:       "FORWARD",
-	feederArgs: []string{""},
-}
-
 // IptablesManager manages the iptables-related configuration for Cilium.
 type IptablesManager struct {
 	haveIp6tables        bool
@@ -487,31 +483,32 @@ func (m *IptablesManager) SupportsOriginalSourceAddr() bool {
 	return (m.haveSocketMatch || m.ipEarlyDemuxDisabled) && option.Config.Tunnel == option.TunnelDisabled
 }
 
-// RemoveRules removes iptables rules installed by Cilium.
-func (m *IptablesManager) RemoveRules(quiet bool) {
+// removeOldRules removes iptables rules installed by Cilium.
+func (m *IptablesManager) removeOldRules(quiet bool) {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, ip4tables, ciliumPrefix)
+		m.removeCiliumRules(t, ip4tables, oldCiliumPrefix)
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.haveIp6tables {
 		tables6 := []string{"nat", "mangle", "raw", "filter"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, ip6tables, ciliumPrefix)
+			m.removeCiliumRules(t, ip6tables, oldCiliumPrefix)
 		}
 	}
 
 	for _, c := range ciliumChains {
+		c.name = "OLD_" + c.name
 		c.remove(m.waitArgs, quiet)
 	}
 }
 
-func (m *IptablesManager) ingressProxyRule(cmd, l4Match, markMatch, mark, port, name string) []string {
+func (m *IptablesManager) ingressProxyRule(l4Match, markMatch, mark, port, name string) []string {
 	return append(m.waitArgs,
 		"-t", "mangle",
-		cmd, ciliumPreMangleChain,
+		"-A", ciliumPreMangleChain,
 		"-p", l4Match,
 		"-m", "mark", "--mark", markMatch,
 		"-m", "comment", "--comment", "cilium: TPROXY to host "+name+" proxy",
@@ -540,7 +537,7 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 		"--set-mark", toProxyMark)
 }
 
-func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
+func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
 	ingressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
@@ -548,26 +545,17 @@ func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyP
 	ingressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	ingressProxyPort := fmt.Sprintf("%d", proxyPort)
 
-	var err error
-	if option.Config.EnableIPv4 {
-		err = ip4tables.runProg(
-			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
-				ingressProxyMark, ingressProxyPort, name),
-			false)
+	if strings.Contains(rules, fmt.Sprintf("CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, ingressMarkMatch)) {
+		return nil
 	}
-	if err == nil && option.Config.EnableIPv6 {
-		err = ip6tables.runProg(
-			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
-				ingressProxyMark, ingressProxyPort, name),
-			false)
-	}
-	return err
+
+	return prog.runProg(m.ingressProxyRule(l4proto, ingressMarkMatch, ingressProxyMark, ingressProxyPort, name), false)
 }
 
-func (m *IptablesManager) egressProxyRule(cmd, l4Match, markMatch, mark, port, name string) []string {
+func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name string) []string {
 	return append(m.waitArgs,
 		"-t", "mangle",
-		cmd, ciliumPreMangleChain,
+		"-A", ciliumPreMangleChain,
 		"-p", l4Match,
 		"-m", "mark", "--mark", markMatch,
 		"-m", "comment", "--comment", "cilium: TPROXY to host "+name+" proxy",
@@ -576,7 +564,7 @@ func (m *IptablesManager) egressProxyRule(cmd, l4Match, markMatch, mark, port, n
 		"--on-port", port)
 }
 
-func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
+func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
 	egressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
@@ -584,20 +572,11 @@ func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPo
 	egressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	egressProxyPort := fmt.Sprintf("%d", proxyPort)
 
-	var err error
-	if option.Config.EnableIPv4 {
-		err = ip4tables.runProg(
-			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
-				egressProxyMark, egressProxyPort, name),
-			false)
+	if strings.Contains(rules, fmt.Sprintf("-A CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, egressMarkMatch)) {
+		return nil
 	}
-	if err == nil && option.Config.EnableIPv6 {
-		err = ip6tables.runProg(
-			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
-				egressProxyMark, egressProxyPort, name),
-			false)
-	}
-	return err
+
+	return prog.runProg(m.egressProxyRule(l4proto, egressMarkMatch, egressProxyMark, egressProxyPort, name), false)
 }
 
 func (m *IptablesManager) installStaticProxyRules() error {
@@ -714,26 +693,111 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	return err
 }
 
-// install or remove rules for a single proxy port
-func (m *IptablesManager) iptProxyRules(cmd string, proxyPort uint16, ingress bool, name string) error {
-	// Redirect packets to the host proxy via TPROXY, as directed by the Cilium
-	// datapath bpf programs via skb marks (egress) or DSCP (ingress).
+func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) {
+	output, err := prog.runProgCombinedOutput(append(m.waitArgs, "-t", table, "-S"), true)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"table": table,
+			"prog":  prog.getProg(),
+		}).WithError(err).Warning("Cannot list rules in table. Layer 7 proxy port may get reallocated, which could cause disruption for traffic selected by L7 policy", prog.getProg(), table)
+		return
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		rule := scanner.Text()
+		if re.MatchString(rule) && strings.Contains(rule, match) {
+			log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
+			args, err := shellwords.Parse(strings.Replace(rule, oldChain, newChain, 1))
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"table":          table,
+					"prog":           prog.getProg(),
+					logfields.Object: rule,
+				}).WithError(err).Warn("Unable to parse TPROXY rule, disruption to traffic selected by L7 policy possible")
+				continue
+			}
+			copyRule := append(append(m.waitArgs, "-t", table), args...)
+			log.WithField(logfields.Object, logfields.Repr(copyRule)).Debugf("Copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
+			err = prog.runProg(copyRule, true)
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"table":          table,
+					"prog":           prog.getProg(),
+					logfields.Object: rule,
+				}).WithError(err).Warn("Unable to copy TPROXY rule, disruption to traffic selected by L7 policy possible")
+			}
+		}
+	}
+}
+
+var tproxyMatch = regexp.MustCompile("CILIUM_PRE_mangle .*cilium: TPROXY")
+
+// copies old proxy rules
+func (m *IptablesManager) copyProxyRules(oldChain string, match string) {
+	if option.Config.EnableIPv4 {
+		m.doCopyProxyRules(ip4tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain)
+	}
+	if option.Config.EnableIPv6 {
+		m.doCopyProxyRules(ip6tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain)
+	}
+}
+
+// Redirect packets to the host proxy via TPROXY, as directed by the Cilium
+// datapath bpf programs via skb marks (egress) or DSCP (ingress).
+func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
+	output, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"}, true)
+	if err != nil {
+		log.WithError(err).Warnf("Unable to list %s TPROXY rules: %s", prog, string(output))
+	}
+	rules := string(output)
 	if ingress {
-		if err := m.iptIngressProxyRule(cmd, "tcp", proxyPort, name); err != nil {
+		if err := m.iptIngressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
 			return err
 		}
-		if err := m.iptIngressProxyRule(cmd, "udp", proxyPort, name); err != nil {
+		if err := m.iptIngressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
 			return err
 		}
 	} else {
-		if err := m.iptEgressProxyRule(cmd, "tcp", proxyPort, name); err != nil {
+		if err := m.iptEgressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
 			return err
 		}
-		if err := m.iptEgressProxyRule(cmd, "udp", proxyPort, name); err != nil {
+		if err := m.iptEgressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
 			return err
 		}
 	}
+	// Delete all other rules for this same proxy name
+	// These may accumulate if there is a bind failure on a previously used port
+	portMatch := fmt.Sprintf("TPROXY --on-port %d ", proxyPort)
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		rule := scanner.Text()
+		if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && strings.Contains(rule, "cilium: TPROXY to host "+name) && !strings.Contains(rule, portMatch) {
+			args, err := shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
+			if err != nil {
+				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s TPROXY rule", prog)
+				continue
+			}
+			deleteRule := append(append(m.waitArgs, "-t", "mangle"), args...)
+			log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Deleting stale %s TPROXY rule from mangle table", prog)
+			err = prog.runProg(deleteRule, true)
+			if err != nil {
+				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to delete %s TPROXY rule", prog)
+			}
+		}
+	}
+
 	return nil
+}
+
+// install or remove rules for a single proxy port
+func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress bool, name string) (err error) {
+	if option.Config.EnableIPv4 {
+		err = m.addProxyRules(ip4tables, proxyPort, ingress, name)
+	}
+	if err == nil && option.Config.EnableIPv6 {
+		err = m.addProxyRules(ip6tables, proxyPort, ingress, name)
+	}
+	return err
 }
 
 func endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr, ingress bool) error {
@@ -842,7 +906,7 @@ func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name
 			Debug("Skipping proxy rule install due to BPF support")
 		return nil
 	}
-	return m.iptProxyRules("-A", proxyPort, ingress, name)
+	return m.iptProxyRules(proxyPort, ingress, name)
 }
 
 // GetProxyPort finds a proxy port used for redirect 'name' installed earlier with InstallProxyRules.
@@ -854,24 +918,28 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 		prog = ip6tables
 	}
 
+	return m.doGetProxyPort(prog, name)
+}
+
+func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
 	res, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, true)
 	if err != nil {
 		return 0
 	}
 
-	re := regexp.MustCompile(name + ".*TPROXY redirect 0.0.0.0:([1-9][0-9]*) mark")
-	str := re.FindString(string(res))
-	portStr := re.ReplaceAllString(str, "$1")
+	re := regexp.MustCompile(name + ".*TPROXY redirect (0.0.0.0|::):([1-9][0-9]*) mark")
+	strs := re.FindAllString(string(res), -1)
+	if len(strs) == 0 {
+		return 0
+	}
+	// Pick the port number from the last match, as rules are appended to the end (-A)
+	portStr := re.ReplaceAllString(strs[len(strs)-1], "$2")
 	portUInt64, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		log.WithError(err).Debugf("Port number cannot be parsed: %s", portStr)
 		return 0
 	}
 	return uint16(portUInt64)
-}
-
-func (m *IptablesManager) RemoveProxyRules(proxyPort uint16, ingress bool, name string) error {
-	return m.iptProxyRules("-D", proxyPort, ingress, name)
 }
 
 func getDeliveryInterface(ifName string) string {
@@ -896,11 +964,6 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 }
 
 func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, ifName, localDeliveryInterface, forwardChain string) error {
-	transient := ""
-	if forwardChain == ciliumTransientForwardChain {
-		transient = " (transient)"
-	}
-
 	// While kube-proxy does change the policy of the iptables FORWARD chain
 	// it doesn't seem to handle all cases, e.g. host network pods that use
 	// the node IP which would still end up in default DENY. Similarly, for
@@ -926,7 +989,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 		m.waitArgs,
 		"-A", forwardChain,
 		"-o", ifName,
-		"-m", "comment", "--comment", "cilium"+transient+": any->cluster on "+ifName+" forward accept",
+		"-m", "comment", "--comment", "cilium: any->cluster on "+ifName+" forward accept",
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
@@ -934,7 +997,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", ifName,
-		"-m", "comment", "--comment", "cilium"+transient+": cluster->any on "+ifName+" forward accept (nodeport)",
+		"-m", "comment", "--comment", "cilium: cluster->any on "+ifName+" forward accept (nodeport)",
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
@@ -942,7 +1005,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", "lxc+",
-		"-m", "comment", "--comment", "cilium"+transient+": cluster->any on lxc+ forward accept",
+		"-m", "comment", "--comment", "cilium: cluster->any on lxc+ forward accept",
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
@@ -954,7 +1017,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", ifPeerName,
-			"-m", "comment", "--comment", "cilium"+transient+": cluster->any on "+ifPeerName+" forward accept (nodeport)",
+			"-m", "comment", "--comment", "cilium: cluster->any on "+ifPeerName+" forward accept (nodeport)",
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
@@ -967,7 +1030,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			m.waitArgs,
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium"+transient+": any->cluster on "+localDeliveryInterface+" forward accept",
+			"-m", "comment", "--comment", "cilium: any->cluster on "+localDeliveryInterface+" forward accept",
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
@@ -975,7 +1038,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium"+transient+": cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
+			"-m", "comment", "--comment", "cilium: cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
@@ -1154,40 +1217,41 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 		"-j", "MARK", "--set-xmark", markAsFromHost), false)
 }
 
-// TransientRulesStart installs iptables rules for Cilium that need to be
-// kept in-tact during agent restart which removes/installs its main rules.
-// Transient rules are then removed once iptables rule update cycle has
-// completed. This is mainly due to interactions with kube-proxy.
-func (m *IptablesManager) TransientRulesStart(ifName string) error {
-	if option.Config.EnableIPv4 {
-		localDeliveryInterface := getDeliveryInterface(ifName)
+// InstallRules installs iptables rules for Cilium in specific use-cases
+// (most specifically, interaction with kube-proxy).
+func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) (err error) {
+	quiet := firstInitialization
 
-		m.TransientRulesEnd(true)
+	// Make sure we have no old "backups"
+	m.removeOldRules(true)
 
-		if err := transientChain.add(m.waitArgs); err != nil {
-			return fmt.Errorf("cannot add custom chain %s: %s", transientChain.name, err)
-		}
-		if err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, transientChain.name); err != nil {
-			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
-		}
-		if err := transientChain.installFeeder(m.waitArgs); err != nil {
-			return fmt.Errorf("cannot install feeder rule %s: %s", transientChain.feederArgs, err)
-		}
+	// Rename any old chains we may have
+	for _, c := range ciliumChains {
+		c.rename(m.waitArgs, "OLD_"+c.name, quiet)
 	}
-	return nil
-}
 
-// TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
-func (m *IptablesManager) TransientRulesEnd(quiet bool) {
-	if option.Config.EnableIPv4 {
-		m.removeCiliumRules("filter", ip4tables, ciliumTransientForwardChain)
-		transientChain.remove(m.waitArgs, quiet)
+	// install rules if needed
+	if install {
+		err = m.installRules(ifName)
+		// copy old proxy rules over
+		match := ""
+		if firstInitialization {
+			match = "cilium-dns-egress"
+		}
+		m.copyProxyRules("OLD_"+ciliumPreMangleChain, match)
 	}
+
+	// only remove old rules if new ones were successfully installed
+	if err == nil {
+		m.removeOldRules(quiet)
+	}
+	return err
 }
 
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
-func (m *IptablesManager) InstallRules(ifName string) error {
+func (m *IptablesManager) installRules(ifName string) error {
+	// Install new rules
 	for _, c := range ciliumChains {
 		if err := c.add(m.waitArgs); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
@@ -1218,7 +1282,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 	localDeliveryInterface := getDeliveryInterface(ifName)
 
 	if err := m.installForwardChainRules(ifName, localDeliveryInterface, ciliumForwardChain); err != nil {
-		return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
+		return fmt.Errorf("cannot install forward chain rules to %s: %w", ciliumForwardChain, err)
 	}
 
 	if option.Config.EnableIPv4 {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -111,6 +111,334 @@ func init() {
 	option.Config.EnableIPv6 = true
 }
 
+func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -E CILIUM_PRE_mangle OLD_CILIUM_PRE_mangle",
+		},
+	}
+	chain := &customChain{
+		table: "mangle",
+		name:  "CILIUM_PRE_mangle",
+	}
+	chain.doRename(mockIp4tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = mockIp4tables.expectations
+	chain.doRename(mockIp6tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestCopyProxyRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-random-proxy proxy" -j TPROXY --on-port 43499 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp4tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestCopyProxyRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-random-proxy proxy" -j TPROXY --on-port 43499 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp6tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	err := mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		},
+	}
+
+	// Adds new proxy rules
+	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Nothing to add
+	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	err = mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		},
+	}
+
+	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
+	mockManager.addProxyRules(mockIp4tables, 43479, false, "cilium-dns-egress")
+	err = mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestGetProxyPort(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -n -L CILIUM_PRE_mangle",
+			out: []byte(
+				`Chain CILIUM_PRE_mangle (1 references)
+target     prot opt source               destination         
+MARK       all  --  0.0.0.0/0            0.0.0.0/0            socket --transparent /* cilium: any->pod redirect proxied traffic to host proxy */ MARK set 0x200
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Finds the latest porte number if multiple rules for the same proxy name
+	port := mockManager.doGetProxyPort(mockIp4tables, "cilium-dns-egress")
+	c.Assert(port, check.Equals, uint16(43479))
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		},
+	}
+
+	// Adds new proxy rules
+	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	err := mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Nothing to add
+	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		},
+	}
+
+	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
+	mockManager.addProxyRules(mockIp6tables, 43479, false, "cilium-dns-egress")
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
 func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
@@ -122,30 +450,85 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 -P FORWARD ACCEPT
 -P OUTPUT ACCEPT
 -P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
 -N CILIUM_POST_mangle
 -N CILIUM_PRE_mangle
 -N KUBE-KUBELET-CANARY
 -N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j CILIUM_PRE_mangle",
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
 		}, {
-			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j CILIUM_POST_mangle",
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 
-	mockManager.removeCiliumRules("mangle", mockIp4tables, ciliumPrefix)
+	// Only removes Cilium chains with the OLD_ prefix
+	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix)
 	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
+		}, {
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Only removes Cilium chains with the OLD_ prefix
+	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix)
+	err := mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -1,0 +1,151 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package iptables
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/blang/semver/v4"
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type iptablesTestSuite struct{}
+
+var _ = check.Suite(&iptablesTestSuite{})
+
+type expectation struct {
+	args string
+	out  []byte
+	err  error
+}
+
+type mockIptables struct {
+	c            *check.C
+	prog         string
+	expectations []expectation
+	index        int
+}
+
+func (ipt *mockIptables) addExpectation(args string, out []byte, err error) {
+	ipt.expectations = append(ipt.expectations, expectation{args: args, out: out, err: err})
+}
+
+func (ipt *mockIptables) getProg() string {
+	return ipt.prog
+}
+
+func (ipt *mockIptables) getVersion() (semver.Version, error) {
+	return semver.Version{}, nil
+}
+
+func (ipt *mockIptables) runProgCombinedOutput(args []string, quiet bool) (out []byte, err error) {
+	a := strings.Join(args, " ")
+	i := ipt.index
+	ipt.index++
+
+	if len(ipt.expectations) < ipt.index {
+		ipt.c.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
+		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+	}
+	if a != ipt.expectations[i].args {
+		ipt.c.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
+		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+	}
+	out = ipt.expectations[i].out
+	err = ipt.expectations[i].err
+
+	return out, err
+}
+
+func (ipt *mockIptables) runProg(args []string, quiet bool) error {
+	out, err := ipt.runProgCombinedOutput(args, quiet)
+	if len(out) > 0 {
+		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
+	}
+	return err
+}
+
+func (ipt *mockIptables) checkExpectations() error {
+	if ipt.index != len(ipt.expectations) {
+		return fmt.Errorf("%d unmet expectations", len(ipt.expectations)-ipt.index)
+	}
+
+	// reset index for further testing
+	ipt.index = 0
+
+	return nil
+}
+
+var mockManager = &IptablesManager{
+	haveIp6tables:        false,
+	haveSocketMatch:      true,
+	haveBPFSocketAssign:  false,
+	ipEarlyDemuxDisabled: false,
+	waitArgs:             nil,
+}
+
+func init() {
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = true
+}
+
+func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j CILIUM_PRE_mangle",
+		}, {
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j CILIUM_POST_mangle",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	mockManager.removeCiliumRules("mangle", mockIp4tables, ciliumPrefix)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -64,18 +64,11 @@ type IptablesManager interface {
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
 	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
 
-	// RemoveProxyRules creates the necessary datapath config (e.g., iptables
-	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
-
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	RemoveRules(quiet bool)
-	InstallRules(ifName string) error
-	TransientRulesStart(ifName string) error
-	TransientRulesEnd(quiet bool)
+	InstallRules(ifName string, quiet, install bool) error
 
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -453,25 +453,11 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if option.Config.InstallIptRules {
-		if err := iptMgr.TransientRulesStart(option.Config.HostDevice); err != nil {
-			log.WithError(err).Warning("failed to install transient iptables rules")
-		}
+	if err := iptMgr.InstallRules(option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
+		return err
 	}
-	// The iptables rules are only removed on the first initialization to
-	// remove stale rules or when iptables is enabled. The first invocation
-	// is silent as rules may not exist.
-	if firstInitialization || option.Config.InstallIptRules {
-		iptMgr.RemoveRules(firstInitialization)
-	}
-	if option.Config.InstallIptRules {
-		err := iptMgr.InstallRules(option.Config.HostDevice)
-		iptMgr.TransientRulesEnd(false)
-		if err != nil {
-			return err
-		}
-	}
-	// Reinstall proxy rules for any running proxies
+
+	// Reinstall proxy rules for any running proxies if needed
 	if p != nil {
 		p.ReinstallRules()
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -955,20 +955,20 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 		// Always execute the finalization code, even if the endpoint is
 		// terminating, in order to properly release resources.
 		e.unconditionalLock()
+		defer e.unlock() // In case Finalize() panics
 		e.getLogger().Debug("Finalizing successful endpoint regeneration")
 		datapathRegenCtx.finalizeList.Finalize()
-		e.unlock()
 	} else {
 		if err := e.lockAlive(); err != nil {
 			e.getLogger().WithError(err).Debug("Skipping unnecessary reverting of endpoint regeneration changes")
 			return
 		}
+		defer e.unlock() // In case Revert() panics
 		e.getLogger().Debug("Reverting endpoint changes after BPF regeneration failed")
 		if err := datapathRegenCtx.revertStack.Revert(); err != nil {
 			e.getLogger().WithError(err).Error("Reverting endpoint regeneration changes failed")
 		}
 		e.getLogger().Debug("Finished reverting endpoint changes after BPF regeneration failed")
-		e.unlock()
 	}
 }
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -256,17 +256,9 @@ func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) 
 	for _, logger := range loggers {
 		switch logger {
 		case Syslog:
-			opts := getLogDriverConfig(Syslog, logOpts)
-			syslogOptValues := make(map[string][]string)
-			syslogOptValues[SSeverity] = mapStringPriorityToSlice(syslogSeverityMap)
-			syslogOptValues[SFacility] = mapStringPriorityToSlice(syslogFacilityMap)
-			if err := opts.validateOpts(Syslog, syslogOpts, syslogOptValues); err != nil {
-				return err
+			if err := setupSyslog(logOpts, tag, debug); err != nil {
+				return fmt.Errorf("failed to set up syslog: %w", err)
 			}
-			if stag, ok := opts[STag]; ok {
-				tag = stag
-			}
-			setupSyslog(opts, tag, debug)
 		default:
 			return fmt.Errorf("provided log driver %q is not a supported log driver", logger)
 		}
@@ -299,8 +291,19 @@ func ConfigureLogLevel(debug bool) {
 
 // setupSyslog sets up and configures syslog with the provided options in
 // logOpts. If some options are not provided, sensible defaults are used.
-func setupSyslog(logOpts LogOptions, tag string, debug bool) {
-	logLevel, ok := logOpts[SLevel]
+func setupSyslog(logOpts LogOptions, tag string, debug bool) error {
+	opts := getLogDriverConfig(Syslog, logOpts)
+	syslogOptValues := make(map[string][]string)
+	syslogOptValues[SSeverity] = mapStringPriorityToSlice(syslogSeverityMap)
+	syslogOptValues[SFacility] = mapStringPriorityToSlice(syslogFacilityMap)
+	if err := opts.validateOpts(Syslog, syslogOpts, syslogOptValues); err != nil {
+		return err
+	}
+	if stag, ok := opts[STag]; ok {
+		tag = stag
+	}
+
+	logLevel, ok := opts[SLevel]
 	if !ok {
 		if debug {
 			logLevel = "debug"
@@ -323,16 +326,16 @@ func setupSyslog(logOpts LogOptions, tag string, debug bool) {
 	severity := syslogLevelMap[level]
 	// Default values for facility if not specified
 	facility := syslog.LOG_KERN
-	if networkStr, ok := logOpts[SNetwork]; ok {
+	if networkStr, ok := opts[SNetwork]; ok {
 		network = networkStr
 	}
-	if addressStr, ok := logOpts[SAddress]; ok {
+	if addressStr, ok := opts[SAddress]; ok {
 		address = addressStr
 	}
-	if severityStr, ok := logOpts[SSeverity]; ok {
+	if severityStr, ok := opts[SSeverity]; ok {
 		severity = syslogSeverityMap[severityStr]
 	}
-	if facilityStr, ok := logOpts[SFacility]; ok {
+	if facilityStr, ok := opts[SFacility]; ok {
 		facility = syslogFacilityMap[facilityStr]
 	}
 
@@ -344,6 +347,8 @@ func setupSyslog(logOpts LogOptions, tag string, debug bool) {
 	// TODO: switch to a per-logger version when we upgrade to logrus >1.0.3
 	logrus.AddHook(h)
 	DefaultLogger.AddHook(h)
+
+	return nil
 }
 
 // GetFormatter returns a configured logrus.Formatter with some specific values

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"log/syslog"
 	"os"
 	"regexp"
 	"strings"
@@ -28,19 +27,12 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
-	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 	"k8s.io/klog/v2"
 )
 
 type LogFormat string
 
 const (
-	SLevel    = "syslog.level"
-	SNetwork  = "syslog.network"
-	SAddress  = "syslog.address"
-	SSeverity = "syslog.severity"
-	SFacility = "syslog.facility"
-	STag      = "syslog.tag"
 	Syslog    = "syslog"
 	LevelOpt  = "level"
 	FormatOpt = "format"
@@ -62,66 +54,6 @@ var (
 	// DefaultLogger is the base logrus logger. It is different from the logrus
 	// default to avoid external dependencies from writing out unexpectedly
 	DefaultLogger = InitializeDefaultLogger()
-
-	// syslogOpts is the set of supported options for syslog configuration.
-	syslogOpts = map[string]bool{
-		SLevel:    true,
-		SNetwork:  true,
-		SAddress:  true,
-		SSeverity: true,
-		SFacility: true,
-		STag:      true,
-	}
-
-	// From /usr/include/sys/syslog.h.
-	syslogSeverityMap = map[string]syslog.Priority{
-		"emerg":   syslog.LOG_EMERG,
-		"panic":   syslog.LOG_EMERG,
-		"alert":   syslog.LOG_ALERT,
-		"crit":    syslog.LOG_CRIT,
-		"err":     syslog.LOG_ERR,
-		"error":   syslog.LOG_ERR,
-		"warn":    syslog.LOG_WARNING,
-		"warning": syslog.LOG_WARNING,
-		"notice":  syslog.LOG_NOTICE,
-		"info":    syslog.LOG_INFO,
-		"debug":   syslog.LOG_DEBUG,
-	}
-
-	// From /usr/include/sys/syslog.h.
-	syslogFacilityMap = map[string]syslog.Priority{
-		"kern":     syslog.LOG_KERN,
-		"user":     syslog.LOG_USER,
-		"mail":     syslog.LOG_MAIL,
-		"daemon":   syslog.LOG_DAEMON,
-		"auth":     syslog.LOG_AUTH,
-		"syslog":   syslog.LOG_SYSLOG,
-		"lpr":      syslog.LOG_LPR,
-		"news":     syslog.LOG_NEWS,
-		"uucp":     syslog.LOG_UUCP,
-		"cron":     syslog.LOG_CRON,
-		"authpriv": syslog.LOG_AUTHPRIV,
-		"ftp":      syslog.LOG_FTP,
-		"local0":   syslog.LOG_LOCAL0,
-		"local1":   syslog.LOG_LOCAL1,
-		"local2":   syslog.LOG_LOCAL2,
-		"local3":   syslog.LOG_LOCAL3,
-		"local4":   syslog.LOG_LOCAL4,
-		"local5":   syslog.LOG_LOCAL5,
-		"local6":   syslog.LOG_LOCAL6,
-		"local7":   syslog.LOG_LOCAL7,
-	}
-
-	// syslogLevelMap maps logrus.Level values to syslog.Priority levels.
-	syslogLevelMap = map[logrus.Level]syslog.Priority{
-		logrus.PanicLevel: syslog.LOG_ALERT,
-		logrus.FatalLevel: syslog.LOG_CRIT,
-		logrus.ErrorLevel: syslog.LOG_ERR,
-		logrus.WarnLevel:  syslog.LOG_WARNING,
-		logrus.InfoLevel:  syslog.LOG_INFO,
-		logrus.DebugLevel: syslog.LOG_DEBUG,
-		logrus.TraceLevel: syslog.LOG_DEBUG,
-	}
 
 	// LevelStringToLogrusLevel maps string representations of logrus.Level into
 	// their corresponding logrus.Level.
@@ -289,68 +221,6 @@ func ConfigureLogLevel(debug bool) {
 	}
 }
 
-// setupSyslog sets up and configures syslog with the provided options in
-// logOpts. If some options are not provided, sensible defaults are used.
-func setupSyslog(logOpts LogOptions, tag string, debug bool) error {
-	opts := getLogDriverConfig(Syslog, logOpts)
-	syslogOptValues := make(map[string][]string)
-	syslogOptValues[SSeverity] = mapStringPriorityToSlice(syslogSeverityMap)
-	syslogOptValues[SFacility] = mapStringPriorityToSlice(syslogFacilityMap)
-	if err := opts.validateOpts(Syslog, syslogOpts, syslogOptValues); err != nil {
-		return err
-	}
-	if stag, ok := opts[STag]; ok {
-		tag = stag
-	}
-
-	logLevel, ok := opts[SLevel]
-	if !ok {
-		if debug {
-			logLevel = "debug"
-		} else {
-			logLevel = "info"
-		}
-	}
-
-	//Validate provided log level.
-	level, err := logrus.ParseLevel(logLevel)
-	if err != nil {
-		DefaultLogger.Fatal(err)
-	}
-
-	DefaultLogger.SetLevel(level)
-
-	network := ""
-	address := ""
-	// Inherit severity from log level if syslog.severity is not specified explicitly
-	severity := syslogLevelMap[level]
-	// Default values for facility if not specified
-	facility := syslog.LOG_KERN
-	if networkStr, ok := opts[SNetwork]; ok {
-		network = networkStr
-	}
-	if addressStr, ok := opts[SAddress]; ok {
-		address = addressStr
-	}
-	if severityStr, ok := opts[SSeverity]; ok {
-		severity = syslogSeverityMap[severityStr]
-	}
-	if facilityStr, ok := opts[SFacility]; ok {
-		facility = syslogFacilityMap[facilityStr]
-	}
-
-	// Create syslog hook.
-	h, err := logrus_syslog.NewSyslogHook(network, address, severity|facility, tag)
-	if err != nil {
-		DefaultLogger.Fatal(err)
-	}
-	// TODO: switch to a per-logger version when we upgrade to logrus >1.0.3
-	logrus.AddHook(h)
-	DefaultLogger.AddHook(h)
-
-	return nil
-}
-
 // GetFormatter returns a configured logrus.Formatter with some specific values
 // we want to have
 func GetFormatter(format LogFormat) logrus.Formatter {
@@ -428,12 +298,4 @@ func CanLogAt(logger *logrus.Logger, level logrus.Level) bool {
 // GetLevel returns the log level of the given logger.
 func GetLevel(logger *logrus.Logger) logrus.Level {
 	return logrus.Level(atomic.LoadUint32((*uint32)(&logger.Level)))
-}
-
-func mapStringPriorityToSlice(m map[string]syslog.Priority) []string {
-	s := make([]string, 0, len(m))
-	for k := range m {
-		s = append(s, k)
-	}
-	return s
 }

--- a/pkg/logging/logging_nosyslog.go
+++ b/pkg/logging/logging_nosyslog.go
@@ -1,0 +1,21 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package logging
+
+func setupSyslog(logOpts LogOptions, tag string, debug bool) error {
+	return nil
+}

--- a/pkg/logging/logging_syslog.go
+++ b/pkg/logging/logging_syslog.go
@@ -1,0 +1,165 @@
+// Copyright 2016-2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package logging
+
+import (
+	"log/syslog"
+
+	"github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+const (
+	SLevel    = "syslog.level"
+	SNetwork  = "syslog.network"
+	SAddress  = "syslog.address"
+	SSeverity = "syslog.severity"
+	SFacility = "syslog.facility"
+	STag      = "syslog.tag"
+)
+
+var (
+	// syslogOpts is the set of supported options for syslog configuration.
+	syslogOpts = map[string]bool{
+		SLevel:    true,
+		SNetwork:  true,
+		SAddress:  true,
+		SSeverity: true,
+		SFacility: true,
+		STag:      true,
+	}
+
+	// From /usr/include/sys/syslog.h.
+	syslogSeverityMap = map[string]syslog.Priority{
+		"emerg":   syslog.LOG_EMERG,
+		"panic":   syslog.LOG_EMERG,
+		"alert":   syslog.LOG_ALERT,
+		"crit":    syslog.LOG_CRIT,
+		"err":     syslog.LOG_ERR,
+		"error":   syslog.LOG_ERR,
+		"warn":    syslog.LOG_WARNING,
+		"warning": syslog.LOG_WARNING,
+		"notice":  syslog.LOG_NOTICE,
+		"info":    syslog.LOG_INFO,
+		"debug":   syslog.LOG_DEBUG,
+	}
+
+	// From /usr/include/sys/syslog.h.
+	syslogFacilityMap = map[string]syslog.Priority{
+		"kern":     syslog.LOG_KERN,
+		"user":     syslog.LOG_USER,
+		"mail":     syslog.LOG_MAIL,
+		"daemon":   syslog.LOG_DAEMON,
+		"auth":     syslog.LOG_AUTH,
+		"syslog":   syslog.LOG_SYSLOG,
+		"lpr":      syslog.LOG_LPR,
+		"news":     syslog.LOG_NEWS,
+		"uucp":     syslog.LOG_UUCP,
+		"cron":     syslog.LOG_CRON,
+		"authpriv": syslog.LOG_AUTHPRIV,
+		"ftp":      syslog.LOG_FTP,
+		"local0":   syslog.LOG_LOCAL0,
+		"local1":   syslog.LOG_LOCAL1,
+		"local2":   syslog.LOG_LOCAL2,
+		"local3":   syslog.LOG_LOCAL3,
+		"local4":   syslog.LOG_LOCAL4,
+		"local5":   syslog.LOG_LOCAL5,
+		"local6":   syslog.LOG_LOCAL6,
+		"local7":   syslog.LOG_LOCAL7,
+	}
+
+	// syslogLevelMap maps logrus.Level values to syslog.Priority levels.
+	syslogLevelMap = map[logrus.Level]syslog.Priority{
+		logrus.PanicLevel: syslog.LOG_ALERT,
+		logrus.FatalLevel: syslog.LOG_CRIT,
+		logrus.ErrorLevel: syslog.LOG_ERR,
+		logrus.WarnLevel:  syslog.LOG_WARNING,
+		logrus.InfoLevel:  syslog.LOG_INFO,
+		logrus.DebugLevel: syslog.LOG_DEBUG,
+		logrus.TraceLevel: syslog.LOG_DEBUG,
+	}
+)
+
+func mapStringPriorityToSlice(m map[string]syslog.Priority) []string {
+	s := make([]string, 0, len(m))
+	for k := range m {
+		s = append(s, k)
+	}
+	return s
+}
+
+// setupSyslog sets up and configures syslog with the provided options in
+// logOpts. If some options are not provided, sensible defaults are used.
+func setupSyslog(logOpts LogOptions, tag string, debug bool) error {
+	opts := getLogDriverConfig(Syslog, logOpts)
+	syslogOptValues := make(map[string][]string)
+	syslogOptValues[SSeverity] = mapStringPriorityToSlice(syslogSeverityMap)
+	syslogOptValues[SFacility] = mapStringPriorityToSlice(syslogFacilityMap)
+	if err := opts.validateOpts(Syslog, syslogOpts, syslogOptValues); err != nil {
+		return err
+	}
+	if stag, ok := opts[STag]; ok {
+		tag = stag
+	}
+
+	logLevel, ok := opts[SLevel]
+	if !ok {
+		if debug {
+			logLevel = "debug"
+		} else {
+			logLevel = "info"
+		}
+	}
+
+	// Validate provided log level.
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		DefaultLogger.Fatal(err)
+	}
+
+	SetLogLevel(level)
+
+	network := ""
+	address := ""
+	// Inherit severity from log level if syslog.severity is not specified explicitly
+	severity := syslogLevelMap[level]
+	// Default values for facility if not specified
+	facility := syslog.LOG_KERN
+	if networkStr, ok := opts[SNetwork]; ok {
+		network = networkStr
+	}
+	if addressStr, ok := opts[SAddress]; ok {
+		address = addressStr
+	}
+	if severityStr, ok := opts[SSeverity]; ok {
+		severity = syslogSeverityMap[severityStr]
+	}
+	if facilityStr, ok := opts[SFacility]; ok {
+		facility = syslogFacilityMap[facilityStr]
+	}
+
+	// Create syslog hook.
+	h, err := logrus_syslog.NewSyslogHook(network, address, severity|facility, tag)
+	if err != nil {
+		DefaultLogger.Fatal(err)
+	}
+	// TODO: switch to a per-logger version when we upgrade to logrus >1.0.3
+	logrus.AddHook(h)
+	DefaultLogger.AddHook(h)
+
+	return nil
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -268,7 +268,7 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
 			err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name)
 			if err != nil {
-				return fmt.Errorf("Can't install proxy rules for %s: %s", pp.name, err)
+				return fmt.Errorf("Cannot install proxy rules for %s: %s", pp.name, err)
 			}
 			pp.rulesPort = pp.proxyPort
 		}
@@ -376,8 +376,7 @@ func (p *Proxy) ReinstallRules() {
 			// This should always succeed if we have managed to start-up properly
 			err := p.datapathUpdater.InstallProxyRules(pp.rulesPort, pp.ingress, pp.name)
 			if err != nil {
-				proxyPortsMutex.Unlock()
-				panic(fmt.Sprintf("Can't install proxy rules for %s: %s", pp.name, err))
+				log.WithError(err).Errorf("Can't install proxy rules for %s", pp.name)
 			}
 		}
 	}
@@ -520,10 +519,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEn
 				err := p.ackProxyPort(pp)
 				proxyPortsMutex.Unlock()
 				if err != nil {
-					// Finalize functions can't error out. This failure can only
-					// happen if there is an internal Cilium logic error regarding
-					// installation of iptables rules.
-					panic(err)
+					log.WithError(err).Errorf("Datapath proxy redirection cannot be enabled for %s, L7 proxy may be bypassed", pp.name)
 				}
 			}
 			// Must return the proxy port when successful

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -51,7 +51,6 @@ const (
 
 type DatapathUpdater interface {
 	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
-	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -262,22 +261,17 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 		// in the datapath, but means that the datapath rules may exist even
 		// if the proxy is not currently configured.
 
-		// Remove old rules, if any and for different port
-		if pp.rulesPort != 0 && pp.rulesPort != pp.proxyPort {
-			scopedLog.Infof("Removing old proxy port rules for %s:%d", pp.name, pp.rulesPort)
-			p.datapathUpdater.RemoveProxyRules(pp.rulesPort, pp.ingress, pp.name)
-			pp.rulesPort = 0
-		}
 		// Add new rules, if needed
 		if pp.rulesPort != pp.proxyPort {
+			// Add rules for the new port
 			// This should always succeed if we have managed to start-up properly
 			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
 			err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name)
 			if err != nil {
 				return fmt.Errorf("Can't install proxy rules for %s: %s", pp.name, err)
 			}
+			pp.rulesPort = pp.proxyPort
 		}
-		pp.rulesPort = pp.proxyPort
 	}
 	pp.nRedirects++
 	return nil

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -15,6 +15,7 @@ $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.21"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="0"? false : true
+$NFS_OPTS = (ENV['NFS_OPTS'] || "nolock").split(",")
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")
@@ -119,7 +120,7 @@ Vagrant.configure("2") do |config|
         if $NFS
             # This network is only used by NFS
             server.vm.network "private_network", ip: "192.168.38.10"
-            server.vm.synced_folder cilium_dir, cilium_path, type: "nfs", nfs_udp: false
+            server.vm.synced_folder cilium_dir, cilium_path, type: "nfs", nfs_udp: false, mount_options: $NFS_OPTS
         else
             server.vm.synced_folder cilium_dir, cilium_path
         end
@@ -190,7 +191,7 @@ Vagrant.configure("2") do |config|
             if $NFS
                 # This network is only used by NFS
                 server.vm.network "private_network", ip: "192.168.38.1#{i}"
-                server.vm.synced_folder cilium_dir, cilium_path, type: "nfs", nfs_udp: false
+                server.vm.synced_folder cilium_dir, cilium_path, type: "nfs", nfs_udp: false, mount_options: $NFS_OPTS
             else
                 server.vm.synced_folder cilium_dir, cilium_path
             end

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -51,16 +51,11 @@ var _ = Describe("K8sCustomCalls", func() {
 		deploymentManager.SetKubectl(kubectl)
 	})
 
-	AfterEach(func() {
-		deploymentManager.DeleteAll()
-	})
-
 	AfterFailed(func() {
 		kubectl.CiliumReport("cilium status", "cilium endpoint list")
 	})
 
 	AfterAll(func() {
-		deploymentManager.DeleteCilium()
 		kubectl.CloseSSHClient()
 	})
 
@@ -113,6 +108,11 @@ var _ = Describe("K8sCustomCalls", func() {
 		AfterEach(func() {
 			_ = kubectl.Delete(yaml)
 			ExpectAllPodsTerminated(kubectl)
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteCilium()
+			deploymentManager.DeleteAll()
 		})
 
 		installPods := func() {


### PR DESCRIPTION
* #16554 -- ci: Disable NFS locking (@gandro)
 * #16600 -- Refactor logging package to split syslog functionality into separate file (@tklauser)
 * #16651 -- tests: rework custom calls's `AfterEach`/`AfterAll` blocks to skip if needed (@qmonnet)
 * #16391 -- iptables: Keep old rules while adding new ones (@jrajahalme)
 * #16560 -- cicd: skip codesql on forks (@ldelossa)
 * #16662 -- k8s: Fix External Workloads service access (@jrajahalme)

Skipped:
 * #16646 -- Better error reporting/catching in agent on nativeRoutingCIDR (@jibi)
   - Probably don't want to deprecate existing options in a stable release, see
     https://github.com/cilium/cilium/pull/16646#issuecomment-870635030

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16554 16600 16651 16391 16560 16662 ; do contrib/backporting/set-labels.py $pr done 1.10; done
```