### PR TITLE
datapath: panic explicitly when IP of direct-routing-device not found

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -25,6 +25,8 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
@@ -51,8 +53,11 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "datapath-linux-config")
 
 // HeaderfileWriter is a wrapper type which implements datapath.ConfigWriter.
 // It manages writing of configuration of datapath program headerfiles.
@@ -435,13 +440,25 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["DIRECT_ROUTING_DEV_IFINDEX"] = fmt.Sprintf("%d", directRoutingIfIndex)
 
 		if option.Config.EnableIPv4 {
-			nodePortIPv4Addrs := node.GetNodePortIPv4AddrsWithDevices()
-			ipv4 := byteorder.NetIPv4ToHost32(nodePortIPv4Addrs[directRoutingIface])
+			ip, ok := node.GetNodePortIPv4AddrsWithDevices()[directRoutingIface]
+			if !ok {
+				log.WithFields(logrus.Fields{
+					"directRoutingIface": directRoutingIface,
+				}).Fatal("NodePort enabled but direct routing device's IPv4 address not found")
+			}
+
+			ipv4 := byteorder.NetIPv4ToHost32(ip)
 			cDefinesMap["IPV4_DIRECT_ROUTING"] = fmt.Sprintf("%d", ipv4)
 		}
 
 		if option.Config.EnableIPv6 {
-			directRoutingIPv6 := node.GetNodePortIPv6AddrsWithDevices()[directRoutingIface]
+			directRoutingIPv6, ok := node.GetNodePortIPv6AddrsWithDevices()[directRoutingIface]
+			if !ok {
+				log.WithFields(logrus.Fields{
+					"directRoutingIface": directRoutingIface,
+				}).Fatal("NodePort enabled but direct routing device's IPv6 address not found")
+			}
+
 			extraMacrosMap["IPV6_DIRECT_ROUTING"] = directRoutingIPv6.String()
 			fw.WriteString(FmtDefineAddress("IPV6_DIRECT_ROUTING", directRoutingIPv6))
 		}


### PR DESCRIPTION
A user reported the follow panic on agent startup:

```
level=info msg="  --devices=''" subsys=daemon
level=info msg="  --direct-routing-device='wg0'" subsys=daemon
...
level=info msg="Trying to auto-enable \"enable-node-port\", \"enable-external-ips\", \"enable-host-reachable-services\", \"enable-host-port\", \"enable-session-affinity\" features" subsys=daemon
...
level=info msg="Cluster-ID is not specified, skipping ClusterMesh initialization" subsys=daemon
panic: runtime error: index out of range [3] with length 0

goroutine 1 [running]:
encoding/binary.bigEndian.Uint32(...)
        /usr/local/go/src/encoding/binary/binary.go:112
github.com/cilium/cilium/pkg/byteorder.HostSliceToNetwork(0x0, 0x0, 0x0, 0xa, 0x4795aa0, 0x41983f8)
        /go/src/github.com/cilium/cilium/pkg/byteorder/byteorder.go:134 +0x24f
github.com/cilium/cilium/pkg/datapath/linux/config.(*HeaderfileWriter).WriteNodeConfig(0x4792cf0, 0x2e86b00, 0xc0005b4fe8, 0xc0000fcc68, 0x0, 0x0)
        /go/src/github.com/cilium/cilium/pkg/datapath/linux/config/config.go:426 +0x47db
github.com/cilium/cilium/daemon/cmd.(*Daemon).createNodeConfigHeaderfile(0xc0001d5200, 0x0, 0x0)
        /go/src/github.com/cilium/cilium/daemon/cmd/datapath.go:72 +0x3e9
github.com/cilium/cilium/daemon/cmd.(*Daemon).init(0xc0001d5200, 0x4239c20, 0x42278e0)
        /go/src/github.com/cilium/cilium/daemon/cmd/daemon.go:233 +0x6a6
```

With some investigations, this is how the panic happened:

1. --devices='' && --direct-routing-device='wg0' resulted in final option.Config.Devices=["eth0"] on his machine; which further led to
2. no ip address was initialized in NodePort IPv4 address map for `wg0` device, then
3. nodePortIPv4Addrs[directRoutingIface] returned an empty net.IP object, and the subsequent byteorder convertion paniced as above

Although it's the user to blame for misconfiguration, the panic message
is not so friendly either for ordinary users determining what's happened
and how to fix it.

This patch improves it by checking the existence of the IP address
before using it, and panic explicitly with more user-friendly messages.

Update: this patch also helps even if c042c05f8bf is added recently, as
the latter also accesses indexes before checking IP existence:

```go
10 // NetIPv4ToHost32 converts an net.IP to a uint32 in host byte order. ip
11 // must be a IPv4 address, otherwise the function will panic.
12 func NetIPv4ToHost32(ip net.IP) uint32 {
13     ipv4 := ip.To4()
14     _ = ipv4[3] // Assert length of ipv4.
15     return Native.Uint32(ipv4)
16 }
```

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>