### PR TITLE
Revert "Removes CEP subresource."

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -454,7 +454,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -34,7 +34,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.23.3"
+	CustomResourceDefinitionSchemaVersion = "1.23.4"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -39,6 +39,7 @@ import (
 // +kubebuilder:printcolumn:JSONPath=".status.state",description="Endpoint current state",name="Endpoint State",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.networking.addressing[0].ipv4",description="Endpoint IPv4 address",name="IPv4",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.networking.addressing[0].ipv6",description="Endpoint IPv6 address",name="IPv6",type=string
+// +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 
 // CiliumEndpoint is the status of a Cilium policy rule.

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -174,7 +174,6 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 								// label based selection for CiliumEndpoints.
 								Labels: pod.GetObjectMeta().GetLabels(),
 							},
-							Status: *mdl,
 						}
 						localCEP, err = ciliumClient.CiliumEndpoints(namespace).Create(ctx, cep, meta_v1.CreateOptions{})
 						if err != nil {
@@ -199,8 +198,6 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					// We return earlier for all error cases so we don't need
 					// to init the local endpoint in non-error cases.
 					needInit = false
-					lastMdl = mdl
-					return nil
 				}
 				// We have no localCEP copy. We need to fetch it for updates, below.
 				// This is unexpected as there should be only 1 writer per CEP, this
@@ -252,7 +249,8 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					ctx, podName,
 					types.JSONPatchType,
 					createStatusPatch,
-					meta_v1.PatchOptions{})
+					meta_v1.PatchOptions{},
+					"status")
 
 				// Handle Update errors or return successfully
 				switch {
@@ -262,6 +260,42 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					scopedLog.WithError(err).Warn("Cannot update CEP due to a revision conflict. The next controller execution will try again")
 					needInit = true
 					return nil
+
+				case err != nil && k8serrors.IsNotFound(err):
+					scopedLog.WithError(err).Warn("Cannot update CEP via subresource, trying direct patch")
+					// Tries to update CEP without specifying `status` as subresource.
+					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Patch(
+						ctx, podName,
+						types.JSONPatchType,
+						createStatusPatch,
+						meta_v1.PatchOptions{})
+					// Handle Update errors or return successfully
+					switch {
+					// Return no error when we see a conflict. We want to retry without a
+					// backoff and the Update* calls returned the current localCEP
+					case err != nil && k8serrors.IsConflict(err):
+						scopedLog.WithError(err).Warn("Cannot update CEP due to a revision conflict. The next controller execution will try again")
+						needInit = true
+						return nil
+
+					// Ensure we re-init when we see a generic error. This will recrate the
+					// CEP.
+					case err != nil:
+						// Suppress logging an error if ep backing the pod was terminated
+						// before CEP could be updated and shut down the controller.
+						if errors.Is(err, context.Canceled) {
+							return nil
+						}
+						scopedLog.WithError(err).Error("Cannot update CEP")
+
+						needInit = true
+						return err
+
+					// A successful update means no more updates unless the endpoint status, aka mdl, changes
+					default:
+						lastMdl = mdl
+						return nil
+					}
 
 				// Ensure we re-init when we see a generic error. This will recrate the
 				// CEP.


### PR DESCRIPTION
This reverts commit 0681343309ef15677c9335802bd724500f1d663d, initially from PR #15632.

Note: we revert the initial changes as-is, but bump up `CustomResourceDefinitionSchemaVersion` to `1.23.4` since the revert itself is a change of the CRD schema.

# Rationale

The commit introduced a regression in clustermesh connectivity with external workloads.

# Identifying the regression

We initially worked on adding external workloads testing to `cilium` with a new workflow running a `cilium-cli` connectivity test on a GKE cluster / GCP VM clustermesh in PR #16789, but were consistently hitting a connectivity issue soon after the GCP VM joined the clustermesh with the GCP VM suddenly being unable to communicate with the cluster.

Example of failing runs:
- https://github.com/cilium/cilium/actions/runs/1050302990
- https://github.com/cilium/cilium/actions/runs/1056640820

This failure was not happening on the `cilium-cli` repository with a similar workflow, with the difference being that `cilium-cli` uses a stable version of Cilium (1.10.3 at the moment).

To check, we cherry-picked the changes from PR #16789 on top of tag `v1.10.3` in a secondary PR #16946, and verified that it worked. This indicated the changes from PR #16789 are sound and a regression in external workloads behavior had happened on `cilium`'s `master` branch.

We bisected / cherry-picked the workflow on top of older commits in order to find the regression, still via secondary PR #16946.

We confirm the regression is due to 0681343309ef15677c9335802bd724500f1d663d by using these 3 scenarios:

1. Running `cilium-cli` connectivity test right on top of 0681343309ef15677c9335802bd724500f1d66:
  - Link: https://github.com/cilium/cilium/commits/db3e9108b1c9020d9cd0549b85aae552fb0bb7ba
  - Log:
```
db3e9108b DO NOT MERGE
da0fbd714 workflows: add external workload conformance test
783dc9a62 k8s: Fix External Workloads service access
068134330 Removes CEP subresource.
3a55d7439 fix warning log for list IPV6 address: move IPV4 to IPv6
```

2. Running `cilium-cli` connectivity test on top of previous `master` commit:
  - Link: https://github.com/cilium/cilium/commits/746f9062dc4fe081e1a6d03921fe9c2abe58acb7
  - Log:
```
746f9062d DO NOT MERGE
6cb37b377 workflows: add external workload conformance test
627d025e8 k8s: Fix External Workloads service access
3a55d7439 fix warning log for list IPV6 address: move IPV4 to IPv6
```

3. Running `cilium-cli` connectivity test on top of current `master` with 0681343309ef15677c9335802bd724500f1d66 reverted:
- Link: https://github.com/cilium/cilium/commits/6bea7087a41c149bfa1781ab7b4a6be88764ec45
- Log:
```
6bea7087a DO NOT MERGE
d6a769efc workflows: add external workload conformance test
55da4e5f0 Revert "Removes CEP subresource."
189cf7f4f contrib: Improve release script guard rails
```

Note: since the regression comes from a commit anterior to the external workloads compatibility fix for `cilium-cli` with Cilium 1.10, added in 929c28f4d7a4515b3145a9bbba22b0fc54573a46 (PR #16662), backporting only the GitHub workflow while searching for the regression was insufficient and we also had cherry-pick the fix in scenarios 1 and 2.

## Results

1. Failing: https://github.com/cilium/cilium/actions/runs/1059788504
2. Successful: https://github.com/cilium/cilium/actions/runs/1059727108
3. Successful: https://github.com/cilium/cilium/actions/runs/1059836909

This failure is consistent, and is the same failure as the one happening in runs of initial workflow PR #16789. This confirms the regression.