### PR TITLE
datapath/linux: enable neighbor discovery in unit tests

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -946,6 +946,11 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
+	prevEnableL2NeighDiscovery := option.Config.EnableL2NeighDiscovery
+	defer func() { option.Config.EnableL2NeighDiscovery = prevEnableL2NeighDiscovery }()
+
+	option.Config.EnableL2NeighDiscovery = true
+
 	prevStateDir := option.Config.StateDir
 	defer func() { option.Config.StateDir = prevStateDir }()
 


### PR DESCRIPTION
This option should be enabled in unit tests since it is also enabled as
a flag in the agent.

Fixes: cee08cd2b299 ("daemon: Make L2 neighbor discovery configurable.")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/17020