### PR TITLE
hubble: Never fail with ErrInvalidRead

### DIFF
--- a/pkg/hubble/container/ring.go
+++ b/pkg/hubble/container/ring.go
@@ -5,7 +5,6 @@ package container
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -18,11 +17,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
-)
-
-var (
-	// ErrInvalidRead indicates that the requested position can no longer be read.
-	ErrInvalidRead = errors.New("read position is no longer valid")
 )
 
 // Capacity is the interface that wraps Cap.
@@ -210,6 +204,21 @@ func (r *Ring) LastWrite() uint64 {
 	return atomic.LoadUint64(&r.write) - 1
 }
 
+func getLostEvent() *v1.Event {
+	now := time.Now().UTC()
+	return &v1.Event{
+		Timestamp: &timestamppb.Timestamp{
+			Seconds: now.Unix(),
+			Nanos:   int32(now.Nanosecond()),
+		},
+		Event: &flowpb.LostEvent{
+			Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+			NumEventsLost: 1,
+			Cpu:           nil,
+		},
+	}
+}
+
 // read the *v1.Event from the given read position. Returns an error if
 // the position is not valid. A position is invalid either because it has
 // already been overwritten by the writer (in which case ErrInvalidRead is
@@ -258,7 +267,7 @@ func (r *Ring) read(read uint64) (*v1.Event, error) {
 		if event == nil {
 			// If the ring buffer is not yet fully populated, we treat nil
 			// as a value which is about to be overwritten
-			return nil, ErrInvalidRead
+			return getLostEvent(), nil
 		}
 		return event, nil
 	// Case: Reader ahead of writer
@@ -266,7 +275,7 @@ func (r *Ring) read(read uint64) (*v1.Event, error) {
 		return nil, io.EOF
 	// Case: Reader behind writer
 	default:
-		return nil, ErrInvalidRead
+		return getLostEvent(), nil
 	}
 }
 
@@ -365,19 +374,8 @@ func (r *Ring) readFrom(ctx context.Context, read uint64, ch chan<- *v1.Event) {
 		default:
 			// The writer overwrote the entry before we had time to read it.
 			// Send a ListEvent to notify the read-miss.
-			now := time.Now().UTC()
 			select {
-			case ch <- &v1.Event{
-				Timestamp: &timestamppb.Timestamp{
-					Seconds: int64(now.Unix()),
-					Nanos:   int32(now.Nanosecond()),
-				},
-				Event: &flowpb.LostEvent{
-					Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
-					NumEventsLost: 1,
-					Cpu:           nil,
-				},
-			}:
+			case ch <- getLostEvent():
 				continue
 			case <-ctx.Done():
 				return

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -70,11 +71,6 @@ func TestRingReader_Previous(t *testing.T) {
 			count:   1,
 			wantErr: io.EOF,
 		},
-		{
-			start:   ^uint64(0),
-			count:   1,
-			wantErr: ErrInvalidRead,
-		},
 	}
 	for _, tt := range tests {
 		name := fmt.Sprintf("read %d, start at position %d", tt.count, tt.start)
@@ -95,6 +91,25 @@ func TestRingReader_Previous(t *testing.T) {
 			assert.Nil(t, reader.Close())
 		})
 	}
+}
+
+func TestRingReader_PreviousLost(t *testing.T) {
+	ring := NewRing(Capacity15)
+	for i := 0; i < 15; i++ {
+		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
+	}
+	reader := NewRingReader(ring, ^uint64(0))
+	expected := &v1.Event{
+		Event: &flowpb.LostEvent{
+			Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+			NumEventsLost: 1,
+			Cpu:           nil,
+		},
+	}
+	actual, err := reader.Previous()
+	assert.NoError(t, err)
+	assert.Equal(t, expected.GetLostEvent(), actual.GetLostEvent())
+	assert.Nil(t, reader.Close())
 }
 
 func TestRingReader_Next(t *testing.T) {
@@ -139,10 +154,6 @@ func TestRingReader_Next(t *testing.T) {
 				{Timestamp: &timestamppb.Timestamp{Seconds: 13}},
 			},
 		}, {
-			start:   ^uint64(0),
-			count:   1,
-			wantErr: ErrInvalidRead,
-		}, {
 			start:   14,
 			count:   1,
 			wantErr: io.EOF,
@@ -167,6 +178,25 @@ func TestRingReader_Next(t *testing.T) {
 			assert.Nil(t, reader.Close())
 		})
 	}
+}
+
+func TestRingReader_NextLost(t *testing.T) {
+	ring := NewRing(Capacity15)
+	for i := 0; i < 15; i++ {
+		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
+	}
+	expected := &v1.Event{
+		Event: &flowpb.LostEvent{
+			Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+			NumEventsLost: 1,
+			Cpu:           nil,
+		},
+	}
+	reader := NewRingReader(ring, ^uint64(0))
+	actual, err := reader.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, expected.GetLostEvent(), actual.GetLostEvent())
+	assert.Nil(t, reader.Close())
 }
 
 func TestRingReader_NextFollow(t *testing.T) {

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -224,8 +224,14 @@ func TestRing_Read(t *testing.T) {
 			args: args{
 				read: 0x0,
 			},
-			want:    nil,
-			wantErr: ErrInvalidRead,
+			want: &v1.Event{
+				Event: &flowpb.LostEvent{
+					Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+					NumEventsLost: 1,
+					Cpu:           nil,
+				},
+			},
+			wantErr: nil,
 		},
 		{
 			name: "we can't read index 0x7 since we are one writing cycle ahead",
@@ -249,8 +255,14 @@ func TestRing_Read(t *testing.T) {
 				// The next possible entry that we can read is 0x10-0x7-0x1 = 0x8 (idx: 0)
 				read: 0x7,
 			},
-			want:    nil,
-			wantErr: ErrInvalidRead,
+			want: &v1.Event{
+				Event: &flowpb.LostEvent{
+					Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+					NumEventsLost: 1,
+					Cpu:           nil,
+				},
+			},
+			wantErr: nil,
 		},
 		{
 			name: "we can read index 0x8 since it's the last entry that we can read in this cycle",
@@ -300,8 +312,14 @@ func TestRing_Read(t *testing.T) {
 				// next to be read: ^uint64(0) (idx: 7), last read: 0xfffffffffffffffe (idx: 6)
 				read: ^uint64(0),
 			},
-			want:    nil,
-			wantErr: ErrInvalidRead,
+			want: &v1.Event{
+				Event: &flowpb.LostEvent{
+					Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+					NumEventsLost: 1,
+					Cpu:           nil,
+				},
+			},
+			wantErr: nil,
 		},
 		{
 			name: "we overflow write and we are trying to read the previous writes, that we can",
@@ -352,8 +370,14 @@ func TestRing_Read(t *testing.T) {
 				// with a cycle that was already overwritten
 				read: ^uint64(0) - 0x7,
 			},
-			want:    nil,
-			wantErr: ErrInvalidRead,
+			want: &v1.Event{
+				Event: &flowpb.LostEvent{
+					Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+					NumEventsLost: 1,
+					Cpu:           nil,
+				},
+			},
+			wantErr: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -367,8 +391,16 @@ func TestRing_Read(t *testing.T) {
 				cycleMask: ^uint64(0) >> tt.fields.cycleExp,
 			}
 			got, got1 := r.read(tt.args.read)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Ring.read() got = %v, want %v", got, tt.want)
+			if tt.want.GetLostEvent() != nil {
+				assert.NotNil(t, got)
+				assert.NotNil(t, got.GetLostEvent())
+				if diff := cmp.Diff(tt.want.GetLostEvent(), got.GetLostEvent(), cmpopts.IgnoreUnexported(flowpb.LostEvent{})); diff != "" {
+					t.Errorf("LostEvent mismatch (-want +got):\n%s", diff)
+				}
+			} else {
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("Ring.read() got = %v, want %v", got, tt.want)
+				}
 			}
 			if got1 != tt.wantErr {
 				t.Errorf("Ring.read() got1 = %v, want %v", got1, tt.wantErr)
@@ -586,9 +618,9 @@ func TestRingFunctionalityInParallel(t *testing.T) {
 		t.Errorf("Read Event should be %+v, got %+v instead", &timestamppb.Timestamp{Seconds: 0}, entry.Timestamp)
 	}
 	lastWrite--
-	_, err = r.read(lastWrite)
-	if err != ErrInvalidRead {
-		t.Errorf("Should not be able to read position %x, got %v", lastWrite, err)
+	lost, _ := r.read(lastWrite)
+	if lost.GetLostEvent() == nil {
+		t.Errorf("Should not be able to read position %x, got %v", lastWrite, lost)
 	}
 }
 

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -534,10 +534,6 @@ func (r *eventsReader) Next(ctx context.Context) (*v1.Event, error) {
 			}
 			e, err = r.ringReader.Next()
 			if err != nil {
-				if errors.Is(err, container.ErrInvalidRead) {
-					// this error is sent over the wire and presented to the user
-					return nil, errors.New("requested data has been overwritten and is no longer available")
-				}
 				return nil, err
 			}
 		}
@@ -606,7 +602,8 @@ func newRingReader(ring *container.Ring, req genericRequest, whitelist, blacklis
 	// correct index, then create a new reader that starts from there
 	for i := ring.Len(); i > 0; i, idx = i-1, idx-1 {
 		e, err := reader.Previous()
-		if errors.Is(err, container.ErrInvalidRead) {
+		lost := e.GetLostEvent()
+		if lost != nil && lost.Source == flowpb.LostEventSource_HUBBLE_RING_BUFFER {
 			idx++ // we went backward 1 too far
 			break
 		} else if err != nil {


### PR DESCRIPTION
Currently GetFlows() fails with the following error when a position in
the ring buffer being read by Ring.read() has been overwritten:

    requested data has been overwritten and is no longer available

This turned out to be impractical as it makes it difficult to read all
the flows in the ring buffer (e.g.. hubble observe --all). GetFlows()
would fail if Hubble observes a single flow between the reader rewinding
to the oldest position and retrieving the entry.

This patch modifies Ring.read() so that GetFlows() returns LostEvent
instead of stopping with an error. The caller of GetFlows() can then
decide how to handle LostEvent.

Note that this makes the behavior of Ring.read() consistent with that
of Ring.readFrom() used in the follow mode. It generates LostEvent and
continues following instead of failing with ErrInvalidRead.

Fixes: #17036

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>