### PR TITLE
operator: misc. refactoring and code removal

### DIFF
--- a/operator/k8s_pod_controller.go
+++ b/operator/k8s_pod_controller.go
@@ -43,7 +43,7 @@ var (
 func enableUnmanagedKubeDNSController() {
 	// These functions will block until the resources are synced with k8s.
 	watchers.CiliumEndpointsInit(k8s.CiliumClient().CiliumV2(), wait.NeverStop)
-	watchers.UnmanagedPodsInit(k8s.WatcherClient())
+	watchers.UnmanagedKubeDNSPodsInit(k8s.WatcherClient())
 
 	controller.NewManager().UpdateController("restart-unmanaged-kube-dns",
 		controller.ControllerParams{
@@ -54,7 +54,7 @@ func enableUnmanagedKubeDNSController() {
 						delete(lastPodRestart, podName)
 					}
 				}
-				for _, podItem := range watchers.UnmanagedPodStore.List() {
+				for _, podItem := range watchers.UnmanagedKubeDNSPodStore.List() {
 					pod, ok := podItem.(*slim_corev1.Pod)
 					if !ok {
 						log.Errorf("unexpected type mapping: found %T, expected %T", pod, &slim_corev1.Pod{})

--- a/operator/watchers/pod.go
+++ b/operator/watchers/pod.go
@@ -36,13 +36,13 @@ var (
 	// PodStoreSynced is closed once the PodStore is synced with k8s.
 	PodStoreSynced = make(chan struct{})
 
-	// UnmanagedPodStore has a minimal copy of the unmanaged kube-dns pods running
+	// UnmanagedKubeDNSPodStore has a minimal copy of the unmanaged kube-dns pods running
 	// in the cluster.
 	// Warning: The pods stored in the cache are not intended to be used for Update
 	// operations in k8s as some of its fields are not populated.
-	UnmanagedPodStore cache.Store
+	UnmanagedKubeDNSPodStore cache.Store
 
-	// UnmanagedPodStoreSynced is closed once the UnmanagedPodStore is synced
+	// UnmanagedPodStoreSynced is closed once the UnmanagedKubeDNSPodStore is synced
 	// with k8s.
 	UnmanagedPodStoreSynced = make(chan struct{})
 )
@@ -109,9 +109,9 @@ func convertToPod(obj interface{}) interface{} {
 	}
 }
 
-func UnmanagedPodsInit(k8sClient kubernetes.Interface) {
+func UnmanagedKubeDNSPodsInit(k8sClient kubernetes.Interface) {
 	var unmanagedPodInformer cache.Controller
-	UnmanagedPodStore, unmanagedPodInformer = informer.NewInformer(
+	UnmanagedKubeDNSPodStore, unmanagedPodInformer = informer.NewInformer(
 		cache.NewFilteredListWatchFromClient(k8sClient.CoreV1().RESTClient(),
 			"pods", v1.NamespaceAll, func(options *metav1.ListOptions) {
 				options.LabelSelector = "k8s-app=kube-dns"


### PR DESCRIPTION
Add better code comments as well as variable names.

Also remove the code handling the GC of CiliumNodes since
that is taken care by Kubernetes has CiliumNodes have owner references
set to the K8s Node.

Signed-off-by: André Martins <andre@cilium.io>