### PR TITLE
docs(k3s): add back the flag to disable network policies

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -21,11 +21,11 @@ Install a Master Node
 =====================
 
 The first step is to install a K3s master node making sure to disable support
-for the default CNI plugin:
+for the default CNI plugin and the built-in network policy enforcer:
 
 .. code-block:: shell-session
 
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none' sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none --disable-network-policy' sh -
 
 Install Agent Nodes (Optional)
 ==============================


### PR DESCRIPTION
This was actually added in https://github.com/cilium/cilium/pull/13783 but got removed again after some other changes.
That flag is required because otherwise any liveness or readiness probes will be classified as *world* traffic and get
dropped if network policies are installed.

Signed-off-by: Rio Kierkels <riokierkels@gmail.com>