### PR TITLE
node-neigh: Wait instead of sleeping in unit tests

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1409,8 +1409,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	}
 	c.Assert(found, check.Equals, false)
 
+	now = time.Now()
 	c.Assert(linuxNodeHandler.NodeAdd(nodev3), check.IsNil)
-	time.Sleep(100 * time.Millisecond) // insertNeighbor is invoked async
+	wait(nodev3.Identity(), &now, false)
 
 	nextHop = net.ParseIP("9.9.9.250")
 	// Check that both node{2,3} are via nextHop (gw)


### PR DESCRIPTION
We can inspect the neighLastPingByNextHop map to check
when insertNeighbor() or deleteNeighbor() was called.

Fixes: e68848b98004 ("remove ARP entries left from previous Cilium run")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/17034