### PR TITLE
crd: Add categories for cilium CRDs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,8 @@ CRD_OPTIONS ?= "crd:crdVersions=v1"
 manifests: ## Generate K8s manifests e.g. CRD, RBAC etc.
 	$(eval TMPDIR := $(shell mktemp -d))
 	cd "./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen" && \
-	go run ./... $(CRD_OPTIONS) paths="$(PWD)/pkg/k8s/apis/cilium.io/v2;$(PWD)/pkg/k8s/apis/cilium.io/v2alpha1" output:crd:artifacts:config="$(TMPDIR)";
+	$(QUIET)$(GO) run ./... $(CRD_OPTIONS) paths="$(PWD)/pkg/k8s/apis/cilium.io/v2;$(PWD)/pkg/k8s/apis/cilium.io/v2alpha1" output:crd:artifacts:config="$(TMPDIR)";
+	$(QUIET)$(GO) run ./tools/crdcheck "$(TMPDIR)"
 	mv ${TMPDIR}/cilium.io_ciliumnetworkpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
 	mv ${TMPDIR}/cilium.io_ciliumclusterwidenetworkpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
 	mv ${TMPDIR}/cilium.io_ciliumendpoints.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
+    - ciliumpolicy
     kind: CiliumClusterwideNetworkPolicy
     listKind: CiliumClusterwideNetworkPolicyList
     plural: ciliumclusterwidenetworkpolicies

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
     kind: CiliumEndpoint
     listKind: CiliumEndpointList
     plural: ciliumendpoints

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumexternalworkloads.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumexternalworkloads.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
     kind: CiliumExternalWorkload
     listKind: CiliumExternalWorkloadList
     plural: ciliumexternalworkloads

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
     kind: CiliumIdentity
     listKind: CiliumIdentityList
     plural: ciliumidentities

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
+    - ciliumpolicy
     kind: CiliumLocalRedirectPolicy
     listKind: CiliumLocalRedirectPolicyList
     plural: ciliumlocalredirectpolicies

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
+    - ciliumpolicy
     kind: CiliumNetworkPolicy
     listKind: CiliumNetworkPolicyList
     plural: ciliumnetworkpolicies

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
     kind: CiliumNode
     listKind: CiliumNodeList
     plural: ciliumnodes

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumegressnatpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumegressnatpolicies.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - cilium
+    - ciliumpolicy
     kind: CiliumEgressNATPolicy
     listKind: CiliumEgressNATPolicyList
     plural: ciliumegressnatpolicies

--- a/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
@@ -17,7 +17,7 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +deepequal-gen:private-method=true
-// +kubebuilder:resource:singular="ciliumclusterwidenetworkpolicy",path="ciliumclusterwidenetworkpolicies",scope="Cluster",shortName={ccnp}
+// +kubebuilder:resource:categories={cilium,ciliumpolicy},singular="ciliumclusterwidenetworkpolicy",path="ciliumclusterwidenetworkpolicies",scope="Cluster",shortName={ccnp}
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 

--- a/pkg/k8s/apis/cilium.io/v2/cew_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cew_types.go
@@ -21,7 +21,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="ciliumexternalworkload",path="ciliumexternalworkloads",scope="Cluster",shortName={cew}
+// +kubebuilder:resource:categories={cilium},singular="ciliumexternalworkload",path="ciliumexternalworkloads",scope="Cluster",shortName={cew}
 // +kubebuilder:printcolumn:JSONPath=".status.id",name="Cilium ID",type=integer
 // +kubebuilder:printcolumn:JSONPath=".status.ip",name="IP",type=string
 // +kubebuilder:subresource:status

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -29,7 +29,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="ciliumlocalredirectpolicy",path="ciliumlocalredirectpolicies",scope="Namespaced",shortName={clrp}
+// +kubebuilder:resource:categories={cilium,ciliumpolicy},singular="ciliumlocalredirectpolicy",path="ciliumlocalredirectpolicies",scope="Namespaced",shortName={clrp}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 
 // CiliumLocalRedirectPolicy is a Kubernetes Custom Resource that contains a

--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -22,7 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +deepequal-gen:private-method=true
-// +kubebuilder:resource:singular="ciliumnetworkpolicy",path="ciliumnetworkpolicies",scope="Namespaced",shortName={cnp,ciliumnp}
+// +kubebuilder:resource:categories={cilium,ciliumpolicy},singular="ciliumnetworkpolicy",path="ciliumnetworkpolicies",scope="Namespaced",shortName={cnp,ciliumnp}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -19,7 +19,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=false
-// +kubebuilder:resource:singular="ciliumendpoint",path="ciliumendpoints",scope="Namespaced",shortName={cep,ciliumep}
+// +kubebuilder:resource:categories={cilium},singular="ciliumendpoint",path="ciliumendpoints",scope="Namespaced",shortName={cep,ciliumep}
 // +kubebuilder:printcolumn:JSONPath=".status.id",description="Cilium endpoint id",name="Endpoint ID",type=integer
 // +kubebuilder:printcolumn:JSONPath=".status.identity.id",description="Cilium identity id",name="Identity ID",type=integer
 // +kubebuilder:printcolumn:JSONPath=".status.policy.ingress.enforcing",description="Ingress enforcement in the endpoint",name="Ingress Enforcement",type=boolean
@@ -206,7 +206,7 @@ type EndpointIdentity struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="ciliumidentity",path="ciliumidentities",scope="Cluster",shortName={ciliumid}
+// +kubebuilder:resource:categories={cilium},singular="ciliumidentity",path="ciliumidentities",scope="Cluster",shortName={ciliumid}
 // +kubebuilder:printcolumn:JSONPath=".metadata.labels.io\\.kubernetes\\.pod\\.namespace",description="The namespace of the entity",name="Namespace",type=string
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",description="The age of the identity",name="Age",type=date
 // +kubebuilder:subresource:status
@@ -304,7 +304,7 @@ type CiliumEndpointList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="ciliumnode",path="ciliumnodes",scope="Cluster",shortName={cn,ciliumn}
+// +kubebuilder:resource:categories={cilium},singular="ciliumnode",path="ciliumnodes",scope="Cluster",shortName={cn,ciliumn}
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/types.go
@@ -4,14 +4,15 @@
 package v2alpha1
 
 import (
-	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="ciliumegressnatpolicy",path="ciliumegressnatpolicies",scope="Cluster"
+// +kubebuilder:resource:categories={cilium,ciliumpolicy},singular="ciliumegressnatpolicy",path="ciliumegressnatpolicies",scope="Cluster"
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",description="The age of the identity",name="Age",type=date
 // +kubebuilder:storageversion
 

--- a/tools/crdcheck/main.go
+++ b/tools/crdcheck/main.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020-2021 Authors of Cilium
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+const mandatoryCategory = "cilium"
+
+type checkCRDFunc func(*crdv1.CustomResourceDefinition) error
+
+var allChecks = []checkCRDFunc{
+	checkForCategory,
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatal(fmt.Sprintf("usage: %s <path>", os.Args[0]))
+	}
+
+	_ = crdv1.AddToScheme(scheme.Scheme)
+
+	if err := filepath.Walk(os.Args[1], func(path string, info os.FileInfo, _ error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		fileContent, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(fileContent, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		crd, ok := obj.(*crdv1.CustomResourceDefinition)
+		if !ok {
+			return nil
+		}
+
+		for _, f := range allChecks {
+			if err = f(crd); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func checkForCategory(crd *crdv1.CustomResourceDefinition) error {
+	if len(crd.Spec.Names.Categories) == 0 || !sliceContains(crd.Spec.Names.Categories, mandatoryCategory) {
+		return fmt.Errorf("category %s missing for %s", mandatoryCategory, crd.GetName())
+	}
+
+	return nil
+}
+
+func sliceContains(slice []string, item string) bool {
+	for _, a := range slice {
+		if a == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This commit is to add categories for cilium CRDs, so that users can
easily query cilium CRs with kubectl commands (e.g. kubectl get
cilium or kubectl get ciliumpolicy). Two categories (e.g. cilium and
ciliumpolicy) are added to start with.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Related slack [conversation](https://cilium.slack.com/archives/C2B917YHE/p1628855497104100)

```release-note
crd: Add categories for cilium CRDs
```
