### PR TITLE
envoy: Keep track of proxy listeners separately

### DIFF
--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -44,6 +44,7 @@ func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServe
 		// Start Envoy on first invocation
 		envoyProxy = envoy.StartEnvoy(stateDir, option.Config.EnvoyLogPath, 0)
 
+		// Add Prometheus listener if the port is (properly) configured
 		if option.Config.ProxyPrometheusPort < 0 || option.Config.ProxyPrometheusPort > 65535 {
 			log.WithField(logfields.Port, option.Config.ProxyPrometheusPort).Error("Envoy: Invalid configured proxy-prometheus-port")
 		} else if option.Config.ProxyPrometheusPort != 0 {


### PR DESCRIPTION
Since the addition of Envoy prometheus listener it has been possible
to have non-proxy listeners configured with Envoy. Waiting for Envoy
N/ACKs must be disabled when no proxy listeners are configured, even
if a prometheus listener may still be configured.

Without this fix adding endpoints may fail due to not receiving N/ACKs
from Envoy after Envoy has been started due to an L7 network policy,
and this policy is removed, if the Cilium option
'--proxy-prometheus-port' is also configured.

Fixes: #12949
Fixes: #16375
Fixes: #16667

```release-note
Envoy configuration with `--proxy-prometheus-port` is fixed.
```
