### PR TITLE
.github: Fix smoke tests sysdump collection from failing prematurely

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -137,7 +137,8 @@ jobs:
           curl -sLO "https://github.com/cilium/hubble/releases/download/${version}/hubble-linux-amd64.tar.gz"
           tar zxf hubble-linux-amd64.tar.gz
           chmod +x ./hubble
-          ./hubble observe --all --output json > hubble-flows.json
+          touch hubble-flows.json
+          ./hubble observe --all --output json > hubble-flows.json || true
 
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -185,7 +185,8 @@ jobs:
           curl -sLO https://github.com/cilium/hubble/releases/download/latest/hubble-linux-amd64.tar.gz
           tar zxf hubble-linux-amd64.tar.gz
           chmod +x ./hubble
-          ./hubble observe --all --output json > hubble-flows.json
+          touch hubble-flows.json
+          ./hubble observe --all --output json > hubble-flows.json || true
 
           curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           python cilium-sysdump.zip --output cilium-sysdump-out


### PR DESCRIPTION
If the `hubble observe` command fails for whatever reason, we don't want
to prevent the collection of the sysdump.

Fixes: 0cbb855a58f (".github: Capture hubble flows when smoke test
fails")
Fixes: https://github.com/cilium/cilium/pull/16968

Signed-off-by: Chris Tarazi <chris@isovalent.com>
