### PR TITLE
ci-multicluster: Fix post-test information gathering

### DIFF
--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -243,12 +243,20 @@ jobs:
         if: ${{ failure() }}
         run: |
           cilium status --context ${{ steps.contexts.outputs.context1 }}
-          cilium clustermesh status --context ${{ steps.contexts.outputs.context1 }}
+          # FIXME: Use of timeout is a workaround for cilium/cilium-cli#384
+          timeout 5s cilium clustermesh status --context ${{ steps.contexts.outputs.context1 }}
           cilium status --context ${{ steps.contexts.outputs.context2 }}
-          cilium clustermesh status --context ${{ steps.contexts.outputs.context2 }}
-          kubectl get pods --all-namespaces -o wide
+          # FIXME: Use of timeout is a workaround for cilium/cilium-cli#384
+          timeout 5s cilium clustermesh status --context ${{ steps.contexts.outputs.context2 }}
+
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          kubectl config use-context ${{ steps.contexts.outputs.context1 }}
+          kubectl get pods --all-namespaces -o wide
+          python cilium-sysdump.zip --output cilium-sysdump-context1
+
+          kubectl config use-context ${{ steps.contexts.outputs.context2 }}
+          kubectl get pods --all-namespaces -o wide
+          python cilium-sysdump.zip --output cilium-sysdump-context2
         shell: bash {0}
 
       - name: Clean up GKE
@@ -263,7 +271,9 @@ jobs:
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
         with:
           name: cilium-sysdump-out.zip
-          path: cilium-sysdump-out.zip
+          path: |
+            cilium-sysdump-context1.zip
+            cilium-sysdump-context2.zip
           retention-days: 5
 
       - name: Set commit status to success


### PR DESCRIPTION
This fixes two issues with the ci-multicluster log gathering:

  1. `cilium clustermesh status` can unfortunately block even when
     not using `--wait`. 
     See cilium/cilium-cli#384
     This causes a failing job to be cancelled, thus causing any
     post-failiure steps to be skipped as well.
     This commit works around the issue by manually adding a timeout to
     the post-failiure `cilium clustermes status` invocation.

  2. Sysdumps were not collected for both clusters. This is fixed by
     manually switching to each cluster context using `kubectl`.
