### PR TITLE
netns: Fix socket leak

### DIFF
--- a/pkg/netns/cookie.go
+++ b/pkg/netns/cookie.go
@@ -12,6 +12,7 @@ func GetNetNSCookie() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer unix.Close(s)
 
 	cookie, err := unix.GetsockoptUint64(s, unix.SOL_SOCKET, SO_NETNS_COOKIE)
 	if err != nil {

--- a/pkg/netns/cookie.go
+++ b/pkg/netns/cookie.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
 package netns
 
 import (


### PR DESCRIPTION
Close the socket if it has been successfully created.

Fixes: 0a4a393d6 ("bpf: Derive host netns cookie via SO_NETNS_COOKIE")
Reported-by: Daniel Borkmann <daniel@iogearbox.net>