### PR TITLE
docs: fix Helm documentation and doc checks

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -35,7 +35,7 @@ jobs:
               - 'cilium-health/cmd/**'
               - 'daemon/cmd/**'
               - 'hubble-relay/cmd/**'
-              - 'install/kubernetes/**/'
+              - 'install/kubernetes/**'
               - 'operator/cmd/**'
 
   # Runs only if code under Documentation or */cmd/ is changed as the docs

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -741,6 +741,10 @@
      - Whether to set the security context on the Hubble UI pods.
      - bool
      - ``true``
+   * - hubble.ui.tls.client
+     - base64 encoded PEM values used to connect to hubble-relay This keypair is presented to Hubble Relay instances for mTLS authentication and is required when hubble.relay.tls.server.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false.
+     - object
+     - ``{"cert":"","key":""}``
    * - hubble.ui.tolerations
      - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
      - list
@@ -838,7 +842,7 @@
      - object
      - ``{}``
    * - monitor
-     - Specify the CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. nativeRoutingCIDR:
+     - Specify the IPv4 CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. ipv4NativeRoutingCIDR:
      - object
      - ``{"enabled":false}``
    * - monitor.enabled

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -93,6 +93,7 @@ MiB
 Minikube
 Monnet
 Mythbusters
+NativeRoutingCIDR
 Netronome
 NewProto
 Nic
@@ -606,7 +607,6 @@ namespaced
 namespaces
 nat
 natMax
-nativeRoutingCIDR
 natively
 neighMax
 netdev


### PR DESCRIPTION
First commit is an update of the Helm reference, so far omitted after some recent changes on the Helm values.

Second commit is a fix to the GitHub workflow conditions to run the Documentation action when Helm values are updated, in order to effectively catch similar omissions in the future.

Only the second commit should be backported, so I won't mark this PR for backports but will do it manually.