### PR TITLE
Fix and add more commands in CI sysdumps

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3532,7 +3532,8 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	kub.reportMapHost(ctx, testPath, reportCmds)
 
 	reportCmds = map[string]string{
-		"journalctl -D /var/log/journal --no-pager -au kubelet": "kubelet.log",
+		"journalctl -D /var/log/journal --no-pager -au kubelet":        "kubelet.log",
+		"journalctl -D /var/log/journal --no-pager -au kube-apiserver": "kube-apiserver.log",
 		"top -n 1 -b": "top.log",
 		"ps aux":      "ps.log",
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3532,9 +3532,9 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	kub.reportMapHost(ctx, testPath, reportCmds)
 
 	reportCmds = map[string]string{
-		"journalctl --no-pager -au kubelet": "kubelet.log",
-		"top -n 1 -b":                       "top.log",
-		"ps aux":                            "ps.log",
+		"journalctl -D /var/log/journal --no-pager -au kubelet": "kubelet.log",
+		"top -n 1 -b": "top.log",
+		"ps aux":      "ps.log",
 	}
 
 	kub.reportMapContext(ctx, testPath, reportCmds, LogGathererNamespace, logGathererSelector(false))

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -31,7 +31,7 @@ spec:
         command:
         - sleep
         image: docker.io/cilium/log-gatherer:v1.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: log-gatherer
         securityContext:
           capabilities:


### PR DESCRIPTION
In order to further debug https://github.com/cilium/cilium/issues/16720 we need to retrieve kube-apiserver logs which is being added by this PR.

Fixes https://github.com/cilium/cilium/issues/14293