### PR TITLE
test: Fix artifact collection for FQDN matchPattern test

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -732,7 +732,7 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 	// No need to create file for bugtool because it creates an archive of files
 	// for us.
 	res := s.ExecWithSudo(
-		fmt.Sprintf("%s -t %s", CiliumBugtool, filepath.Join(s.basePath, testPath)),
+		fmt.Sprintf("%s -t %q", CiliumBugtool, filepath.Join(s.basePath, testPath)),
 		ExecOptions{SkipLog: true})
 	if !res.WasSuccessful() {
 		s.logger.Errorf("Error running bugtool: %s", res.CombineOutput())

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -740,7 +740,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		}
 	})
 
-	It(`Implements matchPattern: "*"`, func() {
+	It(`Implements matchPattern: *`, func() {
 		By(`Importing policy with matchPattern: "*" rule`)
 		fqdnPolicy := `
 [


### PR DESCRIPTION
This pull request fixes a couple artifact collection bugs. See the commits for details.

It was tested with a purposely-broken test at https://jenkins.cilium.io/job/Cilium-PR-Runtime-4.9/5208/testReport/junit/(root)/Suite-runtime/RuntimeFQDNPolicies_Implements_matchPattern___/. You can see the artifact there and it also has the bugtool report. To be compared to the broken artifact collection at https://jenkins.cilium.io/job/cilium-master-runtime-kernel-4.9/2247/testReport/junit/(root)/Suite-runtime/RuntimeFQDNPolicies_Implements_matchPattern_____/.

Fixes: https://github.com/cilium/cilium/issues/16753.
Fixes: https://github.com/cilium/cilium/issues/16754.