### PR TITLE
v1.9 backports 2021-07-05 #2

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -205,15 +205,17 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
 			if (ret < 0)
 				return ret;
 		}
-#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
-		/* See IPv4 case for NO_REDIRECT/ENABLE_REDIRECT_FAST comments */
-		skip_redirect = true;
-#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 	}
 #endif /* ENABLE_NODEPORT */
+
+#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
+	/* See IPv4 case for NO_REDIRECT/ENABLE_REDIRECT_FAST comments */
+	if (!from_host)
+		skip_redirect = true;
+#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {
@@ -462,23 +464,25 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			if (ret < 0)
 				return ret;
 		}
-#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
-		/* Without bpf_redirect_neigh() helper, we cannot redirect a
-		 * packet to a local endpoint in the direct routing mode, as
-		 * the redirect bypasses nf_conntrack table. This makes a
-		 * second reply from the endpoint to be MASQUERADEd or to be
-		 * DROP-ed by k8s's "--ctstate INVALID -j DROP" depending via
-		 * which interface it was inputed. With bpf_redirect_neigh()
-		 * we bypass request and reply path in the host namespace and
-		 * do not run into this issue.
-		 */
-		skip_redirect = true;
-#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 	}
 #endif /* ENABLE_NODEPORT */
+
+#if defined(NO_REDIRECT) && !defined(ENABLE_REDIRECT_FAST)
+	/* Without bpf_redirect_neigh() helper, we cannot redirect a
+	 * packet to a local endpoint in the direct routing mode, as
+	 * the redirect bypasses nf_conntrack table. This makes a
+	 * second reply from the endpoint to be MASQUERADEd or to be
+	 * DROP-ed by k8s's "--ctstate INVALID -j DROP" depending via
+	 * which interface it was inputed. With bpf_redirect_neigh()
+	 * we bypass request and reply path in the host namespace and
+	 * do not run into this issue.
+	 */
+	if (!from_host)
+		skip_redirect = true;
+#endif /* NO_REDIRECT && !ENABLE_REDIRECT_FAST */
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1031,7 +1031,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 #else
 	ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	if (ifindex)
-		return redirect_ep(ifindex, from_host);
+		return redirect_ep(ctx, ifindex, from_host);
 #endif /* ENABLE_ROUTING && ENCAP_IFINDEX && !ENABLE_NODEPORT */
 
 	return CTX_ACT_OK;
@@ -1303,7 +1303,7 @@ skip_policy_enforcement:
 #else
 	ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	if (ifindex)
-		return redirect_ep(ifindex, from_host);
+		return redirect_ep(ctx, ifindex, from_host);
 #endif /* ENABLE_ROUTING && ENCAP_IFINDEX && !ENABLE_NODEPORT */
 
 	return CTX_ACT_OK;

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -88,7 +88,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
-	return redirect_ep(ep->ifindex, from_host);
+	return redirect_ep(ctx, ep->ifindex, from_host);
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
 	ctx_store_meta(ctx, CB_IFINDEX, ep->ifindex);
@@ -130,7 +130,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
-	return redirect_ep(ep->ifindex, from_host);
+	return redirect_ep(ctx, ep->ifindex, from_host);
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
 	ctx_store_meta(ctx, CB_IFINDEX, ep->ifindex);

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -243,6 +243,9 @@ func initKubeProxyReplacementOptions() (strict bool) {
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableNodePort)
 		case option.Config.Tunnel != option.TunnelDisabled:
 			msg = fmt.Sprintf("BPF host routing is only available in native routing mode.")
+		// If we chain CNIs then all bets are off.
+		case option.Config.IsFlannelMasterDeviceSet():
+			msg = fmt.Sprintf("BPF host routing is incompatible with %s.", option.FlannelMasterDevice)
 		// Needs host stack for packet handling.
 		case option.Config.EnableEndpointRoutes:
 			msg = fmt.Sprintf("BPF host routing is incompatible with %s.", option.EnableEndpointRoutes)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -241,8 +241,6 @@ func initKubeProxyReplacementOptions() (strict bool) {
 		switch {
 		case !option.Config.EnableNodePort:
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableNodePort)
-		case option.Config.Tunnel != option.TunnelDisabled:
-			msg = fmt.Sprintf("BPF host routing is only available in native routing mode.")
 		// If we chain CNIs then all bets are off.
 		case option.Config.IsFlannelMasterDeviceSet():
 			msg = fmt.Sprintf("BPF host routing is incompatible with %s.", option.FlannelMasterDevice)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -148,6 +148,7 @@ type Controller struct {
 	uuid              string
 	stop              chan struct{}
 	update            chan struct{}
+	trigger           chan struct{}
 	ctxDoFunc         context.Context
 	cancelDoFunc      context.CancelFunc
 
@@ -177,6 +178,14 @@ func (c *Controller) GetLastError() error {
 	defer c.mutex.RUnlock()
 
 	return c.lastError
+}
+
+// Trigger triggers the controller
+func (c *Controller) Trigger() {
+	select {
+	case c.trigger <- struct{}{}:
+	default:
+	}
 }
 
 // GetLastErrorTimestamp returns the last error returned
@@ -281,6 +290,7 @@ func (c *Controller) runController() {
 			runFunc = true
 
 		case <-time.After(interval):
+		case <-c.trigger:
 		}
 
 	}

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -100,6 +100,7 @@ func (m *Manager) updateController(name string, params ControllerParams) *Contro
 			uuid:       uuid.NewUUID().String(),
 			stop:       make(chan struct{}),
 			update:     make(chan struct{}, 1),
+			trigger:    make(chan struct{}, 1),
 			terminated: make(chan struct{}),
 		}
 		ctrl.updateParamsLocked(params)
@@ -244,6 +245,16 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 	return statuses
 }
 
+// TriggerController triggers the controller with the specified name.
+func (m *Manager) TriggerController(name string) {
+	controller := m.lookup(name)
+	if controller == nil {
+		return
+	}
+
+	controller.Trigger()
+}
+
 // FakeManager returns a fake controller manager with the specified number of
 // failing controllers. The returned manager is identical in any regard except
 // for internal pointers.
@@ -258,6 +269,7 @@ func FakeManager(failingControllers int) *Manager {
 			uuid:              fmt.Sprintf("%d", i),
 			stop:              make(chan struct{}),
 			update:            make(chan struct{}, 1),
+			trigger:           make(chan struct{}, 1),
 			terminated:        make(chan struct{}),
 			lastError:         fmt.Errorf("controller failed"),
 			failureCount:      1,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -345,6 +345,12 @@ type Endpoint struct {
 	isHost bool
 }
 
+// EndpointSyncControllerName returns the controller name to synchronize
+// endpoint in to kubernetes.
+func EndpointSyncControllerName(epID uint16) string {
+	return fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", epID)
+}
+
 // SetAllocator sets the identity allocator for this endpoint.
 func (e *Endpoint) SetAllocator(allocator cache.IdentityAllocator) {
 	e.unconditionalLock()
@@ -2051,6 +2057,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	// Unconditionally force policy recomputation after a new identity has been
 	// assigned.
 	e.forcePolicyComputation()
+
+	// Trigger the sync-to-k8s-ciliumendpoint controller to sync the new
+	// endpoint's identity.
+	e.controllers.TriggerController(EndpointSyncControllerName(e.ID))
 
 	e.unlock()
 

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -43,12 +43,6 @@ const (
 	subsysEndpointSync = "endpointsynchronizer"
 )
 
-// controllerNameOf returns the controller name to synchronize endpoint in to
-// kubernetes.
-func controllerNameOf(epID uint16) string {
-	return fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", epID)
-}
-
 // EndpointSynchronizer currently is an empty type, which wraps around syncing
 // of CiliumEndpoint resources.
 type EndpointSynchronizer struct{}
@@ -61,7 +55,7 @@ type EndpointSynchronizer struct{}
 func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 	var (
 		endpointID     = e.ID
-		controllerName = controllerNameOf(endpointID)
+		controllerName = endpoint.EndpointSyncControllerName(endpointID)
 		scopedLog      = e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 	)
 
@@ -299,7 +293,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 // CEP from Kubernetes once the endpoint is stopped / removed from the
 // Cilium agent.
 func (epSync *EndpointSynchronizer) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
-	controllerName := controllerNameOf(e.ID)
+	controllerName := endpoint.EndpointSyncControllerName(e.ID)
 
 	scopedLog := e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -648,8 +648,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			testHostFirewall(kubectl)
 		})
 
-		// We need to skip this test when using kube-proxy because of #14859.
-		SkipItIf(helpers.RunsWithKubeProxy, "With native routing", func() {
+		It("With native routing", func() {
 			options := map[string]string{
 				"hostFirewall": "true",
 				"tunnel":       "disabled",


### PR DESCRIPTION
 * #16381 -- endpoint: trigger k8s sync controller on identity update (@jibi)
 * #15148 -- bpf: bpf host routing for tunneling (@borkmann)
 * #16136 -- bpf: fix iptables masquerading for node -> remote pod traffic (@jibi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16381 15148 16136; do contrib/backporting/set-labels.py $pr done 1.9; done
```

Fixes: https://github.com/cilium/cilium/issues/16873