### PR TITLE
Auto discover ipv6-mcast-device if not provided

### DIFF
--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -65,26 +65,26 @@ func (s *KubeProxySuite) TearDownTest(c *C) {
 func (s *KubeProxySuite) TestDetectDevices(c *C) {
 	s.withFreshNetNS(c, func() {
 		// 1. No devices = impossible to detect
-		c.Assert(detectDevices(true, true), NotNil)
+		c.Assert(detectDevices(true, true, true), NotNil)
 
 		// 2. No devices, but no detection is required
-		c.Assert(detectDevices(false, false), IsNil)
+		c.Assert(detectDevices(false, false, false), IsNil)
 
 		// 3. Direct routing mode, should find dummy0 for both opts
-		c.Assert(createDummy("dummy0", "192.168.0.1/24"), IsNil)
-		c.Assert(createDummy("dummy1", "192.168.1.2/24"), IsNil)
-		c.Assert(createDummy("dummy2", "192.168.2.3/24"), IsNil)
+		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
+		c.Assert(createDummy("dummy1", "192.168.1.2/24", false), IsNil)
+		c.Assert(createDummy("dummy2", "192.168.2.3/24", false), IsNil)
 		option.Config.EnableIPv4 = true
 		option.Config.EnableIPv6 = false
 		option.Config.Tunnel = option.TunnelDisabled
 		node.SetK8sNodeIP(net.ParseIP("192.168.0.1"))
-		c.Assert(detectDevices(true, true), IsNil)
+		c.Assert(detectDevices(true, true, false), IsNil)
 		c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy0"})
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
 
 		// 4. dummy1 should be detected too
 		c.Assert(addDefaultRoute("dummy1", "192.168.1.1"), IsNil)
-		c.Assert(detectDevices(true, true), IsNil)
+		c.Assert(detectDevices(true, true, false), IsNil)
 		sort.Strings(option.Config.Devices)
 		c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy0", "dummy1"})
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
@@ -92,35 +92,36 @@ func (s *KubeProxySuite) TestDetectDevices(c *C) {
 		// 5. Enable IPv6, dummy1 should not be detected, as no default route for
 		// ipv6 is found
 		option.Config.EnableIPv6 = true
-		c.Assert(detectDevices(true, true), IsNil)
+		c.Assert(detectDevices(true, true, false), IsNil)
 		c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy0"})
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
 
 		// 6. Set random NodeIP, only dummy1 should be detected
 		option.Config.EnableIPv6 = false
 		node.SetK8sNodeIP(net.ParseIP("192.168.34.1"))
-		c.Assert(detectDevices(true, true), IsNil)
+		c.Assert(detectDevices(true, true, false), IsNil)
 		c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy1"})
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy1")
 
 		// 7. With IPv6 node address on dummy3, set cilium_foo interface to node IP,
 		// only dummy3 should be detected matching node IP (no IPv6 default route present)
 		option.Config.EnableIPv6 = true
-		c.Assert(createDummy("dummy3", "2001:db8::face/64"), IsNil)
-		c.Assert(createDummy("cilium_foo", "2001:db8::face/128"), IsNil)
+		c.Assert(createDummy("dummy3", "2001:db8::face/64", true), IsNil)
+		c.Assert(createDummy("cilium_foo", "2001:db8::face/128", true), IsNil)
 		node.SetK8sNodeIP(net.ParseIP("2001:db8::face"))
-		c.Assert(detectDevices(true, true), IsNil)
+		c.Assert(detectDevices(true, true, true), IsNil)
 		c.Assert(option.Config.Devices, checker.DeepEquals, []string{"dummy3"})
+		c.Assert(option.Config.IPv6MCastDevice, checker.DeepEquals, "dummy3")
 	})
 }
 
 func (s *KubeProxySuite) TestExpandDevices(c *C) {
 	s.withFreshNetNS(c, func() {
-		c.Assert(createDummy("dummy0", "192.168.0.1/24"), IsNil)
-		c.Assert(createDummy("dummy1", "192.168.1.2/24"), IsNil)
-		c.Assert(createDummy("other0", "192.168.2.3/24"), IsNil)
-		c.Assert(createDummy("other1", "192.168.3.4/24"), IsNil)
-		c.Assert(createDummy("unmatched", "192.168.4.5/24"), IsNil)
+		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
+		c.Assert(createDummy("dummy1", "192.168.1.2/24", false), IsNil)
+		c.Assert(createDummy("other0", "192.168.2.3/24", false), IsNil)
+		c.Assert(createDummy("other1", "192.168.3.4/24", false), IsNil)
+		c.Assert(createDummy("unmatched", "192.168.4.5/24", false), IsNil)
 
 		option.Config.Devices = []string{"dummy+", "missing+", "other0+" /* duplicates: */, "dum+", "other0", "other1"}
 		expandDevices()
@@ -140,10 +141,15 @@ func (s *KubeProxySuite) withFreshNetNS(c *C, test func()) {
 	test()
 }
 
-func createDummy(iface, ipAddr string) error {
+func createDummy(iface, ipAddr string, ipv6Enabled bool) error {
+	var dummyFlags net.Flags
+	if ipv6Enabled {
+		dummyFlags = net.FlagMulticast
+	}
 	dummy := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{
-			Name: iface,
+			Name:  iface,
+			Flags: dummyFlags,
 		},
 	}
 	if err := netlink.LinkAdd(dummy); err != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2187,7 +2187,7 @@ func (c *DaemonConfig) Validate() error {
 		if !c.EnableIPv6 {
 			return fmt.Errorf("IPv6NDP cannot be enabled when IPv6 is not enabled")
 		}
-		if len(c.IPv6MCastDevice) == 0 {
+		if len(c.IPv6MCastDevice) == 0 && !MightAutoDetectDevices() {
 			return fmt.Errorf("IPv6NDP cannot be enabled without %s", IPv6MCastDevice)
 		}
 	}


### PR DESCRIPTION
This change enables auto discovery of IPv6 multicast device when `enable-ipv6-ndp=true` but `ipv6-mcast-device` is not configured. It removes the requirement to manually configure `ipv6-mcast-device` 

Signed-off-by: Sarvesh Rangnekar <sarveshr@google.com>