### PR TITLE
workflows: Fix change detection of comment-triggered jobs

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -94,14 +94,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -97,14 +97,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -94,14 +94,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -97,14 +97,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -94,14 +94,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -97,14 +97,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -96,14 +96,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -99,14 +99,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -94,14 +94,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -97,14 +97,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -96,14 +96,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -99,14 +99,15 @@ jobs:
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.commits_url }} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
           curl \
              -H "Accept: application/vnd.github.v3+json" \
              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -77,13 +77,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -91,6 +84,23 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -80,13 +80,6 @@ jobs:
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:
-      - name: Retrieve pull request's base and head
-        if: ${{ github.event.issue.pull_request }}
-        id: pr
-        run: |
-          curl ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
-          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
       - name: Checkout code
@@ -94,6 +87,23 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.issue.pull_request.url }} > pr.json
+          commits_url=$(jq -r '.commits_url' pr.json)
+          curl \
+             -H "Accept: application/vnd.github.v3+json" \
+             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+             ${commits_url} > commits.json
+          pr_first_sha=$(jq -r ".[0].sha" commits.json)
+          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
+          echo "::set-output name=base::${pr_parent_sha}"
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721


### PR DESCRIPTION
Commit 98e6ea44 ("workflows: Improve the change check for issue_comment triggers") modified the change detection logic of comment-triggered jobs to use a more appropriate base commit. It used the `github.event.pull_request.commits_url` context to retrieve the list of commits. However, this context is not available to comment-triggered jobs and the jobs are therefore failing.

Instead, we need to retrieve the `commits_url` from the pull request API object, which we are already downloading.

Fixes: https://github.com/cilium/cilium/pull/16841.