### PR TITLE
pkg/fqdn: use LRU in FQDN policy calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/go-openapi/swag v0.19.15
 	github.com/go-openapi/validate v0.20.2
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/gopacket v1.1.19
@@ -151,7 +152,6 @@ require (
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gobuffalo/flect v0.2.0 // indirect
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect


### PR DESCRIPTION
Using an LRU for the memory-intensive operations such as regex.Compile
bring some benefits as presented in the following benchmarks [1]. These
benchmarks assumed there were 2 CNPs that shared 100 FQDN
`matchPattern` on a node with 20 endpoints.

[1]
```
name                             old time/op    new time/op    delta
_perEPAllow_setPortRulesForID-8    13.9ms ± 6%     1.2ms ±63%  -91.10%  (p=0.008 n=5+5)

name                             old alloc/op   new alloc/op   delta
_perEPAllow_setPortRulesForID-8    17.4MB ± 0%     0.6MB ± 0%  -96.56%  (p=0.008 n=5+5)

name                             old allocs/op  new allocs/op  delta
_perEPAllow_setPortRulesForID-8     42.8k ± 0%      8.1k ± 0%  -81.13%  (p=0.008 n=5+5)
```

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Optimize memory consumption for clusters with high number of repeated FQDN matchPattern or matchNames
```
