### PR TITLE
pkg/node: add comments for IPLen in getCiliumHostIPsFromFile

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -544,6 +544,10 @@ func GetNodeAddressing() *models.NodeAddressing {
 }
 
 func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
+	// ipLen is the length of the IP address stored in the node_config.h
+	// it has the same length for both IPv4 and IPv6.
+	const ipLen = net.IPv6len
+
 	var hasIPv4, hasIPv6 bool
 	f, err := os.Open(nodeConfig)
 	switch {
@@ -560,7 +564,7 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 					continue
 				}
 				ipv6 := common.C2GoArray(defineLine[1])
-				if len(ipv6) != net.IPv6len {
+				if len(ipv6) != ipLen {
 					continue
 				}
 				ipv6Router = net.IP(ipv6)
@@ -571,7 +575,7 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 					continue
 				}
 				ipv4 := common.C2GoArray(defineLine[1])
-				if len(ipv4) != net.IPv6len {
+				if len(ipv4) != ipLen {
 					continue
 				}
 				ipv4GW = net.IP(ipv4)

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -161,9 +161,16 @@ func (s *NodeSuite) Test_getCiliumHostIPsFromFile(c *C) {
 	c.Assert(err, IsNil)
 	defer f.Close()
 	fmt.Fprintf(f, `/*
- * Node-IPv6: fd01::b
- * Router-IPv6: f00d::a00:0:0:a4ad
- * Host-IPv4: 10.0.0.1
+ cilium.v6.external.str fd01::b
+ cilium.v6.internal.str f00d::a00:0:0:a4ad
+ cilium.v6.nodeport.str []
+
+ cilium.v4.external.str 192.168.33.11
+ cilium.v4.internal.str 10.0.0.2
+ cilium.v4.nodeport.str []
+
+ cilium.v6.internal.raw 0xf0, 0xd, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa4, 0xad
+ cilium.v4.internal.raw 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xa, 0x0, 0x0, 0x2
  */
 
 #define ENABLE_IPV4 1
@@ -207,7 +214,7 @@ func (s *NodeSuite) Test_getCiliumHostIPsFromFile(c *C) {
 			args: args{
 				nodeConfig: allIPsCorrect,
 			},
-			wantIpv4GW:      net.ParseIP("10.0.0.1"),
+			wantIpv4GW:      net.ParseIP("10.0.0.2"),
 			wantIpv6Router:  net.ParseIP("f00d::a00:0:0:a4ad"),
 			wantIpv6Address: net.ParseIP("fd01::b"),
 		},


### PR DESCRIPTION
The usage of IPv6Len for an IPv4 address was not clear. To prevent
further confusion this commit adds some clarification for that variable.

Signed-off-by: André Martins <andre@cilium.io>