### PR TITLE
Data Path Assignment by Desired CIDR

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -348,7 +348,12 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	var mtuConfig mtu.Configuration
-	externalIP := node.GetIPv4()
+
+	// If tunnel endpoint IP is manually set in tunnel mode, we just use it here
+	externalIP := node.GetDataPathIPv4Addr()
+	if externalIP == nil || option.Config.Tunnel == option.TunnelDisabled {
+		externalIP = node.GetIPv4()
+	}
 	if externalIP == nil {
 		externalIP = node.GetIPv6()
 	}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -745,7 +745,16 @@ func getNodeDeviceLink(ifidxByAddr map[string]int) (netlink.Link, error) {
 		return nil, fmt.Errorf("K8s Node IP is not set")
 	}
 
+	// dataPathIP was setted only when option.Config.Tunnel != option.TunnelDisabled which is
+	// exclusive from option.Config.DirectRoutingDevice, so there is no need to check whether
+	// the routing mode is DirectRouting or Tunnel
+
 	ifindex, found := ifidxByAddr[nodeIP.String()]
+	dataPathIP := node.GetDataPathIPv4Addr()
+	if dataPathIP != nil && option.Config.Tunnel != option.TunnelDisabled {
+		ifindex, found = ifidxByAddr[dataPathIP.String()]
+	}
+
 	if !found {
 		return nil, fmt.Errorf("Cannot find device with %s addr", nodeIP)
 	}

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -150,9 +150,14 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			// with the hostIP so that this traffic can be guided
 			// to a tunnel endpoint destination.
 			nodeIPv4 := node.GetIPv4()
-			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
-				copy(value.TunnelEndpoint[:], ip4)
+			// If the data path IPv4 address is manually set (only for tunnel mode),
+			// don't change value.TunnelEndpoint
+			if tunnelIP := node.GetDataPathIPv4Addr(); tunnelIP == nil {
+				if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
+					copy(value.TunnelEndpoint[:], ip4)
+				}
 			}
+
 		}
 		err := l.bpfMap.Update(&key, &value)
 		if err != nil {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -467,6 +467,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if dataPathIPv4CIDR := option.Config.GetDataPathIPv4CIDR(); dataPathIPv4CIDR != nil {
+		cDefinesMap["DATA_PATH_IPV4_CIDR"] = dataPathIPv4CIDR.String()
+	}
+
 	if option.Config.EnableBandwidthManager {
 		cDefinesMap["ENABLE_BANDWIDTH_MANAGER"] = "1"
 		cDefinesMap["THROTTLE_MAP"] = bwmap.MapName

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -921,8 +921,10 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 	var (
 		oldIP4Cidr, oldIP6Cidr *cidr.CIDR
 		oldIP4, oldIP6         net.IP
+		oldTunnelEndpointIP4   net.IP
 		newIP4                 = newNode.GetNodeIP(false)
 		newIP6                 = newNode.GetNodeIP(true)
+		newTunnelEndpointIP4   = newNode.GetNodeDataPathIPv4()
 		oldKey, newKey         uint8
 		isLocalNode            = false
 	)
@@ -932,6 +934,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		oldIP6Cidr = oldNode.IPv6AllocCIDR
 		oldIP4 = oldNode.GetNodeIP(false)
 		oldIP6 = oldNode.GetNodeIP(true)
+		oldTunnelEndpointIP4 = oldNode.GetNodeDataPathIPv4()
 		oldKey = oldNode.EncryptionKey
 	}
 
@@ -983,9 +986,31 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		// Update the tunnel mapping of the node. In case the
 		// node has changed its CIDR range, a new entry in the
 		// map is created and the old entry is removed.
-		updateTunnelMapping(oldIP4Cidr, newNode.IPv4AllocCIDR, oldIP4, newIP4, firstAddition, n.nodeConfig.EnableIPv4, oldKey, newKey)
+
+		// If the tunnel endpoint IPv4 is manually
+		// set in config, use this addr instead of the nodeIP
+		var oldTunnelIP4, newTunnelIP4 net.IP
+		log.WithField("oldTunnelEndpointIP4", oldTunnelEndpointIP4.String()).Debug("Old tunnel endpoint IPv4 address")
+		log.WithField("newTunnelEndpointIP4", newTunnelEndpointIP4.String()).Debug("New tunnel endpoint IPv4 address")
+		if oldTunnelEndpointIP4 != nil && newTunnelEndpointIP4 != nil {
+			// Use the pre-configured tunnel endpoint IPv4 address instead of the node IP as the tunnel endpoint address
+			oldTunnelIP4 = oldTunnelEndpointIP4
+			newTunnelIP4 = newTunnelEndpointIP4
+		} else if newTunnelEndpointIP4 != nil {
+			oldTunnelIP4 = oldIP4
+			newTunnelIP4 = newTunnelEndpointIP4
+		} else if oldTunnelEndpointIP4 != nil {
+			oldTunnelIP4 = oldTunnelEndpointIP4
+			newTunnelIP4 = newIP4
+		} else {
+			oldTunnelIP4 = oldIP4
+			newTunnelIP4 = newIP4
+		}
+		log.WithField("tunnelIP", newTunnelIP4.String()).Info("Set tunnel endpoint IPv4 address")
+
+		updateTunnelMapping(oldIP4Cidr, newNode.IPv4AllocCIDR, oldTunnelIP4, newTunnelIP4, firstAddition, n.nodeConfig.EnableIPv4, oldKey, newKey)
 		// Not a typo, the IPv4 host IP is used to build the IPv6 overlay
-		updateTunnelMapping(oldIP6Cidr, newNode.IPv6AllocCIDR, oldIP4, newIP4, firstAddition, n.nodeConfig.EnableIPv6, oldKey, newKey)
+		updateTunnelMapping(oldIP6Cidr, newNode.IPv6AllocCIDR, oldTunnelIP4, newTunnelIP4, firstAddition, n.nodeConfig.EnableIPv6, oldKey, newKey)
 
 		if !n.nodeConfig.UseSingleClusterRoute {
 			n.updateOrRemoveNodeRoutes([]*cidr.CIDR{oldIP4Cidr}, []*cidr.CIDR{newNode.IPv4AllocCIDR}, isLocalNode)

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -131,6 +131,14 @@ func useNodeCIDR(n *nodeTypes.Node) {
 	}
 }
 
+// Set data path IPv4 address in node
+func setNodeDataPathIPv4(n *nodeTypes.Node) {
+	if tAddr := n.GetNodeDataPathIPv4(); tAddr != nil {
+		log.Infof("Data path IPV4 prefix: %s", tAddr.String())
+		node.SetDataPathIPv4Addr(tAddr)
+	}
+}
+
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
 func Init(conf k8sconfig.Configuration) error {
@@ -222,6 +230,11 @@ func WaitForNodeInformation(ctx context.Context, nodeGetter nodeGetter) error {
 		}).Info("Received own node information from API server")
 
 		useNodeCIDR(n)
+		// Set node data path IPv4 address
+		// now only used in tunnel mode
+		if option.Config.Tunnel != option.TunnelDisabled {
+			setNodeDataPathIPv4(n)
+		}
 
 		// Note: Node IPs are derived regardless of
 		// option.Config.EnableIPv4 and

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -46,6 +46,10 @@ var (
 	// k8s Node IP (either InternalIP or ExternalIP or nil; the former is preferred)
 	k8sNodeIP net.IP
 
+	// IPv4 data path address,
+	// which is the interface IP matching the manually-set data path CIDR
+	ipv4DataPathAddress net.IP
+
 	ipsecKeyIdentity uint8
 
 	wireguardPubKey string
@@ -276,6 +280,17 @@ func GetRouterInfo() RouterInfo {
 // only in the ENI IPAM mode.
 func SetRouterInfo(info RouterInfo) {
 	routerInfo = info
+}
+
+// GetDataPathIPv4Addr return the data path IPv4 address manually selected
+func GetDataPathIPv4Addr() net.IP {
+	return ipv4DataPathAddress
+}
+
+// SetDataPathIPv4Addr sets the data path IPv4 address (now only valid in tunnel mode).
+// It must be reachable on the network.
+func SetDataPathIPv4Addr(ip net.IP) {
+	ipv4DataPathAddress = ip
 }
 
 // GetHostMasqueradeIPv4 returns the IPv4 address to be used for masquerading

--- a/pkg/node/addressing/addresstype.go
+++ b/pkg/node/addressing/addresstype.go
@@ -15,4 +15,5 @@ const (
 	NodeExternalDNS      AddressType = "ExternalDNS"
 	NodeInternalDNS      AddressType = "InternalDNS"
 	NodeCiliumInternalIP AddressType = "CiliumInternalIP"
+	NodeDataPathIP       AddressType = "DataPathIP"
 )

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -357,7 +357,11 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
 		if address.Type == addressing.NodeCiliumInternalIP || m.conf.EncryptionEnabled() ||
 			option.Config.EnableHostFirewall || option.Config.JoinCluster {
-			tunnelIP = nodeIP
+			if tunnelIP = n.GetNodeDataPathIPv4(); option.Config.Tunnel == option.TunnelDisabled || tunnelIP == nil {
+				log.Debugf("No data path IP manually defined, just use the nodeIP")
+				tunnelIP = nodeIP
+			}
+			log.Debugf("tunnelIP %s", tunnelIP.String())
 		}
 
 		if skipIPCache(address) {

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -262,6 +262,26 @@ func (n *Node) GetExternalIP(ipv6 bool) net.IP {
 	return nil
 }
 
+// Get node data path IPv4 address
+// Now only used in tunnel mode
+func (n *Node) getNodeDataPathIPv4() net.IP {
+
+	for _, addr := range n.IPAddresses {
+		switch addr.Type {
+		// Always chooses a tunnel endpoint address
+		case addressing.NodeDataPathIP:
+			return addr.IP
+		default:
+		}
+	}
+	return nil
+}
+
+func (n *Node) GetNodeDataPathIPv4() net.IP {
+	result := n.getNodeDataPathIPv4()
+	return result
+}
+
 // GetK8sNodeIPs returns k8s Node IP (either InternalIP or ExternalIP or nil;
 // the former is preferred).
 func (n *Node) GetK8sNodeIP() net.IP {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -205,6 +205,15 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 		})
 	}
 
+	// Add the data path IP address
+	log.Debug("Adding local node data path IPv4 address")
+	if node.GetDataPathIPv4Addr() != nil {
+		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeDataPathIP,
+			IP:   node.GetDataPathIPv4Addr(),
+		})
+	}
+
 	if node.GetIPv6Router() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{
 			Type: addressing.NodeCiliumInternalIP,


### PR DESCRIPTION
There's a case that the user may want to select the desired
data path for node2node communication by its own. But now
it seems Cilium can't support that.
This feature enhancement enables the user to set the desired
outgoing interface and its data path IP(v4) address by
a designated CIDR, which may be different from the default
which currently is just the node IP.
The usage of this feature is simply done by adding a declaration
in the installation ConfigMap of Cilium, e.g, by cilium-cli:

data-path-ipv4-cidr: "xxx.xxx.xxx.xxx/yyy"

This patch here just supports overlay tunnel mode now, which would
lead the data traffic and tunnel endpoint selection to the
matched interface IP address by the specified CIDR.

I think it's easy to be extended to direct routing mode in the future
with some more work here.

Signed-off-by: TrevorTaoARM <trevor.tao@arm.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
