### PR TITLE
iptables: Add extra warning message listing missing IPV6 kernel modules

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -413,7 +413,7 @@ func (m *IptablesManager) Init() {
 		"ip6_tables", "ip6table_mangle", "ip6table_raw", "ip6table_filter"); err != nil {
 		if option.Config.EnableIPv6 {
 			log.WithError(err).Warning(
-				"IPv6 is enabled and ip6tables modules could not be initialized")
+				"IPv6 is enabled and ip6tables modules could not be initialized (try loading ip6_tables, ip6table_mangle, ip6table_raw and ip6table_filter modules)")
 		}
 		log.WithError(err).Debug(
 			"ip6tables kernel modules could not be loaded, so IPv6 cannot be used")


### PR DESCRIPTION
This warning is shown only if ipv6 is enabled in cilium.

Fixes: #11162