### PR TITLE
v1.10 backports 2021-07-05

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -140,21 +140,43 @@ jobs:
             az account show
 
       - name: Create AKS cluster
+        id: cluster-creation
         run: |
+          # Create group
           az group create \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --tags "owner=${{ steps.vars.outputs.owner }}"
+            --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
+
+          # Create cluster with a 1 node-count (we will remove this node pool
+          # afterwards)
+          # Details: Basic load balancers are not supported with multiple node
+          # pools. Create a cluster with standard load balancer selected to use
+          # multiple node pools, learn more at https://aka.ms/aks/nodepools.
           az aks create \
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
             --network-plugin azure \
+            --node-count 1 \
+            --load-balancer-sku standard \
+            --generate-ssh-keys
+
+          # Get the name of the node pool that we will delete afterwards
+          echo ::set-output name=nodepool_to_delete::$(az aks nodepool list --cluster-name ${{ env.name }} -g ${{ env.name }} -o json | jq -r '.[0].name')
+
+          # Create a node pool with the taint 'node.cilium.io/agent-not-ready=true:NoSchedule'
+          # and with 'mode=system' as it it the same mode used for the nodepool
+          # created with the cluster.
+          az aks nodepool add \
+            --name nodepool2 \
+            --cluster-name ${{ env.name }} \
+            --resource-group ${{ env.name }} \
             --node-count 2 \
             --node-vm-size Standard_B2s \
             --node-osdisk-size 30 \
-            --load-balancer-sku basic \
-            --generate-ssh-keys
+            --mode system \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule
 
       - name: Get cluster credentials
         run: |
@@ -172,6 +194,17 @@ jobs:
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+
+      - name: Delete the first node pool
+        run: |
+          # We can only delete the first node pool after Cilium is installed
+          # because some pods have Pod Disruption Budgets set. If we try to
+          # delete the first node pool without the second node pool being ready,
+          # AKS will not succeed with the pool deletion because some Deployments
+          # can't cease to exist in the cluster.
+          az aks nodepool delete --name ${{ steps.cluster-creation.outputs.nodepool_to_delete }} \
+            --cluster-name ${{ env.name }} \
+            --resource-group ${{ env.name }}
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -138,10 +138,34 @@ jobs:
 
       - name: Create EKS cluster without nodegroup
         run: |
-          eksctl create cluster \
-            --name ${{ env.clusterName }} \
-            --tags "usage=pr,owner=${{ steps.vars.outputs.owner }}" \
-            --without-nodegroup
+          cat <<EOF > eks-config.yaml
+          apiVersion: eksctl.io/v1alpha5
+          kind: ClusterConfig
+
+          metadata:
+            name: ${{ env.clusterName }}
+            region: ${{ env.region }}
+            tags:
+             usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+             owner: "${{ steps.vars.outputs.owner }}"
+
+          managedNodeGroups:
+          - name: ng-1
+            instanceTypes:
+             - t3.medium
+             - t3a.medium
+            desiredCapacity: 2
+            spot: true
+            privateNetworking: true
+            volumeType: "gp3"
+            volumeSize: 10
+            taints:
+             - key: "node.cilium.io/agent-not-ready"
+               value: "true"
+               effect: "NoSchedule"
+          EOF
+
+          eksctl create cluster -f ./eks-config.yaml
 
       - name: Wait for images to be available
         timeout-minutes: 10
@@ -153,18 +177,6 @@ jobs:
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
-
-      - name: Add managed spot nodegroup
-        run: |
-          eksctl create nodegroup \
-            --cluster ${{ env.clusterName }} \
-            --nodes 2 \
-            --instance-types "t3.medium,t3a.medium" \
-            --node-volume-type gp3 \
-            --node-volume-size 10 \
-            --managed \
-            --spot \
-            --node-private-networking
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -144,6 +144,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --preemptible
 
       - name: Get cluster credentials

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -144,6 +144,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --preemptible
 
       - name: Create GKE cluster 2
@@ -156,6 +157,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
+            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
             --preemptible
 
       - name: Get cluster credentials and setup contexts

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -38,6 +38,7 @@ cilium-agent [flags]
       --bpf-lb-dev-ip-addr-inherit string                    Device name which IP addr is inherited by devices running LB BPF program (--devices)
       --bpf-lb-dsr-dispatch string                           BPF load balancing DSR dispatch method ("opt", "ipip") (default "opt")
       --bpf-lb-dsr-l4-xlate string                           BPF load balancing DSR L4 DNAT method for IPIP ("frontend", "backend") (default "frontend")
+      --bpf-lb-external-clusterip                            Enable external access to ClusterIP services (default false)
       --bpf-lb-maglev-hash-seed string                       Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                        Maglev per service backend table size (parameter M) (default 16381)
       --bpf-lb-map-max int                                   Maximum number of entries in Cilium BPF lbmap (default 65536)

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -41,7 +41,7 @@ On Freeze date
 #. Create a new project named "X.Y.Z" to automatically track the backports
    for that particular release. `Direct Link: <https://github.com/cilium/cilium/projects/new>`_
 
-#. Copy the ``.github/cilium-actions.yml`` from the previous release ``vX.Y-1``
+#. Copy the ``.github/maintainers-little-helper.yaml`` from the previous release ``vX.Y-1``
    change the contents to be relevant for the release ``vX.Y`` and set the
    ``project:`` to be the generated link created by the previous step. The link
    should be something like: ``https://github.com/cilium/cilium/projects/NNN``
@@ -69,7 +69,7 @@ On Freeze date
    #. ``needs-backport/1.2``
 
 
-#. Checkout to master and update the ``.github/cilium-actions.yml`` to have
+#. Checkout to master and update the ``.github/maintainers-little-helper.yaml`` to have
    all the necessary configurations for the backport of the new ``vX.Y`` branch.
    Specifically, ensure that:
 
@@ -80,8 +80,8 @@ On Freeze date
    .. code-block:: shell-session
 
        $ git checkout -b pr/master-cilium-actions-update origin/master
-       $ # modify .github/cilium-actions.yml
-       $ git add .github/cilium-actions.yml
+       $ # modify .github/maintainers-little-helper.yaml
+       $ git add .github/maintainers-little-helper.yaml
        $ git commit
        $ git push
 

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -51,8 +51,7 @@ Deploy Cilium via Helm:
      --set cni.chainingMode=aws-cni \\
      --set enableIPv4Masquerade=false \\
      --set tunnel=disabled \\
-     --set nodeinit.enabled=true \\
-     --set endpointRoutes.enabled=true
+     --set nodeinit.enabled=true
 
 This will enable chaining with the AWS VPC CNI plugin. It will also disable
 tunneling, as it's not required since ENI IP addresses can be directly routed

--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -190,10 +190,6 @@ Install Cilium
 
        Cilium is now deployed and you are ready to scale-up the cluster:
 
-       .. code-block:: shell-session
-
-          eksctl create nodegroup --cluster test-cluster --nodes 2
-
     .. group-tab:: OpenShift
 
        .. include:: requirements-openshift.rst

--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -1,12 +1,13 @@
 Restart unmanaged Pods
 ======================
 
-If you did not use the ``nodeinit.restartPods=true`` in the Helm options when
-deploying Cilium, then unmanaged pods need to be restarted manually.  Restart
-all already running pods which are not running in host-networking mode to
-ensure that Cilium starts managing them. This is required to ensure that all
-pods which have been running before Cilium was deployed have network
-connectivity provided by Cilium and NetworkPolicy applies to them:
+If you did not create a cluster with the nodes tainted with the taint
+``node.cilium.io/agent-not-ready``, then unmanaged pods need to be restarted
+manually. Restart all already running pods which are not running in
+host-networking mode to ensure that Cilium starts managing them. This is
+required to ensure that all pods which have been running before Cilium was
+deployed have network connectivity provided by Cilium and NetworkPolicy applies
+to them:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -382,7 +382,7 @@ per service. If a higher number of backends are provisioned under this setting, 
 difference in reassignments on backend changes will increase.
 
 The ``maglev.hashSeed`` option is recommended to be set in order for Cilium to not rely on the
-fixed built-in seed. The seed is a base64-encoded 16 byte-random number, and can be
+fixed built-in seed. The seed is a base64-encoded 12 byte-random number, and can be
 generated once through ``head -c12 /dev/urandom | base64 -w0``, for example. Every Cilium agent
 in the cluster must use the same hash seed in order for Maglev to work.
 
@@ -392,7 +392,7 @@ given service (with the property of at most 1% difference on backend reassignmen
 
 .. parsed-literal::
 
-    SEED=$(head -c16 /dev/urandom | base64 -w0)
+    SEED=$(head -c12 /dev/urandom | base64 -w0)
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set kubeProxyReplacement=strict \\

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -636,6 +636,12 @@ As an instance example, ``m5n.xlarge`` is used in the config ``nodegroup-config.
       desiredCapacity: 2
       ssh:
         allow: true
+      # taint nodes so that application pods are
+      # not scheduled until Cilium is deployed.
+      taints:
+        - key: "node.cilium.io/agent-not-ready"
+          value: "true"
+          effect: "NoSchedule"
 
 The nodegroup is created with:
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1245,6 +1245,13 @@ For more information, ensure that you have the fix `Pull Request <https://github
     48498    getpeername4
     48494    getpeername6
 
+External Access To ClusterIP Services
+*************************************
+
+As per `k8s Service <https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types>`__,
+Cilium's eBPF kube-proxy replacement by default disallows access to a ClusterIP service from outside the cluster.
+This can be allowed by setting ``bpf.lbExternalClusterIP=true``.
+
 Limitations
 ###########
 
@@ -1275,9 +1282,6 @@ Limitations
       release introduces ``EndpointSliceMirroring`` controller that mirrors custom ``Endpoints``
       resources to corresponding ``EndpointSlices`` and thus allowing backing ``Endpoints``
       to work. For a more detailed discussion see :gh-issue:`12438`.
-    * As per `k8s Service <https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types>`__,
-      Cilium's eBPF kube-proxy replacement disallow access of a ClusterIP service
-      from outside a cluster.
 
 Further Readings
 ################

--- a/Documentation/gettingstarted/requirements-aks.rst
+++ b/Documentation/gettingstarted/requirements-aks.rst
@@ -20,6 +20,9 @@ Direct Routing  Azure IPAM          Kubernetes CRD
   compatibility with Cilium. The Azure network plugin will be replaced with
   Cilium by the installer.
 
+* Node pools must also be created with the taint ``node.cilium.io/agent-not-ready=true:NoSchedule``
+  using ``--node-taints`` option.
+
 **Limitations:**
 
 * All VMs and VM scale sets used in a cluster must belong to the same resource

--- a/Documentation/gettingstarted/requirements-eks.rst
+++ b/Documentation/gettingstarted/requirements-eks.rst
@@ -16,10 +16,35 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
    If you want to chain Cilium on top of the AWS CNI, refer to the guide
    :ref:`chaining_aws_cni`.
 
-**Requirements:**
+The following command creates a Kubernetes cluster with ``eksctl``
+using `Amazon Elastic Kubernetes Service
+<https://aws.amazon.com/eks/>`_.  See `eksctl Installation
+<https://github.com/weaveworks/eksctl>`_ for instructions on how to
+install ``eksctl`` and prepare your account.
 
-* It is recommended to create an EKS cluster without any nodes, install
-  Cilium, and then scale up the number of nodes with Cilium already deployed.
+.. code-block:: shell-session
+
+   export NAME="$(whoami)-$RANDOM"
+   cat <<EOF >eks-config.yaml
+   apiVersion: eksctl.io/v1alpha5
+   kind: ClusterConfig
+
+   metadata:
+     name: ${NAME}
+     region: eu-west-1
+
+   managedNodeGroups:
+   - name: ng-1
+     desiredCapacity: 2
+     privateNetworking: true
+     # taint nodes so that application pods are
+     # not scheduled until Cilium is deployed.
+     taints:
+      - key: "node.cilium.io/agent-not-ready"
+        value: "true"
+        effect: "NoSchedule"
+   EOF
+   eksctl create cluster -f ./eks-config.yaml
 
 **Limitations:**
 

--- a/Documentation/gettingstarted/requirements-gke.rst
+++ b/Documentation/gettingstarted/requirements-gke.rst
@@ -11,5 +11,5 @@ Direct Routing  Kubernetes PodCIDR  Kubernetes CRD
 
 **Requirements:**
 
-* No special requirements. The Cilium installer will automatically
-  reconfigure your GKE cluster to use CNI mode.
+* The cluster must  be created with the taint ``node.cilium.io/agent-not-ready=true:NoSchedule``
+  using ``--node-taints`` option.

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -362,7 +362,7 @@ In order to mount the eBPF filesystem, the following command must be run in the
 host mount namespace. The command must only be run once during the boot process
 of the machine.
 
-   code-block:: shell-session
+   .. code-block:: shell-session
 
 	# mount bpffs /sys/fs/bpf -t bpf
 

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -325,29 +325,9 @@ bool lb6_svc_is_affinity(const struct lb6_service *svc)
 	return svc->flags & SVC_FLAG_AFFINITY;
 }
 
-static __always_inline
-__u8 svc_is_routable_mask(void)
-{
-	__u8 mask = SVC_FLAG_ROUTABLE;
-
-#ifdef ENABLE_LOADBALANCER
-	mask |= SVC_FLAG_LOADBALANCER;
-#endif
-#ifdef ENABLE_NODEPORT
-	mask |= SVC_FLAG_NODEPORT;
-#endif
-#ifdef ENABLE_EXTERNAL_IP
-	mask |= SVC_FLAG_EXTERNAL_IP;
-#endif
-#ifdef ENABLE_HOSTPORT
-	mask |= SVC_FLAG_HOSTPORT;
-#endif
-	return mask;
-}
-
 static __always_inline bool __lb_svc_is_routable(__u8 flags)
 {
-	return (flags & svc_is_routable_mask()) > SVC_FLAG_ROUTABLE;
+	return (flags & SVC_FLAG_ROUTABLE) != 0;
 }
 
 static __always_inline

--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -198,7 +198,7 @@ func initK8s(ctx context.Context) (crdBackend allocator.Backend, crdAllocator *a
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 
-	if err := k8s.WaitForNodeInformation(); err != nil {
+	if err := k8s.WaitForNodeInformation(ctx, k8s.Client()); err != nil {
 		log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 	}
 

--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -10,7 +10,7 @@ MAJ_REGEX='[0-9]\+\.[0-9]\+'
 MIN_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
 REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 for release in $(grep "General Announcement" README.rst \

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -7,7 +7,7 @@ source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 usage() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -993,6 +993,9 @@ func init() {
 	flags.String(option.BGPConfigPath, "/var/lib/cilium/bgp/config.yaml", "Path to file containing the BGP configuration")
 	option.BindEnv(option.BGPConfigPath)
 
+	flags.Bool(option.ExternalClusterIPName, false, "Enable external access to ClusterIP services (default false)")
+	option.BindEnv(option.ExternalClusterIPName)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1734,7 +1734,7 @@ func runDaemon() {
 
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
-		k8s.Client().MarkNodeReady(nodeTypes.GetName())
+		k8s.Client().MarkNodeReady(d.k8sWatcher, nodeTypes.GetName())
 		bootstrapStats.k8sInit.End(true)
 	}
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -256,6 +256,8 @@ contributors across the globe, there is almost always someone available to help.
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
+| livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
+| livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
@@ -338,6 +340,8 @@ contributors across the globe, there is almost always someone available to help.
 | proxy | object | `{"prometheus":{"enabled":true,"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
 | proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
+| readinessProbe.failureThreshold | int | `3` | failure threshold of readiness probe |
+| readinessProbe.periodSeconds | int | `30` | interval between checks of the readiness probe |
 | remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
@@ -348,6 +352,8 @@ contributors across the globe, there is almost always someone available to help.
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | sockops | object | `{"enabled":false}` | Configure BPF socket operations configuration |
+| startupProbe.failureThreshold | int | `105` | failure threshold of startup probe. 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s) |
+| startupProbe.periodSeconds | int | `2` | interval between checks of the startup probe |
 | tls | object | `{"enabled":true,"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | tunnel | string | `"vxlan"` | Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -63,6 +63,7 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
 | bpf.clockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
+| bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
 | bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -121,8 +121,8 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
-          failureThreshold: 24
-          periodSeconds: 2
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           successThreshold: 1
 {{- end }}
         livenessProbe:
@@ -146,7 +146,7 @@ spec:
             - name: "brief"
               value: "true"
 {{- end }}
-          failureThreshold: 10
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
 {{- if semverCompare "<1.20-0" $k8sVersion }}
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -155,7 +155,7 @@ spec:
           # of this field.
           initialDelaySeconds: 120
 {{- end }}
-          periodSeconds: 30
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
@@ -179,11 +179,11 @@ spec:
             - name: "brief"
               value: "true"
 {{- end }}
-          failureThreshold: 3
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if semverCompare "<1.20-0" $k8sVersion }}
           initialDelaySeconds: 5
 {{- end }}
-          periodSeconds: 30
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: 1
           timeoutSeconds: 5
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -300,6 +300,10 @@ data:
 {{- if hasKey .Values.bpf "lbBypassFIBLookup" }}
   bpf-lb-bypass-fib-lookup: {{ .Values.bpf.lbBypassFIBLookup | quote }}
 {{- end }}
+{{- if hasKey .Values.bpf "lbExternalClusterIP" }}
+  bpf-lb-external-clusterip: {{ .Values.bpf.lbExternalClusterIP | quote }}
+{{- end }}
+
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -220,33 +220,6 @@ spec:
               date > {{ .Values.nodeinit.bootstrapFile }}
 {{- end }}
 
-{{- if .Values.nodeinit.restartPods }}
-              echo "Restarting kubenet managed pods"
-              if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
-                # Works for COS, ubuntu
-                # Note the first line is the containerID with a trailing \r
-                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f "$(sed 's/\r//;1q' $f)" || true; done
-              elif [ -n "$(docker ps --format '{{ "{{" }}.Image{{ "}}" }}' | grep ^[0-9]*\.dkr\.ecr\.[a-z]*-[a-z]*-[0-9]*\.amazonaws\.com/amazon-k8s-cni)" ]; then
-                timeout=1
-                for i in $(seq 1 7); do
-                  echo "Checking introspection API"
-                  curl localhost:61679 && retry=false || retry=true
-                  if [ $retry == false ]; then break ; fi
-                  sleep "$timeout"
-                  timeout=$(($timeout * 2))
-                done
-
-                for pod in $(curl "localhost:61679/v1/pods" 2> /dev/null | jq -r '. | keys[]'); do
-                  container_id=$(echo "$pod" | awk -F_ ' { print $3 } ' | cut -c1-12)
-                  echo "Restarting ${container_id}"
-                  docker kill "${container_id}" || true
-                done
-              else
-                # COS-beta (with containerd). Some versions of COS have crictl in /home/kubernetes/bin.
-                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do PATH="${PATH}:/home/kubernetes/bin" crictl stopp "$(sed 's/\r//;1q' $f)" || true; done
-              fi
-{{- end }}
-
               # AKS: If azure-vnet is installed on the node, and (still) configured in bridge mode,
               # configure it as 'transparent' to be consistent with Cilium's CNI chaining config.
               # If the azure-vnet CNI config is not removed, kubelet will execute CNI CHECK commands

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -275,6 +275,9 @@ bpf:
   # first time in a connection.
   monitorFlags: "all"
 
+  # -- Allow cluster external access to ClusterIP services.
+  lbExternalClusterIP: false
+
   # -- Enable native IP masquerade support in eBPF
   #masquerade: true
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -901,6 +901,23 @@ keepDeprecatedLabels: false
 # -- Keep the deprecated probes when deploying Cilium DaemonSet
 keepDeprecatedProbes: false
 
+startupProbe:
+  # -- failure threshold of startup probe.
+  # 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s)
+  failureThreshold: 105
+  # -- interval between checks of the startup probe
+  periodSeconds: 2
+livenessProbe:
+  # -- failure threshold of liveness probe
+  failureThreshold: 10
+  # -- interval between checks of the liveness probe
+  periodSeconds: 30
+readinessProbe:
+  # -- failure threshold of readiness probe
+  failureThreshold: 3
+  # -- interval between checks of the readiness probe
+  periodSeconds: 30
+
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
 # Valid options are "disabled", "probe", "partial", "strict".
 # ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -144,7 +144,7 @@ func (s *Speaker) OnUpdateEndpoints(eps *slim_corev1.Endpoints) {
 }
 
 // OnUpdateNode notifies the Speaker of an update to a node.
-func (s *Speaker) OnUpdateNode(node *slim_corev1.Node) {
+func (s *Speaker) OnUpdateNode(node *v1.Node) {
 	s.queue.Add(nodeEvent(&node.Labels))
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -433,4 +433,8 @@ const (
 
 	// WireguardSubnetV6 is a default wireguard tunnel subnet
 	WireguardSubnetV6 = "fdc9:281f:04d7:9ee9::1/64"
+
+	// ExternalClusterIP enables cluster external access to ClusterIP services.
+	// Defaults to false to retain prior behaviour of not routing external packets to ClusterIPs.
+	ExternalClusterIP = false
 )

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
+	core_v1 "k8s.io/api/core/v1"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -136,4 +137,13 @@ func (k8sCli K8sClient) GetSecrets(ctx context.Context, ns, name string) (map[st
 		return nil, err
 	}
 	return result.Data, nil
+}
+
+// GetK8sNode returns the node with the given nodeName.
+func (k8sCli K8sClient) GetK8sNode(ctx context.Context, nodeName string) (*core_v1.Node, error) {
+	if k8sCli.Interface == nil {
+		return nil, fmt.Errorf("GetK8sNode: No k8s, cannot access k8s nodes")
+	}
+
+	return k8sCli.CoreV1().Nodes().Get(ctx, nodeName, v1.GetOptions{})
 }

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,6 +64,12 @@ const (
 	CiliumK8sAnnotationPrefix = "cilium.io/"
 	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
 	CiliumIdentityAnnotationDeprecated = "cilium-identity"
+
+	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
+	// scheduled. Once cilium is setup it is removed from the node. Mostly
+	// used in cloud providers to prevent existing CNI plugins from managing
+	// pods.
+	AgentNotReadyNodeTaint = "node." + CiliumK8sAnnotationPrefix + "agent-not-ready"
 )
 
 const (

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -171,8 +171,8 @@ func ObjTov1Pod(obj interface{}) *slim_corev1.Pod {
 	return nil
 }
 
-func ObjToV1Node(obj interface{}) *slim_corev1.Node {
-	node, ok := obj.(*slim_corev1.Node)
+func ObjToV1Node(obj interface{}) *v1.Node {
+	node, ok := obj.(*v1.Node)
 	if ok {
 		return node
 	}
@@ -181,7 +181,7 @@ func ObjToV1Node(obj interface{}) *slim_corev1.Node {
 		// Delete was not observed by the watcher but is
 		// removed from kube-apiserver. This is the last
 		// known state and the object no longer exists.
-		node, ok := deletedObj.Obj.(*slim_corev1.Node)
+		node, ok := deletedObj.Obj.(*v1.Node)
 		if ok {
 			return node
 		}

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package benchmarks
 import (
 	"encoding/json"
 	"os"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -460,7 +461,7 @@ func (k *K8sIntegrationSuite) benchmarkInformer(nCycles int, newInformer bool, c
 				UpdateFunc: func(oldObj, newObj interface{}) {
 					if oldK8sNP := k8s.ObjToV1Node(oldObj); oldK8sNP != nil {
 						if newK8sNP := k8s.ObjToV1Node(newObj); newK8sNP != nil {
-							if oldK8sNP.DeepEqual(newK8sNP) {
+							if reflect.DeepEqual(oldK8sNP, newK8sNP) {
 								return
 							}
 						}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -209,13 +209,6 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 	return newNode
 }
 
-// GetNode returns the kubernetes nodeName's node information from the
-// kubernetes api server
-func GetNode(c kubernetes.Interface, nodeName string) (*corev1.Node, error) {
-	// Try to retrieve node's cidr and addresses from k8s's configuration
-	return c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-}
-
 // setNodeNetworkUnavailableFalse sets Kubernetes NodeNetworkUnavailable to
 // false as Cilium is managing the network connectivity.
 // https://kubernetes.io/docs/concepts/architecture/nodes/#condition

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node/addressing"
@@ -212,11 +213,29 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 // setNodeNetworkUnavailableFalse sets Kubernetes NodeNetworkUnavailable to
 // false as Cilium is managing the network connectivity.
 // https://kubernetes.io/docs/concepts/architecture/nodes/#condition
-func setNodeNetworkUnavailableFalse(c kubernetes.Interface, nodeName string) error {
+func setNodeNetworkUnavailableFalse(ctx context.Context, c kubernetes.Interface, nodeGetter nodeGetter, nodeName string) error {
+	n, err := nodeGetter.GetK8sNode(ctx, nodeName)
+	if err != nil {
+		return err
+	}
+
+	const reason = "CiliumIsUp"
+
+	for _, condition := range n.Status.Conditions {
+		if condition.Type == corev1.NodeNetworkUnavailable &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == reason {
+
+			// No need to update node condition as it is already available in
+			// the node status.
+			return nil
+		}
+	}
+
 	condition := corev1.NodeCondition{
 		Type:               corev1.NodeNetworkUnavailable,
 		Status:             corev1.ConditionFalse,
-		Reason:             "CiliumIsUp",
+		Reason:             reason,
 		Message:            "Cilium is running on this node",
 		LastTransitionTime: metav1.Now(),
 		LastHeartbeatTime:  metav1.Now(),
@@ -230,15 +249,68 @@ func setNodeNetworkUnavailableFalse(c kubernetes.Interface, nodeName string) err
 	return err
 }
 
+// removeNodeTaint removes the AgentNotReadyNodeTaint allowing for pods to be
+// scheduled once Cilium is setup. Mostly used in cloud providers to prevent
+// existing CNI plugins from managing pods.
+func removeNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter nodeGetter, nodeName string) error {
+	k8sNode, err := nodeGetter.GetK8sNode(ctx, nodeName)
+	if err != nil {
+		return err
+	}
+
+	var taintFound bool
+
+	var taints []corev1.Taint
+	for _, taint := range k8sNode.Spec.Taints {
+		if taint.Key != ciliumio.AgentNotReadyNodeTaint {
+			taints = append(taints, taint)
+		} else {
+			taintFound = true
+		}
+	}
+
+	// No cilium taints found
+	if !taintFound {
+		log.WithFields(logrus.Fields{
+			logfields.NodeName: nodeName,
+			"taint":            ciliumio.AgentNotReadyNodeTaint,
+		}).Debug("Taint not found in node")
+		return nil
+	}
+	log.WithFields(logrus.Fields{
+		logfields.NodeName: nodeName,
+		"taint":            ciliumio.AgentNotReadyNodeTaint,
+	}).Debug("Removing Node Taint")
+
+	k8sNode.Spec.Taints = taints
+
+	_, err = c.CoreV1().Nodes().Update(ctx, k8sNode, metav1.UpdateOptions{})
+	return err
+}
+
+const (
+	markK8sNodeReadyControllerName = "mark-k8s-node-as-available"
+)
+
 // MarkNodeReady marks the Kubernetes node resource as ready from a networking
 // perspective
-func (k8sCli K8sClient) MarkNodeReady(nodeName string) {
+func (k8sCli K8sClient) MarkNodeReady(nodeGetter nodeGetter, nodeName string) {
 	log.WithField(logfields.NodeName, nodeName).Debug("Setting NetworkUnavailable=false")
 
-	controller.NewManager().UpdateController("mark-k8s-node-as-available",
+	controller.NewManager().UpdateController(markK8sNodeReadyControllerName,
 		controller.ControllerParams{
-			DoFunc: func(_ context.Context) error {
-				return setNodeNetworkUnavailableFalse(k8sCli, nodeName)
+			DoFunc: func(ctx context.Context) error {
+				err := removeNodeTaint(ctx, k8sCli, nodeGetter, nodeName)
+				if err != nil {
+					return err
+				}
+				return setNodeNetworkUnavailableFalse(ctx, k8sCli, nodeGetter, nodeName)
 			},
 		})
+}
+
+// ReMarkNodeReady re-triggers the controller set by 'MarkNodeReady'. If
+// 'MarkNodeReady' has not been executed yet, calling this function be a no-op.
+func (k8sCli K8sClient) ReMarkNodeReady() {
+	controller.NewManager().TriggerController(markK8sNodeReadyControllerName)
 }

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/k8s"
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -31,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -43,7 +43,7 @@ var (
 
 // NodesInit initializes a k8s watcher for node events belonging to the node
 // where Cilium is running.
-func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
+func (k *K8sWatcher) NodesInit(k8sClient *k8s.K8sClient) {
 	onceNodeInitStart.Do(func() {
 		nodeStore, nodeController := informer.NewInformer(
 			cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
@@ -55,6 +55,9 @@ func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
 					var valid bool
 					if node := k8s.ObjToV1Node(obj); node != nil {
 						valid = true
+						if hasAgentNotReadyTaint(node) {
+							k8sClient.ReMarkNodeReady()
+						}
 						err := k.updateK8sNodeV1(nil, node)
 						k.K8sEventProcessed(metricNode, metricCreate, err == nil)
 					}
@@ -65,6 +68,10 @@ func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
 					if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
 						valid = true
 						if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
+							if hasAgentNotReadyTaint(newNode) {
+								k8sClient.ReMarkNodeReady()
+							}
+
 							oldNodeLabels := oldNode.GetLabels()
 							newNodeLabels := newNode.GetLabels()
 							if comparator.MapStringEquals(oldNodeLabels, newNodeLabels) {
@@ -87,6 +94,17 @@ func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
 		go nodeController.Run(wait.NeverStop)
 		k.k8sAPIGroups.AddAPI(k8sAPIGroupNodeV1Core)
 	})
+}
+
+// hasAgentNotReadyTaint returns true if the given node has the Cilium Agen
+// Not Ready Node Taint.
+func hasAgentNotReadyTaint(k8sNode *v1.Node) bool {
+	for _, taint := range k8sNode.Spec.Taints {
+		if taint.Key == ciliumio.AgentNotReadyNodeTaint {
+			return true
+		}
+	}
+	return false
 }
 
 func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *v1.Node) error {

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,64 +15,81 @@
 package watchers
 
 import (
+	"context"
+	"sync"
+
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
-	_, nodeController := informer.NewInformer(
-		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
-			"nodes", v1.NamespaceAll, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName())),
-		&slim_corev1.Node{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				var valid bool
-				if node := k8s.ObjToV1Node(obj); node != nil {
-					valid = true
-					err := k.updateK8sNodeV1(nil, node)
-					k.K8sEventProcessed(metricNode, metricCreate, err == nil)
-				}
-				k.K8sEventReceived(metricNode, metricCreate, valid, false)
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				var valid, equal bool
-				if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
-					valid = true
-					if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
-						oldNodeLabels := oldNode.GetLabels()
-						newNodeLabels := newNode.GetLabels()
-						if comparator.MapStringEquals(oldNodeLabels, newNodeLabels) {
-							equal = true
-						} else {
-							err := k.updateK8sNodeV1(oldNode, newNode)
-							k.K8sEventProcessed(metricNode, metricUpdate, err == nil)
+var (
+	// onceNodeInitStart is used to guarantee that only one function call of
+	// NodesInit is executed.
+	onceNodeInitStart sync.Once
+)
+
+// NodesInit initializes a k8s watcher for node events belonging to the node
+// where Cilium is running.
+func (k *K8sWatcher) NodesInit(k8sClient kubernetes.Interface) {
+	onceNodeInitStart.Do(func() {
+		nodeStore, nodeController := informer.NewInformer(
+			cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+				"nodes", v1.NamespaceAll, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName())),
+			&v1.Node{},
+			0,
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					var valid bool
+					if node := k8s.ObjToV1Node(obj); node != nil {
+						valid = true
+						err := k.updateK8sNodeV1(nil, node)
+						k.K8sEventProcessed(metricNode, metricCreate, err == nil)
+					}
+					k.K8sEventReceived(metricNode, metricCreate, valid, false)
+				},
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					var valid, equal bool
+					if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
+						valid = true
+						if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
+							oldNodeLabels := oldNode.GetLabels()
+							newNodeLabels := newNode.GetLabels()
+							if comparator.MapStringEquals(oldNodeLabels, newNodeLabels) {
+								equal = true
+							} else {
+								err := k.updateK8sNodeV1(oldNode, newNode)
+								k.K8sEventProcessed(metricNode, metricUpdate, err == nil)
+							}
 						}
 					}
-				}
-				k.K8sEventReceived(metricNode, metricUpdate, valid, equal)
+					k.K8sEventReceived(metricNode, metricUpdate, valid, equal)
+				},
 			},
-		},
-		nil,
-	)
+			nil,
+		)
 
-	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, nodeController.HasSynced, k8sAPIGroupNodeV1Core)
-	go nodeController.Run(wait.NeverStop)
-	k.k8sAPIGroups.AddAPI(k8sAPIGroupNodeV1Core)
+		k.nodeStore = nodeStore
+
+		k.blockWaitGroupToSyncResources(wait.NeverStop, nil, nodeController.HasSynced, k8sAPIGroupNodeV1Core)
+		go nodeController.Run(wait.NeverStop)
+		k.k8sAPIGroups.AddAPI(k8sAPIGroupNodeV1Core)
+	})
 }
 
-func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) error {
+func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *v1.Node) error {
 	var oldNodeLabels map[string]string
 	if oldK8sNode != nil {
 		oldNodeLabels = oldK8sNode.GetLabels()
@@ -95,4 +112,25 @@ func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) e
 		return err
 	}
 	return nil
+}
+
+// GetK8sNode returns the *local Node* from the local store.
+func (k *K8sWatcher) GetK8sNode(_ context.Context, nodeName string) (*v1.Node, error) {
+	k.WaitForCacheSync(k8sAPIGroupNodeV1Core)
+	pName := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}
+	nodeInterface, exists, err := k.nodeStore.Get(pName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, k8sErrors.NewNotFound(schema.GroupResource{
+			Group:    "core",
+			Resource: "Node",
+		}, nodeName)
+	}
+	return nodeInterface.(*v1.Node).DeepCopy(), nil
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import (
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -159,7 +160,7 @@ type bgpSpeakerManager interface {
 
 	OnUpdateEndpoints(eps *slim_corev1.Endpoints)
 
-	OnUpdateNode(node *slim_corev1.Node)
+	OnUpdateNode(node *corev1.Node)
 }
 type egressPolicyManager interface {
 	AddEgressPolicy(config egresspolicy.Config) (bool, error)
@@ -203,6 +204,8 @@ type K8sWatcher struct {
 	// variable is written for the first time.
 	podStoreSet  chan struct{}
 	podStoreOnce sync.Once
+
+	nodeStore cache.Store
 
 	namespaceStore cache.Store
 	datapath       datapath.Datapath
@@ -446,7 +449,7 @@ func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context) error {
 	go k.podsInit(k8s.WatcherClient(), asyncControllers)
 
 	// kubernetes nodes
-	k.nodesInit(k8s.WatcherClient())
+	k.NodesInit(k8s.Client())
 
 	// kubernetes namespaces
 	asyncControllers.Add(1)

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -504,6 +504,10 @@ func updateMasterService(fe ServiceKey, nbackends int, revNATID int, svcType loa
 	svcLocal bool, sessionAffinity bool, sessionAffinityTimeoutSec uint32,
 	checkSourceRange bool) error {
 
+	// isRoutable denotes whether this service can be accessed from outside the cluster.
+	isRoutable := !fe.IsSurrogate() &&
+		(svcType != loadbalancer.SVCTypeClusterIP || option.Config.ExternalClusterIP)
+
 	fe.SetBackendSlot(0)
 	zeroValue := fe.NewValue().(ServiceValue)
 	zeroValue.SetCount(nbackends)
@@ -512,7 +516,7 @@ func updateMasterService(fe ServiceKey, nbackends int, revNATID int, svcType loa
 		SvcType:          svcType,
 		SvcLocal:         svcLocal,
 		SessionAffinity:  sessionAffinity,
-		IsRoutable:       !fe.IsSurrogate(),
+		IsRoutable:       isRoutable,
 		CheckSourceRange: checkSourceRange,
 	})
 	zeroValue.SetFlags(flag.UInt16())

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -956,6 +956,10 @@ const (
 	// BGPConfigPath is the file path to the BGP configuration. It is
 	// compatible with MetalLB's configuration.
 	BGPConfigPath = "bgp-config-path"
+
+	// ExternalClusterIPName is the name of the option to enable
+	// cluster external access to ClusterIP services.
+	ExternalClusterIPName = "bpf-lb-external-clusterip"
 )
 
 // Default string arguments
@@ -1962,6 +1966,10 @@ type DaemonConfig struct {
 	// compatible with MetalLB's configuration.
 	BGPConfigPath string
 
+	// ExternalClusterIP enables routing to ClusterIP services from outside
+	// the cluster. This mirrors the behaviour of kube-proxy.
+	ExternalClusterIP bool
+
 	// ARPPingRefreshPeriod is the ARP entries refresher period.
 	ARPPingRefreshPeriod time.Duration
 }
@@ -2009,6 +2017,8 @@ var (
 
 		k8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 		APIRateLimit:                     make(map[string]string),
+
+		ExternalClusterIP: defaults.ExternalClusterIP,
 	}
 )
 
@@ -2518,6 +2528,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableCustomCalls = viper.GetBool(EnableCustomCallsName)
 	c.BGPAnnounceLBIP = viper.GetBool(BGPAnnounceLBIP)
 	c.BGPConfigPath = viper.GetString(BGPConfigPath)
+	c.ExternalClusterIP = viper.GetBool(ExternalClusterIPName)
 
 	err = c.populateMasqueradingSettings()
 	if err != nil {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3645,7 +3645,8 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	kub.reportMapHost(ctx, testPath, reportCmds)
 
 	reportCmds = map[string]string{
-		"journalctl -D /var/log/journal --no-pager -au kubelet": "kubelet.log",
+		"journalctl -D /var/log/journal --no-pager -au kubelet":        "kubelet.log",
+		"journalctl -D /var/log/journal --no-pager -au kube-apiserver": "kube-apiserver.log",
 		"top -n 1 -b": "top.log",
 		"ps aux":      "ps.log",
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3645,9 +3645,9 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	kub.reportMapHost(ctx, testPath, reportCmds)
 
 	reportCmds = map[string]string{
-		"journalctl --no-pager -au kubelet": "kubelet.log",
-		"top -n 1 -b":                       "top.log",
-		"ps aux":                            "ps.log",
+		"journalctl -D /var/log/journal --no-pager -au kubelet": "kubelet.log",
+		"top -n 1 -b": "top.log",
+		"ps aux":      "ps.log",
 	}
 
 	kub.reportMapContext(ctx, testPath, reportCmds, LogGathererNamespace, logGathererSelector(false))

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -587,6 +587,53 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				testCurlFromPods(echoPodLabel, url, 5, 0)
 			}
 		})
+
+		curlClusterIPFromExternalHost := func() *helpers.CmdRes {
+			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, serviceName)
+			ExpectWithOffset(1, err).Should(BeNil(), "Cannot get service %s", serviceName)
+			ExpectWithOffset(1, govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+			httpSVCURL := fmt.Sprintf("http://%s/", net.JoinHostPort(clusterIP, "80"))
+
+			By("testing external connectivity via cluster IP %s", clusterIP)
+
+			status := kubectl.ExecInHostNetNS(context.TODO(), k8s1NodeName, helpers.CurlFail(httpSVCURL))
+			ExpectWithOffset(1, status).Should(helpers.CMDSuccess(), "cannot curl to service IP from host: %s", status.CombineOutput())
+
+			return kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName, helpers.CurlFail(httpSVCURL))
+		}
+
+		SkipItIf(func() bool { return helpers.DoesNotExistNodeWithoutCilium() },
+			"ClusterIP cannot be accessed externally when access is disabled",
+			func() {
+				Expect(curlClusterIPFromExternalHost()).ShouldNot(helpers.CMDSuccess(),
+					"External host %s unexpectedly connected to ClusterIP when lbExternalClusterIP was unset", outsideNodeName)
+			})
+
+		SkipContextIf(func() bool { return helpers.DoesNotExistNodeWithoutCilium() }, "With ClusterIP external access", func() {
+			var (
+				svcIP string
+			)
+			BeforeAll(func() {
+				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+					"bpf.lbExternalClusterIP": "true",
+				})
+				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, serviceName)
+				svcIP = clusterIP
+				Expect(err).Should(BeNil(), "Cannot get service %s", serviceName)
+				res := kubectl.AddIPRoute(outsideNodeName, svcIP, k8s1IP, false)
+				Expect(res).Should(helpers.CMDSuccess(), "Error adding IP route for %s via %s", svcIP, k8s1IP)
+			})
+
+			AfterAll(func() {
+				res := kubectl.DelIPRoute(outsideNodeName, svcIP, k8s1IP)
+				Expect(res).Should(helpers.CMDSuccess(), "Error removing IP route for %s via %s", svcIP, k8s1IP)
+				DeployCiliumAndDNS(kubectl, ciliumFilename)
+			})
+
+			It("ClusterIP can be accessed when external access is enabled", func() {
+				Expect(curlClusterIPFromExternalHost()).Should(helpers.CMDSuccess(), "Could not curl ClusterIP %s from external host", svcIP)
+			})
+		})
 	})
 
 	SkipContextIf(func() bool { return !helpers.RunsOn419OrLaterKernel() }, "Checks local redirect policy", func() {

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -31,7 +31,7 @@ spec:
         command:
         - sleep
         image: docker.io/cilium/log-gatherer:v1.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: log-gatherer
         securityContext:
           capabilities:


### PR DESCRIPTION
* #15650 -- daemon: Add option --bpf-lb-external-clusterip (@joamaki)
 * #16721 -- Fix and add more commands in CI sysdumps (@aanm)
 * #16719 -- docs: fix code-block for bpf mount example (@aanm)
 * #16690 -- Docs: Fix maglev.hashSeed byte size documentation (@gaffneyd4)
 * #16631 -- Improve Cilium integration with managed Kubernetes providers (@aanm)
 * #16750 -- contrib/docs: rename 'cilium-actions.yml' with 'maintainers-little-helper.yaml (@aanm)
 * #16756 -- Revert "docs: add 'endpointRoutes.enabled=true' to aws-cni" (@bmcustodio)
 * #16691 -- bugtool: Collect BPF cgroup programs related information (@aditighag)
 * #16584 -- helm: Allow configuration of probe timers (@jonkerj)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15650 16721 16719 16690 16631 16750 16756 16691 16584; do contrib/backporting/set-labels.py $pr done 1.10; done
```