### PR TITLE
docs: improve the bandwidth manager page

### DIFF
--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -11,7 +11,7 @@ Bandwidth Manager (beta)
 ************************
 
 This guide explains how to configure Cilium's bandwidth manager to
-optimize TCP and UDP workloads and efficiently rate limit individual Pods
+optimize TCP and UDP workloads and efficiently rate limit individual pods
 if needed through the help of EDT (Earliest Departure Time) and eBPF.
 
 The bandwidth manager does not rely on CNI chaining and is natively integrated
@@ -21,7 +21,7 @@ plugin. Due to scalability concerns in particular for multi-queue network
 interfaces, it is not recommended to use the bandwidth CNI plugin which is
 based on TBF (Token Bucket Filter) instead of EDT.
 
-Cilium's bandwidth manager supports the ``kubernetes.io/egress-bandwidth`` Pod
+Cilium's bandwidth manager supports the ``kubernetes.io/egress-bandwidth`` pod
 annotation which is enforced on egress at the native host networking devices.
 The bandwidth enforcement is supported for direct routing as well as tunneling
 mode in Cilium.
@@ -63,19 +63,20 @@ To enable the bandwidth manager on an existing installation, run
    kubectl -n kube-system rollout restart ds/cilium
 
 The native host networking devices are auto detected as native devices which have
-the default route on the host or have Kubernetes InternalIP or ExternalIP assigned.
-InternalIP is preferred over ExternalIP if both exist. To change and manually specify
-the devices, set their names in the ``devices`` helm option, e.g.
-``devices='{eth0,eth1,eth2}'``. Each listed device has to be named the same
-on all Cilium managed nodes.
+the default route on the host or have Kubernetes ``InternalIP`` or ``ExternalIP`` assigned.
+``InternalIP`` is preferred over ``ExternalIP`` if both exist. To change and manually specify
+the devices, set their names in the ``devices`` helm option (e.g.
+``devices='{eth0,eth1,eth2}'``). Each listed device has to be named the same
+on all Cilium-managed nodes.
 
-Verify that the Cilium Pod has come up correctly:
+Verify that the Cilium pods have come up correctly:
 
 .. code-block:: shell-session
 
     $ kubectl -n kube-system get pods -l k8s-app=cilium
     NAME                READY     STATUS    RESTARTS   AGE
     cilium-crf7f        1/1       Running   0          10m
+    cilium-db21a        1/1       Running   0          10m
 
 In order to verify whether the bandwidth manager feature has been enabled in Cilium,
 the ``cilium status`` CLI command provides visibility through the ``BandwidthManager``
@@ -84,45 +85,66 @@ is enforced:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep BandwidthManager
+    $ kubectl -n kube-system exec ds/cilium -- cilium status | grep BandwidthManager
     BandwidthManager:       EDT with BPF   [eth0]
 
-Assuming we have a multi-node cluster, in the next step, we deploy a netperf Pod on
-the node named foobar. The following example deployment yaml limits the egress
-bandwidth of the netperf Pod on the node's physical device:
+To verify that egress bandwidth limits are indeed being enforced, one can deploy two
+``netperf`` pods in different nodes — one acting as a server and one acting as the client:
 
 .. code-block:: yaml
 
-    apiVersion: apps/v1
-    kind: Deployment
+    ---
+    apiVersion: v1
+    kind: Pod
     metadata:
-      name: netperf
+      annotations:
+        # Limits egress bandwidth to 10Mb/s.
+        kubernetes.io/egress-bandwidth: "10M"
+      labels:
+        # This pod will act as server.
+        app.kubernetes.io/name: netperf-server
+      name: netperf-server
     spec:
-      selector:
-        matchLabels:
-          run: netperf
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            run: netperf
-          annotations:
-            kubernetes.io/egress-bandwidth: "10M"
-        spec:
-          nodeName: foobar
-          containers:
-          - name: netperf
-            image: cilium/netperf
-            ports:
-            - containerPort: 12865
+      containers:
+      - name: netperf
+        image: cilium/netperf
+        ports:
+        - containerPort: 12865
+    ---
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      # This pod will act as client.
+      name: netperf-client
+    spec:
+      affinity:
+        # Prevents the client from being scheduled to the
+        # same node as the server.
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - netperf-server
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: netperf
+        args:
+        - sleep
+        - infinity
+        image: cilium/netperf
 
-Once up and running, ``netperf`` client can be invoked from a different node in the
-cluster using the Pod's IP (in this case ``10.217.0.254``) directly. The test streaming
-direction is from the netperf deployment towards the client, hence ``TCP_MAERTS``:
+Once up and running, the ``netperf-client`` pod can be used to test egress bandwidth enforcement
+on the ``netperf-server`` pod. As the test streaming direction is from the ``netperf-server`` pod
+towards the client, we need to check ``TCP_MAERTS``:
 
 .. code-block:: shell-session
 
-  $ netperf -t TCP_MAERTS -H 10.217.0.254
+  $ NETPERF_SERVER_IP=$(kubectl get pod netperf-server -o jsonpath='{.status.podIP}')
+  $ kubectl exec netperf-client -- \
+      netperf -t TCP_MAERTS -H "${NETPERF_SERVER_IP}"
   MIGRATED TCP MAERTS TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.217.0.254 () port 0 AF_INET
   Recv   Send    Send
   Socket Socket  Message  Elapsed
@@ -131,14 +153,15 @@ direction is from the netperf deployment towards the client, hence ``TCP_MAERTS`
 
    87380  16384  16384    10.00       9.56
 
-As can be seen, egress traffic of the netperf Pod has been limited to 10Mbit per second.
+As can be seen, egress traffic of the ``netperf-server`` pdd has been limited to 10Mbit per second.
 
 In order to introspect current endpoint bandwidth settings from BPF side, the following
-command can be run:
+command can be run (replace ``cilium-xxxxx`` with the name of the Cilium pod that is co-located with
+the ``netperf-server`` pod):
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium bpf bandwidth list
+    $ kubectl exec -it -n kube-system cilium-xxxxxx -- cilium bpf bandwidth list
     IDENTITY   EGRESS BANDWIDTH (BitsPerSec)
     491        10M
 

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -11,7 +11,7 @@ Bandwidth Manager (beta)
 ************************
 
 This guide explains how to configure Cilium's bandwidth manager to
-optimize TCP and UDP workloads and efficiently rate limit individual pods
+optimize TCP and UDP workloads and efficiently rate limit individual Pods
 if needed through the help of EDT (Earliest Departure Time) and eBPF.
 
 The bandwidth manager does not rely on CNI chaining and is natively integrated
@@ -21,7 +21,7 @@ plugin. Due to scalability concerns in particular for multi-queue network
 interfaces, it is not recommended to use the bandwidth CNI plugin which is
 based on TBF (Token Bucket Filter) instead of EDT.
 
-Cilium's bandwidth manager supports the ``kubernetes.io/egress-bandwidth`` pod
+Cilium's bandwidth manager supports the ``kubernetes.io/egress-bandwidth`` Pod
 annotation which is enforced on egress at the native host networking devices.
 The bandwidth enforcement is supported for direct routing as well as tunneling
 mode in Cilium.
@@ -69,7 +69,7 @@ the devices, set their names in the ``devices`` helm option (e.g.
 ``devices='{eth0,eth1,eth2}'``). Each listed device has to be named the same
 on all Cilium-managed nodes.
 
-Verify that the Cilium pods have come up correctly:
+Verify that the Cilium Pods have come up correctly:
 
 .. code-block:: shell-session
 
@@ -89,7 +89,7 @@ is enforced:
     BandwidthManager:       EDT with BPF   [eth0]
 
 To verify that egress bandwidth limits are indeed being enforced, one can deploy two
-``netperf`` pods in different nodes — one acting as a server and one acting as the client:
+``netperf`` Pods in different nodes — one acting as a server and one acting as the client:
 
 .. code-block:: yaml
 
@@ -98,7 +98,7 @@ To verify that egress bandwidth limits are indeed being enforced, one can deploy
     kind: Pod
     metadata:
       annotations:
-        # Limits egress bandwidth to 10Mb/s.
+        # Limits egress bandwidth to 10Mbit/s.
         kubernetes.io/egress-bandwidth: "10M"
       labels:
         # This pod will act as server.
@@ -114,7 +114,7 @@ To verify that egress bandwidth limits are indeed being enforced, one can deploy
     apiVersion: v1
     kind: Pod
     metadata:
-      # This pod will act as client.
+      # This Pod will act as client.
       name: netperf-client
     spec:
       affinity:
@@ -136,8 +136,8 @@ To verify that egress bandwidth limits are indeed being enforced, one can deploy
         - infinity
         image: cilium/netperf
 
-Once up and running, the ``netperf-client`` pod can be used to test egress bandwidth enforcement
-on the ``netperf-server`` pod. As the test streaming direction is from the ``netperf-server`` pod
+Once up and running, the ``netperf-client`` Pod can be used to test egress bandwidth enforcement
+on the ``netperf-server`` Pod. As the test streaming direction is from the ``netperf-server`` Pod
 towards the client, we need to check ``TCP_MAERTS``:
 
 .. code-block:: shell-session
@@ -153,11 +153,11 @@ towards the client, we need to check ``TCP_MAERTS``:
 
    87380  16384  16384    10.00       9.56
 
-As can be seen, egress traffic of the ``netperf-server`` pdd has been limited to 10Mbit per second.
+As can be seen, egress traffic of the ``netperf-server`` Pod has been limited to 10Mbit per second.
 
 In order to introspect current endpoint bandwidth settings from BPF side, the following
-command can be run (replace ``cilium-xxxxx`` with the name of the Cilium pod that is co-located with
-the ``netperf-server`` pod):
+command can be run (replace ``cilium-xxxxx`` with the name of the Cilium Pod that is co-located with
+the ``netperf-server`` Pod):
 
 .. code-block:: shell-session
 


### PR DESCRIPTION
Attempts to make the "Bandwidth Manager" page more user-friendly by deploying a server pod and a client pod that is guaranteed to not be colocated with the former. Also provides friendlier commands for making the `netperf` test, as well as to check the status of the bandwidth manager.

Related to this PR is https://github.com/cilium/cilium/pull/16782, but the current one needs backporting to both `v1.9` and `v.10`, whereas https://github.com/cilium/cilium/pull/16782 is only required to be backported to `v1.10`.

```release-note
docs: improve the bandwidth manager page
```