### PR TITLE
.github: do not useDigest in conformance tests

### DIFF
--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -82,10 +82,12 @@ jobs:
              --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
              --set image.tag=${{ steps.vars.outputs.tag }} \
              --set image.pullPolicy=IfNotPresent \
+             --set image.useDigest=false \
              --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
              --set operator.image.suffix=-ci \
              --set operator.image.tag=${{ steps.vars.outputs.tag }} \
              --set operator.image.pullPolicy=IfNotPresent \
+             --set operator.image.useDigest=false \
              --set prometheus.enabled=true \
              --set operator.prometheus.enabled=true \
              --set hubble.enabled=true \

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -97,10 +97,12 @@ jobs:
             --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
             --set image.tag=${{ steps.vars.outputs.tag }} \
             --set image.pullPolicy=IfNotPresent \
+            --set image.useDigest=false \
             --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
             --set operator.image.suffix=-ci \
             --set operator.image.tag=${{ steps.vars.outputs.tag }} \
             --set operator.image.pullPolicy=IfNotPresent \
+            --set operator.image.useDigest=false \
             --set ipv6.enabled=true \
             --set ipv4.enabled=false \
             --set tunnel=disabled \

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -135,10 +135,12 @@ jobs:
              --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
              --set image.tag=${{ steps.vars.outputs.tag }} \
              --set image.pullPolicy=IfNotPresent \
+             --set image.useDigest=false \
              --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
              --set operator.image.suffix=-ci \
              --set operator.image.tag=${{ steps.vars.outputs.tag }} \
              --set operator.image.pullPolicy=IfNotPresent \
+             --set operator.image.useDigest=false \
              --set prometheus.enabled=true \
              --set operator.prometheus.enabled=true \
              --set hubble.enabled=true \


### PR DESCRIPTION
Conformance tests are executed against the code being submitted in a PR.
If `useDigest` is set to true it will use the default digest defined in
the helm charts, which in stable branches is the last stable release.

Fixes: 41f66a1eb4fa (".github: use quay.io images in smoke tests")
Signed-off-by: André Martins <andre@cilium.io>

Note for reviewers: <1.10 branches are not affected since `useDigest` was only set to `true` by default in 1.10