### PR TITLE
policy: Keep track of dependent (deny) entries

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -600,6 +600,13 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 		}
 	}
 
+	// Add dependency deny-L3->deny-L3L4 if allow-L4 exists
+	denyL3, denyL3exists := m[mapKeyDeny_Foo__]
+	denyL3L4, denyL3L4exists := m[mapKeyDeny_FooL4]
+	allowL4, allowL4exists := m[mapKeyAllow___L4]
+	if allowL4exists && !allowL4.IsDeny && denyL3exists && denyL3.IsDeny && denyL3L4exists && denyL3L4.IsDeny {
+		mapKeyDeny_Foo__.AddDependent(m, mapKeyDeny_FooL4)
+	}
 	return m
 }
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -326,13 +326,13 @@ var (
 	mapKeyAllowAll__ = Key{0, 0, 0, dirIngress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithoutSelectors()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithoutOwners()
 	}
 	mapEntryL7Deny_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithoutSelectors()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithoutOwners()
 	}
 	mapEntryL7Proxy = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithoutSelectors()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithoutOwners()
 	}
 )
 
@@ -382,7 +382,7 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 		allowAllIngress := true
 		allowAllEgress := false // Skip egress
 		result.AllowAllIdentities(allowAllIngress, allowAllEgress)
-		result.clearCachedSelectors()
+		result.clearOwners()
 		return result, nil
 	}
 
@@ -414,18 +414,18 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 		}
 	}
 	l4IngressPolicy.Detach(d.Repository.GetSelectorCache())
-	result.clearCachedSelectors()
+	result.clearOwners()
 	return result, nil
 }
 
-// clearCachedSelectors removes CachedSelectors from MapStateEntries
+// clearOwners removes CachedSelectors from MapStateEntries
 // for testing purposes.  Table-driven testing pattern used for these
 // tests does not allow expected MapStateEntries to contain actual
 // CachedSelectors as those have not been inserted to the selector
 // cache at the time when the expectations are created.
-func (m MapState) clearCachedSelectors() {
+func (m MapState) clearOwners() {
 	for k, v := range m {
-		v.selectors = make(map[CachedSelector]struct{})
+		v.owners = make(map[MapStateOwner]struct{})
 		m[k] = v
 	}
 }

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -326,13 +326,13 @@ var (
 	mapKeyAllowAll__ = Key{0, 0, 0, dirIngress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithoutOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false).WithOwners()
 	}
 	mapEntryL7Deny_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithoutOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true).WithOwners()
 	}
 	mapEntryL7Proxy = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithoutOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false).WithOwners()
 	}
 )
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -87,6 +87,8 @@ func (k Key) IsEgress() bool {
 	return k.TrafficDirection == trafficdirection.Egress.Uint8()
 }
 
+type MapStateOwner interface{}
+
 // MapStateEntry is the configuration associated with a Key in a
 // MapState. This is a minimized version of policymap.PolicyEntry.
 type MapStateEntry struct {
@@ -101,9 +103,9 @@ type MapStateEntry struct {
 	// DerivedFromRules tracks the policy rules this entry derives from
 	DerivedFromRules labels.LabelArrayList
 
-	// Selectors collects the selectors in the policy that require this key to be present.
+	// Owners collects the keys in the map and selectors in the policy that require this key to be present.
 	// TODO: keep track which selector needed the entry to be deny, redirect, or just allow.
-	selectors map[CachedSelector]struct{}
+	owners map[MapStateOwner]struct{}
 }
 
 // NewMapStateEntry creates a map state entry. If redirect is true, the
@@ -112,7 +114,7 @@ type MapStateEntry struct {
 // 'cs' is used to keep track of which policy selectors need this entry. If it is 'nil' this entry
 // will become sticky and cannot be completely removed via incremental updates. Even in this case
 // the entry may be overridden or removed by a deny entry.
-func NewMapStateEntry(cs CachedSelector, derivedFrom labels.LabelArrayList, redirect, deny bool) MapStateEntry {
+func NewMapStateEntry(cs MapStateOwner, derivedFrom labels.LabelArrayList, redirect, deny bool) MapStateEntry {
 	var proxyPort uint16
 	if redirect {
 		// Any non-zero value will do, as the callers replace this with the
@@ -125,14 +127,14 @@ func NewMapStateEntry(cs CachedSelector, derivedFrom labels.LabelArrayList, redi
 		ProxyPort:        proxyPort,
 		DerivedFromRules: derivedFrom,
 		IsDeny:           deny,
-		selectors:        map[CachedSelector]struct{}{cs: {}},
+		owners:           map[MapStateOwner]struct{}{cs: {}},
 	}
 }
 
-// MergeSelectors adds selectors from entry 'b' to 'e'. 'b' is not modified.
-func (e *MapStateEntry) MergeSelectors(b *MapStateEntry) {
-	for cs, v := range b.selectors {
-		e.selectors[cs] = v
+// MergeOwners adds owners from entry 'b' to 'e'. 'b' is not modified.
+func (e *MapStateEntry) MergeOwners(b *MapStateEntry) {
+	for owner, v := range b.owners {
+		e.owners[owner] = v
 	}
 }
 
@@ -166,20 +168,20 @@ func (keys MapState) DenyPreferredInsert(newKey Key, newEntry MapStateEntry) {
 
 // addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes'
 func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, deletes MapState) {
-	// Keep all selectors that need this entry so that it is deleted only if all the selectors delete their contribution
+	// Keep all owners that need this entry so that it is deleted only if all the owners delete their contribution
 	updatedEntry := entry
 	oldEntry, exists := keys[key]
 	if exists {
-		// keep the existing selectors map of the old entry
-		updatedEntry.selectors = oldEntry.selectors
-	} else if len(entry.selectors) > 0 {
-		// create a new selectors map
-		updatedEntry.selectors = make(map[CachedSelector]struct{}, len(entry.selectors))
+		// keep the existing owners of the old entry
+		updatedEntry.owners = oldEntry.owners
+	} else if len(entry.owners) > 0 {
+		// create a new owners map
+		updatedEntry.owners = make(map[MapStateOwner]struct{}, len(entry.owners))
 	}
 
 	// TODO: Do we need to merge labels as well?
-	// Merge new selectors to the updated entry without modifying 'entry' as it is being reused by the caller
-	updatedEntry.MergeSelectors(&entry)
+	// Merge new owner to the updated entry without modifying 'entry' as it is being reused by the caller
+	updatedEntry.MergeOwners(&entry)
 	// Update (or insert) the entry
 	keys[key] = updatedEntry
 
@@ -195,15 +197,15 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 // deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
 // The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
-func (keys MapState) deleteKeyWithChanges(key Key, cs CachedSelector, adds, deletes MapState) {
+func (keys MapState) deleteKeyWithChanges(key Key, cs MapStateOwner, adds, deletes MapState) {
 	if entry, exists := keys[key]; exists {
 		if cs != nil {
 			// remove the contribution of the given selector only
-			if _, exists = entry.selectors[cs]; exists {
+			if _, exists = entry.owners[cs]; exists {
 				// Remove the contribution of this selector from the entry
-				delete(entry.selectors, cs)
-				// key is not deleted if other selectors still need it
-				if len(entry.selectors) > 0 {
+				delete(entry.owners, cs)
+				// key is not deleted if other owners still need it
+				if len(entry.owners) > 0 {
 					return
 				}
 			} else {
@@ -320,12 +322,12 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 // RedirectPreferredInsert inserts a new entry giving priority to L7-redirects by
 // not overwriting a L7-redirect entry with a non-redirect entry.
 func (keys MapState) RedirectPreferredInsert(key Key, entry MapStateEntry, adds, deletes MapState) {
-	// Do not overwrite the entry, but only merge selectors if the old entry is a deny or redirect.
+	// Do not overwrite the entry, but only merge owners if the old entry is a deny or redirect.
 	// This prevents an existing deny or redirect being overridden by a non-deny or a non-redirect.
-	// Merging selectors from the new entry to the eisting one has no datapath impact so we skip
+	// Merging owners from the new entry to the existing one has no datapath impact so we skip
 	// adding anything to 'adds' here.
 	if oldEntry, exists := keys[key]; exists && (oldEntry.IsRedirectEntry() || oldEntry.IsDeny) {
-		oldEntry.MergeSelectors(&entry)
+		oldEntry.MergeOwners(&entry)
 		keys[key] = oldEntry
 		return
 	}
@@ -545,7 +547,7 @@ func (mc *MapChanges) consumeMapChanges(policyMapState MapState) (adds, deletes 
 			policyMapState.denyPreferredInsertWithChanges(mc.changes[i].Key, mc.changes[i].Value, adds, deletes)
 		} else {
 			// Delete the contribution of this cs to the key and collect incremental changes
-			for cs := range mc.changes[i].Value.selectors { // get the sole selector
+			for cs := range mc.changes[i].Value.owners { // get the sole selector
 				policyMapState.deleteKeyWithChanges(mc.changes[i].Key, cs, adds, deletes)
 			}
 		}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -187,6 +187,8 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 	// Record an incremental Add if desired and entry is new or changed
 	if adds != nil && (!exists || !oldEntry.DatapathEqual(&entry)) {
+		// Do not leak internal maps to callers
+		updatedEntry.owners = nil
 		adds[key] = updatedEntry
 		// Key add overrides any previous delete of the same key
 		if deletes != nil {
@@ -214,6 +216,8 @@ func (keys MapState) deleteKeyWithChanges(key Key, cs MapStateOwner, adds, delet
 			}
 		}
 		if deletes != nil {
+			// Do not leak internal maps to callers
+			entry.owners = nil
 			deletes[key] = entry
 			// Remove a potential previously added key
 			if adds != nil {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -87,7 +87,11 @@ func (k Key) IsEgress() bool {
 	return k.TrafficDirection == trafficdirection.Egress.Uint8()
 }
 
-type MapStateOwner interface{}
+type MapStateOwner interface {
+	// RemoveDependent removes 'key' from the list of dependent keys of the entry implemeneting MapStateOwner.
+	// This is called when a dependent entry is being deleted.
+	RemoveDependent(MapState, Key)
+}
 
 // MapStateEntry is the configuration associated with a Key in a
 // MapState. This is a minimized version of policymap.PolicyEntry.
@@ -106,6 +110,10 @@ type MapStateEntry struct {
 	// Owners collects the keys in the map and selectors in the policy that require this key to be present.
 	// TODO: keep track which selector needed the entry to be deny, redirect, or just allow.
 	owners map[MapStateOwner]struct{}
+
+	// dependents contains the keys for entries create based on this entry. These entries
+	// will be deleted once all of the owners are deleted.
+	dependents map[Key]struct{}
 }
 
 // NewMapStateEntry creates a map state entry. If redirect is true, the
@@ -131,10 +139,52 @@ func NewMapStateEntry(cs MapStateOwner, derivedFrom labels.LabelArrayList, redir
 	}
 }
 
-// MergeOwners adds owners from entry 'b' to 'e'. 'b' is not modified.
-func (e *MapStateEntry) MergeOwners(b *MapStateEntry) {
-	for owner, v := range b.owners {
-		e.owners[owner] = v
+// AddDependent adds 'key' to the set of dependent keys.
+func (e *MapStateEntry) AddDependent(key Key) {
+	if e.dependents == nil {
+		e.dependents = make(map[Key]struct{}, 1)
+	}
+	e.dependents[key] = struct{}{}
+}
+
+// RemoveDependent removes 'key' from the set of dependent keys.
+func (e *MapStateEntry) RemoveDependent(key Key) {
+	delete(e.dependents, key)
+	// Nil the map when empty. This is mainly to make unit testing easier.
+	if len(e.dependents) == 0 {
+		e.dependents = nil
+	}
+}
+
+// AddDependent adds 'key' to the set of dependent keys.
+func (owner Key) AddDependent(keys MapState, key Key) {
+	if e, exists := keys[owner]; exists {
+		e.AddDependent(key)
+		keys[owner] = e
+	}
+}
+
+// RemoveDependent removes 'key' from the list of dependent keys.
+// This is called when a dependent entry is being deleted.
+func (owner Key) RemoveDependent(keys MapState, key Key) {
+	if e, exists := keys[owner]; exists {
+		e.RemoveDependent(key)
+		keys[owner] = e
+	}
+}
+
+// MergeReferences adds owners and dependents from entry 'entry' to 'e'. 'entry' is not modified.
+func (e *MapStateEntry) MergeReferences(entry *MapStateEntry) {
+	if e.owners == nil && len(entry.owners) > 0 {
+		e.owners = make(map[MapStateOwner]struct{}, len(entry.owners))
+	}
+	for k, v := range entry.owners {
+		e.owners[k] = v
+	}
+
+	// merge dependents
+	for k := range entry.dependents {
+		e.AddDependent(k)
 	}
 }
 
@@ -181,7 +231,7 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 	// TODO: Do we need to merge labels as well?
 	// Merge new owner to the updated entry without modifying 'entry' as it is being reused by the caller
-	updatedEntry.MergeOwners(&entry)
+	updatedEntry.MergeReferences(&entry)
 	// Update (or insert) the entry
 	keys[key] = updatedEntry
 
@@ -189,6 +239,7 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 	if adds != nil && (!exists || !oldEntry.DatapathEqual(&entry)) {
 		// Do not leak internal maps to callers
 		updatedEntry.owners = nil
+		updatedEntry.dependents = nil
 		adds[key] = updatedEntry
 		// Key add overrides any previous delete of the same key
 		if deletes != nil {
@@ -199,31 +250,48 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 // deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
 // The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
-func (keys MapState) deleteKeyWithChanges(key Key, cs MapStateOwner, adds, deletes MapState) {
+func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, deletes MapState) {
 	if entry, exists := keys[key]; exists {
-		if cs != nil {
+		if owner != nil {
 			// remove the contribution of the given selector only
-			if _, exists = entry.owners[cs]; exists {
+			if _, exists = entry.owners[owner]; exists {
 				// Remove the contribution of this selector from the entry
-				delete(entry.owners, cs)
+				delete(entry.owners, owner)
+				owner.RemoveDependent(keys, key)
 				// key is not deleted if other owners still need it
 				if len(entry.owners) > 0 {
 					return
 				}
 			} else {
-				// 'cs' was not found, do not change anything
+				// 'owner' was not found, do not change anything
 				return
 			}
+		}
+
+		// Remove this key from all owners' dependents maps if no owner was given
+		if owner == nil {
+			for owner := range entry.owners {
+				if owner != nil {
+					owner.RemoveDependent(keys, key)
+				}
+			}
+		}
+
+		// Check if dependent entries need to be deleted as well
+		for k := range entry.dependents {
+			keys.deleteKeyWithChanges(k, key, adds, deletes)
 		}
 		if deletes != nil {
 			// Do not leak internal maps to callers
 			entry.owners = nil
+			entry.dependents = nil
 			deletes[key] = entry
 			// Remove a potential previously added key
 			if adds != nil {
 				delete(adds, key)
 			}
 		}
+
 		delete(keys, key)
 	}
 }
@@ -247,13 +315,20 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 			for k, v := range keys {
 				if newKey.TrafficDirection == k.TrafficDirection &&
 					!v.IsDeny &&
-					k.Identity == 0 {
+					k.Identity == 0 && (k.DestPort != 0 || k.Nexthdr != 0) {
 					// create a deny L3-L4 with the same allowed L4 port and proto
 					newKeyCpy := newKey
 					newKeyCpy.DestPort = k.DestPort
 					newKeyCpy.Nexthdr = k.Nexthdr
-					keys.addKeyWithChanges(newKeyCpy, newEntry, adds, deletes)
-
+					// Remove the Cached Selector from the owner's list of the dependent entry
+					newEntryCpy := newEntry
+					newEntryCpy.owners = make(map[MapStateOwner]struct{}, 1)
+					newEntryCpy.owners[newKey] = struct{}{}
+					keys.addKeyWithChanges(newKeyCpy, newEntryCpy, adds, deletes)
+					// L3-only entries can be deleted incrementally so we need to track their
+					// effects on other entries so that those effects can be reverted when the
+					// identity is removed.
+					newEntry.AddDependent(newKeyCpy)
 					l4OnlyAllows[k] = v
 				}
 			}
@@ -302,7 +377,15 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 					// create a deny L3-L4 with the same deny L3
 					newKeyCpy := newKey
 					newKeyCpy.Identity = k.Identity
-					keys.addKeyWithChanges(newKeyCpy, v, adds, deletes)
+					newDenyEntry := v
+					newDenyEntry.dependents = nil
+					// Mark 'v' as an owner of this new entry
+					newDenyEntry.owners = make(map[MapStateOwner]struct{}, 1)
+					newDenyEntry.owners[k] = struct{}{}
+					keys.addKeyWithChanges(newKeyCpy, newDenyEntry, adds, deletes)
+					// Mark the new entry as a dependent of 'v'
+					v.AddDependent(newKeyCpy)
+					keys[k] = v
 				}
 			}
 		}
@@ -331,7 +414,7 @@ func (keys MapState) RedirectPreferredInsert(key Key, entry MapStateEntry, adds,
 	// Merging owners from the new entry to the existing one has no datapath impact so we skip
 	// adding anything to 'adds' here.
 	if oldEntry, exists := keys[key]; exists && (oldEntry.IsRedirectEntry() || oldEntry.IsDeny) {
-		oldEntry.MergeOwners(&entry)
+		oldEntry.MergeReferences(&entry)
 		keys[key] = oldEntry
 		return
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -23,21 +23,21 @@ import (
 	"gopkg.in/check.v1"
 )
 
-// WithSelectors returns a copy of 'e', but selectors replaced with 'selectors'. 'e' is not modified.
-// No selectors is represented with a 'nil' map.
-func (e MapStateEntry) WithSelectors(selectors ...CachedSelector) MapStateEntry {
+// WithOwners returns a copy of 'e', but owners replaced with 'owners'. 'e' is not modified.
+// No owners is represented with a 'nil' map.
+func (e MapStateEntry) WithOwners(owners ...MapStateOwner) MapStateEntry {
 	mse := e
-	mse.selectors = make(map[CachedSelector]struct{}, len(selectors))
-	for _, cs := range selectors {
-		mse.selectors[cs] = struct{}{}
+	mse.owners = make(map[MapStateOwner]struct{}, len(owners))
+	for _, cs := range owners {
+		mse.owners[cs] = struct{}{}
 	}
 	return mse
 }
 
-// WithoutSelectors returns a copy of 'e', but selectors replaced with 'nil'. 'e' is not modified.
+// WithoutOwners returns a copy of 'e', but owners replaced with 'nil'. 'e' is not modified.
 // Note: This is used only in unit tests and helps test readability.
-func (e MapStateEntry) WithoutSelectors() MapStateEntry {
-	return e.WithSelectors()
+func (e MapStateEntry) WithoutOwners() MapStateEntry {
+	return e.WithOwners()
 }
 
 func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
@@ -767,14 +767,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		return TestEgressKey(id, 80, 6)
 	}
 
-	TestEntry := func(proxyPort uint16, deny bool, selectors ...CachedSelector) MapStateEntry {
+	TestEntry := func(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEntry {
 		entry := MapStateEntry{
 			ProxyPort: proxyPort,
 			IsDeny:    deny,
 		}
-		entry.selectors = make(map[CachedSelector]struct{}, len(selectors))
-		for _, cs := range selectors {
-			entry.selectors[cs] = struct{}{}
+		entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		for _, cs := range owners {
+			entry.owners[cs] = struct{}{}
 		}
 		return entry
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -37,7 +37,8 @@ func (e MapStateEntry) WithOwners(owners ...MapStateOwner) MapStateEntry {
 // WithoutOwners returns a copy of 'e', but owners replaced with 'nil'. 'e' is not modified.
 // Note: This is used only in unit tests and helps test readability.
 func (e MapStateEntry) WithoutOwners() MapStateEntry {
-	return e.WithOwners()
+	e.owners = nil
+	return e
 }
 
 func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
@@ -772,7 +773,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			ProxyPort: proxyPort,
 			IsDeny:    deny,
 		}
-		entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		if len(owners) > 0 {
+			entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		}
 		for _, cs := range owners {
 			entry.owners[cs] = struct{}{}
 		}
@@ -805,7 +808,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpIngressKey(42): TestEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -829,8 +832,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpIngressKey(43): TestEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(43): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -845,7 +848,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpIngressKey(44): TestEntry(0, false, csBar),
 		},
 		adds: MapState{
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(44): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -916,10 +919,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
 		},
 		adds: MapState{
-			AnyIngressKey():     TestEntry(0, false, nil),
-			HostIngressKey():    TestEntry(0, false, nil),
-			DNSUDPEgressKey(42): TestEntry(0, false, csBar),
-			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
+			AnyIngressKey():     TestEntry(0, false),
+			HostIngressKey():    TestEntry(0, false),
+			DNSUDPEgressKey(42): TestEntry(0, false),
+			DNSTCPEgressKey(42): TestEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -936,7 +939,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			HttpEgressKey(43):   TestEntry(1, false, csFoo),
 		},
 		adds: MapState{
-			HttpEgressKey(43): TestEntry(1, false, csFoo),
+			HttpEgressKey(43): TestEntry(1, false),
 		},
 		deletes: MapState{},
 	}, {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -18,26 +18,36 @@ package policy
 
 import (
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 
 	"gopkg.in/check.v1"
 )
 
-// WithOwners returns a copy of 'e', but owners replaced with 'owners'. 'e' is not modified.
+// WithOwners replaces owners of 'e' with 'owners'.
 // No owners is represented with a 'nil' map.
 func (e MapStateEntry) WithOwners(owners ...MapStateOwner) MapStateEntry {
-	mse := e
-	mse.owners = make(map[MapStateOwner]struct{}, len(owners))
+	e.owners = make(map[MapStateOwner]struct{}, len(owners))
 	for _, cs := range owners {
-		mse.owners[cs] = struct{}{}
+		e.owners[cs] = struct{}{}
 	}
-	return mse
+	return e
 }
 
-// WithoutOwners returns a copy of 'e', but owners replaced with 'nil'. 'e' is not modified.
+// WithoutOwners clears the 'owners' of 'e'.
 // Note: This is used only in unit tests and helps test readability.
 func (e MapStateEntry) WithoutOwners() MapStateEntry {
 	e.owners = nil
+	return e
+}
+
+// WithDependents 'e' adds 'keys' to 'e.dependents'.
+func (e MapStateEntry) WithDependents(keys ...Key) MapStateEntry {
+	if len(keys) > 0 {
+		for _, key := range keys {
+			e.AddDependent(key)
+		}
+	}
 	return e
 }
 
@@ -728,59 +738,321 @@ func (ds *PolicyTestSuite) TestMapState_DenyPreferredInsert(c *check.C) {
 	}
 }
 
-func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
+func testKey(id int, port uint16, proto uint8, direction trafficdirection.TrafficDirection) Key {
+	return Key{
+		Identity:         uint32(id),
+		DestPort:         port,
+		Nexthdr:          proto,
+		TrafficDirection: direction.Uint8(),
+	}
+}
+
+func testIngressKey(id int, port uint16, proto uint8) Key {
+	return testKey(id, port, proto, trafficdirection.Ingress)
+}
+
+func testEgressKey(id int, port uint16, proto uint8) Key {
+	return testKey(id, port, proto, trafficdirection.Egress)
+}
+
+func DNSUDPEgressKey(id int) Key {
+	return testEgressKey(id, 53, 17)
+}
+
+func DNSTCPEgressKey(id int) Key {
+	return testEgressKey(id, 53, 6)
+}
+
+func HostIngressKey() Key {
+	return testIngressKey(1, 0, 0)
+}
+
+func AnyIngressKey() Key {
+	return testIngressKey(0, 0, 0)
+}
+
+func AnyEgressKey() Key {
+	return testEgressKey(0, 0, 0)
+}
+
+func HttpIngressKey(id int) Key {
+	return testIngressKey(id, 80, 6)
+}
+
+func HttpEgressKey(id int) Key {
+	return testEgressKey(id, 80, 6)
+}
+
+func testEntry(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEntry {
+	entry := MapStateEntry{
+		ProxyPort: proxyPort,
+		IsDeny:    deny,
+	}
+	if len(owners) > 0 {
+		entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+	}
+	for _, owner := range owners {
+		entry.owners[owner] = struct{}{}
+	}
+	return entry
+}
+
+func testEntryD(proxyPort uint16, deny bool, derivedFrom labels.LabelArrayList, owners ...MapStateOwner) MapStateEntry {
+	entry := testEntry(proxyPort, deny, owners...)
+	entry.DerivedFromRules = derivedFrom
+	return entry
+}
+
+func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 	csFoo := newTestCachedSelector("Foo", false)
 	csBar := newTestCachedSelector("Bar", false)
 
-	TestKey := func(id int, port uint16, proto uint8, direction trafficdirection.TrafficDirection) Key {
-		return Key{
-			Identity:         uint32(id),
-			DestPort:         port,
-			Nexthdr:          proto,
-			TrafficDirection: direction.Uint8(),
-		}
+	type args struct {
+		cs       *testCachedSelector
+		adds     []int
+		deletes  []int
+		port     uint16
+		proto    uint8
+		ingress  bool
+		redirect bool
+		deny     bool
 	}
-	TestIngressKey := func(id int, port uint16, proto uint8) Key {
-		return TestKey(id, port, proto, trafficdirection.Ingress)
-	}
-	TestEgressKey := func(id int, port uint16, proto uint8) Key {
-		return TestKey(id, port, proto, trafficdirection.Egress)
-	}
-	DNSUDPEgressKey := func(id int) Key {
-		return TestEgressKey(id, 53, 17)
-	}
-	DNSTCPEgressKey := func(id int) Key {
-		return TestEgressKey(id, 53, 6)
-	}
-	HostIngressKey := func() Key {
-		return TestIngressKey(1, 0, 0)
-	}
-	AnyIngressKey := func() Key {
-		return TestIngressKey(0, 0, 0)
-	}
-	//AnyEgressKey := func() Key {
-	//	return TestEgressKey(0, 0, 0)
-	//}
-	HttpIngressKey := func(id int) Key {
-		return TestIngressKey(id, 80, 6)
-	}
-	HttpEgressKey := func(id int) Key {
-		return TestEgressKey(id, 80, 6)
+	tests := []struct {
+		continued bool // Start from the end state of the previous test
+		name      string
+		setup     MapState
+		args      []args // changes applied, in order
+		state     MapState
+		adds      MapState
+		deletes   MapState
+	}{{
+		name: "test-0 - Adding identity to an existing state",
+		setup: MapState{
+			AnyIngressKey():   testEntry(0, false),
+			HttpIngressKey(0): testEntry(12345, false, nil),
+		},
+		args: []args{
+			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():          testEntry(0, false),
+			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):        testEntry(12345, false, nil),
+			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+		},
+		adds: MapState{
+			testIngressKey(41, 0, 0): testEntry(0, true),
+			HttpIngressKey(41):       testEntry(0, true),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-1 - Adding identity to an existing state",
+		args: []args{
+			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():          testEntry(0, false),
+			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
+			testIngressKey(42, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(42)),
+			HttpIngressKey(0):        testEntry(12345, false, nil),
+			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+			HttpIngressKey(42):       testEntry(0, true).WithOwners(testIngressKey(42, 0, 0)),
+		},
+		adds: MapState{
+			testIngressKey(42, 0, 0): testEntry(0, true),
+			HttpIngressKey(42):       testEntry(0, true),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-2 - Removing the same key",
+		args: []args{
+			{cs: csFoo, adds: nil, deletes: []int{42}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
+		},
+		state: MapState{
+			AnyIngressKey():          testEntry(0, false),
+			testIngressKey(41, 0, 0): testEntry(0, true, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):        testEntry(12345, false, nil),
+			HttpIngressKey(41):       testEntry(0, true).WithOwners(testIngressKey(41, 0, 0)),
+		},
+		adds: MapState{},
+		deletes: MapState{
+			testIngressKey(42, 0, 0): testEntry(0, true), // removed key
+			HttpIngressKey(42):       testEntry(0, true), // removed dependent key
+		},
+	}, {
+		name: "test-3 - Adding 2 identities, and deleting a nonexisting key on an empty state",
+		args: []args{
+			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, false, csFoo),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+		},
+		adds: MapState{
+			HttpIngressKey(42): testEntry(0, false),
+			HttpIngressKey(43): testEntry(0, false),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-4 - Adding Bar also selecting 42",
+		args: []args{
+			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, false, csFoo, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
+		},
+		adds: MapState{
+			HttpIngressKey(44): testEntry(0, false),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-5 - Deleting 42 from Foo, remains on Bar and no deletes",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-5b - Deleting 42 from Foo again, not deleted",
+		args: []args{
+			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			HttpIngressKey(42): testEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-6 - Deleting 42 from Bar, deleted",
+		args: []args{
+			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
+		},
+		adds: MapState{},
+		deletes: MapState{
+			HttpIngressKey(42): testEntry(0, false),
+		},
+	}, {
+		continued: true,
+		name:      "test-6b - Adding an entry that already exists, no adds",
+		args: []args{
+			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
+		},
+		adds:    MapState{},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-7a - egress HTTP proxy (setup)",
+		args: []args{
+			{cs: nil, adds: []int{0}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
+			{cs: nil, adds: []int{1}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
+		},
+		state: MapState{
+			AnyIngressKey():     testEntry(0, false, nil),
+			HostIngressKey():    testEntry(0, false, nil),
+			DNSUDPEgressKey(42): testEntry(0, false, csBar),
+			DNSTCPEgressKey(42): testEntry(0, false, csBar),
+		},
+		adds: MapState{
+			AnyIngressKey():     testEntry(0, false),
+			HostIngressKey():    testEntry(0, false),
+			DNSUDPEgressKey(42): testEntry(0, false),
+			DNSTCPEgressKey(42): testEntry(0, false),
+		},
+		deletes: MapState{},
+	}, {
+		continued: true,
+		name:      "test-7b - egress HTTP proxy (incremental update)",
+		args: []args{
+			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
+		},
+		state: MapState{
+			AnyIngressKey():     testEntry(0, false, nil),
+			HostIngressKey():    testEntry(0, false, nil),
+			DNSUDPEgressKey(42): testEntry(0, false, csBar),
+			DNSTCPEgressKey(42): testEntry(0, false, csBar),
+			HttpEgressKey(43):   testEntry(1, false, csFoo),
+		},
+		adds: MapState{
+			HttpEgressKey(43): testEntry(1, false),
+		},
+		deletes: MapState{},
+	}, {
+		continued: false,
+		name:      "test-n - title",
+		args:      []args{
+			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+		},
+		state: MapState{
+			//HttpIngressKey(42): testEntry(0, false, csFoo),
+		},
+		adds: MapState{
+			//HttpIngressKey(42): testEntry(0, false),
+		},
+		deletes: MapState{
+			//HttpIngressKey(43): testEntry(0, false),
+		},
+	},
 	}
 
-	TestEntry := func(proxyPort uint16, deny bool, owners ...MapStateOwner) MapStateEntry {
-		entry := MapStateEntry{
-			ProxyPort: proxyPort,
-			IsDeny:    deny,
+	policyMapState := MapState{}
+
+	for _, tt := range tests {
+		policyMaps := MapChanges{}
+		if !tt.continued {
+			if tt.setup != nil {
+				policyMapState = tt.setup
+			} else {
+				policyMapState = MapState{}
+			}
 		}
-		if len(owners) > 0 {
-			entry.owners = make(map[MapStateOwner]struct{}, len(owners))
+		for _, x := range tt.args {
+			dir := trafficdirection.Egress
+			if x.ingress {
+				dir = trafficdirection.Ingress
+			}
+			adds := x.cs.addSelections(x.adds...)
+			deletes := x.cs.deleteSelections(x.deletes...)
+			var cs CachedSelector
+			if x.cs != nil {
+				cs = x.cs
+			}
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, nil)
 		}
-		for _, cs := range owners {
-			entry.owners[cs] = struct{}{}
-		}
-		return entry
+		adds, deletes := policyMaps.consumeMapChanges(policyMapState)
+		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
+		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
+		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))
 	}
+}
+
+func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
+	csFoo := newTestCachedSelector("Foo", false)
+	csBar := newTestCachedSelector("Bar", false)
 
 	type args struct {
 		cs       *testCachedSelector
@@ -805,10 +1077,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): testEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -820,7 +1092,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		state: MapState{},
 		adds:  MapState{},
 		deletes: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
 		},
 	}, {
 		name: "test-3 - Adding 2 identities, and deleting a nonexisting key on an empty state",
@@ -828,12 +1100,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
+			HttpIngressKey(42): testEntry(0, false, csFoo),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
-			HttpIngressKey(43): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
+			HttpIngressKey(43): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -843,12 +1115,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csFoo, csBar),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(42): testEntry(0, false, csFoo, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds: MapState{
-			HttpIngressKey(44): TestEntry(0, false),
+			HttpIngressKey(44): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -858,9 +1130,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csBar),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(42): testEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -871,9 +1143,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(42): TestEntry(0, false, csBar),
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(42): testEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -884,12 +1156,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds: MapState{},
 		deletes: MapState{
-			HttpIngressKey(42): TestEntry(0, false),
+			HttpIngressKey(42): testEntry(0, false),
 		},
 	}, {
 		continued: true,
@@ -898,8 +1170,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			HttpIngressKey(43): TestEntry(0, false, csFoo),
-			HttpIngressKey(44): TestEntry(0, false, csBar),
+			HttpIngressKey(43): testEntry(0, false, csFoo),
+			HttpIngressKey(44): testEntry(0, false, csBar),
 		},
 		adds:    MapState{},
 		deletes: MapState{},
@@ -913,16 +1185,16 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():     TestEntry(0, false, nil),
-			HostIngressKey():    TestEntry(0, false, nil),
-			DNSUDPEgressKey(42): TestEntry(0, false, csBar),
-			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
+			AnyIngressKey():     testEntry(0, false, nil),
+			HostIngressKey():    testEntry(0, false, nil),
+			DNSUDPEgressKey(42): testEntry(0, false, csBar),
+			DNSTCPEgressKey(42): testEntry(0, false, csBar),
 		},
 		adds: MapState{
-			AnyIngressKey():     TestEntry(0, false),
-			HostIngressKey():    TestEntry(0, false),
-			DNSUDPEgressKey(42): TestEntry(0, false),
-			DNSTCPEgressKey(42): TestEntry(0, false),
+			AnyIngressKey():     testEntry(0, false),
+			HostIngressKey():    testEntry(0, false),
+			DNSUDPEgressKey(42): testEntry(0, false),
+			DNSTCPEgressKey(42): testEntry(0, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -932,14 +1204,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
 		state: MapState{
-			AnyIngressKey():     TestEntry(0, false, nil),
-			HostIngressKey():    TestEntry(0, false, nil),
-			DNSUDPEgressKey(42): TestEntry(0, false, csBar),
-			DNSTCPEgressKey(42): TestEntry(0, false, csBar),
-			HttpEgressKey(43):   TestEntry(1, false, csFoo),
+			AnyIngressKey():     testEntry(0, false, nil),
+			HostIngressKey():    testEntry(0, false, nil),
+			DNSUDPEgressKey(42): testEntry(0, false, csBar),
+			DNSTCPEgressKey(42): testEntry(0, false, csBar),
+			HttpEgressKey(43):   testEntry(1, false, csFoo),
 		},
 		adds: MapState{
-			HttpEgressKey(43): TestEntry(1, false),
+			HttpEgressKey(43): testEntry(1, false),
 		},
 		deletes: MapState{},
 	}, {
@@ -949,13 +1221,13 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
 		state: MapState{
-			//HttpIngressKey(42): TestEntry(0, false, csFoo),
+			//HttpIngressKey(42): testEntry(0, false, csFoo),
 		},
 		adds: MapState{
-			//HttpIngressKey(42): TestEntry(0, false),
+			//HttpIngressKey(42): testEntry(0, false),
 		},
 		deletes: MapState{
-			//HttpIngressKey(43): TestEntry(0, false),
+			//HttpIngressKey(43): testEntry(0, false),
 		},
 	},
 	}

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -488,7 +488,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                          allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithSelectors(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 		},
@@ -502,7 +502,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -498,8 +498,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	// maps on the policy got cleared
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -670,8 +670,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	c.Assert(policy.policyMapChanges.changes, IsNil)
 
 	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 	c.Assert(deletes, checker.Equals, MapState{
 		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -652,7 +652,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		PolicyOwner: DummyOwner{},
 		PolicyMapState: MapState{
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                          allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithSelectors(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                    rule1MapStateEntry,
 		},
@@ -674,7 +674,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
 	})
 	c.Assert(deletes, checker.Equals, MapState{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutSelectors(),
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
 	})
 
 	// Assign an empty mutex so that checker.Equal does not complain about the

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -56,6 +56,9 @@ type CachedSelector interface {
 	// String returns the string representation of this selector.
 	// Used as a map key.
 	String() string
+
+	// RemoveDependent implements MapStateOwner interface
+	RemoveDependent(keys MapState, key Key)
 }
 
 // CachedSelectorSlice is a slice of CachedSelectors that can be sorted.
@@ -328,6 +331,9 @@ func (s *selectorManager) Equal(b *selectorManager) bool {
 //
 // No locking needed.
 //
+
+// RemoveDependent implements MapStateOwner interface
+func (s *selectorManager) RemoveDependent(keys MapState, key Key) {}
 
 // GetSelections returns the set of numeric identities currently
 // selected.  The cached selections can be concurrently updated. In

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -183,6 +183,9 @@ func newTestCachedSelector(name string, wildcard bool, selections ...int) *testC
 	return cs
 }
 
+// RemoveDependent implements MapStateOwner interface
+func (cs *testCachedSelector) RemoveDependent(keys MapState, key Key) {}
+
 // returns selections as []identity.NumericIdentity
 func (cs *testCachedSelector) addSelections(selections ...int) (adds []identity.NumericIdentity) {
 	for _, id := range selections {


### PR DESCRIPTION
MapState entries that should be deleted together with some other
entry are "dependent entries". These are created for some deny
entries. Keep track of them, and delete them when the main entry is
deleted via an incremental update that happens when an identity is
removed.
