### PR TITLE
v1.9 backports 2021-07-14

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -148,6 +148,7 @@ type Controller struct {
 	uuid              string
 	stop              chan struct{}
 	update            chan struct{}
+	trigger           chan struct{}
 	ctxDoFunc         context.Context
 	cancelDoFunc      context.CancelFunc
 
@@ -177,6 +178,14 @@ func (c *Controller) GetLastError() error {
 	defer c.mutex.RUnlock()
 
 	return c.lastError
+}
+
+// Trigger triggers the controller
+func (c *Controller) Trigger() {
+	select {
+	case c.trigger <- struct{}{}:
+	default:
+	}
 }
 
 // GetLastErrorTimestamp returns the last error returned
@@ -281,6 +290,7 @@ func (c *Controller) runController() {
 			runFunc = true
 
 		case <-time.After(interval):
+		case <-c.trigger:
 		}
 
 	}

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -100,6 +100,7 @@ func (m *Manager) updateController(name string, params ControllerParams) *Contro
 			uuid:       uuid.NewUUID().String(),
 			stop:       make(chan struct{}),
 			update:     make(chan struct{}, 1),
+			trigger:    make(chan struct{}, 1),
 			terminated: make(chan struct{}),
 		}
 		ctrl.updateParamsLocked(params)
@@ -244,6 +245,16 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 	return statuses
 }
 
+// TriggerController triggers the controller with the specified name.
+func (m *Manager) TriggerController(name string) {
+	controller := m.lookup(name)
+	if controller == nil {
+		return
+	}
+
+	controller.Trigger()
+}
+
 // FakeManager returns a fake controller manager with the specified number of
 // failing controllers. The returned manager is identical in any regard except
 // for internal pointers.
@@ -258,6 +269,7 @@ func FakeManager(failingControllers int) *Manager {
 			uuid:              fmt.Sprintf("%d", i),
 			stop:              make(chan struct{}),
 			update:            make(chan struct{}, 1),
+			trigger:           make(chan struct{}, 1),
 			terminated:        make(chan struct{}),
 			lastError:         fmt.Errorf("controller failed"),
 			failureCount:      1,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -345,6 +345,12 @@ type Endpoint struct {
 	isHost bool
 }
 
+// EndpointSyncControllerName returns the controller name to synchronize
+// endpoint in to kubernetes.
+func EndpointSyncControllerName(epID uint16) string {
+	return fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", epID)
+}
+
 // SetAllocator sets the identity allocator for this endpoint.
 func (e *Endpoint) SetAllocator(allocator cache.IdentityAllocator) {
 	e.unconditionalLock()
@@ -2051,6 +2057,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	// Unconditionally force policy recomputation after a new identity has been
 	// assigned.
 	e.forcePolicyComputation()
+
+	// Trigger the sync-to-k8s-ciliumendpoint controller to sync the new
+	// endpoint's identity.
+	e.controllers.TriggerController(EndpointSyncControllerName(e.ID))
 
 	e.unlock()
 

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -43,12 +43,6 @@ const (
 	subsysEndpointSync = "endpointsynchronizer"
 )
 
-// controllerNameOf returns the controller name to synchronize endpoint in to
-// kubernetes.
-func controllerNameOf(epID uint16) string {
-	return fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", epID)
-}
-
 // EndpointSynchronizer currently is an empty type, which wraps around syncing
 // of CiliumEndpoint resources.
 type EndpointSynchronizer struct{}
@@ -61,7 +55,7 @@ type EndpointSynchronizer struct{}
 func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
 	var (
 		endpointID     = e.ID
-		controllerName = controllerNameOf(endpointID)
+		controllerName = endpoint.EndpointSyncControllerName(endpointID)
 		scopedLog      = e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 	)
 
@@ -299,7 +293,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 // CEP from Kubernetes once the endpoint is stopped / removed from the
 // Cilium agent.
 func (epSync *EndpointSynchronizer) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
-	controllerName := controllerNameOf(e.ID)
+	controllerName := endpoint.EndpointSyncControllerName(e.ID)
 
 	scopedLog := e.Logger(subsysEndpointSync).WithField("controller", controllerName)
 


### PR DESCRIPTION
 * #16381 -- endpoint: trigger k8s sync controller on identity update (@jibi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16381; do contrib/backporting/set-labels.py $pr done 1.9; done
```