### PR TITLE
v1.8 backports 2021-08-10

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1415,8 +1415,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	}
 	c.Assert(found, check.Equals, false)
 
+	now = time.Now()
 	c.Assert(linuxNodeHandler.NodeAdd(nodev3), check.IsNil)
-	time.Sleep(100 * time.Millisecond) // insertNeighbor is invoked async
+	wait(nodev3.Identity(), &now, false)
 
 	nextHop = net.ParseIP("9.9.9.250")
 	// Check that both node{2,3} are via nextHop (gw)


### PR DESCRIPTION
* ~#17000 -- config: Fix incorrect packet path with IPsec and endpoint routes (@pchaigno)~
 * #17035 -- node-neigh: Wait instead of sleeping in unit tests (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17035; do contrib/backporting/set-labels.py $pr done 1.8; done
```