### PR TITLE
lbmap: Log svc update after bpf() syscall invocation

### DIFF
--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -552,12 +552,6 @@ func deleteBackendLocked(key BackendKey) error {
 }
 
 func updateServiceEndpoint(key ServiceKey, value ServiceValue) error {
-	log.WithFields(logrus.Fields{
-		logfields.ServiceKey:   key,
-		logfields.ServiceValue: value,
-		logfields.BackendSlot:  key.GetBackendSlot(),
-	}).Debug("Upserting service entry")
-
 	if key.GetBackendSlot() != 0 && value.RevNatKey().GetKey() == 0 {
 		return fmt.Errorf("invalid RevNat ID (0) in the Service Value")
 	}
@@ -565,7 +559,17 @@ func updateServiceEndpoint(key ServiceKey, value ServiceValue) error {
 		return err
 	}
 
-	return key.Map().Update(key.ToNetwork(), value.ToNetwork())
+	if err := key.Map().Update(key.ToNetwork(), value.ToNetwork()); err != nil {
+		return err
+	}
+
+	log.WithFields(logrus.Fields{
+		logfields.ServiceKey:   key,
+		logfields.ServiceValue: value,
+		logfields.BackendSlot:  key.GetBackendSlot(),
+	}).Debug("Upserted service entry")
+
+	return nil
 }
 
 type svcMap map[string]loadbalancer.SVC


### PR DESCRIPTION
This will allows us with debugging CI flakes (e.g., \[1\]) in which it is
not clear when service has been provisioned into the BPF maps.

\[1\]: https://github.com/cilium/cilium/issues/16399