### PR TITLE
lbmap: fix deletion and recreation logic for maglev maps

### DIFF
--- a/pkg/maps/lbmap/maglev_outer_map.go
+++ b/pkg/maps/lbmap/maglev_outer_map.go
@@ -98,7 +98,7 @@ func MaglevOuterMapTableSize(mapName string) (bool, uint32) {
 	var firstKey MaglevOuterKey
 	if err = prevMap.NextKey(nil, &firstKey); err != nil {
 		// The outer map exists but it's empty.
-		return false, UnknownMaglevTableSize
+		return true, UnknownMaglevTableSize
 	}
 
 	var firstVal MaglevOuterVal


### PR DESCRIPTION
When a maglev BPF map is initialized, before creating it we check if it
already exists, and if its inner map size matches the desired maglev
table size ("M" parameter), so that we can delete and recreate it in
case of a mismatch.

The lbmap.MaglevOuterMapTableSize function is reponsible for reporting
to the caller if the map already exists and its inner map size.

Currently, if the map exists but its empty, MaglevOuterMapTableSize will
incorrectly return false (i.e. "map does not exist"), preventing
lbmap.deleteMapIfMNotMatch from deleting it in case of a mismatch with
the M parameter.

This commit fixes this logic.

Fixes: #16844
Fixes: 879f9ebdb8a44ee4d66589c33a73de1f074d7ada