### PR TITLE
Fix alias of cilium-health get

### DIFF
--- a/cilium-health/cmd/get.go
+++ b/cilium-health/cmd/get.go
@@ -28,7 +28,7 @@ import (
 // healthGetCmd represents the get command
 var healthGetCmd = &cobra.Command{
 	Use:     "get",
-	Aliases: []string{"inspect, show"},
+	Aliases: []string{"inspect", "show"},
 	Short:   "Display local cilium agent status",
 	Run: func(cmd *cobra.Command, args []string) {
 		result, err := client.Restapi.GetHealthz(nil)


### PR DESCRIPTION
Currently, the alias of `cilium-health get` is `cilium-health "inspect, show"`, not `cilium-health inspect` or `cilium-health show`.

/cc @joestringer 