### PR TITLE
docs: account for bandwidth manager now being disabled by default

### DIFF
--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -43,15 +43,24 @@ by Cilium's bandwidth manager.
 
 .. include:: k8s-install-download-release.rst
 
-The Cilium bandwidth manager is enabled by default for new deployments via Helm:
+Cilium's bandwidth manager is disabled by default on new installations.
+To install Cilium with the bandwidth manager enabled, run
 
 .. parsed-literal::
 
    helm install cilium |CHART_RELEASE| \\
-     --namespace kube-system
+     --namespace kube-system \\
+     --bandwidthManager=true
 
-The option for Helm is controllable through ``bandwidthManager`` with a
-possible setting of ``true`` (default) and ``false``.
+To enable the bandwidth manager on an existing installation, run
+
+.. parsed-literal::
+
+   helm upgrade cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --reuse-values \\
+     --bandwidthManager=true
+   kubectl -n kube-system rollout restart ds/cilium
 
 The native host networking devices are auto detected as native devices which have
 the default route on the host or have Kubernetes InternalIP or ExternalIP assigned.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -829,6 +829,14 @@
      - Enable Layer 7 network policy.
      - bool
      - ``true``
+   * - livenessProbe.failureThreshold
+     - failure threshold of liveness probe
+     - int
+     - ``10``
+   * - livenessProbe.periodSeconds
+     - interval between checks of the liveness probe
+     - int
+     - ``30``
    * - localRedirectPolicy
      - Enable Local Redirect Policy.
      - bool
@@ -1157,6 +1165,14 @@
      - Enable creation of Resource-Based Access Control configuration.
      - bool
      - ``true``
+   * - readinessProbe.failureThreshold
+     - failure threshold of readiness probe
+     - int
+     - ``3``
+   * - readinessProbe.periodSeconds
+     - interval between checks of the readiness probe
+     - int
+     - ``30``
    * - remoteNodeIdentity
      - Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
      - bool
@@ -1197,6 +1213,14 @@
      - Configure BPF socket operations configuration
      - object
      - ``{"enabled":false}``
+   * - startupProbe.failureThreshold
+     - failure threshold of startup probe. 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s)
+     - int
+     - ``105``
+   * - startupProbe.periodSeconds
+     - interval between checks of the startup probe
+     - int
+     - ``2``
    * - tls
      - Configure TLS configuration in the agent.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -358,6 +358,7 @@ extraConfigmapMounts
 extraEnv
 extraHostPathMounts
 extraInitContainers
+failureThreshold
 fallback
 filename
 filenames
@@ -541,6 +542,7 @@ listenHost
 listenPort
 liveblog
 liveness
+livenessProbe
 llc
 llvm
 loadBalancer
@@ -652,6 +654,7 @@ parsers
 pc
 pcap
 perf
+periodSeconds
 pipelining
 playbook
 pluggable
@@ -788,6 +791,7 @@ stapbpf
 starfighter
 starfighters
 startup
+startupProbe
 stateful
 statsd
 structs


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/16380 disabled the bandwidth manager by default.