### PR TITLE
option: Fix ipvlan master device config

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1233,7 +1233,7 @@ func initEnv(cmd *cobra.Command) {
 
 	switch option.Config.DatapathMode {
 	case datapathOption.DatapathModeVeth:
-		if name := viper.GetString(option.IpvlanMasterDevice); name != "undefined" {
+		if name := option.Config.IpvlanMasterDevice; name != "undefined" {
 			log.WithField(logfields.IpvlanMasterDevice, name).
 				Fatal("ipvlan master device cannot be set in the 'veth' datapath mode")
 		}
@@ -1262,7 +1262,7 @@ func initEnv(cmd *cobra.Command) {
 		// the swagger API is that in future we might deprecate --device
 		// parameter with e.g. some auto-detection mechanism, thus for
 		// ipvlan it is desired to have a separate one, see PR #6608.
-		iface := viper.GetString(option.IpvlanMasterDevice)
+		iface := option.Config.IpvlanMasterDevice
 		if iface == "undefined" {
 			log.WithField(logfields.IpvlanMasterDevice, option.Config.Devices[0]).
 				Fatal("ipvlan master device must be specified in the 'ipvlan' datapath mode")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1426,6 +1426,7 @@ type DaemonConfig struct {
 	IPv6Range                     string
 	IPv4ServiceRange              string
 	IPv6ServiceRange              string
+	IpvlanMasterDevice            string
 	K8sAPIServer                  string
 	K8sKubeConfigPath             string
 	K8sClientBurst                int
@@ -2479,6 +2480,7 @@ func (c *DaemonConfig) Populate() {
 	c.IPTablesLockTimeout = viper.GetDuration(IPTablesLockTimeout)
 	c.IPTablesRandomFully = viper.GetBool(IPTablesRandomFully)
 	c.IPSecKeyFile = viper.GetString(IPSecKeyFileName)
+	c.IpvlanMasterDevice = viper.GetString(IpvlanMasterDevice)
 	c.ModePreFilter = viper.GetString(PrefilterMode)
 	c.EnableMonitor = viper.GetBool(EnableMonitorName)
 	c.MonitorAggregation = viper.GetString(MonitorAggregationName)


### PR DESCRIPTION
All options should be read from pkg/option, this is the only exception.
Move it over to be properly consistent with our usage of viper.
