### PR TITLE
tooling: introduce target for generating json compilation database

### DIFF
--- a/bpf/.gitignore
+++ b/bpf/.gitignore
@@ -1,6 +1,7 @@
 # when updating this file, make sure to update `BPF_SRCFILES_IGNORE` in `Makefile.defs`
 cilium-map-migrate
 cilium-probe-kernel-hz
+compile_commands.json
 *.i
 *.s
 .rebuild_all

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-.PHONY: all bpf_all build_all subdirs install clean
+.PHONY: all bpf_all build_all subdirs install clean gen_compile_commands
 
 SUBDIRS = sockops custom
 
@@ -318,3 +318,12 @@ clean:
 		$(MAKE) $(SUBMAKEOPTS) -C $(TARGET) clean;)
 	$(QUIET)rm -fr *.o *.ll *.i *.s
 	$(QUIET)rm -f $(TARGET)
+
+
+BEAR_CLI   = $(shell which bear 2> /dev/null)
+gen_compile_commands:
+ifeq (, $(BEAR_CLI))
+	@echo "bear cli must be in $PATH to generate json compilation database"
+else
+	bear -- make
+endif


### PR DESCRIPTION
both mainstream c language servers (clangd, ccls) require a json compilation
database to function correctly.

this patch adds a makefile target which utilizes the 'bear' cli to
compile this json database.

after the database is generated all code within the bpf directory is
indexable by clangd and ccls allowing the tooling to work correctly.

Signed-off-by: Louis DeLosSantos <louis@isovalent.com>