### PR TITLE
v1.9 backports 2021-08-17

### DIFF
--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -286,9 +286,9 @@ func deleteRule(r route.Rule) error {
 }
 
 // retrieveIfIndexFromMAC finds the corresponding device index (ifindex) for a
-// given MAC address. This is useful for creating rules and routes in order to
-// specify the table. When the ifindex is found, the device is brought up and
-// its MTU is set.
+// given MAC address, excluding Linux slave devices. This is useful for
+// creating rules and routes in order to specify the table. When the ifindex is
+// found, the device is brought up and its MTU is set.
 func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	var link netlink.Link
 
@@ -298,6 +298,11 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	}
 
 	for _, l := range links {
+		// Linux slave devices have the same MAC address as their master
+		// device, but we want the master device.
+		if l.Attrs().Slave != nil {
+			continue
+		}
 		if l.Attrs().HardwareAddr.String() == mac.String() {
 			if link != nil {
 				return -1, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -300,7 +301,7 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	for _, l := range links {
 		// Linux slave devices have the same MAC address as their master
 		// device, but we want the master device.
-		if l.Attrs().Slave != nil {
+		if l.Attrs().RawFlags&unix.IFF_SLAVE != 0 {
 			continue
 		}
 		if l.Attrs().HardwareAddr.String() == mac.String() {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -289,35 +289,35 @@ func deleteRule(r route.Rule) error {
 // given MAC address. This is useful for creating rules and routes in order to
 // specify the table. When the ifindex is found, the device is brought up and
 // its MTU is set.
-func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (index int, err error) {
-	var links []netlink.Link
+func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
+	var link netlink.Link
 
-	links, err = netlink.LinkList()
+	links, err := netlink.LinkList()
 	if err != nil {
-		err = fmt.Errorf("unable to list interfaces: %s", err)
-		return
+		return -1, fmt.Errorf("unable to list interfaces: %w", err)
 	}
 
-	for _, link := range links {
-		if link.Attrs().HardwareAddr.String() == mac.String() {
-			index = link.Attrs().Index
-
-			if err = netlink.LinkSetMTU(link, mtu); err != nil {
-				err = fmt.Errorf("unable to change MTU of link %s to %d: %s", link.Attrs().Name, mtu, err)
-				return
+	for _, l := range links {
+		if l.Attrs().HardwareAddr.String() == mac.String() {
+			if link != nil {
+				return -1, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)
 			}
-
-			if err = netlink.LinkSetUp(link); err != nil {
-				err = fmt.Errorf("unable to up link %s: %s", link.Attrs().Name, err)
-				return
-			}
-
-			return
+			link = l
 		}
 	}
 
-	err = fmt.Errorf("interface with MAC %s not found", mac)
-	return
+	if link == nil {
+		return -1, fmt.Errorf("interface with MAC %s not found", mac)
+	}
+
+	if err = netlink.LinkSetMTU(link, mtu); err != nil {
+		return -1, fmt.Errorf("unable to change MTU of link %s to %d: %w", link.Attrs().Name, mtu, err)
+	}
+	if err = netlink.LinkSetUp(link); err != nil {
+		return -1, fmt.Errorf("unable to up link %s: %w", link.Attrs().Name, err)
+	}
+
+	return link.Attrs().Index, nil
 }
 
 // computeTableIDFromIfaceNumber returns a computed per-ENI route table ID for the given

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -377,6 +377,10 @@ func (rpm *Manager) getAndUpsertPolicySvcConfig(config *LRPConfig) {
 	case svcFrontendSinglePort:
 		// Get service frontend with the clusterIP and the policy config (unnamed) port.
 		ip := rpm.svcCache.GetServiceFrontendIP(*config.serviceID, lb.SVCTypeClusterIP)
+		if ip == nil {
+			// The LRP will be applied when the selected service is added later.
+			return
+		}
 		config.frontendMappings[0].feAddr.IP = ip
 		rpm.updateConfigSvcFrontend(config, config.frontendMappings[0].feAddr)
 
@@ -387,6 +391,10 @@ func (rpm *Manager) getAndUpsertPolicySvcConfig(config *LRPConfig) {
 			ports[i] = mapping.fePort
 		}
 		ip := rpm.svcCache.GetServiceFrontendIP(*config.serviceID, lb.SVCTypeClusterIP)
+		if ip == nil {
+			// The LRP will be applied when the selected service is added later.
+			return
+		}
 		for _, feM := range config.frontendMappings {
 			feM.feAddr.IP = ip
 			rpm.updateConfigSvcFrontend(config, feM.feAddr)


### PR DESCRIPTION
 * #16216 -- pkg/redirectpolicy: Make code robust against incorrect policy configu… (@aditighag)
 * #17169 -- routing: Fix incorrect interface selection for egress pod routes (@pchaigno)
 * #17189 --  Fix Linux slave interface detection (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16216 17169 17189; do contrib/backporting/set-labels.py $pr done 1.9; done
```