### PR TITLE
docs: clarify language on libceph and kernel 5.8 in kubeproxy-free GSG

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1264,9 +1264,9 @@ Limitations
 
     * Cilium's eBPF kube-proxy replacement currently cannot be used with :ref:`gsg_encryption`.
     * Cilium's eBPF kube-proxy replacement relies upon the :ref:`host-services` feature
-      which uses eBPF cgroup hooks to implement the service translation. The getpeername(2)
-      hook address translation in eBPF is only available for v5.8 kernels. It is known to
-      currently not work with libceph deployments.
+      which uses eBPF cgroup hooks to implement the service translation. Using it with libceph
+      deployments currently requires support for the getpeername(2) hook address translation in
+      eBPF, which is only available for kernels v5.8 and higher.
     * Cilium's eBPF kube-proxy acceleration in XDP can only be used in a single device setup
       as a "one-legged" / hairpin load balancer scenario. In case of a multi-device environment,
       where auto-detection selects more than a single device to expose NodePort, the option


### PR DESCRIPTION
In kube-proxy free documentation limitations section it was not totally clear what libceph worked with. The current text could be interpreted kernel v5.8 provides the necessary functions but still does not work with libceph.
Make it clear that kernel 5.8 provides the necessary bits to make kubeproxy-free work with libceph. Based on Slack discussion this is what it was supposed to mean.

Signed-off-by: Ville Ojamo <bluikko@users.noreply.github.com>