### PR TITLE
inctimer: Fix bug where timer fired immediately

### DIFF
--- a/pkg/inctimer/inctimer_test.go
+++ b/pkg/inctimer/inctimer_test.go
@@ -21,6 +21,18 @@ import (
 	"time"
 )
 
+func TestTimerAfter(t *testing.T) {
+	for i := 0; i < 100_000; i++ {
+		tr, done := New()
+		select {
+		case <-tr.After(time.Second):
+			t.Fatal("`IncTimer` fired too soon")
+		default:
+		}
+		done()
+	}
+}
+
 func TestTimerHardReset(t *testing.T) {
 	tr, done := New()
 	defer done()


### PR DESCRIPTION
This fixes a bug where the `IncTimer.After` would fire immediately due
to a rare race. See the comment in the diff as to how the race
could occur. This commit also adds a unit test which has a high
likelihood of triggering the bug in the old code.

Discovered this will debugging https://github.com/cilium/cilium/issues/15442 (which is not fully fixed by this PR,
but the reason why that other unit test faililure surfaced sporadically was
because of this bug here)

```release-note
Fix bug where timers used for retries sometimes fired immediately
```