### PR TITLE
workflows: fix Relay pgrep check when using additional flags

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -248,7 +248,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |
@@ -257,7 +257,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pkill -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Create custom IPsec secret
         run: |
@@ -280,7 +280,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -245,7 +245,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -223,7 +223,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |
@@ -232,7 +232,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pkill -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Create custom IPsec secret
         run: |
@@ -255,7 +255,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -207,7 +207,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |
@@ -216,7 +216,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pkill -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Install Cilium with tunnel datapath
         run: |
@@ -235,7 +235,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Restart connectivity test pods
         run: |
@@ -249,7 +249,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pkill -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Create custom IPsec secret
         run: |
@@ -272,7 +272,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Restart connectivity test pods
         run: |
@@ -287,7 +287,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pkill -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Install Cilium with encryption and tunnel datapath
         run: |
@@ -307,7 +307,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |
@@ -98,7 +98,7 @@ jobs:
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
-          pkill -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Install Cilium with encryption
         run: |
@@ -117,7 +117,7 @@ jobs:
         run: |
           cilium hubble port-forward&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -277,7 +277,7 @@ jobs:
         run: |
           cilium hubble port-forward --context ${{ steps.contexts.outputs.context1 }}&
           sleep 10s
-          [[ $(pgrep -f "cilium hubble port-forward|kubectl port-forward.*hubble-relay" | wc -l) == 2 ]]
+          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
         run: |


### PR DESCRIPTION
When passing additional flags to `cilium hubble port-forward`, both the original command and `kubectl` child process might be conflated with additional flags.

We add wildcards for matching the additional flags.

Fixes 00ae9fb492f0c6313277106bdf50c740d0d395cc
Follow-up to #16787