### PR TITLE
Documentation: dont use docker for check-cmdref

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -34,7 +34,7 @@ update-cmdref: builder-image
 
 check: builder-image update-cmdref
 	@$(ECHO_CHECK) cmdref
-	$(QUIET)$(DOCKER_RUN) ./check-cmdref.sh
+	$(QUIET) ./check-cmdref.sh
 	@$(ECHO_CHECK) examples
 	$(QUIET)$(DOCKER_RUN) ./check-examples.sh
 


### PR DESCRIPTION
check-cmdref just uses bash and git, so there is no reason to run it in
a container.

At the same time, running it in a container causes the script to not
work when using it in a directory created with git clone --reference,
because in this case git object live outside of the directory that is
mounted in the docker container and git diff will fail.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>
