### PR TITLE
workflows: Revert changes to comment-triggered workflows

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -91,18 +91,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -94,18 +94,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -91,18 +91,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -94,18 +94,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -91,18 +91,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -94,18 +94,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -93,18 +93,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -96,18 +96,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -91,18 +91,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -94,18 +94,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -93,18 +93,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -96,18 +96,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -88,18 +88,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -91,18 +91,8 @@ jobs:
         if: ${{ github.event.issue.pull_request }}
         id: pr
         run: |
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.issue.pull_request.url }} > pr.json
-          commits_url=$(jq -r '.commits_url' pr.json)
-          curl \
-             -H "Accept: application/vnd.github.v3+json" \
-             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-             ${commits_url} > commits.json
-          pr_first_sha=$(jq -r ".[0].sha" commits.json)
-          pr_parent_sha=$(git rev-parse "${pr_first_sha}^")
-          echo "::set-output name=base::${pr_parent_sha}"
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
           echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}


### PR DESCRIPTION
This commit reverts 98e6ea44 ("workflows: Improve the change check for issue_comment triggers").

That issue and its tentative fix are breaking comment-triggered workflows. In the latest version, it was failing because `git rev-parse` needs the pull request's branch to be fetched to work.