### PR TITLE
bugtool: Default pprof to the agent's gops port

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -40,7 +40,7 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-label string          Kubernetes label for Cilium pod (default "k8s-app=cilium")
       --k8s-mode                  Require Kubernetes pods to be found or fail
       --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
-      --pprof-port int            Port on which pprof server is exposed (default 6060)
+      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:9890, operator:9891, apiserver:9892 (default 9890)
       --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
   -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -84,7 +84,13 @@ var (
 func init() {
 	BugtoolRootCmd.Flags().BoolVar(&archive, "archive", true, "Create archive when false skips deletion of the output directory")
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
-	BugtoolRootCmd.Flags().IntVar(&pprofPort, "pprof-port", 6060, "Port on which pprof server is exposed")
+	BugtoolRootCmd.Flags().IntVar(&pprofPort,
+		"pprof-port", defaults.GopsPortAgent,
+		fmt.Sprintf(
+			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d, apiserver:%d",
+			defaults.GopsPortAgent, defaults.GopsPortOperator, defaults.GopsPortApiserver,
+		),
+	)
 	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")
 	BugtoolRootCmd.Flags().StringVarP(&archiveType, "archiveType", "o", "tar", "Archive type: tar | gz")
 	BugtoolRootCmd.Flags().BoolVar(&k8s, "k8s-mode", false, "Require Kubernetes pods to be found or fail")


### PR DESCRIPTION
None of our binaries listen on 6060 anymore since we
switched the ports to avoid collisions. Bugtool will now
default to the agent's port, but inline other available
options.

```
❯ ./cilium-bugtool --help | grep pprof-port
      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:9890, operator:9891, apiserver:9892 (default 9890)
```

Signed-off-by: Glib Smaga <code@gsmaga.com>