### PR TITLE
Fix Azure-related data races

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -220,7 +220,7 @@ func parseInterface(iface *network.Interface, subnets ipamTypes.SubnetMap, usePr
 	}
 
 	if iface.ID != nil {
-		i.ID = *iface.ID
+		i.SetID(*iface.ID)
 	}
 
 	if iface.Name != nil {

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -82,8 +82,12 @@ func (a *API) UpdateSubnets(subnets []*ipamTypes.Subnet) {
 
 func (a *API) UpdateInstances(instances *ipamTypes.InstanceMap) {
 	a.mutex.Lock()
-	a.instances = instances.DeepCopy()
+	a.updateInstancesLocked(instances)
 	a.mutex.Unlock()
+}
+
+func (a *API) updateInstancesLocked(instances *ipamTypes.InstanceMap) {
+	a.instances = instances.DeepCopy()
 }
 
 // SetMockError modifies the mock API to return an error for a particular

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -186,8 +186,8 @@ func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName
 	}
 
 	foundInterface := false
-
-	err := a.instances.ForeachInterface("", func(id, _ string, iface ipamTypes.InterfaceRevision) error {
+	instances := a.instances.DeepCopy()
+	err := instances.ForeachInterface("", func(id, _ string, iface ipamTypes.InterfaceRevision) error {
 		intf, ok := iface.Resource.(*types.AzureInterface)
 		if !ok {
 			return fmt.Errorf("invalid interface object")
@@ -224,6 +224,8 @@ func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName
 	if err != nil {
 		return err
 	}
+
+	a.updateInstancesLocked(instances)
 
 	if !foundInterface {
 		return fmt.Errorf("interface %s not found", interfaceName)

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -44,8 +44,10 @@ func (e *MockSuite) TestMock(c *check.C) {
 
 	ifaceID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11"
 	instances = ipamTypes.NewInstanceMap()
+	resource := &types.AzureInterface{Name: "eth0"}
+	resource.SetID(ifaceID)
 	instances.Update("vm1", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{ID: ifaceID, Name: "eth0"},
+		Resource: resource.DeepCopy(),
 	})
 	api.UpdateInstances(instances)
 	instances, err = api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
@@ -74,8 +76,10 @@ func (e *MockSuite) TestMock(c *check.C) {
 
 	vmIfaceID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Network/networkInterfaces/vm22-if"
 	vmInstances := ipamTypes.NewInstanceMap()
+	resource = &types.AzureInterface{Name: "eth0"}
+	resource.SetID(vmIfaceID)
 	vmInstances.Update("vm2", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{ID: vmIfaceID, Name: "eth0"},
+		Resource: resource.DeepCopy(),
 	})
 	c.Assert(err, check.IsNil)
 	c.Assert(vmInstances.NumInstances(), check.Equals, 1)

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -71,37 +71,40 @@ var (
 
 func iteration1(api *apimock.API, mngr *InstancesManager) {
 	instances := ipamTypes.NewInstanceMap()
+
+	resource := &types.AzureInterface{
+		SecurityGroup: "sg1",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.1.1",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("intf-1")
 	instances.Update("i-1", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{
-			ID:            "intf-1",
-			SecurityGroup: "sg1",
-			Addresses: []types.AzureAddress{
-				{
-					IP:     "1.1.1.1",
-					Subnet: "subnet-1",
-					State:  types.StateSucceeded,
-				},
-			},
-			State: types.StateSucceeded,
-		},
+		Resource: resource.DeepCopy(),
 	})
 
+	resource = &types.AzureInterface{
+		SecurityGroup: "sg3",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.3.3",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("intf-3")
 	instances.Update("i-2", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{
-			ID:            "intf-3",
-			SecurityGroup: "sg3",
-			Addresses: []types.AzureAddress{
-				{
-					IP:     "1.1.3.3",
-					Subnet: "subnet-1",
-					State:  types.StateSucceeded,
-				},
-			},
-			State: types.StateSucceeded,
-		},
+		Resource: resource.DeepCopy(),
 	})
-	api.UpdateInstances(instances)
 
+	api.UpdateInstances(instances)
 	mngr.Resync(context.Background())
 }
 
@@ -109,50 +112,56 @@ func iteration2(api *apimock.API, mngr *InstancesManager) {
 	api.UpdateSubnets(subnets2)
 
 	instances := ipamTypes.NewInstanceMap()
-	instances.Update("i-1", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{
-			ID:            "intf-1",
-			SecurityGroup: "sg1",
-			Addresses: []types.AzureAddress{
-				{
-					IP:     "1.1.1.1",
-					Subnet: "subnet-1",
-					State:  types.StateSucceeded,
-				},
-			},
-			State: types.StateSucceeded,
-		},
-	})
-	instances.Update("i-1", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{
-			ID:            "intf-2",
-			SecurityGroup: "sg2",
-			Addresses: []types.AzureAddress{
-				{
-					IP:     "3.3.3.3",
-					Subnet: "subnet-3",
-					State:  types.StateSucceeded,
-				},
-			},
-			State: types.StateSucceeded,
-		},
-	})
-	instances.Update("i-2", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{
-			ID:            "intf-3",
-			SecurityGroup: "sg3",
-			Addresses: []types.AzureAddress{
-				{
-					IP:     "1.1.3.3",
-					Subnet: "subnet-1",
-					State:  types.StateSucceeded,
-				},
-			},
-			State: types.StateSucceeded,
-		},
-	})
-	api.UpdateInstances(instances)
 
+	resource := &types.AzureInterface{
+		SecurityGroup: "sg1",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.1.1",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("intf-1")
+	instances.Update("i-1", ipamTypes.InterfaceRevision{
+		Resource: resource.DeepCopy(),
+	})
+
+	resource = &types.AzureInterface{
+		SecurityGroup: "sg2",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "3.3.3.3",
+				Subnet: "subnet-3",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("intf-2")
+	instances.Update("i-1", ipamTypes.InterfaceRevision{
+		Resource: resource.DeepCopy(),
+	})
+
+	resource = &types.AzureInterface{
+		SecurityGroup: "sg3",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.3.3",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("intf-3")
+	instances.Update("i-2", ipamTypes.InterfaceRevision{
+		Resource: resource.DeepCopy(),
+	})
+
+	api.UpdateInstances(instances)
 	mngr.Resync(context.TODO())
 }
 

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -173,20 +173,22 @@ func (e *IPAMSuite) TestIpamPreAllocate8(c *check.C) {
 	c.Assert(instances, check.Not(check.IsNil))
 
 	m := ipamTypes.NewInstanceMap()
-	m.Update("vm1", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{
-			ID:            "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11",
-			Name:          "eth0",
-			SecurityGroup: "sg1",
-			Addresses: []types.AzureAddress{
-				{
-					IP:     "1.1.1.1",
-					Subnet: "subnet-1",
-					State:  types.StateSucceeded,
-				},
+
+	resource := &types.AzureInterface{
+		Name:          "eth0",
+		SecurityGroup: "sg1",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.1.1",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
 			},
-			State: types.StateSucceeded,
 		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
+	m.Update("vm1", ipamTypes.InterfaceRevision{
+		Resource: resource.DeepCopy(),
 	})
 	api.UpdateInstances(m)
 
@@ -233,20 +235,22 @@ func (e *IPAMSuite) TestIpamMinAllocate10(c *check.C) {
 	c.Assert(instances, check.Not(check.IsNil))
 
 	m := ipamTypes.NewInstanceMap()
-	m.Update("vm1", ipamTypes.InterfaceRevision{
-		Resource: &types.AzureInterface{
-			ID:            "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11",
-			Name:          "eth0",
-			SecurityGroup: "sg1",
-			Addresses: []types.AzureAddress{
-				{
-					IP:     "1.1.1.1",
-					Subnet: "subnet-1",
-					State:  types.StateSucceeded,
-				},
+
+	resource := &types.AzureInterface{
+		Name:          "eth0",
+		SecurityGroup: "sg1",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.1.1",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
 			},
-			State: types.StateSucceeded,
 		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
+	m.Update("vm1", ipamTypes.InterfaceRevision{
+		Resource: resource.DeepCopy(),
 	})
 	api.UpdateInstances(m)
 
@@ -313,16 +317,16 @@ func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
 	allInstances := ipamTypes.NewInstanceMap()
 
 	for i := range state {
+		resource := &types.AzureInterface{
+			Name:          "eth0",
+			SecurityGroup: "sg1",
+			Addresses:     []types.AzureAddress{},
+			State:         types.StateSucceeded,
+		}
+		resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
 		allInstances.Update(fmt.Sprintf("vm%d", i), ipamTypes.InterfaceRevision{
-			Resource: &types.AzureInterface{
-				ID:            fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i),
-				Name:          "eth0",
-				SecurityGroup: "sg1",
-				Addresses:     []types.AzureAddress{},
-				State:         types.StateSucceeded,
-			},
+			Resource: resource.DeepCopy(),
 		})
-
 	}
 
 	api.UpdateInstances(allInstances)
@@ -389,14 +393,15 @@ func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLi
 	c.ResetTimer()
 
 	for i := range state {
+		resource := &types.AzureInterface{
+			Name:          "eth0",
+			SecurityGroup: "sg1",
+			Addresses:     []types.AzureAddress{},
+			State:         types.StateSucceeded,
+		}
+		resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
 		allInstances.Update(fmt.Sprintf("vm%d", i), ipamTypes.InterfaceRevision{
-			Resource: &types.AzureInterface{
-				ID:            fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i),
-				Name:          "eth0",
-				SecurityGroup: "sg1",
-				Addresses:     []types.AzureAddress{},
-				State:         types.StateSucceeded,
-			},
+			Resource: resource.DeepCopy(),
 		})
 	}
 

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -127,6 +127,13 @@ type AzureInterface struct {
 	resourceGroup string `json:"-"`
 }
 
+// SetID sets the Azure interface ID, as well as extracting other fields from
+// the ID itself.
+func (a *AzureInterface) SetID(id string) {
+	a.ID = id
+	a.extractIDs()
+}
+
 // InterfaceID returns the identifier of the interface
 func (a *AzureInterface) InterfaceID() string {
 	return a.ID
@@ -159,25 +166,16 @@ func (a *AzureInterface) extractIDs() {
 
 // GetResourceGroup returns the resource group the interface belongs to
 func (a *AzureInterface) GetResourceGroup() string {
-	if a.resourceGroup == "" {
-		a.extractIDs()
-	}
 	return a.resourceGroup
 }
 
 // GetVMScaleSetName returns the VM scale set name the interface belongs to
 func (a *AzureInterface) GetVMScaleSetName() string {
-	if a.vmssName == "" {
-		a.extractIDs()
-	}
 	return a.vmssName
 }
 
 // GetVMID returns the VM ID the interface belongs to
 func (a *AzureInterface) GetVMID() string {
-	if a.vmID == "" {
-		a.extractIDs()
-	}
 	return a.vmID
 }
 

--- a/pkg/azure/types/types_test.go
+++ b/pkg/azure/types/types_test.go
@@ -62,12 +62,11 @@ func (e *TypesSuite) TestForeachAddresses(c *check.C) {
 }
 
 func (e *TypesSuite) TestExtractIDs(c *check.C) {
-	vmssIntf := AzureInterface{
-		ID: "/subscriptions/xxx/resourceGroups/MC_aks-test_aks-test_westeurope/providers/Microsoft.Compute/virtualMachineScaleSets/aks-nodepool1-10706209-vmss/virtualMachines/3/networkInterfaces/aks-nodepool1-10706209-vmss",
-	}
-	vmIntf := AzureInterface{
-		ID: "/subscriptions/xxx/resourceGroups/az-test-rg/providers/Microsoft.Network/networkInterfaces/pods-interface",
-	}
+	vmssIntf := AzureInterface{}
+	vmssIntf.SetID("/subscriptions/xxx/resourceGroups/MC_aks-test_aks-test_westeurope/providers/Microsoft.Compute/virtualMachineScaleSets/aks-nodepool1-10706209-vmss/virtualMachines/3/networkInterfaces/aks-nodepool1-10706209-vmss")
+
+	vmIntf := AzureInterface{}
+	vmIntf.SetID("/subscriptions/xxx/resourceGroups/az-test-rg/providers/Microsoft.Network/networkInterfaces/pods-interface")
 
 	c.Assert(vmssIntf.GetResourceGroup(), check.Equals, "MC_aks-test_aks-test_westeurope")
 	c.Assert(vmssIntf.GetVMID(), check.Equals, "3")


### PR DESCRIPTION
- azure/api/mock: Add (*API).updateInstancesLocked helper
- azure/api/mock: Make copy of instance map to avoid data races
- azure: Set interface ID upfront in a dedicated method

Fixes: https://github.com/cilium/cilium/issues/13619
