### PR TITLE
datapath: Sort VLAN IDs in generated macros

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -610,6 +610,7 @@ func vlanFilterMacros() (string, error) {
 	vlansCount := 0
 	for _, v := range vlansByIfIndex {
 		vlansCount += len(v)
+		sort.Ints(v) // sort Vlanids in-place since netlink.LinkList() may return them in any order
 	}
 
 	if vlansCount == 0 {


### PR DESCRIPTION
Apparently netlink.LinkList() can return VLAN IDs in any order. Sort
them to get consistent generated macros.

Fixes: #17104
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
