### PR TITLE
Tidy up Kubernetes watcher synchronization

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -562,7 +562,7 @@ func runServer(cmd *cobra.Command) {
 		if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 			log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 		}
-		synced.SyncCRDs(context.TODO(), synced.AllCRDResourceNames, &synced.Resources{}, &synced.APIGroups{})
+		synced.SyncCRDs(context.TODO(), synced.AllCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
 		ciliumK8sClient = k8s.CiliumClient()
 	}
 

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sconstv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -65,42 +66,32 @@ var (
 	comparableCRDSchemaVersion = versioncheck.MustVersion(k8sconstv2.CustomResourceDefinitionSchemaVersion)
 )
 
+type crdCreationFn func(clientset apiextensionsclient.Interface) error
+
 // CreateCustomResourceDefinitions creates our CRD objects in the Kubernetes
 // cluster.
 func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) error {
 	g, _ := errgroup.WithContext(context.Background())
 
-	g.Go(func() error {
-		return createCNPCRD(clientset)
-	})
-
-	g.Go(func() error {
-		return createCCNPCRD(clientset)
-	})
-
-	g.Go(func() error {
-		return createCEPCRD(clientset)
-	})
-
-	g.Go(func() error {
-		return createNodeCRD(clientset)
-	})
-
-	g.Go(func() error {
-		return createCEWCRD(clientset)
-	})
-
-	g.Go(func() error {
-		return createIdentityCRD(clientset)
-	})
-
-	g.Go(func() error {
-		return createCLRPCRD(clientset)
-	})
-
-	g.Go(func() error {
-		return createCENPCRD(clientset)
-	})
+	resourceToCreateFnMapping := map[string]crdCreationFn{
+		synced.CRDResourceName(k8sconstv2.CNPName):        createCNPCRD,
+		synced.CRDResourceName(k8sconstv2.CCNPName):       createCCNPCRD,
+		synced.CRDResourceName(k8sconstv2.CNName):         createNodeCRD,
+		synced.CRDResourceName(k8sconstv2.CIDName):        createIdentityCRD,
+		synced.CRDResourceName(k8sconstv2.CEPName):        createCEPCRD,
+		synced.CRDResourceName(k8sconstv2.CEWName):        createCEWCRD,
+		synced.CRDResourceName(k8sconstv2.CLRPName):       createCLRPCRD,
+		synced.CRDResourceName(k8sconstv2alpha1.CENPName): createCENPCRD,
+	}
+	for _, r := range synced.OperatorCRDResourceNames() {
+		fn, ok := resourceToCreateFnMapping[r]
+		if !ok {
+			log.Fatalf("Unknown resource %s. Please update pkg/k8s/apis/cilium.io/client to understand this type.", r)
+		}
+		g.Go(func() error {
+			return fn(clientset)
+		})
+	}
 
 	return g.Wait()
 }

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -63,6 +63,12 @@ func AgentCRDResourceNames() []string {
 	return agentCRDResourceNames(false)
 }
 
+// OperatorCRDResourceNames returns a list of all CRD resource names that the
+// operator may register.
+func OperatorCRDResourceNames() []string {
+	return append(agentCRDResourceNames(false), CRDResourceName(v2.CEWName))
+}
+
 // AllCRDResourceNames returns a list of all CRD resource names that the
 // clustermesh-apiserver or testsuite may register.
 func AllCRDResourceNames() []string {

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -32,28 +32,41 @@ const (
 	k8sAPIGroupCRD = "CustomResourceDefinition"
 )
 
-var (
-	// AgentCRDResourceNames is a list of all CRD resource names
-	// the Cilium agent needs to wait to be registered before
-	// initializing any k8s watchers.
-	AgentCRDResourceNames = []string{
-		crdResourceName(v2.CNPName),
-		crdResourceName(v2.CCNPName),
-		crdResourceName(v2.CEPName),
-		crdResourceName(v2.CNName),
-		crdResourceName(v2.CIDName),
-		crdResourceName(v2.CLRPName),
-		crdResourceName(v2alpha1.CENPName),
-	}
-	// AllCRDResourceNames is a list of all CRD resource names
-	// Cilium Operator is registering.
-	AllCRDResourceNames = append([]string{
-		crdResourceName(v2.CEWName),
-	}, AgentCRDResourceNames...)
-)
-
-func crdResourceName(crd string) string {
+func CRDResourceName(crd string) string {
 	return "crd:" + crd
+}
+
+func agentCRDResourceNames(override bool) []string {
+	result := []string{
+		CRDResourceName(v2.CNPName),
+		CRDResourceName(v2.CCNPName),
+		CRDResourceName(v2.CNName),
+		CRDResourceName(v2.CIDName),
+	}
+
+	if override || !option.Config.DisableCiliumEndpointCRD {
+		result = append(result, CRDResourceName(v2.CEPName))
+	}
+	if override || option.Config.EnableEgressGateway {
+		result = append(result, CRDResourceName(v2alpha1.CENPName))
+	}
+	if override || option.Config.EnableLocalRedirectPolicy {
+		result = append(result, CRDResourceName(v2.CLRPName))
+	}
+
+	return result
+}
+
+// AgentCRDResourceNames returns a list of all CRD resource names the Cilium
+// agent needs to wait to be registered before initializing any k8s watchers.
+func AgentCRDResourceNames() []string {
+	return agentCRDResourceNames(false)
+}
+
+// AllCRDResourceNames returns a list of all CRD resource names that the
+// clustermesh-apiserver or testsuite may register.
+func AllCRDResourceNames() []string {
+	return append(agentCRDResourceNames(true), CRDResourceName(v2.CEWName))
 }
 
 // SyncCRDs will sync Cilium CRDs to ensure that they have all been
@@ -154,7 +167,7 @@ func SyncCRDs(ctx context.Context, crdNames []string, rs *Resources, ag *APIGrou
 func (s *crdState) add(obj interface{}) {
 	if pom := k8s.ObjToV1PartialObjectMetadata(obj); pom != nil {
 		s.Lock()
-		s.m[crdResourceName(pom.GetName())] = true
+		s.m[CRDResourceName(pom.GetName())] = true
 		s.Unlock()
 	}
 }
@@ -162,7 +175,7 @@ func (s *crdState) add(obj interface{}) {
 func (s *crdState) remove(obj interface{}) {
 	if pom := k8s.ObjToV1PartialObjectMetadata(obj); pom != nil {
 		s.Lock()
-		s.m[crdResourceName(pom.GetName())] = false
+		s.m[CRDResourceName(pom.GetName())] = false
 		s.Unlock()
 	}
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -393,22 +393,7 @@ func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context) error {
 	k.servicesInit(k8s.WatcherClient(), swgSvcs, serviceOptModifier)
 
 	// kubernetes endpoints
-	swgEps := lock.NewStoppableWaitGroup()
-
-	// We only enable either "Endpoints" or "EndpointSlice"
-	switch {
-	case k8s.SupportsEndpointSlice():
-		// We don't add the service option modifier here, as endpointslices do not
-		// mirror service proxy name label present in the corresponding service.
-		connected := k.endpointSlicesInit(k8s.WatcherClient(), swgEps)
-		// The cluster has endpoint slices so we should not check for v1.Endpoints
-		if connected {
-			break
-		}
-		fallthrough
-	default:
-		k.endpointsInit(k8s.WatcherClient(), swgEps, serviceOptModifier)
-	}
+	k.initEndpointsOrSlices(k8s.WatcherClient(), serviceOptModifier)
 
 	// cilium network policies
 	k.ciliumNetworkPoliciesInit(ciliumNPClient)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4411,7 +4411,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"resourcequota":      "cilium-resource-quota cilium-operator-resource-quota",
 		}
 
-		crdsToDelete = synced.AllCRDResourceNames
+		crdsToDelete = synced.AllCRDResourceNames()
 	)
 
 	wg.Add(len(resourcesToDelete))


### PR DESCRIPTION
Cilium should no longer register or wait to sync k8s resources that are disabled such as LRP.

See commits for more details.