### PR TITLE
helm: Remove redundant capabilities

### DIFF
--- a/examples/kubernetes-istio/istio-sidecar-injector-configmap-debug.yaml
+++ b/examples/kubernetes-istio/istio-sidecar-injector-configmap-debug.yaml
@@ -22,9 +22,6 @@ data:
         - "*"
         imagePullPolicy: Always
         securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
           privileged: true
         restartPolicy: Always
       - args:

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -241,10 +241,6 @@ spec:
         {{- end }}
         {{- end }}
         securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_MODULE
           privileged: true
         volumeMounts:
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
@@ -426,9 +422,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
           privileged: true
         volumeMounts:
         {{- /* CRI-O already mounts the BPF filesystem */ -}}

--- a/test/k8sT/manifests/demo-customcalls.yaml
+++ b/test/k8sT/manifests/demo-customcalls.yaml
@@ -105,10 +105,6 @@ spec:
     args:
       - "1000h"
     securityContext:
-      capabilities:
-        add:
-        - NET_ADMIN
-        - SYS_MODULE
       privileged: true
     volumeMounts:
       - mountPath: /sys/fs/bpf

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -34,11 +34,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: log-gatherer
         securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_MODULE
-            - SYS_ADMIN
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf

--- a/test/k8sT/manifests/registry-adder/templates/daemonset.yaml
+++ b/test/k8sT/manifests/registry-adder/templates/daemonset.yaml
@@ -32,11 +32,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: registry-adder
         securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_MODULE
-            - SYS_ADMIN
           privileged: true
         volumeMounts:
         - mountPath: /etc/docker

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -11,10 +11,6 @@ spec:
     args:
       - "1000h"
     securityContext:
-      capabilities:
-        add:
-        - NET_ADMIN
-        - SYS_MODULE
       privileged: true
     volumeMounts:
       - mountPath: /sys/fs/bpf


### PR DESCRIPTION
The cilium agent container already runs as a privileged container, so
there is no need to grant additional capabilities, as it already has all
of them. This section will become relevant again once we remove
`privileged` from the DaemonSet, but in the meantime there is no reason
to keep an incomplete and redundant list of capabilities.

I did a quick `git blame` on the source of the two capabilities that we had,
and I don't see any rationale as to why they were added. It's also clear
that the set of capabilities is incomplete, as evident by the list
provided in #14446.

I also manually verified this locally, here is the set of capabilities
given to the `cilium-agent` process _with this change applied_,
note `sys_module` and `net_admin` are both present.

```
# pscap -a
ppid  pid   name        command           capabilities
0     1     root        cilium-agent      chown, dac_override, dac_read_search, fowner, fsetid, kill, setgid, setuid, setpcap, linux_immutable, net_bind_service, net_broadcast, net_admin, net_raw, ipc_lock, ipc_owner, sys_module, sys_rawio, sys_chroot, sys_ptrace, sys_pacct, sys_admin, sys_boot, sys_nice, sys_resource, sys_time, sys_tty_config, mknod, lease, audit_write, audit_control, setfcap, mac_override, mac_admin, syslog, wake_alarm, block_suspend, audit_read
```

Fixes: #17118
