### PR TITLE
bpf: Derive host netns cookie via SO_NETNS_COOKIE

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -18,6 +18,10 @@
 #define SYS_REJECT	0
 #define SYS_PROCEED	1
 
+#ifndef HOST_NETNS_COOKIE
+# define HOST_NETNS_COOKIE   get_netns_cookie(NULL)
+#endif
+
 static __always_inline __maybe_unused bool is_v4_loopback(__be32 daddr)
 {
 	/* Check for 127.0.0.0/8 range, RFC3330. */
@@ -87,7 +91,7 @@ ctx_in_hostns(void *ctx __maybe_unused, __net_cookie *cookie)
 
 	if (cookie)
 		*cookie = own_cookie;
-	return own_cookie == get_netns_cookie(NULL);
+	return own_cookie == HOST_NETNS_COOKIE;
 #else
 	if (cookie)
 		*cookie = 0;

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	"github.com/cilium/cilium/pkg/maps/sockmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
+	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -252,6 +253,18 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 		if option.Config.EnableHostServicesPeer {
 			cDefinesMap["ENABLE_HOST_SERVICES_PEER"] = "1"
+		}
+		if cookie, err := netns.GetNetNSCookie(); err == nil {
+			// When running in nested environments (e.g. Kind), cilium-agent does
+			// not run in the host netns. So, in such cases the cookie comparison
+			// based on bpf_get_netns_cookie(NULL) for checking whether a socket
+			// belongs to a host netns does not work.
+			//
+			// To fix this, we derive the cookie of the netns in which cilium-agent
+			// runs via getsockopt(...SO_NETNS_COOKIE...) and then use it in the
+			// check above. This is based on an assumption that cilium-agent
+			// always runs with "hostNetwork: true".
+			cDefinesMap["HOST_NETNS_COOKIE"] = fmt.Sprintf("%d", cookie)
 		}
 	}
 

--- a/pkg/netns/cookie.go
+++ b/pkg/netns/cookie.go
@@ -1,0 +1,22 @@
+package netns
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+const SO_NETNS_COOKIE = 71
+
+// GetNetNSCookie tries to retrieve the cookie of the host netns.
+func GetNetNSCookie() (uint64, error) {
+	s, err := unix.Socket(unix.AF_INET, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	cookie, err := unix.GetsockoptUint64(s, unix.SOL_SOCKET, SO_NETNS_COOKIE)
+	if err != nil {
+		return 0, err
+	}
+
+	return cookie, nil
+}


### PR DESCRIPTION
When running in nested environments (e.g. Kind), cilium-agent does not
run in the host netns. So, in such cases the cookie comparison based on
bpf_get_netns_cookie(NULL) in bpf_sock.c for checking whether a socket
belongs to a host netns does not work. This breaks some socket-lb
functionality.

To fix this, we derive the cookie of the netns in which cilium-agent
runs via getsockopt(...SO_NETNS_COOKIE...) and then use it in the check
above. This is based on an assumption that cilium-agent always runs with
"hostNetwork: true".

Fix #14956 