### PR TITLE
test/bpf: Flag to continue in case of errors

### DIFF
--- a/test/bpf/check-complexity.sh
+++ b/test/bpf/check-complexity.sh
@@ -57,4 +57,4 @@ if ! grep -q "CILIUM_CALL_SIZE.*25" "$BPFDIR/lib/common.h" ; then
 	exit 1
 fi
 
-"$TESTDIR/verifier-test.sh" -v | get_insn_cnt | annotate_section_names
+"$TESTDIR/verifier-test.sh" -v -f | get_insn_cnt | annotate_section_names

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -28,6 +28,7 @@ XDP_PROGS=${XDP_PROGS:-$ALL_XDP_PROGS}
 IGNORED_PROGS="bpf_alignchecker tests/bpf_ct_tests custom/bpf_custom"
 ALL_PROGS="${IGNORED_PROGS} ${ALL_CG_PROGS} ${ALL_TC_PROGS} ${ALL_XDP_PROGS}"
 VERBOSE=false
+FORCE=false
 RUN_ALL_TESTS=false
 
 BPFFS=${BPFFS:-"/sys/fs/bpf"}
@@ -72,7 +73,7 @@ function load_prog {
 	echo "=> Loading ${name}..."
 	if $VERBOSE; then
 		# Redirect stderr to stdout to assist caller parsing
-		${loader} $args verbose 2>&1
+		${loader} $args verbose 2>&1 || $FORCE
 	else
 		# Only run verbose mode if loading fails.
 		${loader} $args 2>/dev/null \
@@ -192,7 +193,7 @@ function load_sockops_prog {
 
 	echo "=> Loading ${p}.c:${section}..."
 	if $VERBOSE; then
-		$BPFTOOL -m prog load "$prog.o" "$pinpath" $map_args 2>&1
+		$BPFTOOL -m prog load "$prog.o" "$pinpath" $map_args 2>&1 || $FORCE
 	else
 		$BPFTOOL -m prog load "$prog.o" "$pinpath" $map_args 2>/dev/null \
 		|| $BPFTOOL -m prog load "$prog.o" "$pinpath" $map_args
@@ -267,6 +268,9 @@ function handle_args {
 			shift;;
 		-v|--verbose)
 			VERBOSE=true
+			shift;;
+		-f|--force)
+			FORCE=true
 			shift;;
 		*)
 			echo "Unrecognized argument '$1'" 1>&2

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -157,23 +157,6 @@ function cg_prog_type_init {
 	fi
 }
 
-function load_sock_prog {
-	prog=$1
-	pinpath=$2
-	prog_type=$3
-	attach_type=$4
-	section=$5
-
-	local args="pin $pinpath obj ${prog}.o type $prog_type \
-		    attach_type $attach_type sec $section"
-	if $VERBOSE; then
-		$TC exec bpf $args verbose 2>&1
-	else
-		$TC exec bpf $args 2>/dev/null \
-		|| $TC exec bpf $args verbose
-	fi
-}
-
 function load_sockops_prog {
 	prog="$1"
 	pinpath="$2"


### PR DESCRIPTION
This pull request adds a new flag `--force` to instruct `verifier-test.sh` to ignore errors when failing to load a program and continue with subsequent programs. That enables us to get a full picture of the complexity reported by the verifier, even if one of the programs fails.