### PR TITLE
v1.9 backports 2021-07-05 #2

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -205,15 +205,17 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
 			if (ret < 0)
 				return ret;
 		}
-#if defined(ENCAP_IFINDEX) || (defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST))
-		/* See IPv4 case for NO_REDIRECT/ENABLE_REDIRECT_FAST comments */
-		skip_redirect = true;
-#endif /* ENCAP_IFINDEX || (NO_REDIRECT && !ENABLE_REDIRECT_FAST) */
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 	}
 #endif /* ENABLE_NODEPORT */
+
+#if defined(ENCAP_IFINDEX)|| (defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST))
+	/* See IPv4 case for NO_REDIRECT/ENABLE_REDIRECT_FAST comments */
+	if (!from_host)
+		skip_redirect = true;
+#endif /* ENCAP_IFINDEX || (NO_REDIRECT && !ENABLE_REDIRECT_FAST) */
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {
@@ -455,23 +457,26 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			if (ret < 0)
 				return ret;
 		}
-#if defined(ENCAP_IFINDEX) || (defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST))
-		/* Without bpf_redirect_neigh() helper, we cannot redirect a
-		 * packet to a local endpoint in the direct routing mode, as
-		 * the redirect bypasses nf_conntrack table. This makes a
-		 * second reply from the endpoint to be MASQUERADEd or to be
-		 * DROP-ed by k8s's "--ctstate INVALID -j DROP" depending via
-		 * which interface it was inputed. With bpf_redirect_neigh()
-		 * we bypass request and reply path in the host namespace and
-		 * do not run into this issue.
-		 */
-		skip_redirect = true;
-#endif /* ENCAP_IFINDEX || (NO_REDIRECT && !ENABLE_REDIRECT_FAST) */
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 	}
 #endif /* ENABLE_NODEPORT */
+
+#if defined(ENCAP_IFINDEX) || (defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST))
+	/* Without bpf_redirect_neigh() helper, we cannot redirect a
+	 * packet to a local endpoint in the direct routing mode, as
+	 * the redirect bypasses nf_conntrack table. This makes a
+	 * second reply from the endpoint to be MASQUERADEd or to be
+	 * DROP-ed by k8s's "--ctstate INVALID -j DROP" depending via
+	 * which interface it was inputed. With bpf_redirect_neigh()
+	 * we bypass request and reply path in the host namespace and
+	 * do not run into this issue.
+	 */
+	if (!from_host)
+		skip_redirect = true;
+#endif /* ENCAP_IFINDEX || (NO_REDIRECT && !ENABLE_REDIRECT_FAST) */
+
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -648,8 +648,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			testHostFirewall(kubectl)
 		})
 
-		// We need to skip this test when using kube-proxy because of #14859.
-		SkipItIf(helpers.RunsWithKubeProxy, "With native routing", func() {
+		It("With native routing", func() {
 			options := map[string]string{
 				"hostFirewall": "true",
 				"tunnel":       "disabled",


### PR DESCRIPTION
 * #16136 -- bpf: fix iptables masquerading for node -> remote pod traffic (@jibi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16136; do contrib/backporting/set-labels.py $pr done 1.9; done
```