### PR TITLE
daemon: Add --derive-masquerade-ip-addr-from-device opt

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -658,6 +658,10 @@ func init() {
 	flags.Bool(option.EnableBPFMasquerade, false, "Masquerade packets from endpoints leaving the host with BPF instead of iptables")
 	option.BindEnv(option.EnableBPFMasquerade)
 
+	flags.String(option.DeriveMasqIPAddrFromDevice, "", "Device name from which Cilium derives the IP addr for BPF masquerade")
+	flags.MarkHidden(option.DeriveMasqIPAddrFromDevice)
+	option.BindEnv(option.DeriveMasqIPAddrFromDevice)
+
 	flags.Bool(option.EnableIPMasqAgent, false, "Enable BPF ip-masq-agent")
 	option.BindEnv(option.EnableIPMasqAgent)
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -142,7 +142,7 @@ func InitNodePortAddrs(devices []string, inheritIPAddrFromDevice string) error {
 		if inheritIPAddrFromDevice != "" {
 			inheritedIP, err = firstGlobalV4Addr(inheritIPAddrFromDevice, GetK8sNodeIP(), !preferPublicIP)
 			if err != nil {
-				return fmt.Errorf("Failed to determine IPv4 of %s for NodePort", inheritIPAddrFromDevice)
+				return fmt.Errorf("failed to determine IPv4 of %s for NodePort", inheritIPAddrFromDevice)
 			}
 		}
 		ipv4NodePortAddrs = make(map[string]net.IP, len(devices))
@@ -152,7 +152,7 @@ func InitNodePortAddrs(devices []string, inheritIPAddrFromDevice string) error {
 			} else {
 				ip, err := firstGlobalV4Addr(device, GetK8sNodeIP(), !preferPublicIP)
 				if err != nil {
-					return fmt.Errorf("Failed to determine IPv4 of %s for NodePort", device)
+					return fmt.Errorf("failed to determine IPv4 of %s for NodePort", device)
 				}
 				ipv4NodePortAddrs[device] = ip
 			}
@@ -187,6 +187,18 @@ func InitNodePortAddrs(devices []string, inheritIPAddrFromDevice string) error {
 func InitBPFMasqueradeAddrs(devices []string) error {
 	if option.Config.EnableIPv4 {
 		ipv4MasqAddrs = make(map[string]net.IP, len(devices))
+
+		if ifaceName := option.Config.DeriveMasqIPAddrFromDevice; ifaceName != "" {
+			ip, err := firstGlobalV4Addr(ifaceName, nil, preferPublicIP)
+			if err != nil {
+				return fmt.Errorf("Failed to determine IPv4 of %s for BPF masq", ifaceName)
+			}
+			for _, device := range devices {
+				ipv4MasqAddrs[device] = ip
+			}
+			return nil
+		}
+
 		for _, device := range devices {
 			ip, err := firstGlobalV4Addr(device, nil, preferPublicIP)
 			if err != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -333,6 +333,9 @@ const (
 	// EnableBPFMasquerade masquerades packets from endpoints leaving the host with BPF instead of iptables
 	EnableBPFMasquerade = "enable-bpf-masquerade"
 
+	// DeriveMasqIPAddrFromDevice is device name which IP addr is used for BPF masquerades
+	DeriveMasqIPAddrFromDevice = "derive-masquerade-ip-addr-from-device"
+
 	// EnableIPMasqAgent enables BPF ip-masq-agent
 	EnableIPMasqAgent = "enable-ip-masq-agent"
 
@@ -1445,26 +1448,27 @@ type DaemonConfig struct {
 
 	// Masquerade specifies whether or not to masquerade packets from endpoints
 	// leaving the host.
-	EnableIPv4Masquerade   bool
-	EnableIPv6Masquerade   bool
-	EnableBPFMasquerade    bool
-	EnableBPFClockProbe    bool
-	EnableIPMasqAgent      bool
-	EnableEgressGateway    bool
-	IPMasqAgentConfigPath  string
-	InstallIptRules        bool
-	MonitorAggregation     string
-	PreAllocateMaps        bool
-	IPv6NodeAddr           string
-	IPv4NodeAddr           string
-	SidecarIstioProxyImage string
-	SocketPath             string
-	TracePayloadlen        int
-	Version                string
-	PProf                  bool
-	PProfPort              int
-	PrometheusServeAddr    string
-	ToFQDNsMinTTL          int
+	EnableIPv4Masquerade       bool
+	EnableIPv6Masquerade       bool
+	EnableBPFMasquerade        bool
+	DeriveMasqIPAddrFromDevice string
+	EnableBPFClockProbe        bool
+	EnableIPMasqAgent          bool
+	EnableEgressGateway        bool
+	IPMasqAgentConfigPath      string
+	InstallIptRules            bool
+	MonitorAggregation         string
+	PreAllocateMaps            bool
+	IPv6NodeAddr               string
+	IPv4NodeAddr               string
+	SidecarIstioProxyImage     string
+	SocketPath                 string
+	TracePayloadlen            int
+	Version                    string
+	PProf                      bool
+	PProfPort                  int
+	PrometheusServeAddr        string
+	ToFQDNsMinTTL              int
 
 	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
 	// for each FQDN selector in endpoint's restored DNS rules
@@ -2530,6 +2534,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableIPv4Masquerade = viper.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
 	c.EnableIPv6Masquerade = viper.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
 	c.EnableBPFMasquerade = viper.GetBool(EnableBPFMasquerade)
+	c.DeriveMasqIPAddrFromDevice = viper.GetString(DeriveMasqIPAddrFromDevice)
 
 	c.populateLoadBalancerSettings()
 	c.populateDevices()


### PR DESCRIPTION
The new option is used to specify a device which globally scoped IP addr
should be used for BPF-based masquerading.

This is a workaround for an environment which uses ECMP for outgoing
traffic and it has a dedicated device which IP addr should be used for
the masquerading. The workaround is relevant until
https://github.com/cilium/cilium/issues/17158 has been resolved (thus,
we hide the flag).