### PR TITLE
v1.9 backports 2021-07-01

### DIFF
--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -72,24 +72,12 @@ func (f *fakeDatapath) InstallProxyRules(uint16, bool, string) error {
 	return nil
 }
 
-func (f *fakeDatapath) RemoveProxyRules(uint16, bool, string) error {
-	return nil
-}
-
 func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *fakeDatapath) RemoveRules(quiet bool) {}
-
-func (f *fakeDatapath) InstallRules(ifName string) error {
+func (f *fakeDatapath) InstallRules(ifName string, quiet, install bool) error {
 	return nil
-}
-func (f *fakeDatapath) TransientRulesStart(ifName string) error {
-	return nil
-}
-func (f *fakeDatapath) TransientRulesEnd(quiet bool) {
-	return
 }
 
 func (m *fakeDatapath) GetProxyPort(name string) uint16 {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
-	go_version "github.com/blang/semver"
+	"github.com/blang/semver"
 	"github.com/mattn/go-shellwords"
 )
 
@@ -76,26 +76,47 @@ type customChain struct {
 	ipv6       bool // ip6tables chain in addition to iptables chain
 }
 
-func getVersion(prog string) (go_version.Version, error) {
-	b, err := exec.WithTimeout(defaults.ExecTimeout, prog, "--version").CombinedOutput(log, false)
+type iptablesInterface interface {
+	getProg() string
+	getVersion() (semver.Version, error)
+	runProgCombinedOutput(args []string, quiet bool) ([]byte, error)
+	runProg(args []string, quiet bool) error
+}
+
+type ipt struct {
+	prog string
+}
+
+// package name is iptables so we use ip4tables internally for "iptables"
+var (
+	ip4tables = &ipt{prog: "iptables"}
+	ip6tables = &ipt{prog: "ip6tables"}
+)
+
+func (ipt *ipt) getProg() string {
+	return ipt.prog
+}
+
+func (ipt *ipt) getVersion() (semver.Version, error) {
+	b, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, "--version").CombinedOutput(log, false)
 	if err != nil {
-		return go_version.Version{}, err
+		return semver.Version{}, err
 	}
 	v := regexp.MustCompile("v([0-9]+(\\.[0-9]+)+)")
 	vString := v.FindStringSubmatch(string(b))
 	if vString == nil {
-		return go_version.Version{}, fmt.Errorf("no iptables version found in string: %s", string(b))
+		return semver.Version{}, fmt.Errorf("no iptables version found in string: %s", string(b))
 	}
 	return versioncheck.Version(vString[1])
 }
 
-func runProgCombinedOutput(prog string, args []string, quiet bool) ([]byte, error) {
-	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, !quiet)
+func (ipt *ipt) runProgCombinedOutput(args []string, quiet bool) ([]byte, error) {
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, args...).CombinedOutput(log, !quiet)
 	return out, err
 }
 
-func runProg(prog string, args []string, quiet bool) error {
-	_, err := runProgCombinedOutput(prog, args, quiet)
+func (ipt *ipt) runProg(args []string, quiet bool) error {
+	_, err := ipt.runProgCombinedOutput(args, quiet)
 	return err
 }
 
@@ -132,10 +153,10 @@ func KernelHasNetfilter() bool {
 func (c *customChain) add(waitArgs []string) error {
 	var err error
 	if option.Config.EnableIPv4 {
-		err = runProg("iptables", append(waitArgs, "-t", c.table, "-N", c.name), false)
+		err = ip4tables.runProg(append(waitArgs, "-t", c.table, "-N", c.name), false)
 	}
 	if err == nil && option.Config.EnableIPv6 && c.ipv6 == true {
-		err = runProg("ip6tables", append(waitArgs, "-t", c.table, "-N", c.name), false)
+		err = ip6tables.runProg(append(waitArgs, "-t", c.table, "-N", c.name), false)
 	}
 	return err
 }
@@ -156,10 +177,10 @@ func reverseRule(rule string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
+func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) {
 	args := append(m.waitArgs, "-t", table, "-S")
 
-	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, true)
+	out, err := prog.runProgCombinedOutput(args, false)
 	if err != nil {
 		return
 	}
@@ -202,7 +223,7 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 			if len(reversedRule) > 0 {
 				deleteRule := append(append(m.waitArgs, "-t", table), reversedRule...)
 				log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Removing %s rule", prog)
-				err = runProg(prog, deleteRule, true)
+				err = prog.runProg(deleteRule, true)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to delete Cilium %s rule", prog)
 				}
@@ -212,8 +233,8 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 }
 
 func (c *customChain) remove(waitArgs []string, quiet bool) {
-	doProcess := func(c *customChain, prog string, args []string, operation string, quiet bool) {
-		combinedOutput, err := runProgCombinedOutput(prog, args, true)
+	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
+		combinedOutput, err := prog.runProgCombinedOutput(args, true)
 		if err != nil {
 			// If the chain is for transient rules and deletion
 			// fails for a reason other than the chain not being
@@ -221,26 +242,24 @@ func (c *customChain) remove(waitArgs []string, quiet bool) {
 			// This is to help debug #11276.
 			msgChainNotFound := ": No chain/target/match by that name.\n"
 			debugTransientRules := c.name == ciliumTransientForwardChain &&
-				string(combinedOutput) != prog+msgChainNotFound
+				string(combinedOutput) != prog.getProg()+msgChainNotFound
 			if !quiet || debugTransientRules {
 				log.Warnf(string(combinedOutput))
 				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to process chain %s with %s (%s)", c.name, prog, operation)
 			}
 		}
 	}
-	doRemove := func(c *customChain, prog string, waitArgs []string, quiet bool) {
+	doRemove := func(c *customChain, prog iptablesInterface, waitArgs []string, quiet bool) {
 		args := append(waitArgs, "-t", c.table, "-F", c.name)
 		doProcess(c, prog, args, "flush", quiet)
 		args = append(waitArgs, "-t", c.table, "-X", c.name)
 		doProcess(c, prog, args, "delete", quiet)
 	}
 	if option.Config.EnableIPv4 {
-		prog := "iptables"
-		doRemove(c, prog, waitArgs, quiet)
+		doRemove(c, ip4tables, waitArgs, quiet)
 	}
 	if option.Config.EnableIPv6 && c.ipv6 {
-		prog := "ip6tables"
-		doRemove(c, prog, waitArgs, quiet)
+		doRemove(c, ip6tables, waitArgs, quiet)
 	}
 }
 
@@ -252,13 +271,13 @@ func (c *customChain) installFeeder(waitArgs []string) error {
 
 	for _, feedArgs := range c.feederArgs {
 		if option.Config.EnableIPv4 {
-			err := runProg("iptables", append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
+			err := ip4tables.runProg(append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
 			if err != nil {
 				return err
 			}
 		}
 		if option.Config.EnableIPv6 && c.ipv6 == true {
-			err := runProg("ip6tables", append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
+			err := ip6tables.runProg(append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
 			if err != nil {
 				return err
 			}
@@ -362,7 +381,7 @@ type IptablesManager struct {
 // availability.
 func (m *IptablesManager) Init() {
 	modulesManager := &modules.ModulesManager{}
-	ip6tables := true
+	haveIp6tables := true
 	if err := modulesManager.Init(); err != nil {
 		log.WithError(err).Fatal(
 			"Unable to get information about kernel modules")
@@ -381,9 +400,9 @@ func (m *IptablesManager) Init() {
 		}
 		log.WithError(err).Debug(
 			"ip6tables kernel modules could not be loaded, so IPv6 cannot be used")
-		ip6tables = false
+		haveIp6tables = false
 	}
-	m.haveIp6tables = ip6tables
+	m.haveIp6tables = haveIp6tables
 
 	if err := modulesManager.FindOrLoadModules("xt_socket"); err != nil {
 		if option.Config.Tunnel == option.TunnelDisabled {
@@ -426,7 +445,7 @@ func (m *IptablesManager) Init() {
 	}
 	m.haveBPFSocketAssign = option.Config.EnableBPFTProxy
 
-	v, err := getVersion("iptables")
+	v, err := ip4tables.getVersion()
 	if err == nil {
 		switch {
 		case isWaitSecondsMinVersion(v):
@@ -452,14 +471,14 @@ func (m *IptablesManager) RemoveRules(quiet bool) {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, "iptables", ciliumPrefix)
+		m.removeCiliumRules(t, ip4tables, ciliumPrefix)
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.haveIp6tables {
 		tables6 := []string{"mangle", "raw", "filter"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, "ip6tables", ciliumPrefix)
+			m.removeCiliumRules(t, ip6tables, ciliumPrefix)
 		}
 	}
 
@@ -510,13 +529,13 @@ func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyP
 
 	var err error
 	if option.Config.EnableIPv4 {
-		err = runProg("iptables",
+		err = ip4tables.runProg(
 			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
 				ingressProxyMark, ingressProxyPort, name),
 			false)
 	}
 	if err == nil && option.Config.EnableIPv6 {
-		err = runProg("ip6tables",
+		err = ip6tables.runProg(
 			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
 				ingressProxyMark, ingressProxyPort, name),
 			false)
@@ -546,13 +565,13 @@ func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPo
 
 	var err error
 	if option.Config.EnableIPv4 {
-		err = runProg("iptables",
+		err = ip4tables.runProg(
 			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
 				egressProxyMark, egressProxyPort, name),
 			false)
 	}
 	if err == nil && option.Config.EnableIPv6 {
-		err = runProg("ip6tables",
+		err = ip6tables.runProg(
 			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
 				egressProxyMark, egressProxyPort, name),
 			false)
@@ -569,7 +588,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	var err error
 	if option.Config.EnableIPv4 {
 		// No conntrack for traffic to proxy
-		err = runProg("iptables", append(
+		err = ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
@@ -579,7 +598,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumInputChain,
@@ -589,7 +608,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic that is heading to lxc+
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
@@ -600,7 +619,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic that is heading to cilium_host
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
@@ -612,7 +631,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumOutputChain,
@@ -622,12 +641,12 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil && m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
-			err = runProg("iptables", m.inboundProxyRedirectRule("-A"), false)
+			err = ip4tables.runProg(m.inboundProxyRedirectRule("-A"), false)
 		}
 	}
 	if err == nil && option.Config.EnableIPv6 {
 		// No conntrack for traffic to ingress proxy
-		err = runProg("ip6tables", append(
+		err = ip6tables.runProg(append(
 			m.waitArgs,
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
@@ -637,7 +656,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("ip6tables", append(
+			err = ip6tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumInputChain,
@@ -647,7 +666,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic
-			err = runProg("ip6tables", append(
+			err = ip6tables.runProg(append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
@@ -658,7 +677,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("ip6tables", append(
+			err = ip6tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumOutputChain,
@@ -668,7 +687,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil && m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
-			err = runProg("ip6tables", m.inboundProxyRedirectRule("-A"), false)
+			err = ip6tables.runProg(m.inboundProxyRedirectRule("-A"), false)
 		}
 	}
 	return err
@@ -709,12 +728,12 @@ func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name
 // By convention "ingress" or "egress" is part of 'name' so it does not need to be specified explicitly.
 // Returns 0 a TPROXY entry with 'name' can not be found.
 func (m *IptablesManager) GetProxyPort(name string) uint16 {
-	prog := "iptables"
+	prog := ip4tables
 	if !option.Config.EnableIPv4 {
-		prog = "ip6tables"
+		prog = ip6tables
 	}
 
-	res, err := runProgCombinedOutput(prog, []string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, false)
+	res, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, true)
 	if err != nil {
 		return 0
 	}
@@ -744,18 +763,18 @@ func getDeliveryInterface(ifName string) string {
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
 	if option.Config.EnableIPv4 {
-		err := m.installForwardChainRulesIpX("iptables", ifName, localDeliveryInterface, forwardChain)
+		err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, forwardChain)
 		if err != nil {
 			return err
 		}
 	}
 	if option.Config.EnableIPv6 {
-		return m.installForwardChainRulesIpX("ip6tables", ifName, localDeliveryInterface, forwardChain)
+		return m.installForwardChainRulesIpX(ip6tables, ifName, localDeliveryInterface, forwardChain)
 	}
 	return nil
 }
 
-func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliveryInterface, forwardChain string) error {
+func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, ifName, localDeliveryInterface, forwardChain string) error {
 	transient := ""
 	if forwardChain == ciliumTransientForwardChain {
 		transient = " (transient)"
@@ -782,7 +801,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 	//  - Node running backend:
 	//       IN=eno1 OUT=cilium_host
 	//       IN=lxc... OUT=eno1
-	if err := runProg(prog, append(
+	if err := prog.runProg(append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-o", ifName,
@@ -790,7 +809,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg(prog, append(
+	if err := prog.runProg(append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", ifName,
@@ -798,7 +817,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg(prog, append(
+	if err := prog.runProg(append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", "lxc+",
@@ -810,7 +829,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 	// TODO: Make 'cilium_net' configurable if we ever support other than "cilium_host" as the Cilium host device.
 	if ifName == "cilium_host" {
 		ifPeerName := "cilium_net"
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", ifPeerName,
@@ -823,7 +842,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 	// same (enable-endpoint-routes), a separate set of rules to allow
 	// from/to delivery interface is required.
 	if localDeliveryInterface != ifName {
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
@@ -831,7 +850,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
@@ -856,7 +875,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 		if err := transientChain.add(m.waitArgs); err != nil {
 			return fmt.Errorf("cannot add custom chain %s: %s", transientChain.name, err)
 		}
-		if err := m.installForwardChainRulesIpX("iptables", ifName, localDeliveryInterface, transientChain.name); err != nil {
+		if err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, transientChain.name); err != nil {
 			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
 		}
 		if err := transientChain.installFeeder(m.waitArgs); err != nil {
@@ -869,7 +888,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 // TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
 func (m *IptablesManager) TransientRulesEnd(quiet bool) {
 	if option.Config.EnableIPv4 {
-		m.removeCiliumRules("filter", "iptables", ciliumTransientForwardChain)
+		m.removeCiliumRules("filter", ip4tables, ciliumTransientForwardChain)
 		transientChain.remove(m.waitArgs, quiet)
 	}
 }
@@ -932,7 +951,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		// originated from the host.
 		matchFromProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyMask)
 		markAsFromHost := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkHost, linux_defaults.MagicMarkHostMask)
-		if err := runProg("iptables", append(
+		if err := ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", "filter",
 			"-A", ciliumOutputChain,
@@ -972,7 +991,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				if option.Config.IPTablesRandomFully {
 					progArgs = append(progArgs, "--random-fully")
 				}
-				if err := runProg("iptables", progArgs, false); err != nil {
+				if err := ip4tables.runProg(progArgs, false); err != nil {
 					return err
 				}
 			} else {
@@ -988,7 +1007,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				if option.Config.IPTablesRandomFully {
 					progArgs = append(progArgs, "--random-fully")
 				}
-				if err := runProg("iptables", progArgs, false); err != nil {
+				if err := ip4tables.runProg(progArgs, false); err != nil {
 					return err
 				}
 			}
@@ -998,7 +1017,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			// are considered.
 
 			// Exclude proxy return traffic from the masquerade rules.
-			if err := runProg("iptables", append(
+			if err := ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "nat",
 				"-A", ciliumPostNatChain,
@@ -1016,7 +1035,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				// * Must be targeted for the ifName interface
 				// * Must be targeted to an IP that is not local
 				// * May not already be originating from the node's pod CIDR.
-				if err := runProg("iptables", append(
+				if err := ip4tables.runProg(append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
@@ -1037,7 +1056,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			// The following conditions must be met:
 			// * Must be targeted for local endpoint
 			// * Must be from 127.0.0.1
-			if err := runProg("iptables", append(
+			if err := ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "nat",
 				"-A", ciliumPostNatChain,
@@ -1064,7 +1083,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			//    on the same node
 			//  - kiam if source and server are on the same node
 			if !option.Config.EnableEndpointRoutes {
-				if err := runProg("iptables", append(
+				if err := ip4tables.runProg(append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
@@ -1117,12 +1136,12 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 	return nil
 }
 
-func (m *IptablesManager) ciliumNoTrackXfrmRules(prog, input string) error {
+func (m *IptablesManager) ciliumNoTrackXfrmRules(prog iptablesInterface, input string) error {
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
 	for _, match := range []string{matchFromIPSecDecrypt, matchFromIPSecEncrypt} {
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-t", "raw", input, ciliumPreRawChain,
 			"-m", "mark", "--mark", match,
@@ -1148,7 +1167,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 
 		comment := "exclude xfrm marks from " + table + " " + chain + " chain"
 
-		if err := runProg("iptables", append(
+		if err := ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", table,
 			"-A", chain,
@@ -1158,7 +1177,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 			return err
 		}
 
-		return runProg("iptables", append(
+		return ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", table,
 			"-A", chain,
@@ -1189,7 +1208,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 
 func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 	if option.Config.EnableIPv4 {
-		return m.ciliumNoTrackXfrmRules("iptables", "-I")
+		return m.ciliumNoTrackXfrmRules(ip4tables, "-I")
 	}
 	return nil
 }
@@ -1210,7 +1229,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 	// Note: these rules need the xt_connmark module (iptables usually
 	// loads it when required, unless loading modules after boot has been
 	// disabled).
-	if err := runProg("iptables", append(
+	if err := ip4tables.runProg(append(
 		m.waitArgs,
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
@@ -1221,7 +1240,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		false); err != nil {
 		return err
 	}
-	return runProg("iptables", append(
+	return ip4tables.runProg(append(
 		m.waitArgs,
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -520,9 +520,9 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
-	ingressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
+	ingressMarkMatch := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy|port)
 	// TPROXY params
-	ingressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
+	ingressProxyMark := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy)
 	ingressProxyPort := fmt.Sprintf("%d", proxyPort)
 
 	if strings.Contains(rules, fmt.Sprintf("CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, ingressMarkMatch)) {
@@ -547,9 +547,9 @@ func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name s
 func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
-	egressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
+	egressMarkMatch := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy|port)
 	// TPROXY params
-	egressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
+	egressProxyMark := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy)
 	egressProxyPort := fmt.Sprintf("%d", proxyPort)
 
 	if strings.Contains(rules, fmt.Sprintf("-A CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, egressMarkMatch)) {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -225,18 +225,18 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		},
 	}
 
 	// Adds new proxy rules
-	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -260,16 +260,16 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		},
 	}
 
 	// Nothing to add
-	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -293,18 +293,18 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		},
 	}
 
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp4tables, 43479, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }
@@ -359,9 +359,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43477",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43477",
 		},
 	}
 
@@ -427,9 +427,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43479",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43479",
 		},
 	}
 

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -1,0 +1,151 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package iptables
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/blang/semver"
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type iptablesTestSuite struct{}
+
+var _ = check.Suite(&iptablesTestSuite{})
+
+type expectation struct {
+	args string
+	out  []byte
+	err  error
+}
+
+type mockIptables struct {
+	c            *check.C
+	prog         string
+	expectations []expectation
+	index        int
+}
+
+func (ipt *mockIptables) addExpectation(args string, out []byte, err error) {
+	ipt.expectations = append(ipt.expectations, expectation{args: args, out: out, err: err})
+}
+
+func (ipt *mockIptables) getProg() string {
+	return ipt.prog
+}
+
+func (ipt *mockIptables) getVersion() (semver.Version, error) {
+	return semver.Version{}, nil
+}
+
+func (ipt *mockIptables) runProgCombinedOutput(args []string, quiet bool) (out []byte, err error) {
+	a := strings.Join(args, " ")
+	i := ipt.index
+	ipt.index++
+
+	if len(ipt.expectations) < ipt.index {
+		ipt.c.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
+		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+	}
+	if a != ipt.expectations[i].args {
+		ipt.c.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
+		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+	}
+	out = ipt.expectations[i].out
+	err = ipt.expectations[i].err
+
+	return out, err
+}
+
+func (ipt *mockIptables) runProg(args []string, quiet bool) error {
+	out, err := ipt.runProgCombinedOutput(args, quiet)
+	if len(out) > 0 {
+		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
+	}
+	return err
+}
+
+func (ipt *mockIptables) checkExpectations() error {
+	if ipt.index != len(ipt.expectations) {
+		return fmt.Errorf("%d unmet expectations", len(ipt.expectations)-ipt.index)
+	}
+
+	// reset index for further testing
+	ipt.index = 0
+
+	return nil
+}
+
+var mockManager = &IptablesManager{
+	haveIp6tables:        false,
+	haveSocketMatch:      true,
+	haveBPFSocketAssign:  false,
+	ipEarlyDemuxDisabled: false,
+	waitArgs:             nil,
+}
+
+func init() {
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = true
+}
+
+func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j CILIUM_PRE_mangle",
+		}, {
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j CILIUM_POST_mangle",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	mockManager.removeCiliumRules("mangle", mockIp4tables, ciliumPrefix)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -111,6 +111,334 @@ func init() {
 	option.Config.EnableIPv6 = true
 }
 
+func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -E CILIUM_PRE_mangle OLD_CILIUM_PRE_mangle",
+		},
+	}
+	chain := &customChain{
+		table: "mangle",
+		name:  "CILIUM_PRE_mangle",
+	}
+	chain.doRename(mockIp4tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = mockIp4tables.expectations
+	chain.doRename(mockIp6tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestCopyProxyRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-random-proxy proxy" -j TPROXY --on-port 43499 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp4tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestCopyProxyRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-random-proxy proxy" -j TPROXY --on-port 43499 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp6tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	err := mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		},
+	}
+
+	// Adds new proxy rules
+	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Nothing to add
+	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	err = mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		},
+	}
+
+	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
+	mockManager.addProxyRules(mockIp4tables, 43479, false, "cilium-dns-egress")
+	err = mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestGetProxyPort(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -n -L CILIUM_PRE_mangle",
+			out: []byte(
+				`Chain CILIUM_PRE_mangle (1 references)
+target     prot opt source               destination         
+MARK       all  --  0.0.0.0/0            0.0.0.0/0            socket --transparent /* cilium: any->pod redirect proxied traffic to host proxy */ MARK set 0x200
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Finds the latest porte number if multiple rules for the same proxy name
+	port := mockManager.doGetProxyPort(mockIp4tables, "cilium-dns-egress")
+	c.Assert(port, check.Equals, uint16(43479))
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		},
+	}
+
+	// Adds new proxy rules
+	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	err := mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Nothing to add
+	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		},
+	}
+
+	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
+	mockManager.addProxyRules(mockIp6tables, 43479, false, "cilium-dns-egress")
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
 func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
@@ -122,30 +450,85 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 -P FORWARD ACCEPT
 -P OUTPUT ACCEPT
 -P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
 -N CILIUM_POST_mangle
 -N CILIUM_PRE_mangle
 -N KUBE-KUBELET-CANARY
 -N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j CILIUM_PRE_mangle",
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
 		}, {
-			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j CILIUM_POST_mangle",
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 
-	mockManager.removeCiliumRules("mangle", mockIp4tables, ciliumPrefix)
+	// Only removes Cilium chains with the OLD_ prefix
+	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix)
 	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
+		}, {
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Only removes Cilium chains with the OLD_ prefix
+	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix)
+	err := mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -63,18 +63,11 @@ type IptablesManager interface {
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
 	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
 
-	// RemoveProxyRules creates the necessary datapath config (e.g., iptables
-	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
-
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	RemoveRules(quiet bool)
-	InstallRules(ifName string) error
-	TransientRulesStart(ifName string) error
-	TransientRulesEnd(quiet bool)
+	InstallRules(ifName string, quiet, install bool) error
 
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -453,25 +453,11 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if option.Config.InstallIptRules {
-		if err := iptMgr.TransientRulesStart(option.Config.HostDevice); err != nil {
-			log.WithError(err).Warning("failed to install transient iptables rules")
-		}
+	if err := iptMgr.InstallRules(option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
+		return err
 	}
-	// The iptables rules are only removed on the first initialization to
-	// remove stale rules or when iptables is enabled. The first invocation
-	// is silent as rules may not exist.
-	if firstInitialization || option.Config.InstallIptRules {
-		iptMgr.RemoveRules(firstInitialization)
-	}
-	if option.Config.InstallIptRules {
-		err := iptMgr.InstallRules(option.Config.HostDevice)
-		iptMgr.TransientRulesEnd(false)
-		if err != nil {
-			return err
-		}
-	}
-	// Reinstall proxy rules for any running proxies
+
+	// Reinstall proxy rules for any running proxies if needed
 	if p != nil {
 		p.ReinstallRules()
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -935,20 +935,20 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 		// Always execute the finalization code, even if the endpoint is
 		// terminating, in order to properly release resources.
 		e.unconditionalLock()
+		defer e.unlock() // In case Finalize() panics
 		e.getLogger().Debug("Finalizing successful endpoint regeneration")
 		datapathRegenCtx.finalizeList.Finalize()
-		e.unlock()
 	} else {
 		if err := e.lockAlive(); err != nil {
 			e.getLogger().WithError(err).Debug("Skipping unnecessary reverting of endpoint regeneration changes")
 			return
 		}
+		defer e.unlock() // In case Revert() panics
 		e.getLogger().Debug("Reverting endpoint changes after BPF regeneration failed")
 		if err := datapathRegenCtx.revertStack.Revert(); err != nil {
 			e.getLogger().WithError(err).Error("Reverting endpoint regeneration changes failed")
 		}
 		e.getLogger().Debug("Finished reverting endpoint changes after BPF regeneration failed")
-		e.unlock()
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -268,7 +268,7 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
 			err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name)
 			if err != nil {
-				return fmt.Errorf("Can't install proxy rules for %s: %s", pp.name, err)
+				return fmt.Errorf("Cannot install proxy rules for %s: %s", pp.name, err)
 			}
 			pp.rulesPort = pp.proxyPort
 		}
@@ -376,8 +376,7 @@ func (p *Proxy) ReinstallRules() {
 			// This should always succeed if we have managed to start-up properly
 			err := p.datapathUpdater.InstallProxyRules(pp.rulesPort, pp.ingress, pp.name)
 			if err != nil {
-				proxyPortsMutex.Unlock()
-				panic(fmt.Sprintf("Can't install proxy rules for %s: %s", pp.name, err))
+				log.WithError(err).Errorf("Can't install proxy rules for %s", pp.name)
 			}
 		}
 	}
@@ -520,10 +519,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEn
 				err := p.ackProxyPort(pp)
 				proxyPortsMutex.Unlock()
 				if err != nil {
-					// Finalize functions can't error out. This failure can only
-					// happen if there is an internal Cilium logic error regarding
-					// installation of iptables rules.
-					panic(err)
+					log.WithError(err).Errorf("Datapath proxy redirection cannot be enabled for %s, L7 proxy may be bypassed", pp.name)
 				}
 			}
 			// Must return the proxy port when successful

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -51,7 +51,6 @@ const (
 
 type DatapathUpdater interface {
 	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
-	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -262,22 +261,17 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 		// in the datapath, but means that the datapath rules may exist even
 		// if the proxy is not currently configured.
 
-		// Remove old rules, if any and for different port
-		if pp.rulesPort != 0 && pp.rulesPort != pp.proxyPort {
-			scopedLog.Infof("Removing old proxy port rules for %s:%d", pp.name, pp.rulesPort)
-			p.datapathUpdater.RemoveProxyRules(pp.rulesPort, pp.ingress, pp.name)
-			pp.rulesPort = 0
-		}
 		// Add new rules, if needed
 		if pp.rulesPort != pp.proxyPort {
+			// Add rules for the new port
 			// This should always succeed if we have managed to start-up properly
 			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
 			err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name)
 			if err != nil {
 				return fmt.Errorf("Can't install proxy rules for %s: %s", pp.name, err)
 			}
+			pp.rulesPort = pp.proxyPort
 		}
-		pp.rulesPort = pp.proxyPort
 	}
 	pp.nRedirects++
 	return nil


### PR DESCRIPTION
 * #16391 -- iptables: Keep old rules while adding new ones (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16391; do contrib/backporting/set-labels.py $pr done 1.9; done
```

```release-note
DNS proxy is now more available during Cilium restarts, including upgrades. 
```
