### PR TITLE
Include '*.mesh.cilium.io' in 'clustermesh-apiserver''s server certificate.

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -77,14 +77,10 @@
      - Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency.
      - bool
      - ``false``
-   * - bpf.waitForMount
-     - Force the cilium-agent DaemonSet to wait in an initContainer until the eBPF filesystem has been mounted.
-     - bool
-     - ``false``
    * - certgen
      - Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually.
      - object
-     - ``{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.4"},"podLabels":{},"ttlSecondsAfterFinished":1800}``
+     - ``{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.5"},"podLabels":{},"ttlSecondsAfterFinished":1800}``
    * - certgen.podLabels
      - Labels to be added to hubble-certgen pods
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -70,7 +70,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
-| certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.4"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.5"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |
 | certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |
 | cgroup | object | `{"autoMount":{"enabled":true},"hostRoot":"/run/cilium/cgroupv2"}` | Configure cgroup related configuration |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -140,7 +140,7 @@ ca.key: {{ .cmca.Key | b64enc }}
 {{- template "clustermesh.apiserver.generate.ca" . }}
 {{- $CN := "clustermesh-apiserver.cilium.io" }}
 {{- $IPs := (list "127.0.0.1") }}
-{{- $SANs := (list $CN) }}
+{{- $SANs := (list $CN "*.mesh.cilium.io") }}
 {{- $cert := genSignedCert $CN $IPs $SANs (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .cmca -}}
 ca.crt: {{ .cmca.Cert | b64enc }}
 tls.crt: {{ $cert.Cert | b64enc }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -538,7 +538,7 @@ hostServices:
 certgen:
   image:
     repository: quay.io/cilium/certgen
-    tag: v0.1.4
+    tag: v0.1.5
     pullPolicy: Always
   # -- Seconds after which the completed job pod will be deleted
   ttlSecondsAfterFinished: 1800


### PR DESCRIPTION
Currently, the server certificate generated by Helm for `clustermesh-apiserver` doesn't include `*.mesh.cilium.io`, which is used alongside host aliases when establishing a cluster mesh. This PR addresses that by adding said domain to the list of SANs. It additionally brings in `v0.1.5` of `cilium/certgen`, which adds `*.mesh.cilium.io` to the list of SANs for the server certificate generated for `clustermesh-apiserver` when `clustermesh.apiserver.tls.auto.method` is set to `cronJob`.

```release-note
Add '*.mesh.cilium.io' to the list of SANs for the server certificate of 'clustermesh-apiserver'.
```
