### PR TITLE
test/helpers: add the json output debug in case of failure

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2883,7 +2883,7 @@ func (kub *Kubectl) CiliumPolicyRevision(pod string) (int, error) {
 
 	revision, err := res.Filter("{.revision}")
 	if err != nil {
-		return -1, fmt.Errorf("cannot get revision from json: %s", err)
+		return -1, fmt.Errorf("cannot get revision from json output '%s': %s", res.CombineOutput(), err)
 	}
 
 	revi, err := strconv.Atoi(strings.Trim(revision.String(), "\n"))


### PR DESCRIPTION
With this information it will help debug further the reason why some
tests failed when they hit 'unexpected end of JSON input' error.

Signed-off-by: André Martins <andre@cilium.io>

Related with https://github.com/cilium/cilium/issues/17069