### PR TITLE
workflows: disable scheduled runs for 1.10 workflows

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -5,10 +5,6 @@ on:
   issue_comment:
     types:
       - created
-
-  # Run every 6 hours
-  schedule:
-    - cron:  '30 0/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -5,9 +5,6 @@ on:
   issue_comment:
     types:
       - created
-  # Run every 6 hours
-  schedule:
-    - cron:  '0 1/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -5,9 +5,6 @@ on:
   issue_comment:
     types:
       - created
-  # Run every 6 hours
-  schedule:
-    - cron:  '0 2/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -5,9 +5,6 @@ on:
   issue_comment:
     types:
       - created
-  # Run every 6 hours
-  schedule:
-    - cron:  '0 3/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -5,9 +5,6 @@ on:
   issue_comment:
     types:
       - created
-  # Run every 6 hours
-  schedule:
-    - cron:  '0 5/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:


### PR DESCRIPTION
With the current setup, the scheduled runs on 1.10 workflows are testing exactly the same as the regular workflows. Since this doubles the amount and cost of testing for no reason, we disable schedule runs on 1.10 workflows.

We can always re-enable them later on when we actually rework them to use the v1.10 branches instead.
