### PR TITLE
test: Fix helper to retrieve tail call counters

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -753,7 +753,7 @@ func (kub *Kubectl) CountMissedTailCalls() (int, error) {
 			return -1, fmt.Errorf("Failed to run %s in pod %s: %s", cmd, ciliumPod, res.CombineOutput())
 		}
 		if res.Stdout() == "" {
-			return 0, nil
+			continue
 		}
 
 		for _, cnt := range res.ByLines() {


### PR DESCRIPTION
If the tail call counter was zero (absent) on the first node, the helper function would simply return as if it was absent on all nodes. This pull request fixes that bug.

Fixes: https://github.com/cilium/cilium/pull/13097.