### PR TITLE
[DO NOT MERGE] default to global.imageRegistry when defined.

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -70,7 +70,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
-| certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.5"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"image":{"pullPolicy":"Always","registry":"quay.io","repository":"cilium/certgen","tag":"v0.1.5"},"podLabels":{},"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |
 | certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |
 | cgroup | object | `{"autoMount":{"enabled":true},"hostRoot":"/run/cilium/cgroupv2"}` | Configure cgroup related configuration |
@@ -80,8 +80,8 @@ contributors across the globe, there is almost always someone available to help.
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true. WARNING: Use with care! |
 | cluster.id | int | `nil` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh. |
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh. |
-| clustermesh.apiserver.etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.4.13"}` | Clustermesh API server etcd image. |
-| clustermesh.apiserver.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver","tag":"latest","useDigest":false}` | Clustermesh API server image. |
+| clustermesh.apiserver.etcd.image | object | `{"pullPolicy":"Always","registry":"quay.io","repository":"coreos/etcd","tag":"v3.4.13"}` | Clustermesh API server etcd image. |
+| clustermesh.apiserver.image | object | `{"digest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/clustermesh-apiserver","tag":"latest","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
@@ -157,7 +157,7 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.extraConfigmapMounts | list | `[]` | Additional cilium-etcd-operator ConfigMap mounts. |
 | etcd.extraHostPathMounts | list | `[]` | Additional cilium-etcd-operator hostPath mounts. |
 | etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
-| etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7"}` | cilium-etcd-operator image. |
+| etcd.image | object | `{"digest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/cilium-etcd-operator","tag":"v2.0.7","useDigest":false}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.nodeSelector | object | `{}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | etcd.podAnnotations | object | `{}` | Annotations to be added to cilium-etcd-operator pods |
@@ -194,7 +194,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
-| hubble.relay.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay","tag":"latest","useDigest":false}` | Hubble-relay container image. |
+| hubble.relay.image | object | `{"digest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/hubble-relay","tag":"latest","useDigest":false}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -223,17 +223,17 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.ca.key | string | `""` | The CA private key (optional). If it is provided, then it will be used by hubble.tls.auto.method=cronJob to generate all other certificates. Otherwise, a ephemeral CA is generated if hubble.tls.auto.enabled=true. |
 | hubble.tls.enabled | bool | `true` | Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network. |
 | hubble.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
-| hubble.ui.backend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"latest"}` | Hubble-ui backend image. |
+| hubble.ui.backend.image | object | `{"digest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/hubble-ui-backend","tag":"latest","useDigest":false}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
-| hubble.ui.frontend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"latest"}` | Hubble-ui frontend image. |
+| hubble.ui.frontend.image | object | `{"digest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/hubble-ui","tag":"latest","useDigest":false}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
 | hubble.ui.priorityClassName | string | `""` | The priority class to use for hubble-ui |
-| hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.18.2@sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7"}` | Hubble-ui ingress proxy image. |
+| hubble.ui.proxy.image | object | `{"digest":"sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7","pullPolicy":"Always","registry":"docker.io","repository":"envoyproxy/envoy","tag":"v1.18.2","useDigest":true}` | Hubble-ui ingress proxy image. |
 | hubble.ui.proxy.resources | object | `{}` | Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment. |
 | hubble.ui.replicas | int | `1` | The number of replicas of Hubble UI to deploy. |
 | hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
@@ -242,8 +242,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd` or `kvstore`). |
-| image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Agent container image. |
-| imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
+| image | object | `{"digest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/cilium","tag":"latest","useDigest":false}` | Agent container image. |
+| imagePullSecrets | string | `nil` |  |
 | installIptablesRules | bool | `true` | Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy. |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
@@ -279,7 +279,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |
 | nodeinit.extraHostPathMounts | list | `[]` | Additional nodeinit host path mounts. |
 | nodeinit.extraInitContainers | list | `[]` | Additional nodeinit init containers. |
-| nodeinit.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
+| nodeinit.image | object | `{"pullPolicy":"Always","registry":"quay.io","repository":"cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8","useDigest":false}` | node-init image. |
 | nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
@@ -299,7 +299,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
-| operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest","useDigest":false}` | cilium-operator image. |
+| operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","digest":"","genericDigest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/operator","suffix":"","tag":"latest","useDigest":false}` | cilium-operator image. |
 | operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
@@ -325,7 +325,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.extraEnv | object | `{}` | Additional preflight environment variables. |
 | preflight.extraHostPathMounts | list | `[]` | Additional preflight host path mounts. |
 | preflight.extraInitContainers | list | `[]` | Additional preflight init containers. |
-| preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
+| preflight.image | object | `{"digest":"","pullPolicy":"Always","registry":"quay.io","repository":"cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -6,7 +6,7 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Render full image uri from given values, e.g:
+Render full image URI from given values, e.g:
 ```
 optional 
 global.imageRegistry:
@@ -18,7 +18,8 @@ image:
   digest: abcdefgh
 ```
 then `include "image.url" (list $ . .Values.image)`
-will return `quay.io/cilium/cilium:v1.10.1@abcdefgh` preferring the global.imageRegistry for all imageurls.
+will return `quay.io/cilium/cilium:v1.10.1@abcdefgh`
+preferring the `global.imageRegistry` for all `image.url`s.
 */}}
 {{- define "image.url" -}}
   {{- $globalContext := index . 0 }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -70,7 +70,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-agent
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.sleepAfterInit }}
         command:
@@ -325,7 +325,7 @@ spec:
         {{- end }}
       {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["cilium"]
         args:
@@ -352,7 +352,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: CGROUP_ROOT
@@ -381,7 +381,7 @@ spec:
       {{- end }}
       {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
       - name: wait-for-node-init
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - sh
@@ -396,7 +396,7 @@ spec:
           mountPath: {{ .Values.nodeinit.bootstrapFile }}
       {{- end }}
       - name: clean-cilium-state
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /init-container.sh

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       containers:
         - name: node-init
-          image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
+          image: {{ include "image.url" (list $ . .Values.nodeinit.image) | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-operator
-        image: {{ include "cilium.operator.image" . }}
+        image: {{ include "image.url" (list $ . .Values.operator.image) | quote }}
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         command:
         - cilium-operator-{{ include "cilium.operator.cloud" . }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -28,14 +28,14 @@ spec:
       {{- end }}
       initContainers:
         - name: clean-cilium-state
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "image.url" (list $ . .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/echo"]
           args:
           - "hello"
       containers:
         - name: cilium-pre-flight-check
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "image.url" (list $ . .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:
@@ -70,7 +70,7 @@ spec:
           {{- end }}
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "image.url" (list $ . .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
         - name: cnp-validator
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "image.url" (list $ . .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       initContainers:
       - name: etcd-init
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.clustermesh.apiserver.etcd.image) | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
@@ -69,7 +69,7 @@ spec:
           mountPath: /var/run/etcd
       containers:
       - name: etcd
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.clustermesh.apiserver.etcd.image) | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         command:
         - /usr/local/bin/etcd
@@ -98,7 +98,7 @@ spec:
         - name: etcd-data-dir
           mountPath: /var/run/etcd
       - name: apiserver
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.clustermesh.apiserver.image) | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -70,7 +70,7 @@ spec:
           value: "revision"
         - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
           value: "25000"
-        image: {{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag }}
+        image: {{ include "image.url" (list $ . .Values.etcd.image) | quote }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
         - name: hubble-relay
-          image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
+          image: {{ include "image.url" (list $ . .Values.hubble.relay.image) | quote }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       containers:
       - name: frontend
-        image: {{ include "cilium.image" .Values.hubble.ui.frontend.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.hubble.ui.frontend.image) | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
         ports:
         - name: http
@@ -58,7 +58,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
       - name: backend
-        image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.hubble.ui.backend.image) | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
         env:
         - name: EVENTS_SERVER_PORT
@@ -94,7 +94,7 @@ spec:
           readOnly: true
         {{- end }}
       - name: proxy
-        image: {{ include "cilium.image" .Values.hubble.ui.proxy.image | quote }}
+        image: {{ include "image.url" (list $ . .Values.hubble.ui.proxy.image) | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.proxy.image.pullPolicy }}
         ports:
         - name: http

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -4,6 +4,17 @@
 # For example: 1.7, 1.8, 1.9
 # upgradeCompatibility: '1.8'
 
+# global:
+# -- set a global image registry if you are mirroring images locally.
+#   imageRegistry: 
+#   - "myrepo.myorg.com:6443"
+
+
+#-- Configure image pull secrets for pulling container images
+imagePullSecrets:
+#- name: "image-pull-secret"
+
+
 debug:
   # -- Enable debug logging
   enabled: false
@@ -13,9 +24,7 @@ rbac:
   # -- Enable creation of Resource-Based Access Control configuration.
   create: true
 
-# -- Configure image pull secrets for pulling container images
-imagePullSecrets:
-# - name: "image-pull-secret"
+
 
 # kubeConfigPath: ~/.kube/config
 # k8sServiceHost:
@@ -81,7 +90,8 @@ rollOutCiliumPods: false
 
 # -- Agent container image.
 image:
-  repository: quay.io/cilium/cilium
+  registry: quay.io
+  repository: cilium/cilium
   tag: latest
   pullPolicy: Always
   # cilium-digest
@@ -538,6 +548,8 @@ hostServices:
 certgen:
   image:
     repository: quay.io/cilium/certgen
+    registry: quay.io
+    repository: cilium/certgen
     tag: v0.1.5
     pullPolicy: Always
   # -- Seconds after which the completed job pod will be deleted
@@ -647,7 +659,8 @@ hubble:
 
     # -- Hubble-relay container image.
     image:
-      repository: quay.io/cilium/hubble-relay
+      registry: quay.io
+      repository:  cilium/hubble-relay
       tag: latest
        # hubble-relay-digest
       digest: ""
@@ -746,8 +759,11 @@ hubble:
     backend:
       # -- Hubble-ui backend image.
       image:
-        repository: quay.io/cilium/hubble-ui-backend
+        registry: quay.io
+        repository: cilium/hubble-ui-backend
         tag: latest
+        digest: ""
+        useDigest: false
         pullPolicy: Always
       # [Example]
       # resources:
@@ -763,8 +779,11 @@ hubble:
     frontend:
       # -- Hubble-ui frontend image.
       image:
-        repository: quay.io/cilium/hubble-ui
+        registry: quay.io
+        repository: cilium/hubble-ui
         tag: latest
+        digest: ""
+        useDigest: false
         pullPolicy: Always
       # [Example]
       # resources:
@@ -780,8 +799,11 @@ hubble:
     proxy:
       # -- Hubble-ui ingress proxy image.
       image:
-        repository: docker.io/envoyproxy/envoy
-        tag: v1.18.2@sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7
+        registry: docker.io
+        repository: envoyproxy/envoy
+        tag: v1.18.2
+        digest: "sha256:e8b37c1d75787dd1e712ff389b0d37337dc8a174a63bed9c34ba73359dc67da7"
+        useDigest: true
         pullPolicy: Always
       # [Example]
       # resources:
@@ -1133,8 +1155,11 @@ etcd:
 
   # -- cilium-etcd-operator image.
   image:
-    repository: quay.io/cilium/cilium-etcd-operator
+    registry: quay.io
+    repository: cilium/cilium-etcd-operator
     tag: v2.0.7
+    digest: ""
+    useDigest: false
     pullPolicy: Always
 
   # -- The priority class to use for cilium-etcd-operator
@@ -1235,8 +1260,10 @@ operator:
 
   # -- cilium-operator image.
   image:
-    repository: quay.io/cilium/operator
+    registry: quay.io
+    repository: cilium/operator
     tag: latest
+    digest: ""
     # operator-generic-digest
     genericDigest: ""
     # operator-azure-digest
@@ -1376,8 +1403,10 @@ nodeinit:
 
   # -- node-init image.
   image:
-    repository: quay.io/cilium/startup-script
+    registry: quay.io
+    repository: cilium/startup-script
     tag: 62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
+    useDigest: false
     pullPolicy: Always
 
   # -- The priority class to use for the nodeinit pod.
@@ -1459,7 +1488,8 @@ preflight:
 
   # -- Cilium pre-flight image.
   image:
-    repository: quay.io/cilium/cilium
+    registry: quay.io
+    repository: cilium/cilium
     tag: latest
     # cilium-digest
     digest: ""
@@ -1571,7 +1601,8 @@ clustermesh:
   apiserver:
     # -- Clustermesh API server image.
     image:
-      repository: quay.io/cilium/clustermesh-apiserver
+      registry: quay.io
+      repository: cilium/clustermesh-apiserver
       tag: latest
       # clustermesh-apiserver-digest
       digest: ""
@@ -1581,7 +1612,8 @@ clustermesh:
     etcd:
       # -- Clustermesh API server etcd image.
       image:
-        repository: quay.io/coreos/etcd
+        registry: quay.io
+        repository: coreos/etcd
         tag: v3.4.13
         pullPolicy: Always
 


### PR DESCRIPTION
* updated all `image:` references to a consistent template call.
* reconfigured template `cilium.image` to `image.url` and made it apply
  generically to all images.
* fixed up the values for all image references to be consistent for digest handling. 

Since this change references a global variable `global.imageRegistry` this value can be inherited from parent charts.

for reference the `image.url` template assumes the following definition of an image url:
```
quay.io/cilium/cilium:latest@sha256:23423423423423423
registry is the value before the first /
repository is the remaining text until :
tag is the text before @
the last bit is the image digest. 
```

Since these are the assumptions, all images should have the following values when defined in the values file: 
```
image:
  registry: quay.io
  repository: cilium/cilium
  tag: latest
  pullPolicy: Always
  # cilium-digest
  digest: ""
  useDigest: false
```

and when we template the image url:
```
image: {{ include "image.url" (list $ . .Values.this.image) | quote }}
```
This passes to the image.url template the global scope (which would include .Values.global) and the local scope so that we can default to the local registry value if the global imageRegistry is not defined. 

Fixes: #17203
```release-note
with this change a user can optionally set global.imageRegistry and this change the registry part of the image url.
```

Signed-off-by: Duffie Cooley <dcooley@isovalent.com>