### PR TITLE
daemon: make consecutive quorum errors threshold configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -187,6 +187,7 @@ cilium-agent [flags]
       --kube-proxy-replacement-healthz-bind-address string   The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --kvstore string                                       Key-value store type
       --kvstore-connectivity-timeout duration                Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-max-consecutive-quorum-errors int            Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
       --kvstore-opt map                                      Key-value store options (default map[])
       --kvstore-periodic-sync duration                       Periodic KVstore synchronization interval (default 5m0s)
       --label-prefix-file string                             Valid label prefixes file path

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -331,6 +331,13 @@ Deprecated Options
 * ``native-routing-cidr``: This option has been deprecated in favor of
   ``ipv4-native-routing-cidr`` and will be removed in 1.12.
 
+New Options
+~~~~~~~~~~~
+
+* ``kvstore-max-consecutive-quorum-errors``: This option configures the max
+  acceptable kvstore consecutive quorum errors before the agent assumes
+  permanent failure.
+
 .. _1.10_upgrade_notes:
 
 1.10 Upgrade Notes

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -506,6 +506,9 @@ func init() {
 	flags.MarkHidden(option.KVstoreLeaseTTL)
 	option.BindEnv(option.KVstoreLeaseTTL)
 
+	flags.Int(option.KVstoreMaxConsecutiveQuorumErrorsName, defaults.KVstoreMaxConsecutiveQuorumErrors, "Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure")
+	option.BindEnv(option.KVstoreMaxConsecutiveQuorumErrorsName)
+
 	flags.Duration(option.KVstorePeriodicSync, defaults.KVstorePeriodicSync, "Periodic KVstore synchronization interval")
 	option.BindEnv(option.KVstorePeriodicSync)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -324,6 +324,10 @@ const (
 	// KVstoreLeaseTTL is the time-to-live of the kvstore lease.
 	KVstoreLeaseTTL = 15 * time.Minute
 
+	// KVstoreMaxConsecutiveQuorumErrors is the maximum number of acceptable
+	// kvstore consecutive quorum errors before the agent assumes permanent failure
+	KVstoreMaxConsecutiveQuorumErrors = 2
+
 	// KVstoreKeepAliveIntervalFactor is the factor to calculate the interval
 	// from KVstoreLeaseTTL in which KVstore lease is being renewed.
 	KVstoreKeepAliveIntervalFactor = 3

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -62,10 +62,6 @@ const (
 	EtcdRateLimitOption = "etcd.qps"
 
 	minRequiredVersionStr = ">=3.1.0"
-
-	// consecutiveQuorumErrorsThreshold is the number of acceptable quorum
-	// errors before the agent assumes permanent failure
-	consecutiveQuorumErrorsThreshold = 2
 )
 
 var (
@@ -1156,7 +1152,7 @@ func (e *etcdClient) statusChecker() {
 		e.statusLock.Lock()
 
 		switch {
-		case consecutiveQuorumErrors > consecutiveQuorumErrorsThreshold:
+		case consecutiveQuorumErrors > option.Config.KVstoreMaxConsecutiveQuorumErrors:
 			e.latestErrorStatus = fmt.Errorf("quorum check failed %d times in a row: %s",
 				consecutiveQuorumErrors, quorumError)
 			e.latestStatusSnapshot = e.latestErrorStatus.Error()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -656,6 +656,10 @@ const (
 	// KVstoreLeaseTTL is the time-to-live for lease in kvstore.
 	KVstoreLeaseTTL = "kvstore-lease-ttl"
 
+	// KVstoreMaxConsecutiveQuorumErrorsName is the maximum number of acceptable
+	// kvstore consecutive quorum errors before the agent assumes permanent failure
+	KVstoreMaxConsecutiveQuorumErrorsName = "kvstore-max-consecutive-quorum-errors"
+
 	// KVstorePeriodicSync is the time interval in which periodic
 	// synchronization with the kvstore occurs
 	KVstorePeriodicSync = "kvstore-periodic-sync"
@@ -1538,6 +1542,10 @@ type DaemonConfig struct {
 
 	// KVstoreLeaseTTL is the time-to-live for kvstore lease.
 	KVstoreLeaseTTL time.Duration
+
+	// KVstoreMaxConsecutiveQuorumErrors is the maximum number of acceptable
+	// kvstore consecutive quorum errors before the agent assumes permanent failure
+	KVstoreMaxConsecutiveQuorumErrors int
 
 	// KVstorePeriodicSync is the time interval in which periodic
 	// synchronization with the kvstore occurs
@@ -2440,6 +2448,7 @@ func (c *DaemonConfig) Populate() {
 	c.KVstoreKeepAliveInterval = c.KVstoreLeaseTTL / defaults.KVstoreKeepAliveIntervalFactor
 	c.KVstorePeriodicSync = viper.GetDuration(KVstorePeriodicSync)
 	c.KVstoreConnectivityTimeout = viper.GetDuration(KVstoreConnectivityTimeout)
+	c.KVstoreMaxConsecutiveQuorumErrors = viper.GetInt(KVstoreMaxConsecutiveQuorumErrorsName)
 	c.IPAllocationTimeout = viper.GetDuration(IPAllocationTimeout)
 	c.LabelPrefixFile = viper.GetString(LabelPrefixFile)
 	c.Labels = viper.GetStringSlice(Labels)


### PR DESCRIPTION
On detecting heartbeat (written by cilium-operator) missing from kvstore
with consecutive probes, the clustermesh module in cilium-agent will
re-connect kvstore.  For large clusters/meshes, e.g. clusters with
thousands of nodes, the concurrent reconnecting and list+watching
behaviors pose significant pressue on kvstore, to the extent of crashing
it.

The threshold is currently hardcoded as 2, and this patch makes it
configurable, which gives users a chance to choose from fast failure, or
being more patient on encountering kvstore/operator/k8s-control-plane
problems.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>