### PR TITLE
Enable Cilium Tunnel VXLAN connectivity to external VXLAN device

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -221,9 +221,8 @@ struct endpoint_key {
 	union {
 		struct {
 			__u32		ip4;
-			__u32		pad1;
-			__u32		pad2;
-			__u32		pad3;
+			__u32		vni;
+			mac_t		dmac;
 		};
 		union v6addr	ip6;
 	};

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -109,6 +109,21 @@ static __always_inline int eth_store_daddr(struct __ctx_buff *ctx,
 #endif
 }
 
+static __always_inline int eth_memcpy_daddr(struct __ctx_buff *ctx,
+                                          const __u8 *mac, int off)
+{
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+
+	if (ctx_no_room(data + off + ETH_ALEN, data_end))
+		return -EFAULT;
+	/* Need to use builtin here since mac came potentially from
+	 * struct bpf_fib_lookup where it's not aligned on stack. :(
+	 */
+	__bpf_memcpy_builtin(data + off, mac, ETH_ALEN);
+	return 0;
+}
+
 static __always_inline int eth_store_proto(struct __ctx_buff *ctx,
 					   const __u16 proto, int off)
 {


### PR DESCRIPTION
Load balancer like BIG-IP has VNI key based VXLAN device implementation, when use
BIG-IP as north-south bound traffic load balancer to Kubernetes pod managed by Cilium
in Cilium VXLAN tunnel mode, the egress packet from Cilium pod before encapsulation
uses the pod host side MAC address as the destination MAC address, when this egress packet
reaches to the external VXLAN device, the MAC address does not match the VTEP MAC address
of the external VXLAN device, the packet is dropped.

Also Cilium tunnel VXLAN uses pod label derived identity as the VXLAN tunnel VNI key value
that does not match the VNI key external VXLAN device uses, this patch
address above issues.

There is one important BPF verifier/compiler related  issue observed when writing this patch.
When using eth_store_daddr() from bpf/lib/eth.h to re-write the MAC address
The prog failed to pass BPF verifier check with  “R1 invalid mem access ‘inv’”,
see full detail in https://github.com/cilium/cilium/issues/16517.
from “commit 9c857217834” (bpf: optimized memcpy/memzero with dw-wide copies), this patch used
less efficient __builtin_memcpy() to write the MAC address, and it is only used
When tunnel->vni is set, to reduce the impact of Cilium data path

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
