### PR TITLE
prefer k8snodeIP when picking masq IP

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -200,12 +200,16 @@ func InitBPFMasqueradeAddrs(devices []string) error {
 		}
 
 		for _, device := range devices {
-			ip, err := firstGlobalV4Addr(device, nil, preferPublicIP)
+			ip, err := firstGlobalV4Addr(device, GetK8sNodeIP(), preferPublicIP)
 			if err != nil {
 				return fmt.Errorf("Failed to determine IPv4 of %s for BPF masq", device)
 			}
 
 			ipv4MasqAddrs[device] = ip
+			log.WithFields(logrus.Fields{
+				logfields.IPv4:   ip,
+				logfields.Device: device,
+			}).Info("Masquerading IP selected for device")
 		}
 	}
 

--- a/pkg/node/address_linux_test.go
+++ b/pkg/node/address_linux_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2016-2020 Authors of Cilium
+
+//go:build !darwin && privileged_tests
+// +build !darwin,privileged_tests
+
+package node
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type NodePrivilegedSuite struct{}
+
+var _ = Suite(&NodePrivilegedSuite{})
+
+func (s *NodePrivilegedSuite) SetUpTest(c *C) {
+
+}
+
+func (s *NodePrivilegedSuite) Test_firstGlobalV4Addr(c *C) {
+	testCases := []struct {
+		name           string
+		ipsOnInterface []string
+		preferredIP    string
+		preferPublic   bool
+		want           string
+	}{
+		{
+			name:           "public IP preferred by default",
+			ipsOnInterface: []string{"192.168.0.1", "21.0.0.1"},
+			want:           "21.0.0.1",
+		},
+		{
+			name:           "prefer IP when not preferPublic",
+			ipsOnInterface: []string{"192.168.0.1", "21.0.0.1"},
+			preferredIP:    "192.168.0.1",
+			want:           "192.168.0.1",
+		},
+		{
+			name:           "preferPublic when not prefer IP",
+			ipsOnInterface: []string{"192.168.0.1", "21.0.0.1"},
+			preferPublic:   true,
+			want:           "21.0.0.1",
+		},
+		{
+			name:           "preferPublic when prefer IP",
+			ipsOnInterface: []string{"192.168.0.1", "21.0.0.1"},
+			preferPublic:   true,
+			preferredIP:    "192.168.0.1",
+			want:           "21.0.0.1",
+		},
+	}
+	const ifName = "dummy_iface"
+	for _, tc := range testCases {
+		err := setupDummyDevice(ifName, tc.ipsOnInterface...)
+		c.Assert(err, IsNil)
+
+		got, err := firstGlobalV4Addr(ifName, net.ParseIP(tc.preferredIP), tc.preferPublic)
+		if err != nil {
+			c.Error(err)
+		} else {
+			c.Check(tc.want, Equals, got.String())
+		}
+		removeDevice(ifName)
+	}
+}
+
+func setupDummyDevice(name string, ips ...string) error {
+	dummy := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: name,
+		},
+	}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		return fmt.Errorf("netlink.LinkAdd failed: %v", err)
+	}
+
+	if err := netlink.LinkSetUp(dummy); err != nil {
+		removeDevice(name)
+		return fmt.Errorf("netlink.LinkSetUp failed: %v", err)
+	}
+
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil || ip.To4() == nil {
+			removeDevice(name)
+			return fmt.Errorf("invalid ipv4 IP : %v", ipStr)
+		}
+		ipnet := &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
+		addr := &netlink.Addr{IPNet: ipnet}
+		if err := netlink.AddrAdd(dummy, addr); err != nil {
+			removeDevice(name)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func removeDevice(name string) {
+	l, err := netlink.LinkByName(name)
+	if err == nil {
+		netlink.LinkDel(l)
+	}
+}


### PR DESCRIPTION
Current code picks masquerading IP for a device with firstGlobalV4Addr()
without passing a preferred IP so it picks the first IP after sorting
all IPs on the devices. When picked IP floats away (like those
configured by keepalived), egress is broken.

This commit mitigates the problem for k8snode device by preferring k8s node IP.

Signed-off-by: Yuan Liu <liuyuan@google.com>

```release-note
Prefers k8s node IP when picking masquerading IPs
```
