### PR TITLE
test/K8sBookInfo: Readiness probes for test pods

### DIFF
--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -55,6 +55,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9080
 ---
 ##################################################################################################
 # Reviews service
@@ -99,6 +103,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9080
 ---
 ##################################################################################################
 # Productpage service
@@ -144,4 +152,8 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9080
 ---

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -53,6 +53,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9080
 ---
 ##################################################################################################
 # Reviews service v2
@@ -82,4 +86,8 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9080
 ---


### PR DESCRIPTION
The test pods used in the k8sBookInfo test did not have readiness probe. Therefore, from time to time, the pods would be marked as Ready before their application was listening on the server's port. The subsequent connectivity check would thus fail with a TCP RST.

This commit fixes that issue by defining a proper readiness probe for all pods used in K8sBookInfo, such that the test will only proceed once the application is ready to serve requests.

Fixes: https://github.com/cilium/cilium/issues/16632.