### PR TITLE
docs: update documents for ICMP CNP

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -727,6 +727,57 @@ ports other than port 80.
 
         .. literalinclude:: ../../examples/policies/l4/cidr_l4_combined.json
 
+Limit ICMP/ICMPv6 types
+-----------------------
+
+ICMP policy can be specified in addition to layer 3 policies or independently.
+It restricts the ability of an endpoint to emit and/or receive packets on a
+particular ICMP/ICMPv6 type (currently ICMP/ICMPv6 code is not supported).
+If any ICMP policy is specified, layer 4 and ICMP communication will be blocked
+unless it's related to a connection that is otherwise allowed by the policy.
+
+ICMP policy can be specified at both ingress and egress using the
+``icmps`` field. The ``icmps`` field takes a ``ICMPField`` structure
+which is defined as follows:
+
+.. code-block:: go
+
+        // ICMPField is a ICMP field.
+        type ICMPField struct {
+        	// Family is a IP address version.
+        	// Currently, we support `IPv4` and `IPv6`.
+        	// `IPv4` is set as default.
+        	//
+        	// +default=IPv4
+        	// +optional
+        	Family string `json:"family,omitempty"`
+
+        	// Type is a ICMP-type.
+        	// It should be 0-255 (8bit).
+        	Type uint8 `json:"type"`
+        }
+
+Example (ICMP/ICMPv6)
+~~~~~~~~~~~~~~~~~~~~~
+
+The following rule limits all endpoints with the label ``app=myService`` to
+only be able to emit packets using ICMP with type 8 and ICMPv6 with type 128,
+to any layer 3 destination:
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l4/icmp.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l4/icmp.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l4/icmp.json
+
 
 
 .. _l7_policy:

--- a/examples/policies/l4/icmp.json
+++ b/examples/policies/l4/icmp.json
@@ -1,0 +1,10 @@
+[{
+  "labels": [{"key": "name", "value": "icmp-rule"}],
+  "endpointSelector": {"matchLabels":{"app":"myService"}},
+  "egress": [{
+    "icmps": [
+      {"fields":[ {"type": 8, "family": "IPv4"}]},
+      {"fields":[ {"type": 128, "family": "IPv6"}]}
+    ]
+  }]
+}]

--- a/examples/policies/l4/icmp.yaml
+++ b/examples/policies/l4/icmp.yaml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "icmp-rule"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: myService
+  egress:
+  - icmps:
+    - fields:
+      - type: 8
+        family: IPv4
+      - type: 128
+        family: IPv6


### PR DESCRIPTION
Related: #14609

Add the section for ICMP/ICMPv6 policy in the "Layer 4 Eexamples" chapter.
Note: this PR should be merged after ICMP CNP is implemented without a feature flag.