### PR TITLE
test: fix Infinite loop during VM provisioning

### DIFF
--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -86,6 +86,10 @@ pipeline {
                 timeout(time: 150, unit: 'MINUTES')
             }
 
+            environment {
+                POLL_TIMEOUT_SECONDS=300
+            }
+
             steps {
                 sh 'cd ${TESTDIR}; vagrant ssh k8s1-${K8S_VERSION} -c "cd /home/vagrant/go/${PROJ_PATH}; sudo ./test/kubernetes-test.sh ${DOCKER_TAG}"'
             }


### PR DESCRIPTION
Fixes: #16871

An environment variable in the Jenkins file has been set up to provide a timeout for polling of Cilium Pods.

Signed-off-by: Gaurav Genani <h3llix.pvt@gmail.com>
