### PR TITLE
github: fix GH workflows to handle push events to stable branches

### DIFF
--- a/.github/workflows/coccicheck.yaml
+++ b/.github/workflows/coccicheck.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.8
 
 jobs:
     coccicheck:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.8
 
 jobs:
     build-html:

--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.8
 
 jobs:
   go-mod:

--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.8
 
 jobs:
   preflight-clusterrole:


### PR DESCRIPTION
As these workflows exist in the stable branches, they should be executed
whenever a push is made into the respective stable branch.

Signed-off-by: André Martins <andre@cilium.io>