### PR TITLE
test: Don't pass namespace for CCNPs

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -896,7 +896,7 @@ func testHostFirewall(kubectl *helpers.Kubectl) {
 
 	demoHostPolicies := helpers.ManifestGet(kubectl.BasePath(), "host-policies.yaml")
 	By(fmt.Sprintf("Applying policies %s", demoHostPolicies))
-	_, err := kubectl.CiliumPolicyAction(randomNs, demoHostPolicies, helpers.KubectlApply, helpers.HelperTimeout)
+	_, err := kubectl.CiliumClusterwidePolicyAction(demoHostPolicies, helpers.KubectlApply, helpers.HelperTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", demoHostPolicies, err))
 
 	var wg sync.WaitGroup

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -879,14 +879,14 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 							})
 
 							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
-							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
 								helpers.KubectlApply, helpers.HelperTimeout)
 							Expect(err).Should(BeNil(),
 								"Policy %s cannot be applied", ccnpHostPolicy)
 						})
 
 						AfterAll(func() {
-							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
 								helpers.KubectlDelete, helpers.HelperTimeout)
 							Expect(err).Should(BeNil(),
 								"Policy %s cannot be deleted", ccnpHostPolicy)
@@ -1011,14 +1011,14 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 							})
 
 							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
-							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
 								helpers.KubectlApply, helpers.HelperTimeout)
 							Expect(err).Should(BeNil(),
 								"Policy %s cannot be applied", ccnpHostPolicy)
 						})
 
 						AfterAll(func() {
-							_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, ccnpHostPolicy,
+							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
 								helpers.KubectlDelete, helpers.HelperTimeout)
 							Expect(err).Should(BeNil(),
 								"Policy %s cannot be deleted", ccnpHostPolicy)


### PR DESCRIPTION
Host policies are CCNPs and therefore not namespaces. To avoid the following warning, we should therefore avoid passing a namespace name to `kubectl apply` and `kubectl delete`.

    warning: deleting cluster-scoped resources, not scoped to the provided namespace