### PR TITLE
github: fix GH workflows to handle push events to stable branches

### DIFF
--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -8,7 +8,7 @@ on:
       - 'test/**'
   push:
     branches:
-      - master
+      - v1.10
     paths-ignore:
       - 'Documentation/**'
       - 'test/**'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -9,7 +9,7 @@ on:
       - reopened
   push:
     branches:
-      - master
+      - v1.10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}


### PR DESCRIPTION
As these workflows exist in the stable branches, they should be executed
whenever a push is made into the respective stable branch.

Signed-off-by: André Martins <andre@cilium.io>