### PR TITLE
1.10 backport for envoy: Update to release 1.18.4

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:eb9e137d466aab551e9729c36
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:97595216784cd503cf345952a394355a50f81a13@sha256:78911a5032e092084608650624dbba5c6e70f357dc13fb6b5c855bdee40d0759 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:9b1701da9cc035a1696f3e492ee2526101262e56@sha256:c0e0586bf97e69b9c16c95eff707a264c1c00bb89371205e88f6849d12ed2de2 as cilium-envoy
 
 #
 # Hubble CLI

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:eb9e137d466aab551e9729c36
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:e83275091139101e7ff29284ef35c56f4cd6bfc3@sha256:3ae9ae3ca32eb30816c9e6a655dcb36e7ba4183c8c0c93ad58b72ad6c064aa0b as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:97595216784cd503cf345952a394355a50f81a13@sha256:78911a5032e092084608650624dbba5c6e70f357dc13fb6b5c855bdee40d0759 as cilium-envoy
 
 #
 # Hubble CLI

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1022,7 +1022,6 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 			},
 		},
 		Admin: &envoy_config_bootstrap.Admin{
-			AccessLogPath: "/dev/null",
 			Address: &envoy_config_core.Address{
 				Address: &envoy_config_core.Address_Pipe{
 					Pipe: &envoy_config_core.Pipe{Path: adminPath},


### PR DESCRIPTION
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
Cilium Envoy integration is updated to release 1.18.4.
```
