### PR TITLE
Checks k8s metadata for pod before removing IP from ipcache

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -210,16 +210,22 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 		namedPortsChanged := false
 		for _, pair := range endpoint.Networking.Addressing {
 			if pair.IPV4 != "" {
-				portsChanged := ipcache.IPIdentityCache.Delete(pair.IPV4, source.CustomResource)
-				if portsChanged {
-					namedPortsChanged = true
+				k8sMeta := ipcache.IPIdentityCache.GetK8sMetadata(pair.IPV4)
+				if k8sMeta.Namespace == endpoint.Namespace && k8sMeta.PodName == endpoint.Name {
+					portsChanged := ipcache.IPIdentityCache.Delete(pair.IPV4, source.CustomResource)
+					if portsChanged {
+						namedPortsChanged = true
+					}
 				}
 			}
 
 			if pair.IPV6 != "" {
-				portsChanged := ipcache.IPIdentityCache.Delete(pair.IPV6, source.CustomResource)
-				if portsChanged {
-					namedPortsChanged = true
+				k8sMeta := ipcache.IPIdentityCache.GetK8sMetadata(pair.IPV6)
+				if k8sMeta.Namespace == endpoint.Namespace && k8sMeta.PodName == endpoint.Name {
+					portsChanged := ipcache.IPIdentityCache.Delete(pair.IPV6, source.CustomResource)
+					if portsChanged {
+						namedPortsChanged = true
+					}
 				}
 			}
 		}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -841,7 +841,10 @@ func (k *K8sWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 			continue
 		}
 
-		ipcache.IPIdentityCache.Delete(podIP, source.Kubernetes)
+		k8sMeta := ipcache.IPIdentityCache.GetK8sMetadata(podIP)
+		if k8sMeta.Namespace == pod.Namespace && k8sMeta.PodName == pod.Name {
+			ipcache.IPIdentityCache.Delete(podIP, source.Kubernetes)
+		}
 	}
 
 	if len(errs) != 0 {


### PR DESCRIPTION
This is to prevent removing ip cache when a Pod's IP is reused. We will
only remove ip cache entry if the k8s metadata associated with the IP is
"current", meaning tha the last time we update this entry, it is from
the same pod or CEP.

Fixes: #16565 