### PR TITLE
Revert "config: Fix incorrect packet path with IPsec and endpoint rou…

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -227,10 +227,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_EGRESS_GATEWAY"] = "1"
 	}
 
-	if option.Config.EnableEndpointRoutes {
-		cDefinesMap["ENABLE_ENDPOINT_ROUTES"] = "1"
-	}
-
 	if option.Config.EnableHostReachableServices {
 		if option.Config.EnableHostServicesTCP {
 			cDefinesMap["ENABLE_HOST_SERVICES_TCP"] = "1"
@@ -817,6 +813,10 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 
 	if e.RequireRouting() {
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
+	}
+
+	if e.RequireEndpointRoute() {
+		fmt.Fprintf(fw, "#define ENABLE_ENDPOINT_ROUTES 1\n")
 	}
 
 	if e.DisableSIPVerification() {


### PR DESCRIPTION
…tes"

This reverts commit 7ef59aa9d7d059998ad1a8b4e1c552447090c3d1.

After performing a git bisect where connectivity test had to pass 3
times consecutively this commit was the first that hit the current
ci-aks failures that we have been having in our CI, thus it is being
reverted.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/17022

cc @pchaigno 