### PR TITLE
v1.10 backports 2021-07-28

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1165,6 +1165,13 @@ a fixed cookie value as a trade-off. This makes all applications on the host to
 select the same service endpoint for a given service with session affinity configured.
 To disable the feature, set ``config.sessionAffinity=false``.
 
+When the fixed cookie value is not used, a service affinity of a service with
+multiple ports is per service IP and port. Meaning that all requests for a
+given service sent from the same source and to the service same port will be routed
+to the same service endpoints; but two requests for the same service, sent from
+the same source but to different service ports may be routed to distinct service
+endpoints.
+
 kube-proxy Replacement Health Check server
 ******************************************
 To enable health check server for the kube-proxy replacement, the

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -156,11 +156,17 @@ generate_commit_list_for_pr () {
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
     entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
-    upstream_commit="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
-    upstream_id="$(git log -n1 --pretty=format:"%ae%at" $upstream_commit)"
-    if [ "$entry_id" == "${upstream_id}" ]; then
-      echo -e "     |  ${upstream_commit} via $entry_sha (\"$entry_sub\")"
-    else
+    related_commits="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
+    found_commit=0
+    for upstream_commit in ${related_commits}; do
+      upstream_id="$(git log -n1 --pretty=format:"%ae%at" $upstream_commit)"
+      if [ "$entry_id" == "${upstream_id}" ]; then
+        echo -e "     |  ${upstream_commit} via $entry_sha (\"$entry_sub\")"
+        found_commit=1
+        break
+      fi
+    done
+    if [ "$found_commit" -ne 1 ]; then
       echo -e "     |  Warning: No commit correlation found!    via $entry_sha (\"$entry_sub\")"
     fi
   done < $tmp_file

--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -339,11 +339,9 @@ func (s *Service) watchRecording(ctx context.Context, h *sink.Handle, stream rec
 		}
 
 		select {
-		case _, ok := <-h.StatsUpdated:
-			if !ok {
-				// sink closed
-				return
-			}
+		case <-h.StatsUpdated:
+		case <-h.Done:
+			return
 		case <-ctx.Done():
 			return
 		}

--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -59,12 +59,6 @@ type Service struct {
 	opts     recorderoption.Options
 }
 
-type recording struct {
-	ruleID   uint16
-	filePath string
-	handle   *sink.Handle
-}
-
 func NewService(r *recorder.Recorder, d *sink.Dispatch, options ...recorderoption.Option) (*Service, error) {
 	opts := recorderoption.Default
 	for _, o := range options {
@@ -89,52 +83,143 @@ func NewService(r *recorder.Recorder, d *sink.Dispatch, options ...recorderoptio
 	}, nil
 }
 
+func recordingStoppedResponse(stats sink.Statistics, filePath string) *recorderpb.RecordResponse {
+	return &recorderpb.RecordResponse{
+		NodeName: nodeTypes.GetName(),
+		Time:     timestamppb.Now(),
+		ResponseType: &recorderpb.RecordResponse_Stopped{
+			Stopped: &recorderpb.RecordingStoppedResponse{
+				Stats: &recorderpb.RecordingStatistics{
+					BytesCaptured:   stats.BytesWritten,
+					PacketsCaptured: stats.PacketsWritten,
+					BytesLost:       stats.BytesLost,
+					PacketsLost:     stats.PacketsLost,
+				},
+				Filesink: &recorderpb.FileSinkResult{
+					FilePath: filePath,
+				},
+			},
+		},
+	}
+}
+
+func recordingRunningResponse(stats sink.Statistics) *recorderpb.RecordResponse {
+	return &recorderpb.RecordResponse{
+		NodeName: nodeTypes.GetName(),
+		Time:     timestamppb.Now(),
+		ResponseType: &recorderpb.RecordResponse_Running{
+			Running: &recorderpb.RecordingRunningResponse{
+				Stats: &recorderpb.RecordingStatistics{
+					BytesCaptured:   stats.BytesWritten,
+					PacketsCaptured: stats.PacketsWritten,
+					BytesLost:       stats.BytesLost,
+					PacketsLost:     stats.PacketsLost,
+				},
+			},
+		},
+	}
+}
+
 func (s *Service) Record(stream recorderpb.Recorder_RecordServer) error {
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 
-	req, err := stream.Recv()
-	if err != nil {
+	// Spawn a go routine that forwards any received messages in order to be
+	// able to use select on it
+	reqCh := make(chan *recorderpb.RecordRequest)
+	errCh := make(chan error, 1)
+	go func() {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				errCh <- fmt.Errorf("failed to receive from recorder client: %w", err)
+				return
+			}
+
+			select {
+			case reqCh <- req:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	var (
+		recording *sink.Handle
+		filePath  string
+		err       error
+	)
+
+	// Wait for the initial StartRecording message
+	select {
+	case req := <-reqCh:
+		startRecording := req.GetStart()
+		if startRecording == nil {
+			return fmt.Errorf("received invalid request %q, expected start request", req)
+		}
+
+		// The startRecording helper spawns a clean up go routine to remove all
+		// state associated with this recording when the context ctx is cancelled.
+		recording, filePath, err = s.startRecording(ctx, startRecording)
+		if err != nil {
+			return err
+		}
+	case err = <-errCh:
 		return err
-	}
-	startRecording := req.GetStart()
-	if startRecording == nil {
-		return fmt.Errorf("received invalid request %q, expected start request", req)
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
-	rec, err := s.startRecording(ctx, startRecording)
+	// Send back a confirmation that the recording has started
+	err = stream.Send(recordingRunningResponse(recording.Stats()))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to confirmation response: %w", err)
 	}
 
-	go s.watchRecording(ctx, rec.handle, stream)
+	for {
+		select {
+		// This case happens when the client has sent us a new request.
+		// We expect a start request if recording is nil, and a stop request
+		// otherwise.
+		case req := <-reqCh:
+			if req.GetStop() != nil {
+				recording.Stop()
+			} else {
+				return fmt.Errorf("received invalid request %q, expected stop request", req)
+			}
+		// This case is hit whenever the recording has updated the statistics (i.e.
+		// packets have been captured). We fetch the latest statistics and forward
+		// them to the client
+		case <-recording.StatsUpdated:
+			err = stream.Send(recordingRunningResponse(recording.Stats()))
+			if err != nil {
+				return fmt.Errorf("failed to send recording running response: %w", err)
+			}
+		// This case happens when the recording has stopped (i.e. due to the above
+		// explicit shutdown or because an error has occurred). If no error has
+		// occurred, we assemble the final RecordingStoppedResponse and exit.
+		// If an error occurred, we propagate it by returning it from this stub.
+		case <-recording.Done:
+			err = recording.Err()
+			if err != nil {
+				return fmt.Errorf("recorder recording error: %w", err)
+			}
 
-	req, err = stream.Recv()
-	if err != nil {
-		return err
+			err = stream.Send(recordingStoppedResponse(recording.Stats(), filePath))
+			if err != nil {
+				return fmt.Errorf("failed to send recording stopped response: %w", err)
+			}
+
+			return nil
+		// The following two cases happen when the client stream is either
+		// closed or cancelled. Simply return an error such that it is logged,
+		// and exit.
+		case err = <-errCh:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
-
-	if req.GetStop() == nil {
-		return fmt.Errorf("received invalid request %q, expected stop request", req)
-	}
-
-	resp, err := s.stopRecording(ctx, rec)
-	if err != nil {
-		return err
-	}
-
-	err = stream.Send(&recorderpb.RecordResponse{
-		NodeName: nodeTypes.GetName(),
-		Time:     timestamppb.Now(),
-		ResponseType: &recorderpb.RecordResponse_Stopped{
-			Stopped: resp,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 const fileExistsRetries = 100
@@ -206,7 +291,12 @@ func parseFilters(include []*recorderpb.Filter) ([]recorder.RecorderTuple, error
 
 var fileSinkPrefixRegex = regexp.MustCompile("^[a-z][a-z0-9]{0,19}$")
 
-func (s *Service) startRecording(ctx context.Context, req *recorderpb.StartRecording) (*recording, error) {
+// startRecording starts a new recording. It will clean up any state
+// associated with the recording if ctx is cancelled or handle.Stop is called.
+func (s *Service) startRecording(
+	ctx context.Context,
+	req *recorderpb.StartRecording,
+) (handle *sink.Handle, filePath string, err error) {
 	capLen := req.GetMaxCaptureLength()
 	prefix := req.GetFilesink().GetFilePrefix()
 	if prefix == "" {
@@ -214,42 +304,43 @@ func (s *Service) startRecording(ctx context.Context, req *recorderpb.StartRecor
 	}
 
 	if !fileSinkPrefixRegex.MatchString(prefix) {
-		return nil, fmt.Errorf("invalid file sink prefix: %q", prefix)
+		return nil, "", fmt.Errorf("invalid file sink prefix: %q", prefix)
 	}
 
 	filters, err := parseFilters(req.GetInclude())
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	leaseID := s.ruleIDs.LeaseAvailableID()
 	ruleID := uint16(leaseID)
 	if leaseID == idpool.NoID {
-		return nil, errors.New("unable to allocate capture rule id")
+		return nil, "", errors.New("unable to allocate capture rule id")
 	}
 
-	f, filePath, err := createPcapFile(s.opts.StoragePath, prefix)
+	var f *os.File
+	f, filePath, err = createPcapFile(s.opts.StoragePath, prefix)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	r := &recording{ruleID: ruleID, filePath: filePath}
 	defer func() {
 		// clean up the recording if any of the subsequent steps fails
 		if err != nil {
-			_, _ = s.recorder.DeleteRecorder(recorder.ID(r.ruleID))
+			_, _ = s.recorder.DeleteRecorder(recorder.ID(ruleID))
 			// remove the created pcap file
 			_ = f.Close()
-			_ = os.Remove(r.filePath)
+			_ = os.Remove(filePath)
 			// release will also invalidate the lease
-			_ = s.ruleIDs.Release(idpool.ID(r.ruleID))
+			_ = s.ruleIDs.Release(idpool.ID(ruleID))
 		}
 	}()
 
-	log.WithFields(logrus.Fields{
-		"ruleID":   r.ruleID,
-		"filePath": r.filePath,
-	}).Debug("starting new recording")
+	scopedLog := log.WithFields(logrus.Fields{
+		"ruleID":   ruleID,
+		"filePath": filePath,
+	})
+	scopedLog.Debug("starting new recording")
 
 	config := sink.PcapSink{
 		RuleID: ruleID,
@@ -260,9 +351,9 @@ func (s *Service) startRecording(ctx context.Context, req *recorderpb.StartRecor
 		Writer: pcap.NewWriter(f),
 	}
 
-	r.handle, err = s.dispatch.StartSink(ctx, config)
+	handle, err = s.dispatch.StartSink(ctx, config)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	recInfo := &recorder.RecInfo{
@@ -272,78 +363,21 @@ func (s *Service) startRecording(ctx context.Context, req *recorderpb.StartRecor
 	}
 	_, err = s.recorder.UpsertRecorder(recInfo)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
+
+	// Ensure to delete the above recorder when the sink has stopped
+	go func() {
+		<-handle.Done
+		scopedLog.Debug("stopping recording")
+		_, err := s.recorder.DeleteRecorder(recorder.ID(ruleID))
+		if err != nil {
+			scopedLog.WithError(err).Warning("failed to delete recorder")
+		}
+		s.ruleIDs.Release(idpool.ID(ruleID))
+	}()
 
 	s.ruleIDs.Use(leaseID)
 
-	return r, nil
-}
-
-func (s *Service) stopRecording(ctx context.Context, r *recording) (*recorderpb.RecordingStoppedResponse, error) {
-	log.WithFields(logrus.Fields{
-		"ruleID":   r.ruleID,
-		"filePath": r.filePath,
-	}).Debug("stopping recording")
-
-	_, err := s.recorder.DeleteRecorder(recorder.ID(r.ruleID))
-	if err != nil {
-		return nil, err
-	}
-
-	r.handle.Stop()
-	select {
-	case <-r.handle.Done:
-		if err = r.handle.Err(); err != nil {
-			return nil, err
-		}
-	case <-ctx.Done():
-		return nil, fmt.Errorf("timed out waiting for sink to close: %w", ctx.Err())
-	}
-	stats := r.handle.Stats()
-
-	s.ruleIDs.Release(idpool.ID(r.ruleID))
-
-	return &recorderpb.RecordingStoppedResponse{
-		Stats: &recorderpb.RecordingStatistics{
-			BytesCaptured:   stats.BytesWritten,
-			PacketsCaptured: stats.PacketsWritten,
-			BytesLost:       stats.BytesLost,
-			PacketsLost:     stats.PacketsLost,
-		},
-		Filesink: &recorderpb.FileSinkResult{FilePath: r.filePath},
-	}, nil
-}
-
-func (s *Service) watchRecording(ctx context.Context, h *sink.Handle, stream recorderpb.Recorder_RecordServer) {
-	for {
-		stats := h.Stats()
-		err := stream.Send(&recorderpb.RecordResponse{
-			NodeName: nodeTypes.GetName(),
-			Time:     timestamppb.Now(),
-			ResponseType: &recorderpb.RecordResponse_Running{
-				Running: &recorderpb.RecordingRunningResponse{
-					Stats: &recorderpb.RecordingStatistics{
-						BytesCaptured:   stats.BytesWritten,
-						PacketsCaptured: stats.PacketsWritten,
-						BytesLost:       stats.BytesLost,
-						PacketsLost:     stats.PacketsLost,
-					}},
-			},
-		})
-		if err != nil {
-			// errors are expected if the client disconnects early, therefore
-			// we do not log this as an error or warning
-			log.WithError(err).Debug("failed to send recording update")
-			return
-		}
-
-		select {
-		case <-h.StatsUpdated:
-		case <-h.Done:
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
+	return handle, filePath, nil
 }

--- a/pkg/hubble/recorder/sink/dispatch.go
+++ b/pkg/hubble/recorder/sink/dispatch.go
@@ -45,11 +45,29 @@ type record struct {
 
 // Handle enables the owner to subscribe to sink statistics
 type Handle struct {
-	// C is a channel on which receives a new empty message whenever there
-	// was an update to the sink statistics. It is closed when the sink stops
-	// updating.
-	C    <-chan struct{}
+	// StatsUpdated is a channel on which receives a new empty message whenever
+	// there was an update to the sink statistics.
+	StatsUpdated <-chan struct{}
+	// Done is a channel which is closed when this sink has been shut down.
+	Done <-chan struct{}
+
 	sink *sink
+}
+
+// Stats returns the latest statistics for this sink.
+func (h *Handle) Stats() Statistics {
+	return h.sink.copyStats()
+}
+
+// Stop requests the underlying sink to stop. Handle.Done will be closed
+// once the sink has drained its queue and stopped.
+func (h *Handle) Stop() {
+	h.sink.stop()
+}
+
+// Err returns the last error on this sink once the channel has stopped
+func (h *Handle) Err() error {
+	return h.sink.err()
 }
 
 // Statistics contains the statistics for a pcap sink
@@ -58,6 +76,13 @@ type Statistics struct {
 	BytesWritten   uint64
 	PacketsLost    uint64
 	BytesLost      uint64
+}
+
+// PcapSink defines the parameters of a sink which writes to a pcap.RecordWriter
+type PcapSink struct {
+	RuleID uint16
+	Header pcap.Header
+	Writer pcap.RecordWriter
 }
 
 // Dispatch implements consumer.MonitorConsumer and dispatches incoming
@@ -90,50 +115,37 @@ func NewDispatch(sinkQueueSize int) (*Dispatch, error) {
 	}, nil
 }
 
-// RegisterSink registers a new sink for the given rule ID. Any captures with a
-// matching rule ID will be forwarded to the pcap sink w. The provided header
-// is written to the pcap sink w upon initialization.
-func (d *Dispatch) RegisterSink(ctx context.Context, ruleID uint16, w pcap.RecordWriter, header pcap.Header) (*Handle, error) {
+// StartSink starts a new sink for the pcap sink configuration p. Any
+// captures with a matching rule ID will be forwarded to the pcap sink p.Writer.
+// The provided p.Header is written to the pcap sink during initialization.
+// The sink is unregistered automatically when it stops. A sink is stopped for
+// one of the following four reasons. In all cases, Handle.Done will be closed.
+//  - Explicitly via Handle.Stop (Handle.Err() == nil)
+//  - When the context ctx is cancelled (Handle.Err() != nil)
+//  - When an error occurred (Handle.Err() != nil)
+func (d *Dispatch) StartSink(ctx context.Context, p PcapSink) (*Handle, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if _, ok := d.sinkByRuleID[ruleID]; ok {
-		return nil, fmt.Errorf("sink for rule id %d already registered", ruleID)
+	if _, ok := d.sinkByRuleID[p.RuleID]; ok {
+		return nil, fmt.Errorf("sink for rule id %d already registered", p.RuleID)
 	}
 
-	s := startSink(ctx, w, header, d.sinkQueueSize)
-	d.sinkByRuleID[ruleID] = s
+	s := startSink(ctx, p, d.sinkQueueSize)
+	d.sinkByRuleID[p.RuleID] = s
+
+	go func() {
+		<-s.done
+		d.mutex.Lock()
+		delete(d.sinkByRuleID, p.RuleID)
+		d.mutex.Unlock()
+	}()
+
 	return &Handle{
-		C:    s.trigger,
-		sink: s,
+		StatsUpdated: s.trigger,
+		Done:         s.done,
+		sink:         s,
 	}, nil
-}
-
-// UnregisterSink will stop and unregister the sink for the given ruleID.
-// It waits for any pending packets to be forwarded to the sink before closing
-// it and returns the final statistics or an error, if an error occurred.
-func (d *Dispatch) UnregisterSink(ctx context.Context, ruleID uint16) (stats Statistics, err error) {
-	d.mutex.Lock()
-	s, ok := d.sinkByRuleID[ruleID]
-	delete(d.sinkByRuleID, ruleID)
-	// unlock early to avoid holding the lock during s.close() which may block
-	d.mutex.Unlock()
-
-	if !ok {
-		return Statistics{}, fmt.Errorf("no sink found for rule id %d", ruleID)
-	}
-
-	s.stop()
-	select {
-	case <-s.done:
-		if err = s.err(); err != nil {
-			return Statistics{}, err
-		}
-	case <-ctx.Done():
-		return Statistics{}, fmt.Errorf("timed out waiting for sink to close: %w", ctx.Err())
-	}
-
-	return s.copyStats(), nil
 }
 
 func (d *Dispatch) decodeRecordCaptureLocked(data []byte) (rec record, err error) {
@@ -254,8 +266,4 @@ func (d *Dispatch) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
 // NotifyAgentEvent implements consumer.MonitorConsumer
 func (d *Dispatch) NotifyAgentEvent(typ int, message interface{}) {
 	// ignored
-}
-
-func (h *Handle) Stats() Statistics {
-	return h.sink.copyStats()
 }

--- a/pkg/hubble/recorder/sink/sink.go
+++ b/pkg/hubble/recorder/sink/sink.go
@@ -57,8 +57,6 @@ func startSink(ctx context.Context, p PcapSink, queueSize int) *sink {
 			closeErr := p.Writer.Close()
 
 			s.mutex.Lock()
-			close(s.trigger)
-			s.trigger = nil
 			if err == nil {
 				s.lastError = closeErr
 			} else {

--- a/pkg/hubble/recorder/sink/sink.go
+++ b/pkg/hubble/recorder/sink/sink.go
@@ -38,7 +38,7 @@ type sink struct {
 //  - sink.stop is called
 //  - ctx is cancelled
 //  - an error occurred
-func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueSize int) *sink {
+func startSink(ctx context.Context, p PcapSink, queueSize int) *sink {
 	s := &sink{
 		mutex:     lock.Mutex{},
 		queue:     make(chan record, queueSize),
@@ -54,7 +54,7 @@ func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueS
 		// close the channels when exiting.
 		var err error
 		defer func() {
-			closeErr := w.Close()
+			closeErr := p.Writer.Close()
 
 			s.mutex.Lock()
 			close(s.trigger)
@@ -68,7 +68,7 @@ func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueS
 			s.mutex.Unlock()
 		}()
 
-		if err = w.WriteHeader(hdr); err != nil {
+		if err = p.Writer.WriteHeader(p.Header); err != nil {
 			return
 		}
 
@@ -82,7 +82,7 @@ func startSink(ctx context.Context, w pcap.RecordWriter, hdr pcap.Header, queueS
 					OriginalLength: rec.origLen,
 				}
 
-				if err = w.WriteRecord(pcapRecord, rec.data); err != nil {
+				if err = p.Writer.WriteRecord(pcapRecord, rec.data); err != nil {
 					return
 				}
 

--- a/pkg/inctimer/inctimer_test.go
+++ b/pkg/inctimer/inctimer_test.go
@@ -21,6 +21,18 @@ import (
 	"time"
 )
 
+func TestTimerAfter(t *testing.T) {
+	for i := 0; i < 100_000; i++ {
+		tr, done := New()
+		select {
+		case <-tr.After(time.Second):
+			t.Fatal("`IncTimer` fired too soon")
+		default:
+		}
+		done()
+	}
+}
+
 func TestTimerHardReset(t *testing.T) {
 	tr, done := New()
 	defer done()


### PR DESCRIPTION
* #16955 -- inctimer: Fix bug where timer fired immediately (@gandro)
 * #16954 -- docs: Clarify SA target in KPR gsg (@brb)
 * #16907 -- backporting: Suggest only one related commit for a backport (@joestringer)
 * #16472 -- hubble/recorder: Refactor service implementation to fix multiple races (@gandro)
    - Hit non-trivial conflicts, fixed by keeping new code and using `GetName` instead of non-existing (on v1.10) `GetAbsoluteNodeName`.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16955 16954 16907 16472; do contrib/backporting/set-labels.py $pr done 1.10; done
```