### PR TITLE
docs: Add missed build tag flags in testing docs

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -249,12 +249,12 @@ example patch that shows how this can be achieved.
                  steps {
                      parallel(
                          "Runtime":{
-    -                        sh 'cd ${TESTDIR}; ginkgo --focus="RuntimeValidated"'
-    +                        sh 'cd ${TESTDIR}; ginkgo --focus="XFoooo"'
+    -                        sh 'cd ${TESTDIR}; ginkgo --focus="RuntimeValidated" --tags=integration_tests'
+    +                        sh 'cd ${TESTDIR}; ginkgo --focus="XFoooo" --tags=integration_tests'
                          },
                          "K8s-1.9":{
-    -                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus="K8sValidated" ${FAILFAST}'
-    +                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus="K8sFooooo" ${FAILFAST}'
+    -                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus="K8sValidated" --tags=integration_tests ${FAILFAST}'
+    +                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus="K8sFooooo" --tags=integration_tests ${FAILFAST}'
                          },
                          failFast: true
                      )

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -72,7 +72,7 @@ here is an example showing what tests will be ran using Ginkgo's dryRun option:
 
 .. code-block:: shell-session
 
-    $ ginkgo --focus="Runtime" -dryRun
+    $ ginkgo --focus="Runtime" -dryRun --tags=integration_tests
     Running Suite: runtime
     ======================
     Random Seed: 1516125117
@@ -444,7 +444,7 @@ Example how to run ginkgo using ``dlv``:
 
 .. code-block:: shell-session
 
-	dlv test . -- --ginkgo.focus="Runtime" -ginkgo.v=true --cilium.provision=false
+	dlv test . --build-flags="-tags=integration_tests" -- --ginkgo.focus="Runtime" -ginkgo.v=true --cilium.provision=false
 
 Running End-To-End Tests In Other Environments via kubeconfig
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -479,7 +479,7 @@ An example invocation is
 
 .. code-block:: shell-session
 
-  CNI_INTEGRATION=eks K8S_VERSION=1.16 ginkgo --focus="K8s" -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=eks K8S_VERSION=1.16 ginkgo --focus="K8s" --tags=integration_tests -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.passCLIEnvironment=true
 
 Running in GKE
 ^^^^^^^^^^^^^^
@@ -507,7 +507,7 @@ cluster.
   export CLUSTER_ZONE=us-west2-a
   export NATIVE_CIDR="$(gcloud container clusters describe $CLUSTER_NAME --zone $CLUSTER_ZONE --format 'value(clusterIpv4Cidr)')"
 
-  CNI_INTEGRATION=gke K8S_VERSION=1.17 ginkgo --focus="K8sDemo" -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.hubble-relay-image="quay.io/cilium/hubble-relay-ci" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=gke K8S_VERSION=1.17 ginkgo --focus="K8sDemo" --tags=integration_tests -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.hubble-relay-image="quay.io/cilium/hubble-relay-ci" -cilium.passCLIEnvironment=true
 
 .. note:: The kubernetes version defaults to 1.21 but can be configured with
           versions between 1.16 and 1.21. Version should match the server
@@ -596,7 +596,7 @@ To run this you can use the following command:
 
 .. code-block:: shell-session
 
-    ginkgo -- --cilium.provision=false --cilium.SSHConfig="cat ssh-config"
+    ginkgo --tags=integration_tests -- --cilium.provision=false --cilium.SSHConfig="cat ssh-config"
 
 
 VMs for Testing


### PR DESCRIPTION
PR #16914 missed a couple of places where the integration_test build tag
needs to be set.

Signed-off-by: Tom Payne <tom@isovalent.com>
