### PR TITLE
v1.8 backports 2021-07-01

### DIFF
--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -72,24 +72,12 @@ func (f *fakeDatapath) InstallProxyRules(uint16, bool, string) error {
 	return nil
 }
 
-func (f *fakeDatapath) RemoveProxyRules(uint16, bool, string) error {
-	return nil
-}
-
 func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *fakeDatapath) RemoveRules(quiet bool) {}
-
-func (f *fakeDatapath) InstallRules(ifName string) error {
+func (f *fakeDatapath) InstallRules(ifName string, quiet, install bool) error {
 	return nil
-}
-func (f *fakeDatapath) TransientRulesStart(ifName string) error {
-	return nil
-}
-func (f *fakeDatapath) TransientRulesEnd(quiet bool) {
-	return
 }
 
 func (m *fakeDatapath) GetProxyPort(name string) uint16 {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -518,9 +518,9 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
-	ingressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
+	ingressMarkMatch := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy|port)
 	// TPROXY params
-	ingressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
+	ingressProxyMark := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy)
 	ingressProxyPort := fmt.Sprintf("%d", proxyPort)
 
 	if strings.Contains(rules, fmt.Sprintf("CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, ingressMarkMatch)) {
@@ -545,9 +545,9 @@ func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name s
 func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
-	egressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
+	egressMarkMatch := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy|port)
 	// TPROXY params
-	egressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
+	egressProxyMark := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy)
 	egressProxyPort := fmt.Sprintf("%d", proxyPort)
 
 	if strings.Contains(rules, fmt.Sprintf("-A CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, egressMarkMatch)) {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -36,26 +36,26 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/versioncheck"
+	"github.com/sirupsen/logrus"
 
 	"github.com/blang/semver"
 	"github.com/mattn/go-shellwords"
 )
 
 const (
-	ciliumPrefix                = "CILIUM_"
-	ciliumInputChain            = "CILIUM_INPUT"
-	ciliumOutputChain           = "CILIUM_OUTPUT"
-	ciliumOutputRawChain        = "CILIUM_OUTPUT_raw"
-	ciliumPostNatChain          = "CILIUM_POST_nat"
-	ciliumOutputNatChain        = "CILIUM_OUTPUT_nat"
-	ciliumPreNatChain           = "CILIUM_PRE_nat"
-	ciliumPostMangleChain       = "CILIUM_POST_mangle"
-	ciliumPreMangleChain        = "CILIUM_PRE_mangle"
-	ciliumPreRawChain           = "CILIUM_PRE_raw"
-	ciliumForwardChain          = "CILIUM_FORWARD"
-	ciliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
-	feederDescription           = "cilium-feeder:"
-	xfrmDescription             = "cilium-xfrm-notrack:"
+	oldCiliumPrefix       = "OLD_CILIUM_"
+	ciliumInputChain      = "CILIUM_INPUT"
+	ciliumOutputChain     = "CILIUM_OUTPUT"
+	ciliumOutputRawChain  = "CILIUM_OUTPUT_raw"
+	ciliumPostNatChain    = "CILIUM_POST_nat"
+	ciliumOutputNatChain  = "CILIUM_OUTPUT_nat"
+	ciliumPreNatChain     = "CILIUM_PRE_nat"
+	ciliumPostMangleChain = "CILIUM_POST_mangle"
+	ciliumPreMangleChain  = "CILIUM_PRE_mangle"
+	ciliumPreRawChain     = "CILIUM_PRE_raw"
+	ciliumForwardChain    = "CILIUM_FORWARD"
+	feederDescription     = "cilium-feeder:"
+	xfrmDescription       = "cilium-xfrm-notrack:"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -189,9 +189,6 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 	for scanner.Scan() {
 		rule := scanner.Text()
 		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering removing %s rule", prog)
-		if match != ciliumTransientForwardChain && strings.Contains(rule, ciliumTransientForwardChain) {
-			continue
-		}
 
 		// All rules installed by cilium either belong to a chain with
 		// the name CILIUM_ or call a chain with the name CILIUM_:
@@ -203,8 +200,7 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 			// disabled chains
 			skipFeeder := false
 			for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-				// we skip if the match is ciliumTransientForwardChain since we don't want to touch it
-				if match != ciliumTransientForwardChain && strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
+				if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
 					log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
 					skipFeeder = true
 					break
@@ -232,21 +228,29 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 	}
 }
 
+func (c *customChain) doRename(prog iptablesInterface, waitArgs []string, name string, quiet bool) {
+	args := append(waitArgs, "-t", c.table, "-E", c.name, name)
+	operation := "rename"
+	combinedOutput, err := prog.runProgCombinedOutput(args, true)
+	if err != nil && !quiet {
+		log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog, c.name, string(combinedOutput))
+	}
+}
+
+func (c *customChain) rename(waitArgs []string, name string, quiet bool) {
+	if option.Config.EnableIPv4 {
+		c.doRename(ip4tables, waitArgs, name, quiet)
+	}
+	if option.Config.EnableIPv6 && c.ipv6 {
+		c.doRename(ip6tables, waitArgs, name, quiet)
+	}
+}
+
 func (c *customChain) remove(waitArgs []string, quiet bool) {
 	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
 		combinedOutput, err := prog.runProgCombinedOutput(args, true)
-		if err != nil {
-			// If the chain is for transient rules and deletion
-			// fails for a reason other than the chain not being
-			// present, log the error.
-			// This is to help debug #11276.
-			msgChainNotFound := ": No chain/target/match by that name.\n"
-			debugTransientRules := c.name == ciliumTransientForwardChain &&
-				string(combinedOutput) != prog.getProg()+msgChainNotFound
-			if !quiet || debugTransientRules {
-				log.Warnf(string(combinedOutput))
-				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to process chain %s with %s (%s)", c.name, prog, operation)
-			}
+		if err != nil && !quiet {
+			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog.getProg(), c.name, string(combinedOutput))
 		}
 	}
 	doRemove := func(c *customChain, prog iptablesInterface, waitArgs []string, quiet bool) {
@@ -361,13 +365,6 @@ var ciliumChains = []customChain{
 	},
 }
 
-var transientChain = customChain{
-	name:       ciliumTransientForwardChain,
-	table:      "filter",
-	hook:       "FORWARD",
-	feederArgs: []string{""},
-}
-
 // IptablesManager manages the iptables-related configuration for Cilium.
 type IptablesManager struct {
 	haveIp6tables        bool
@@ -464,31 +461,32 @@ func (m *IptablesManager) SupportsOriginalSourceAddr() bool {
 	return (m.haveSocketMatch || m.ipEarlyDemuxDisabled) && option.Config.Tunnel == option.TunnelDisabled
 }
 
-// RemoveRules removes iptables rules installed by Cilium.
-func (m *IptablesManager) RemoveRules(quiet bool) {
+// removeOldRules removes iptables rules installed by Cilium.
+func (m *IptablesManager) removeOldRules(quiet bool) {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, ip4tables, ciliumPrefix)
+		m.removeCiliumRules(t, ip4tables, oldCiliumPrefix)
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.haveIp6tables {
 		tables6 := []string{"mangle", "raw", "filter"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, ip6tables, ciliumPrefix)
+			m.removeCiliumRules(t, ip6tables, oldCiliumPrefix)
 		}
 	}
 
 	for _, c := range ciliumChains {
+		c.name = "OLD_" + c.name
 		c.remove(m.waitArgs, quiet)
 	}
 }
 
-func (m *IptablesManager) ingressProxyRule(cmd, l4Match, markMatch, mark, port, name string) []string {
+func (m *IptablesManager) ingressProxyRule(l4Match, markMatch, mark, port, name string) []string {
 	return append(m.waitArgs,
 		"-t", "mangle",
-		cmd, ciliumPreMangleChain,
+		"-A", ciliumPreMangleChain,
 		"-p", l4Match,
 		"-m", "mark", "--mark", markMatch,
 		"-m", "comment", "--comment", "cilium: TPROXY to host "+name+" proxy",
@@ -517,7 +515,7 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 		"--set-mark", toProxyMark)
 }
 
-func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
+func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
 	ingressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
@@ -525,26 +523,17 @@ func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyP
 	ingressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	ingressProxyPort := fmt.Sprintf("%d", proxyPort)
 
-	var err error
-	if option.Config.EnableIPv4 {
-		err = ip4tables.runProg(
-			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
-				ingressProxyMark, ingressProxyPort, name),
-			false)
+	if strings.Contains(rules, fmt.Sprintf("CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, ingressMarkMatch)) {
+		return nil
 	}
-	if err == nil && option.Config.EnableIPv6 {
-		err = ip6tables.runProg(
-			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
-				ingressProxyMark, ingressProxyPort, name),
-			false)
-	}
-	return err
+
+	return prog.runProg(m.ingressProxyRule(l4proto, ingressMarkMatch, ingressProxyMark, ingressProxyPort, name), false)
 }
 
-func (m *IptablesManager) egressProxyRule(cmd, l4Match, markMatch, mark, port, name string) []string {
+func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name string) []string {
 	return append(m.waitArgs,
 		"-t", "mangle",
-		cmd, ciliumPreMangleChain,
+		"-A", ciliumPreMangleChain,
 		"-p", l4Match,
 		"-m", "mark", "--mark", markMatch,
 		"-m", "comment", "--comment", "cilium: TPROXY to host "+name+" proxy",
@@ -553,7 +542,7 @@ func (m *IptablesManager) egressProxyRule(cmd, l4Match, markMatch, mark, port, n
 		"--on-port", port)
 }
 
-func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
+func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
 	egressMarkMatch := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy|port)
@@ -561,20 +550,11 @@ func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPo
 	egressProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	egressProxyPort := fmt.Sprintf("%d", proxyPort)
 
-	var err error
-	if option.Config.EnableIPv4 {
-		err = ip4tables.runProg(
-			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
-				egressProxyMark, egressProxyPort, name),
-			false)
+	if strings.Contains(rules, fmt.Sprintf("-A CILIUM_PRE_mangle -p %s -m mark --mark %s", l4proto, egressMarkMatch)) {
+		return nil
 	}
-	if err == nil && option.Config.EnableIPv6 {
-		err = ip6tables.runProg(
-			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
-				egressProxyMark, egressProxyPort, name),
-			false)
-	}
-	return err
+
+	return prog.runProg(m.egressProxyRule(l4proto, egressMarkMatch, egressProxyMark, egressProxyPort, name), false)
 }
 
 func (m *IptablesManager) installStaticProxyRules() error {
@@ -691,30 +671,115 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	return err
 }
 
-// install or remove rules for a single proxy port
-func (m *IptablesManager) iptProxyRules(cmd string, proxyPort uint16, ingress bool, name string) error {
-	// Redirect packets to the host proxy via TPROXY, as directed by the Cilium
-	// datapath bpf programs via skb marks (egress) or DSCP (ingress).
+func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) {
+	output, err := prog.runProgCombinedOutput(append(m.waitArgs, "-t", table, "-S"), true)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"table": table,
+			"prog":  prog.getProg(),
+		}).WithError(err).Warning("Cannot list rules in table. Layer 7 proxy port may get reallocated, which could cause disruption for traffic selected by L7 policy", prog.getProg(), table)
+		return
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		rule := scanner.Text()
+		if re.MatchString(rule) && strings.Contains(rule, match) {
+			log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
+			args, err := shellwords.Parse(strings.Replace(rule, oldChain, newChain, 1))
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"table":          table,
+					"prog":           prog.getProg(),
+					logfields.Object: rule,
+				}).WithError(err).Warn("Unable to parse TPROXY rule, disruption to traffic selected by L7 policy possible")
+				continue
+			}
+			copyRule := append(append(m.waitArgs, "-t", table), args...)
+			log.WithField(logfields.Object, logfields.Repr(copyRule)).Debugf("Copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
+			err = prog.runProg(copyRule, true)
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"table":          table,
+					"prog":           prog.getProg(),
+					logfields.Object: rule,
+				}).WithError(err).Warn("Unable to copy TPROXY rule, disruption to traffic selected by L7 policy possible")
+			}
+		}
+	}
+}
+
+var tproxyMatch = regexp.MustCompile("CILIUM_PRE_mangle .*cilium: TPROXY")
+
+// copies old proxy rules
+func (m *IptablesManager) copyProxyRules(oldChain string, match string) {
+	if option.Config.EnableIPv4 {
+		m.doCopyProxyRules(ip4tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain)
+	}
+	if option.Config.EnableIPv6 {
+		m.doCopyProxyRules(ip6tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain)
+	}
+}
+
+// Redirect packets to the host proxy via TPROXY, as directed by the Cilium
+// datapath bpf programs via skb marks (egress) or DSCP (ingress).
+func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
+	output, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"}, true)
+	if err != nil {
+		log.WithError(err).Warnf("Unable to list %s TPROXY rules: %s", prog, string(output))
+	}
+	rules := string(output)
 	if ingress {
-		if err := m.iptIngressProxyRule(cmd, "tcp", proxyPort, name); err != nil {
+		if err := m.iptIngressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
 			return err
 		}
-		if err := m.iptIngressProxyRule(cmd, "udp", proxyPort, name); err != nil {
+		if err := m.iptIngressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
 			return err
 		}
 	} else {
-		if err := m.iptEgressProxyRule(cmd, "tcp", proxyPort, name); err != nil {
+		if err := m.iptEgressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
 			return err
 		}
-		if err := m.iptEgressProxyRule(cmd, "udp", proxyPort, name); err != nil {
+		if err := m.iptEgressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
 			return err
 		}
 	}
+	// Delete all other rules for this same proxy name
+	// These may accumulate if there is a bind failure on a previously used port
+	portMatch := fmt.Sprintf("TPROXY --on-port %d ", proxyPort)
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		rule := scanner.Text()
+		if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && strings.Contains(rule, "cilium: TPROXY to host "+name) && !strings.Contains(rule, portMatch) {
+			args, err := shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
+			if err != nil {
+				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s TPROXY rule", prog)
+				continue
+			}
+			deleteRule := append(append(m.waitArgs, "-t", "mangle"), args...)
+			log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Deleting stale %s TPROXY rule from mangle table", prog)
+			err = prog.runProg(deleteRule, true)
+			if err != nil {
+				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to delete %s TPROXY rule", prog)
+			}
+		}
+	}
+
 	return nil
 }
 
+// install or remove rules for a single proxy port
+func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress bool, name string) (err error) {
+	if option.Config.EnableIPv4 {
+		err = m.addProxyRules(ip4tables, proxyPort, ingress, name)
+	}
+	if err == nil && option.Config.EnableIPv6 {
+		err = m.addProxyRules(ip6tables, proxyPort, ingress, name)
+	}
+	return err
+}
+
 func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
-	return m.iptProxyRules("-A", proxyPort, ingress, name)
+	return m.iptProxyRules(proxyPort, ingress, name)
 }
 
 // GetProxyPort finds a proxy port used for redirect 'name' installed earlier with InstallProxyRules.
@@ -726,24 +791,28 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 		prog = ip6tables
 	}
 
+	return m.doGetProxyPort(prog, name)
+}
+
+func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
 	res, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, true)
 	if err != nil {
 		return 0
 	}
 
-	re := regexp.MustCompile(name + ".*TPROXY redirect 0.0.0.0:([1-9][0-9]*) mark")
-	str := re.FindString(string(res))
-	portStr := re.ReplaceAllString(str, "$1")
-	portInt, err := strconv.Atoi(portStr)
+	re := regexp.MustCompile(name + ".*TPROXY redirect (0.0.0.0|::):([1-9][0-9]*) mark")
+	strs := re.FindAllString(string(res), -1)
+	if len(strs) == 0 {
+		return 0
+	}
+	// Pick the port number from the last match, as rules are appended to the end (-A)
+	portStr := re.ReplaceAllString(strs[len(strs)-1], "$2")
+	portUInt64, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		log.WithError(err).Debugf("Port number cannot be parsed: %s", portStr)
 		return 0
 	}
-	return uint16(portInt)
-}
-
-func (m *IptablesManager) RemoveProxyRules(proxyPort uint16, ingress bool, name string) error {
-	return m.iptProxyRules("-D", proxyPort, ingress, name)
+	return uint16(portUInt64)
 }
 
 func getDeliveryInterface(ifName string) string {
@@ -768,11 +837,6 @@ func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterfac
 }
 
 func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, ifName, localDeliveryInterface, forwardChain string) error {
-	transient := ""
-	if forwardChain == ciliumTransientForwardChain {
-		transient = " (transient)"
-	}
-
 	// While kube-proxy does change the policy of the iptables FORWARD chain
 	// it doesn't seem to handle all cases, e.g. host network pods that use
 	// the node IP which would still end up in default DENY. Similarly, for
@@ -798,7 +862,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 		m.waitArgs,
 		"-A", forwardChain,
 		"-o", ifName,
-		"-m", "comment", "--comment", "cilium"+transient+": any->cluster on "+ifName+" forward accept",
+		"-m", "comment", "--comment", "cilium: any->cluster on "+ifName+" forward accept",
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
@@ -806,7 +870,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", ifName,
-		"-m", "comment", "--comment", "cilium"+transient+": cluster->any on "+ifName+" forward accept (nodeport)",
+		"-m", "comment", "--comment", "cilium: cluster->any on "+ifName+" forward accept (nodeport)",
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
@@ -814,7 +878,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", "lxc+",
-		"-m", "comment", "--comment", "cilium"+transient+": cluster->any on lxc+ forward accept",
+		"-m", "comment", "--comment", "cilium: cluster->any on lxc+ forward accept",
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
@@ -826,7 +890,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", ifPeerName,
-			"-m", "comment", "--comment", "cilium"+transient+": cluster->any on "+ifPeerName+" forward accept (nodeport)",
+			"-m", "comment", "--comment", "cilium: cluster->any on "+ifPeerName+" forward accept (nodeport)",
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
@@ -839,7 +903,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			m.waitArgs,
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium"+transient+": any->cluster on "+localDeliveryInterface+" forward accept",
+			"-m", "comment", "--comment", "cilium: any->cluster on "+localDeliveryInterface+" forward accept",
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
@@ -847,7 +911,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium"+transient+": cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
+			"-m", "comment", "--comment", "cilium: cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
@@ -855,40 +919,40 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 	return nil
 }
 
-// TransientRulesStart installs iptables rules for Cilium that need to be
-// kept in-tact during agent restart which removes/installs its main rules.
-// Transient rules are then removed once iptables rule update cycle has
-// completed. This is mainly due to interactions with kube-proxy.
-func (m *IptablesManager) TransientRulesStart(ifName string) error {
-	if option.Config.EnableIPv4 {
-		localDeliveryInterface := getDeliveryInterface(ifName)
+// InstallRules installs iptables rules for Cilium in specific use-cases
+// (most specifically, interaction with kube-proxy).
+func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) (err error) {
+	quiet := firstInitialization
 
-		m.TransientRulesEnd(true)
+	// Make sure we have no old "backups"
+	m.removeOldRules(true)
 
-		if err := transientChain.add(m.waitArgs); err != nil {
-			return fmt.Errorf("cannot add custom chain %s: %s", transientChain.name, err)
-		}
-		if err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, transientChain.name); err != nil {
-			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
-		}
-		if err := transientChain.installFeeder(m.waitArgs); err != nil {
-			return fmt.Errorf("cannot install feeder rule %s: %s", transientChain.feederArgs, err)
-		}
+	// Rename any old chains we may have
+	for _, c := range ciliumChains {
+		c.rename(m.waitArgs, "OLD_"+c.name, quiet)
 	}
-	return nil
-}
 
-// TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
-func (m *IptablesManager) TransientRulesEnd(quiet bool) {
-	if option.Config.EnableIPv4 {
-		m.removeCiliumRules("filter", ip4tables, ciliumTransientForwardChain)
-		transientChain.remove(m.waitArgs, quiet)
+	// install rules if needed
+	if install {
+		err = m.installRules(ifName)
+		// copy old proxy rules over
+		match := ""
+		if firstInitialization {
+			match = "cilium-dns-egress"
+		}
+		m.copyProxyRules("OLD_"+ciliumPreMangleChain, match)
 	}
+
+	// only remove old rules if new ones were successfully installed
+	if err == nil {
+		m.removeOldRules(quiet)
+	}
+	return err
 }
 
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
-func (m *IptablesManager) InstallRules(ifName string) error {
+func (m *IptablesManager) installRules(ifName string) error {
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
@@ -922,7 +986,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 	localDeliveryInterface := getDeliveryInterface(ifName)
 
 	if err := m.installForwardChainRules(ifName, localDeliveryInterface, ciliumForwardChain); err != nil {
-		return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
+		return fmt.Errorf("cannot install forward chain rules to %s: %w", ciliumForwardChain, err)
 	}
 
 	if option.Config.EnableIPv4 {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
-	go_version "github.com/blang/semver"
+	"github.com/blang/semver"
 	"github.com/mattn/go-shellwords"
 )
 
@@ -76,26 +76,47 @@ type customChain struct {
 	ipv6       bool // ip6tables chain in addition to iptables chain
 }
 
-func getVersion(prog string) (go_version.Version, error) {
-	b, err := exec.WithTimeout(defaults.ExecTimeout, prog, "--version").CombinedOutput(log, false)
+type iptablesInterface interface {
+	getProg() string
+	getVersion() (semver.Version, error)
+	runProgCombinedOutput(args []string, quiet bool) ([]byte, error)
+	runProg(args []string, quiet bool) error
+}
+
+type ipt struct {
+	prog string
+}
+
+// package name is iptables so we use ip4tables internally for "iptables"
+var (
+	ip4tables = &ipt{prog: "iptables"}
+	ip6tables = &ipt{prog: "ip6tables"}
+)
+
+func (ipt *ipt) getProg() string {
+	return ipt.prog
+}
+
+func (ipt *ipt) getVersion() (semver.Version, error) {
+	b, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, "--version").CombinedOutput(log, false)
 	if err != nil {
-		return go_version.Version{}, err
+		return semver.Version{}, err
 	}
 	v := regexp.MustCompile("v([0-9]+(\\.[0-9]+)+)")
 	vString := v.FindStringSubmatch(string(b))
 	if vString == nil {
-		return go_version.Version{}, fmt.Errorf("no iptables version found in string: %s", string(b))
+		return semver.Version{}, fmt.Errorf("no iptables version found in string: %s", string(b))
 	}
 	return versioncheck.Version(vString[1])
 }
 
-func runProgCombinedOutput(prog string, args []string, quiet bool) ([]byte, error) {
-	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, !quiet)
+func (ipt *ipt) runProgCombinedOutput(args []string, quiet bool) ([]byte, error) {
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, args...).CombinedOutput(log, !quiet)
 	return out, err
 }
 
-func runProg(prog string, args []string, quiet bool) error {
-	_, err := runProgCombinedOutput(prog, args, quiet)
+func (ipt *ipt) runProg(args []string, quiet bool) error {
+	_, err := ipt.runProgCombinedOutput(args, quiet)
 	return err
 }
 
@@ -132,10 +153,10 @@ func KernelHasNetfilter() bool {
 func (c *customChain) add(waitArgs []string) error {
 	var err error
 	if option.Config.EnableIPv4 {
-		err = runProg("iptables", append(waitArgs, "-t", c.table, "-N", c.name), false)
+		err = ip4tables.runProg(append(waitArgs, "-t", c.table, "-N", c.name), false)
 	}
 	if err == nil && option.Config.EnableIPv6 && c.ipv6 == true {
-		err = runProg("ip6tables", append(waitArgs, "-t", c.table, "-N", c.name), false)
+		err = ip6tables.runProg(append(waitArgs, "-t", c.table, "-N", c.name), false)
 	}
 	return err
 }
@@ -156,10 +177,10 @@ func reverseRule(rule string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
+func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) {
 	args := append(m.waitArgs, "-t", table, "-S")
 
-	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, true)
+	out, err := prog.runProgCombinedOutput(args, false)
 	if err != nil {
 		return
 	}
@@ -202,7 +223,7 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 			if len(reversedRule) > 0 {
 				deleteRule := append(append(m.waitArgs, "-t", table), reversedRule...)
 				log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Removing %s rule", prog)
-				err = runProg(prog, deleteRule, true)
+				err = prog.runProg(deleteRule, true)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to delete Cilium %s rule", prog)
 				}
@@ -212,8 +233,8 @@ func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 }
 
 func (c *customChain) remove(waitArgs []string, quiet bool) {
-	doProcess := func(c *customChain, prog string, args []string, operation string, quiet bool) {
-		combinedOutput, err := runProgCombinedOutput(prog, args, true)
+	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
+		combinedOutput, err := prog.runProgCombinedOutput(args, true)
 		if err != nil {
 			// If the chain is for transient rules and deletion
 			// fails for a reason other than the chain not being
@@ -221,26 +242,24 @@ func (c *customChain) remove(waitArgs []string, quiet bool) {
 			// This is to help debug #11276.
 			msgChainNotFound := ": No chain/target/match by that name.\n"
 			debugTransientRules := c.name == ciliumTransientForwardChain &&
-				string(combinedOutput) != prog+msgChainNotFound
+				string(combinedOutput) != prog.getProg()+msgChainNotFound
 			if !quiet || debugTransientRules {
 				log.Warnf(string(combinedOutput))
 				log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to process chain %s with %s (%s)", c.name, prog, operation)
 			}
 		}
 	}
-	doRemove := func(c *customChain, prog string, waitArgs []string, quiet bool) {
+	doRemove := func(c *customChain, prog iptablesInterface, waitArgs []string, quiet bool) {
 		args := append(waitArgs, "-t", c.table, "-F", c.name)
 		doProcess(c, prog, args, "flush", quiet)
 		args = append(waitArgs, "-t", c.table, "-X", c.name)
 		doProcess(c, prog, args, "delete", quiet)
 	}
 	if option.Config.EnableIPv4 {
-		prog := "iptables"
-		doRemove(c, prog, waitArgs, quiet)
+		doRemove(c, ip4tables, waitArgs, quiet)
 	}
 	if option.Config.EnableIPv6 && c.ipv6 {
-		prog := "ip6tables"
-		doRemove(c, prog, waitArgs, quiet)
+		doRemove(c, ip6tables, waitArgs, quiet)
 	}
 }
 
@@ -252,13 +271,13 @@ func (c *customChain) installFeeder(waitArgs []string) error {
 
 	for _, feedArgs := range c.feederArgs {
 		if option.Config.EnableIPv4 {
-			err := runProg("iptables", append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
+			err := ip4tables.runProg(append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
 			if err != nil {
 				return err
 			}
 		}
 		if option.Config.EnableIPv6 && c.ipv6 == true {
-			err := runProg("ip6tables", append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
+			err := ip6tables.runProg(append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
 			if err != nil {
 				return err
 			}
@@ -361,7 +380,7 @@ type IptablesManager struct {
 // availability.
 func (m *IptablesManager) Init() {
 	modulesManager := &modules.ModulesManager{}
-	ip6tables := true
+	haveIp6tables := true
 	if err := modulesManager.Init(); err != nil {
 		log.WithError(err).Fatal(
 			"Unable to get information about kernel modules")
@@ -380,9 +399,9 @@ func (m *IptablesManager) Init() {
 		}
 		log.WithError(err).Debug(
 			"ip6tables kernel modules could not be loaded, so IPv6 cannot be used")
-		ip6tables = false
+		haveIp6tables = false
 	}
-	m.haveIp6tables = ip6tables
+	m.haveIp6tables = haveIp6tables
 
 	if err := modulesManager.FindOrLoadModules("xt_socket"); err != nil {
 		if option.Config.Tunnel == option.TunnelDisabled {
@@ -424,7 +443,7 @@ func (m *IptablesManager) Init() {
 		m.haveSocketMatch = true
 	}
 
-	v, err := getVersion("iptables")
+	v, err := ip4tables.getVersion()
 	if err == nil {
 		switch {
 		case isWaitSecondsMinVersion(v):
@@ -450,14 +469,14 @@ func (m *IptablesManager) RemoveRules(quiet bool) {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, "iptables", ciliumPrefix)
+		m.removeCiliumRules(t, ip4tables, ciliumPrefix)
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.haveIp6tables {
 		tables6 := []string{"mangle", "raw", "filter"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, "ip6tables", ciliumPrefix)
+			m.removeCiliumRules(t, ip6tables, ciliumPrefix)
 		}
 	}
 
@@ -508,13 +527,13 @@ func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyP
 
 	var err error
 	if option.Config.EnableIPv4 {
-		err = runProg("iptables",
+		err = ip4tables.runProg(
 			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
 				ingressProxyMark, ingressProxyPort, name),
 			false)
 	}
 	if err == nil && option.Config.EnableIPv6 {
-		err = runProg("ip6tables",
+		err = ip6tables.runProg(
 			m.ingressProxyRule(cmd, l4proto, ingressMarkMatch,
 				ingressProxyMark, ingressProxyPort, name),
 			false)
@@ -544,13 +563,13 @@ func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPo
 
 	var err error
 	if option.Config.EnableIPv4 {
-		err = runProg("iptables",
+		err = ip4tables.runProg(
 			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
 				egressProxyMark, egressProxyPort, name),
 			false)
 	}
 	if err == nil && option.Config.EnableIPv6 {
-		err = runProg("ip6tables",
+		err = ip6tables.runProg(
 			m.egressProxyRule(cmd, l4proto, egressMarkMatch,
 				egressProxyMark, egressProxyPort, name),
 			false)
@@ -567,7 +586,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	var err error
 	if option.Config.EnableIPv4 {
 		// No conntrack for traffic to proxy
-		err = runProg("iptables", append(
+		err = ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
@@ -577,7 +596,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumInputChain,
@@ -587,7 +606,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic that is heading to lxc+
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
@@ -598,7 +617,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic that is heading to cilium_host
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
@@ -610,7 +629,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("iptables", append(
+			err = ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumOutputChain,
@@ -620,12 +639,12 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil && m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
-			err = runProg("iptables", m.inboundProxyRedirectRule("-A"), false)
+			err = ip4tables.runProg(m.inboundProxyRedirectRule("-A"), false)
 		}
 	}
 	if err == nil && option.Config.EnableIPv6 {
 		// No conntrack for traffic to ingress proxy
-		err = runProg("ip6tables", append(
+		err = ip6tables.runProg(append(
 			m.waitArgs,
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
@@ -635,7 +654,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("ip6tables", append(
+			err = ip6tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumInputChain,
@@ -645,7 +664,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic
-			err = runProg("ip6tables", append(
+			err = ip6tables.runProg(append(
 				m.waitArgs,
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
@@ -656,7 +675,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		if err == nil {
 			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = runProg("ip6tables", append(
+			err = ip6tables.runProg(append(
 				m.waitArgs,
 				"-t", "filter",
 				"-A", ciliumOutputChain,
@@ -666,7 +685,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 		}
 		if err == nil && m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
-			err = runProg("ip6tables", m.inboundProxyRedirectRule("-A"), false)
+			err = ip6tables.runProg(m.inboundProxyRedirectRule("-A"), false)
 		}
 	}
 	return err
@@ -702,12 +721,12 @@ func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name
 // By convention "ingress" or "egress" is part of 'name' so it does not need to be specified explicitly.
 // Returns 0 a TPROXY entry with 'name' can not be found.
 func (m *IptablesManager) GetProxyPort(name string) uint16 {
-	prog := "iptables"
+	prog := ip4tables
 	if !option.Config.EnableIPv4 {
-		prog = "ip6tables"
+		prog = ip6tables
 	}
 
-	res, err := runProgCombinedOutput(prog, []string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, false)
+	res, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, true)
 	if err != nil {
 		return 0
 	}
@@ -737,18 +756,18 @@ func getDeliveryInterface(ifName string) string {
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
 	if option.Config.EnableIPv4 {
-		err := m.installForwardChainRulesIpX("iptables", ifName, localDeliveryInterface, forwardChain)
+		err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, forwardChain)
 		if err != nil {
 			return err
 		}
 	}
 	if option.Config.EnableIPv6 {
-		return m.installForwardChainRulesIpX("ip6tables", ifName, localDeliveryInterface, forwardChain)
+		return m.installForwardChainRulesIpX(ip6tables, ifName, localDeliveryInterface, forwardChain)
 	}
 	return nil
 }
 
-func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliveryInterface, forwardChain string) error {
+func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, ifName, localDeliveryInterface, forwardChain string) error {
 	transient := ""
 	if forwardChain == ciliumTransientForwardChain {
 		transient = " (transient)"
@@ -775,7 +794,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 	//  - Node running backend:
 	//       IN=eno1 OUT=cilium_host
 	//       IN=lxc... OUT=eno1
-	if err := runProg(prog, append(
+	if err := prog.runProg(append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-o", ifName,
@@ -783,7 +802,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg(prog, append(
+	if err := prog.runProg(append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", ifName,
@@ -791,7 +810,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 		"-j", "ACCEPT"), false); err != nil {
 		return err
 	}
-	if err := runProg(prog, append(
+	if err := prog.runProg(append(
 		m.waitArgs,
 		"-A", forwardChain,
 		"-i", "lxc+",
@@ -803,7 +822,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 	// TODO: Make 'cilium_net' configurable if we ever support other than "cilium_host" as the Cilium host device.
 	if ifName == "cilium_host" {
 		ifPeerName := "cilium_net"
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", ifPeerName,
@@ -816,7 +835,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 	// same (enable-endpoint-routes), a separate set of rules to allow
 	// from/to delivery interface is required.
 	if localDeliveryInterface != ifName {
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
@@ -824,7 +843,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog, ifName, localDeliver
 			"-j", "ACCEPT"), false); err != nil {
 			return err
 		}
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
@@ -849,7 +868,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 		if err := transientChain.add(m.waitArgs); err != nil {
 			return fmt.Errorf("cannot add custom chain %s: %s", transientChain.name, err)
 		}
-		if err := m.installForwardChainRulesIpX("iptables", ifName, localDeliveryInterface, transientChain.name); err != nil {
+		if err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, transientChain.name); err != nil {
 			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
 		}
 		if err := transientChain.installFeeder(m.waitArgs); err != nil {
@@ -862,7 +881,7 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 // TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
 func (m *IptablesManager) TransientRulesEnd(quiet bool) {
 	if option.Config.EnableIPv4 {
-		m.removeCiliumRules("filter", "iptables", ciliumTransientForwardChain)
+		m.removeCiliumRules("filter", ip4tables, ciliumTransientForwardChain)
 		transientChain.remove(m.waitArgs, quiet)
 	}
 }
@@ -925,7 +944,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		// originated from the host.
 		matchFromProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyMask)
 		markAsFromHost := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkHost, linux_defaults.MagicMarkHostMask)
-		if err := runProg("iptables", append(
+		if err := ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", "filter",
 			"-A", ciliumOutputChain,
@@ -965,7 +984,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				if option.Config.IPTablesRandomFully {
 					progArgs = append(progArgs, "--random-fully")
 				}
-				if err := runProg("iptables", progArgs, false); err != nil {
+				if err := ip4tables.runProg(progArgs, false); err != nil {
 					return err
 				}
 			} else {
@@ -981,7 +1000,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				if option.Config.IPTablesRandomFully {
 					progArgs = append(progArgs, "--random-fully")
 				}
-				if err := runProg("iptables", progArgs, false); err != nil {
+				if err := ip4tables.runProg(progArgs, false); err != nil {
 					return err
 				}
 			}
@@ -989,8 +1008,8 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			// The following rule exclude traffic from the remaining rules in this chain.
 			// If this rule matches, none of the remaining rules in this chain
 
-			// Exclude proxy return traffic from the masquerade rules
-			if err := runProg("iptables", append(
+			// Exclude proxy return traffic from the masquerade rules.
+			if err := ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "nat",
 				"-A", ciliumPostNatChain,
@@ -1008,7 +1027,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				// * Must be targeted for the ifName interface
 				// * Must be targeted to an IP that is not local
 				// * May not already be originating from the node's pod CIDR.
-				if err := runProg("iptables", append(
+				if err := ip4tables.runProg(append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
@@ -1029,7 +1048,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			// The following conditions must be met:
 			// * Must be targeted for local endpoint
 			// * Must be from 127.0.0.1
-			if err := runProg("iptables", append(
+			if err := ip4tables.runProg(append(
 				m.waitArgs,
 				"-t", "nat",
 				"-A", ciliumPostNatChain,
@@ -1056,7 +1075,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			//    on the same node
 			//  - kiam if source and server are on the same node
 			if !option.Config.EnableEndpointRoutes {
-				if err := runProg("iptables", append(
+				if err := ip4tables.runProg(append(
 					m.waitArgs,
 					"-t", "nat",
 					"-A", ciliumPostNatChain,
@@ -1109,12 +1128,12 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 	return nil
 }
 
-func (m *IptablesManager) ciliumNoTrackXfrmRules(prog, input string) error {
+func (m *IptablesManager) ciliumNoTrackXfrmRules(prog iptablesInterface, input string) error {
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
 	for _, match := range []string{matchFromIPSecDecrypt, matchFromIPSecEncrypt} {
-		if err := runProg(prog, append(
+		if err := prog.runProg(append(
 			m.waitArgs,
 			"-t", "raw", input, ciliumPreRawChain,
 			"-m", "mark", "--mark", match,
@@ -1140,7 +1159,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 
 		comment := "exclude xfrm marks from " + table + " " + chain + " chain"
 
-		if err := runProg("iptables", append(
+		if err := ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", table,
 			"-A", chain,
@@ -1150,7 +1169,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 			return err
 		}
 
-		return runProg("iptables", append(
+		return ip4tables.runProg(append(
 			m.waitArgs,
 			"-t", table,
 			"-A", chain,
@@ -1181,7 +1200,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 
 func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 	if option.Config.EnableIPv4 {
-		return m.ciliumNoTrackXfrmRules("iptables", "-I")
+		return m.ciliumNoTrackXfrmRules(ip4tables, "-I")
 	}
 	return nil
 }
@@ -1202,7 +1221,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 	// Note: these rules need the xt_connmark module (iptables usually
 	// loads it when required, unless loading modules after boot has been
 	// disabled).
-	if err := runProg("iptables", append(
+	if err := ip4tables.runProg(append(
 		m.waitArgs,
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
@@ -1213,7 +1232,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		false); err != nil {
 		return err
 	}
-	return runProg("iptables", append(
+	return ip4tables.runProg(append(
 		m.waitArgs,
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -1,0 +1,150 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package iptables
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/blang/semver"
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type iptablesTestSuite struct{}
+
+var _ = check.Suite(&iptablesTestSuite{})
+
+type expectation struct {
+	args string
+	out  []byte
+	err  error
+}
+
+type mockIptables struct {
+	c            *check.C
+	prog         string
+	expectations []expectation
+	index        int
+}
+
+func (ipt *mockIptables) addExpectation(args string, out []byte, err error) {
+	ipt.expectations = append(ipt.expectations, expectation{args: args, out: out, err: err})
+}
+
+func (ipt *mockIptables) getProg() string {
+	return ipt.prog
+}
+
+func (ipt *mockIptables) getVersion() (semver.Version, error) {
+	return semver.Version{}, nil
+}
+
+func (ipt *mockIptables) runProgCombinedOutput(args []string, quiet bool) (out []byte, err error) {
+	a := strings.Join(args, " ")
+	i := ipt.index
+	ipt.index++
+
+	if len(ipt.expectations) < ipt.index {
+		ipt.c.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
+		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+	}
+	if a != ipt.expectations[i].args {
+		ipt.c.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
+		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+	}
+	out = ipt.expectations[i].out
+	err = ipt.expectations[i].err
+
+	return out, err
+}
+
+func (ipt *mockIptables) runProg(args []string, quiet bool) error {
+	out, err := ipt.runProgCombinedOutput(args, quiet)
+	if len(out) > 0 {
+		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
+	}
+	return err
+}
+
+func (ipt *mockIptables) checkExpectations() error {
+	if ipt.index != len(ipt.expectations) {
+		return fmt.Errorf("%d unmet expectations", len(ipt.expectations)-ipt.index)
+	}
+
+	// reset index for further testing
+	ipt.index = 0
+
+	return nil
+}
+
+var mockManager = &IptablesManager{
+	haveIp6tables:        false,
+	haveSocketMatch:      true,
+	ipEarlyDemuxDisabled: false,
+	waitArgs:             nil,
+}
+
+func init() {
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = true
+}
+
+func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j CILIUM_PRE_mangle",
+		}, {
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j CILIUM_POST_mangle",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	mockManager.removeCiliumRules("mangle", mockIp4tables, ciliumPrefix)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -224,18 +224,18 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		},
 	}
 
 	// Adds new proxy rules
-	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -259,16 +259,16 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		},
 	}
 
 	// Nothing to add
-	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -292,18 +292,18 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
 -A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
 		},
 	}
 
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp4tables, 43479, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }
@@ -358,9 +358,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43477",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43477",
 		},
 	}
 
@@ -426,9 +426,9 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43479",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43479",
 		},
 	}
 

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -110,6 +110,334 @@ func init() {
 	option.Config.EnableIPv6 = true
 }
 
+func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -E CILIUM_PRE_mangle OLD_CILIUM_PRE_mangle",
+		},
+	}
+	chain := &customChain{
+		table: "mangle",
+		name:  "CILIUM_PRE_mangle",
+	}
+	chain.doRename(mockIp4tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = mockIp4tables.expectations
+	chain.doRename(mockIp6tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestCopyProxyRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-random-proxy proxy" -j TPROXY --on-port 43499 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp4tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestCopyProxyRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-random-proxy proxy" -j TPROXY --on-port 43499 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp6tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	err := mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		},
+	}
+
+	// Adds new proxy rules
+	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Nothing to add
+	mockManager.addProxyRules(mockIp4tables, 43477, false, "cilium-dns-egress")
+	err = mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		},
+	}
+
+	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
+	mockManager.addProxyRules(mockIp4tables, 43479, false, "cilium-dns-egress")
+	err = mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestGetProxyPort(c *check.C) {
+	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -n -L CILIUM_PRE_mangle",
+			out: []byte(
+				`Chain CILIUM_PRE_mangle (1 references)
+target     prot opt source               destination         
+MARK       all  --  0.0.0.0/0            0.0.0.0/0            socket --transparent /* cilium: any->pod redirect proxied traffic to host proxy */ MARK set 0x200
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd5a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43477 mark 0x200/0xffffffff
+TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xd7a90200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 0.0.0.0:43479 mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Finds the latest porte number if multiple rules for the same proxy name
+	port := mockManager.doGetProxyPort(mockIp4tables, "cilium-dns-egress")
+	c.Assert(port, check.Equals, uint16(43479))
+	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43477",
+		},
+	}
+
+	// Adds new proxy rules
+	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	err := mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		},
+	}
+
+	// Nothing to add
+	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x00000200 --on-port 43479",
+		},
+	}
+
+	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
+	mockManager.addProxyRules(mockIp6tables, 43479, false, "cilium-dns-egress")
+	err = mockIp6tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
 func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
@@ -121,30 +449,85 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 -P FORWARD ACCEPT
 -P OUTPUT ACCEPT
 -P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
 -N CILIUM_POST_mangle
 -N CILIUM_PRE_mangle
 -N KUBE-KUBELET-CANARY
 -N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
 -A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
 -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j CILIUM_PRE_mangle",
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
 		}, {
-			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j CILIUM_POST_mangle",
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
 		}, {
-			args: "-t mangle -D CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 
-	mockManager.removeCiliumRules("mangle", mockIp4tables, ciliumPrefix)
+	// Only removes Cilium chains with the OLD_ prefix
+	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix)
 	err := mockIp4tables.checkExpectations()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
+	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
+	mockIp6tables.expectations = []expectation{
+		{
+			args: "-t mangle -S",
+			out: []byte(
+				`-P PREROUTING ACCEPT
+-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-P POSTROUTING ACCEPT
+-N OLD_CILIUM_POST_mangle
+-N OLD_CILIUM_PRE_mangle
+-N CILIUM_POST_mangle
+-N CILIUM_PRE_mangle
+-N KUBE-KUBELET-CANARY
+-N KUBE-PROXY-CANARY
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
+-A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
+-A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
+-A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+-A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
+`),
+		}, {
+			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
+		}, {
+			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		}, {
+			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		},
+	}
+
+	// Only removes Cilium chains with the OLD_ prefix
+	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix)
+	err := mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -68,18 +68,11 @@ type IptablesManager interface {
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
 	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
 
-	// RemoveProxyRules creates the necessary datapath config (e.g., iptables
-	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
-
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	RemoveRules(quiet bool)
-	InstallRules(ifName string) error
-	TransientRulesStart(ifName string) error
-	TransientRulesEnd(quiet bool)
+	InstallRules(ifName string, quiet, install bool) error
 
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -446,25 +446,11 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if option.Config.InstallIptRules {
-		if err := iptMgr.TransientRulesStart(option.Config.HostDevice); err != nil {
-			log.WithError(err).Warning("failed to install transient iptables rules")
-		}
+	if err := iptMgr.InstallRules(option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
+		return err
 	}
-	// The iptables rules are only removed on the first initialization to
-	// remove stale rules or when iptables is enabled. The first invocation
-	// is silent as rules may not exist.
-	if firstInitialization || option.Config.InstallIptRules {
-		iptMgr.RemoveRules(firstInitialization)
-	}
-	if option.Config.InstallIptRules {
-		err := iptMgr.InstallRules(option.Config.HostDevice)
-		iptMgr.TransientRulesEnd(false)
-		if err != nil {
-			return err
-		}
-	}
-	// Reinstall proxy rules for any running proxies
+
+	// Reinstall proxy rules for any running proxies if needed
 	if p != nil {
 		p.ReinstallRules()
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -916,20 +916,20 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 		// Always execute the finalization code, even if the endpoint is
 		// terminating, in order to properly release resources.
 		e.unconditionalLock()
+		defer e.unlock() // In case Finalize() panics
 		e.getLogger().Debug("Finalizing successful endpoint regeneration")
 		datapathRegenCtx.finalizeList.Finalize()
-		e.unlock()
 	} else {
 		if err := e.lockAlive(); err != nil {
 			e.getLogger().WithError(err).Debug("Skipping unnecessary reverting of endpoint regeneration changes")
 			return
 		}
+		defer e.unlock() // In case Revert() panics
 		e.getLogger().Debug("Reverting endpoint changes after BPF regeneration failed")
 		if err := datapathRegenCtx.revertStack.Revert(); err != nil {
 			e.getLogger().WithError(err).Error("Reverting endpoint regeneration changes failed")
 		}
 		e.getLogger().Debug("Finished reverting endpoint changes after BPF regeneration failed")
-		e.unlock()
 	}
 }
 


### PR DESCRIPTION
 * #16391 -- iptables: Keep old rules while adding new ones (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16391; do contrib/backporting/set-labels.py $pr done 1.8; done
```

```release-note
DNS proxy is now more available during Cilium restarts, including upgrades. 
```
