### PR TITLE
Makefile: fix typo in helper message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -606,7 +606,7 @@ help: Makefile ## Display help for the Makefile, from https://www.thapaliya.com/
 	$(call print_help_line,"docker-plugin-image","Build cilium-docker plugin image")
 	$(call print_help_line,"docker-hubble-relay-image","Build hubble-relay docker image")
 	$(call print_help_line,"docker-clustermesh-apiserver-image","Build docker image for Cilium clustermesh APIServer")
-	$(call print_help_line,"docker-opeartor-image","Build cilium-operator docker image")
+	$(call print_help_line,"docker-operator-image","Build cilium-operator docker image")
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 


### PR DESCRIPTION
Fixes: 2186ae4c3079 ("make: add help target to root Makefile for printing info about available targets")
Signed-off-by: André Martins <andre@cilium.io>