### PR TITLE
[v1.10] Fixes for platforms where init container fails to run 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ debug: all
 
 include Makefile.defs
 
-SUBDIRS_CILIUM_CONTAINER := proxylib envoy bpf cilium daemon cilium-health bugtool
+SUBDIRS_CILIUM_CONTAINER := proxylib envoy bpf cilium daemon cilium-health bugtool tools/mount
 SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools hubble-relay
 
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-cni

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -391,6 +391,7 @@ spec:
           - -c
           - 'mount | grep "$CGROUP_ROOT type cgroup2" || { echo "Mounting cgroup filesystem..."; mount -t cgroup2 none $CGROUP_ROOT; }'
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
           - mountPath: /hostpid1ns
             name: host-proc-ns

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -382,19 +382,24 @@ spec:
         env:
           - name: CGROUP_ROOT
             value: {{ .Values.cgroup.hostRoot }}
+          - name: BIN_PATH
+            value: {{ .Values.cni.binPath }}
         command:
-          - nsenter
-          - --cgroup=/hostproc/1/ns/cgroup
-          - --mount=/hostproc/1/ns/mnt
-          - --
           - sh
           - -c
-          - 'mount | grep "$CGROUP_ROOT type cgroup2" || { echo "Mounting cgroup filesystem..."; mount -t cgroup2 none $CGROUP_ROOT; }'
+          # The statically linked Go program binary is invoked to avoid any
+          # dependency on utilities like sh and mount that can be missing on certain
+          # distros installed on the underlying host. Copy the binary to the
+          # same directory where we install cilium cni plugin so that exec permissions
+          # are available.
+          - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
           - mountPath: /hostproc
             name: hostproc
+          - mountPath: /hostbin
+            name: cni-path
         securityContext:
           privileged: true
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -384,8 +384,8 @@ spec:
             value: {{ .Values.cgroup.hostRoot }}
         command:
           - nsenter
-          - --cgroup=/hostpid1ns/cgroup
-          - --mount=/hostpid1ns/mnt
+          - --cgroup=/hostproc/1/ns/cgroup
+          - --mount=/hostproc/1/ns/mnt
           - --
           - sh
           - -c
@@ -393,8 +393,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
-          - mountPath: /hostpid1ns
-            name: host-proc-ns
+          - mountPath: /hostproc
+            name: hostproc
         securityContext:
           privileged: true
 {{- end }}
@@ -500,9 +500,9 @@ spec:
 {{- if .Values.cgroup.autoMount.enabled }}
       # To mount cgroup2 filesystem on the host
       - hostPath:
-          path: /proc/1/ns
+          path: /proc
           type: Directory
-        name: host-proc-ns
+        name: hostproc
 {{- end }}
       # To keep state between restarts / upgrades for cgroup2 filesystem
       - hostPath:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,9 +1,9 @@
-# Copyright 2017-2019 Authors of Cilium
+# Copyright 2017-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 include ../Makefile.defs
 
-SUBDIRS := alignchecker maptool
+SUBDIRS := alignchecker maptool mount
 
 .PHONY: all $(SUBDIRS) clean install
 

--- a/tools/mount/.gitignore
+++ b/tools/mount/.gitignore
@@ -1,0 +1,1 @@
+cilium-mount

--- a/tools/mount/Makefile
+++ b/tools/mount/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2021 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+include ../../Makefile.defs
+
+TARGET := cilium-mount
+
+.PHONY: all $(TARGET) $(SUBDIRS) clean install
+
+all: $(TARGET)
+
+$(TARGET):
+	@$(ECHO_GO)
+	$(QUIET)$(GO_BUILD) -o $@
+
+clean:
+	@$(ECHO_CLEAN)
+	-$(QUIET)rm -f $(TARGET)
+	$(QUIET)$(GO_CLEAN)
+
+install:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+
+install-binary: install
+
+install-bash-completion:

--- a/tools/mount/main.go
+++ b/tools/mount/main.go
@@ -1,0 +1,35 @@
+//  Copyright 2021 Authors of Cilium
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cilium/cilium/pkg/cgroups"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <cgroup-mount-point> \n\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	cgroupMountPoint := os.Args[1]
+	// This program is executed by an init container so we purposely don't
+	// exit with any error codes. In case of errors, the function will log warnings,
+	// but we don't block cilium agent pod from running.
+	cgroups.CheckOrMountCgrpFS(cgroupMountPoint)
+}


### PR DESCRIPTION
* #16815 -- Fixes for platforms where init container fails to run (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16815; do contrib/backporting/set-labels.py $pr done 1.10; done
```