### PR TITLE
istio: Update to release 1.9.6

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -38,20 +38,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.8.2 <https://github.com/cilium/istio/releases/tag/1.8.2>`_:
+Download the `cilium enhanced istioctl version 1.9.6 <https://github.com/cilium/istio/releases/tag/1.9.6>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. code-block:: shell-session
 
-        curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-linux-amd64.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.9.6/cilium-istioctl-1.9.6-linux-amd64.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. code-block:: shell-session
 
-        curl -L https://github.com/cilium/istio/releases/download/1.8.2/cilium-istioctl-1.8.2-osx.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.9.6/cilium-istioctl-1.9.6-osx.tar.gz | tar xz
 
 .. note::
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -37,7 +37,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.8.2"
+		istioVersion = "1.9.6"
 
 		// Modifiers for pre-release testing, normally empty
 		prerelease     = "" // "-beta.1"
@@ -47,9 +47,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.8.2" +
-		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.8.2" +
-		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.8.2" +
+		// " --set values.pilot.image=quay.io/cilium/istio_pilot:1.9.6" + prerelease +
+		// " --set values.global.proxy.image=quay.io/cilium/istio_proxy:1.9.6" + prerelease +
+		// " --set values.global.proxy_init.image=quay.io/cilium/istio_proxy:1.9.6" + prerelease +
 		// " --set values.global.proxy.logLevel=trace"
 		// " --set values.global.logging.level=debug"
 		// " --set values.global.mtls.auto=false"


### PR DESCRIPTION
Update Cilium Istio integration to Istio release 1.9.6.

The new docker images are being served from quay.io instead of docker.io.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
Cilium Istio integration is updated to Istio release 1.9.6.
```
