### PR TITLE
contrib: Explicitly set remote for backport branches

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -53,6 +53,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $AUTHORS
 


### PR DESCRIPTION
Before this change, the backporting scripts would correctly push to the
user's remote, but the default remote for the backport branch was left
as origin (typically cilium/cilium).

This commit sets the backporting branch's remote to the user's remote,
so further pushes from the command line (e.g. after adding more commits
or rebasing) go by default to the correct remote.

Signed-off-by: Tom Payne <tom@isovalent.com>
