### PR TITLE
docs: Fix missing quote in gcloud command for GKE

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -58,7 +58,7 @@ Install Cilium
 
        .. code-block:: shell-session
 
-          NATIVE_CIDR="$(gcloud container clusters describe "${NAME} --zone "${ZONE}" --format 'value(clusterIpv4Cidr)')"
+          NATIVE_CIDR="$(gcloud container clusters describe "${NAME}" --zone "${ZONE}" --format 'value(clusterIpv4Cidr)')"
           echo $NATIVE_CIDR
 
        Deploy Cilium release via Helm:


### PR DESCRIPTION
This was causing the command to fail if copy-pasted directly.

Fixes: 3662560f897 ("Add new unified Helm guide")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
