### PR TITLE
checkpatch: update image to fix checks on commit object and message

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://quay.io/cilium/cilium-checkpatch:514a240252e61d47b8814a5e57843505c0325b77@sha256:f88bbc4dbd8ace809c84581fae8b2dbbbc89433d641f1edf0f892d92be996020
+        uses: docker://quay.io/cilium/cilium-checkpatch:af84067d2768e30c69e5d00e3efd82273f229e80@sha256:1d73dba63806ef51463426c1590760f697b5604475cd73cd342117d45c44ef97
       - name: Send slack notification
         if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}
         uses: 8398a7/action-slack@e74cd4e48f4452e8158dc4f8bcfc780ae6203364


### PR DESCRIPTION
Pull the latest image for checkpatch (following https://github.com/cilium/image-tools/pull/131). This image:

- Fixes the parsing of commit objects, improving checks on commit object length.
- Fixes the way commits with no bpf/ modification are checked, thus improving checks on commit message presence.
