### PR TITLE
node-init: remove aws iptables rules in eni mode

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/poststart.bash
+++ b/install/kubernetes/cilium/files/nodeinit/poststart.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# When running in AWS ENI mode, it's likely that 'aws-node' has
+# had a chance to install SNAT iptables rules. These can result
+# in dropped traffic, so we should attempt to remove them.
+# We do it using a 'postStart' hook since this may need to run
+# for nodes which might have already been init'ed but may still
+# have dangling rules. This is safe because there are no
+# dependencies on anything that is part of the startup script
+# itself, and can be safely run multiple times per node (e.g. in
+# case of a restart).
+if [[ "$(iptables-save | grep -c AWS-SNAT-CHAIN)" != "0" ]];
+then
+    echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
+    iptables-save | grep -v AWS-SNAT-CHAIN | iptables-restore
+fi
+echo 'Done!'

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -34,22 +34,27 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
       containers:
         - name: node-init
           image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           securityContext:
             privileged: true
+          volumeMounts:
+            # To access iptables concurrently with other processes (e.g. kube-proxy)
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
           lifecycle:
 {{- if and (.Values.eni.enabled) (not .Values.enableIPv4Masquerade) }}
             postStart:
               exec:
                 command:
-                  - "nsenter"
-                  - "-t"
-                  - "1"
-                  - "-m"
-                  - "--"
                   - "/bin/sh"
                   - "-c"
                   - |

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -40,8 +40,42 @@ spec:
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           securityContext:
             privileged: true
-          {{- if .Values.nodeinit.revertReconfigureKubelet }}
           lifecycle:
+{{- if and (.Values.eni.enabled) (not .Values.enableIPv4Masquerade) }}
+            postStart:
+              exec:
+                command:
+                  - "nsenter"
+                  - "-t"
+                  - "1"
+                  - "-m"
+                  - "--"
+                  - "/bin/sh"
+                  - "-c"
+                  - |
+                    #!/bin/bash
+
+                    set -o errexit
+                    set -o pipefail
+                    set -o nounset
+
+                    # When running in AWS ENI mode, it's likely that 'aws-node' has
+                    # had a chance to install SNAT iptables rules. These can result
+                    # in dropped traffic, so we should attempt to remove them.
+                    # We do it using a 'postStart' hook since this may need to run
+                    # for nodes which might have already been init'ed but may still
+                    # have dangling rules. This is safe because there are no
+                    # dependencies on anything that is part of the startup script
+                    # itself, and can be safely run multiple times per node (e.g. in
+                    # case of a restart).
+                    if [[ "$(iptables-save | grep -c AWS-SNAT-CHAIN)" != "0" ]];
+                    then
+                      echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
+                      iptables-save | grep -v AWS-SNAT-CHAIN | iptables-restore
+                    fi
+                    echo 'Done!'
+{{- end }}
+{{- if .Values.nodeinit.revertReconfigureKubelet }}
             preStop:
               exec:
                 command:

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -58,27 +58,7 @@ spec:
                   - "/bin/sh"
                   - "-c"
                   - |
-                    #!/bin/bash
-
-                    set -o errexit
-                    set -o pipefail
-                    set -o nounset
-
-                    # When running in AWS ENI mode, it's likely that 'aws-node' has
-                    # had a chance to install SNAT iptables rules. These can result
-                    # in dropped traffic, so we should attempt to remove them.
-                    # We do it using a 'postStart' hook since this may need to run
-                    # for nodes which might have already been init'ed but may still
-                    # have dangling rules. This is safe because there are no
-                    # dependencies on anything that is part of the startup script
-                    # itself, and can be safely run multiple times per node (e.g. in
-                    # case of a restart).
-                    if [[ "$(iptables-save | grep -c AWS-SNAT-CHAIN)" != "0" ]];
-                    then
-                      echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
-                      iptables-save | grep -v AWS-SNAT-CHAIN | iptables-restore
-                    fi
-                    echo 'Done!'
+                    {{- tpl (.Files.Get "files/nodeinit/poststart.bash") . | nindent 20 }}
 {{- end }}
 {{- if .Values.nodeinit.revertReconfigureKubelet }}
             preStop:


### PR DESCRIPTION
When running in AWS ENI mode, it's likely that `aws-node` has had a chance to install SNAT iptables rules. These can result in dropped traffic, so we should attempt to remove them. We do it using a `postStart` hook since this may need to run for nodes which might have already been init'ed (as they may still have dangling rules). This is safe because there are no dependencies on anything that is part of the startup script itself, and can be safely run multiple times per node (e.g. in case of a restart).

```release-note
node-init: cleanup snat iptables rules when running in eni mode with masquerading disabled
```