### PR TITLE
workflows: disable scheduled runs for 1.10 AKS workflow

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -5,9 +5,6 @@ on:
   issue_comment:
     types:
       - created
-  # Run every 6 hours
-  schedule:
-    - cron:  '0 0/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:


### PR DESCRIPTION
We missed this one in #17023.

Fixes: e6287baa42ff132d0456da8450cfedb3f7974257