### PR TITLE
.github: set link for GH issue feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -91,7 +91,7 @@ assignees: ''
 
 
 [release blockers]: https://github.com/cilium/cilium/labels/release-blocker%2F1.X
-[backport PRs]: https://github.com/cilium/cilium/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+backports
+[backport PRs]: https://github.com/cilium/cilium/pulls?q=is%3Aopen+is%3Apr+label%3Abackport%2F1.X
 [Cilium release-notes tool]: https://github.com/cilium/release
 [Docker Hub]: https://hub.docker.com/orgs/cilium/repositories
 [Cilium charts]: https://github.com/cilium/charts


### PR DESCRIPTION
To check for backport PRs we should check the label backport/1.X.

Signed-off-by: André Martins <andre@cilium.io>