### PR TITLE
Avoid transitive dependency on github.com/miekg/dns in policy API

### DIFF
--- a/pkg/fqdn/dns/dns.go
+++ b/pkg/fqdn/dns/dns.go
@@ -1,5 +1,11 @@
 // Copyright 2021 Authors of Cilium
 //
+// Based on code from github.com/miekg/dns which is:
+//
+// Copyright 2009 The Go Authors. All rights reserved.
+// Copyright 2011 Miek Gieben. All rights reserved.
+// Copyright 2014 CloudFlare. All rights reserved.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/fqdn/dns/dns.go
+++ b/pkg/fqdn/dns/dns.go
@@ -1,0 +1,44 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import "strings"
+
+// These functions were copied and adapted from github.com/miekg/dns.
+
+// isFQDN reports whether the domain name s is fully qualified.
+func isFQDN(s string) bool {
+	s2 := strings.TrimSuffix(s, ".")
+	if s == s2 {
+		return false
+	}
+
+	i := strings.LastIndexFunc(s2, func(r rune) bool {
+		return r != '\\'
+	})
+
+	// Test whether we have an even number of escape sequences before
+	// the dot or none.
+	return (len(s2)-i)%2 != 0
+}
+
+// FQDN returns the fully qualified domain name from s.
+// If s is already fully qualified, it behaves as the identity function.
+func FQDN(s string) string {
+	if isFQDN(s) {
+		return strings.ToLower(s)
+	}
+	return strings.ToLower(s) + "."
+}

--- a/pkg/fqdn/dns/dns_test.go
+++ b/pkg/fqdn/dns/dns_test.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package dns
+
+import "testing"
+
+func TestIsFQDN(t *testing.T) {
+	for _, tt := range []struct {
+		s      string
+		expect bool
+	}{
+		{".", true},
+		{"\\.", false},
+		{"\\\\.", true},
+		{"\\\\\\.", false},
+		{"\\\\\\\\.", true},
+		{"a.", true},
+		{"a\\.", false},
+		{"a\\\\.", true},
+		{"a\\\\\\.", false},
+		{"ab.", true},
+		{"ab\\.", false},
+		{"ab\\\\.", true},
+		{"ab\\\\\\.", false},
+		{"..", true},
+		{".\\.", false},
+		{".\\\\.", true},
+		{".\\\\\\.", false},
+		{"example.org.", true},
+		{"example.org\\.", false},
+		{"example.org\\\\.", true},
+		{"example.org\\\\\\.", false},
+		{"example\\.org.", true},
+		{"example\\\\.org.", true},
+		{"example\\\\\\.org.", true},
+		{"\\example.org.", true},
+		{"\\\\example.org.", true},
+		{"\\\\\\example.org.", true},
+	} {
+		if got := isFQDN(tt.s); got != tt.expect {
+			t.Errorf("isFQDN(%q) = %t, expected %t", tt.s, got, tt.expect)
+		}
+	}
+}
+
+func TestFQDN(t *testing.T) {
+	for _, tt := range []struct {
+		s      string
+		expect string
+	}{
+		{".", "."},
+		{"\\.", "\\.."},
+		{"example.org", "example.org."},
+		{"example.org.", "example.org."},
+		{"example.org\\.", "example.org\\.."},
+		{"example.org\\\\.", "example.org\\\\."},
+		{"EXAMPLE.ORG", "example.org."},
+		{"eXAMPLE.org.", "example.org."},
+	} {
+		if got := FQDN(tt.s); got != tt.expect {
+			t.Errorf("isFQDN(%q) = %q, expected %q", tt.s, got, tt.expect)
+		}
+	}
+}

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -17,12 +17,11 @@ package fqdn
 import (
 	"net"
 	"regexp"
-	"strings"
 
+	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 )
 
@@ -106,7 +105,7 @@ func mapSelectorsToIPs(fqdnSelectors map[api.FQDNSelector]struct{}, cache *DNSCa
 
 // prepareMatchName ensures a ToFQDNs.matchName field is used consistently.
 func prepareMatchName(matchName string) string {
-	return strings.ToLower(dns.Fqdn(matchName))
+	return dns.FQDN(matchName)
 }
 
 // KeepUniqueNames removes duplicate names from the given slice while

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/miekg/dns"
+	"github.com/cilium/cilium/pkg/fqdn/dns"
 )
 
 const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
@@ -44,7 +44,7 @@ func Sanitize(pattern string) string {
 		return pattern
 	}
 
-	return strings.ToLower(dns.Fqdn(pattern))
+	return dns.FQDN(pattern)
 }
 
 // ToRegexp converts a MatchPattern field into a regexp string. It does not

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/miekg/dns"
 
 	. "gopkg.in/check.v1"
 )
@@ -61,7 +61,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
@@ -73,7 +73,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
@@ -110,7 +110,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
@@ -118,8 +118,8 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
 	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
-		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
-		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
+		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
+		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 2, Commentf("More than 2 FQDN selectors while only 2 were added"))
 	c.Assert(len(selIPMap[ciliumIOSel]), Equals, 2, Commentf("Incorrect number of IPs for cilium.io selector"))
@@ -131,8 +131,8 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
 	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
-		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
-		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
+		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
+		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap[ciliumIOSel]), Equals, 2, Commentf("Incorrect number of IPs for cilium.io selector"))
 	c.Assert(len(selIPMap[githubSel]), Equals, 2, Commentf("Incorrect number of IPs for github.com selector"))

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -17,11 +17,9 @@ package api
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
+	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
-
-	"github.com/miekg/dns"
 )
 
 var (
@@ -101,7 +99,7 @@ func (s *FQDNSelector) sanitize() error {
 func (s *FQDNSelector) ToRegex() (*regexp.Regexp, error) {
 	var preparedMatch string
 	if s.MatchName != "" {
-		preparedMatch = strings.ToLower(dns.Fqdn(s.MatchName))
+		preparedMatch = dns.FQDN(s.MatchName)
 	} else {
 		preparedMatch = matchpattern.Sanitize(s.MatchPattern)
 	}


### PR DESCRIPTION
Introduce a new helper package duplicating `IsFqdn` and `Fqdn` from the `github.com/miekg/dns` to avoid transitively depending on that package in out-of-tree users of the policy API, namely `github.com/cilium/cilium-cli`. This will e.g. allow to fix https://github.com/cilium/cilium-cli/issues/231.

See individual commits for details.