### PR TITLE
docs: ignore `__pycache__` directory created by custom spelling filters

### DIFF
--- a/Documentation/.gitignore
+++ b/Documentation/.gitignore
@@ -1,5 +1,6 @@
 _build
 _api
 _preview
+_exts/__pycache__
 Pipfile
 Pipfile.lock


### PR DESCRIPTION
We recently added a custom filter for spell checking, in order to have better control on the case for some specific terms. This custom filter is written as a Python function in a dedicated file, and it turns out that this file is pre-compiled when building the documentation. Let's add the relevant `__pycache__` directory to the `.gitignore` in the documentation directory.

Fixes: 871047700c1f ("docs: add custom spelling filter to check WireGuard spelling")
Fixes: #16513
