### PR TITLE
.github: harden permissions on GH workflows

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -23,7 +23,11 @@ on:
   # pull_request: {}
   ###
 
-permissions: read-all
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # So that Sibz/github-status-action can write into the status API
+  statuses: write
 
 concurrency:
   # Structure:


### PR DESCRIPTION
None of the GH workflows need the GITHUB_TOKEN to have write
permissions for all scopes. This commit hardens the access values for
each GH workflow accordingly their needs.

Fixes: 4286608cba1e (".github: harden permissions on GH workflows")
Signed-off-by: André Martins <andre@cilium.io>