### PR TITLE
Make go test ./... succeed by default

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -5,7 +5,7 @@ set -o errexit
 export CFLAGS="-Werror"
 
 make -j 2
-make unit-tests
+make integration-tests
 
 $HOME/gopath/bin/goveralls -coverprofile=coverage-all.out -service=travis-ci || true
 

--- a/Documentation/contributing/development/debugging.rst
+++ b/Documentation/contributing/development/debugging.rst
@@ -380,11 +380,11 @@ To compile a Cilium binary with race detection, you can do:
     ``BASE_IMAGE`` which can be the ``cilium/cilium-runtime`` image from the
     root Dockerfile found in the Cilium repository.
 
-To run unit tests with race detection, you can do:
+To run integration tests with race detection, you can do:
 
 .. code-block:: shell-session
 
-    $ make RACE=1 unit-tests
+    $ make RACE=1 integration-tests
 
 ~~~~~~~~~~~~~~~~~~
 Deadlock detection
@@ -400,5 +400,5 @@ For example:
 .. code-block:: shell-session
 
     $ make LOCKDEBUG=1
-    $ # Deadlock detection during unit tests:
-    $ make LOCKDEBUG=1 unit-tests
+    $ # Deadlock detection during integration tests:
+    $ make LOCKDEBUG=1 integration-tests

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -51,7 +51,9 @@ contribute to Cilium:
 + python3-pip                                                  | latest                       | N/A (OS-specific)                                |
 +--------------------------------------------------------------+------------------------------+--------------------------------------------------+
 
-For `unit_testing`, you will need to run ``docker`` without privileges. You can usually achieve this by adding your current user to the ``docker`` group.
+For `integration_testing`, you will need to run ``docker`` without privileges.
+You can usually achieve this by adding your current user to the ``docker``
+group.
 
 Finally, in order to run Cilium locally on VMs, you need:
 
@@ -415,7 +417,7 @@ Making Changes
 
 #. Make sure your changes meet the following criteria:
 
-   #. New code is covered by :ref:`unit_testing`.
+   #. New code is covered by :ref:`integration_testing`.
    #. End to end integration / runtime tests have been extended or added. If
       not required, mention in the commit message what existing test covers the
       new code.
@@ -425,7 +427,7 @@ Making Changes
 #. Run ``git diff --check`` to catch obvious white space violations
 #. Run ``make`` to build your changes. This will also run ``make lint`` and error out
    on any golang linting errors. The rules are configured in ``.golangci.yaml``
-#. See :ref:`unit_testing` on how to run unit tests.
+#. See :ref:`integration_testing` on how to run integration tests.
 #. See :ref:`testsuite` for information how to run the end to end integration
    tests
 #. If you are making documentation changes, you can generate documentation files

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -64,7 +64,7 @@ To run all of the runtime tests, execute the following command from the ``test``
 
 .. code-block:: shell-session
 
-    ginkgo --focus="Runtime"
+    ginkgo --focus="Runtime" --tags=integration_tests
 
 Ginkgo searches for all tests in all subdirectories that are "named" beginning
 with the string "Runtime" and contain any characters after it. For instance,
@@ -115,14 +115,14 @@ To run all of the Kubernetes tests, run the following command from the ``test`` 
 
 .. code-block:: shell-session
 
-    ginkgo --focus="K8s"
+    ginkgo --focus="K8s" --tags=integration_tests
 
 To run a specific test from the Kubernetes tests suite, run the following command
 from the ``test`` directory:
 
 .. code-block:: shell-session
 
-    ginkgo --focus="K8s.*Check iptables masquerading with random-fully"
+    ginkgo --focus="K8s.*Check iptables masquerading with random-fully" --tags=integration_tests
 
 Similar to the Runtime test suite, Ginkgo searches for all tests in all
 subdirectories that are "named" beginning with the string "K8s" and
@@ -142,7 +142,7 @@ supported version of Kubernetes, run the test suite with the following format:
 
 .. code-block:: shell-session
 
-    K8S_VERSION=<version> ginkgo --focus="K8s"
+    K8S_VERSION=<version> ginkgo --focus="K8s" --tags=integration_tests
 
 .. note::
 
@@ -175,7 +175,7 @@ To run all of the Nightly tests, run the following command from the ``test`` dir
 
 .. code-block:: shell-session
 
-    ginkgo --focus="Nightly"
+    ginkgo --focus="Nightly" --tags=integration_tests
 
 Similar to the other test suites, Ginkgo searches for all tests in all
 subdirectories that are "named" beginning with the string "Nightly" and contain
@@ -266,7 +266,7 @@ If you want to run one specified test, there are a few options:
 
   .. code-block:: shell-session
 
-      ginkgo --focus "Runtime.*L7"
+      ginkgo --focus "Runtime.*L7" --tags=integration_tests
 
 
 This will focus on tests that contain "Runtime", followed by any

--- a/Documentation/contributing/testing/unit.rst
+++ b/Documentation/contributing/testing/unit.rst
@@ -4,16 +4,16 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
-.. _unit_testing:
+.. _integration_testing:
 
-Unit Testing
-============
+Integration Testing
+===================
 
 Cilium uses the standard `go test <https://golang.org/pkg/testing/>`__ framework
 in combination with `gocheck <http://labix.org/gocheck>`__ for richer testing
 functionality.
 
-.. _unit_testing_prerequisites:
+.. _integration_testing_prerequisites:
 
 Prerequisites
 ^^^^^^^^^^^^^
@@ -28,12 +28,18 @@ both etcd and consul. To start the local instances, run:
 Running all tests
 ^^^^^^^^^^^^^^^^^
 
-To run unit tests over the entire repository, run the following command in the
-project root directory:
+To run integration tests over the entire repository, run the following command
+in the project root directory:
 
 .. code-block:: shell-session
 
-    $ make unit-tests
+    $ make integration-tests
+
+To run just unit tests, run:
+
+.. code-block:: shell-session
+
+    $ go test ./...
 
 Testing individual packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,17 +61,18 @@ If you need more verbose output, you can pass in the ``-check.v`` and
     $ cd pkg/kvstore
     $ go test -check.v -check.vv
 
-If the unit tests have some prerequisites like :ref:`unit_testing_prerequisites`,
-you can use the following command to automatically set up the prerequisites,
-run the unit tests and tear down the prerequisites:
+Integration tests have some prerequisites like
+:ref:`integration_testing_prerequisites`, you can use the following command to
+automatically set up the prerequisites, run the unit tests and tear down the
+prerequisites:
 
 .. code-block:: shell-session
 
-    $ make unit-tests TESTPKGS=pkg/kvstore
+    $ make integration-tests TESTPKGS=pkg/kvstore
 
 Some packages have privileged tests. They are not run by default when you run
-the unit tests for the respective package. The privileged test files have an
-entry at the top of the test file as shown.
+the integration tests for the respective package. The privileged test files have
+an entry at the top of the test file as shown.
 
 ::
 

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,7 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddres
 	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-TEST_UNITTEST_LDFLAGS= -ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyConfigFile=/tmp/cilium-consul-certs/cilium-consul.yaml \
-	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 \
-	-X github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr=$(LOGLEVEL)"
+TEST_UNITTEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 define print_help_line
 	@printf "  \033[36m%-29s\033[0m %s.\n" $(1) $(2)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Authors of Cilium
+# Copyright 2017-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 ##@ Default
@@ -59,11 +59,9 @@ DOCKER_FLAGS ?=
 
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 \
 	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
-	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 TEST_UNITTEST_LDFLAGS= -ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyConfigFile=/tmp/cilium-consul-certs/cilium-consul.yaml \
-	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 \
 	-X github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr=$(LOGLEVEL)"
 

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ $(SUBDIRS): force ## Execute default make target(make all) for the provided subd
 
 PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $$pkg; done | xargs grep --include='*.go' -ril '+build [^!]*privileged_tests' | xargs dirname | sort | uniq)
 PRIV_TEST_PKGS ?= $(PRIV_TEST_PKGS_EVAL)
-tests-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run unit-tests for Cilium that requires elevated privileges.
+tests-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run integration-tests for Cilium that requires elevated privileges.
 tests-privileged:
-	# cilium-map-migrate is a dependency of some unit tests.
+	# cilium-map-migrate is a dependency of some integration tests.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf cilium-map-migrate
 	$(MAKE) init-coverage
 	for pkg in $(patsubst %,github.com/cilium/cilium/%,$(PRIV_TEST_PKGS)); do \
@@ -144,7 +144,7 @@ tests-privileged:
 	done
 	$(MAKE) generate-cov
 
-start-kvstores: ## Start running kvstores required for running Cilium unit-tests. More specifically this will run etcd and consul containers.
+start-kvstores: ## Start running kvstores required for running Cilium integration-tests. More specifically this will run etcd and consul containers.
 ifeq ($(SKIP_KVSTORES),"false")
 	@echo Starting key-value store containers...
 	-$(QUIET)$(CONTAINER_ENGINE) rm -f "cilium-etcd-test-container" 2> /dev/null
@@ -180,7 +180,7 @@ ifeq ($(SKIP_KVSTORES),"false")
 	$(QUIET)rm -rf /tmp/cilium-consul-certs
 endif
 
-generate-cov: ## Generate coverage report for Cilium unit-tests.
+generate-cov: ## Generate coverage report for Cilium integration-tests.
 	# Remove generated code from coverage
 	$(QUIET) grep -Ev '(^github.com/cilium/cilium/api/v1)|(generated.deepcopy.go)|(^github.com/cilium/cilium/pkg/k8s/client/)' \
 		coverage-all-tmp.out > coverage-all.out
@@ -188,11 +188,12 @@ generate-cov: ## Generate coverage report for Cilium unit-tests.
 	$(QUIET) rm coverage.out coverage-all-tmp.out
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
 
-init-coverage: ## Initialize converage report for Cilium unit-tests.
+init-coverage: ## Initialize converage report for Cilium integration-tests.
 	$(QUIET) echo "mode: count" > coverage-all-tmp.out
 	$(QUIET) echo "mode: count" > coverage.out
 
-unit-tests: start-kvstores ## Runs all unit-tests for Cilium.
+integration-tests: GO_TAGS_FLAGS+=integration_tests
+integration-tests: start-kvstores ## Runs all integration-tests for Cilium.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tools/maptool/
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C test/bpf/
 	test/bpf/unit-test
@@ -212,9 +213,10 @@ endif
 	$(MAKE) generate-cov
 	$(MAKE) stop-kvstores
 
-bench: start-kvstores ## Run benchmarks for Cilium unit-tests in the repository.
+bench: start-kvstores ## Run benchmarks for Cilium integration-tests in the repository.
 	# Process the packages in different subshells. See comment in the
-	# "unit-tests" target above for an explanation.## Builds components required for cilium-agent container.
+	# "integration-tests" target above for an explanation.## Builds components
+	# required for cilium-agent container.
 	$(QUIET)for pkg in $(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)); do \
 		$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) \
 			$$pkg \
@@ -225,7 +227,7 @@ bench: start-kvstores ## Run benchmarks for Cilium unit-tests in the repository.
 bench-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run benchmarks for priviliged tests.
 bench-privileged:
 	# Process the packages in different subshells. See comment in the
-	# "unit-tests" target above for an explanation.
+	# "integration-tests" target above for an explanation.
 	$(QUIET)for pkg in $(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)); do \
 		$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(GOTEST_BASE) $(BENCHFLAGS) $$pkg \
 		|| exit 1; \

--- a/contrib/shell/test.sh
+++ b/contrib/shell/test.sh
@@ -44,7 +44,7 @@ function watchdo
 function watchtest_
 {
 
-    watchdo "." "make --quiet build unit-tests"
+    watchdo "." "make --quiet build integration-tests"
 }
 
 # Watch a file or directory for changes and trigger tests when it is modified.

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cmd
 

--- a/daemon/cmd/debuginfo_test.go
+++ b/daemon/cmd/debuginfo_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cmd
 

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018-2020 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cmd
 

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019-2020 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cmd
 

--- a/daemon/cmd/ipcache_test.go
+++ b/daemon/cmd/ipcache_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019-2020 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cmd
 

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cmd
 

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -156,7 +156,7 @@ pipeline {
             steps {
                 dir("${TESTDIR}"){
                     sh 'env'
-                    sh 'ginkgo --focus="${FOCUS}" -v -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.passCLIEnvironment=true -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.holdEnvironment=false -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.operator-suffix="-ci"'
+                    sh 'ginkgo --focus="${FOCUS}" --tags=integration_tests -v -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.passCLIEnvironment=true -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.holdEnvironment=false -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.operator-suffix="-ci"'
                 }
             }
             post {

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -233,7 +233,7 @@ pipeline {
             }
             steps {
                 sh 'env'
-                sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="${FOCUS}" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.operator-suffix="-ci"'
+                sh 'cd ${TESTDIR}; HOME=${GOPATH} ginkgo --focus="${FOCUS}" --tags=integration_tests -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.runQuarantined=${RUN_QUARANTINED} -cilium.image=${CILIUM_IMAGE} -cilium.tag=${CILIUM_TAG} -cilium.operator-image=${CILIUM_OPERATOR_IMAGE} -cilium.operator-tag=${CILIUM_OPERATOR_TAG} -cilium.hubble-relay-image=${HUBBLE_RELAY_IMAGE} -cilium.hubble-relay-tag=${HUBBLE_RELAY_TAG} -cilium.operator-suffix="-ci"'
             }
             post {
                 always {

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -133,7 +133,7 @@ pipeline {
                 TESTDIR="${GOPATH}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED}'
+                sh 'cd ${TESTDIR}; ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" --tags=integration_tests -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED}'
             }
             post {
                 always {

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package clustermesh
 

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package clustermesh
 

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package clustermesh
 

--- a/pkg/datapath/loader/hash.go
+++ b/pkg/datapath/loader/hash.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
 package loader
 

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
 // +build privileged_tests
 
@@ -40,7 +40,7 @@ var (
 	dirInfo *directoryInfo
 	ep      = testutils.NewTestEndpoint()
 	hostEp  = testutils.NewTestHostEndpoint()
-	bpfDir  = filepath.Join(testutils.CiliumRootDir, "bpf")
+	bpfDir  = filepath.Join("..", "..", "..", "bpf")
 )
 
 // SetTestIncludes allows test files to configure additional include flags.

--- a/pkg/elf/elf_test.go
+++ b/pkg/elf/elf_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
 // +build !privileged_tests
 
@@ -15,8 +15,6 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-
-	"github.com/cilium/cilium/pkg/testutils"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -25,7 +23,7 @@ type ELFTestSuite struct{}
 var (
 	_ = Suite(&ELFTestSuite{})
 
-	baseObjPath = filepath.Join(testutils.CiliumRootDir, "test", "bpf", "elf-demo.o")
+	baseObjPath = filepath.Join("..", "..", "test", "bpf", "elf-demo.o")
 )
 
 const elfObjCopy = "elf-demo-copy.o"

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package endpoint
 

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 Authors of Cilium
+// Copyright 2020-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package endpoint
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
 package endpoint
 
@@ -36,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -534,29 +533,6 @@ func (e *Endpoint) HostInterface() string {
 		return ""
 	}
 	return e.ifName
-}
-
-// getK8sPodLabels returns all labels that exist in the endpoint and were
-// derived from k8s pod.
-func (e *Endpoint) getK8sPodLabels() labels.Labels {
-	e.unconditionalRLock()
-	defer e.runlock()
-	allLabels := e.OpLabels.AllLabels()
-	if allLabels == nil {
-		return nil
-	}
-
-	allLabelsFromK8s := allLabels.GetFromSource(labels.LabelSourceK8s)
-
-	k8sEPPodLabels := labels.Labels{}
-	for k, v := range allLabelsFromK8s {
-		if !strings.HasPrefix(v.Key, ciliumio.PodNamespaceMetaLabels) &&
-			!strings.HasPrefix(v.Key, ciliumio.PolicyLabelServiceAccount) &&
-			!strings.HasPrefix(v.Key, ciliumio.PodNamespaceLabel) {
-			k8sEPPodLabels[k] = v
-		}
-	}
-	return k8sEPPodLabels
 }
 
 // GetLabelsSHA returns the SHA of labels

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019-2020 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package endpoint
 

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package endpoint
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package endpoint
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package endpoint
 

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package endpoint
 

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cache
 

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cache
 

--- a/pkg/identity/cache/local_test.go
+++ b/pkg/identity/cache/local_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package cache
 

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2020 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package allocator
 

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package kvstore
 

--- a/pkg/kvstore/kvstore_test.go
+++ b/pkg/kvstore/kvstore_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package kvstore
 

--- a/pkg/kvstore/lock_test.go
+++ b/pkg/kvstore/lock_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package kvstore
 

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -395,36 +395,6 @@ func (s *SharedStore) DeleteLocalKey(ctx context.Context, key NamedKey) {
 	}
 }
 
-// getLocalKeys returns all local keys
-func (s *SharedStore) getLocalKeys() []Key {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
-	keys := make([]Key, len(s.localKeys))
-	idx := 0
-	for _, key := range s.localKeys {
-		keys[idx] = key
-		idx++
-	}
-
-	return keys
-}
-
-// getSharedKeys returns all shared keys
-func (s *SharedStore) getSharedKeys() []Key {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
-	keys := make([]Key, len(s.sharedKeys))
-	idx := 0
-	for _, key := range s.sharedKeys {
-		keys[idx] = key
-		idx++
-	}
-
-	return keys
-}
-
 func (s *SharedStore) getLogger() *logrus.Entry {
 	return log.WithFields(logrus.Fields{
 		"storeName": s.name,

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
-// +build !privileged_tests
+// +build !privileged_tests,integration_tests
 
 package store
 
@@ -311,4 +311,34 @@ func (s *StoreSuite) TestStoreCollaboration(c *C) {
 		log.Debugf("totalKeys %d == keys1 %d == keys2 %d", totalKeys, len(keys1), len(keys2))
 		return len(keys1) == totalKeys && len(keys1) == len(keys2)
 	}), IsNil)
+}
+
+// getLocalKeys returns all local keys
+func (s *SharedStore) getLocalKeys() []Key {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	keys := make([]Key, len(s.localKeys))
+	idx := 0
+	for _, key := range s.localKeys {
+		keys[idx] = key
+		idx++
+	}
+
+	return keys
+}
+
+// getSharedKeys returns all shared keys
+func (s *SharedStore) getSharedKeys() []Key {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	keys := make([]Key, len(s.sharedKeys))
+	idx := 0
+	for _, key := range s.sharedKeys {
+		keys[idx] = key
+		idx++
+	}
+
+	return keys
 }

--- a/pkg/testutils/const.go
+++ b/pkg/testutils/const.go
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright 2019 Authors of Cilium
-
-package testutils
-
-var (
-	CiliumRootDir = "" // Populated from ldflags in Makefile
-)

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,19 +19,19 @@ all: build
 
 build:
 	@$(ECHO_GINKGO)$@
-	$(GINKGO) build
+	$(GINKGO) build -tags=integration_tests
 	$(QUIET)$(MAKE) -C bpf/
 
 test: run k8s
 
 run:
-	ginkgo --focus "Runtime" -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
+	ginkgo --focus "Runtime" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
 
 k8s:
-	ginkgo --focus "K8s" -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
+	ginkgo --focus "K8s" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
 
 nightly:
-	ginkgo --focus "Nightly" -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
+	ginkgo --focus "Nightly" -v --tags integration_tests -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
 
 clean:
 	@$(ECHO_CLEAN)

--- a/test/packet/README.md
+++ b/test/packet/README.md
@@ -26,6 +26,6 @@ export TF_VAR_metal_plan="c1.small.x86"
 13) Run `screen` which will create a new terminal, this is helpful as you can leave your terminal while tests are running and come back again afterwards.
 14) Enter the `test` directory with `cd test`
 15) Run the ginkgo command to initialize the tests, for example:
-`K8S_VERSION=1.14 ginkgo --focus="K8s" -v -- --cilium.showCommands --cilium.holdEnvironment=true`
+`K8S_VERSION=1.14 ginkgo --focus="K8s" --tags integration_tests -v -- --cilium.showCommands --cilium.holdEnvironment=true`
 16) Once tests are running and if you are running `screen`, you can leave the terminal
 by typing `CTRL+a+d`, to resume again type `screen -r`

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2021 Authors of Cilium
+
+// +build integration_tests
 
 package ciliumTest
 


### PR DESCRIPTION
This PR makes

```console
$ go test ./...
```

succeed by default. Before, it would fail due to many unit tests actually being integration tests needing a running etcd server and the requirement for various linker flags to be present to set various test configuration variables.

See the individual commits for more details.
