### PR TITLE
docs: fix code-block formatting for XDP load example

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -2734,14 +2734,14 @@ simplicity.
 
   .. code-block:: shell-session
 
-  # ip link set dev em1 xdp pinned /sys/fs/bpf/prog
+    # ip link set dev em1 xdp pinned /sys/fs/bpf/prog
 
   iproute2 can also use the short form that is relative to the detected mount
   point of the BPF file system:
 
   .. code-block:: shell-session
 
-  # ip link set dev em1 xdp pinned m:prog
+    # ip link set dev em1 xdp pinned m:prog
 
 When loading BPF programs, iproute2 will automatically detect the mounted
 file system instance in order to perform pinning of nodes. In case no mounted


### PR DESCRIPTION
On load XDP BPF example section at "BPF and XDP Reference Guide"
there are minor formatting issues related to code-block.
Thus, this commit fixes these minor formatting issues.

----
![2](https://user-images.githubusercontent.com/17492826/125621201-f89f8ab1-10ab-43f0-80ac-56bee5240975.png)

----

Signed-off-by: Claudia J. Kang <claudiajkang@gmail.com>
