### PR TITLE
github: fix GH workflows to handle push events to stable branches

### DIFF
--- a/.github/workflows/bpf-checks.yaml
+++ b/.github/workflows/bpf-checks.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.9
 
 jobs:
   checkpatch:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.9
 
 jobs:
   build-html:

--- a/.github/workflows/go-check.yaml
+++ b/.github/workflows/go-check.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.9
 
 permissions: read-all
 

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
       - v1.9
-      - v[0-9]+.[0-9]+
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
 
 jobs:
   lint:
@@ -27,79 +23,3 @@ jobs:
         with:
           entrypoint: make
           args: -C images check-runtime-image check-builder-image
-  build-and-push:
-    if: (github.repository == 'cilium/cilium' && github.event_name != 'pull_request')
-    name: Build and push all images
-    runs-on: ubuntu-18.04
-    needs: lint
-    steps:
-      - uses: actions/checkout@v1
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Register binfmt from multi-platform builds
-        with:
-          entrypoint: docker
-          args: run --privileged linuxkit/binfmt:5d33e7346e79f9c13a73c6952669e47a53b063d4
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Run make lint
-        with:
-          entrypoint: make
-          args: -C images lint
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Run make runtime-image
-        env:
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        with:
-          entrypoint: make
-          # this will only get rebuilt when there changes in images/runtime
-          args: -C images runtime-image PUSH=true
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Run make builder-image
-        env:
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        with:
-          entrypoint: make
-          # this will only get rebuilt when there changes in images/builder
-          args: -C images builder-image PUSH=true
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Run make cilium-image
-        env:
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        with:
-          entrypoint: make
-          args: -C images cilium-image PUSH=true
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Run make cilium-test-image
-        env:
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        with:
-          entrypoint: make
-          args: -C images cilium-test-image PUSH=true
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Run make operator-image
-        env:
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        with:
-          entrypoint: make
-          args: -C images operator-image PUSH=true
-      - uses: docker://docker.io/cilium/image-maker:bc81755ec8f6c5afcb10a416cef73f99a35fee2c
-        name: Run make hubble-relay-image
-        env:
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        with:
-          entrypoint: make
-          args: -C images hubble-relay-image PUSH=true
-
-      - name: Send slack notification
-        if: ${{ (cancelled() || failure()) && (github.event_name == 'schedule' || github.event_name == 'push') }}
-        uses: 8398a7/action-slack@dcc8c8e9dd8802e21a712dc0c003db97b42efe43
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - master
+      - v1.9
       - v[0-9]+.[0-9]+
     tags:
       - v[0-9]+.[0-9]+.[0-9]+

--- a/.github/workflows/smoke-test-ipv6.yaml
+++ b/.github/workflows/smoke-test-ipv6.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.9
 
 permissions: read-all
 

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - v1.9
 
 permissions: read-all
 


### PR DESCRIPTION
As these workflows exist in the stable branches, they should be executed
whenever a push is made into the respective stable branch.

Signed-off-by: André Martins <andre@cilium.io>

---

Also remove certain steps in the Images workflow that are deprecated and is not required to be running.