### PR TITLE
workflows: retry GCP VM creation up to 3 times

### DIFF
--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -189,18 +189,23 @@ jobs:
           gcloud info
 
       - name: Create GCP VM
-        run: |
-          gcloud compute instances create ${{ env.vmName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-            --zone ${{ env.zone }} \
-            --machine-type e2-custom-2-4096 \
-            --boot-disk-type pd-standard \
-            --boot-disk-size 10GB \
-            --preemptible \
-            --image-project ubuntu-os-cloud \
-            --image-family ubuntu-2004-lts \
-            --metadata hostname=${{ env.vmName }} \
-            --metadata-from-file startup-script=${{ env.vmStartupScript}}
+        uses: nick-invision/retry@45ba062d357edb3b29c4a94b456b188716f61020
+        with:
+          retry_on: error
+          timeout_minutes: 1
+          max_attempts: 3
+          command: |
+            gcloud compute instances create ${{ env.vmName }} \
+              --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+              --zone ${{ env.zone }} \
+              --machine-type e2-custom-2-4096 \
+              --boot-disk-type pd-standard \
+              --boot-disk-size 10GB \
+              --preemptible \
+              --image-project ubuntu-os-cloud \
+              --image-family ubuntu-2004-lts \
+              --metadata hostname=${{ env.vmName }} \
+              --metadata-from-file startup-script=${{ env.vmStartupScript}}
 
       - name: Create GKE cluster
         run: |

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -192,18 +192,23 @@ jobs:
           gcloud info
 
       - name: Create GCP VM
-        run: |
-          gcloud compute instances create ${{ env.vmName }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-            --zone ${{ env.zone }} \
-            --machine-type e2-custom-2-4096 \
-            --boot-disk-type pd-standard \
-            --boot-disk-size 10GB \
-            --preemptible \
-            --image-project ubuntu-os-cloud \
-            --image-family ubuntu-2004-lts \
-            --metadata hostname=${{ env.vmName }} \
-            --metadata-from-file startup-script=${{ env.vmStartupScript}}
+        uses: nick-invision/retry@45ba062d357edb3b29c4a94b456b188716f61020
+        with:
+          retry_on: error
+          timeout_minutes: 1
+          max_attempts: 3
+          command: |
+            gcloud compute instances create ${{ env.vmName }} \
+              --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
+              --zone ${{ env.zone }} \
+              --machine-type e2-custom-2-4096 \
+              --boot-disk-type pd-standard \
+              --boot-disk-size 10GB \
+              --preemptible \
+              --image-project ubuntu-os-cloud \
+              --image-family ubuntu-2004-lts \
+              --metadata hostname=${{ env.vmName }} \
+              --metadata-from-file startup-script=${{ env.vmStartupScript}}
 
       - name: Create GKE cluster
         run: |


### PR DESCRIPTION
Fixes an issue where the GCP VM fails to create:

```
Run gcloud compute instances create cilium-cilium-cli-1046557892-vm \
WARNING: You have selected a disk size of under [200GB]. This may result in poor I/O performance. For more information, see: https://developers.google.com/compute/docs/disks#performance.
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - The resource 'projects/***/regions/us-west2/subnetworks/default' is not ready
```

From GCP documentation, this comes from simultaneous resource operations (https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-vm-creation) however we have no control over that. Their only recommendation is to add retries.

Considering it's an infrastructure issue and it also is easily contained to the GCP VM creation step, this is acceptable.

Picked up from https://github.com/cilium/cilium-cli/pull/463.

Fixes: #17063