### PR TITLE
test: Redeploy DNS after endpointRoutes reconfiguration

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -316,6 +316,10 @@ func GetCiliumNamespace(integration string) string {
 type Kubectl struct {
 	Executor
 	*serviceCache
+
+	// ciliumOptions is a cache of the most recent configuration options
+	// used to install Cilium via CiliumInstall().
+	ciliumOptions map[string]string
 }
 
 // CreateKubectl initializes a Kubectl helper with the provided vmName and log
@@ -383,6 +387,7 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 
 	// Clean any leftover resources in the default namespace
 	k.CleanNamespace(DefaultNamespace)
+	k.ciliumOptions = make(map[string]string)
 
 	return k
 }
@@ -2038,15 +2043,22 @@ iteratePods:
 	}
 }
 
+// RedeployDNS deletes the kube-dns pods and does not wait for the deletion
+// to complete. Useful to ensure that the pods are recreated after datapath
+// configuration changes.
+func (kub *Kubectl) RedeployDNS() *CmdRes {
+	return kub.DeleteResource("pod", "-n "+KubeSystemNamespace+" -l "+kubeDNSLabel)
+}
+
 // RedeployKubernetesDnsIfNecessary validates if the Kubernetes DNS is
 // functional and re-deploys it if it is not and then waits for it to deploy
 // successfully and become operational. See ValidateKubernetesDNS() for the
 // list of conditions that must be met for Kubernetes DNS to be considered
 // operational.
-func (kub *Kubectl) RedeployKubernetesDnsIfNecessary() {
+func (kub *Kubectl) RedeployKubernetesDnsIfNecessary(force bool) {
 	ginkgoext.By("Validating if Kubernetes DNS is deployed")
 	err := kub.ValidateKubernetesDNS()
-	if err == nil {
+	if err == nil && !force {
 		ginkgoext.By("Kubernetes DNS is up and operational")
 		return
 	} else {
@@ -2054,7 +2066,7 @@ func (kub *Kubectl) RedeployKubernetesDnsIfNecessary() {
 	}
 
 	ginkgoext.By("Restarting Kubernetes DNS (-l %s)", kubeDNSLabel)
-	res := kub.DeleteResource("pod", "-n "+KubeSystemNamespace+" -l "+kubeDNSLabel)
+	res := kub.RedeployDNS()
 	if !res.WasSuccessful() {
 		ginkgoext.Failf("Unable to delete DNS pods: %s", res.OutputPrettyPrint())
 	}
@@ -2512,6 +2524,8 @@ func (kub *Kubectl) CiliumInstall(filename string, options map[string]string) er
 	if !res.WasSuccessful() {
 		return res.GetErr("Unable to apply YAML")
 	}
+
+	kub.ciliumOptions = options
 
 	return nil
 }
@@ -4463,4 +4477,10 @@ func (kub *Kubectl) NslookupInPod(namespace, pod string, target string) (err err
 		return err
 	}
 	return nil
+}
+
+// CiliumOptions returns the most recently used set of options for installing
+// Cilium into the cluster.
+func (kub *Kubectl) CiliumOptions() map[string]string {
+	return kub.ciliumOptions
 }


### PR DESCRIPTION
In general up until now, Cilium has expected endpointRoutes mode to be
set to exactly one value upon deployment and for that value to stay the
same for the remainder of operation. Toggling it can lead to a mix of
endpoints in different datapath modes which is not well covered in CI.

In Github issue #16717 we observed that if the testsuite toggles this
setting then we can end up with kubedns pods remaining in endpoint
routes mode, even though the rest of the daemon (and other pods) are not
configured in this mode. This can lead to connectivity issues in DNS,
and a range of test failures in subsequent tests because DNS is broken.

Longer term to resolve this, we could improve on Cilium to ensure that
users can successfully toggle this setting on or off at runtime and
properly handle this case, or alternatively shift all logic over to
endpoint-routes mode by default and disable the other option.

Given that CI for the master branch is in a poor state due to this issue
today, and that part of the issue is CI reconfiguring the datapath state
of Cilium during the test setup in an unsupported manner, this commit
proposes to force DNS pod redeployment as part of setup any time a test
reconfigures the endpointRoutes mode. This should mitigate the testing
side issue while we mull over the right longer-term solution.

Fixes: #16717
Fixes: https://github.com/cilium/cilium/pull/16227
Related: #14955
