### PR TITLE
github: Increase workflow timeout

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -109,7 +109,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Set up job variables
         id: vars


### PR DESCRIPTION
Increase conformance-gke timeout to avoid fail due to cancelled test
as in:

installation-and-connectivity
cancelled 2 hours ago in 30m 13s


[=] Test [client-egress]
....
[=] Test [echo-ingress]
Error: The operation was canceled.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
