### PR TITLE
Docs: Fix maglev.hashSeed byte size documentation

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -382,7 +382,7 @@ per service. If a higher number of backends are provisioned under this setting, 
 difference in reassignments on backend changes will increase.
 
 The ``maglev.hashSeed`` option is recommended to be set in order for Cilium to not rely on the
-fixed built-in seed. The seed is a base64-encoded 16 byte-random number, and can be
+fixed built-in seed. The seed is a base64-encoded 12 byte-random number, and can be
 generated once through ``head -c12 /dev/urandom | base64 -w0``, for example. Every Cilium agent
 in the cluster must use the same hash seed in order for Maglev to work.
 
@@ -392,7 +392,7 @@ given service (with the property of at most 1% difference on backend reassignmen
 
 .. parsed-literal::
 
-    SEED=$(head -c16 /dev/urandom | base64 -w0)
+    SEED=$(head -c12 /dev/urandom | base64 -w0)
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set kubeProxyReplacement=strict \\


### PR DESCRIPTION
Update documentation on maglev hash seed to instruct users to generate a 12 byte seed (instead of 16 bytes), according to this error message from cilium v1.9.4 (when a 16 byte seed had been used):
```
Failed to initialize maglev hash seeds: Decoded hash seed is 16 bytes (not 12 bytes)
```