### PR TITLE
test: Move instrumentation to AfterFailed instead of AfterAll

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1154,6 +1154,15 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						})
 
 						AfterAll(func() {
+							kubectl.Delete(frr)
+							kubectl.Delete(bgpConfigMap)
+							kubectl.Delete(lbSVC)
+							// Delete temp files
+							os.Remove(frr)
+							os.Remove(bgpConfigMap)
+						})
+
+						AfterFailed(func() {
 							res := kubectl.CiliumExecContext(
 								context.TODO(),
 								ciliumPodK8s1,
@@ -1178,13 +1187,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 								res.CombineOutput().Bytes(),
 								"tests-loadbalancer-hubble-observe-debug-events-k8s2.log",
 							)
-
-							kubectl.Delete(frr)
-							kubectl.Delete(bgpConfigMap)
-							kubectl.Delete(lbSVC)
-							// Delete temp files
-							os.Remove(frr)
-							os.Remove(bgpConfigMap)
 						})
 
 						It("Connectivity to endpoint via LB", func() {


### PR DESCRIPTION
When inspecting a sysdump of this failing test, the expected artifacts
containing the instrumentation (debug-events) are not present. This is
because AfterAll is not called when the test fails. The logic should be
in AfterFailed.

Fixes: e63aa2b ("test: Instrument LB IP via BGP test with debug-events")
Fixes: https://github.com/cilium/cilium/pull/16445

Signed-off-by: Chris Tarazi <chris@isovalent.com>
