### PR TITLE
policy: Fix `cilium policy trace` output when only deny rules are applied

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -536,7 +536,13 @@ func (p *Repository) GetRulesMatching(lbls labels.LabelArray) (ingressMatch bool
 			if len(r.Ingress) > 0 {
 				ingressMatch = true
 			}
+			if len(r.IngressDeny) > 0 {
+				ingressMatch = true
+			}
 			if len(r.Egress) > 0 {
+				egressMatch = true
+			}
+			if len(r.EgressDeny) > 0 {
 				egressMatch = true
 			}
 		}


### PR DESCRIPTION
Currently, deny rules are not counted in `*Repository.GetRulesMatching()`.
Therefore, this function returns false even though a rule is applied if it is a deny rule.
This causes a wrong output of `policy trace` commnad in some cases.

This PR makes this function to count ingress/egress deny rules.
Also, update the e2e test case for checking `policy trace` works correctly when there is only a deny rule exists.