### PR TITLE
v1.8 backports 2021-07-15

### DIFF
--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -41,7 +41,7 @@ On Freeze date
 #. Create a new project named "X.Y.Z" to automatically track the backports
    for that particular release. `Direct Link: <https://github.com/cilium/cilium/projects/new>`_
 
-#. Copy the ``.github/cilium-actions.yml`` from the previous release ``vX.Y-1``
+#. Copy the ``.github/maintainers-little-helper.yaml`` from the previous release ``vX.Y-1``
    change the contents to be relevant for the release ``vX.Y`` and set the
    ``project:`` to be the generated link created by the previous step. The link
    should be something like: ``https://github.com/cilium/cilium/projects/NNN``
@@ -69,7 +69,7 @@ On Freeze date
    #. ``needs-backport/1.2``
 
 
-#. Checkout to master and update the ``.github/cilium-actions.yml`` to have
+#. Checkout to master and update the ``.github/maintainers-little-helper.yaml`` to have
    all the necessary configurations for the backport of the new ``vX.Y`` branch.
    Specifically, ensure that:
 
@@ -79,11 +79,11 @@ On Freeze date
 
    ::
 
-       git checkout -b pr/master-cilium-actions-update origin/master
-       # modify .github/cilium-actions.yml
-       git add .github/cilium-actions.yml
-       git commit
-       git push
+       $ git checkout -b pr/master-cilium-actions-update origin/master
+       $ # modify .github/maintainers-little-helper.yaml
+       $ git add .github/maintainers-little-helper.yaml
+       $ git commit
+       $ git push
 
 #. Continue with the next step only after the previous steps are merged into
    master.

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -52,6 +52,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 

--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -10,7 +10,7 @@ MAJ_REGEX='[0-9]\+\.[0-9]\+'
 MIN_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
 REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 for release in $(grep "General Announcement" README.rst \

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -7,7 +7,7 @@ source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
-ACTS_YAML=".github/cilium-actions.yml"
+ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 usage() {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3489,9 +3489,9 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	kub.reportMapHost(ctx, testPath, reportCmds)
 
 	reportCmds = map[string]string{
-		"journalctl --no-pager -au kubelet": "kubelet.log",
-		"top -n 1 -b":                       "top.log",
-		"ps aux":                            "ps.log",
+		"journalctl -D /var/log/journal --no-pager -au kubelet": "kubelet.log",
+		"top -n 1 -b": "top.log",
+		"ps aux":      "ps.log",
 	}
 
 	kub.reportMapContext(ctx, testPath, reportCmds, LogGathererNamespace, logGathererSelector(false))

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3489,7 +3489,8 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	kub.reportMapHost(ctx, testPath, reportCmds)
 
 	reportCmds = map[string]string{
-		"journalctl -D /var/log/journal --no-pager -au kubelet": "kubelet.log",
+		"journalctl -D /var/log/journal --no-pager -au kubelet":        "kubelet.log",
+		"journalctl -D /var/log/journal --no-pager -au kube-apiserver": "kube-apiserver.log",
 		"top -n 1 -b": "top.log",
 		"ps aux":      "ps.log",
 	}

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -30,8 +30,8 @@ spec:
         - "10000"
         command:
         - sleep
-        image: docker.io/cilium/log-gatherer:v1.0
-        imagePullPolicy: Always
+        image: docker.io/cilium/log-gatherer:v1.1
+        imagePullPolicy: IfNotPresent
         name: log-gatherer
         securityContext:
           capabilities:


### PR DESCRIPTION
 * #16721 -- Fix and add more commands in CI sysdumps (@aanm)
   * Minor conflict in log-gatherer pod spec. Bumped to v1.1.
 * #16750 -- contrib/docs: rename 'cilium-actions.yml' with 'maintainers-little-helper.yaml (@aanm)
   * Minor conflict in docs
 * #16804 -- contrib: Explicitly set remote for backport branches (@twpayne)

Skipped until I hear from @jrajahalme that the benefit outweighs the risks:
 * #16801 -- Fix potential deadlock in pod identity updates (@jrajahalme)

Skipped since it seems to break VM provisioning for test-upstream-k8s job (see comments below)
* #16554 -- ci: Disable NFS locking (@gandro)
   * Minor conflict, resolved by applying the new option to the old config

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16721 16750 16804; do contrib/backporting/set-labels.py $pr done 1.8; done
```