### PR TITLE
workflows: add test exceptions for failing L7 tests on EKS with IPsec

### DIFF
--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -269,7 +269,11 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test --force-deploy --flow-validation=disabled
+          cilium connectivity test --force-deploy --flow-validation=disabled \
+            --test '!client-egress-l7,!echo-ingress-l7'
+      # workaround for L7 tests issues on EKS with IPsec enabled
+      # TODO: remove both test exceptions once:
+      # - https://github.com/cilium/cilium/issues/17139 is fixed
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -272,7 +272,11 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test --force-deploy --flow-validation=disabled
+          cilium connectivity test --force-deploy --flow-validation=disabled \
+            --test '!client-egress-l7,!echo-ingress-l7'
+      # workaround for L7 tests issues on EKS with IPsec enabled
+      # TODO: remove both test exceptions once:
+      # - https://github.com/cilium/cilium/issues/17139 is fixed
 
       - name: Post-test information gathering
         if: ${{ !success() }}


### PR DESCRIPTION
CLI 0.8.6 added new L7 tests coverage, which consistently fails on EKS with IPsec enabled when it should be working.

We add test temporary exceptions until we fix the issue.

More details in #17139.