### PR TITLE
workflows: increase VM creation retry count on external workloads

### DIFF
--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -193,7 +193,7 @@ jobs:
         with:
           retry_on: error
           timeout_minutes: 1
-          max_attempts: 3
+          max_attempts: 10
           command: |
             gcloud compute instances create ${{ env.vmName }} \
               --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -196,7 +196,7 @@ jobs:
         with:
           retry_on: error
           timeout_minutes: 1
-          max_attempts: 3
+          max_attempts: 10
           command: |
             gcloud compute instances create ${{ env.vmName }} \
               --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \


### PR DESCRIPTION
Seems like 3 is not enough, bumping to 10 as we did on `cilium-cli` (https://github.com/cilium/cilium-cli/pull/473).