### PR TITLE
Fix Linux slave interface detection

### DIFF
--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -289,7 +290,7 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	for _, l := range links {
 		// Linux slave devices have the same MAC address as their master
 		// device, but we want the master device.
-		if l.Attrs().Slave != nil {
+		if l.Attrs().RawFlags&unix.IFF_SLAVE != 0 {
 			continue
 		}
 		if l.Attrs().HardwareAddr.String() == mac.String() {


### PR DESCRIPTION
Using method `netlink.Slave()` doesn't always work. In particular, it doesn't work on AKS, maybe because there's no master
bond interface in that case. We should instead rely on the flags passed by Linux's netlink API.

Tested with a small [reproduction commit](https://github.com/cilium/cilium/commit/2014ba4d5afde28fb0e0233076db63214df727fa) on top of this pull request:
- Failing AKS workflow before this patch: https://github.com/cilium/cilium/actions/runs/1146904598.
- Successful AKS workflow after this patch: https://github.com/cilium/cilium/actions/runs/1146999077.

Fixes: https://github.com/cilium/cilium/pull/17169.