### PR TITLE
install/kubernetes: remove duplicated 'key' in volumes

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -413,7 +413,6 @@ spec:
               name: cilium-config
               key: clean-cilium-bpf-state
               optional: true
-              key: wait-bpf-mount
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}


### PR DESCRIPTION
This key was accidentally left out and should be removed as the correct
'key' is 'clean-cilium-bpf-state'.

Fixes: f7a3f59fd749 ("install/kubernetes: use bidirectional mounts to mount bpf fs")
Signed-off-by: André Martins <andre@cilium.io>