### PR TITLE
workflows: Skip FQDN tests in AWS-CNI workflow

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -251,7 +251,7 @@ jobs:
         run: |
           cilium connectivity test \
             --flow-validation=disabled \
-            --test '!pod-to-world-toFQDNs' # L7 policies are not supported in chaining mode.
+            --test '!fqdn' # L7 policies are not supported in chaining mode.
 
       - name: Post-test information gathering
         if: ${{ failure() }}


### PR DESCRIPTION
Commit d78968ee (".github: AWS-CNI end-to-end test") skipped the FQDN test in cilium connectivity test for the AWS-CNI workflow because L7 policies aren't supported in chaining mode. That test was skipped using:

    cilium connectivity test --test '!pod-to-world-toFQDNs'

However, in commit d9eff9a ("ci: Bump cilium-cli version") the cilium-cli version was updated from v0.6 to v0.8.1. In between those version the name of the FQDN test changed (to `to-fqdns`). This commit therefore updates the filter expression to filter all test with FQDN in their name:

    cilium connectivity test --test '!fqdn'

I tested the above correctly skips the `to-fqdns` test locally with a GKE cluster.

Fixes: https://github.com/cilium/cilium/pull/16617.