### PR TITLE
dev-doctor: Bump minimum hub version requirement for backporting

### DIFF
--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -187,7 +187,8 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 				ifNotFound:    checkError,
 				versionArgs:   []string{"--version"},
 				versionRegexp: regexp.MustCompile(`hub\s+version\s+(\d+.\d+\.\d+)`),
-				minVersion:    &semver.Version{Major: 2, Minor: 0, Patch: 0},
+				minVersion:    &semver.Version{Major: 2, Minor: 14, Patch: 0},
+				hint:          `Download the latest version from https://github.com/github/hub/releases.`,
 			},
 			&envVarCheck{
 				name:            "GITHUB_TOKEN",


### PR DESCRIPTION
Backporting scripts need a version of github.com/github/hub that support
the api command. The version of hub distributed with Ubuntu 20.04 LTS is
2.7.0, which is too old. Bump the minimum hub version to 2.14 as this is
definitely new enough and was released 18 months ago.

Signed-off-by: Tom Payne <tom@isovalent.com>
