### PR TITLE
contrib/backporting: allow checking specific PRs

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -185,7 +185,7 @@ gitlib::github_api_token
 
 echo "Checking for backports on branch '${STABLE_BRANCH}'"
 
-stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
+stable_prs=(${stable_prs:$(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}")})
 echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 


### PR DESCRIPTION
With this change it will be possible to pass specific PRs to the
check-stable script.

For example:
```
stable_prs="17147 17217" ./contrib/backporting/check-stable v1.10
```

Signed-off-by: André Martins <andre@cilium.io>