### PR TITLE
cleanup helm chart

### DIFF
--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "Checking for differences between preflight and agent clusterrole"
           diff \
              -I '^[ ]\{2\}name: cilium.*' \
-             -I '^Keep file in synced with.*' \
+             -I '^Keep file in sync with.*' \
              -I '{{- if.*' \
              cilium-agent/clusterrole.yaml \
              cilium-preflight/clusterrole.yaml

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -53,7 +53,7 @@ jobs:
           echo "Checking for differences between preflight and agent clusterrole"
           diff \
              -I '^[ ]\{2\}name: cilium.*' \
-             -I '^Keep file in synced with.*' \
+             -I '^Keep file in sync with.*' \
              -I '{{- if.*' \
              cilium-agent/clusterrole.yaml \
              cilium-preflight/clusterrole.yaml

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -141,6 +141,10 @@
      - Labels to be added to clustermesh-apiserver pods
      - object
      - ``{}``
+   * - clustermesh.apiserver.priorityClassName
+     - The priority class to use for clustermesh-apiserver
+     - string
+     - ``""``
    * - clustermesh.apiserver.replicas
      - Number of replicas run for the clustermesh-apiserver deployment.
      - int
@@ -450,7 +454,7 @@
      - object
      - ``{}``
    * - etcd.priorityClassName
-     - cilium-etcd-operator priorityClassName
+     - The priority class to use for cilium-etcd-operator
      - string
      - ``""``
    * - etcd.resources
@@ -597,6 +601,10 @@
      - Labels to be added to hubble-relay pods
      - object
      - ``{}``
+   * - hubble.relay.priorityClassName
+     - The priority class to use for hubble-relay
+     - string
+     - ``""``
    * - hubble.relay.replicas
      - Number of replicas run for the hubble-relay deployment.
      - int
@@ -721,6 +729,10 @@
      - Labels to be added to hubble-ui pods
      - object
      - ``{}``
+   * - hubble.ui.priorityClassName
+     - The priority class to use for hubble-ui
+     - string
+     - ``""``
    * - hubble.ui.proxy.image
      - Hubble-ui ingress proxy image.
      - object
@@ -1006,7 +1018,7 @@
      - object
      - ``{}``
    * - operator.priorityClassName
-     - cilium-operator priorityClassName
+     - The priority class to use for cilium-operator
      - string
      - ``""``
    * - operator.prometheus

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -324,6 +324,9 @@ Removed Options
   and is now removed.
 * ``hubble-flow-buffer-size``: This option was deprecated in 1.10 in favor
   of ``hubble-event-buffer-capacity``. It is now removed.
+* The ``Capabilities`` Helm value has been removed. When using ``helm template``
+  to generate the Kubernetes manifest for a specific Kubernetes version,
+  please use the ``--kube-version`` flag (introduced in Helm 3.6.0) instead.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -86,6 +86,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
+| clustermesh.apiserver.priorityClassName | string | `""` | The priority class to use for clustermesh-apiserver |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
 | clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as     resources:       limits:         cpu: 1000m         memory: 1024M       requests:         cpu: 100m         memory: 64Mi |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
@@ -163,7 +164,7 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.podAnnotations | object | `{}` | Annotations to be added to cilium-etcd-operator pods |
 | etcd.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | etcd.podLabels | object | `{}` | Labels to be added to cilium-etcd-operator pods |
-| etcd.priorityClassName | string | `""` | cilium-etcd-operator priorityClassName |
+| etcd.priorityClassName | string | `""` | The priority class to use for cilium-etcd-operator |
 | etcd.resources | object | `{}` | cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | etcd.securityContext | object | `{}` | Security context to be added to cilium-etcd-operator pods |
 | etcd.ssl | bool | `false` | Enable use of TLS/SSL for connectivity to etcd. (auto-enabled if managed=true) |
@@ -200,6 +201,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
 | hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
+| hubble.relay.priorityClassName | string | `""` | The priority class to use for hubble-relay |
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
 | hubble.relay.resources | object | `{}` | Specifies the resources for the hubble-relay pods |
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
@@ -231,6 +233,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
+| hubble.ui.priorityClassName | string | `""` | The priority class to use for hubble-ui |
 | hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.18.2@sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7"}` | Hubble-ui ingress proxy image. |
 | hubble.ui.proxy.resources | object | `{}` | Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment. |
 | hubble.ui.replicas | int | `1` | The number of replicas of Hubble UI to deploy. |
@@ -302,7 +305,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
-| operator.priorityClassName | string | `""` | cilium-operator priorityClassName |
+| operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
 | operator.prometheus | object | `{"enabled":false,"port":6942,"serviceMonitor":{"enabled":false}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -6,6 +6,48 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Render full image name from given values, e.g:
+```
+image:
+  repository: quay.io/cilium/cilium
+  tag: v1.10.1
+  useDigest: true
+  digest: abcdefgh
+```
+then `include "cilium.image" .Values.image`
+will return `quay.io/cilium/cilium:v1.10.1@abcdefgh`
+*/}}
+{{- define "cilium.image" -}}
+{{- $digest := (.useDigest | default false) | ternary (printf "@%s" .digest) "" -}}
+{{- printf "%s:%s%s" .repository .tag $digest -}}
+{{- end -}}
+
+{{/*
+Return user specify priorityClass or default criticalPriorityClass
+Usage:
+  include "cilium.priorityClass" (list $ <priorityClass> <criticalPriorityClass>)
+where:
+* `priorityClass`: is user specify priorityClass e.g `.Values.operator.priorityClassName`
+* `criticalPriorityClass`: default criticalPriorityClass, e.g `"system-cluster-critical"`
+  This value is used when `priorityClass` is `nil` and 
+  `.Values.enableCriticalPriorityClass=true` and kubernetes supported it.
+*/}}
+{{- define "cilium.priorityClass" -}}
+{{- $root := index . 0 -}}
+{{- $priorityClass := index . 1 -}}
+{{- $criticalPriorityClass := index . 2 -}}
+{{- if $priorityClass }}
+  {{- $priorityClass }}
+{{- else if and $root.Values.enableCriticalPriorityClass $criticalPriorityClass -}}
+  {{- if and (eq $root.Release.Namespace "kube-system") (semverCompare ">=1.10-0" $root.Capabilities.KubeVersion.Version) -}}
+    {{- $criticalPriorityClass }}
+  {{- else if semverCompare ">=1.17-0" $root.Capabilities.KubeVersion.Version -}}
+    {{- $criticalPriorityClass }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "ingress.apiVersion" -}}

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -1,6 +1,6 @@
-{{- if and (.Values.agent) (not .Values.preflight.enabled) }}
+{{- if and .Values.agent (not .Values.preflight.enabled) }}
 {{- /*
-Keep file in synced with cilium-preflight-clusterrole.yaml
+Keep file in sync with cilium-preflight/clusterrole.yaml
 */ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.agent) (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -1,96 +1,87 @@
-{{- if and (.Values.agent) (not .Values.preflight.enabled) }}
+{{- if and .Values.agent (not .Values.preflight.enabled) }}
 
 {{- /*  Default values with backwards compatibility */ -}}
-{{- $defaultKeepDeprecatedProbes := "true" -}}
+{{- $defaultKeepDeprecatedProbes := true -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
-{{- $defaultKeepDeprecatedProbes = "false" -}}
+  {{- $defaultKeepDeprecatedProbes = false -}}
 {{- end -}}
-
-{{- /* Workaround so that we can set the minimal k8s version that we support */ -}}
-{{- $k8sVersion := .Capabilities.KubeVersion.Version -}}
-{{- $k8sMajor := .Capabilities.KubeVersion.Major -}}
-{{- $k8sMinor := .Capabilities.KubeVersion.Minor -}}
-
-{{- if .Values.Capabilities -}}
-{{- if .Values.Capabilities.KubeVersion -}}
-{{- if .Values.Capabilities.KubeVersion.Version -}}
-{{- $k8sVersion = .Values.Capabilities.KubeVersion.Version -}}
-{{- if .Values.Capabilities.KubeVersion.Major -}}
-{{- $k8sMajor = toString (.Values.Capabilities.KubeVersion.Major) -}}
-{{- if .Values.Capabilities.KubeVersion.Minor -}}
-{{- $k8sMinor = toString (.Values.Capabilities.KubeVersion.Minor) -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  labels:
-    k8s-app: cilium
-{{- if .Values.keepDeprecatedLabels }}
-    kubernetes.io/cluster-service: "true"
-{{- if and (eq .Release.Namespace "kube-system" ) .Values.gke.enabled }}
-{{- fail "Invalid configuration: Installing Cilium on GKE with 'kubernetes.io/cluster-service' labels on 'kube-system' namespace causes Cilium DaemonSet to be removed by GKE. Either install Cilium on a different Namespace or install with '--set keepDeprecatedLabels=false'"}}
-{{- end }}
-{{- end }}
   name: cilium
   namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cilium
+    {{- if .Values.keepDeprecatedLabels }}
+    kubernetes.io/cluster-service: "true"
+    {{- if and .Values.gke.enabled (eq .Release.Namespace "kube-system" ) }}
+      {{- fail "Invalid configuration: Installing Cilium on GKE with 'kubernetes.io/cluster-service' labels on 'kube-system' namespace causes Cilium DaemonSet to be removed by GKE. Either install Cilium on a different Namespace or install with '--set keepDeprecatedLabels=false'" }}
+    {{- end }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       k8s-app: cilium
-{{- if .Values.keepDeprecatedLabels }}
+      {{- if .Values.keepDeprecatedLabels }}
       kubernetes.io/cluster-service: "true"
-{{- end }}
-{{- with .Values.updateStrategy }}
+      {{- end }}
+  {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | trim | nindent 4 }}
-{{- end }}
+  {{- end }}
   template:
     metadata:
       annotations:
-{{- if and .Values.prometheus.enabled (not .Values.prometheus.serviceMonitor.enabled) }}
+        {{- if and .Values.prometheus.enabled (not .Values.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: "{{ .Values.prometheus.port }}"
         prometheus.io/scrape: "true"
-{{- end }}
-{{- if .Values.rollOutCiliumPods }}
+        {{- end }}
+        {{- if .Values.rollOutCiliumPods }}
         # ensure pods roll when configmap updates
         cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
-{{- end }}
+        {{- end }}
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-{{- with .Values.podAnnotations }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
       labels:
         k8s-app: cilium
-{{- if .Values.keepDeprecatedLabels }}
+        {{- if .Values.keepDeprecatedLabels }}
         kubernetes.io/cluster-service: "true"
-{{- end }}
-{{- with .Values.podLabels }}
+        {{- end }}
+        {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
-{{- if .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-{{- end }}
-{{- if .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 6 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-{{- if .Values.sleepAfterInit }}
-      - command: [ "/bin/bash", "-c", "--" ]
-        args: [ "while true; do sleep 30; done;" ]
+      - name: cilium-agent
+        image: {{ include "cilium.image" .Values.image | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.sleepAfterInit }}
+        command:
+        - /bin/bash
+        - -c
+        - --
+        args:
+        - |
+          while true; do
+            sleep 30;
+          done
         livenessProbe:
           exec:
             command:
@@ -99,22 +90,18 @@ spec:
           exec:
             command:
             - "true"
-{{- else }}
-      - args:
-        - --config-dir=/tmp/cilium/config-map
-{{- with .Values.extraArgs }}
-        {{- toYaml . | trim | nindent 8 }}
-{{- end }}
+        {{- else }}
         command:
         - cilium-agent
-{{- if semverCompare ">=1.20-0" $k8sVersion }}
+        args:
+        - --config-dir=/tmp/cilium/config-map
+        {{- with .Values.extraArgs }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+        {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.Version }}
         startupProbe:
           httpGet:
-{{- if .Values.ipv4.enabled }}
-            host: '127.0.0.1'
-{{- else }}
-            host: '::1'
-{{- end }}
+            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
             path: /healthz
             port: {{ .Values.healthPort }}
             scheme: HTTP
@@ -124,69 +111,61 @@ spec:
           failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           successThreshold: 1
-{{- end }}
+        {{- end }}
         livenessProbe:
-{{- if or .Values.keepDeprecatedProbes (eq $defaultKeepDeprecatedProbes "true") }}
+          {{- if or .Values.keepDeprecatedProbes $defaultKeepDeprecatedProbes }}
           exec:
             command:
             - cilium
             - status
             - --brief
-{{- else }}
+          {{- else }}
           httpGet:
-{{- if .Values.ipv4.enabled }}
-            host: '127.0.0.1'
-{{- else }}
-            host: '::1'
-{{- end }}
+            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
             path: /healthz
             port: {{ .Values.healthPort }}
             scheme: HTTP
             httpHeaders:
             - name: "brief"
               value: "true"
-{{- end }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-{{- if semverCompare "<1.20-0" $k8sVersion }}
+          {{- end }}
+          {{- if semverCompare "<1.20-0" .Capabilities.KubeVersion.Version }}
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           # Starting from Kubernetes 1.20, we are using startupProbe instead
           # of this field.
           initialDelaySeconds: 120
-{{- end }}
+          {{- end }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: 1
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           timeoutSeconds: 5
         readinessProbe:
-{{- if or .Values.keepDeprecatedProbes (eq $defaultKeepDeprecatedProbes "true") }}
+          {{- if or .Values.keepDeprecatedProbes $defaultKeepDeprecatedProbes }}
           exec:
             command:
             - cilium
             - status
             - --brief
-{{- else }}
+          {{- else }}
           httpGet:
-{{- if .Values.ipv4.enabled }}
-            host: '127.0.0.1'
-{{- else }}
-            host: '::1'
-{{- end }}
+            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
             path: /healthz
             port: {{ .Values.healthPort }}
             scheme: HTTP
             httpHeaders:
             - name: "brief"
               value: "true"
-{{- end }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-{{- if semverCompare "<1.20-0" $k8sVersion }}
+          {{- end }}
+          {{- if semverCompare "<1.20-0" .Capabilities.KubeVersion.Version }}
           initialDelaySeconds: 5
-{{- end }}
+          {{- end }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: 1
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           timeoutSeconds: 5
-{{- end }}
+        {{- end }}
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -203,67 +182,64 @@ spec:
         - name: CILIUM_CNI_CHAINING_MODE
           valueFrom:
             configMapKeyRef:
-              key: cni-chaining-mode
               name: cilium-config
+              key: cni-chaining-mode
               optional: true
         - name: CILIUM_CUSTOM_CNI_CONF
           valueFrom:
             configMapKeyRef:
-              key: custom-cni-conf
               name: cilium-config
+              key: custom-cni-conf
               optional: true
-{{- if .Values.k8sServiceHost }}
+        {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}
-{{- end }}
-{{- if .Values.k8sServicePort }}
+        {{- end }}
+        {{- if .Values.k8sServicePort }}
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.k8sServicePort | quote }}
-{{- end }}
-{{- with .Values.extraEnv }}
-{{ toYaml . | trim | indent 8 }}
-{{- end }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.cni.install }}
+        {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+        {{- if .Values.cni.install }}
         lifecycle:
           postStart:
             exec:
               command:
               - "/cni-install.sh"
-              - "--enable-debug={{- if .Values.debug.enabled }}true{{- else }}false{{- end }}"
-              - "--cni-exclusive={{- if .Values.cni.exclusive }}true{{- else }}false{{- end }}"
+              - "--enable-debug={{ .Values.debug.enabled }}"
+              - "--cni-exclusive={{ .Values.cni.exclusive }}"
           preStop:
             exec:
               command:
               - /cni-uninstall.sh
-{{- end }}
-{{- if .Values.resources }}
+        {{- end }}
+        {{- with .Values.resources }}
         resources:
-          {{- toYaml .Values.resources | trim | nindent 10 }}
-{{- end }}
-        name: cilium-agent
-{{- if or .Values.prometheus.enabled .Values.hubble.metrics.enabled }}
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
+        {{- if or .Values.prometheus.enabled .Values.hubble.metrics.enabled }}
         ports:
-{{- if .Values.prometheus.enabled }}
-        - containerPort: {{ .Values.prometheus.port }}
+        {{- if .Values.prometheus.enabled }}
+        - name: prometheus
+          containerPort: {{ .Values.prometheus.port }}
           hostPort: {{ .Values.prometheus.port }}
-          name: prometheus
           protocol: TCP
-{{- if .Values.proxy.prometheus.enabled }}          
-        - containerPort: {{ .Values.proxy.prometheus.port }}
+        {{- if .Values.proxy.prometheus.enabled }}
+        - name: envoy-metrics
+          containerPort: {{ .Values.proxy.prometheus.port }}
           hostPort: {{ .Values.proxy.prometheus.port }}
-          name: envoy-metrics
           protocol: TCP
-{{- end }}
-{{- end }}
-{{- if .Values.hubble.metrics.enabled }}
-        - containerPort: {{ .Values.hubble.metrics.port }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.hubble.metrics.enabled }}
+        - name: hubble-metrics
+          containerPort: {{ .Values.hubble.metrics.port }}
           hostPort: {{ .Values.hubble.metrics.port }}
-          name: hubble-metrics
           protocol: TCP
-{{- end }}
-{{- end }}
+        {{- end }}
+        {{- end }}
         securityContext:
           capabilities:
             add:
@@ -271,357 +247,350 @@ spec:
             - SYS_MODULE
           privileged: true
         volumeMounts:
-{{- /* CRI-O already mounts the BPF filesystem */ -}}
-{{- if not (eq .Values.containerRuntime.integration "crio") }}
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
-{{- end }}
-{{- if not (contains "/run/cilium/cgroupv2" .Values.cgroup.hostRoot) }}
+        {{- /* CRI-O already mounts the BPF filesystem */ -}}
+        {{- if not (eq .Values.containerRuntime.integration "crio") }}
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        {{- end }}
+        {{- if not (contains "/run/cilium/cgroupv2" .Values.cgroup.hostRoot) }}
         # Check for duplicate mounts before mounting
-        - mountPath: {{ .Values.cgroup.hostRoot }}
-          name: cilium-cgroup
-{{- end}}
-        - mountPath: /var/run/cilium
-          name: cilium-run
-        - mountPath: /host/opt/cni/bin
-          name: cni-path
-        - mountPath: {{ .Values.cni.hostConfDirMountPath }}
-          name: etc-cni-netd
-{{- if .Values.etcd.enabled }}
-        - mountPath: /var/lib/etcd-config
-          name: etcd-config-path
+        - name: cilium-cgroup
+          mountPath: {{ .Values.cgroup.hostRoot }}
+        {{- end}}
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        - name: cni-path
+          mountPath: /host/opt/cni/bin
+        - name: etc-cni-netd
+          mountPath: {{ .Values.cni.hostConfDirMountPath }}
+        {{- if .Values.etcd.enabled }}
+        - name: etcd-config-path
+          mountPath: /var/lib/etcd-config
           readOnly: true
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
-        - mountPath: /var/lib/etcd-secrets
-          name: etcd-secrets
+        {{- if or .Values.etcd.ssl .Values.etcd.managed }}
+        - name: etcd-secrets
+          mountPath: /var/lib/etcd-secrets
           readOnly: true
-{{- end }}
-{{- end }}
-        - mountPath: /var/lib/cilium/clustermesh
-          name: clustermesh-secrets
+        {{- end }}
+        {{- end }}
+        - name: clustermesh-secrets
+          mountPath: /var/lib/cilium/clustermesh
           readOnly: true
-        - mountPath: /tmp/cilium/config-map
-          name: cilium-config-path
+        - name: cilium-config-path
+          mountPath: /tmp/cilium/config-map
           readOnly: true
-{{- if .Values.ipMasqAgent.enabled }}
-        - mountPath: /etc/config
-          name: ip-masq-agent
+        {{- if .Values.ipMasqAgent.enabled }}
+        - name: ip-masq-agent
+          mountPath: /etc/config
           readOnly: true
-{{- end }}
-{{- if .Values.cni.configMap }}
-        - mountPath: {{ .Values.cni.confFileMountPath }}
-          name: cni-configuration
+        {{- end }}
+        {{- if .Values.cni.configMap }}
+        - name: cni-configuration
+          mountPath: {{ .Values.cni.confFileMountPath }}
           readOnly: true
-{{- end }}
+        {{- end }}
           # Needed to be able to load kernel modules
-        - mountPath: /lib/modules
-          name: lib-modules
+        - name: lib-modules
+          mountPath: /lib/modules
           readOnly: true
-        - mountPath: /run/xtables.lock
-          name: xtables-lock
-{{- if and ( .Values.encryption.enabled ) ( eq .Values.encryption.type "ipsec" ) }}
-  {{- if .Values.encryption.ipsec.mountPath }}
-        - mountPath: {{ .Values.encryption.ipsec.mountPath }}
-  {{- else }}
-        - mountPath: {{ .Values.encryption.mountPath }}
-  {{- end }}
-          name: cilium-ipsec-secrets
-{{- end }}
-{{- if .Values.kubeConfigPath }}
-        - mountPath: {{ .Values.kubeConfigPath }}
-          name: kube-config
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+        {{- if and .Values.encryption.enabled (eq .Values.encryption.type "ipsec") }}
+        - name: cilium-ipsec-secrets
+          mountPath: {{ .Values.encryption.ipsec.mountPath | default .Values.encryption.mountPath }}
+        {{- end }}
+        {{- if .Values.kubeConfigPath }}
+        - name: kube-config
+          mountPath: {{ .Values.kubeConfigPath }}
           readOnly: true
-{{- end }}
-{{- if .Values.bgp.enabled }}
-        - mountPath: /var/lib/cilium/bgp
-          name: bgp-config-path
+        {{- end }}
+        {{- if .Values.bgp.enabled }}
+        - name: bgp-config-path
+          mountPath: /var/lib/cilium/bgp
           readOnly: true
-{{- end }}
-{{- if and (.Values.hubble.enabled) (hasKey .Values.hubble "listenAddress") (.Values.hubble.tls.enabled) }}
-        - mountPath: /var/lib/cilium/tls/hubble
-          name: hubble-tls
+        {{- end }}
+        {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
+        - name: hubble-tls
+          mountPath: /var/lib/cilium/tls/hubble
           readOnly: true
-{{- end }}
-{{- range .Values.extraHostPathMounts }}
-        - mountPath: {{ .mountPath }}
-          name: {{ .name }}
+        {{- end }}
+        {{- range .Values.extraHostPathMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
           readOnly: {{ .readOnly }}
-{{- if .mountPropagation }}
+          {{- if .mountPropagation }}
           mountPropagation: {{ .mountPropagation }}
-{{- end }}
-{{- end }}
-{{- if .Values.monitor.enabled }}
+          {{- end }}
+        {{- end }}
+      {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
+        image: {{ include "cilium.image" .Values.image | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["cilium"]
         args:
         - monitor
-{{- range $type := .Values.monitor.eventTypes }}
+        {{- range $type := .Values.monitor.eventTypes }}
         - --type={{ $type }}
-{{- end }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- end }}
         volumeMounts:
-        - mountPath: /var/run/cilium
-          name: cilium-run
-{{- if .Values.monitor.resources }}
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        {{- with .Values.monitor.resources }}
         resources:
-          {{- toYaml .Values.monitor.resources | trim | nindent 10 }}
-{{- end }}
-{{- end }}
-{{- if (and .Values.etcd.managed (not .Values.etcd.k8sService)) }}
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
-{{- end }}
+      {{- end }}
       hostNetwork: true
       initContainers:
-{{- if .Values.cgroup.autoMount.enabled }}
+      {{- if .Values.cgroup.autoMount.enabled }}
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        env:
-          - name: CGROUP_ROOT
-            value: {{ .Values.cgroup.hostRoot }}
-          - name: BIN_PATH
-            value: {{ .Values.cni.binPath }}
-        command:
-          - sh
-          - -c
-          # The statically linked Go program binary is invoked to avoid any
-          # dependency on utilities like sh and mount that can be missing on certain
-          # distros installed on the underlying host. Copy the binary to the
-          # same directory where we install cilium cni plugin so that exec permissions
-          # are available.
-          - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: CGROUP_ROOT
+          value: {{ .Values.cgroup.hostRoot }}
+        - name: BIN_PATH
+          value: {{ .Values.cni.binPath }}
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh and mount that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |
+          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
+          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+          rm /hostbin/cilium-mount
         volumeMounts:
-          - mountPath: /hostproc
-            name: hostproc
-          - mountPath: /hostbin
-            name: cni-path
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
         securityContext:
           privileged: true
-{{- end }}
-{{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
+      {{- end }}
+      {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
       - name: wait-for-node-init
-        command: ['sh', '-c', 'until stat {{ .Values.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - sh
+        - -c
+        - |
+          until test -f {{ .Values.nodeinit.bootstrapFile | quote }}; do
+            echo "Waiting on node-init to run...";
+            sleep 1;
+          done
         volumeMounts:
-        - mountPath: {{ .Values.nodeinit.bootstrapFile }}
-          name: cilium-bootstrap-file
-{{- end }}
-      - command:
+        - name: cilium-bootstrap-file
+          mountPath: {{ .Values.nodeinit.bootstrapFile }}
+      {{- end }}
+      - name: clean-cilium-state
+        image: {{ include "cilium.image" .Values.image | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
         - /init-container.sh
         env:
         - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
-              key: clean-cilium-state
               name: cilium-config
+              key: clean-cilium-state
               optional: true
         - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
-              key: clean-cilium-bpf-state
               name: cilium-config
+              key: clean-cilium-bpf-state
               optional: true
         - name: CILIUM_WAIT_BPF_MOUNT
           valueFrom:
             configMapKeyRef:
-              key: wait-bpf-mount
               name: cilium-config
+              key: wait-bpf-mount
               optional: true
-{{- if .Values.k8sServiceHost }}
+        {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}
-{{- end }}
-{{- if .Values.k8sServicePort }}
+        {{- end }}
+        {{- if .Values.k8sServicePort }}
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.k8sServicePort | quote }}
-{{- end }}
-{{- if .Values.extraEnv }}
-{{ toYaml .Values.extraEnv | indent 8 }}
-{{- end }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        name: clean-cilium-state
+        {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         securityContext:
           capabilities:
             add:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-{{- /* CRI-O already mounts the BPF filesystem */ -}}
-{{- if not (eq .Values.containerRuntime.integration "crio") }}
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
-{{- /* Required for wait-bpf-mount to work */}}
+        {{- /* CRI-O already mounts the BPF filesystem */ -}}
+        {{- if not (eq .Values.containerRuntime.integration "crio") }}
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          {{- /* Required for wait-bpf-mount to work */}}
           mountPropagation: HostToContainer
-{{- end }}
-{{- if .Values.cgroup.autoMount.enabled }}
+        {{- end }}
           # Required to mount cgroup filesystem from the host to cilium agent pod
-        - mountPath: {{ .Values.cgroup.hostRoot }}
-          name: cilium-cgroup
+        - name: cilium-cgroup
+          mountPath: {{ .Values.cgroup.hostRoot }}
           mountPropagation: HostToContainer
-{{-  else }}
-          # Required to mount cgroup filesystem from the host to cilium agent pod
-        - mountPath: {{ .Values.cgroup.hostRoot }}
-          name: cilium-cgroup
-          mountPropagation: HostToContainer
-{{- end }}
-        - mountPath: /var/run/cilium
-          name: cilium-run
-{{- if .Values.nodeinit.resources }}
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        {{- with .Values.nodeinit.resources }}
         resources:
-          {{- toYaml .Values.nodeinit.resources | trim | nindent 10 }}
-{{- end }}
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
       restartPolicy: Always
-{{- if and (or (and (eq .Release.Namespace "kube-system") (gt $k8sMinor "10")) (ge $k8sMinor "17") (gt $k8sMajor "1")) .Values.enableCriticalPriorityClass }}
-      priorityClassName: system-node-critical
-{{- end }}
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}
       terminationGracePeriodSeconds: 1
-{{- with .Values.tolerations }}
+      {{- with .Values.tolerations }}
       tolerations:
-      {{- toYaml . | trim | nindent 6 }}
-{{- end }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       volumes:
         # To keep state between restarts / upgrades
-      - hostPath:
+      - name: cilium-run
+        hostPath:
           path: {{ .Values.daemon.runPath }}
           type: DirectoryOrCreate
-        name: cilium-run
-{{- /* CRI-O already mounts the BPF filesystem */ -}}
-{{- if not (eq .Values.containerRuntime.integration "crio") }}
+      {{- /* CRI-O already mounts the BPF filesystem */ -}}
+      {{- if not (eq .Values.containerRuntime.integration "crio") }}
         # To keep state between restarts / upgrades for bpf maps
-      - hostPath:
+      - name: bpf-maps
+        hostPath:
           path: /sys/fs/bpf
           type: DirectoryOrCreate
-        name: bpf-maps
-{{- end }}
-{{- if .Values.cgroup.autoMount.enabled }}
+      {{- end }}
+      {{- if .Values.cgroup.autoMount.enabled }}
       # To mount cgroup2 filesystem on the host
-      - hostPath:
+      - name: hostproc
+        hostPath:
           path: /proc
           type: Directory
-        name: hostproc
-{{- end }}
+      {{- end }}
       # To keep state between restarts / upgrades for cgroup2 filesystem
-      - hostPath:
+      - name: cilium-cgroup
+        hostPath:
           path: {{ .Values.cgroup.hostRoot}}
           type: DirectoryOrCreate
-        name: cilium-cgroup
       # To install cilium cni plugin in the host
-      - hostPath:
+      - name: cni-path
+        hostPath:
           path:  {{ .Values.cni.binPath }}
           type: DirectoryOrCreate
-        name: cni-path
         # To install cilium cni configuration in the host
-      - hostPath:
+      - name: etc-cni-netd
+        hostPath:
           path: {{ .Values.cni.confPath }}
           type: DirectoryOrCreate
-        name: etc-cni-netd
         # To be able to load kernel modules
-      - hostPath:
+      - name: lib-modules
+        hostPath:
           path: /lib/modules
-        name: lib-modules
         # To access iptables concurrently with other processes (e.g. kube-proxy)
-      - hostPath:
+      - name: xtables-lock
+        hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
-        name: xtables-lock
-{{- if .Values.kubeConfigPath }}
-      - hostPath:
+      {{- if .Values.kubeConfigPath }}
+      - name: kube-config
+        hostPath:
           path: {{ .Values.kubeConfigPath }}
           type: FileOrCreate
-        name: kube-config
-{{- end }}
-{{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
-      - hostPath:
+      {{- end }}
+      {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
+      - name: cilium-bootstrap-file
+        hostPath:
           path: {{ .Values.nodeinit.bootstrapFile }}
           type: FileOrCreate
-        name: cilium-bootstrap-file
-{{- end }}
-{{- range .Values.extraHostPathMounts }}
+      {{- end }}
+      {{- range .Values.extraHostPathMounts }}
       - name: {{ .name }}
         hostPath:
           path: {{ .hostPath }}
-{{- if .hostPathType }}
+          {{- if .hostPathType }}
           type: {{ .hostPathType }}
-{{- end }}
-{{- end }}
-{{- if .Values.etcd.enabled }}
+          {{- end }}
+      {{- end }}
+      {{- if .Values.etcd.enabled }}
         # To read the etcd config stored in config maps
-      - configMap:
+      - name: etcd-config-path
+        configMap:
+          name: cilium-config
           defaultMode: 420
           items:
           - key: etcd-config
             path: etcd.config
-          name: cilium-config
-        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
+      {{- if or .Values.etcd.ssl .Values.etcd.managed }}
       - name: etcd-secrets
         secret:
+          secretName: cilium-etcd-secrets
           defaultMode: 420
           optional: true
-          secretName: cilium-etcd-secrets
-{{- end }}
-{{- end }}
+      {{- end }}
+      {{- end }}
         # To read the clustermesh configuration
       - name: clustermesh-secrets
         secret:
+          secretName: cilium-clustermesh
           defaultMode: 420
           optional: true
-          secretName: cilium-clustermesh
         # To read the configuration from the config map
-      - configMap:
+      - name: cilium-config-path
+        configMap:
           name: cilium-config
-        name: cilium-config-path
-{{- if and .Values.ipMasqAgent .Values.ipMasqAgent.enabled }}
-      - configMap:
+      {{- if and .Values.ipMasqAgent .Values.ipMasqAgent.enabled }}
+      - name: ip-masq-agent
+        configMap:
           name: ip-masq-agent
           optional: true
           items:
           - key: config
             path: ip-masq-agent
-        name: ip-masq-agent
-{{- end }}
-{{- if and ( .Values.encryption.enabled ) ( eq .Values.encryption.type "ipsec" ) }}
+      {{- end }}
+      {{- if and .Values.encryption.enabled (eq .Values.encryption.type "ipsec") }}
       - name: cilium-ipsec-secrets
         secret:
-  {{- if .Values.encryption.ipsec.secretName }}
-          secretName: {{ .Values.encryption.ipsec.secretName }}
-  {{- else }}
-          secretName: {{ .Values.encryption.secretName }}
-  {{- end }}
-{{- end }}
-{{- if .Values.cni.configMap }}
+          secretName: {{ .Values.encryption.ipsec.secretName | default .Values.encryption.secretName }}
+      {{- end }}
+      {{- if .Values.cni.configMap }}
       - name: cni-configuration
         configMap:
           name: {{ .Values.cni.configMap }}
-{{- end }}
-{{- if .Values.bgp.enabled }}
-      - configMap:
+      {{- end }}
+      {{- if .Values.bgp.enabled }}
+      - name: bgp-config-path
+        configMap:
           name: bgp-config
-        name: bgp-config-path
-{{- end }}
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
+      {{- end }}
+      {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
       - name: hubble-tls
         projected:
           sources:
           - secret:
               name: hubble-server-certs
-              items:
-                - key: ca.crt
-                  path: client-ca.crt
-                - key: tls.crt
-                  path: server.crt
-                - key: tls.key
-                  path: server.key
               optional: true
-{{- end }}
+              items:
+              - key: ca.crt
+                path: client-ca.crt
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -1,6 +1,7 @@
-{{- if and (.Values.agent) (not .Values.preflight.enabled) (.Values.prometheus.enabled) (.Values.prometheus.serviceMonitor.enabled) }}
-kind: Service
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.prometheus.enabled }}
+{{- if .Values.prometheus.serviceMonitor.enabled }}
 apiVersion: v1
+kind: Service
 metadata:
   name: cilium-agent
   namespace: {{ .Release.Namespace }}
@@ -9,6 +10,8 @@ metadata:
 spec:
   clusterIP: None
   type: ClusterIP
+  selector:
+    k8s-app: cilium
   ports:
   - name: metrics
     port: {{ .Values.prometheus.port }}
@@ -18,50 +21,26 @@ spec:
     port: {{ .Values.proxy.prometheus.port }}
     protocol: TCP
     targetPort: envoy-metrics
-  selector:
-    k8s-app: cilium
-{{- else if and (.Values.prometheus.enabled) (.Values.proxy.prometheus.enabled) }}
-kind: Service
+{{- else if .Values.proxy.prometheus.enabled }}
 apiVersion: v1
+kind: Service
 metadata:
   name: cilium-agent
   namespace: {{ .Release.Namespace }}
   annotations:
-    prometheus.io/scrape: 'true'
+    prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.proxy.prometheus.port | quote }}
   labels:
     k8s-app: cilium
 spec:
   clusterIP: None
   type: ClusterIP
+  selector:
+    k8s-app: cilium
   ports:
   - name: envoy-metrics
     port: {{ .Values.proxy.prometheus.port }}
     protocol: TCP
     targetPort: envoy-metrics
-  selector:
-    k8s-app: cilium
 {{- end }}
-{{- if and .Values.hubble.metrics.enabled }}
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: hubble-metrics
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: {{ .Values.hubble.metrics.port | quote }}
-  labels:
-    k8s-app: hubble
-spec:
-  clusterIP: None
-  type: ClusterIP
-  ports:
-  - name: hubble-metrics
-    port: {{ .Values.hubble.metrics.port }}
-    protocol: TCP
-    targetPort: hubble-metrics
-  selector:
-    k8s-app: cilium
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.agent) (.Values.serviceAccounts.cilium.create) (not .Values.preflight.enabled) }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccounts.cilium.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.cilium.annotations | indent 4 }}
+    {{- toYaml .Values.serviceAccounts.cilium.annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -17,19 +17,19 @@
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
-{{- $defaultEnableCnpStatusUpdates = "false" -}}
-{{- $defaultBpfMapDynamicSizeRatio = 0.0025 -}}
-{{- $defaultBpfMasquerade = "true" -}}
-{{- $defaultBpfClockProbe = "true" -}}
-{{- $defaultIPAM = "cluster-pool" -}}
-{{- $defaultSessionAffinity = "true" -}}
-{{- if .Values.ipv4.enabled }}
-{{- $defaultOperatorApiServeAddr = "127.0.0.1:9234" -}}
-{{- else -}}
-{{- $defaultOperatorApiServeAddr = "[::1]:9234" -}}
-{{- end }}
-{{- $defaultBpfCtTcpMax = 0 -}}
-{{- $defaultBpfCtAnyMax = 0 -}}
+  {{- $defaultEnableCnpStatusUpdates = "false" -}}
+  {{- $defaultBpfMapDynamicSizeRatio = 0.0025 -}}
+  {{- $defaultBpfMasquerade = "true" -}}
+  {{- $defaultBpfClockProbe = "true" -}}
+  {{- $defaultIPAM = "cluster-pool" -}}
+  {{- $defaultSessionAffinity = "true" -}}
+  {{- if .Values.ipv4.enabled }}
+    {{- $defaultOperatorApiServeAddr = "127.0.0.1:9234" -}}
+  {{- else -}}
+    {{- $defaultOperatorApiServeAddr = "[::1]:9234" -}}
+  {{- end }}
+  {{- $defaultBpfCtTcpMax = 0 -}}
+  {{- $defaultBpfCtAnyMax = 0 -}}
 {{- end -}}
 
 {{- /* Default values when 1.10 was initially deployed */ -}}
@@ -41,7 +41,7 @@
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
 {{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement $defaultKubeProxyReplacement) -}}
-
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -53,29 +53,29 @@ data:
   # storage. This can either be provided with an external kvstore or with the
   # help of cilium-etcd-operator which operates an etcd cluster automatically.
   kvstore: etcd
-{{- if .Values.etcd.k8sService }}
+  {{- if .Values.etcd.k8sService }}
   kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config", "etcd.operator": "true"}'
-{{- else }}
+  {{- else }}
   kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'
-{{- end }}
+  {{- end }}
 
   # This etcd-config contains the etcd endpoints of your cluster. If you use
   # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
-{{- if .Values.etcd.managed }}
+      {{- if .Values.etcd.managed }}
       - https://cilium-etcd-client.{{ .Release.Namespace }}.svc:2379
-{{- else }}
-{{- range .Values.etcd.endpoints }}
+      {{- else }}
+      {{- range .Values.etcd.endpoints }}
       - {{ . }}
-{{- end }}
-{{- end }}
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
+      {{- end }}
+      {{- end }}
+    {{- if or .Values.etcd.ssl .Values.etcd.managed }}
     trusted-ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     key-file: '/var/lib/etcd-secrets/etcd-client.key'
     cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
-{{- end }}
+    {{- end }}
 {{- end }}
 
 {{- if hasKey .Values "conntrackGCInterval" }}
@@ -729,7 +729,7 @@ data:
 {{- end }}
 
 {{- if and .Values.bgp.enabled (not .Values.bgp.announce.loadbalancerIP) }}
-{{ fail "BGP was enabled, but no announcements were enabled. Please enable one or more announcements." }}
+  {{ fail "BGP was enabled, but no announcements were enabled. Please enable one or more announcements." }}
 {{- else if and .Values.bgp.enabled .Values.bgp.announce.loadbalancerIP }}
   bgp-announce-lb-ip: {{ .Values.bgp.announce.loadbalancerIP | quote }}
 {{- end }}
@@ -744,6 +744,6 @@ data:
 {{- end }}
 
 {{- if .Values.extraConfig }}
-{{ toYaml .Values.extraConfig | indent 2 }}
+  {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -1,24 +1,5 @@
 {{- if .Values.nodeinit.enabled }}
-
-{{- /* Workaround so that we can set the minimal k8s version that we support */ -}}
-{{- $k8sVersion := .Capabilities.KubeVersion.Version -}}
-{{- $k8sMajor := .Capabilities.KubeVersion.Major -}}
-{{- $k8sMinor := .Capabilities.KubeVersion.Minor -}}
-
-{{- if .Values.Capabilities -}}
-{{- if .Values.Capabilities.KubeVersion -}}
-{{- if .Values.Capabilities.KubeVersion.Version -}}
-{{- $k8sVersion = .Values.Capabilities.KubeVersion.Version -}}
-{{- if .Values.Capabilities.KubeVersion.Major -}}
-{{- $k8sMajor = toString (.Values.Capabilities.KubeVersion.Major) -}}
-{{- if .Values.Capabilities.KubeVersion.Minor -}}
-{{- $k8sMinor = toString (.Values.Capabilities.KubeVersion.Minor) -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -33,49 +14,46 @@ spec:
   template:
     metadata:
       annotations:
-{{- with .Values.nodeinit.podAnnotations }}
+        {{- with .Values.nodeinit.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
       labels:
         app: cilium-node-init
-{{- with .Values.nodeinit.podLabels }}
+        {{- with .Values.nodeinit.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
-{{- with .Values.tolerations }}
+      {{- with .Values.tolerations }}
       tolerations:
-      {{- toYaml . | trim | nindent 6 }}
-{{- end }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       hostPID: true
       hostNetwork: true
-{{- if and (or (and (eq .Release.Namespace "kube-system") (gt $k8sMinor "10")) (ge $k8sMinor "17") (gt $k8sMajor "1")) .Values.enableCriticalPriorityClass }}
-      priorityClassName: system-node-critical
-{{- end }}
-{{- if .Values.imagePullSecrets }}
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.nodeinit.priorityClassName "system-node-critical") }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{ toYaml .Values.imagePullSecrets | indent 6 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: node-init
-          image: {{ .Values.nodeinit.image.repository }}:{{ .Values.nodeinit.image.tag }}
+          image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           securityContext:
             privileged: true
-{{- if .Values.nodeinit.revertReconfigureKubelet }}
+          {{- if .Values.nodeinit.revertReconfigureKubelet }}
           lifecycle:
             preStop:
               exec:
                 command:
-                  - "nsenter"
-                  - "-t"
-                  - "1"
-                  - "-m"
-                  - "--"
-                  - "/bin/sh"
-                  - "-c"
+                  - nsenter
+                  - --target=1
+                  - --mount
+                  - --
+                  - /bin/sh
+                  - -c
                   - |
                     {{- tpl (.Files.Get "files/nodeinit/prestop.bash") . | nindent 20 }}
-{{- end }}
+          {{- end }}
           env:
           - name: CHECKPOINT_PATH
             value: /tmp/node-init.cilium.io

--- a/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- define "cilium.operator.cloud" -}}
+{{- $cloud := "generic" -}}
+{{- if .Values.eni.enabled -}}
+  {{- $cloud = "aws" -}}
+{{- else if .Values.azure.enabled -}}
+  {{- $cloud = "azure" -}}
+{{- else if .Values.alibabacloud.enabled -}}
+  {{- $cloud = "alibabacloud" -}}
+{{- end -}}
+{{- $cloud -}}
+{{- end -}}
+
+{{/*
+Return cilium operator image
+*/}}
+{{- define "cilium.operator.image" -}}
+{{- $cloud := include "cilium.operator.cloud" . }}
+{{- $digest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.digest) "" -}}
+{{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $digest -}}
+{{- end -}}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -1,24 +1,4 @@
-{{- if .Values.operator.enabled }}
-
-{{- /* Workaround so that we can set the minimal k8s version that we support */ -}}
-{{- $k8sVersion := .Capabilities.KubeVersion.Version -}}
-{{- $k8sMajor := .Capabilities.KubeVersion.Major -}}
-{{- $k8sMinor := .Capabilities.KubeVersion.Minor -}}
-
-{{- if .Values.Capabilities -}}
-{{- if .Values.Capabilities.KubeVersion -}}
-{{- if .Values.Capabilities.KubeVersion.Version -}}
-{{- $k8sVersion = .Values.Capabilities.KubeVersion.Version -}}
-{{- if .Values.Capabilities.KubeVersion.Major -}}
-{{- $k8sMajor = toString (.Values.Capabilities.KubeVersion.Major) -}}
-{{- if .Values.Capabilities.KubeVersion.Minor -}}
-{{- $k8sMinor = toString (.Values.Capabilities.KubeVersion.Minor) -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -1,32 +1,13 @@
 {{- if .Values.operator.enabled }}
-
-{{- /* Workaround so that we can set the minimal k8s version that we support */ -}}
-{{- $k8sVersion := .Capabilities.KubeVersion.Version -}}
-{{- $k8sMajor := .Capabilities.KubeVersion.Major -}}
-{{- $k8sMinor := .Capabilities.KubeVersion.Minor -}}
-
-{{- if .Values.Capabilities -}}
-{{- if .Values.Capabilities.KubeVersion -}}
-{{- if .Values.Capabilities.KubeVersion.Version -}}
-{{- $k8sVersion = .Values.Capabilities.KubeVersion.Version -}}
-{{- if .Values.Capabilities.KubeVersion.Major -}}
-{{- $k8sMajor = toString (.Values.Capabilities.KubeVersion.Major) -}}
-{{- if .Values.Capabilities.KubeVersion.Minor -}}
-{{- $k8sMinor = toString (.Values.Capabilities.KubeVersion.Minor) -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     io.cilium/app: operator
     name: cilium-operator
-  name: cilium-operator
-  namespace: {{ .Release.Namespace }}
 spec:
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
@@ -35,58 +16,53 @@ spec:
     matchLabels:
       io.cilium/app: operator
       name: cilium-operator
-{{- with .Values.operator.updateStrategy }}
+  {{- with .Values.operator.updateStrategy }}
   strategy:
     {{- toYaml . | trim | nindent 4 }}
-{{- end }}
+  {{- end }}
   template:
     metadata:
       annotations:
-{{- if .Values.operator.rollOutPods }}
+        {{- if .Values.operator.rollOutPods }}
         # ensure pods roll when configmap updates
         cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
-{{- end }}
-{{- if and .Values.operator.prometheus.enabled (not .Values.operator.prometheus.serviceMonitor.enabled) }}
+        {{- end }}
+        {{- if and .Values.operator.prometheus.enabled (not .Values.operator.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: {{ .Values.operator.prometheus.port | quote }}
         prometheus.io/scrape: "true"
-{{- end }}
-{{- with .Values.operator.podAnnotations }}
+        {{- end }}
+        {{- with .Values.operator.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
       labels:
         io.cilium/app: operator
         name: cilium-operator
-{{- with .Values.operator.podLabels }}
+        {{- with .Values.operator.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
       # In HA mode, cilium-operator pods must not be scheduled on the same
       # node as they will clash with each other.
-  {{- if .Values.operator.affinity }}
+      {{- with .Values.operator.affinity }}
       affinity:
-  {{- toYaml .Values.operator.affinity | trim | nindent 8 }}
-  {{- end }}
-{{- if .Values.imagePullSecrets }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 6 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-      - args:
+      - name: cilium-operator
+        image: {{ include "cilium.operator.image" . }}
+        imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+        command:
+        - cilium-operator-{{ include "cilium.operator.cloud" . }}
+        args:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
-{{- with .Values.operator.extraArgs }}
+        {{- with .Values.operator.extraArgs }}
         {{- toYaml . | trim | nindent 8 }}
-{{- end }}
-        command:
-{{- if .Values.eni.enabled }}
-        - cilium-operator-aws
-{{- else if .Values.azure.enabled }}
-        - cilium-operator-azure
-{{- else if .Values.alibabacloud.enabled}}
-        - cilium-operator-alibabacloud
-{{- else }}
-        - cilium-operator-generic
-{{- end }}
+        {{- end }}
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -104,97 +80,84 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-{{- if (and .Values.eni.enabled (not .Values.eni.iamRole )) }}
+        {{- if and .Values.eni.enabled (not .Values.eni.iamRole ) }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              key: AWS_ACCESS_KEY_ID
               name: cilium-aws
+              key: AWS_ACCESS_KEY_ID
               optional: true
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              key: AWS_SECRET_ACCESS_KEY
               name: cilium-aws
+              key: AWS_SECRET_ACCESS_KEY
               optional: true
         - name: AWS_DEFAULT_REGION
           valueFrom:
             secretKeyRef:
-              key: AWS_DEFAULT_REGION
               name: cilium-aws
+              key: AWS_DEFAULT_REGION
               optional: true
-{{- end }}
-{{- if .Values.alibabacloud.enabled }}
+        {{- end }}
+        {{- if .Values.alibabacloud.enabled }}
         - name: ALIBABA_CLOUD_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              key: ALIBABA_CLOUD_ACCESS_KEY_ID
               name: cilium-alibabacloud
+              key: ALIBABA_CLOUD_ACCESS_KEY_ID
               optional: true
         - name: ALIBABA_CLOUD_ACCESS_KEY_SECRET
           valueFrom:
             secretKeyRef:
-              key: ALIBABA_CLOUD_ACCESS_KEY_SECRET
               name: cilium-alibabacloud
+              key: ALIBABA_CLOUD_ACCESS_KEY_SECRET
               optional: true
-{{- end }}
-{{- if .Values.k8sServiceHost }}
+        {{- end }}
+        {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}
-{{- end }}
-{{- if .Values.k8sServicePort }}
+        {{- end }}
+        {{- if .Values.k8sServicePort }}
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.k8sServicePort | quote }}
-{{- end }}
-{{- if .Values.azure.subscriptionID }}
+        {{- end }}
+        {{- if .Values.azure.enabled }}
+        {{- if .Values.azure.subscriptionID }}
         - name: AZURE_SUBSCRIPTION_ID
           value: {{ .Values.azure.subscriptionID }}
-{{- end }}
-{{- if .Values.azure.tenantID }}
+        {{- end }}
+        {{- if .Values.azure.tenantID }}
         - name: AZURE_TENANT_ID
           value: {{ .Values.azure.tenantID }}
-{{- end }}
-{{- if .Values.azure.resourceGroup }}
+        {{- end }}
+        {{- if .Values.azure.resourceGroup }}
         - name: AZURE_RESOURCE_GROUP
           value: {{ .Values.azure.resourceGroup }}
-{{- end }}
-{{- if .Values.azure.clientID }}
+        {{- end }}
+        {{- if .Values.azure.clientID }}
         - name: AZURE_CLIENT_ID
           value: {{ .Values.azure.clientID }}
-{{- end }}
-{{- if .Values.azure.clientSecret }}
+        {{- end }}
+        {{- if .Values.azure.clientSecret }}
         - name: AZURE_CLIENT_SECRET
           value: {{ .Values.azure.clientSecret }}
-{{- end }}
-{{- range $key, $value := .Values.operator.extraEnv }}
+        {{- end }}
+        {{- end }}
+        {{- range $key, $value := .Values.operator.extraEnv }}
         - name: {{ $key }}
           value: {{ $value }}
-{{- end }}
-{{- if .Values.eni.enabled }}
-        image: "{{ .Values.operator.image.repository }}-aws{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.awsDigest }}{{ end }}"
-{{- else if .Values.azure.enabled }}
-        image: "{{ .Values.operator.image.repository }}-azure{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.azureDigest }}{{ end }}"
-{{- else if .Values.alibabacloud.enabled }}
-        image: "{{ .Values.operator.image.repository }}-alibabacloud{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.alibabacloudDigest }}{{ end }}"
-{{- else }}
-        image: "{{ .Values.operator.image.repository }}-generic{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.genericDigest }}{{ end }}"
-{{- end }}
-        imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
-        name: cilium-operator
-{{- if .Values.operator.prometheus.enabled }}
+        {{- end }}        
+        {{- if .Values.operator.prometheus.enabled }}
         ports:
-        - containerPort: {{ .Values.operator.prometheus.port }}
+        - name: prometheus
+          containerPort: {{ .Values.operator.prometheus.port }}
           hostPort: {{ .Values.operator.prometheus.port }}
-          name: prometheus
           protocol: TCP
-{{- end }}
+        {{- end }}
         livenessProbe:
           httpGet:
-{{- if .Values.ipv4.enabled }}
-            host: '127.0.0.1'
-{{- else }}
-            host: '::1'
-{{- end }}
+            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
             path: /healthz
             port: 9234
             scheme: HTTP
@@ -202,101 +165,99 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
         volumeMounts:
-        - mountPath: /tmp/cilium/config-map
-          name: cilium-config-path
+        - name: cilium-config-path
+          mountPath: /tmp/cilium/config-map
           readOnly: true
-{{- if .Values.etcd.enabled }}
-        - mountPath: /var/lib/etcd-config
-          name: etcd-config-path
+        {{- if .Values.etcd.enabled }}
+        - name: etcd-config-path
+          mountPath: /var/lib/etcd-config
           readOnly: true
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
-        - mountPath: /var/lib/etcd-secrets
-          name: etcd-secrets
+        {{- if or .Values.etcd.ssl .Values.etcd.managed }}
+        - name: etcd-secrets
+          mountPath: /var/lib/etcd-secrets
           readOnly: true
-{{- end }}
-{{- end }}
-{{- if .Values.kubeConfigPath }}
-        - mountPath: {{ .Values.kubeConfigPath }}
-          name: kube-config
+        {{- end }}
+        {{- end }}
+        {{- if .Values.kubeConfigPath }}
+        - name: kube-config
+          mountPath: {{ .Values.kubeConfigPath }}
           readOnly: true
-{{- end }}
-{{- range .Values.operator.extraHostPathMounts }}
-        - mountPath: {{ .mountPath }}
-          name: {{ .name }}
+        {{- end }}
+        {{- range .Values.operator.extraHostPathMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
           readOnly: {{ .readOnly }}
-{{- if .mountPropagation }}
+          {{- if .mountPropagation }}
           mountPropagation: {{ .mountPropagation }}
-{{- end }}
-{{- end }}
-{{- if .Values.bgp.enabled }}
-        - mountPath: /var/lib/cilium/bgp
-          name: bgp-config-path
+          {{- end }}
+        {{- end }}
+        {{- if .Values.bgp.enabled }}
+        - name: bgp-config-path
+          mountPath: /var/lib/cilium/bgp
           readOnly: true
-{{- end }}
-{{- if .Values.operator.resources }}
+        {{- end }}
+        {{- with .Values.operator.resources }}
         resources:
-          {{- toYaml .Values.operator.resources | trim | nindent 10 }}
-{{- end }}
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
       hostNetwork: true
-{{- if (and .Values.etcd.managed (not .Values.etcd.k8sService)) }}
+      {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
-{{- end }}
+      {{- end }}
       restartPolicy: Always
-{{- if and (or (and (eq .Release.Namespace "kube-system") (gt $k8sMinor "10")) (ge $k8sMinor "17") (gt $k8sMajor "1")) .Values.enableCriticalPriorityClass }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.operator.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.operator.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.operator.name | quote }}
-{{- with .Values.operator.nodeSelector }}
+      {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
-{{- end }}
-{{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-      {{- toYaml . | trim | nindent 6 }}
-{{- end }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       volumes:
         # To read the configuration from the config map
-      - configMap:
+      - name: cilium-config-path
+        configMap:
           name: cilium-config
-        name: cilium-config-path
-{{- if .Values.etcd.enabled }}
+      {{- if .Values.etcd.enabled }}
       # To read the etcd config stored in config maps
-      - configMap:
+      - name: etcd-config-path
+        configMap:
+          name: cilium-config
           defaultMode: 420
           items:
           - key: etcd-config
             path: etcd.config
-          name: cilium-config
-        name: etcd-config-path
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
+      {{- if or .Values.etcd.ssl .Values.etcd.managed }}
         # To read the k8s etcd secrets in case the user might want to use TLS
       - name: etcd-secrets
         secret:
+          secretName: cilium-etcd-secrets
           defaultMode: 420
           optional: true
-          secretName: cilium-etcd-secrets
-{{- end }}
-{{- end }}
-{{- if .Values.kubeConfigPath }}
-      - hostPath:
+      {{- end }}
+      {{- end }}
+      {{- if .Values.kubeConfigPath }}
+      - name: kube-config
+        hostPath:
           path: {{ .Values.kubeConfigPath }}
           type: FileOrCreate
-        name: kube-config
-{{- end }}
-{{- range .Values.operator.extraHostPathMounts }}
+      {{- end }}
+      {{- range .Values.operator.extraHostPathMounts }}
       - name: {{ .name }}
         hostPath:
           path: {{ .hostPath }}
-{{- if .hostPathType }}
+          {{- if .hostPathType }}
           type: {{ .hostPathType }}
-{{- end }}
-{{- end }}
-{{- if .Values.bgp.enabled }}
-      - configMap:
+          {{- end }}
+      {{- end }}
+      {{- if .Values.bgp.enabled }}
+      - name: bgp-config-path
+        configMap:
           name: bgp-config
-        name: bgp-config-path
-{{- end }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/service.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.operator.enabled) (.Values.operator.prometheus.enabled) (.Values.operator.prometheus.serviceMonitor.enabled) }}
+{{- if and .Values.operator.enabled .Values.operator.prometheus.enabled .Values.operator.prometheus.serviceMonitor.enabled }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
@@ -1,14 +1,15 @@
 {{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
+{{- if and .Values.eni.enabled .Values.eni.iamRole }}
+  {{ $_ := set .Values.serviceAccounts.operator.annotations "eks.amazonaws.com/role-arn" .Values.eni.iamRole }}
+{{- end}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.operator.name | quote }}
   namespace: {{ .Release.Namespace }}
-  {{- if and .Values.eni.enabled .Values.eni.iamRole }}
-  {{ $_ := set .Values.serviceAccounts.operator.annotations "eks.amazonaws.com/role-arn" .Values.eni.iamRole }}
-  {{- end}}
   {{- if .Values.serviceAccounts.operator.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.operator.annotations | indent 4 }}
+    {{- toYaml .Values.serviceAccounts.operator.annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
@@ -1,13 +1,9 @@
-{{- if and (.Values.operator.enabled) (.Values.operator.prometheus.enabled) (.Values.operator.prometheus.serviceMonitor.enabled) }}
+{{- if and .Values.operator.enabled .Values.operator.prometheus.enabled .Values.operator.prometheus.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-operator
-  {{- if .Values.operator.prometheus.serviceMonitor.namespace }}
-  namespace: {{ .Values.operator.prometheus.serviceMonitor.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ .Values.operator.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.preflight.enabled }}
 {{- /*
-Keep file in synced with cilium-agent-clusterrole.yaml
+Keep file in sync with cilium-agent/clusterrole.yaml
 */ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.preflight.enabled) (.Values.serviceAccounts.preflight.create) }}
+{{- if and .Values.preflight.enabled .Values.serviceAccounts.preflight.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -11,31 +11,31 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-{{- with .Values.preflight.podAnnotations }}
+      {{- with .Values.preflight.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-{{- end }}
+      {{- end }}
       labels:
         k8s-app: cilium-pre-flight-check
         kubernetes.io/cluster-service: "true"
-{{- with .Values.preflight.podLabels }}
+        {{- with .Values.preflight.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
-{{- if .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{ toYaml .Values.imagePullSecrets | indent 6 }}
-{{- end }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       initContainers:
         - name: clean-cilium-state
-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/echo"]
           args:
           - "hello"
       containers:
         - name: cilium-pre-flight-check
-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:
@@ -56,28 +56,29 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-          - mountPath: /var/run/cilium
-            name: cilium-run
-{{- if .Values.etcd.enabled }}
-          - mountPath: /var/lib/etcd-config
-            name: etcd-config-path
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          {{- if .Values.etcd.enabled }}
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
             readOnly: true
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
-          - mountPath: /var/lib/etcd-secrets
-            name: etcd-secrets
+          {{- if or .Values.etcd.ssl .Values.etcd.managed }}
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
             readOnly: true
-{{- end }}
-{{- end }}
-
-{{- if ne .Values.preflight.tofqdnsPreCache "" }}
+          {{- end }}
+          {{- end }}
+        {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]
           args:
-          - -c
-          - "cilium preflight fqdn-poller --tofqdns-pre-cache {{ .Values.preflight.tofqdnsPreCache }} && touch /tmp/ready-tofqdns-precache"
+          - -ec
+          - |
+            cilium preflight fqdn-poller --tofqdns-pre-cache {{ .Values.preflight.tofqdnsPreCache }};
+            touch /tmp/ready-tofqdns-precache;
           livenessProbe:
             exec:
               command:
@@ -93,28 +94,28 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           env:
-{{- if .Values.k8sServiceHost }}
+          {{- if .Values.k8sServiceHost }}
           - name: KUBERNETES_SERVICE_HOST
             value: {{ .Values.k8sServiceHost | quote }}
-{{- end }}
-{{- if .Values.k8sServicePort }}
+          {{- end }}
+          {{- if .Values.k8sServicePort }}
           - name: KUBERNETES_SERVICE_PORT
             value: {{ .Values.k8sServicePort | quote }}
-{{- end }}
+          {{- end }}
           volumeMounts:
-          - mountPath: /var/run/cilium
-            name: cilium-run
-{{- if .Values.etcd.enabled }}
-          - mountPath: /var/lib/etcd-config
-            name: etcd-config-path
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          {{- if .Values.etcd.enabled }}
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
             readOnly: true
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
-          - mountPath: /var/lib/etcd-secrets
-            name: etcd-secrets
+          {{- if or .Values.etcd.ssl .Values.etcd.managed }}
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
             readOnly: true
-{{- end }}
-{{- end }}
-{{- end }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
       hostNetwork: true
       # This is here to seamlessly allow migrate-identity to work with
       # etcd-operator setups. The assumption is that other cases would also
@@ -123,39 +124,40 @@ spec:
       # enabled when etcd.managed=true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       terminationGracePeriodSeconds: 1
-{{- with .Values.tolerations }}
+      {{- with .Values.tolerations }}
       tolerations:
-      {{- toYaml . | trim | nindent 6 }}
-{{- end }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       volumes:
         # To keep state between restarts / upgrades
-      - hostPath:
+      - name: cilium-run
+        hostPath:
           path: /var/run/cilium
           type: DirectoryOrCreate
-        name: cilium-run
-      - hostPath:
+      - name: bpf-maps
+        hostPath:
           path: /sys/fs/bpf
           type: DirectoryOrCreate
-        name: bpf-maps
-{{- if .Values.etcd.enabled }}
+      {{- if .Values.etcd.enabled }}
         # To read the etcd config stored in config maps
-      - configMap:
+      - name: etcd-config-path
+        configMap:
+          name: cilium-config
           defaultMode: 420
           items:
           - key: etcd-config
             path: etcd.config
-          name: cilium-config
-        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-{{- if or .Values.etcd.ssl .Values.etcd.managed }}
+      {{- if or .Values.etcd.ssl .Values.etcd.managed }}
       - name: etcd-secrets
         secret:
+          secretName: cilium-etcd-secrets
           defaultMode: 420
           optional: true
-          secretName: cilium-etcd-secrets
-{{- end }}
-{{- end }}
+      {{- end }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.preflight.enabled }}
-{{- if .Values.preflight.validateCNPs }}
+{{- if and .Values.preflight.enabled .Values.preflight.validateCNPs }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,16 +11,16 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-{{- with .Values.preflight.podAnnotations }}
+      {{- with .Values.preflight.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-{{- end }}
+      {{- end }}
       labels:
         k8s-app: cilium-pre-flight-check-deployment
         kubernetes.io/cluster-service: "true"
-{{- with .Values.preflight.podLabels }}
+        {{- with .Values.preflight.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
       affinity:
         podAffinity:
@@ -33,19 +32,21 @@ spec:
                 values:
                 - cilium
             topologyKey: "kubernetes.io/hostname"
-{{- if .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{ toYaml .Values.imagePullSecrets | indent 8 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-{{- if .Values.preflight.validateCNPs }}
         - name: cnp-validator
-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:
-          - -c
-          - "cilium preflight validate-cnp && touch /tmp/ready-validate-cnp && sleep 1h"
+          - -ec
+          - |
+            cilium preflight validate-cnp;
+            touch /tmp/ready-validate-cnp;
+            sleep 1h;
           livenessProbe:
             exec:
               command:
@@ -60,30 +61,27 @@ spec:
               - /tmp/ready-validate-cnp
             initialDelaySeconds: 5
             periodSeconds: 5
-{{- if not ( and ( empty ( .Values.k8sServiceHost ))  ( empty ( .Values.k8sServicePort ))) }}
           env:
-{{- if .Values.k8sServiceHost }}
+          {{- if .Values.k8sServiceHost }}
           - name: KUBERNETES_SERVICE_HOST
             value: {{ .Values.k8sServiceHost | quote }}
-{{- end }}
-{{- if .Values.k8sServicePort }}
+          {{- end }}
+          {{- if .Values.k8sServicePort }}
           - name: KUBERNETES_SERVICE_PORT
             value: {{ .Values.k8sServicePort | quote }}
-{{- end }}
-{{- end }}
-{{- end }}
+          {{- end }}
       hostNetwork: true
       restartPolicy: Always
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       terminationGracePeriodSeconds: 1
-{{- with .Values.preflight.nodeSelector }}
+      {{- with .Values.preflight.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
-{{- end }}
-{{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-      {{- toYaml . | trim | nindent 6 }}
-{{- end }}
-{{- end }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccounts.preflight.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.preflight.annotations | indent 4 }}
+    {{ toYaml .Values.serviceAccounts.preflight.annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (.Values.serviceAccounts.clustermeshApiserver.create) }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -3,51 +3,42 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clustermesh-apiserver
+  namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: clustermesh-apiserver
-  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.clustermesh.apiserver.replicas }}
   selector:
     matchLabels:
       k8s-app: clustermesh-apiserver
-{{- with .Values.clustermesh.apiserver.updateStrategy }}
-  strategy: {{- toYaml . | nindent 4 }}
-{{- end }}
+  {{- with .Values.clustermesh.apiserver.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:
-{{- with .Values.clustermesh.apiserver.podAnnotations }}
+        {{- with .Values.clustermesh.apiserver.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
       labels:
         k8s-app: clustermesh-apiserver
-{{- with .Values.clustermesh.apiserver.podLabels }}
+        {{- with .Values.clustermesh.apiserver.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
-{{- with .Values.imagePullSecrets }}
-      imagePullSecrets: {{- toYaml . | nindent 8 }}
-{{- end }}
-      restartPolicy: Always
-      serviceAccount: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
-      serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: etcd-init
-        image: {{ .Values.clustermesh.apiserver.etcd.image.repository }}:{{ .Values.clustermesh.apiserver.etcd.image.tag }}
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
-        env:
-        - name: ETCDCTL_API
-          value: "3"
-        - name: HOSTNAME_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         command: ["/bin/sh", "-c"]
         args:
         - >
           rm -rf /var/run/etcd/*;
-          export ETCDCTL_API=3;
           /usr/local/bin/etcd --data-dir=/var/run/etcd --name=clustermesh-apiserver --listen-client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster-token=clustermesh-apiserver --initial-cluster-state=new --auto-compaction-retention=1 &
           export rootpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
           echo $rootpw | etcdctl --interactive=false user add root;
@@ -66,13 +57,6 @@ spec:
           etcdctl user grant-role remote remote;
           etcdctl auth enable;
           exit
-        volumeMounts:
-        - mountPath: /var/run/etcd
-          name: etcd-data-dir
-      containers:
-      - name: etcd
-        image: {{ .Values.clustermesh.apiserver.etcd.image.repository }}:{{ .Values.clustermesh.apiserver.etcd.image.tag }}
-        imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         env:
         - name: ETCDCTL_API
           value: "3"
@@ -80,90 +64,97 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        command:
-          - /usr/local/bin/etcd
-        args:
-          - --data-dir=/var/run/etcd
-          - --name=clustermesh-apiserver
-          - --client-cert-auth
-          - --trusted-ca-file=/var/lib/etcd-secrets/ca.crt
-          - --cert-file=/var/lib/etcd-secrets/tls.crt
-          - --key-file=/var/lib/etcd-secrets/tls.key
-          - --listen-client-urls=https://127.0.0.1:2379,https://$(HOSTNAME_IP):2379
-          - --advertise-client-urls=https://$(HOSTNAME_IP):2379
-          - --initial-cluster-token=clustermesh-apiserver
-          - --auto-compaction-retention=1
         volumeMounts:
-        - mountPath: /var/lib/etcd-secrets
-          name: etcd-server-secrets
+        - name: etcd-data-dir
+          mountPath: /var/run/etcd
+      containers:
+      - name: etcd
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
+        imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
+        command:
+        - /usr/local/bin/etcd
+        args:
+        - --data-dir=/var/run/etcd
+        - --name=clustermesh-apiserver
+        - --client-cert-auth
+        - --trusted-ca-file=/var/lib/etcd-secrets/ca.crt
+        - --cert-file=/var/lib/etcd-secrets/tls.crt
+        - --key-file=/var/lib/etcd-secrets/tls.key
+        - --listen-client-urls=https://127.0.0.1:2379,https://$(HOSTNAME_IP):2379
+        - --advertise-client-urls=https://$(HOSTNAME_IP):2379
+        - --initial-cluster-token=clustermesh-apiserver
+        - --auto-compaction-retention=1
+        env:
+        - name: ETCDCTL_API
+          value: "3"
+        - name: HOSTNAME_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        volumeMounts:
+        - name: etcd-server-secrets
+          mountPath: /var/lib/etcd-secrets
           readOnly: true
-        - mountPath: /var/run/etcd
-          name: etcd-data-dir
-      - name: "apiserver"
-        image: "{{ .Values.clustermesh.apiserver.image.repository }}:{{ .Values.clustermesh.apiserver.image.tag }}{{ if .Values.clustermesh.apiserver.image.useDigest }}@{{ .Values.clustermesh.apiserver.image.digest }}{{ end }}"
+        - name: etcd-data-dir
+          mountPath: /var/run/etcd
+      - name: apiserver
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
-          - /usr/bin/clustermesh-apiserver
+        - /usr/bin/clustermesh-apiserver
         args:
-{{- if .Values.debug.enabled }}
-          - --debug
-{{- end }}
-          - --cluster-name=$(CLUSTER_NAME)
-          - --kvstore-opt
-          - etcd.config=/var/lib/cilium/etcd-config.yaml
+        {{- if .Values.debug.enabled }}
+        - --debug
+        {{- end }}
+        - --cluster-name=$(CLUSTER_NAME)
+        - --kvstore-opt
+        - etcd.config=/var/lib/cilium/etcd-config.yaml
         env:
         - name: CLUSTER_NAME
           valueFrom:
             configMapKeyRef:
-              key: cluster-name
               name: cilium-config
+              key: cluster-name
         - name: CLUSTER_ID
           valueFrom:
             configMapKeyRef:
-              key: cluster-id
               name: cilium-config
+              key: cluster-id
               optional: true
         - name: IDENTITY_ALLOCATION_MODE
           valueFrom:
             configMapKeyRef:
-              key: identity-allocation-mode
               name: cilium-config
-{{- with .Values.clustermesh.apiserver.resources }}
-        resources: {{- toYaml . | nindent 10 }}
-{{- end }}
+              key: identity-allocation-mode
+        {{- with .Values.clustermesh.apiserver.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
-        - mountPath: /var/lib/cilium/etcd-secrets
-          name: etcd-admin-client
+        - name: etcd-admin-client
+          mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
       volumes:
       - name: etcd-server-secrets
-        projected:
+        secret:
+          secretName: clustermesh-apiserver-server-cert
           defaultMode: 0420
-          sources:
-          - secret:
-              name: clustermesh-apiserver-ca-cert
-              items:
-              - key: ca.crt
-                path: ca.crt
-          - secret:
-              name: clustermesh-apiserver-server-cert
       - name: etcd-admin-client
-        projected:
+        secret:
+          secretName: clustermesh-apiserver-admin-cert
           defaultMode: 0420
-          sources:
-          - secret:
-              name: clustermesh-apiserver-ca-cert
-              items:
-              - key: ca.crt
-                path: ca.crt
-          - secret:
-              name: clustermesh-apiserver-admin-cert
       - name: etcd-data-dir
         emptyDir: {}
-{{- with .Values.clustermesh.apiserver.nodeSelector }}
-      nodeSelector: {{- toYaml . | nindent 8 }}
-{{- end }}
-{{- with .Values.clustermesh.apiserver.tolerations }}
-      tolerations: {{- toYaml . | nindent 8 }}
-{{- end }}
+      restartPolicy: Always
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}
+      serviceAccount: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
+      {{- with .Values.clustermesh.apiserver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clustermesh.apiserver.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -2,23 +2,24 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "clustermesh-apiserver"
+  name: clustermesh-apiserver
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: clustermesh-apiserver
-{{- with .Values.clustermesh.apiserver.service.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
-{{- end }}
+  {{- with .Values.clustermesh.apiserver.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.clustermesh.apiserver.service.type }}
   selector:
     k8s-app: clustermesh-apiserver
   ports:
   - port: 2379
-{{- if and (eq "NodePort" .Values.clustermesh.apiserver.service.type) .Values.clustermesh.apiserver.service.nodePort }}
+    {{- if and (eq "NodePort" .Values.clustermesh.apiserver.service.type) .Values.clustermesh.apiserver.service.nodePort }}
     nodePort: {{ .Values.clustermesh.apiserver.service.nodePort }}
-{{- end }}
-{{- if and (eq "LoadBalancer" .Values.clustermesh.apiserver.service.type) .Values.clustermesh.apiserver.service.loadBalancerIP }}
+    {{- end }}
+  {{- if and (eq "LoadBalancer" .Values.clustermesh.apiserver.service.type) .Values.clustermesh.apiserver.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.clustermesh.apiserver.service.loadBalancerIP }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
@@ -4,7 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
   namespace: {{ .Release.Namespace }}
-{{- with .Values.serviceAccounts.clustermeshApiserver.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
-{{- end }}
+  {{- with .Values.serviceAccounts.clustermeshApiserver.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -1,24 +1,4 @@
 {{- if .Values.etcd.managed }}
-
-{{- /* Workaround so that we can set the minimal k8s version that we support */ -}}
-{{- $k8sVersion := .Capabilities.KubeVersion.Version -}}
-{{- $k8sMajor := .Capabilities.KubeVersion.Major -}}
-{{- $k8sMinor := .Capabilities.KubeVersion.Minor -}}
-
-{{- if .Values.Capabilities -}}
-{{- if .Values.Capabilities.KubeVersion -}}
-{{- if .Values.Capabilities.KubeVersion.Version -}}
-{{- $k8sVersion = .Values.Capabilities.KubeVersion.Version -}}
-{{- if .Values.Capabilities.KubeVersion.Major -}}
-{{- $k8sMajor = toString (.Values.Capabilities.KubeVersion.Major) -}}
-{{- if .Values.Capabilities.KubeVersion.Minor -}}
-{{- $k8sMinor = toString (.Values.Capabilities.KubeVersion.Minor) -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,9 +75,7 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-{{- if and (or (and (eq .Release.Namespace "kube-system") (gt $k8sMinor "10")) (ge $k8sMinor "17") (gt $k8sMajor "1")) .Values.enableCriticalPriorityClass }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}
       restartPolicy: Always
       serviceAccount: {{ .Values.serviceAccounts.etcd.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.etcd.name | quote }}

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hubble.relay.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.relay.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -13,17 +13,17 @@ data:
     retry-timeout: {{ .Values.hubble.relay.retryTimeout }}
     sort-buffer-len-max: {{ .Values.hubble.relay.sortBufferLenMax }}
     sort-buffer-drain-timeout: {{ .Values.hubble.relay.sortBufferDrainTimeout }}
-{{- if .Values.hubble.tls.enabled }}
+    {{- if .Values.hubble.tls.enabled }}
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
-{{- else }}
+    {{- else }}
     disable-client-tls: true
-{{- end }}
-{{- if .Values.hubble.relay.tls.server.enabled }}
+    {{- end }}
+    {{- if and .Values.hubble.tls.enabled .Values.hubble.relay.tls.server.enabled }}
     tls-server-cert-file: /var/lib/hubble-relay/tls/server.crt
     tls-server-key-file: /var/lib/hubble-relay/tls/server.key
-{{- else }}
+    {{- else }}
     disable-server-tls: true
-{{- end }}
+    {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -1,36 +1,35 @@
-{{- if .Values.hubble.relay.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.relay.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hubble-relay
+  namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: hubble-relay
-  namespace: {{ .Release.Namespace }}
 spec:
-
   replicas: {{ .Values.hubble.relay.replicas }}
   selector:
     matchLabels:
       k8s-app: hubble-relay
-{{- with .Values.hubble.relay.updateStrategy }}
+  {{- with .Values.hubble.relay.updateStrategy }}
   strategy:
-{{ toYaml .  | trim | indent 4 }}
-{{- end }}
+    {{- toYaml .  | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:
-{{- if .Values.hubble.relay.rollOutPods }}
+        {{- if .Values.hubble.relay.rollOutPods }}
         # ensure pods roll when configmap updates
-        cilium.io/hubble-relay-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-relay-configmap.yaml") . | sha256sum | quote }}
-{{- end }}
-{{- with .Values.hubble.relay.podAnnotations }}
+        cilium.io/hubble-relay-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-relay/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- with .Values.hubble.relay.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
       labels:
         k8s-app: hubble-relay
-{{- with .Values.hubble.relay.podLabels }}
+        {{- with .Values.hubble.relay.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
       affinity:
         podAffinity:
@@ -42,21 +41,21 @@ spec:
                   values:
                     - cilium
             topologyKey: "kubernetes.io/hostname"
-{{- if .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: hubble-relay
-          image: "{{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}{{ if .Values.hubble.relay.image.useDigest }}@{{ .Values.hubble.relay.image.digest }}{{ end }}"
+          image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay
           args:
             - serve
-{{- if .Values.debug.enabled }}
-            - "--debug"
-{{- end }}
+          {{- if .Values.debug.enabled }}
+            - --debug
+          {{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.hubble.relay.listenPort }}
@@ -66,48 +65,50 @@ spec:
           livenessProbe:
             tcpSocket:
               port: grpc
-{{- with .Values.hubble.relay.resources }}
+          {{- with .Values.hubble.relay.resources }}
           resources:
             {{- toYaml . | trim | nindent 12 }}
-{{- end }}
+          {{- end }}
           volumeMounts:
-          - mountPath: {{ dir .Values.hubble.socketPath }}
-            name: hubble-sock-dir
+          - name: hubble-sock-dir
+            mountPath: {{ dir .Values.hubble.socketPath }}
             readOnly: true
-          - mountPath: /etc/hubble-relay
-            name: config
+          - name: config
+            mountPath: /etc/hubble-relay
             readOnly: true
-{{- if .Values.hubble.tls.enabled }}
-          - mountPath: /var/lib/hubble-relay/tls
-            name: tls
+          {{- if .Values.hubble.tls.enabled }}
+          - name: tls
+            mountPath: /var/lib/hubble-relay/tls
             readOnly: true
-{{- end }}
+          {{- end }}
       restartPolicy: Always
+      priorityClassName: {{ .Values.hubble.relay.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.relay.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.relay.name | quote }}
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 0
-{{- with .Values.hubble.relay.nodeSelector }}
+      {{- with .Values.hubble.relay.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
-{{- end }}
-{{- with .Values.hubble.relay.tolerations }}
+      {{- end }}
+      {{- with .Values.hubble.relay.tolerations }}
       tolerations:
-      {{- toYaml . | trim | nindent 8 }}
-{{- end }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       volumes:
-      - configMap:
+      - name: config
+        configMap:
           name: hubble-relay-config
           items:
           - key: config.yaml
             path: config.yaml
-        name: config
-      - hostPath:
+      - name: hubble-sock-dir
+        hostPath:
           path: {{ dir .Values.hubble.socketPath }}
           type: Directory
-        name: hubble-sock-dir
-{{- if .Values.hubble.tls.enabled }}
-      - projected:
+      {{- if .Values.hubble.tls.enabled }}
+      - name: tls
+        projected:
           sources:
           - secret:
               name: hubble-relay-client-certs
@@ -118,7 +119,7 @@ spec:
                   path: client.crt
                 - key: tls.key
                   path: client.key
-{{- if .Values.hubble.relay.tls.server.enabled }}
+          {{- if .Values.hubble.relay.tls.server.enabled }}
           - secret:
               name: hubble-relay-server-certs
               items:
@@ -126,7 +127,6 @@ spec:
                   path: server.crt
                 - key: tls.key
                   path: server.key
-{{- end }}
-        name: tls
-{{- end }}
+          {{- end }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hubble.relay.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.relay.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -12,12 +12,10 @@ spec:
     k8s-app: hubble-relay
   ports:
   - protocol: TCP
-{{- if .Values.hubble.relay.servicePort }}
+  {{- if .Values.hubble.relay.servicePort }}
     port: {{ .Values.hubble.relay.servicePort }}
-{{- else if .Values.hubble.relay.tls.server.enabled }}
-    port: 443
-{{- else }}
-    port: 80
-{{- end }}
+  {{- else }}
+    port: {{ .Values.hubble.relay.tls.server.enabled | ternary 443 80 }}
+  {{- end }}
     targetPort: {{ .Values.hubble.relay.listenPort }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.hubble.relay.enabled) (.Values.serviceAccounts.relay.create) -}}
+{{- if and .Values.hubble.enabled .Values.hubble.relay.enabled .Values.serviceAccounts.relay.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
@@ -1,44 +1,44 @@
-{{- if and (.Values.hubble.ui.enabled) (.Values.serviceAccounts.ui.create) }}
+{{- if and .Values.hubble.enabled .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hubble-ui
 rules:
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - componentstatuses
-      - endpoints
-      - namespaces
-      - nodes
-      - pods
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - cilium.io
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - componentstatuses
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.hubble.ui.enabled) (.Values.serviceAccounts.ui.create) }}
+{{- if and .Values.hubble.enabled .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -9,6 +9,6 @@ roleRef:
   name: hubble-ui
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Release.Namespace }}
   name: {{ .Values.serviceAccounts.ui.name | quote }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hubble.ui.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.ui.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -6,5 +6,5 @@ metadata:
   name: hubble-ui-envoy
   namespace: {{ .Release.Namespace }}
 data:
-{{ (.Files.Glob "files/envoy/*").AsConfig | indent 2 }}
+  {{ (.Files.Glob "files/envoy/*").AsConfig | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.hubble.ui.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.ui.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
+  name: hubble-ui
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: hubble-ui
-  name: hubble-ui
 spec:
   replicas: {{ .Values.hubble.ui.replicas }}
   selector:
@@ -14,116 +14,121 @@ spec:
   template:
     metadata:
       annotations:
-{{- if .Values.hubble.ui.rollOutPods }}
+        {{- if .Values.hubble.ui.rollOutPods }}
         # ensure pods roll when configmap updates
-        cilium.io/hubble-ui-envoy-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-ui-configmap.yaml") . | sha256sum | quote }}
-{{- end }}
-{{- with .Values.hubble.ui.podAnnotations }}
+        cilium.io/hubble-ui-envoy-configmap-checksum: {{ include (print $.Template.BasePath "/hubble-ui/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- with .Values.hubble.ui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
       labels:
         k8s-app: hubble-ui
-{{- with .Values.hubble.ui.podLabels }}
+        {{- with .Values.hubble.ui.podLabels }}
         {{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- end }}
     spec:
       {{- if .Values.hubble.ui.securityContext.enabled }}
       securityContext:
         runAsUser: 1001
       {{- end }}
+      priorityClassName: {{ .Values.hubble.ui.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.ui.name | quote }}
-{{- with .Values.hubble.ui.nodeSelector }}
+      {{- with .Values.hubble.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
-{{- end }}
-{{- with .Values.hubble.ui.tolerations }}
+      {{- end }}
+      {{- with .Values.hubble.ui.tolerations }}
       tolerations:
-      {{- toYaml . | trim | nindent 6 }}
-{{- end }}
-{{- if .Values.imagePullSecrets }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 6 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-        - name: frontend
-          image: "{{ .Values.hubble.ui.frontend.image.repository }}:{{ .Values.hubble.ui.frontend.image.tag }}"
-          imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
-          ports:
-            - containerPort: 8080
-              name: http
-          resources:
-            {{- toYaml .Values.hubble.ui.frontend.resources | trim | nindent 12 }}
-        - name: backend
-          image: "{{ .Values.hubble.ui.backend.image.repository }}:{{ .Values.hubble.ui.backend.image.tag }}"
-          imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
-          env:
-            - name: EVENTS_SERVER_PORT
-              value: "8090"
-{{- if .Values.hubble.relay.tls.server.enabled }}
-            - name: FLOWS_API_ADDR
-              value: "hubble-relay:443"
-            - name: TLS_TO_RELAY_ENABLED
-              value: "true"
-            - name: TLS_RELAY_SERVER_NAME
-              value: ui.hubble-relay.cilium.io
-            - name: TLS_RELAY_CA_CERT_FILES
-              value: /var/lib/hubble-ui/certs/hubble-relay-ca.crt
-            - name: TLS_RELAY_CLIENT_CERT_FILE
-              value: /var/lib/hubble-ui/certs/client.crt
-            - name: TLS_RELAY_CLIENT_KEY_FILE
-              value: /var/lib/hubble-ui/certs/client.key
-{{- else }}
-            - name: FLOWS_API_ADDR
-              value: "hubble-relay:80"
-{{- end }}
-          ports:
-            - containerPort: 8090
-              name: grpc
-          resources:
-            {{- toYaml .Values.hubble.ui.backend.resources  | trim | nindent 12 }}
-          volumeMounts:
-            {{- if .Values.hubble.relay.tls.server.enabled }}
-            - mountPath: /var/lib/hubble-ui/certs
-              name: hubble-ui-client-certs
-              readOnly: true
-            {{- end }}
-        - name: proxy
-          image: "{{ .Values.hubble.ui.proxy.image.repository }}:{{ .Values.hubble.ui.proxy.image.tag }}"
-          imagePullPolicy: {{ .Values.hubble.ui.proxy.image.pullPolicy }}
-          ports:
-            - containerPort: 8081
-              name: http
-          resources:
-          {{- toYaml .Values.hubble.ui.proxy.resources | trim | nindent 12 }}
-          command: ["envoy"]
-          args:
-            [
-              "-c",
-              "/etc/envoy.yaml",
-              "-l",
-              "info"
-            ]
-          volumeMounts:
-            - name: hubble-ui-envoy-yaml
-              mountPath: /etc/envoy.yaml
-              subPath: envoy.yaml
-      volumes:
-        - name: hubble-ui-envoy-yaml
-          configMap:
-            name: hubble-ui-envoy
+      - name: frontend
+        image: {{ include "cilium.image" .Values.hubble.ui.frontend.image | quote }}
+        imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: 8080
+        {{- with .Values.hubble.ui.frontend.resources }}
+        resources:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
+      - name: backend
+        image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
+        imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
+        env:
+        - name: EVENTS_SERVER_PORT
+          value: "8090"
+        {{- if .Values.hubble.relay.tls.server.enabled }}
+        - name: FLOWS_API_ADDR
+          value: "hubble-relay:443"
+        - name: TLS_TO_RELAY_ENABLED
+          value: "true"
+        - name: TLS_RELAY_SERVER_NAME
+          value: ui.hubble-relay.cilium.io
+        - name: TLS_RELAY_CA_CERT_FILES
+          value: /var/lib/hubble-ui/certs/hubble-relay-ca.crt
+        - name: TLS_RELAY_CLIENT_CERT_FILE
+          value: /var/lib/hubble-ui/certs/client.crt
+        - name: TLS_RELAY_CLIENT_KEY_FILE
+          value: /var/lib/hubble-ui/certs/client.key
+        {{- else }}
+        - name: FLOWS_API_ADDR
+          value: "hubble-relay:80"
+        {{- end }}
+        ports:
+        - name: grpc
+          containerPort: 8090
+        {{- with .Values.hubble.ui.backend.resources }}
+        resources:
+          {{- toYaml .  | trim | nindent 10 }}
+        {{- end }}
+        volumeMounts:
         {{- if .Values.hubble.relay.tls.server.enabled }}
         - name: hubble-ui-client-certs
-          projected:
-            sources:
-            - secret:
-                name: hubble-ui-client-certs
-                items:
-                  - key: ca.crt
-                    path: hubble-relay-ca.crt
-                  - key: tls.crt
-                    path: client.crt
-                  - key: tls.key
-                    path: client.key
+          mountPath: /var/lib/hubble-ui/certs
+          readOnly: true
         {{- end }}
+      - name: proxy
+        image: {{ include "cilium.image" .Values.hubble.ui.proxy.image | quote }}
+        imagePullPolicy: {{ .Values.hubble.ui.proxy.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: 8081
+        {{- with .Values.hubble.ui.proxy.resources }}
+        resources:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
+        command: [envoy]
+        args:
+        - -c
+        - /etc/envoy.yaml
+        - -l
+        - info
+        volumeMounts:
+        - name: hubble-ui-envoy-yaml
+          mountPath: /etc/envoy.yaml
+          subPath: envoy.yaml
+      volumes:
+      - name: hubble-ui-envoy-yaml
+        configMap:
+          name: hubble-ui-envoy
+      {{- if .Values.hubble.relay.tls.server.enabled }}
+      - name: hubble-ui-client-certs
+        projected:
+          sources:
+          - secret:
+              name: hubble-ui-client-certs
+              items:
+                - key: ca.crt
+                  path: hubble-relay-ca.crt
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.hubble.ui.enabled) (.Values.hubble.ui.ingress.enabled) -}}
+{{- if and .Values.hubble.enabled .Values.hubble.ui.enabled .Values.hubble.ui.ingress.enabled }}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -6,21 +6,21 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: hubble-ui
-{{- with .Values.hubble.ui.ingress.annotations }}
+  {{- with .Values.hubble.ui.ingress.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-{{- if .Values.hubble.ui.ingress.tls }}
+  {{- if .Values.hubble.ui.ingress.tls }}
   tls:
-{{ toYaml .Values.hubble.ui.ingress.tls | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.hubble.ui.ingress.tls | nindent 4 }}
+  {{- end }}
   rules:
   {{- range .Values.hubble.ui.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
           - path: /
-{{ include "ingress.paths" $ | indent 12 }}
+            {{- include "ingress.paths" $ | nindent 12 }}
   {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.hubble.ui.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.ui.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
   name: hubble-ui
+  namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: hubble-ui
-  namespace: {{ .Release.Namespace }}
 spec:
+  type: ClusterIP
   selector:
     k8s-app: hubble-ui
   ports:
     - name: http
       port: 80
       targetPort: 8081
-  type: ClusterIP
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.hubble.ui.enabled) (.Values.serviceAccounts.ui.create) -}}
+{{- if and .Values.hubble.enabled .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.hubble.enabled .Values.hubble.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.hubble.metrics.port | quote }}
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: hubble-metrics
+    port: {{ .Values.hubble.metrics.port }}
+    protocol: TCP
+    targetPort: hubble-metrics
+  selector:
+    k8s-app: cilium
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
@@ -1,22 +1,24 @@
-{{- if and .Values.agent (not .Values.preflight.enabled) .Values.prometheus.enabled .Values.prometheus.serviceMonitor.enabled }}
----
+{{- if and .Values.hubble.enabled .Values.hubble.metrics.enabled .Values.hubble.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: cilium-agent
+  name: hubble
   namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      k8s-app: cilium
+      k8s-app: hubble
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}
   endpoints:
-  - port: metrics
+  - port: hubble-metrics
     interval: 10s
     honorLabels: true
     path: /metrics
-  targetLabels:
-  - k8s-app
+    relabelings:
+    - sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
+      replacement: ${1}
 {{- end }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -11,7 +11,7 @@
 {{- end }}
 
 {{/* validate service monitoring CRDs */}}
-{{- if and (.Values.prometheus.enabled) (or (.Values.prometheus.serviceMonitor.enabled) (.Values.operator.prometheus.serviceMonitor.enabled)) }}
+{{- if and .Values.prometheus.enabled (or .Values.prometheus.serviceMonitor.enabled .Values.operator.prometheus.serviceMonitor.enabled) }}
   {{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
       {{ fail "Service Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml" }}
   {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -679,6 +679,9 @@ hubble:
     #
     tolerations: []
 
+    # -- The priority class to use for hubble-relay
+    priorityClassName: ""
+
     # -- hubble-relay update strategy
     updateStrategy:
       rollingUpdate:
@@ -812,6 +815,9 @@ hubble:
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     #
     tolerations: []
+
+    # -- The priority class to use for hubble-ui
+    priorityClassName: ""
 
     # -- hubble-ui update strategy.
     updateStrategy:
@@ -1135,7 +1141,7 @@ etcd:
     tag: v2.0.7
     pullPolicy: Always
 
-  # -- cilium-etcd-operator priorityClassName
+  # -- The priority class to use for cilium-etcd-operator
   priorityClassName: ""
 
   # -- Additional cilium-etcd-operator container arguments.
@@ -1253,7 +1259,7 @@ operator:
   # -- For using with an existing serviceAccount.
   serviceAccountName: cilium-operator
 
-  # -- cilium-operator priorityClassName
+  # -- The priority class to use for cilium-operator
   priorityClassName: ""
 
   # -- cilium-operator update strategy
@@ -1628,6 +1634,9 @@ clustermesh:
       rollingUpdate:
         maxUnavailable: 1
       type: RollingUpdate
+
+    # -- The priority class to use for clustermesh-apiserver
+    priorityClassName: ""
 
     tls:
       # -- Configure automatic TLS certificates generation.


### PR DESCRIPTION
This is next part of refactoring helm chart #16792 with the following changes:

1. remove `.Values.Capabilities` in favor of `--kube-version` in helm template,  as discussion in [#16752](https://github.com/cilium/cilium/pull/16752#discussion_r663973932)

2. Unify image using `cilium.image` template.
https://github.com/cilium/cilium/blob/c95f6fda172cd93bf2848b17dcc8bfdbe5ed63f4/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml#L226
Currently, configuring image is quite long, and not consistent between components (some support digest, some are not). By using `cilium.image` template, it's make configuring image shorter, easier to read and consistent between components.

3. support `priorityClassName`.
Currently, some components (e.g agent) support define `priorityClassName` in values file, but not using in template :|, other components (e.g hubble-ui, hublle-relay) are not support `priorityClassName`. So, with this MR, `priorityClassName` is supported in all components.

4. move `hubble-metrics` service & `hubble`  ServiceMonitor to seperated file (in `hubble` folder)

5. remove unnecessary parentheses
![Screenshot from 2021-07-15 20-30-29](https://user-images.githubusercontent.com/6848311/125796528-355e3ac3-3459-4b58-b984-437907b3da36.png)

6. make `name` as the first attribute of object
7. using `nindent` instead of `indent`
![Screenshot from 2021-07-15 18-48-14](https://user-images.githubusercontent.com/6848311/125783238-32723d10-8da0-41d4-9254-d037e9a123f8.png)

8. using default and ternary instead of if-else
![Screenshot from 2021-07-15 18-47-15](https://user-images.githubusercontent.com/6848311/125783097-e63dfc0f-0c8d-4289-b914-c851fc24f10a.png)

9. using `with` instead of `if` when it's possible
![Screenshot from 2021-07-23 15-40-35](https://user-images.githubusercontent.com/6848311/126759544-98d49705-e7c6-4feb-8bae-dedb567c3f38.png)

Signed-off-by: Đặng Minh Dũng <dungdm93@live.com>