### PR TITLE
policy: Fix derived-from labels

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -277,8 +277,8 @@ var (
 				FromEndpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
 			},
 		}})
-	lblsAllowLocalHostIngress = labels.LabelArray{
-		labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowLocalHostIngress, labels.LabelSourceReserved),
+	lblsAllowAllIngress = labels.LabelArray{
+		labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 	}
 
 	lbls_____NoDeny = labels.ParseLabelArray("deny")
@@ -1104,7 +1104,7 @@ func Test_AllowAll(t *testing.T) {
 		rules    api.Rules
 		result   MapState
 	}{
-		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, MapState{mapKeyAllowAll__: mapEntryL7None_(lblsAllowLocalHostIngress)}},
+		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, MapState{mapKeyAllowAll__: mapEntryL7None_(lblsAllowAllIngress)}},
 		{1, api.WildcardEndpointSelector, api.Rules{rule____AllowAll}, MapState{mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll)}},
 	}
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -45,11 +45,12 @@ var (
 )
 
 const (
-	LabelKeyPolicyDerivedFrom  = "io.cilium.policy.derived-from"
-	LabelAllowLocalHostIngress = "allow-localhost-ingress"
-	LabelAllowAnyIngress       = "allow-any-ingress"
-	LabelAllowAnyEgress        = "allow-any-egress"
-	LabelVisibilityAnnotation  = "visibility-annotation"
+	LabelKeyPolicyDerivedFrom   = "io.cilium.policy.derived-from"
+	LabelAllowLocalHostIngress  = "allow-localhost-ingress"
+	LabelAllowRemoteHostIngress = "allow-remotehost-ingress"
+	LabelAllowAnyIngress        = "allow-any-ingress"
+	LabelAllowAnyEgress         = "allow-any-egress"
+	LabelVisibilityAnnotation   = "visibility-annotation"
 )
 
 // MapState is a state of a policy map.
@@ -349,6 +350,11 @@ func (keys MapState) DetermineAllowLocalhostIngress() {
 			var isHostDenied bool
 			v, ok := keys[localHostKey]
 			isHostDenied = ok && v.IsDeny
+			derivedFrom := labels.LabelArrayList{
+				labels.LabelArray{
+					labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowRemoteHostIngress, labels.LabelSourceReserved),
+				},
+			}
 			es := NewMapStateEntry(nil, derivedFrom, false, isHostDenied)
 			keys.DenyPreferredInsert(localRemoteNodeKey, es)
 		}
@@ -368,7 +374,7 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 		}
 		derivedFrom := labels.LabelArrayList{
 			labels.LabelArray{
-				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowLocalHostIngress, labels.LabelSourceReserved),
+				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 			},
 		}
 		keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false)


### PR DESCRIPTION
Use the "allow-any-ingress" label instead of "allow-localhost-ingress"
when allowing all on ingress.

Define a new "allow-remotehost-ingress" label and use that when
allowing remote hosts instead of "allow-localhost-ingress".

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
```release-note
`allow-any-ingress` and `allow-remotehost-ingress` are now used instead of `allow-localhost-ingress` in policy rule `derivedFrom` list when appropriate.
```