### PR TITLE
pkg/k8s: use a controller manager in K8sClient

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -282,6 +282,7 @@ func (c *Controller) runController() {
 
 		case <-runTimer.After(interval):
 		case <-c.trigger:
+			runFunc = true
 		}
 
 	}

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -29,6 +29,9 @@ type K8sClient struct {
 	// kubernetes.Interface is the object through which interactions with
 	// Kubernetes are performed.
 	kubernetes.Interface
+
+	// ctrlMgr is the manager of controllers for this K8sClient.
+	ctrlMgr *controller.Manager
 }
 
 // K8sCiliumClient is a wrapper around clientset.Interface.

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/controller"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	slim_apiextclientsetscheme "github.com/cilium/cilium/pkg/k8s/slim/k8s/apiextensions-client/clientset/versioned/scheme"
@@ -37,7 +38,9 @@ import (
 
 var (
 	// k8sCLI is the default client.
-	k8sCLI = &K8sClient{}
+	k8sCLI = &K8sClient{
+		ctrlMgr: controller.NewManager(),
+	}
 
 	// k8sWatcherCLI is the client dedicated k8s structure watchers.
 	k8sWatcherCLI = &K8sClient{}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -296,7 +296,7 @@ const (
 func (k8sCli K8sClient) MarkNodeReady(nodeGetter nodeGetter, nodeName string) {
 	log.WithField(logfields.NodeName, nodeName).Debug("Setting NetworkUnavailable=false")
 
-	controller.NewManager().UpdateController(markK8sNodeReadyControllerName,
+	k8sCli.ctrlMgr.UpdateController(markK8sNodeReadyControllerName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				err := removeNodeTaint(ctx, k8sCli, nodeGetter, nodeName)
@@ -311,5 +311,5 @@ func (k8sCli K8sClient) MarkNodeReady(nodeGetter nodeGetter, nodeName string) {
 // ReMarkNodeReady re-triggers the controller set by 'MarkNodeReady'. If
 // 'MarkNodeReady' has not been executed yet, calling this function be a no-op.
 func (k8sCli K8sClient) ReMarkNodeReady() {
-	controller.NewManager().TriggerController(markK8sNodeReadyControllerName)
+	k8sCli.ctrlMgr.TriggerController(markK8sNodeReadyControllerName)
 }


### PR DESCRIPTION
Since "controller.NewManager()" returns a new Manager, triggering a
controller from this newly returned manager does not work because the
manager does not have any controller set in it. In order to be able
to re-trigger controllers, a single instance of this manager is set in
the K8sClient struct.

Fixes: bd34b95a7939 ("pkg/k8s: remove node.cilium.io/agent-not-ready taint from nodes")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/17103

```release-note
Remove `node.cilium.io/agent-not-ready` node taints if they are re-added after Cilium has started
```
