### PR TITLE
v1.9 backports 2021-07-20

### DIFF
--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -52,6 +52,7 @@ echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
 hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -733,7 +733,7 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 	// No need to create file for bugtool because it creates an archive of files
 	// for us.
 	res := s.ExecWithSudo(
-		fmt.Sprintf("%s -t %s", CiliumBugtool, filepath.Join(s.basePath, testPath)),
+		fmt.Sprintf("%s -t %q", CiliumBugtool, filepath.Join(s.basePath, testPath)),
 		ExecOptions{SkipLog: true})
 	if !res.WasSuccessful() {
 		s.logger.Errorf("Error running bugtool: %s", res.CombineOutput())

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -741,7 +741,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		}
 	})
 
-	It(`Implements matchPattern: "*"`, func() {
+	It(`Implements matchPattern: *`, func() {
 		By(`Importing policy with matchPattern: "*" rule`)
 		fqdnPolicy := `
 [

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -333,7 +333,7 @@ var _ = AfterEach(func() {
 
 		_, err := exec.Command(
 			"/bin/bash", "-c",
-			fmt.Sprintf("zip -qr %s %s", zipFilePath, path)).CombinedOutput()
+			fmt.Sprintf("zip -qr \"%s\" \"%s\"", zipFilePath, path)).CombinedOutput()
 		if err != nil {
 			log.WithError(err).Errorf("cannot create zip file '%s'", zipFilePath)
 		}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -325,7 +325,7 @@ var _ = AfterEach(func() {
 	}
 
 	// This piece of code is to enable zip attachments on Junit Output.
-	if ginkgo.CurrentGinkgoTestDescription().Failed && helpers.IsRunningOnJenkins() {
+	if TestFailed() && helpers.IsRunningOnJenkins() {
 		// ReportDirectory is already created. No check the error
 		path, _ := helpers.CreateReportDirectory()
 		zipFileName := fmt.Sprintf("%s_%s.zip", helpers.MakeUID(), GetTestName())
@@ -341,7 +341,7 @@ var _ = AfterEach(func() {
 		GinkgoPrint("[[ATTACHMENT|%s]]", zipFileName)
 	}
 
-	if !ginkgo.CurrentGinkgoTestDescription().Failed && helpers.IsRunningOnJenkins() {
+	if !TestFailed() && helpers.IsRunningOnJenkins() {
 		// If the test success delete the monitor.log filename to not store all
 		// the data in Jenkins
 		testPath, err := helpers.CreateReportDirectory()


### PR DESCRIPTION
* #16489 -- test: Fix artifact collection for bad log failures (@pchaigno)
 * #16540 -- test: Fix missing artifacts for tests with parentheses  (@pchaigno)

 * #16759 -- test: Fix artifact collection for FQDN matchPattern test (@pchaigno)
 * #16804 -- contrib: Explicitly set remote for backport branches (@twpayne)

Skipped:
 * #16908 -- Misc. GH workflow improvements and hardness (@aanm)
   * @aanm Does this even make sense on v1.9? These workflows are not present there.
 * #16589 -- vagrant: Bump all Vagrant box versions (@pchaigno)
   * Removed due to suspicion it causes test regression for upstream k8s test.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16489 16540 16759 16804; do contrib/backporting/set-labels.py $pr done 1.9; done
```