### PR TITLE
test: do not useDigest in upstream tests

### DIFF
--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -12,9 +12,11 @@ helm template --validate install/kubernetes/cilium \
   --namespace=kube-system \
   --set image.tag=$1 \
   --set image.repository=quay.io/cilium/cilium-ci \
+  --set image.useDigest=false \
   --set operator.image.repository=quay.io/cilium/operator \
   --set operator.image.tag=$1 \
   --set operator.image.suffix=-ci \
+  --set operator.image.useDigest=false \
   --set debug.enabled=true \
   --set k8s.requireIPv4PodCIDR=true \
   --set pprof.enabled=true \


### PR DESCRIPTION
Upstream tests should be executed against the code being submitted
in a PR. If `useDigest` is set to true it will use the default digest
defined in the helm charts, which in stable branches is the last
stable release and not the code being submitted in a PR.

Fixes: 41f66a1eb4fa (".github: use quay.io images in smoke tests")
Signed-off-by: André Martins <andre@cilium.io>