### PR TITLE
workflows: Fix Hubble flow capture in smoke tests

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -133,7 +133,7 @@ jobs:
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          version="$(curl -sL0 'https://api.github.com/repos/cilium/hubble/releases/latest' | jq -r .tag_name)"
+          version=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
           curl -sLO "https://github.com/cilium/hubble/releases/download/${version}/hubble-linux-amd64.tar.gz"
           tar zxf hubble-linux-amd64.tar.gz
           chmod +x ./hubble

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -182,7 +182,8 @@ jobs:
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          curl -sLO https://github.com/cilium/hubble/releases/download/latest/hubble-linux-amd64.tar.gz
+          version=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+          curl -sLO "https://github.com/cilium/hubble/releases/download/${version}/hubble-linux-amd64.tar.gz"
           tar zxf hubble-linux-amd64.tar.gz
           chmod +x ./hubble
           touch hubble-flows.json


### PR DESCRIPTION
The step "Capture cilium-sysdump" currently fails in smoke tests with:

    gzip: stdin: not in gzip format
    tar: Child returned status 1
    tar: Error is not recoverable: exiting now
    Error: Process completed with exit code 2.

This is happening because we attempt to download the latest `hubble` binary at URL https://github.com/cilium/hubble/releases/download/latest/hubble-linux-amd64.tar.gz and fail to decompress the downloaded file. That's because the downloaded file contains only "Not found".

Indeed, URL https://github.com/cilium/hubble/releases/download/latest/hubble-linux-amd64.tar.gz doesn't exist, the correct URL is https://github.com/cilium/hubble/releases/latest/download/hubble-linux-amd64.tar.gz. Never mind that other releases are downloaded at https://github.com/cilium/hubble/releases/download/$TAG/hubble-linux-amd64.tar.gz ¯\_(ツ)_/¯

Fixes: https://github.com/cilium/cilium/pull/16968
/cc @christarazi 