### PR TITLE
ci-multicluster: Fix post-test information gathering 

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -15,13 +15,29 @@ on:
   ###
 
 concurrency:
-  # In case of PR comment, we can't simply append the comment to the group name
-  # as that is too long and results in an error. Instead we check if it's a
-  # trigger phrase and append a simple 'trigger-phrase'.
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number + trigger phrase
+  #   - pull_request: PR number + label name
+  #
+  # This structure ensures a unique concurrency group name is generated for each type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number} {trigger phrase}
+  # - pull_request: {name} pull_request {PR number} {label name}
   group: |
-    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
-     ${{ (startsWith(github.event.comment.body, 'ci-aks') ||
-          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{ github.event.issue.number || github.event.pull_request.number || github.sha }}
+    ${{ github.event_name == 'issue_comment' && (
+      startsWith(github.event.comment.body, 'ci-aks') ||
+      startsWith(github.event.comment.body, 'test-me-please')
+    ) && 'ci-aks' }}
+    ${{ github.event_name == 'pull_request'
+      && github.event.label.name == 'ci-run/aks'
+      && 'ci-run/aks' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -15,13 +15,29 @@ on:
   ###
 
 concurrency:
-  # In case of PR comment, we can't simply append the comment to the group name
-  # as that is too long and results in an error. Instead we check if it's a
-  # trigger phrase and append a simple 'trigger-phrase'.
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number + trigger phrase
+  #   - pull_request: PR number + label name
+  #
+  # This structure ensures a unique concurrency group name is generated for each type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number} {trigger phrase}
+  # - pull_request: {name} pull_request {PR number} {label name}
   group: |
-    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
-     ${{ (startsWith(github.event.comment.body, 'ci-awscni') ||
-          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{ github.event.issue.number || github.event.pull_request.number || github.sha }}
+    ${{ github.event_name == 'issue_comment' && (
+      startsWith(github.event.comment.body, 'ci-awscni') ||
+      startsWith(github.event.comment.body, 'test-me-please')
+    ) && 'ci-awscni' }}
+    ${{ github.event_name == 'pull_request'
+      && github.event.label.name == 'ci-run/awscni'
+      && 'ci-run/awscni' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -15,13 +15,29 @@ on:
   ###
 
 concurrency:
-  # In case of PR comment, we can't simply append the comment to the group name
-  # as that is too long and results in an error. Instead we check if it's a
-  # trigger phrase and append a simple 'trigger-phrase'.
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number + trigger phrase
+  #   - pull_request: PR number + label name
+  #
+  # This structure ensures a unique concurrency group name is generated for each type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number} {trigger phrase}
+  # - pull_request: {name} pull_request {PR number} {label name}
   group: |
-    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
-     ${{ (startsWith(github.event.comment.body, 'ci-eks') ||
-          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{ github.event.issue.number || github.event.pull_request.number || github.sha }}
+    ${{ github.event_name == 'issue_comment' && (
+      startsWith(github.event.comment.body, 'ci-eks') ||
+      startsWith(github.event.comment.body, 'test-me-please')
+    ) && 'ci-eks' }}
+    ${{ github.event_name == 'pull_request'
+      && github.event.label.name == 'ci-run/eks'
+      && 'ci-run/eks' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -15,13 +15,29 @@ on:
   ###
 
 concurrency:
-  # In case of PR comment, we can't simply append the comment to the group name
-  # as that is too long and results in an error. Instead we check if it's a
-  # trigger phrase and append a simple 'trigger-phrase'.
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number + trigger phrase
+  #   - pull_request: PR number + label name
+  #
+  # This structure ensures a unique concurrency group name is generated for each type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number} {trigger phrase}
+  # - pull_request: {name} pull_request {PR number} {label name}
   group: |
-    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
-     ${{ (startsWith(github.event.comment.body, 'ci-gke') ||
-          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{ github.event.issue.number || github.event.pull_request.number || github.sha }}
+    ${{ github.event_name == 'issue_comment' && (
+      startsWith(github.event.comment.body, 'ci-gke') ||
+      startsWith(github.event.comment.body, 'test-me-please')
+    ) && 'ci-gke' }}
+    ${{ github.event_name == 'pull_request'
+      && github.event.label.name == 'ci-run/gke'
+      && 'ci-run/gke' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -243,12 +243,20 @@ jobs:
         if: ${{ failure() }}
         run: |
           cilium status --context ${{ steps.contexts.outputs.context1 }}
-          cilium clustermesh status --context ${{ steps.contexts.outputs.context1 }}
+          # FIXME: Use of timeout is a workaround for cilium/cilium-cli#384
+          timeout 5s cilium clustermesh status --context ${{ steps.contexts.outputs.context1 }}
           cilium status --context ${{ steps.contexts.outputs.context2 }}
-          cilium clustermesh status --context ${{ steps.contexts.outputs.context2 }}
-          kubectl get pods --all-namespaces -o wide
+          # FIXME: Use of timeout is a workaround for cilium/cilium-cli#384
+          timeout 5s cilium clustermesh status --context ${{ steps.contexts.outputs.context2 }}
+
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          kubectl config use-context ${{ steps.contexts.outputs.context1 }}
+          kubectl get pods --all-namespaces -o wide
+          python cilium-sysdump.zip --output cilium-sysdump-context1
+
+          kubectl config use-context ${{ steps.contexts.outputs.context2 }}
+          kubectl get pods --all-namespaces -o wide
+          python cilium-sysdump.zip --output cilium-sysdump-context2
         shell: bash {0}
 
       - name: Clean up GKE
@@ -263,7 +271,9 @@ jobs:
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
         with:
           name: cilium-sysdump-out.zip
-          path: cilium-sysdump-out.zip
+          path: |
+            cilium-sysdump-context1.zip
+            cilium-sysdump-context2.zip
           retention-days: 5
 
       - name: Set commit status to success

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -15,13 +15,29 @@ on:
   ###
 
 concurrency:
-  # In case of PR comment, we can't simply append the comment to the group name
-  # as that is too long and results in an error. Instead we check if it's a
-  # trigger phrase and append a simple 'trigger-phrase'.
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number + trigger phrase
+  #   - pull_request: PR number + label name
+  #
+  # This structure ensures a unique concurrency group name is generated for each type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number} {trigger phrase}
+  # - pull_request: {name} pull_request {PR number} {label name}
   group: |
-    "${{ github.workflow }} ${{ github.event.issue.pull_request.url || 'scheduled' }}
-     ${{ (startsWith(github.event.comment.body, 'ci-multicluster') ||
-          startsWith(github.event.comment.body, 'test-me-please')) && 'trigger-phrase' }}"
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{ github.event.issue.number || github.event.pull_request.number || github.sha }}
+    ${{ github.event_name == 'issue_comment' && (
+      startsWith(github.event.comment.body, 'ci-multicluster') ||
+      startsWith(github.event.comment.body, 'test-me-please')
+    ) && 'ci-multicluster' }}
+    ${{ github.event_name == 'pull_request'
+      && github.event.label.name == 'ci-run/multicluster'
+      && 'ci-run/multicluster' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -9,9 +9,9 @@ on:
   schedule:
     - cron:  '0 3/6 * * *'
   ### FOR TESTING PURPOSES
-  # pull_request:
-  #  types:
-  #    - "labeled"
+  pull_request:
+    types:
+      - "labeled"
   ###
 
 concurrency:
@@ -209,6 +209,7 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
+          exit 1 # XXX: remove me, fail on purpose
           cilium clustermesh status --wait --context ${{ steps.contexts.outputs.context1 }}
           cilium clustermesh status --wait --context ${{ steps.contexts.outputs.context2 }}
 


### PR DESCRIPTION
This fixes two issues with the ci-multicluster log gathering:

  1. `cilium clustermesh status` can unfortunately block even when
     not using `--wait`. 
     See cilium/cilium-cli#384
     This causes a failing job to be cancelled, thus causing any
     post-failiure steps to be skipped as well.
     This commit works around the issue by manually adding a timeout to
     the post-failiure `cilium clustermes status` invocation.

  2. Sysdumps were not collected for both clusters. This is fixed by
     manually switching to each cluster context using `kubectl`.