### PR TITLE
test: Retrieve the private interface in an Eventually

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -699,10 +699,17 @@ var _ = Describe("K8sDatapathConfig", func() {
 	SkipContextIf(func() bool {
 		return helpers.RunsOnGKE() || helpers.RunsWithoutKubeProxy()
 	}, "Transparent encryption DirectRouting", func() {
-		It("Check connectivity with transparent encryption and direct routing", func() {
-			privateIface, err := kubectl.GetPrivateIface()
-			Expect(err).Should(BeNil(), "Unable to determine private iface")
+		var privateIface string
+		BeforeAll(func() {
+			Eventually(func() (string, error) {
+				iface, err := kubectl.GetPrivateIface()
+				privateIface = iface
+				return iface, err
+			}, helpers.MidCommandTimeout, time.Second).ShouldNot(BeEmpty(),
+				"Unable to determine private iface")
+		})
 
+		It("Check connectivity with transparent encryption and direct routing", func() {
 			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                     "disabled",


### PR DESCRIPTION
Upon sysdump inspection of
https://github.com/cilium/cilium/issues/16479, it's possible that the
failures in retrieving the private interface are time-sensative. As
https://github.com/cilium/cilium/issues/16479#issuecomment-885917267
points out, the output of `ip a` actually showed that the interface the
test was looking for existed, so it's very likely a timing issue. This
commit attempts to fix this flake by retrying until we are able to
extract out the interface.

Fixes: https://github.com/cilium/cilium/issues/16479
