### PR TITLE
workflows: Skip L7 test in AWS-CNI chaining mode

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -261,7 +261,7 @@ jobs:
         run: |
           cilium connectivity test \
             --flow-validation=disabled \
-            --test '!fqdn' # L7 policies are not supported in chaining mode.
+            --test '!fqdn,!l7' # L7 policies are not supported in chaining mode.
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -264,7 +264,7 @@ jobs:
         run: |
           cilium connectivity test \
             --flow-validation=disabled \
-            --test '!fqdn' # L7 policies are not supported in chaining mode.
+            --test '!fqdn,!l7' # L7 policies are not supported in chaining mode.
 
       - name: Post-test information gathering
         if: ${{ !success() }}


### PR DESCRIPTION
L7 policies, including FQDN policies, are not supported in chaining mode. The Cilium CLI added a new L7 test in v0.8.6 which doesn't match our existing filtering pattern ('!fqdn'). This pull request updates the pattern to also exclude that new test.