### PR TITLE
Louis/bgp testing

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -176,7 +176,7 @@ type Daemon struct {
 
 	redirectPolicyManager *redirectpolicy.Manager
 
-	bgpSpeaker *speaker.Speaker
+	bgpSpeaker *speaker.MetalLBSpeaker
 
 	egressPolicyManager *egresspolicy.Manager
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -401,10 +401,14 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	d.redirectPolicyManager = redirectpolicy.NewRedirectPolicyManager(d.svc)
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
-		d.bgpSpeaker = speaker.New(ctx, speaker.Opts{
+		d.bgpSpeaker, err = speaker.New(ctx, speaker.Opts{
 			LoadBalancerIP: option.Config.BGPAnnounceLBIP,
 			PodCIDR:        option.Config.BGPAnnouncePodCIDR,
 		})
+		if err != nil {
+			log.WithError(err).Error("Error creating new BGP speaker")
+			return nil, nil, err
+		}
 	}
 
 	d.egressPolicyManager = egresspolicy.NewEgressPolicyManager()

--- a/operator/main.go
+++ b/operator/main.go
@@ -414,7 +414,7 @@ func onOperatorStartLeading(ctx context.Context) {
 
 	if operatorOption.Config.BGPAnnounceLBIP {
 		log.Info("Starting LB IP allocator")
-		operatorWatchers.StartLBIPAllocator(option.Config)
+		operatorWatchers.StartLBIPAllocator(ctx, option.Config)
 	}
 
 	if kvstoreEnabled() {

--- a/operator/watchers/bgp.go
+++ b/operator/watchers/bgp.go
@@ -15,6 +15,8 @@
 package watchers
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/bgp/manager"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/lock"
@@ -23,7 +25,7 @@ import (
 // StartLBIPAllocator starts the service watcher if it hasn't already and looks
 // for service of type LoadBalancer. Once it finds a service of that type, it
 // will try to allocate an external IP (LoadBalancerIP) for it.
-func StartLBIPAllocator(cfg ServiceSyncConfiguration) {
+func StartLBIPAllocator(ctx context.Context, cfg ServiceSyncConfiguration) {
 	optsModifier, err := utils.GetServiceListOptionsModifier(cfg)
 	if err != nil {
 		log.WithError(err).Fatal("Error creating service option modifier")
@@ -33,11 +35,14 @@ func StartLBIPAllocator(cfg ServiceSyncConfiguration) {
 	swgEps := lock.NewStoppableWaitGroup()
 	InitServiceWatcher(cfg, swgSvcs, swgEps, optsModifier)
 
-	m := manager.New(serviceIndexer)
+	m, err := manager.New(ctx, serviceIndexer)
+	if err != nil {
+		log.WithError(err).Fatal("Error creating BGP manager")
+	}
 	serviceSubscribers.Register(m)
 
 	go func() {
 		<-k8sSvcCacheSynced
-		m.MarkSynced(m.Logger())
+		m.MarkSynced()
 	}()
 }

--- a/pkg/bgp/manager/metallb.go
+++ b/pkg/bgp/manager/metallb.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package speaker abstracts the BGP speaker controller from MetalLB. This
+// package provides BGP announcements based on K8s object event handling.
+package manager
+
+import (
+	"context"
+	"os"
+
+	bgpconfig "github.com/cilium/cilium/pkg/bgp/config"
+	bgpk8s "github.com/cilium/cilium/pkg/bgp/k8s"
+	bgplog "github.com/cilium/cilium/pkg/bgp/log"
+	"github.com/cilium/cilium/pkg/option"
+
+	metallballoc "go.universe.tf/metallb/pkg/allocator"
+	metallbctl "go.universe.tf/metallb/pkg/controller"
+	"go.universe.tf/metallb/pkg/k8s"
+	"go.universe.tf/metallb/pkg/k8s/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// Controller provides a method set for interfacing with a BGP Controller.
+//
+// This interface is heavily modeled after MetalLB's controller
+// as it's the first BGP integration for Cilium's use cases.
+//
+// If other BGP integrations are desired, consider building out custom types
+// and a more abstracted method set.
+type Controller interface {
+	SetBalancer(name string, srvRo *v1.Service, eps k8s.EpsOrSlices) types.SyncState
+}
+
+type metalLBController struct {
+	c      *metallbctl.Controller
+	logger *bgplog.Logger
+}
+
+func newMetalLBController(ctx context.Context) (Controller, error) {
+	logger := &bgplog.Logger{Entry: log}
+	c := &metallbctl.Controller{
+		Client: bgpk8s.New(logger.Logger),
+		IPs:    metallballoc.New(),
+	}
+
+	f, err := os.Open(option.Config.BGPConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	config, err := bgpconfig.Parse(f)
+	if err != nil {
+		return nil, err
+	}
+	c.SetConfig(logger, config)
+
+	return &metalLBController{
+		c,
+		logger,
+	}, nil
+}
+
+func (c *metalLBController) SetBalancer(name string, srvRo *v1.Service, eps k8s.EpsOrSlices) types.SyncState {
+	return c.c.SetBalancer(c.logger, name, srvRo, eps)
+}

--- a/pkg/bgp/manager/metallb.go
+++ b/pkg/bgp/manager/metallb.go
@@ -41,6 +41,7 @@ import (
 // and a more abstracted method set.
 type Controller interface {
 	SetBalancer(name string, srvRo *v1.Service, eps k8s.EpsOrSlices) types.SyncState
+	MarkSynced()
 }
 
 type metalLBController struct {
@@ -75,4 +76,8 @@ func newMetalLBController(ctx context.Context) (Controller, error) {
 
 func (c *metalLBController) SetBalancer(name string, srvRo *v1.Service, eps k8s.EpsOrSlices) types.SyncState {
 	return c.c.SetBalancer(c.logger, name, srvRo, eps)
+}
+
+func (c *metalLBController) MarkSynced() {
+	c.c.MarkSynced(c.logger)
 }

--- a/pkg/bgp/manager/subscriber.go
+++ b/pkg/bgp/manager/subscriber.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	mlbk8s "go.universe.tf/metallb/pkg/k8s"
 
 	"go.universe.tf/metallb/pkg/k8s/types"
 	v1 "k8s.io/api/core/v1"
@@ -134,7 +135,7 @@ func (m *Manager) process(event interface{}) types.SyncState {
 // reconcile calls down to the MetalLB controller to reconcile the service
 // object, which will allocate it an LB IP.
 func (m *Manager) reconcile(name string, svc *slim_corev1.Service) types.SyncState {
-	return m.SetBalancer(m.Logger(), name, toV1Service(svc), nil)
+	return m.controller.SetBalancer(name, toV1Service(svc), mlbk8s.EpsOrSlices{})
 }
 
 // forceResync re-adds all the services from the indexer to the queue. See

--- a/pkg/bgp/speaker/events.go
+++ b/pkg/bgp/speaker/events.go
@@ -85,9 +85,9 @@ func (s *MetalLBSpeaker) do(key interface{}) types.SyncState {
 
 	switch k := key.(type) {
 	case svcEvent:
-		return s.SetService(s.logger, k.id.String(), k.svc, k.eps)
+		return s.speaker.SetService(k.id.String(), k.svc, k.eps)
 	case epEvent:
-		return s.SetService(s.logger, k.id.String(), k.svc, k.eps)
+		return s.speaker.SetService(k.id.String(), k.svc, k.eps)
 	case nodeEvent:
 		return s.handleNodeEvent(k)
 	default:
@@ -114,7 +114,7 @@ func (s *MetalLBSpeaker) handleNodeEvent(k nodeEvent) types.SyncState {
 	}
 
 	if s.announceLBIP {
-		if r := s.SetNodeLabels(s.logger, *k.labels); r != types.SyncStateSuccess {
+		if r := s.speaker.SetNodeLabels(*k.labels); r != types.SyncStateSuccess {
 			failed = true
 			ret = r
 		}

--- a/pkg/bgp/speaker/events.go
+++ b/pkg/bgp/speaker/events.go
@@ -47,7 +47,7 @@ type nodeEvent struct {
 // loop is only stopped (implicitly) when the Agent is shutting down.
 //
 // Adapted from go.universe.tf/metallb/pkg/k8s/k8s.go.
-func (s *Speaker) run(ctx context.Context) {
+func (s *MetalLBSpeaker) run(ctx context.Context) {
 	for {
 		// only check ctx here, we'll allow any in-flight
 		// events to be processed completely.
@@ -80,7 +80,7 @@ func (s *Speaker) run(ctx context.Context) {
 // do performs the appropriate action depending on the event type. For example,
 // if it is a service event (svcEvent), then it will call into MetalLB's
 // SetService() to perform BGP announcements.
-func (s *Speaker) do(key interface{}) types.SyncState {
+func (s *MetalLBSpeaker) do(key interface{}) types.SyncState {
 	defer s.queue.Done(key)
 
 	switch k := key.(type) {
@@ -96,7 +96,7 @@ func (s *Speaker) do(key interface{}) types.SyncState {
 	}
 }
 
-func (s *Speaker) handleNodeEvent(k nodeEvent) types.SyncState {
+func (s *MetalLBSpeaker) handleNodeEvent(k nodeEvent) types.SyncState {
 	var (
 		ret    types.SyncState
 		failed bool

--- a/pkg/bgp/speaker/metallb.go
+++ b/pkg/bgp/speaker/metallb.go
@@ -1,0 +1,107 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package speaker abstracts the BGP speaker controller from MetalLB. This
+// package provides BGP announcements based on K8s object event handling.
+package speaker
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	bgpconfig "github.com/cilium/cilium/pkg/bgp/config"
+	bgpk8s "github.com/cilium/cilium/pkg/bgp/k8s"
+	bgplog "github.com/cilium/cilium/pkg/bgp/log"
+	nodetypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+
+	"go.universe.tf/metallb/pkg/k8s/types"
+	metallbspr "go.universe.tf/metallb/pkg/speaker"
+)
+
+// Speaker provides a method set for interfacing
+// with a BGP speaker.
+//
+// This interface is heavily modeled after MetalLB's speaker
+// as it's the first BGP integration for Cilium's use cases.
+//
+// If other BGP integrations are desired, consider building out custom types
+// and a more abstracted method set.
+type Speaker interface {
+	SetService(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState
+	SetNodeLabels(labels map[string]string) types.SyncState
+	PeerSessions() []metallbspr.Session
+}
+
+// metalLBSpeaker implements the Speaker interface
+// and is thin wrapper around the metallb controller proper.
+type metalLBSpeaker struct {
+	C      *metallbspr.Controller
+	logger *bgplog.Logger
+}
+
+// newMetalLBSpeaker will create a new Speaker powered by
+// a MetalLB BGP Speaker.
+//
+// This constructor expects option.Config.BGPConfigPath to point to
+// a valid filesystem path where a MetalLB configure resides.
+// It's an error if the config cannot be parsed.
+//
+// The MetalLB speaker will use the value of nodetypes.GetName() as
+// its node identity.
+func newMetalLBSpeaker(ctx context.Context) (Speaker, error) {
+	logger := &bgplog.Logger{Entry: log}
+	client := bgpk8s.New(logger.Logger)
+
+	c, err := metallbspr.NewController(metallbspr.ControllerConfig{
+		MyNode:        nodetypes.GetName(),
+		Logger:        logger,
+		SList:         nil, // BGP speaker doesn't use speakerlist
+		DisableLayer2: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.Client = client
+
+	f, err := os.Open(option.Config.BGPConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	config, err := bgpconfig.Parse(f)
+	if err != nil {
+		return nil, err
+	}
+	if ss := c.SetConfig(logger, config); ss == types.SyncStateError {
+		return nil, fmt.Errorf("failed to set MetalLB config")
+	}
+
+	return metalLBSpeaker{
+		C:      c,
+		logger: logger,
+	}, nil
+}
+
+func (m metalLBSpeaker) SetService(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState {
+	return m.C.SetService(m.logger, name, svc, eps)
+}
+func (m metalLBSpeaker) SetNodeLabels(labels map[string]string) types.SyncState {
+	return m.C.SetNodeLabels(m.logger, labels)
+}
+func (m metalLBSpeaker) PeerSessions() []metallbspr.Session {
+	return m.C.PeerSessions()
+}

--- a/pkg/bgp/speaker/pod_cidr.go
+++ b/pkg/bgp/speaker/pod_cidr.go
@@ -33,7 +33,7 @@ var (
 func (s *MetalLBSpeaker) withDraw() error {
 	log.Infof("chris withDrawal of all BGP routes")
 	var wg sync.WaitGroup // waitgroup here since we don't care about errors
-	for _, session := range s.PeerSessions() {
+	for _, session := range s.speaker.PeerSessions() {
 		go func(sess metallbspr.Session) { // Need an outer closure to capture session.
 			wg.Add(1)
 			// providing an empty array or advertisements will
@@ -52,7 +52,7 @@ func (s *MetalLBSpeaker) withDraw() error {
 func (s *MetalLBSpeaker) announcePodCIDRs(cidrs []string) error {
 	log.Infof("chris announcePodCIDRs(%v)", cidrs)
 	var eg errgroup.Group
-	for _, session := range s.PeerSessions() {
+	for _, session := range s.speaker.PeerSessions() {
 		func(sess metallbspr.Session) { // Need an outer closure to capture session.
 			eg.Go(func() error {
 				err := s.announce(sess, cidrs)

--- a/pkg/bgp/speaker/pod_cidr.go
+++ b/pkg/bgp/speaker/pod_cidr.go
@@ -30,7 +30,7 @@ var (
 	emptyAdverts = []*metallbbgp.Advertisement{}
 )
 
-func (s *Speaker) withDraw() error {
+func (s *MetalLBSpeaker) withDraw() error {
 	log.Infof("chris withDrawal of all BGP routes")
 	var wg sync.WaitGroup // waitgroup here since we don't care about errors
 	for _, session := range s.PeerSessions() {
@@ -49,7 +49,7 @@ func (s *Speaker) withDraw() error {
 	return nil
 }
 
-func (s *Speaker) announcePodCIDRs(cidrs []string) error {
+func (s *MetalLBSpeaker) announcePodCIDRs(cidrs []string) error {
 	log.Infof("chris announcePodCIDRs(%v)", cidrs)
 	var eg errgroup.Group
 	for _, session := range s.PeerSessions() {
@@ -67,7 +67,7 @@ func (s *Speaker) announcePodCIDRs(cidrs []string) error {
 	return eg.Wait()
 }
 
-func (s *Speaker) announce(session metallbspr.Session, cidrs []string) error {
+func (s *MetalLBSpeaker) announce(session metallbspr.Session, cidrs []string) error {
 	adverts := make([]*metallbbgp.Advertisement, 0, len(cidrs))
 	for _, c := range cidrs {
 		parsed, err := cidr.ParseCIDR(c)

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -19,17 +19,12 @@ package speaker
 import (
 	"context"
 	"errors"
-	"os"
 
-	bgpconfig "github.com/cilium/cilium/pkg/bgp/config"
-	bgpk8s "github.com/cilium/cilium/pkg/bgp/k8s"
-	bgplog "github.com/cilium/cilium/pkg/bgp/log"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/lock"
 	nodetypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
 
 	metallbspr "go.universe.tf/metallb/pkg/speaker"
 	v1 "k8s.io/api/core/v1"
@@ -45,37 +40,13 @@ var _ subscriber.Node = (*MetalLBSpeaker)(nil)
 
 // New creates a new MetalLB BGP speaker controller. Options are provided to
 // specify what the Speaker should announce via BGP.
-func New(ctx context.Context, opts Opts) *MetalLBSpeaker {
-	logger := &bgplog.Logger{Entry: log}
-	client := bgpk8s.New(logger.Logger)
-
-	c, err := metallbspr.NewController(metallbspr.ControllerConfig{
-		MyNode:        nodetypes.GetName(),
-		Logger:        logger,
-		SList:         nil, // BGP speaker doesn't use speakerlist
-		DisableLayer2: true,
-	})
+func New(ctx context.Context, opts Opts) (*MetalLBSpeaker, error) {
+	ctrl, err := newMetalLBSpeaker(ctx)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to initialize BGP speaker controller")
+		return nil, err
 	}
-	c.Client = client
-
-	f, err := os.Open(option.Config.BGPConfigPath)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to open BGP config file")
-	}
-	defer f.Close()
-
-	config, err := bgpconfig.Parse(f)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to parse BGP configuration")
-	}
-	c.SetConfig(logger, config)
-
 	spkr := &MetalLBSpeaker{
-		Controller: c,
-
-		logger: logger,
+		speaker: ctrl,
 
 		announceLBIP:    opts.LoadBalancerIP,
 		announcePodCIDR: opts.PodCIDR,
@@ -89,7 +60,7 @@ func New(ctx context.Context, opts Opts) *MetalLBSpeaker {
 
 	log.Info("Started BGP speaker")
 
-	return spkr
+	return spkr, nil
 }
 
 // Opts represents what the Speaker can announce.
@@ -102,9 +73,7 @@ type Opts struct {
 // MetalLB's logic for making BGP announcements. It is responsible for
 // announcing BGP messages containing a loadbalancer IP address to peers.
 type MetalLBSpeaker struct {
-	*metallbspr.Controller
-
-	logger *bgplog.Logger
+	speaker Speaker
 
 	announceLBIP, announcePodCIDR bool
 


### PR DESCRIPTION
This PR introduces the necessary commits for testing Cilium's BGP Speaker and BGP Manager in isolation. 

A new interface is built which abstracts the MetalLB code slightly. This will allow unit tests to instantiate Cilium's speaker and manager with a mock. 

Each mock will be able to record the invocation of their methods, useful in proving the Speaker  and Manager are using the MetalLB components correctly. 

This PR will merge back into "pr/christarazi/podcidrs-bgp" topic branch and NOT master. 