### PR TITLE
ebpf unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,6 @@ init-coverage: ## Initialize converage report for Cilium unit-tests.
 unit-tests: start-kvstores ## Runs all unit-tests for Cilium.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tools/maptool/
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C test/bpf/
-	test/bpf/unit-test
 ifeq ($(SKIP_VET),"false")
 	$(MAKE) govet
 endif
@@ -476,9 +475,10 @@ govet: ## Run govet on Go source files in the repository.
     ./test/k8sT/... \
     ./tools/...
 
-lint: ## Run golangci-lint.
+lint: ## Run golangci-lint and check if the helper headers in bpf/mock are up-to-date.
 	@$(ECHO_CHECK) golangci-lint
 	$(QUIET) golangci-lint run
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf/mock/ check_helper_headers
 
 logging-subsys-field: ## Validate logrus subsystem field for logs in Go source code.
 	@$(ECHO_CHECK) contrib/scripts/check-logging-subsys-field.sh

--- a/bpf/mock/Dockerfile
+++ b/bpf/mock/Dockerfile
@@ -1,0 +1,8 @@
+FROM docker.io/library/ubuntu:20.04
+RUN apt-get update
+RUN apt-get -y install build-essential
+RUN apt-get -y install clang
+RUN apt-get -y install ruby-full
+RUN apt-get -y install git
+RUN git clone --recursive https://github.com/ThrowTheSwitch/CMock.git
+RUN git -C CMock reset --hard 3d4ba8d20b8958da5dace7dd5d31155c94b60819

--- a/bpf/mock/Makefile
+++ b/bpf/mock/Makefile
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2021 Authors of Cilium
+
+include ../../Makefile.defs
+include ../../Makefile.quiet
+
+builder-image: Dockerfile
+	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
+	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 docker pull
+	$(QUIET)tar c Dockerfile \
+	 | $(CONTAINER_ENGINE) build --tag cilium/bpf-mock -
+
+DOCKER_CTR_ROOT_DIR := /src
+DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
+		--workdir $(DOCKER_CTR_ROOT_DIR)/mock \
+		--volume $(CURDIR)/..:$(DOCKER_CTR_ROOT_DIR) \
+		--user "$(shell id -u):$(shell id -g)"
+DOCKER_RUN := $(DOCKER_CTR) cilium/bpf-mock
+
+check_helper_headers: generate_helper_headers mock_helpers
+	# Check if helpers.h, helpers_skb.h and helpers_xdp.h are up to date.
+	# Generate temp headers from lib/helpers.h, lib/helpers_skb.h and lib/helpers_xdp.h.
+	# Compare them to the headers within the current directory.
+	# The temp headers are removed after finishing.
+	rm helpers.h helpers_skb.h helpers_xdp.h mock_helpers.h mock_helpers.c mock_helpers_skb.h mock_helpers_skb.c mock_helpers_xdp.h mock_helpers_xdp.c;
+
+generate_helper_headers:
+	# Auto-generate helpers.h, helpers_skb.h, and helpers_xdp.h.
+	# Take contents from bpf/helpers.h, bpf/helpers_skb.h and bpf/helpers_xdp.h.
+	# Prune to be ready to mock and save to the current directory.
+	sed -f helpers.sed ../include/bpf/helpers.h > helpers.h; \
+	sed -f helpers_skb.sed ../include/bpf/helpers_skb.h > helpers_skb.h; \
+	sed -f helpers_xdp.sed ../include/bpf/helpers_xdp.h > helpers_xdp.h;
+
+mock_helpers: builder-image
+	# Generate mock libraries for helpers.h, helpers_skb.h and helpers_xdp.h with CMock.
+	$(QUIET) $(DOCKER_RUN) ./mock_helpers.sh; \
+	mv mocks/* ./; \
+	rmdir mocks;
+
+mock_customized: builder-image
+	# Take the name of the header to be mocked.
+	# Generate the corresponding mock library.
+	$(QUIET) $(DOCKER_RUN) ./mock_customized.sh $(filename); \
+	mv mocks/* ./; \
+	rmdir mocks;
+

--- a/bpf/mock/README.md
+++ b/bpf/mock/README.md
@@ -1,0 +1,82 @@
+## Dependencies
+
+You do not have to install the following dependencies because there is a
+container provided.
+
+[CMock](https://github.com/ThrowTheSwitch/CMock)
+
+CMock is a mock and stub generator and runtime for unit testing C. We avoid
+using C++ mocking frameworks because of some style difference between C and C++.
+
+[Ruby](https://www.ruby-lang.org/)
+
+Ruby is a common programming language. Since CMock relies on Ruby to generate mock
+libraries, it is necessary to install Ruby first.
+
+## Creating Unit Tests
+
+### Generating Mock Libraries
+
+Check if the mock libraries for the helper functions are up to date and follow
+the instructions:
+
+```bash
+make -C bpf/mock check_helper_headers
+```
+
+If the mock libraries for the helper functions are out of date, run
+
+```bash
+make -C bpf/mock generate_helper_headers
+```
+
+or manually add the new helpers to mock/helpers.h, then run
+
+
+```bash
+make -C bpf/mock mock_helpers
+```
+
+to generate mock libraries for the helpers.
+
+If there is a need to mock customized functions, first create a header
+containing the declarations of the functions to be mocked, then run
+
+```bash
+make -C bpf/mock mock_customized filename=NAME_OF_THE_HEADER_TO_BE_MOCKED
+```
+
+to generate mock library for them.
+
+There is a demo header conntrack\_stub.h inside the current directory containing the declarations of the functions in lib/conntrack.h, run
+
+```bash
+make -C bpf/mock mock_customized filename=conntrack_stub.h
+```
+
+to generate the corresponding mock library.
+
+### Creating a Test Program
+
+For the details on how to make use of mock libraries, see [CMock: A Summary](https://github.com/ThrowTheSwitch/CMock/blob/master/docs/CMock_Summary.md).
+
+There is a demo test program nat\_test.h in Cilium/bpf/tests/.
+
+## Run Unit Tests
+
+### Compiling and Linking
+
+To compile and link all the related files into an executable file, create a C
+file that calls the test functions.
+
+There is a demo C file nat-test.c in Cilium/test/bpf/ and a target nat-test in
+the Makefile, run
+
+```bash
+make -C test/bpf nat-test
+```
+
+to produce a demo executable file.
+
+The rule of the target nat-test in Makefile can be referred to create
+self-defined tests.

--- a/bpf/mock/bpf.yaml
+++ b/bpf/mock/bpf.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021 Authors of Cilium
+
+# Specify CMock configuration options here.
+# For details, see https://github.com/ThrowTheSwitch/CMock/blob/master/docs/CMock_Summary.md#config-options.
+
+:cmock:
+  :mock_prefix: mock_
+  :plugins:
+          - :ignore
+          - :ignore_arg
+          - :expect_any_args
+          - :callback
+          - :return_thru_ptr
+

--- a/bpf/mock/conntrack_stub.h
+++ b/bpf/mock/conntrack_stub.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// Header of functions to be mocked in conntrack.h.
+// It is used to generate corresponding mock functions in conntrack.h.
+// If other functions in conntrack.h are needed, please add the function
+// declarations at the bottom. To avoid conflict between functions in
+// bpf/builtins.h and string.h, define __BPF_BUILTINS__ in conntrack_stub.h to
+// make sure the mock library can be compiled without functions in
+// bpf/builtins.h. To avoid conflict, we do not name the mock customized
+// functions as the original name like mock helper functions because customized
+// functions are actually implemented. Instead, we use "mock_" as the prefix of
+// each mock customized function.
+#define __BPF_BUILTINS__
+#include <bpf/ctx/skb.h>
+#include "lib/common.h"
+
+
+int mock_ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx, int off, int dir, struct ct_state *ct_state, __u32 *monitor);
+int mock_ct_create4(const void *map_main, const void *map_related, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx, const int dir, const struct ct_state *ct_state, bool proxy_redirect);

--- a/bpf/mock/helpers.sed
+++ b/bpf/mock/helpers.sed
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021 Authors of Cilium
+
+# 1 Add [GENERATED FROM bpf/helpers.h] at the front.
+# 2 Delete lines start with [#ifndef BPF_] and ends with [#endif].
+# 3 Delete lines start with [#if __ctx_is] and ends with [#endif].
+# 4 Replace ["compiler.h"] by [<bpf/compiler.h>].
+# 5 Delete lines containing [ctx/ctx.h].
+# 6 Replace [__BPF_HELPERS] by [__MOCK_HELPERS].
+# 7 Remove [static].
+# 8&9 Restruct the functions to normal styles.
+# 10 Remove [_printf(1, 3)] in function trace_printk.
+# 11 Remove remappings.
+
+1 s|^|/\* GENERATED FROM bpf/helpers\.h \*/\n|;
+/#ifndef BPF_/,/#endif/d;
+/#if __ctx_is/,/#endif/d;
+s|"compiler\.h"|<bpf/compiler\.h>|g;
+/ctx\/ctx.h/d;
+s/__BPF_HELPERS\(.*__\)/__MOCK_HELPERS\1/g;
+s/static //g;
+s/BPF_\w*(\(\w*\), /\1(/g;
+s/BPF_\w*(\(\w*\)/\1(/g;
+s/__printf(.*) //g;
+/ =/{ N; s/ =.*;/;/ };

--- a/bpf/mock/helpers_skb.sed
+++ b/bpf/mock/helpers_skb.sed
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021 Authors of Cilium
+
+# 1 Add [GENERATED FROM bpf/helpers_skb.h] at the front.
+# 2 Delete lines start with [#ifndef BPF_] and ends with [#endif].
+# 3 Delete lines start with [#if __ctx_is] and ends with [#endif].
+# 4 Replace ["features_skb.h"] by [<bpf/features_skb.h>].
+# 5 Replace ["compiler.h"] by [<bpf/compiler.h>].
+# 6 Delete lines containing [helpers.h].
+# 7 Replace [__BPF_HELPERS] by [__MOCK_HELPERS].
+# 8 Remove [static].
+# 9&10 Restruct the functions to normal styles.
+# 11 Remove remappings.
+
+1 s|^|/\* GENERATED FROM bpf/helpers_skb\.h \*/\n|;
+/#ifndef BPF_/,/#endif/d;
+/#if __ctx_is/,/#endif/d;
+s|"features_skb\.h"|<bpf/features_skb\.h>|g;
+s|"compiler\.h"|<bpf/compiler\.h>|g;
+/"helpers\.h"/d;
+s/__BPF_HELPERS\(.*__\)/__MOCK_HELPERS\1/g;
+s/static //g;
+s/BPF_\w*(\(\w*\), /\1(/g;
+s/BPF_\w*(\(\w*\)/\1(/g;
+/ =/{ N; s/ =.*;/;/ };

--- a/bpf/mock/helpers_xdp.sed
+++ b/bpf/mock/helpers_xdp.sed
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2021 Authors of Cilium
+
+# 1 Add [GENERATED FROM bpf/helpers_xdp.h] at the front.
+# 2 Delete lines start with [#ifndef BPF_] and ends with [#endif].
+# 3 Delete lines start with [#if __ctx_is] and ends with [#endif].
+# 4 Replace ["features_xdp.h"] by [<bpf/features_xdp.h>].
+# 5 Replace ["compiler.h"] by [<bpf/compiler.h>].
+# 6 Delete lines containing [helpers.h].
+# 7 Replace [__BPF_HELPERS] by [__MOCK_HELPERS].
+# 8 Remove [static].
+# 9&10 Restruct the functions to normal styles.
+# 11 Remove remappings.
+
+1 s|^|/\* GENERATED FROM bpf/helpers_xdp\.h \*/\n|;
+/#ifndef BPF_/,/#endif/d;
+/#if __ctx_is/,/#endif/d;
+s|"features_xdp\.h"|<bpf/features_xdp\.h>|g;
+s|"compiler\.h"|<bpf/compiler\.h>|g;
+/"helpers\.h"/d;
+s/__BPF_HELPERS\(.*__\)/__MOCK_HELPERS\1/g;
+s/static //g;
+s/BPF_\w*(\(\w*\), /\1(/g;
+s/BPF_\w*(\(\w*\)/\1(/g;
+/ =/{ N; s/ =.*;/;/ };

--- a/bpf/mock/mock_customized.sh
+++ b/bpf/mock/mock_customized.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ruby ../../CMock/lib/cmock.rb -obpf.yaml $1

--- a/bpf/mock/mock_helpers.sh
+++ b/bpf/mock/mock_helpers.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ruby ../../CMock/lib/cmock.rb -obpf.yaml helpers.h
+ruby ../../CMock/lib/cmock.rb -obpf.yaml helpers_skb.h
+ruby ../../CMock/lib/cmock.rb -obpf.yaml helpers_xdp.h

--- a/bpf/tests/nat_test.h
+++ b/bpf/tests/nat_test.h
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// sample unit test program for functions in nat.h
+// It contains function definitions for testing "snat_v4_track_local".
+// "test_snat_v4_track_local" uses mock functions in conntrack.h. If other
+// functions in nat.h need to be tested, please add the function definitions
+// at the bottom. Do not forget to generate mock libraries for functions in
+// conntrack.h before testing.
+
+#define __BPF_HELPERS_SKB__
+#define __BPF_HELPERS__
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+
+#define htons bpf_htons
+#define ntohs bpf_ntohs
+
+#include <stdio.h>
+#include <assert.h>
+
+// Include unity test framework and all the mock libraries.
+#include "unity.h"
+#include "mock/mock_helpers.h"
+#include "mock/mock_helpers_skb.h"
+#include "mock/mock_conntrack_stub.h"
+
+// To avoid conflict between functions in bpf/builtins.h and string.h, define
+// __BPF_BUILTINS__ in conntrack_stub.h to make sure the mock library can be
+// compiled without functions in bpf/builtins.h. Undefine __BPF_BUILTINS__ and
+// include bpf/builtins.h here.
+#undef __BPF_BUILTINS__
+#include "bpf/builtins.h"
+
+#include "bpf/ctx/skb.h"
+#include "node_config.h"
+
+// To use mock library for functions in lib/conntrack.h, lib/conntrack.h must
+// be inlcude as well as mock/mock_conntrack_stub.h.
+#include "lib/conntrack.h"
+
+// Define macros like the followings to make sure the original customized
+// functions are mapped to the mock functions. To avoid conflict, we do not
+// name the mock customized functions as the original name like mock helper
+// functions because customized functions are actually implemented. Instead, we
+// use "mock_" as the prefix of each mock customized function.
+#define ct_lookup4 mock_ct_lookup4
+#define ct_create4 mock_ct_create4
+
+// The file containing the functions to be tested must be included after
+// defining the above macros.
+#include "lib/nat.h"
+
+// Undefine the original customized functions.
+#undef ct_lookup4
+#undef ct_create4
+
+void test_snat_v4_track_local() {
+    struct __ctx_buff ctx;
+    struct ipv4_ct_tuple tuple;
+    struct ipv4_nat_entry state;
+    struct ipv4_nat_target target;
+
+
+    // If there is an error in ct_lookup4, it will return a negative value. We
+    // can simply assume it to be -1 because the actually value does not matter.
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(-1);
+    // So snat_v4_track_local will return exactly the same value which means
+    // an error occurs when snat_v4_track_local is looking for the ipv4_ct_tuple.
+    assert(snat_v4_track_local(&ctx, &tuple, &state, NAT_DIR_EGRESS, 0,
+                               &target) == -1);
+
+    // If ct_lookup4 finds an entry, it will return a positive value. We can
+    // also assume it to be 1 because the actually value does not matter.
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(1);
+    // So snat_v4_track_local will return 0 which means snat_v4_track_local
+    // successfully tracks ipv4_ct_tuple.
+    assert(!snat_v4_track_local(&ctx, &tuple, &state, NAT_DIR_EGRESS, 0,
+                                &target));
+
+    // If ct_lookup4 does not find an entry, it will return CT_NEW which equals
+    // to zero. Then if ct_create4 fails creating the entry, it will return a
+    // negative value which is assumed as -1 since the actual value does not
+    // matter.
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(CT_NEW);
+    mock_ct_create4_ExpectAnyArgsAndReturn(-1);
+    // So snat_v4_track_local will return that value which means an error occurs
+    // when snat_v4_track_local is trying to create the ipv4_ct_tuple.
+    assert(snat_v4_track_local(&ctx, &tuple, &state, NAT_DIR_EGRESS, 0,
+                               &target) == -1);
+
+    // If ct_lookup4 does not find an entry, it will return CT_NEW which equals
+    // to zero. Then if ct_create4 successfully creates the entry, it will
+    // return 0.
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(CT_NEW);
+    mock_ct_create4_ExpectAnyArgsAndReturn(0);
+    // So snat_v4_track_local will return 0 which means snat_v4_track_local
+    // successfully creates the ipv4_ct_tuple.
+    assert(!snat_v4_track_local(&ctx, &tuple, &state, NAT_DIR_EGRESS, 0,
+                                &target));
+}

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include ../../Makefile.defs
+include ../../Makefile.quiet
+
+DOCKER_CTR_ROOT_DIR := /src
+DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
+		--workdir $(DOCKER_CTR_ROOT_DIR)/test/bpf \
+		--volume $(ROOT_DIR):$(DOCKER_CTR_ROOT_DIR) \
+		--user "$(shell id -u):$(shell id -g)"
+DOCKER_RUN := $(DOCKER_CTR) cilium/bpf-mock
 
 FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc --all) -O2
 FLAGS_CLANG := -Wall -Wextra -Werror -Wshadow -Wno-unused-parameter
@@ -19,8 +27,10 @@ CLANG ?= $(QUIET) clang
 LLC ?= llc
 
 BPF_TARGETS := elf-demo.o
-TARGETS := $(BPF_TARGETS) unit-test
-all: $(TARGETS)
+ALL_TESTS := unit-test nat-test
+TARGETS := $(BPF_TARGETS) $(ALL_TESTS)
+
+all: $(TARGETS) unit-tests
 
 elf-demo.o: elf-demo.c
 	@$(ECHO_CC)
@@ -30,6 +40,22 @@ elf-demo.o: elf-demo.c
 	@$(ECHO_CC)
 	$(CLANG) ${FLAGS_CLANG} ${FLAGS} -I../../bpf/ $< -o $@
 
+nat-test: nat-test.c $(LIB)
+	@$(ECHO_CC)
+	make -C $(ROOT_DIR)/bpf/mock generate_helper_headers
+	make -C $(ROOT_DIR)/bpf/mock mock_helpers
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=conntrack_stub.h
+	$(QUIET) $(DOCKER_RUN) $(CLANG) -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc --all) -O2 -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../bpf/mock/mock_helpers.c ../../bpf/mock/mock_helpers_skb.c ../../bpf/mock/mock_conntrack_stub.c -o $@
+	rm ../../bpf/mock/mock_conntrack_stub.c ../../bpf/mock/mock_conntrack_stub.h ../../bpf/mock/mock_helpers.c ../../bpf/mock/mock_helpers.h ../../bpf/mock/mock_helpers_skb.c ../../bpf/mock/mock_helpers_skb.h ../../bpf/mock/mock_helpers_xdp.c ../../bpf/mock/mock_helpers_xdp.h ../../bpf/mock/helpers.h ../../bpf/mock/helpers_skb.h ../../bpf/mock/helpers_xdp.h;
+
+unit-tests: $(ALL_TESTS)
+	@$(ECHO_CHECK)
+	for test in $^; do \
+		$(ECHO_CHECK) $$test; \
+		$(ROOT_DIR)/$(RELATIVE_DIR)/$$test; \
+	done
+
 clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET)rm -f $(TARGETS)
+

--- a/test/bpf/nat-test.c
+++ b/test/bpf/nat-test.c
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// source file for nat_test.h.
+// It contains contains main functions to run test functions nat_test.h.
+// It is used to perform unit test on functions in nat.h.
+
+#include "tests/nat_test.h"
+
+void setUp(void) {
+    // set stuff up here
+}
+
+void tearDown(void) {
+    // clean stuff up here
+}
+
+
+int main(int argc, char *argv[])
+{
+    test_snat_v4_track_local();
+    return 0;
+}


### PR DESCRIPTION
Considering that eBPF programs are in essence C programs, we propose to leverage existing C-native testing infrastructure to dramatically improve eBPF testing experience and enhance productivity. To this end we generate mock interfaces for kernel-based helper functions and also customized functions in Cilium with CMock. By including the generated mock module, eBPF programs can be easily and conveniently unit-tested as normal C programs.

We demonstrate the approach by performing a sample unit test on functions in
lib/nat.h. The test functions are written in nat_test.h.

To make the demo, run "make -C test/bpf nat-test" to produce an executable file.

As we briefly introduced this work in the Cilium dev sync session on July 7, we would like to get feedbacks, especially on which funtions in Cilium need this coverage.

Signed-off-by: Xinyuan Zhang <zhangxinyuan@google.com>