### PR TITLE
Revert "docs: add 'endpointRoutes.enabled=true' to aws-cni"

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -61,8 +61,7 @@ Deploy Cilium via Helm:
      --set cni.chainingMode=aws-cni \\
      --set enableIPv4Masquerade=false \\
      --set tunnel=disabled \\
-     --set nodeinit.enabled=true \\
-     --set endpointRoutes.enabled=true
+     --set nodeinit.enabled=true
 
 This will enable chaining with the AWS VPC CNI plugin. It will also disable
 tunneling, as it's not required since ENI IP addresses can be directly routed


### PR DESCRIPTION
This reverts commit 437e2bbd745a074b6dd140e4bd17208e3ba499f0. The original issue has been fixed, and hence this can be removed (c.f. https://github.com/cilium/cilium/pull/16227).