### PR TITLE
backporting: Suggest only one related commit for a backport

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -156,11 +156,17 @@ generate_commit_list_for_pr () {
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
     entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
-    upstream_commit="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
-    upstream_id="$(git log -n1 --pretty=format:"%ae%at" $upstream_commit)"
-    if [ "$entry_id" == "${upstream_id}" ]; then
-      echo -e "     |  ${upstream_commit} via $entry_sha (\"$entry_sub\")"
-    else
+    related_commits="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
+    found_commit=0
+    for upstream_commit in ${related_commits}; do
+      upstream_id="$(git log -n1 --pretty=format:"%ae%at" $upstream_commit)"
+      if [ "$entry_id" == "${upstream_id}" ]; then
+        echo -e "     |  ${upstream_commit} via $entry_sha (\"$entry_sub\")"
+        found_commit=1
+        break
+      fi
+    done
+    if [ "$found_commit" -ne 1 ]; then
       echo -e "     |  Warning: No commit correlation found!    via $entry_sha (\"$entry_sub\")"
     fi
   done < $tmp_file


### PR DESCRIPTION
Recently, the check-stable script has suggested every single possible           
match for commits where the name does not uniquely identify the commit.         
This can be a bit confusing to backporters since it looks like there are        
many commits to backport as part of this PR, but the second and later           
ones are not necessary to backport.                                             
                                                                                
     * PR: 16589 -- vagrant: Bump all Vagrant box versions (@pchaigno) -- https://github.com/cilium/cilium/pull/16589
       Merge with 1 commit(s) merged at: Tue, 22 Jun 2021 12:36:17 -0700!       
         Branch:     master (!)                          refs/pull/16589/head   
                     ----------                          -------------------    
         v (start)                                                              
         |  edf76fb1ef6b58d5ef90b439d54134f314ed086e                            
    5bef5d77137a9ecc5d3f2b72149307ffdd52cd42                                    
    4dc60e6faf654d7424ee959867a774205b3fed13                                    
    816b3231cdbc39f4bcdd3e6f5b40a056459a478c                                    
    51826b31087496d108044f3bffbf304580fffb4a                                    
    df8238d451d755d5be75e202be89b4f88067c77b                                    
    a4e7bc6c1f0e96078793458b6719b9a3999b89db via fb723f8133c40faa068a5a401f594622668b2753 ("vagrant: Bump all Vagrant box versions")
         v (end)                                                                
                                                                                
Probably within the last year of commits, we should be able to correlate        
the exact commit that needs backporting, so iterate through those to            
find the exact commit. If none of those are the correct commit, fail out        
and push back to the backporter to figure out.                                  
                                                                                
This allows us to now accurately pick the correct commit in most cases:         
                                                                                
     * PR: 16589 -- vagrant: Bump all Vagrant box versions (@pchaigno) -- https://github.com/cilium/cilium/pull/16589
       Merge with 1 commit(s) merged at: Tue, 22 Jun 2021 12:36:17 -0700!       
         Branch:     master (!)                          refs/pull/16589/head   
                     ----------                          -------------------    
         v (start)                                                              
         |  edf76fb1ef6b58d5ef90b439d54134f314ed086e via fb723f8133c40faa068a5a401f594622668b2753 ("vagrant: Bump all Vagrant box versions")
         v (end)                                                                
                                                                                
Manually tested by substituting a known commit into 'related_commits',          
and by checking the current v1.8 backports which includes an ambiguous                                                                                                              
commit due to a revert+reapply in the master branch.

Fixes: #16572