### PR TITLE
test: Delete DNS pods in AfterAll for datapath tests

### DIFF
--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -113,6 +113,7 @@ var _ = Describe("K8sCustomCalls", func() {
 		AfterAll(func() {
 			deploymentManager.DeleteCilium()
 			deploymentManager.DeleteAll()
+			kubectl.RedeployDNS()
 		})
 
 		installPods := func() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -55,6 +55,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	AfterAll(func() {
 		deploymentManager.DeleteCilium()
+		kubectl.RedeployDNS()
 		kubectl.CloseSSHClient()
 	})
 


### PR DESCRIPTION
Commit a0e77127dcd7 ("test: Redeploy DNS after changing endpointRoutes")
didn't go quite far enough: It ensured that between individual tests in
a given file, the DNS pods would be redeployed during the next run if
there were significant enough datapath changes. However, the way it did
this was by storing state within the 'kubectl' variable, which is
recreated in each test file. So if the last test in one CI run enabled
endpoint routes mode, then the DNS pods would not be redeployed to
disable endpoint routes mode as part of the next test.

Fix it by just deleting the overall kube-dns deployment at the end of
any test files which reconfigure this datapath option. I assume that the
next test will set up DNS again if it's not available.

Reported-by: Chris Tarazi <chris@isovalent.com>
Fixes: 0e77127dcd7 ("test: Redeploy DNS after changing endpointRoutes")
Fixes: #16717
