### PR TITLE
Support TLS certificate auto-generation using certmanager

### DIFF
--- a/Documentation/concepts/observability/hubble-configuration.rst
+++ b/Documentation/concepts/observability/hubble-configuration.rst
@@ -16,38 +16,29 @@ Cilium :ref:`gs_install` guide.
 
 .. _hubble_configure_tls_certs:
 
-Use custom TLS certificates
----------------------------
+TLS certificates
+================
 
 When Hubble Relay is deployed, Hubble listens on a TCP port on the host
 network. This allows Hubble Relay to communicate with all Hubble instances in
 the cluster. Connections between Hubble server and Hubble Relay instances are
 secured using mutual TLS (mTLS) by default.
 
-TLS certificates are automatically generated and distributed as Kubernetes
-secrets for use by Hubble and Hubble Relay provided that
-``hubble.tls.auto.enabled`` is set to ``true`` (default). This is achieved
-either via Helm when using Helm or via a Kubernetes CronJob when using
-``experimental-install.yaml``.
+TLS certificates can be provided by manually on the Helm install command (user
+provided) or generate automatically via either:
 
-.. note::
+* `helm <https://helm.sh/docs/chart_template_guide/function_list/#gensignedcert>`__
+* cilium's `certgen <https://github.com/cilium/certgen>`__ (using a Kubernetes CronJob)
+* `cert-manager <https://cert-manager.io/>`__
 
-   When using Helm, TLS certificates are (re-)generated every time Helm is used
-   for install or upgrade. As Hubble server and Hubble Relay support TLS
-   certificates hot reloading, including CA certificates, this does not disrupt
-   any existing connection. New connections are automatically established using
-   the new certificates without having to restart Hubble server or Hubble
-   Relay.
-
-Hubble allows using custom TLS certificates rather than relying on
-automatically generated ones. This can be useful when using Hubble Relay in a
-cluster mesh scenario for instance or when using certificates signed by a
-specific certificate authority (CA) is required.
+User provided certificates
+--------------------------
 
 In order to use custom TLS certificates ``hubble.tls.auto.enabled`` must
 be set to ``false`` and TLS certificates manually provided.
+This can be done by specifying the options below to Helm at install or upgrade time.
 
-This can be done by specifying the options below to Helm at install or upgrade time::
+::
 
     --set hubble.tls.auto.enabled=false                          # disable automatic TLS certificate generation
     --set-file hubble.tls.ca.cert=ca.crt.b64                     # certificate of the CA that signs all certificates
@@ -57,10 +48,13 @@ This can be done by specifying the options below to Helm at install or upgrade t
     --set-file hubble.relay.tls.client.key=relay-client.key.b64  # private key for Hubble Relay client certificate
     --set-file hubble.relay.tls.server.cert=relay-server.crt.b64 # server certificate for Hubble Relay
     --set-file hubble.relay.tls.server.key=relay-server.key.b64  # private key for Hubble Relay server certificate
+    --set-file hubble.ui.tls.client.cert=ui-client.crt.b64       # client certificate for Hubble UI
+    --set-file hubble.ui.tls.client.key=ui-client.key.b64        # private key for Hubble UI client certificate
 
-Options ``hubble.relay.tls.server.cert`` and ``hubble.relay.tls.server.key``
-only need to be provided when ``hubble.relay.tls.server.enabled`` is set to
-``true`` to enable TLS for the Hubble Relay server (defaults to ``false``).
+Options ``hubble.relay.tls.server.cert``, ``hubble.relay.tls.server.key``
+``hubble.ui.tls.client.cert`` and ``hubble.ui.tls.client.key``
+only need to be provided when ``hubble.relay.tls.server.enabled=true`` (default ``false``)
+which enable TLS for the Hubble Relay server.
 
 .. note::
 
@@ -70,3 +64,132 @@ only need to be provided when ``hubble.relay.tls.server.enabled`` is set to
    of the certificate for Hubble server MUST be set to
    ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
    cluster name defined by ``cluster.name`` (defaults to ``default``).
+
+Auto generated certificates via Helm
+------------------------------------
+
+When using Helm, TLS certificates are (re-)generated every time Helm is used
+for install or upgrade. As Hubble server and Hubble Relay support TLS
+certificates hot reloading, including CA certificates, this does not disrupt
+any existing connection. New connections are automatically established using
+the new certificates without having to restart Hubble server or Hubble
+Relay.
+
+::
+
+    --set hubble.tls.auto.enabled=true               # enable automatic TLS certificate generation
+    --set hubble.tls.auto.method=helm                # auto generate certificates using helm method
+    --set hubble.tls.auto.certValidityDuration=1095  # certificates validity duration in days (default 3 years)
+
+The downside of this method is certificates are not auto-renewed.
+So re-install is required when certificates are expired.
+
+Auto generated certificates via Kubernetes CronJob
+--------------------------------------------------
+
+Like helm method, TLS certificates are generated at installation time. And a kubernetes CronJob
+is used to schedule for certificates regeneration (regardless of their expiration date).
+
+::
+
+    --set hubble.tls.auto.enabled=true               # enable automatic TLS certificate generation
+    --set hubble.tls.auto.method=cronJob             # auto generate certificates using cronJob method
+    --set hubble.tls.auto.certValidityDuration=1095  # certificates validity duration in days (default 3 years)
+    --set hubble.tls.auto.schedule="0 0 1 */4 *"     # schedule for certificates re-generation (crontab syntax)
+
+Auto generated certificates via cert-manager
+--------------------------------------------
+
+This method rely on `cert-manager <https://cert-manager.io/>`__ to generate certificate.
+``cert-manager`` now becomes de-facto way to manage TLS on k8s, and compared to above methods,
+it has the following advantages:
+
+* No need for extra cronJob
+* Support multiple issuers: CA, Vault, Let's Encrypt, Google CAS,...
+  You can choose the issuer that fits your organization's requirements.
+* Manage certs via a CRD, which is more straightforward than inspecting the PEM file.
+* Auto-renew certificates
+
+**Installation steps**:
+
+1. First install `cert-manager <https://cert-manager.io/docs/installation/>`__ and setup `issuer <https://cert-manager.io/docs/configuration/>`_.
+   Please make sure that your issuer is be able to create certificates under the ``cilium.io`` domain name.
+2. Install/upgrade cilium with bellow configs:
+
+::
+
+    --set hubble.tls.auto.enabled=true               # enable automatic TLS certificate generation
+    --set hubble.tls.auto.method=certmanager         # auto generate certificates using cert-manager
+    --set hubble.tls.auto.certValidityDuration=1095  # certificates validity duration in days (default 3 years)
+    --set hubble.tls.auto.certManagerIssuerRef.group="cert-manager.io" # Reference to cert-manager's issuer
+    --set hubble.tls.auto.certManagerIssuerRef.kind="ClusterIssuer"
+    --set hubble.tls.auto.certManagerIssuerRef.name="ca-issuer"
+
+**Troubleshooting**:
+
+If you get the following error while install cilium (and cert-manager), it's because
+cert-manager ValidatingWebhook (which used to verify the Certificate CRD resources)
+is not available (blocked due to CNI is not available).
+
+::
+
+    Error: Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp x.x.x.x:443: connect: connection refused
+
+There are several ways to overcome above issue, such as:
+
+* Option 1: disable validation on cilium installed namespace
+
+.. code-block:: shell-session
+
+    $ # We assume cilium installed in kube-system namespace
+    $ kubectl label namespace kube-system cert-manager.io/disable-validation=true
+
+    $ helm install cert-manager ...
+    $ kubectl apply -f issuer.yaml
+    $ helm install cilium ...
+
+* Option 2: install cert-manager CRDs first
+
+.. code-block:: shell-session
+
+    $ # see https://cert-manager.io/docs/installation/helm/#option-1-installing-crds-with-kubectl
+    $ kubectl create -f cert-manager.crds.yaml
+
+    $ # cert-manager MUST be installed after cilium
+    $ helm install cilium ...
+
+    $ helm install cert-manager ...
+    $ kubectl apply -f issuer.yaml
+
+* Option 3: install cert-manager webhook with hostNetwork
+
+.. code-block:: shell-session
+
+    $ helm install cert-manager jetstack/cert-manager \
+            --set webhook.hostNetwork=true \
+            --set webhook.tolerations='["operator": "Exists"]'
+    $ kubectl apply -f issuer.yaml
+
+    $ helm install cilium ...
+
+* Option 4: upgrade cilium from disabled-TLS installation
+
+.. code-block:: shell-session
+
+    $ helm install cilium cilium/cilium \
+            --set hubble.tls.enabled=false \
+            ...
+
+    $ helm install cert-manager ...
+    $ kubectl apply -f issuer.yaml
+
+    $ # waiting for node ready, and cert-manager available
+    $ helm upgrade cilium cilium/cilium \
+            --set hubble.tls.enabled=true \
+            ...
+
+.. note::
+
+   ``issuer.yaml`` in snippet above is issuer used by cilium.
+   See `cert-manager Issuer Configuration docs <https://cert-manager.io/docs/configuration/>`__
+   to create that file.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -290,6 +290,8 @@ decapsulated
 decapsulation
 decrypt
 decrypted
+de
+facto
 deletetopic
 demux
 dereference
@@ -898,6 +900,7 @@ waitForMount
 waker
 wakeup
 walkthrough
+webhook
 webservice
 wellKnownIdentities
 whitelist

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -93,7 +93,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |
 | clustermesh.apiserver.tls.admin | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key. Used if 'auto' is not enabled. |
 | clustermesh.apiserver.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm"}` | Configure automatic TLS certificates generation. A Kubernetes CronJob is used the generate any certificates not provided by the user at installation time. |
-| clustermesh.apiserver.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when clustermesh.apiserver.tls.auto.method=certmanager |
+| clustermesh.apiserver.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when clustermesh.apiserver.tls.auto.method=certmanager. If not specified, a CA issuer will be created. |
 | clustermesh.apiserver.tls.auto.certValidityDuration | int | `1095` | Generated certificates validity duration in days. |
 | clustermesh.apiserver.tls.auto.enabled | bool | `true` | When set to true, automatically generate a CA and certificates to enable mTLS between clustermesh-apiserver and external workload instances. If set to false, the certs to be provided by setting appropriate values below. |
 | clustermesh.apiserver.tls.ca | object | `{"cert":"","key":""}` | base64 encoded PEM values for the ExternalWorkload CA certificate and private key. |
@@ -221,7 +221,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.socketPath | string | `"/var/run/cilium/hubble.sock"` | Unix domain socket path to listen to when Hubble is enabled. |
 | hubble.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"ca":{"cert":"","key":""},"enabled":true,"server":{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble |
 | hubble.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"}` | Configure automatic TLS certificates generation. |
-| hubble.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when hubble.tls.auto.method=certmanager |
+| hubble.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when hubble.tls.auto.method=certmanager. If not specified, a CA issuer will be created. |
 | hubble.tls.auto.certValidityDuration | int | `1095` | Generated certificates validity duration in days. |
 | hubble.tls.auto.enabled | bool | `true` | Auto-generate certificates. When set to true, automatically generate a CA and certificates to enable mTLS between Hubble server and Hubble Relay instances. If set to false, the certs for Hubble server need to be provided by setting appropriate values below. |
 | hubble.tls.auto.method | string | `"helm"` | Set the method to auto-generate certificates. Supported values: - helm:         This method uses Helm to generate all certificates. - cronJob:      This method uses a Kubernetes CronJob the generate any                 certificates not provided by the user at installation                 time. - certmanager:  This method use cert-manager to generate & rotate certificates. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -92,7 +92,8 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.service.nodePort | int | `32379` | Optional port to use as the node port for apiserver access. |
 | clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |
 | clustermesh.apiserver.tls.admin | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key. Used if 'auto' is not enabled. |
-| clustermesh.apiserver.tls.auto | object | `{"certValidityDuration":1095,"enabled":true,"method":"helm"}` | Configure automatic TLS certificates generation. A Kubernetes CronJob is used the generate any certificates not provided by the user at installation time. |
+| clustermesh.apiserver.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm"}` | Configure automatic TLS certificates generation. A Kubernetes CronJob is used the generate any certificates not provided by the user at installation time. |
+| clustermesh.apiserver.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when clustermesh.apiserver.tls.auto.method=certmanager |
 | clustermesh.apiserver.tls.auto.certValidityDuration | int | `1095` | Generated certificates validity duration in days. |
 | clustermesh.apiserver.tls.auto.enabled | bool | `true` | When set to true, automatically generate a CA and certificates to enable mTLS between clustermesh-apiserver and external workload instances. If set to false, the certs to be provided by setting appropriate values below. |
 | clustermesh.apiserver.tls.ca | object | `{"cert":"","key":""}` | base64 encoded PEM values for the ExternalWorkload CA certificate and private key. |
@@ -100,7 +101,9 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.tls.ca.key | string | `""` | Optional CA private key. If it is provided, it will be used by the 'cronJob' method to generate all other certificates. Otherwise, an ephemeral CA is generated. |
 | clustermesh.apiserver.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver client certificate and private key. Used if 'auto' is not enabled. |
 | clustermesh.apiserver.tls.remote | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver remote cluster certificate and private key. Used if 'auto' is not enabled. |
-| clustermesh.apiserver.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver server certificate and private key. Used if 'auto' is not enabled. |
+| clustermesh.apiserver.tls.server | object | `{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the clustermesh-apiserver server certificate and private key. Used if 'auto' is not enabled. |
+| clustermesh.apiserver.tls.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
+| clustermesh.apiserver.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
 | clustermesh.apiserver.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | clustermesh.apiserver.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | clustermesh-apiserver update strategy |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
@@ -208,22 +211,27 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
 | hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
 | hubble.relay.sortBufferLenMax | string | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
-| hubble.relay.tls | object | `{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"key":""}}` | TLS configuration for Hubble Relay |
+| hubble.relay.tls | object | `{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble Relay |
 | hubble.relay.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values for the hubble-relay client certificate and private key This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
-| hubble.relay.tls.server | object | `{"cert":"","enabled":false,"key":""}` | base64 encoded PEM values for the hubble-relay server certificate and private key |
+| hubble.relay.tls.server | object | `{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the hubble-relay server certificate and private key |
+| hubble.relay.tls.server.extraDnsNames | list | `[]` | extra DNS names added to certificate when its auto gen |
+| hubble.relay.tls.server.extraIpAddresses | list | `[]` | extra IP addresses added to certificate when its auto gen |
 | hubble.relay.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | hubble.relay.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-relay update strategy |
 | hubble.socketPath | string | `"/var/run/cilium/hubble.sock"` | Unix domain socket path to listen to when Hubble is enabled. |
-| hubble.tls | object | `{"auto":{"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"ca":{"cert":"","key":""},"enabled":true,"server":{"cert":"","key":""}}` | TLS configuration for Hubble |
-| hubble.tls.auto | object | `{"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"}` | Configure automatic TLS certificates generation. |
+| hubble.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"ca":{"cert":"","key":""},"enabled":true,"server":{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble |
+| hubble.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"}` | Configure automatic TLS certificates generation. |
+| hubble.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when hubble.tls.auto.method=certmanager |
 | hubble.tls.auto.certValidityDuration | int | `1095` | Generated certificates validity duration in days. |
 | hubble.tls.auto.enabled | bool | `true` | Auto-generate certificates. When set to true, automatically generate a CA and certificates to enable mTLS between Hubble server and Hubble Relay instances. If set to false, the certs for Hubble server need to be provided by setting appropriate values below. |
-| hubble.tls.auto.method | string | `"helm"` | Set the method to auto-generate certificates. Supported values: - helm:      This method uses Helm to generate all certificates. - cronJob:   This method uses a Kubernetes CronJob the generate any              certificates not provided by the user at installation              time. |
+| hubble.tls.auto.method | string | `"helm"` | Set the method to auto-generate certificates. Supported values: - helm:         This method uses Helm to generate all certificates. - cronJob:      This method uses a Kubernetes CronJob the generate any                 certificates not provided by the user at installation                 time. - certmanager:  This method use cert-manager to generate & rotate certificates. |
 | hubble.tls.auto.schedule | string | `"0 0 1 */4 *"` | Schedule for certificates regeneration (regardless of their expiration date). Only used if method is "cronJob". If nil, then no recurring job will be created. Instead, only the one-shot job is deployed to generate the certificates at installation time. Defaults to midnight of the first day of every fourth month. For syntax, see https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule |
 | hubble.tls.ca | object | `{"cert":"","key":""}` | base64 encoded PEM values for the Hubble CA certificate and private key. |
 | hubble.tls.ca.key | string | `""` | The CA private key (optional). If it is provided, then it will be used by hubble.tls.auto.method=cronJob to generate all other certificates. Otherwise, a ephemeral CA is generated if hubble.tls.auto.enabled=true. |
 | hubble.tls.enabled | bool | `true` | Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network. |
-| hubble.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
+| hubble.tls.server | object | `{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
+| hubble.tls.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
+| hubble.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
 | hubble.ui.backend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"latest"}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/_helpers.tpl
@@ -1,0 +1,9 @@
+{{- define "clustermesh-apiserver-generate-certs.certmanager.issuer" }}
+{{- if .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef }}
+  {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef }}
+{{- else }}
+  group: cert-manager.io
+  kind: Issuer
+  name: clustermesh-apiserver-issuer
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: clustermesh-apiserver-admin-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: clustermesh-apiserver-admin-cert
+  commonName: root
+  dnsNames:
+  - localhost
+  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: clustermesh-apiserver-admin-cert
   commonName: root
   dnsNames:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.externalWorkloads.enabled .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: clustermesh-apiserver-client-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: clustermesh-apiserver-client-cert
+  commonName: externalworkload
+  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: clustermesh-apiserver-client-cert
   commonName: externalworkload
   duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/clustermesh-apiserver-issuer.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/clustermesh-apiserver-issuer.yaml
@@ -1,0 +1,21 @@
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") (not .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef) }}
+{{- $_ := include "clustermesh-apiserver-generate-certs.helm.setup-ca" . -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clustermesh-apiserver-ca-cert
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ .cmca.Cert | b64enc }}
+  ca.key: {{ .cmca.Key  | b64enc }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: clustermesh-apiserver-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: clustermesh-apiserver-ca-cert
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: clustermesh-apiserver-remote-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: clustermesh-apiserver-remote-cert
+  commonName: remote
+  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: clustermesh-apiserver-remote-cert
   commonName: remote
   duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: clustermesh-apiserver-server-cert
   commonName: clustermesh-apiserver.cilium.io
   dnsNames:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -1,0 +1,19 @@
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: clustermesh-apiserver-server-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: clustermesh-apiserver-server-cert
+  commonName: clustermesh-apiserver.cilium.io
+  dnsNames:
+  - clustermesh-apiserver.cilium.io
+  ipAddresses:
+  - 127.0.0.1
+  - ::1
+  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -12,8 +12,15 @@ spec:
   commonName: clustermesh-apiserver.cilium.io
   dnsNames:
   - clustermesh-apiserver.cilium.io
+  - "*.mesh.cilium.io"
+  {{- range $dns := .Values.clustermesh.apiserver.tls.server.extraDnsNames }}
+  - {{ $dns | quote }}
+  {{- end }}
   ipAddresses:
-  - 127.0.0.1
-  - ::1
+  - "127.0.0.1"
+  - "::1"
+  {{- range $ip := .Values.clustermesh.apiserver.tls.server.extraIpAddresses }}
+  - {{ $ip | quote }}
+  {{- end }}
   duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -1,8 +1,8 @@
 {{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "clustermesh-apiserver-generate-certs.helm.setup-ca" . -}}
 {{- $cn := "clustermesh-apiserver.cilium.io" }}
-{{- $ip := list "127.0.0.1" "::1" }}
-{{- $dns := list $cn }}
+{{- $ip := prepend .Values.clustermesh.apiserver.tls.server.extraIpAddresses "127.0.0.1" "::1" }}
+{{- $dns := prepend .Values.clustermesh.apiserver.tls.server.extraDnsNames $cn "*.mesh.cilium.io" }}
 {{- $cert := genSignedCert $cn $ip $dns (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .cmca -}}
 ---
 apiVersion: v1

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -1,7 +1,7 @@
 {{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "clustermesh-apiserver-generate-certs.helm.setup-ca" . -}}
 {{- $cn := "clustermesh-apiserver.cilium.io" }}
-{{- $ip := list "127.0.0.1" }}
+{{- $ip := list "127.0.0.1" "::1" }}
 {{- $dns := list $cn }}
 {{- $cert := genSignedCert $cn $ip $dns (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .cmca -}}
 ---

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/_helpers.tpl
@@ -1,0 +1,9 @@
+{{- define "hubble-generate-certs.certmanager.issuer" }}
+{{- if .Values.hubble.tls.auto.certManagerIssuerRef }}
+  {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef }}
+{{- else }}
+  group: cert-manager.io
+  kind: Issuer
+  name: hubble-issuer
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/hubble-issuer.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/hubble-issuer.yaml
@@ -1,0 +1,21 @@
+{{- if and (or .Values.agent .Values.hubble.relay.enabled .Values.hubble.ui.enabled) .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") (not .Values.hubble.tls.auto.certManagerIssuerRef) }}
+{{- $_ := include "hubble-generate-certs.helm.setup-ca" . -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubble-ca-secret
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ .ca.Cert | b64enc }}
+  ca.key: {{ .ca.Key  | b64enc }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: hubble-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: hubble-ca-secret
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") .Values.hubble.relay.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hubble-relay-client-certs
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: hubble-relay-client-certs
+  commonName: *.hubble-relay.cilium.io
+  dnsNames:
+  - *.hubble-relay.cilium.io
+  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: hubble-relay-client-certs
   commonName: "*.hubble-relay.cilium.io"
   dnsNames:

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -9,8 +9,8 @@ spec:
   issuerRef:
     {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: hubble-relay-client-certs
-  commonName: *.hubble-relay.cilium.io
+  commonName: "*.hubble-relay.cilium.io"
   dnsNames:
-  - *.hubble-relay.cilium.io
-  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+  - "*.hubble-relay.cilium.io"
+  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hubble-relay-server-certs
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: hubble-relay-server-certs
+  commonName: *.hubble-relay.cilium.io
+  dnsNames:
+  - *.hubble-relay.cilium.io
+  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -9,8 +9,15 @@ spec:
   issuerRef:
     {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: hubble-relay-server-certs
-  commonName: *.hubble-relay.cilium.io
+  commonName: "*.hubble-relay.cilium.io"
   dnsNames:
-  - *.hubble-relay.cilium.io
-  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+  - "*.hubble-relay.cilium.io"
+  {{- range $dns := .Values.hubble.relay.tls.server.extraDnsNames }}
+  - {{ $dns | quote }}
+  {{- end }}
+  ipAddresses:
+  {{- range $ip := .Values.hubble.relay.tls.server.extraIpAddresses }}
+  - {{ $ip | quote }}
+  {{- end }}
+  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: hubble-relay-server-certs
   commonName: "*.hubble-relay.cilium.io"
   dnsNames:

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: hubble-server-certs
   commonName: {{ $cn | quote }}
   dnsNames:

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") }}
+{{- $cn := list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hubble-server-certs
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: hubble-server-certs
+  commonName: {{ $cn }}
+  dnsNames:
+  - $cn
+  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -10,8 +10,15 @@ spec:
   issuerRef:
     {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: hubble-server-certs
-  commonName: {{ $cn }}
+  commonName: {{ $cn | quote }}
   dnsNames:
-  - $cn
-  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+  - {{ $cn | quote }}
+  {{- range $dns := .Values.hubble.tls.server.extraDnsNames }}
+  - {{ $dns | quote }}
+  {{- end }}
+  ipAddresses:
+  {{- range $ip := .Values.hubble.tls.server.extraIpAddresses }}
+  - {{ $ip | quote }}
+  {{- end }}
+  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") .Values.hubble.ui.enabled .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hubble-ui-client-certs
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+  secretName: hubble-ui-client-certs
+  commonName: *.hubble-ui.cilium.io
+  dnsNames:
+  - *.hubble-ui.cilium.io
+  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   issuerRef:
-    {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
+    {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: hubble-ui-client-certs
   commonName: "*.hubble-ui.cilium.io"
   dnsNames:

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -9,8 +9,8 @@ spec:
   issuerRef:
     {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: hubble-ui-client-certs
-  commonName: *.hubble-ui.cilium.io
+  commonName: "*.hubble-ui.cilium.io"
   dnsNames:
-  - *.hubble-ui.cilium.io
-  duration: {{ printf "%ds" .Values.hubble.tls.auto.certValidityDuration }}
+  - "*.hubble-ui.cilium.io"
+  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "helm") .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
 {{- $_ := include "hubble-generate-certs.helm.setup-ca" . -}}
 {{- $cn := "*.hubble-relay.cilium.io" }}
-{{- $dns := list $cn }}
-{{- $cert := genSignedCert $cn nil $dns (.Values.hubble.tls.auto.certValidityDuration | int) .ca -}}
+{{- $ip := .Values.hubble.relay.tls.server.extraIpAddresses }}
+{{- $dns := prepend .Values.hubble.relay.tls.server.extraDnsNames $cn }}
+{{- $cert := genSignedCert $cn $ip $dns (.Values.hubble.tls.auto.certValidityDuration | int) .ca -}}
 ---
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "helm") }}
 {{- $_ := include "hubble-generate-certs.helm.setup-ca" . -}}
 {{- $cn := list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." }}
-{{- $dns := list $cn }}
-{{- $cert := genSignedCert $cn nil $dns (.Values.hubble.tls.auto.certValidityDuration | int) .ca -}}
+{{- $ip := .Values.hubble.tls.server.extraIpAddresses }}
+{{- $dns := prepend .Values.hubble.tls.server.extraDnsNames $cn }}
+{{- $cert := genSignedCert $cn $ip $dns (.Values.hubble.tls.auto.certValidityDuration | int) .ca -}}
 ---
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -16,3 +16,15 @@
       {{ fail "Service Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml" }}
   {{- end }}
 {{- end }}
+
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") }}
+  {{- if not .Values.hubble.tls.auto.certManagerIssuerRef }}
+    {{ fail "Hubble TLS certgen method=certmanager requires user specify .Values.hubble.tls.auto.certManagerIssuerRef" }}
+  {{- end }}  
+{{- end }}
+
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+  {{- if not .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef }}
+    {{ fail "ClusterMesh TLS certgen method=certmanager requires user specify .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef" }}
+  {{- end }}  
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -635,7 +635,8 @@ hubble:
       #   group: cert-manager.io
       #   kind: ClusterIssuer
       #   name: ca-issuer
-      # -- certmanager issuer used when hubble.tls.auto.method=certmanager
+      # -- certmanager issuer used when hubble.tls.auto.method=certmanager.
+      # If not specified, a CA issuer will be created.
       certManagerIssuerRef: {}
     # -- base64 encoded PEM values for the Hubble CA certificate and private key.
     ca:
@@ -1691,7 +1692,8 @@ clustermesh:
         #   group: cert-manager.io
         #   kind: ClusterIssuer
         #   name: ca-issuer
-        # -- certmanager issuer used when clustermesh.apiserver.tls.auto.method=certmanager
+        # -- certmanager issuer used when clustermesh.apiserver.tls.auto.method=certmanager.
+        # If not specified, a CA issuer will be created.
         certManagerIssuerRef: {}
       # -- base64 encoded PEM values for the ExternalWorkload CA certificate and private key.
       ca:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -613,10 +613,11 @@ hubble:
       # appropriate values below.
       enabled: true
       # -- Set the method to auto-generate certificates. Supported values:
-      # - helm:      This method uses Helm to generate all certificates.
-      # - cronJob:   This method uses a Kubernetes CronJob the generate any
-      #              certificates not provided by the user at installation
-      #              time.
+      # - helm:         This method uses Helm to generate all certificates.
+      # - cronJob:      This method uses a Kubernetes CronJob the generate any
+      #                 certificates not provided by the user at installation
+      #                 time.
+      # - certmanager:  This method use cert-manager to generate & rotate certificates.
       method: helm
       # -- Generated certificates validity duration in days.
       certValidityDuration: 1095
@@ -628,6 +629,14 @@ hubble:
       # Defaults to midnight of the first day of every fourth month. For syntax, see
       # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
       schedule: "0 0 1 */4 *"
+      
+      # [Example]
+      # certManagerIssuerRef:
+      #   group: cert-manager.io
+      #   kind: ClusterIssuer
+      #   name: ca-issuer
+      # -- certmanager issuer used when hubble.tls.auto.method=certmanager
+      certManagerIssuerRef: {}
     # -- base64 encoded PEM values for the Hubble CA certificate and private key.
     ca:
       cert: ""
@@ -1647,10 +1656,11 @@ clustermesh:
         # If set to false, the certs to be provided by setting appropriate values below.
         enabled: true
         # Sets the method to auto-generate certificates. Supported values:
-        # - helm:      This method uses Helm to generate all certificates.
-        # - cronJob:   This method uses a Kubernetes CronJob the generate any
-        #              certificates not provided by the user at installation
-        #              time.
+        # - helm:         This method uses Helm to generate all certificates.
+        # - cronJob:      This method uses a Kubernetes CronJob the generate any
+        #                 certificates not provided by the user at installation
+        #                 time.
+        # - certmanager:  This method use cert-manager to generate & rotate certificates.
         method: helm
         # -- Generated certificates validity duration in days.
         certValidityDuration: 1095
@@ -1667,6 +1677,14 @@ clustermesh:
         # fourth month. For syntax, see
         # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
         # schedule: "0 0 1 */4 *"
+        
+        # [Example]
+        # certManagerIssuerRef:
+        #   group: cert-manager.io
+        #   kind: ClusterIssuer
+        #   name: ca-issuer
+        # -- certmanager issuer used when clustermesh.apiserver.tls.auto.method=certmanager
+        certManagerIssuerRef: {}
       # -- base64 encoded PEM values for the ExternalWorkload CA certificate and private key.
       ca:
         # -- Optional CA cert. If it is provided, it will be used by the 'cronJob' method to

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -648,6 +648,10 @@ hubble:
     server:
       cert: ""
       key: ""
+      # -- Extra DNS names added to certificate when it's auto generated
+      extraDnsNames: []
+      # -- Extra IP addresses added to certificate when it's auto generated
+      extraIpAddresses: []
 
   relay:
     # -- Enable Hubble Relay (requires hubble.enabled=true)
@@ -718,6 +722,10 @@ hubble:
         # These values need to be set manually if hubble.tls.auto.enabled is false.
         cert: ""
         key: ""
+        # -- extra DNS names added to certificate when its auto gen
+        extraDnsNames: []
+        # -- extra IP addresses added to certificate when its auto gen
+        extraIpAddresses: []
 
     # -- Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
     dialTimeout: ~
@@ -1698,6 +1706,10 @@ clustermesh:
       server:
         cert: ""
         key: ""
+        # -- Extra DNS names added to certificate when it's auto generated
+        extraDnsNames: []
+        # -- Extra IP addresses added to certificate when it's auto generated
+        extraIpAddresses: []
       # -- base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key.
       # Used if 'auto' is not enabled.
       admin:


### PR DESCRIPTION
This is fourth part of #16792 that add support tls autogen using [cert-manager](https://cert-manager.io/)

cert-manager (under CNCF umbrella) has become de-facto way to create and manage certificates.
Compare to other methods that cilium chart currently supported, this has some advantages:
* Support multiple issuers: CA, Vault, Let's encrypt, Google CAS,...
* Auto-renew certificate when it pass 2/3 life time.
* Manage cert via a CRD resource, which show much more easier than inspect the PEM file.

