### PR TITLE
pkg/k8s: re-add CiliumIsUp Node condition even if removed

### DIFF
--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -55,7 +55,7 @@ func (k *K8sWatcher) NodesInit(k8sClient *k8s.K8sClient) {
 					var valid bool
 					if node := k8s.ObjToV1Node(obj); node != nil {
 						valid = true
-						if hasAgentNotReadyTaint(node) {
+						if hasAgentNotReadyTaint(node) || !k8s.HasCiliumIsUpCondition(node) {
 							k8sClient.ReMarkNodeReady()
 						}
 						err := k.updateK8sNodeV1(nil, node)
@@ -68,7 +68,7 @@ func (k *K8sWatcher) NodesInit(k8sClient *k8s.K8sClient) {
 					if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
 						valid = true
 						if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
-							if hasAgentNotReadyTaint(newNode) {
+							if hasAgentNotReadyTaint(newNode) || !k8s.HasCiliumIsUpCondition(newNode) {
 								k8sClient.ReMarkNodeReady()
 							}
 


### PR DESCRIPTION
If the CiliumIsUp Node condition is removed either by accident or due
a concurrency issue when updating the node from different entities,
Cilium is now able to re-add the node condition back to the node again.

Fixes: bd34b95a7939 ("pkg/k8s: remove node.cilium.io/agent-not-ready taint from nodes")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/16846