### PR TITLE
Fixes out-of-sycn CEP update

### DIFF
--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -199,8 +199,13 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					// We return earlier for all error cases so we don't need
 					// to init the local endpoint in non-error cases.
 					needInit = false
-					lastMdl = mdl
-					return nil
+					lastMdl = &localCEP.Status
+					// We still need to update the CEP if localCEP is out of sync with upstream.
+					// We only return if upstream is NOT out-of-sync here.
+					if mdl.DeepEqual(lastMdl) {
+						scopedLog.Debug("Skipping CiliumEndpoint update because it has not changed")
+						return nil
+					}
 				}
 				// We have no localCEP copy. We need to fetch it for updates, below.
 				// This is unexpected as there should be only 1 writer per CEP, this


### PR DESCRIPTION
Today endpoint synchronizer code won't update the upstream CEP upon
initialization if it finds the CEP to be created exists in the
api-server but still updates local cache. This creates issues when
CEPs become out-of-sync while agent is down. For example, we see
endpoints become out-of-sync because endpoint sychronizer won't
update the CEP when a node is preempted and comes back quickly with
GKE preemptables. The chain of event is:
- Node preempted and comes back quickly
- CEPs for old pods present in apiserver
- Agent starts to regen endpoints
- Endpointsynchronizer does not update CEP upon initilization but local
cache *lastMdl* is updated with new CEP
- Remote nodes have old CEP with old IP
- Traffic from (reinstated) pods with new IP becomes *unmanaged* to
Cilium.

This fixes the above issue by setting local cache to upstream when
initilization fails due to existing CEP.

Fixes: 4f958ad4e21bc4a56f5ad74eb6b88afbeb2d217f

Signed-off-by: Weilong Cui <cuiwl@google.com>
