### PR TITLE
v1.10 backports 2021-08-18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -606,7 +606,7 @@ help: Makefile ## Display help for the Makefile, from https://www.thapaliya.com/
 	$(call print_help_line,"docker-plugin-image","Build cilium-docker plugin image")
 	$(call print_help_line,"docker-hubble-relay-image","Build hubble-relay docker image")
 	$(call print_help_line,"docker-clustermesh-apiserver-image","Build docker image for Cilium clustermesh APIServer")
-	$(call print_help_line,"docker-opeartor-image","Build cilium-operator docker image")
+	$(call print_help_line,"docker-operator-image","Build cilium-operator docker image")
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -286,9 +286,9 @@ func deleteRule(r route.Rule) error {
 }
 
 // retrieveIfIndexFromMAC finds the corresponding device index (ifindex) for a
-// given MAC address. This is useful for creating rules and routes in order to
-// specify the table. When the ifindex is found, the device is brought up and
-// its MTU is set.
+// given MAC address, excluding Linux slave devices. This is useful for
+// creating rules and routes in order to specify the table. When the ifindex is
+// found, the device is brought up and its MTU is set.
 func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	var link netlink.Link
 
@@ -298,6 +298,11 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	}
 
 	for _, l := range links {
+		// Linux slave devices have the same MAC address as their master
+		// device, but we want the master device.
+		if l.Attrs().Slave != nil {
+			continue
+		}
 		if l.Attrs().HardwareAddr.String() == mac.String() {
 			if link != nil {
 				return -1, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -289,35 +289,35 @@ func deleteRule(r route.Rule) error {
 // given MAC address. This is useful for creating rules and routes in order to
 // specify the table. When the ifindex is found, the device is brought up and
 // its MTU is set.
-func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (index int, err error) {
-	var links []netlink.Link
+func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
+	var link netlink.Link
 
-	links, err = netlink.LinkList()
+	links, err := netlink.LinkList()
 	if err != nil {
-		err = fmt.Errorf("unable to list interfaces: %s", err)
-		return
+		return -1, fmt.Errorf("unable to list interfaces: %w", err)
 	}
 
-	for _, link := range links {
-		if link.Attrs().HardwareAddr.String() == mac.String() {
-			index = link.Attrs().Index
-
-			if err = netlink.LinkSetMTU(link, mtu); err != nil {
-				err = fmt.Errorf("unable to change MTU of link %s to %d: %s", link.Attrs().Name, mtu, err)
-				return
+	for _, l := range links {
+		if l.Attrs().HardwareAddr.String() == mac.String() {
+			if link != nil {
+				return -1, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)
 			}
-
-			if err = netlink.LinkSetUp(link); err != nil {
-				err = fmt.Errorf("unable to up link %s: %s", link.Attrs().Name, err)
-				return
-			}
-
-			return
+			link = l
 		}
 	}
 
-	err = fmt.Errorf("interface with MAC %s not found", mac)
-	return
+	if link == nil {
+		return -1, fmt.Errorf("interface with MAC %s not found", mac)
+	}
+
+	if err = netlink.LinkSetMTU(link, mtu); err != nil {
+		return -1, fmt.Errorf("unable to change MTU of link %s to %d: %w", link.Attrs().Name, mtu, err)
+	}
+	if err = netlink.LinkSetUp(link); err != nil {
+		return -1, fmt.Errorf("unable to up link %s: %w", link.Attrs().Name, err)
+	}
+
+	return link.Attrs().Index, nil
 }
 
 // computeTableIDFromIfaceNumber returns a computed per-ENI route table ID for the given

--- a/pkg/hubble/container/ring.go
+++ b/pkg/hubble/container/ring.go
@@ -16,7 +16,6 @@ package container
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -29,11 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
-)
-
-var (
-	// ErrInvalidRead indicates that the requested position can no longer be read.
-	ErrInvalidRead = errors.New("read position is no longer valid")
 )
 
 // Capacity is the interface that wraps Cap.
@@ -221,6 +215,21 @@ func (r *Ring) LastWrite() uint64 {
 	return atomic.LoadUint64(&r.write) - 1
 }
 
+func getLostEvent() *v1.Event {
+	now := time.Now().UTC()
+	return &v1.Event{
+		Timestamp: &timestamppb.Timestamp{
+			Seconds: now.Unix(),
+			Nanos:   int32(now.Nanosecond()),
+		},
+		Event: &flowpb.LostEvent{
+			Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+			NumEventsLost: 1,
+			Cpu:           nil,
+		},
+	}
+}
+
 // read the *v1.Event from the given read position. Returns an error if
 // the position is not valid. A position is invalid either because it has
 // already been overwritten by the writer (in which case ErrInvalidRead is
@@ -269,7 +278,7 @@ func (r *Ring) read(read uint64) (*v1.Event, error) {
 		if event == nil {
 			// If the ring buffer is not yet fully populated, we treat nil
 			// as a value which is about to be overwritten
-			return nil, ErrInvalidRead
+			return getLostEvent(), nil
 		}
 		return event, nil
 	// Case: Reader ahead of writer
@@ -277,7 +286,7 @@ func (r *Ring) read(read uint64) (*v1.Event, error) {
 		return nil, io.EOF
 	// Case: Reader behind writer
 	default:
-		return nil, ErrInvalidRead
+		return getLostEvent(), nil
 	}
 }
 
@@ -376,19 +385,8 @@ func (r *Ring) readFrom(ctx context.Context, read uint64, ch chan<- *v1.Event) {
 		default:
 			// The writer overwrote the entry before we had time to read it.
 			// Send a ListEvent to notify the read-miss.
-			now := time.Now().UTC()
 			select {
-			case ch <- &v1.Event{
-				Timestamp: &timestamppb.Timestamp{
-					Seconds: int64(now.Unix()),
-					Nanos:   int32(now.Nanosecond()),
-				},
-				Event: &flowpb.LostEvent{
-					Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
-					NumEventsLost: 1,
-					Cpu:           nil,
-				},
-			}:
+			case ch <- getLostEvent():
 				continue
 			case <-ctx.Done():
 				return

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -373,6 +373,10 @@ func (rpm *Manager) getAndUpsertPolicySvcConfig(config *LRPConfig) {
 	case svcFrontendSinglePort:
 		// Get service frontend with the clusterIP and the policy config (unnamed) port.
 		ip := rpm.svcCache.GetServiceFrontendIP(*config.serviceID, lb.SVCTypeClusterIP)
+		if ip == nil {
+			// The LRP will be applied when the selected service is added later.
+			return
+		}
 		config.frontendMappings[0].feAddr.IP = ip
 		rpm.updateConfigSvcFrontend(config, config.frontendMappings[0].feAddr)
 
@@ -383,6 +387,10 @@ func (rpm *Manager) getAndUpsertPolicySvcConfig(config *LRPConfig) {
 			ports[i] = mapping.fePort
 		}
 		ip := rpm.svcCache.GetServiceFrontendIP(*config.serviceID, lb.SVCTypeClusterIP)
+		if ip == nil {
+			// The LRP will be applied when the selected service is added later.
+			return
+		}
 		for _, feM := range config.frontendMappings {
 			feM.feAddr.IP = ip
 			rpm.updateConfigSvcFrontend(config, feM.feAddr)


### PR DESCRIPTION
* #17128 -- Makefile: fix typo in helper message (@aanm)
 * #16216 -- pkg/redirectpolicy: Make code robust against incorrect policy configu… (@aditighag)
 * #17169 -- routing: Fix incorrect interface selection for egress pod routes (@pchaigno)
 * #17064 -- datapath: panic explicitly when IP of direct-routing-device not found (@ArthurChiao)
 * #17046 -- hubble: Never fail with ErrInvalidRead (@michi-covalent)

Had to make a small amendment to db3ad2994c1caf2d8b3b82e9fbb79e399bc69d75 since 1.10 still used HostSliceToNetwork in the ipv4 case.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17128 16216 17169 17064 17046; do contrib/backporting/set-labels.py $pr done 1.10; done
```