### PR TITLE
.gitattributes: Hide Documentation/_static.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@ examples/kubernetes/connectivity-check/connectivity-*.yaml linguist-generated
 pkg/k8s/apis/cilium.io/v2/client/crds/*.yaml linguist-generated
 Documentation/cmdref/** linguist-generated
 Documentation/helm-values.rst linguist-generated
+Documentation/_static/* -diff
+*svg -diff


### PR DESCRIPTION
Treat `Documentation/_static` and `*svg` as binary in git so that when performing a
git diff or git grep, it prints just one line diff rather than matching
the content of some terse javascript file:

    $ git grep "\.fo"
    Binary file Documentation/_static/copybutton.js matches
