### PR TITLE
v1.8 backport: ci: Disable NFS locking

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -15,6 +15,7 @@ $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.18"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="0"? false : true
+$NFS_OPTS = (ENV['NFS_OPTS'] || "nolock").split(",")
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")
@@ -65,7 +66,8 @@ Vagrant.configure("2") do |config|
             # This network is only used by NFS
             server.vm.network "private_network", ip: "192.168.38.10"
             server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
-                type: "nfs", nfs_udp: false
+                type: "nfs", nfs_udp: false, mount_options: $NFS_OPTS
+
         else
             server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium"
         end
@@ -130,7 +132,8 @@ Vagrant.configure("2") do |config|
                 # This network is only used by NFS
                 server.vm.network "private_network", ip: "192.168.38.1#{i}"
                 server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
-                    type: "nfs", nfs_udp: false
+                    type: "nfs", nfs_udp: false, mount_options: $NFS_OPTS
+
             else
                 server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium"
             end


### PR DESCRIPTION
The last 1.8 backporting round (#16912), skipped  #16554  due to CI failures in the  test-upstream-k8s pipeline.

This PR is a backport of just  #16554.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ contrib/backporting/set-labels.py 16554 done 1.8
```