### PR TITLE
clustermesh: fix CEP status patch

### DIFF
--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -408,7 +408,7 @@ func (m *VMManager) UpdateCiliumEndpointResource(name string, id *identity.Ident
 			log.WithError(err).Fatalf("json.Marshal(%v) failed", replaceCEPStatus)
 		}
 		localCEP, err = m.ciliumClient.CiliumV2().CiliumEndpoints(namespace).Patch(context.TODO(), name,
-			types.JSONPatchType, createStatusPatch, metav1.PatchOptions{}, "status")
+			types.JSONPatchType, createStatusPatch, metav1.PatchOptions{})
 		if err != nil {
 			if errors.IsConflict(err) {
 				log.WithError(err).Warn("Unable to update CiliumEndpoint resource, will retry")


### PR DESCRIPTION
In 0681343309ef15677c9335802bd724500f1d663d (from PR #15632), we changed CEP CRD schema and removed the `status` subresource.

This broke clustermesh logic as it was still trying to update CEP using the now removed `status` subresource. In particular, this resulted in a loss of connectivity in clustermeshes with external workloads: the VM could initially join the cluster but would immediately lose connectivity after failing to update the CEP resource (see #16984 for full context).

We change the clustermesh logic to adhere to the new CEP update CRD schema.

Fixes: 0681343309ef15677c9335802bd724500f1d663d