### PR TITLE
workflows: Improve the change check for `issue_comment` triggers

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -80,13 +80,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -94,6 +87,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -83,13 +83,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -97,6 +90,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -80,13 +80,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -94,6 +87,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -83,13 +83,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -97,6 +90,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -80,13 +80,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -94,6 +87,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -83,13 +83,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -97,6 +90,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -82,13 +82,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -96,6 +89,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -85,13 +85,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -99,6 +92,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -80,13 +80,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -94,6 +87,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -83,13 +83,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -97,6 +90,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -82,13 +82,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -96,6 +89,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -85,13 +85,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -99,6 +92,22 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.commits_url }} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721


### PR DESCRIPTION
Joe reported that the CI 3.0 tests were triggered in his pull request, even though it only touched `test/` code and [we should skip those tests in that case](https://github.com/cilium/cilium/blob/v1.10.2/.github/workflows/conformance-aks.yaml#L69). The logs revealed that happened because the workflow had an incorrect view of the pull request diff (saw more changes than existed).

To retrieve the set of changed files, we instruct the paths-filter GitHub action to compare `.base.sha` and `.head.sha`. `.head.sha` points to the tip of the pull request branch. `.base.sha` however doesn't point to the last master commit of the pull request branch (the commit on which the pull request is based). Instead it points to the latest master commit at the time you trigger the workflows.

This pull request fixes this by  manually retrieving the base commit via the GitHub API.