### PR TITLE
contrib/docs: rename 'cilium-actions.yml' with 'maintainers-little-helper.yaml

### DIFF
--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -48,7 +48,7 @@ On Freeze date
 #. Create a new project named "X.Y.Z" to automatically track the backports
    for that particular release. `Direct Link: <https://github.com/cilium/cilium/projects/new>`_
 
-#. Copy the ``.github/cilium-actions.yml`` from the previous release ``vX.Y-1``
+#. Copy the ``.github/maintainers-little-helper.yaml`` from the previous release ``vX.Y-1``
    change the contents to be relevant for the release ``vX.Y`` and set the
    ``project:`` to be the generated link created by the previous step. The link
    should be something like: ``https://github.com/cilium/cilium/projects/NNN``
@@ -76,7 +76,7 @@ On Freeze date
    #. ``needs-backport/1.2``
 
 
-#. Checkout to master and update the ``.github/cilium-actions.yml`` to have
+#. Checkout to master and update the ``.github/maintainers-little-helper.yaml`` to have
    all the necessary configurations for the backport of the new ``vX.Y`` branch.
    Specifically, ensure that:
 
@@ -87,8 +87,8 @@ On Freeze date
    .. code-block:: shell-session
 
        $ git checkout -b pr/master-cilium-actions-update origin/master
-       $ # modify .github/cilium-actions.yml
-       $ git add .github/cilium-actions.yml
+       $ # modify .github/maintainers-little-helper.yaml
+       $ git add .github/maintainers-little-helper.yaml
        $ git commit
        $ git push
 

--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -10,7 +10,7 @@ MAJ_REGEX='[0-9]\+\.[0-9]\+'
 MIN_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
 REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 latest_stable=""

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -7,7 +7,7 @@ source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 usage() {


### PR DESCRIPTION
Commit a93c0ed53691 renamed the MLH configuration file. Unfortunately in
a lot of places this filename was set and this commit renames those
locations with this new filename.

Fixes: a93c0ed53691 (".github: Rename maintainer's little helper's config file")
Signed-off-by: André Martins <andre@cilium.io>