### PR TITLE
test: Increase service/DNS timeout from 30 to 240 seconds

### DIFF
--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -99,7 +99,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 				}
 				return true
 			}
-			err := helpers.WithTimeout(body, fmt.Sprintf("unable to resolve DNS for service %s in pod %s", service, pod), &helpers.TimeoutConfig{Timeout: 30 * time.Second})
+			err := helpers.WithTimeout(body, fmt.Sprintf("unable to resolve DNS for service %s in pod %s", service, pod), &helpers.TimeoutConfig{Timeout: 240 * time.Second})
 			return err
 		}
 


### PR DESCRIPTION
Increase the timeout for service to acquire it's backends in hopes
the 30 seconds was simply too optimistic in some scenarios. This could
avoid test flakes like:
```
Failed to resolve kafka-service DNS entry in pod empire-outpost-8888-544cdcd9b8-72hgl
Expected
    <*errors.errorString | 0xc001e05fd0>: {
        s: "unable to resolve DNS for service kafka-service in pod empire-outpost-8888-544cdcd9b8-72hgl: 30s timeout expired",
    }
to be nil
/home/jenkins/workspace/Cilium-PR-K8s-1.21-kernel-4.9/src/github.com/cilium/cilium/test/k8sT/KafkaPolicies.go:157
```
In the above case the service did not have any backends yet, even when
the backend pod was up and running. Give k8s apiserver a bit more time
to converge.
```
            "status": {
                "loadBalancer": {}
            }
```
(from `svc.json` in https://jenkins.cilium.io/job/Cilium-PR-K8s-1.21-kernel-4.9/939/testReport/junit/Suite-k8s-1/21/K8sKafkaPolicyTest_Kafka_Policy_Tests_KafkaPolicies/)

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
