### PR TITLE
test: Delete the test namespace in CLI test

### DIFF
--- a/test/k8sT/cli.go
+++ b/test/k8sT/cli.go
@@ -154,6 +154,8 @@ var _ = Describe("K8sCLI", func() {
 				_, err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3L4DenyPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
+
+				kubectl.NamespaceDelete(namespaceForTest)
 			})
 		})
 


### PR DESCRIPTION
Delete the test namespace so that the pods therein are not leaked into other tests.

Fixes: #17132
