### PR TITLE
[v1.10] fix condition for running documentation GitHub action on Helm updates

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,7 +30,7 @@ jobs:
               - 'cilium-health/cmd/**'
               - 'daemon/cmd/**'
               - 'hubble-relay/cmd/**'
-              - 'install/kubernetes/**/'
+              - 'install/kubernetes/**'
               - 'operator/cmd/**'
 
   # Runs only if code under Documentation or */cmd/ is changed as the docs


### PR DESCRIPTION
 * #16737  (@qmonnet)
   Manual backport because only one commit of the two in the PR needed a backport.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ contrib/backporting/set-labels.py 16737 done 1.10
```