### PR TITLE
[v1.10] install/kubernetes: re-add restartPods

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -220,6 +220,33 @@ spec:
               date > {{ .Values.nodeinit.bootstrapFile }}
 {{- end }}
 
+{{- if .Values.nodeinit.restartPods }}
+              echo "Restarting kubenet managed pods"
+              if [ ! -f /etc/crictl.yaml ] || grep -q 'docker' /etc/crictl.yaml; then
+                # Works for COS, ubuntu
+                # Note the first line is the containerID with a trailing \r
+                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f "$(sed 's/\r//;1q' $f)" || true; done
+              elif [ -n "$(docker ps --format '{{ "{{" }}.Image{{ "}}" }}' | grep ^[0-9]*\.dkr\.ecr\.[a-z]*-[a-z]*-[0-9]*\.amazonaws\.com/amazon-k8s-cni)" ]; then
+                timeout=1
+                for i in $(seq 1 7); do
+                  echo "Checking introspection API"
+                  curl localhost:61679 && retry=false || retry=true
+                  if [ $retry == false ]; then break ; fi
+                  sleep "$timeout"
+                  timeout=$(($timeout * 2))
+                done
+
+                for pod in $(curl "localhost:61679/v1/pods" 2> /dev/null | jq -r '. | keys[]'); do
+                  container_id=$(echo "$pod" | awk -F_ ' { print $3 } ' | cut -c1-12)
+                  echo "Restarting ${container_id}"
+                  docker kill "${container_id}" || true
+                done
+              else
+                # COS-beta (with containerd). Some versions of COS have crictl in /home/kubernetes/bin.
+                for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do PATH="${PATH}:/home/kubernetes/bin" crictl stopp "$(sed 's/\r//;1q' $f)" || true; done
+              fi
+{{- end }}
+
               # AKS: If azure-vnet is installed on the node, and (still) configured in bridge mode,
               # configure it as 'transparent' to be consistent with Cilium's CNI chaining config.
               # If the azure-vnet CNI config is not removed, kubelet will execute CNI CHECK commands


### PR DESCRIPTION
This option will be removed in Cilium 1.11 and is now deprecated in 1.10
but that does not mean that it should be removed from the 1.10 branch.
For existing clusters, users might not be able to provision a cluster
with the necessary node taints and as a backup they will have to re-use
the restartPods option.

Signed-off-by: André Martins <andre@cilium.io>