### PR TITLE
[v1.10] Plumb Azure interface's VPC / primary CIDR and set it as native routing CIDR in Azure IPAM mode

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -275,10 +275,11 @@ func restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 		cidr = node.GetIPv6AllocRange()
 		fromFS = node.GetIPv6Router()
 	} else {
-		if ipam := option.Config.IPAMMode(); ipam == ipamOption.IPAMCRD || ipam == ipamOption.IPAMENI || ipam == ipamOption.IPAMAlibabaCloud {
+		switch option.Config.IPAMMode() {
+		case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 			// The native routing CIDR is the pod CIDR in these IPAM modes.
 			cidr = option.Config.IPv4NativeRoutingCIDR()
-		} else {
+		default:
 			cidr = node.GetIPv4AllocRange()
 		}
 		fromFS = node.GetInternalIPv4Router()

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -258,6 +258,9 @@ func parseInterface(iface *network.Interface, subnets ipamTypes.SubnetMap, usePr
 				if ip.Subnet != nil {
 					addr.Subnet = *ip.Subnet.ID
 					if subnet, ok := subnets[addr.Subnet]; ok {
+						if subnet.CIDR != nil {
+							i.CIDR = subnet.CIDR.String()
+						}
 						if gateway := deriveGatewayIP(subnet.CIDR.IP); gateway != "" {
 							i.GatewayIP = gateway
 							i.Gateway = gateway

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -122,6 +122,11 @@ type AzureInterface struct {
 	// +optional
 	Gateway string `json:"gateway"`
 
+	// CIDR is the range that the interface belongs to.
+	//
+	// +optional
+	CIDR string `json:"cidr,omitempty"`
+
 	// vmssName is the name of the virtual machine scale set. This field is
 	// set by extractIDs()
 	vmssName string `json:"-"`

--- a/pkg/azure/types/zz_generated.deepequal.go
+++ b/pkg/azure/types/zz_generated.deepequal.go
@@ -83,6 +83,9 @@ func (in *AzureInterface) DeepEqual(other *AzureInterface) bool {
 	if in.Gateway != other.Gateway {
 		return false
 	}
+	if in.CIDR != other.CIDR {
+		return false
+	}
 	if in.vmssName != other.vmssName {
 		return false
 	}

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -214,8 +214,8 @@ func deriveVpcCIDR(node *ciliumv2.CiliumNode) (result *cidr.CIDR) {
 			c, err := cidr.ParseCIDR(eni.VPC.PrimaryCIDR)
 			if err == nil {
 				result = c
+				return
 			}
-			return
 		}
 	}
 	// return AlibabaCloud vpc CIDR
@@ -223,6 +223,7 @@ func deriveVpcCIDR(node *ciliumv2.CiliumNode) (result *cidr.CIDR) {
 		c, err := cidr.ParseCIDR(node.Spec.AlibabaCloud.CIDRBlock)
 		if err == nil {
 			result = c
+			return
 		}
 	}
 	return

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -218,6 +218,15 @@ func deriveVpcCIDR(node *ciliumv2.CiliumNode) (result *cidr.CIDR) {
 			}
 		}
 	}
+	if len(node.Status.Azure.Interfaces) > 0 {
+		for _, azif := range node.Status.Azure.Interfaces {
+			c, err := cidr.ParseCIDR(azif.CIDR)
+			if err == nil {
+				result = c
+				return
+			}
+		}
+	}
 	// return AlibabaCloud vpc CIDR
 	if len(node.Status.AlibabaCloud.ENIs) > 0 {
 		c, err := cidr.ParseCIDR(node.Spec.AlibabaCloud.CIDRBlock)
@@ -261,7 +270,7 @@ func (n *nodeStore) hasMinimumIPsInPool() (minimumReached bool, required, numAva
 			minimumReached = true
 		}
 
-		if n.conf.IPAMMode() == ipamOption.IPAMENI || n.conf.IPAMMode() == ipamOption.IPAMAlibabaCloud {
+		if n.conf.IPAMMode() == ipamOption.IPAMENI || n.conf.IPAMMode() == ipamOption.IPAMAzure || n.conf.IPAMMode() == ipamOption.IPAMAlibabaCloud {
 			if vpcCIDR := deriveVpcCIDR(n.ownNode); vpcCIDR != nil {
 				if nativeCIDR := n.conf.IPv4NativeRoutingCIDR(); nativeCIDR != nil {
 					logFields := logrus.Fields{
@@ -525,6 +534,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 			if iface.ID == ipInfo.Resource {
 				result.PrimaryMAC = iface.MAC
 				result.GatewayIP = iface.Gateway
+				result.CIDRs = append(result.CIDRs, iface.CIDR)
 				// For now, we can hardcode the interface number to a valid
 				// integer because it will not be used in the allocation result
 				// anyway. To elaborate, Azure IPAM mode automatically sets

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -399,6 +399,10 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        cidr:
+                          description: CIDR is the range that the interface belongs
+                            to.
+                          type: string
                         gateway:
                           description: Gateway is the interface's subnet's default
                             route

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -34,7 +34,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.23.2"
+	CustomResourceDefinitionSchemaVersion = "1.23.3"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"


### PR DESCRIPTION
* #16696 -- Plumb Azure interface's VPC / primary CIDR and set it as native routing CIDR in Azure IPAM mode (@christarazi )

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16696; do contrib/backporting/set-labels.py $pr done 1.10; done
```