### PR TITLE
cilium: Don't report health error when disabled

### DIFF
--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -14,6 +14,7 @@ import (
 	pkg "github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/command"
 	healthPkg "github.com/cilium/cilium/pkg/health/client"
+	"github.com/cilium/cilium/pkg/health/defaults"
 
 	"github.com/spf13/cobra"
 )
@@ -95,7 +96,18 @@ func statusDaemon() {
 			os.Exit(1)
 		}
 
-		healthPkg.GetAndFormatHealthStatus(w, true, allHealth, healthLines)
+		healthEnabled := false
+		for _, c := range sr.Controllers {
+			if c.Name == defaults.HealthEPName {
+				healthEnabled = true
+				break
+			}
+		}
+		if healthEnabled {
+			healthPkg.GetAndFormatHealthStatus(w, true, allHealth, healthLines)
+		} else {
+			fmt.Fprint(w, "Cluster health:\t\tProbe disabled\n")
+		}
 		w.Flush()
 	}
 }

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/cleanup"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -50,7 +51,7 @@ func (d *Daemon) initHealth() {
 	// Wait for the API, then launch the controller
 	var client *health.Client
 
-	controller.NewManager().UpdateController("cilium-health-ep",
+	controller.NewManager().UpdateController(defaults.HealthEPName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				var err error

--- a/pkg/health/defaults/defaults.go
+++ b/pkg/health/defaults/defaults.go
@@ -16,4 +16,8 @@ const (
 
 	// HTTPPathPort is used for probing base HTTP path connectivity
 	HTTPPathPort = daemon.ClusterHealthPort
+
+	// HealthEPName is the name used for the health endpoint, which is also
+	// used by the CLI client to detect when connectivity health is enabled
+	HealthEPName = "cilium-health-ep"
 )


### PR DESCRIPTION
When the user configures --enable-health-checking=false, 'cilium status'
would previously print:

```
  $ cilium status
  ...
  Cluster health:               Warning   cilium-health daemon unreachable
```

This would occur despite the user explicitly disabling the feature. To
better reflect whether the feature is enabled or not, check in the
status response whether there is a health endpoint. If there is one,
then the feature is enabled and we can query & print its status. If
there isn't one, then the feature is disabled and we won't get a
successful response anyway, so just report back that the feature is
disabled instead:

```
  $ cilium status
  ...
  Cluster health:               Probe disabled
```