### PR TITLE
workflows: remove label filters for testing workflows

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -9,9 +9,18 @@ on:
   schedule:
     - cron:  '0 0/6 * * *'
   ### FOR TESTING PURPOSES
-  # pull_request:
-  #  types:
-  #    - "labeled"
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
   ###
 
 concurrency:
@@ -33,12 +42,12 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-aks') ||
         (startsWith(github.event.comment.body, 'test-me-please'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/aks'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
@@ -73,12 +82,12 @@ jobs:
   installation-and-connectivity:
     needs: check_changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-aks') ||
         (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/aks'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -9,9 +9,18 @@ on:
   schedule:
     - cron:  '30 0/6 * * *'
   ### FOR TESTING PURPOSES
-  # pull_request:
-  #  types:
-  #    - "labeled"
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
   ###
 
 concurrency:
@@ -33,12 +42,12 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-awscni') ||
         (startsWith(github.event.comment.body, 'test-me-please'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/awscni'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
@@ -73,12 +82,12 @@ jobs:
   installation-and-connectivity:
     needs: check_changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-awscni') ||
         (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/awscni'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -9,9 +9,18 @@ on:
   schedule:
     - cron:  '0 1/6 * * *'
   ### FOR TESTING PURPOSES
-  # pull_request:
-  #  types:
-  #    - "labeled"
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
   ###
 
 concurrency:
@@ -33,12 +42,12 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-eks') ||
         (startsWith(github.event.comment.body, 'test-me-please'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/eks'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
@@ -73,12 +82,12 @@ jobs:
   installation-and-connectivity:
     needs: check_changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-eks') ||
         (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/eks'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -9,9 +9,18 @@ on:
   schedule:
     - cron:  '0 2/6 * * *'
   ### FOR TESTING PURPOSES
-  # pull_request:
-  #  types:
-  #    - "labeled"
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
   ###
 
 concurrency:
@@ -33,12 +42,12 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-gke') ||
         (startsWith(github.event.comment.body, 'test-me-please'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/gke'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
@@ -73,12 +82,12 @@ jobs:
   installation-and-connectivity:
     needs: check_changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-gke') ||
         (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/gke'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -9,9 +9,18 @@ on:
   schedule:
     - cron:  '0 3/6 * * *'
   ### FOR TESTING PURPOSES
-  # pull_request:
-  #  types:
-  #    - "labeled"
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
   ###
 
 concurrency:
@@ -34,12 +43,12 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-multicluster') ||
         (startsWith(github.event.comment.body, 'test-me-please'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/multicluster'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
@@ -74,12 +83,12 @@ jobs:
   installation-and-connectivity:
     needs: check_changes
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-multicluster') ||
         (startsWith(github.event.comment.body, 'test-me-please') && (needs.check_changes.outputs.tested == 'true'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/multicluster'
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -9,9 +9,18 @@ on:
   schedule:
     - cron:  '0 5/6 * * *'
   ### FOR TESTING PURPOSES
-  # pull_request:
-  #  types:
-  #    - "labeled"
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  # 
+  # pull_request: {}
   ###
 
 concurrency:
@@ -28,12 +37,12 @@ jobs:
   setup-and-test:
     name: Setup & Test
     if: |
-      (github.event.issue.pull_request && (
+      (github.event_name == 'issue_comment' && (
         startsWith(github.event.comment.body, 'ci-l4lb') ||
         (startsWith(github.event.comment.body, 'test-me-please'))
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
-      github.event.label.name == 'ci-run/l4lb'
+      github.event_name == 'pull_request'
     # We need nested virtualisation which is supported only by MacOS runner
     runs-on: macos-10.15
     timeout-minutes: 30


### PR DESCRIPTION
Previously, we used `pull_request` `labeled` events for testing changes to workflows from PRs. This was actually a remnant of our first CI 3.0 implementation to be able to run workflows on-demand rather than on every PR push, before we switched to `issue_comment` triggers.

We remove the `labeled` filter as they only make it way more complicated for contributors to test workflow changes. Instead, we switch to a more simple workflow where simply uncommenting the `pull_request` trigger is enough to be able to start testing changes to a workflow.