### PR TITLE
v1.10 backports 2021-08-23

### DIFF
--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -300,7 +301,7 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	for _, l := range links {
 		// Linux slave devices have the same MAC address as their master
 		// device, but we want the master device.
-		if l.Attrs().Slave != nil {
+		if l.Attrs().RawFlags&unix.IFF_SLAVE != 0 {
 			continue
 		}
 		if l.Attrs().HardwareAddr.String() == mac.String() {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -824,17 +824,14 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (he
 		if err != nil {
 			return false, err
 		}
-		// Clean up map contents
-		e.getLogger().Debug("flushing old PolicyMap")
-		e.policyDebug(nil, "runPreCompilationSteps flushing old PolicyMap")
-		err = e.policyMap.DeleteAll()
+
+		// Synchronize the in-memory realized state with BPF map entries,
+		// so that any potential discrepancy between desired and realized
+		// state would be dealt with by the following e.syncPolicyMap.
+		e.realizedPolicy.PolicyMapState, err = e.dumpPolicyMapToMapState()
 		if err != nil {
 			return false, err
 		}
-
-		// Also reset the in-memory state of the realized state as the
-		// BPF map content is guaranteed to be empty right now.
-		e.realizedPolicy.PolicyMapState = make(policy.MapState)
 		e.initPolicyMapPressureMetric()
 		e.updatePolicyMapPressureMetric()
 	}

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -324,10 +324,13 @@ func (e *Endpoint) restoreIdentity() error {
 			return ErrNotAlive
 		case <-gotInitialGlobalIdentities:
 		}
+	}
 
-		if option.Config.KVStore != "" {
-			ipcache.WaitForKVStoreSync()
-		}
+	// Wait for ipcache sync before regeneration for endpoints including
+	// the ones with fixed identity (e.g. host endpoint), this ensures that
+	// the regenerated datapath always lookups from a ready ipcache map.
+	if option.Config.KVStore != "" {
+		ipcache.WaitForKVStoreSync()
 	}
 
 	if err := e.lockAlive(); err != nil {

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -19,6 +19,7 @@ package npds
 import (
 	"context"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -38,8 +39,8 @@ func Test(t *testing.T) {
 }
 
 type ClientSuite struct {
-	acks  int
-	nacks int
+	acks  uint64
+	nacks uint64
 }
 
 var _ = Suite(&ClientSuite{})
@@ -64,10 +65,10 @@ func (cs *ClientSuite) UpsertNetworkPolicy(c *C, s *envoy.XDSServer, p *cilium.N
 	callback := func(err error) {
 		if err == nil {
 			log.Debug("ACK Callback called")
-			cs.acks++
+			atomic.AddUint64(&cs.acks, 1)
 		} else {
 			log.Debug("NACK Callback called")
-			cs.nacks++
+			atomic.AddUint64(&cs.nacks, 1)
 		}
 	}
 
@@ -105,6 +106,6 @@ func (s *ClientSuite) TestRequestAllResources(c *C) {
 	s.UpsertNetworkPolicy(c, xdsServer, resources[0])
 
 	time.Sleep(DialDelay * BackOffLimit)
-	c.Assert(s.acks, Equals, 1)
-	c.Assert(s.nacks, Equals, 0)
+	c.Assert(atomic.LoadUint64(&s.acks), Equals, uint64(1))
+	c.Assert(atomic.LoadUint64(&s.nacks), Equals, uint64(0))
 }

--- a/proxylib/test/accesslog_server.go
+++ b/proxylib/test/accesslog_server.go
@@ -111,6 +111,11 @@ func StartAccessLogServer(accessLogName string, bufSize int) *AccessLogServer {
 				log.WithError(err).Warn("Failed to accept access log connection")
 				continue
 			}
+
+			if atomic.LoadUint32(&server.closing) != 0 {
+				break
+			}
+
 			log.Debug("Accepted access log connection")
 
 			server.conns = append(server.conns, uc)

--- a/proxylib/test/accesslog_server.go
+++ b/proxylib/test/accesslog_server.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/lock"
 	cilium "github.com/cilium/proxy/go/cilium/api"
 
 	"github.com/golang/protobuf/proto"
@@ -37,6 +38,7 @@ type AccessLogServer struct {
 	Logs     chan cilium.EntryType
 	closing  uint32 // non-zero if closing, accessed atomically
 	listener *net.UnixListener
+	mu       lock.Mutex // protects conns
 	conns    []*net.UnixConn
 }
 
@@ -45,9 +47,11 @@ func (s *AccessLogServer) Close() {
 	if s != nil {
 		atomic.StoreUint32(&s.closing, 1)
 		s.listener.Close()
+		s.mu.Lock()
 		for _, conn := range s.conns {
 			conn.Close()
 		}
+		s.mu.Unlock()
 		os.Remove(s.Path)
 	}
 }
@@ -118,7 +122,9 @@ func StartAccessLogServer(accessLogName string, bufSize int) *AccessLogServer {
 
 			log.Debug("Accepted access log connection")
 
+			server.mu.Lock()
 			server.conns = append(server.conns, uc)
+			server.mu.Unlock()
 			// Serve this access log socket in a goroutine, so we can serve multiple
 			// connections concurrently.
 			go server.accessLogger(uc)


### PR DESCRIPTION
* #16298 -- proxylib/test: fix data race between StartAccessLogServer and Close (@tklauser)
 * #17115 -- policy: Fix transient policy deny during agent restart (@jaffcheng)
 * #17141 -- proxylib: Fix data races in unit tests (@gandro)
 * #17189 -- Fix Linux slave interface detection (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16298 17115 17141 17189; do contrib/backporting/set-labels.py $pr done 1.10; done
```