### PR TITLE
checkpatch: update image to improve checks and extend to all commits

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://quay.io/cilium/cilium-checkpatch:cc7e6b5811f46d7b040dedfe2f6b0010c2c51a12@sha256:9160b6ca58eb99a3ed5d567a494b2e2001325ebad32029c5bd17a8ae4df01044
+        uses: docker://quay.io/cilium/cilium-checkpatch:514a240252e61d47b8814a5e57843505c0325b77@sha256:f88bbc4dbd8ace809c84581fae8b2dbbbc89433d641f1edf0f892d92be996020
       - name: Send slack notification
         if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
         uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43


### PR DESCRIPTION
Pull the changes from https://github.com/cilium/image-tools/pull/121:

- The checkpatch.pl script is now run for _all_ commits of the PR, instead of just the commits touching files under `bpf/`. We do not want to check the code in directories other than `bpf/`; the interest here is to run the checks on the commit log messages. Therefore, pass commit logs without a diff to checkpatch for commits unrelated to `bpf/`. This makes more checks but note that passing checkpatch is not currently required by the CI for validating the PRs on the Cilium repository.

- Format errors and warnings based on the available workflow commands for GitHub Actions. This should make the output easier to read on GitHub.

- Update the checkpatch.pl patch itself (and its spelling file) from the version coming with kernel 5.12.
