### PR TITLE
v1.9 backport 2021-07-15

### DIFF
--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -95,7 +95,10 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) {
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.
 func (d *Daemon) UpdateIdentities(added, deleted cache.IdentityCache) {
-	d.policy.GetSelectorCache().UpdateIdentities(added, deleted)
+	wg := &sync.WaitGroup{}
+	d.policy.GetSelectorCache().UpdateIdentities(added, deleted, wg)
+	// Wait for update propagation to endpoints before triggering policy updates
+	wg.Wait()
 	d.TriggerPolicyUpdates(false, "one or more identities created or deleted")
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -107,7 +107,7 @@ func waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup) error {
 
 // UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
 // have had their PolicyMaps updated against the Endpoint's desired policy state.
-func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context) *sync.WaitGroup {
+func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
 	var epWG sync.WaitGroup
 	var wg sync.WaitGroup
 
@@ -131,6 +131,8 @@ func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context) *sync.WaitGrou
 	// TODO: bound by number of CPUs?
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint) {
+			// Proceed only after all notifications have been delivered to endpoints
+			notifyWg.Wait()
 			if err := ep.ApplyPolicyMapChanges(proxyWaitGroup); err != nil {
 				ep.Logger("endpointmanager").WithError(err).Warning("Failed to apply policy map changes. These will be re-applied in future updates.")
 			}

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -115,6 +115,12 @@ type XDSServer struct {
 	// Value holds the number of redirects using the listener named by the key.
 	listeners map[string]*Listener
 
+	// proxyListeners is the count of redirection proxy listeners in 'listeners'.
+	// When this is zero, cilium should not wait for NACKs/ACKs from envoy.
+	// This value is different from len(listeners) due to non-proxy listeners
+	// (e.g., prometheus listener)
+	proxyListeners int
+
 	// networkPolicyCache publishes network policy configuration updates to
 	// Envoy proxies.
 	networkPolicyCache *xds.Cache
@@ -441,21 +447,24 @@ func (s *XDSServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 		if err != nil {
 			log.WithField(logfields.Port, port).WithError(err).Debug("Envoy: Adding metrics listener failed")
 			// Remove the added listener in case of a failure
-			s.RemoveListener(metricsListenerName, nil)
+			s.removeListener(metricsListenerName, nil, false)
 		} else {
 			log.WithField(logfields.Port, port).Info("Envoy: Listening for prometheus metrics")
 		}
-	})
+	}, false)
 }
 
 // addListener either reuses an existing listener with 'name', or creates a new one.
 // 'listenerConf()' is only called if a new listener is being created.
-func (s *XDSServer) addListener(name string, port uint16, listenerConf func() *envoy_config_listener.Listener, wg *completion.WaitGroup, cb func(err error)) {
+func (s *XDSServer) addListener(name string, port uint16, listenerConf func() *envoy_config_listener.Listener, wg *completion.WaitGroup, cb func(err error), isProxyListener bool) {
 	s.mutex.Lock()
 	listener := s.listeners[name]
 	if listener == nil {
 		listener = &Listener{}
 		s.listeners[name] = listener
+		if isProxyListener {
+			s.proxyListeners++
+		}
 	}
 	listener.count++
 	listener.mutex.Lock() // needed for other than 'count'
@@ -586,11 +595,16 @@ func (s *XDSServer) AddListener(name string, kind policy.L7ParserType, port uint
 
 	s.addListener(name, port, func() *envoy_config_listener.Listener {
 		return s.getListenerConf(name, kind, port, isIngress, mayUseOriginalSourceAddr)
-	}, wg, nil)
+	}, wg, nil, true)
 }
 
 // RemoveListener removes an existing Envoy Listener.
 func (s *XDSServer) RemoveListener(name string, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
+	return s.removeListener(name, wg, true)
+}
+
+// removeListener removes an existing Envoy Listener.
+func (s *XDSServer) removeListener(name string, wg *completion.WaitGroup, isProxyListener bool) xds.AckingResourceMutatorRevertFunc {
 	log.Debugf("Envoy: RemoveListener %s", name)
 
 	var listenerRevertFunc xds.AckingResourceMutatorRevertFunc
@@ -600,6 +614,9 @@ func (s *XDSServer) RemoveListener(name string, wg *completion.WaitGroup) xds.Ac
 	if ok && listener != nil {
 		listener.count--
 		if listener.count == 0 {
+			if isProxyListener {
+				s.proxyListeners--
+			}
 			delete(s.listeners, name)
 			listenerRevertFunc = s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, nil)
 		}
@@ -613,6 +630,9 @@ func (s *XDSServer) RemoveListener(name string, wg *completion.WaitGroup) xds.Ac
 		s.mutex.Lock()
 		if listenerRevertFunc != nil {
 			listenerRevertFunc(completion)
+			if isProxyListener {
+				s.proxyListeners++
+			}
 		}
 		listener.count++
 		s.listeners[name] = listener
@@ -1396,7 +1416,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 	// query for network policies and therefore will never ACK them, and we'd
 	// wait forever.
 	if !ep.HasSidecarProxy() {
-		if len(s.listeners) == 0 {
+		if s.proxyListeners == 0 {
 			wg = nil
 		}
 	}
@@ -1454,7 +1474,7 @@ func (s *XDSServer) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *p
 	// If there are no listeners configured, the local node's Envoy proxy won't
 	// query for network policies and therefore will never ACK them, and we'd
 	// wait forever.
-	if !ep.HasSidecarProxy() && len(s.listeners) == 0 {
+	if !ep.HasSidecarProxy() && s.proxyListeners == 0 {
 		return
 	}
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -181,12 +182,14 @@ var (
 
 func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	// Add these identities
+	wg := &sync.WaitGroup{}
 	testSelectorCache.UpdateIdentities(cache.IdentityCache{
 		dstID1: labels.Labels{"Dst1": labels.NewLabel("Dst1", "test", labels.LabelSourceK8s)}.LabelArray(),
 		dstID2: labels.Labels{"Dst2": labels.NewLabel("Dst2", "test", labels.LabelSourceK8s)}.LabelArray(),
 		dstID3: labels.Labels{"Dst3": labels.NewLabel("Dst3", "test", labels.LabelSourceK8s)}.LabelArray(),
 		dstID4: labels.Labels{"Dst4": labels.NewLabel("Dst4", "test", labels.LabelSourceK8s)}.LabelArray(),
-	}, nil)
+	}, nil, wg)
+	wg.Wait()
 
 	s.repo = policy.NewPolicyRepository(nil, nil)
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 
 	"github.com/sirupsen/logrus"
 )
@@ -426,8 +426,8 @@ func (l4Filter *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficd
 }
 
 // IdentitySelectionUpdated implements CachedSelectionUser interface
-// This call is made while holding name manager and selector cache
-// locks, must beware of deadlocking!
+// This call is made from a single goroutine in FIFO order to keep add
+// and delete events ordered properly. No locks are held.
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
-	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/cilium/proxy/go/cilium/api"
 
 	"github.com/sirupsen/logrus"
 )
@@ -426,8 +426,8 @@ func (l4Filter *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficd
 }
 
 // IdentitySelectionUpdated implements CachedSelectionUser interface
-// This call is made from a single goroutine in FIFO order to keep add
-// and delete events ordered properly. No locks are held.
+// This call is made while holding name manager and selector cache
+// locks, must beware of deadlocking!
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -17,6 +17,8 @@
 package policy
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -356,6 +358,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDenyWildcard(c *C) {
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -433,12 +436,14 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	testSelectorCache.UpdateIdentities(added1, nil)
 	// Cleanup the identities from the testSelectorCache
 	defer testSelectorCache.UpdateIdentities(nil, added1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	testSelectorCache.UpdateIdentities(nil, deleted1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -17,8 +17,6 @@
 package policy
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -358,7 +356,6 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDenyWildcard(c *C) {
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
-	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -436,14 +433,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	testSelectorCache.UpdateIdentities(added1, nil)
 	// Cleanup the identities from the testSelectorCache
 	defer testSelectorCache.UpdateIdentities(nil, added1)
-	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	testSelectorCache.UpdateIdentities(nil, deleted1)
-	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
@@ -204,10 +203,11 @@ func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Reposit
 	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
 	testRepo := NewPolicyRepository(mgr.GetIdentityCache(), nil)
 
-	var wg sync.WaitGroup
 	SetPolicyEnabled(option.DefaultEnforcement)
 	GenerateNumIdentities(3000)
-	testSelectorCache.UpdateIdentities(identityCache, nil)
+	wg := &sync.WaitGroup{}
+	testSelectorCache.UpdateIdentities(identityCache, nil, wg)
+	wg.Wait()
 	testRepo.selectorCache = testSelectorCache
 	rulez, _ := testRepo.AddList(ruleGenFunc(numRules))
 
@@ -219,7 +219,8 @@ func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Reposit
 	})
 
 	epsToRegen := NewEndpointSet(nil)
-	rulez.UpdateRulesEndpointsCaches(epSet, epsToRegen, &wg)
+	wg = &sync.WaitGroup{}
+	rulez.UpdateRulesEndpointsCaches(epSet, epsToRegen, wg)
 	wg.Wait()
 
 	c.Assert(epSet.Len(), Equals, 0)
@@ -521,8 +522,9 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 	added1 := cache.IdentityCache{
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
-	testSelectorCache.UpdateIdentities(added1, nil)
-	time.Sleep(100 * time.Millisecond)
+	wg := &sync.WaitGroup{}
+	testSelectorCache.UpdateIdentities(added1, nil, wg)
+	wg.Wait()
 	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -599,17 +601,19 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 		identity.NumericIdentity(194): labels.ParseSelectLabelArray("id=resolve_test_1", "num=3"),
 	}
-	testSelectorCache.UpdateIdentities(added1, nil)
+	wg := &sync.WaitGroup{}
+	testSelectorCache.UpdateIdentities(added1, nil, wg)
 	// Cleanup the identities from the testSelectorCache
-	defer testSelectorCache.UpdateIdentities(nil, added1)
-	time.Sleep(100 * time.Millisecond)
+	defer testSelectorCache.UpdateIdentities(nil, added1, wg)
+	wg.Wait()
 	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
-	testSelectorCache.UpdateIdentities(nil, deleted1)
-	time.Sleep(100 * time.Millisecond)
+	wg = &sync.WaitGroup{}
+	testSelectorCache.UpdateIdentities(nil, deleted1, wg)
+	wg.Wait()
 	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
@@ -522,7 +521,6 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
-	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -602,14 +600,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	testSelectorCache.UpdateIdentities(added1, nil)
 	// Cleanup the identities from the testSelectorCache
 	defer testSelectorCache.UpdateIdentities(nil, added1)
-	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	testSelectorCache.UpdateIdentities(nil, deleted1)
-	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
@@ -521,6 +522,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
 	}
 	testSelectorCache.UpdateIdentities(added1, nil)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 0)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -600,12 +602,14 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	testSelectorCache.UpdateIdentities(added1, nil)
 	// Cleanup the identities from the testSelectorCache
 	defer testSelectorCache.UpdateIdentities(nil, added1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 3)
 
 	deleted1 := cache.IdentityCache{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
 	}
 	testSelectorCache.UpdateIdentities(nil, deleted1)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(policy.policyMapChanges.changes, HasLen, 4)
 
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"unsafe"
 
@@ -153,7 +152,7 @@ type identitySelector interface {
 	removeUser(CachedSelectionUser, identityNotifier) (last bool)
 
 	// This may be called while the NameManager lock is held
-	notifyUsers(sc *SelectorCache, added, deleted []identity.NumericIdentity)
+	notifyUsers(added, deleted []identity.NumericIdentity)
 
 	numUsers() int
 }
@@ -184,17 +183,6 @@ func getIdentityCache(ids cache.IdentityCache) scIdentityCache {
 	return idCache
 }
 
-// userNotification stores the information needed to call
-// IdentitySelectionUpdated callbacks to notify users of selector's
-// identity changes. These are queued to be able to call the callbacks
-// in FIFO order while not holding any locks.
-type userNotification struct {
-	user     CachedSelectionUser
-	selector CachedSelector
-	added    []identity.NumericIdentity
-	deleted  []identity.NumericIdentity
-}
-
 // SelectorCache caches identities, identity selectors, and the
 // subsets of identities each selector selects.
 type SelectorCache struct {
@@ -209,14 +197,6 @@ type SelectorCache struct {
 	selectors map[string]identitySelector
 
 	localIdentityNotifier identityNotifier
-
-	// userCond is a condition variable for receiving signals
-	// about addition of new elements in userNotes
-	userCond *sync.Cond
-	// userMutex protects userNotes and is linked to userCond
-	userMutex lock.Mutex
-	// userNotes holds a FIFO list of user notifications to be made
-	userNotes []userNotification
 }
 
 // GetModel returns the API model of the SelectorCache.
@@ -243,46 +223,12 @@ func (sc *SelectorCache) GetModel() models.SelectorCache {
 	return selCacheMdl
 }
 
-func (sc *SelectorCache) handleUserNotifications() {
-	for {
-		sc.userMutex.Lock()
-		for len(sc.userNotes) == 0 {
-			sc.userCond.Wait()
-		}
-		// get the current batch of notifications and release the lock so that SelectorCache
-		// can't block on userMutex while we call IdentitySelectionUpdated callbacks below.
-		notifications := sc.userNotes
-		sc.userNotes = nil
-		sc.userMutex.Unlock()
-
-		for _, n := range notifications {
-			n.user.IdentitySelectionUpdated(n.selector, n.added, n.deleted)
-		}
-	}
-}
-
-func (sc *SelectorCache) queueUserNotification(user CachedSelectionUser, selector CachedSelector, added, deleted []identity.NumericIdentity) {
-	sc.userMutex.Lock()
-	sc.userNotes = append(sc.userNotes, userNotification{
-		user:     user,
-		selector: selector,
-		added:    added,
-		deleted:  deleted,
-	})
-	sc.userMutex.Unlock()
-	sc.userCond.Signal()
-}
-
 // NewSelectorCache creates a new SelectorCache with the given identities.
 func NewSelectorCache(ids cache.IdentityCache) *SelectorCache {
-	sc := &SelectorCache{
+	return &SelectorCache{
 		idCache:   getIdentityCache(ids),
 		selectors: make(map[string]identitySelector),
 	}
-	sc.userCond = sync.NewCond(&sc.userMutex)
-	go sc.handleUserNotifications()
-
-	return sc
 }
 
 // SetLocalIdentityNotifier injects the provided identityNotifier into the
@@ -429,10 +375,10 @@ type fqdnSelector struct {
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.
-func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.NumericIdentity) {
+func (f *fqdnSelector) notifyUsers(added, deleted []identity.NumericIdentity) {
 	for user := range f.users {
 		// pass 'f' to the user as '*fqdnSelector'
-		sc.queueUserNotification(user, f, added, deleted)
+		user.IdentitySelectionUpdated(f, added, deleted)
 	}
 }
 
@@ -488,10 +434,10 @@ type labelIdentitySelector struct {
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.
-func (l *labelIdentitySelector) notifyUsers(sc *SelectorCache, added, deleted []identity.NumericIdentity) {
+func (l *labelIdentitySelector) notifyUsers(added, deleted []identity.NumericIdentity) {
 	for user := range l.users {
 		// pass 'l' to the user as '*labelIdentitySelector'
-		sc.queueUserNotification(user, l, added, deleted)
+		user.IdentitySelectionUpdated(l, added, deleted)
 	}
 }
 
@@ -621,7 +567,7 @@ func (sc *SelectorCache) updateFQDNSelector(fqdnSelec api.FQDNSelector, identiti
 	// getting the CIDR identities which correspond to this FQDNSelector. This
 	// is the primary difference here between FQDNSelector and IdentitySelector.
 	fqdnSel.updateSelections()
-	fqdnSel.notifyUsers(sc, added, deleted) // disjoint sets, see the comment above
+	fqdnSel.notifyUsers(added, deleted) // disjoint sets, see the comment above
 }
 
 // AddFQDNSelector adds the given api.FQDNSelector in to the selector cache. If
@@ -880,7 +826,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted cache.IdentityCache) {
 				}
 				if len(dels)+len(adds) > 0 {
 					idSel.updateSelections()
-					idSel.notifyUsers(sc, adds, dels)
+					idSel.notifyUsers(adds, dels)
 				}
 			case *fqdnSelector:
 				// This is a no-op right now. We don't encode in the identities

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -44,6 +44,7 @@ func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServe
 		// Start Envoy on first invocation
 		envoyProxy = envoy.StartEnvoy(stateDir, option.Config.EnvoyLogPath, 0)
 
+		// Add Prometheus listener if the port is (properly) configured
 		if option.Config.ProxyPrometheusPort < 0 || option.Config.ProxyPrometheusPort > 65535 {
 			log.WithField(logfields.Port, option.Config.ProxyPrometheusPort).Error("Envoy: Invalid configured proxy-prometheus-port")
 		} else if option.Config.ProxyPrometheusPort != 0 {


### PR DESCRIPTION
* #16834 -- envoy: Keep track of proxy listeners separately (@jrajahalme)
* #16769 -- Revert "policy: Make selectorcache callbacks lock-free" (@aanm)
* #16801 -- Fix potential deadlock in pod identity updates (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16834 16769 16801; do contrib/backporting/set-labels.py $pr done 1.9; done
```
