### PR TITLE
Align values.yaml with templates

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -465,10 +465,6 @@
      - Additional cilium-etcd-operator container arguments.
      - list
      - ``[]``
-   * - etcd.extraInitContainers
-     - Additional InitContainers to initialize the pod.
-     - list
-     - ``[]``
    * - etcd.image
      - cilium-etcd-operator image.
      - object
@@ -551,10 +547,6 @@
      - ``{}``
    * - extraHostPathMounts
      - Additional agent hostPath mounts.
-     - list
-     - ``[]``
-   * - extraInitContainers
-     - Additional InitContainers to initialize the pod.
      - list
      - ``[]``
    * - gke.enabled
@@ -1037,10 +1029,6 @@
      - Additional nodeinit environment variables.
      - object
      - ``{}``
-   * - nodeinit.extraInitContainers
-     - Additional nodeinit init containers.
-     - list
-     - ``[]``
    * - nodeinit.image
      - node-init image.
      - object
@@ -1099,10 +1087,6 @@
      - ``{}``
    * - operator.extraHostPathMounts
      - Additional cilium-operator hostPath mounts.
-     - list
-     - ``[]``
-   * - operator.extraInitContainers
-     - Additional InitContainers to initialize the pod.
      - list
      - ``[]``
    * - operator.identityGCInterval
@@ -1217,10 +1201,6 @@
      - Additional preflight environment variables.
      - object
      - ``{}``
-   * - preflight.extraInitContainers
-     - Additional preflight init containers.
-     - list
-     - ``[]``
    * - preflight.image
      - Cilium pre-flight image.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1100,7 +1100,7 @@
    * - nodeinit.securityContext
      - Security context to be added to nodeinit pods.
      - object
-     - ``{}``
+     - ``{"privileged":true}``
    * - nodeinit.tolerations
      - Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
      - list

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1221,10 +1221,6 @@
      - Security context to be added to cilium-operator pods
      - object
      - ``{}``
-   * - operator.serviceAccountName
-     - For using with an existing serviceAccount.
-     - string
-     - ``"cilium-operator"``
    * - operator.skipCRDCreation
      - Skip CRDs creation for cilium-operator
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -569,6 +569,10 @@
      - TCP port for the agent health API. This is not the port for cilium-health.
      - int
      - ``9876``
+   * - hostAliases
+     - Host aliases for cilium-agent.
+     - list
+     - ``[]``
    * - hostFirewall
      - Configure the host firewall.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -10,9 +10,9 @@
      - Type
      - Default
    * - affinity
-     - Pod affinity for cilium-agent.
+     - Affinity for cilium-agent.
      - object
-     - ``{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]},{"matchExpressions":[{"key":"beta.kubernetes.io/os","operator":"In","values":["linux"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"k8s-app","operator":"In","values":["cilium"]}]},"topologyKey":"kubernetes.io/hostname"}]}}``
+     - ``{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}``
    * - agent
      - Install the cilium agent resources.
      - bool
@@ -129,6 +129,10 @@
      - Name of the cluster. Only required for Cluster Mesh.
      - string
      - ``"default"``
+   * - clustermesh.apiserver.affinity
+     - Affinity for clustermesh.apiserver
+     - object
+     - ``{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}``
    * - clustermesh.apiserver.etcd.image
      - Clustermesh API server etcd image.
      - object
@@ -621,6 +625,10 @@
      - Labels to add to ServiceMonitor hubble
      - object
      - ``{}``
+   * - hubble.relay.affinity
+     - Affinity for hubble-replay
+     - object
+     - ``{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}``
    * - hubble.relay.dialTimeout
      - Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
      - string
@@ -781,6 +789,10 @@
      - Extra IP addresses added to certificate when it's auto generated
      - list
      - ``[]``
+   * - hubble.ui.affinity
+     - Affinity for hubble-ui
+     - object
+     - ``{}``
    * - hubble.ui.backend.image
      - Hubble-ui backend image.
      - object
@@ -1017,6 +1029,14 @@
      - Enable the Cilium NodePort service implementation.
      - bool
      - ``false``
+   * - nodeSelector
+     - Node selector for cilium-agent.
+     - object
+     - ``{"kubernetes.io/os":"linux"}``
+   * - nodeinit.affinity
+     - Affinity for cilium-nodeinit
+     - object
+     - ``{}``
    * - nodeinit.bootstrapFile
      - bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet
      - string
@@ -1066,9 +1086,9 @@
      - object
      - ``{"type":"RollingUpdate"}``
    * - operator.affinity
-     - cilium-operator affinity
+     - Affinity for cilium-operator
      - object
-     - ``{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"io.cilium/app","operator":"In","values":["operator"]}]},"topologyKey":"kubernetes.io/hostname"}]}}``
+     - ``{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}``
    * - operator.enabled
      - Enable the cilium-operator component (required).
      - bool
@@ -1193,6 +1213,10 @@
      - Enable Go pprof debugging
      - bool
      - ``false``
+   * - preflight.affinity
+     - Affinity for cilium-preflight
+     - object
+     - ``{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}``
    * - preflight.enabled
      - Enable Cilium pre-flight resources (required for upgrade)
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -465,10 +465,6 @@
      - Additional cilium-etcd-operator container arguments.
      - list
      - ``[]``
-   * - etcd.extraHostPathMounts
-     - Additional cilium-etcd-operator hostPath mounts.
-     - list
-     - ``[]``
    * - etcd.extraInitContainers
      - Additional InitContainers to initialize the pod.
      - list
@@ -1041,10 +1037,6 @@
      - Additional nodeinit environment variables.
      - object
      - ``{}``
-   * - nodeinit.extraHostPathMounts
-     - Additional nodeinit host path mounts.
-     - list
-     - ``[]``
    * - nodeinit.extraInitContainers
      - Additional nodeinit init containers.
      - list
@@ -1225,10 +1217,6 @@
      - Additional preflight environment variables.
      - object
      - ``{}``
-   * - preflight.extraHostPathMounts
-     - Additional preflight host path mounts.
-     - list
-     - ``[]``
    * - preflight.extraInitContainers
      - Additional preflight init containers.
      - list

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -465,10 +465,6 @@
      - Additional cilium-etcd-operator container arguments.
      - list
      - ``[]``
-   * - etcd.extraConfigmapMounts
-     - Additional cilium-etcd-operator ConfigMap mounts.
-     - list
-     - ``[]``
    * - etcd.extraHostPathMounts
      - Additional cilium-etcd-operator hostPath mounts.
      - list
@@ -553,10 +549,6 @@
      - extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap.
      - object
      - ``{}``
-   * - extraConfigmapMounts
-     - Additional agent ConfigMap mounts.
-     - list
-     - ``[]``
    * - extraEnv
      - Additional agent container environment variables.
      - object
@@ -1045,10 +1037,6 @@
      - Enable the node initialization DaemonSet
      - bool
      - ``false``
-   * - nodeinit.extraConfigmapMounts
-     - Additional nodeinit ConfigMap mounts.
-     - list
-     - ``[]``
    * - nodeinit.extraEnv
      - Additional nodeinit environment variables.
      - object
@@ -1111,10 +1099,6 @@
      - ``"5m0s"``
    * - operator.extraArgs
      - Additional cilium-operator container arguments.
-     - list
-     - ``[]``
-   * - operator.extraConfigmapMounts
-     - Additional cilium-operator ConfigMap mounts.
      - list
      - ``[]``
    * - operator.extraEnv
@@ -1237,10 +1221,6 @@
      - Enable Cilium pre-flight resources (required for upgrade)
      - bool
      - ``false``
-   * - preflight.extraConfigmapMounts
-     - Additional preflight ConfigMap mounts.
-     - list
-     - ``[]``
    * - preflight.extraEnv
      - Additional preflight environment variables.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -178,7 +178,7 @@
      - int
      - ``1``
    * - clustermesh.apiserver.resources
-     - Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as     resources:       limits:         cpu: 1000m         memory: 1024M       requests:         cpu: 100m         memory: 64Mi
+     - Resource requests and limits for the clustermesh-apiserver
      - object
      - ``{}``
    * - clustermesh.apiserver.service.annotations

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -557,6 +557,14 @@
      - Additional agent hostPath mounts.
      - list
      - ``[]``
+   * - extraVolumeMounts
+     - Additional agent volumeMounts.
+     - list
+     - ``[]``
+   * - extraVolumes
+     - Additional agent volumes.
+     - list
+     - ``[]``
    * - gke.enabled
      - Enable Google Kubernetes Engine integration
      - bool
@@ -1131,6 +1139,14 @@
      - ``[]``
    * - operator.extraHostPathMounts
      - Additional cilium-operator hostPath mounts.
+     - list
+     - ``[]``
+   * - operator.extraVolumeMounts
+     - Additional cilium-operator volumeMounts.
+     - list
+     - ``[]``
+   * - operator.extraVolumes
+     - Additional cilium-operator volumes.
      - list
      - ``[]``
    * - operator.identityGCInterval

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -137,6 +137,10 @@
      - Clustermesh API server etcd image.
      - object
      - ``{"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.4.13"}``
+   * - clustermesh.apiserver.extraEnv
+     - Additional clustermesh-apiserver environment variables.
+     - list
+     - ``[]``
    * - clustermesh.apiserver.image
      - Clustermesh API server image.
      - object
@@ -547,8 +551,8 @@
      - ``{}``
    * - extraEnv
      - Additional agent container environment variables.
-     - object
-     - ``{}``
+     - list
+     - ``[]``
    * - extraHostPathMounts
      - Additional agent hostPath mounts.
      - list
@@ -637,6 +641,10 @@
      - Enable Hubble Relay (requires hubble.enabled=true)
      - bool
      - ``false``
+   * - hubble.relay.extraEnv
+     - Additional hubble-relay environment variables.
+     - list
+     - ``[]``
    * - hubble.relay.image
      - Hubble-relay container image.
      - object
@@ -793,6 +801,10 @@
      - Affinity for hubble-ui
      - object
      - ``{}``
+   * - hubble.ui.backend.extraEnv
+     - Additional hubble-ui backend environment variables.
+     - list
+     - ``[]``
    * - hubble.ui.backend.image
      - Hubble-ui backend image.
      - object
@@ -805,6 +817,10 @@
      - Whether to enable the Hubble UI.
      - bool
      - ``false``
+   * - hubble.ui.frontend.extraEnv
+     - Additional hubble-ui frontend environment variables.
+     - list
+     - ``[]``
    * - hubble.ui.frontend.image
      - Hubble-ui frontend image.
      - object
@@ -845,6 +861,10 @@
      - The priority class to use for hubble-ui
      - string
      - ``""``
+   * - hubble.ui.proxy.extraEnv
+     - Additional hubble-ui proxy environment variables.
+     - list
+     - ``[]``
    * - hubble.ui.proxy.image
      - Hubble-ui ingress proxy image.
      - object
@@ -1047,8 +1067,8 @@
      - ``false``
    * - nodeinit.extraEnv
      - Additional nodeinit environment variables.
-     - object
-     - ``{}``
+     - list
+     - ``[]``
    * - nodeinit.image
      - node-init image.
      - object
@@ -1103,8 +1123,8 @@
      - ``[]``
    * - operator.extraEnv
      - Additional cilium-operator environment variables.
-     - object
-     - ``{}``
+     - list
+     - ``[]``
    * - operator.extraHostPathMounts
      - Additional cilium-operator hostPath mounts.
      - list
@@ -1223,8 +1243,8 @@
      - ``false``
    * - preflight.extraEnv
      - Additional preflight environment variables.
-     - object
-     - ``{}``
+     - list
+     - ``[]``
    * - preflight.image
      - Cilium pre-flight image.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -431,6 +431,7 @@ healthz
 herokuapp
 hexData
 hoc
+hostAliases
 hostConfDirMountPath
 hostFirewall
 hostNetwork

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -372,6 +372,8 @@ extraDnsNames
 extraEnv
 extraHostPathMounts
 extraIpAddresses
+extraVolumeMounts
+extraVolumes
 facto
 failureThreshold
 fallback
@@ -924,6 +926,7 @@ virtualization
 vlan
 vmlinux
 vtep
+volumeMounts
 vxlan
 waitForMount
 waker

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -368,7 +368,6 @@ externalIPs
 externalWorkloads
 extraArgs
 extraConfig
-extraConfigmapMounts
 extraDnsNames
 extraEnv
 extraHostPathMounts

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -371,7 +371,6 @@ extraConfig
 extraDnsNames
 extraEnv
 extraHostPathMounts
-extraInitContainers
 extraIpAddresses
 facto
 failureThreshold

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -85,6 +85,7 @@ contributors across the globe, there is almost always someone available to help.
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh. |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
 | clustermesh.apiserver.etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.4.13"}` | Clustermesh API server etcd image. |
+| clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver","tag":"latest","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
@@ -187,7 +188,7 @@ contributors across the globe, there is almost always someone available to help.
 | externalWorkloads.enabled | bool | `false` | Enable support for external workloads, such as VMs (false by default). |
 | extraArgs | list | `[]` | Additional agent container arguments. |
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
-| extraEnv | object | `{}` | Additional agent container environment variables. |
+| extraEnv | list | `[]` | Additional agent container environment variables. |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
@@ -210,6 +211,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
+| hubble.relay.extraEnv | list | `[]` | Additional hubble-relay environment variables. |
 | hubble.relay.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay","tag":"latest","useDigest":false}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
@@ -249,9 +251,11 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
 | hubble.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
 | hubble.ui.affinity | object | `{}` | Affinity for hubble-ui |
+| hubble.ui.backend.extraEnv | list | `[]` | Additional hubble-ui backend environment variables. |
 | hubble.ui.backend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"latest"}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
+| hubble.ui.frontend.extraEnv | list | `[]` | Additional hubble-ui frontend environment variables. |
 | hubble.ui.frontend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"latest"}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
@@ -262,6 +266,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
 | hubble.ui.priorityClassName | string | `""` | The priority class to use for hubble-ui |
+| hubble.ui.proxy.extraEnv | list | `[]` | Additional hubble-ui proxy environment variables. |
 | hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.18.4@sha256:e5c2bb2870d0e59ce917a5100311813b4ede96ce4eb0c6bfa879e3fbe3e83935"}` | Hubble-ui ingress proxy image. |
 | hubble.ui.proxy.resources | object | `{}` | Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment. |
 | hubble.ui.replicas | int | `1` | The number of replicas of Hubble UI to deploy. |
@@ -312,7 +317,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.affinity | object | `{}` | Affinity for cilium-nodeinit |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
-| nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |
+| nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
 | nodeinit.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
@@ -326,7 +331,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.enabled | bool | `true` | Enable the cilium-operator component (required). |
 | operator.endpointGCInterval | string | `"5m0s"` | Interval for endpoint garbage collection. |
 | operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
-| operator.extraEnv | object | `{}` | Additional cilium-operator environment variables. |
+| operator.extraEnv | list | `[]` | Additional cilium-operator environment variables. |
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
@@ -356,7 +361,7 @@ contributors across the globe, there is almost always someone available to help.
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
-| preflight.extraEnv | object | `{}` | Additional preflight environment variables. |
+| preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -53,7 +53,7 @@ contributors across the globe, there is almost always someone available to help.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]},{"matchExpressions":[{"key":"beta.kubernetes.io/os","operator":"In","values":["linux"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"k8s-app","operator":"In","values":["cilium"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Pod affinity for cilium-agent. |
+| affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
@@ -83,6 +83,7 @@ contributors across the globe, there is almost always someone available to help.
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true. WARNING: Use with care! |
 | cluster.id | int | `nil` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh. |
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh. |
+| clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
 | clustermesh.apiserver.etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.4.13"}` | Clustermesh API server etcd image. |
 | clustermesh.apiserver.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver","tag":"latest","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -206,6 +207,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
+| hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay","tag":"latest","useDigest":false}` | Hubble-relay container image. |
@@ -246,6 +248,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.server | object | `{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
 | hubble.tls.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
 | hubble.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
+| hubble.ui.affinity | object | `{}` | Affinity for hubble-ui |
 | hubble.ui.backend.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"latest"}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
@@ -305,6 +308,8 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.bindProtection | bool | `true` | Set to true to prevent applications binding to service ports. |
 | nodePort.enableHealthCheck | bool | `true` | Enable healthcheck nodePort server for NodePort services |
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
+| nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for cilium-agent. |
+| nodeinit.affinity | object | `{}` | Affinity for cilium-nodeinit |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |
@@ -317,7 +322,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.securityContext | object | `{}` | Security context to be added to nodeinit pods. |
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
-| operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"io.cilium/app","operator":"In","values":["operator"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | cilium-operator affinity |
+| operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |
 | operator.enabled | bool | `true` | Enable the cilium-operator component (required). |
 | operator.endpointGCInterval | string | `"5m0s"` | Interval for endpoint garbage collection. |
 | operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
@@ -349,6 +354,7 @@ contributors across the globe, there is almost always someone available to help.
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
+| preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | object | `{}` | Additional preflight environment variables. |
 | preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -190,6 +190,8 @@ contributors across the globe, there is almost always someone available to help.
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
 | extraEnv | list | `[]` | Additional agent container environment variables. |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
+| extraVolumeMounts | list | `[]` | Additional agent volumeMounts. |
+| extraVolumes | list | `[]` | Additional agent volumes. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9876` | TCP port for the agent health API. This is not the port for cilium-health. |
@@ -334,6 +336,8 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
 | operator.extraEnv | list | `[]` | Additional cilium-operator environment variables. |
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
+| operator.extraVolumeMounts | list | `[]` | Additional cilium-operator volumeMounts. |
+| operator.extraVolumes | list | `[]` | Additional cilium-operator volumes. |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest","useDigest":false}` | cilium-operator image. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -167,7 +167,6 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |
 | etcd.endpoints | list | `["https://CHANGE-ME:2379"]` | List of etcd endpoints (not needed when using managed=true). |
 | etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
-| etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7"}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.nodeSelector | object | `{}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -189,7 +188,6 @@ contributors across the globe, there is almost always someone available to help.
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
 | extraEnv | object | `{}` | Additional agent container environment variables. |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
-| extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9876` | TCP port for the agent health API. This is not the port for cilium-health. |
@@ -310,7 +308,6 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |
-| nodeinit.extraInitContainers | list | `[]` | Additional nodeinit init containers. |
 | nodeinit.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
@@ -326,7 +323,6 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
 | operator.extraEnv | object | `{}` | Additional cilium-operator environment variables. |
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
-| operator.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest","useDigest":false}` | cilium-operator image. |
@@ -355,7 +351,6 @@ contributors across the globe, there is almost always someone available to help.
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | object | `{}` | Additional preflight environment variables. |
-| preflight.extraInitContainers | list | `[]` | Additional preflight init containers. |
 | preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -167,7 +167,6 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |
 | etcd.endpoints | list | `["https://CHANGE-ME:2379"]` | List of etcd endpoints (not needed when using managed=true). |
 | etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
-| etcd.extraConfigmapMounts | list | `[]` | Additional cilium-etcd-operator ConfigMap mounts. |
 | etcd.extraHostPathMounts | list | `[]` | Additional cilium-etcd-operator hostPath mounts. |
 | etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7"}` | cilium-etcd-operator image. |
@@ -189,7 +188,6 @@ contributors across the globe, there is almost always someone available to help.
 | externalWorkloads.enabled | bool | `false` | Enable support for external workloads, such as VMs (false by default). |
 | extraArgs | list | `[]` | Additional agent container arguments. |
 | extraConfig | object | `{}` | extraConfig allows you to specify additional configuration parameters to be included in the cilium-config configmap. |
-| extraConfigmapMounts | list | `[]` | Additional agent ConfigMap mounts. |
 | extraEnv | object | `{}` | Additional agent container environment variables. |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
 | extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
@@ -312,7 +310,6 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
-| nodeinit.extraConfigmapMounts | list | `[]` | Additional nodeinit ConfigMap mounts. |
 | nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |
 | nodeinit.extraHostPathMounts | list | `[]` | Additional nodeinit host path mounts. |
 | nodeinit.extraInitContainers | list | `[]` | Additional nodeinit init containers. |
@@ -329,7 +326,6 @@ contributors across the globe, there is almost always someone available to help.
 | operator.enabled | bool | `true` | Enable the cilium-operator component (required). |
 | operator.endpointGCInterval | string | `"5m0s"` | Interval for endpoint garbage collection. |
 | operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
-| operator.extraConfigmapMounts | list | `[]` | Additional cilium-operator ConfigMap mounts. |
 | operator.extraEnv | object | `{}` | Additional cilium-operator environment variables. |
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
 | operator.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
@@ -360,7 +356,6 @@ contributors across the globe, there is almost always someone available to help.
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
-| preflight.extraConfigmapMounts | list | `[]` | Additional preflight ConfigMap mounts. |
 | preflight.extraEnv | object | `{}` | Additional preflight environment variables. |
 | preflight.extraHostPathMounts | list | `[]` | Additional preflight host path mounts. |
 | preflight.extraInitContainers | list | `[]` | Additional preflight init containers. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -167,7 +167,6 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |
 | etcd.endpoints | list | `["https://CHANGE-ME:2379"]` | List of etcd endpoints (not needed when using managed=true). |
 | etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
-| etcd.extraHostPathMounts | list | `[]` | Additional cilium-etcd-operator hostPath mounts. |
 | etcd.extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | etcd.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7"}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
@@ -311,7 +310,6 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |
-| nodeinit.extraHostPathMounts | list | `[]` | Additional nodeinit host path mounts. |
 | nodeinit.extraInitContainers | list | `[]` | Additional nodeinit init containers. |
 | nodeinit.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -357,7 +355,6 @@ contributors across the globe, there is almost always someone available to help.
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | object | `{}` | Additional preflight environment variables. |
-| preflight.extraHostPathMounts | list | `[]` | Additional preflight host path mounts. |
 | preflight.extraInitContainers | list | `[]` | Additional preflight init containers. |
 | preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -325,7 +325,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
 | nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| nodeinit.securityContext | object | `{}` | Security context to be added to nodeinit pods. |
+| nodeinit.securityContext | object | `{"privileged":true}` | Security context to be added to nodeinit pods. |
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -193,6 +193,7 @@ contributors across the globe, there is almost always someone available to help.
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9876` | TCP port for the agent health API. This is not the port for cilium-health. |
+| hostAliases | list | `[]` | Host aliases for cilium-agent. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -356,7 +356,6 @@ contributors across the globe, there is almost always someone available to help.
 | operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
-| operator.serviceAccountName | string | `"cilium-operator"` | For using with an existing serviceAccount. |
 | operator.skipCRDCreation | bool | `false` | Skip CRDs creation for cilium-operator |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -95,7 +95,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.priorityClassName | string | `""` | The priority class to use for clustermesh-apiserver |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
-| clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as     resources:       limits:         cpu: 1000m         memory: 1024M       requests:         cpu: 100m         memory: 64Mi |
+| clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
 | clustermesh.apiserver.service.nodePort | int | `32379` | Optional port to use as the node port for apiserver access. |
 | clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -334,12 +334,6 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
       {{- end }}
-      {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
-      # In managed etcd mode, Cilium must be able to resolve the DNS name of
-      # the etcd service
-      dnsPolicy: ClusterFirstWithHostNet
-      {{- end }}
-      hostNetwork: true
       initContainers:
       {{- if .Values.cgroup.autoMount.enabled }}
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
@@ -440,6 +434,16 @@ spec:
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}
       terminationGracePeriodSeconds: 1
+      hostNetwork: true
+      {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
+      # In managed etcd mode, Cilium must be able to resolve the DNS name of
+      # the etcd service
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -60,10 +60,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -444,6 +440,14 @@ spec:
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}
       terminationGracePeriodSeconds: 1
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -316,6 +316,9 @@ spec:
           mountPropagation: {{ .mountPropagation }}
           {{- end }}
         {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
         image: {{ include "cilium.image" .Values.image | quote }}
@@ -513,14 +516,6 @@ spec:
           path: {{ .Values.nodeinit.bootstrapFile }}
           type: FileOrCreate
       {{- end }}
-      {{- range .Values.extraHostPathMounts }}
-      - name: {{ .name }}
-        hostPath:
-          path: {{ .hostPath }}
-          {{- if .hostPathType }}
-          type: {{ .hostPathType }}
-          {{- end }}
-      {{- end }}
       {{- if .Values.etcd.enabled }}
         # To read the etcd config stored in config maps
       - name: etcd-config-path
@@ -592,5 +587,16 @@ spec:
                 path: server.crt
               - key: tls.key
                 path: server.key
+      {{- end }}
+      {{- range .Values.extraHostPathMounts }}
+      - name: {{ .name }}
+        hostPath:
+          path: {{ .hostPath }}
+          {{- if .hostPathType }}
+          type: {{ .hostPathType }}
+          {{- end }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -23,10 +23,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | trim | nindent 8 }}
-      {{- end }}
       hostPID: true
       hostNetwork: true
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.nodeinit.priorityClassName "system-node-critical") }}
@@ -83,4 +79,16 @@ spec:
           - name: STARTUP_SCRIPT
             value: |
               {{- tpl (.Files.Get "files/nodeinit/startup.bash") . | nindent 14 }}
+      {{- with .Values.nodeinit.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeinit.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeinit.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -82,6 +82,10 @@ spec:
           - name: STARTUP_SCRIPT
             value: |
               {{- tpl (.Files.Get "files/nodeinit/startup.bash") . | nindent 14 }}
+          {{- with .Values.nodeinit.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeinit.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       app: cilium-node-init
+  {{- with .Values.nodeinit.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -23,9 +27,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      hostPID: true
-      hostNetwork: true
-      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.nodeinit.priorityClassName "system-node-critical") }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -45,7 +46,7 @@ spec:
             - mountPath: /run/xtables.lock
               name: xtables-lock
           lifecycle:
-{{- if .Values.eni.enabled }}
+            {{- if .Values.eni.enabled }}
             postStart:
               exec:
                 command:
@@ -53,8 +54,8 @@ spec:
                   - "-c"
                   - |
                     {{- tpl (.Files.Get "files/nodeinit/poststart-eni.bash") . | nindent 20 }}
-{{- end }}
-{{- if .Values.nodeinit.revertReconfigureKubelet }}
+            {{- end }}
+            {{- if .Values.nodeinit.revertReconfigureKubelet }}
             preStop:
               exec:
                 command:
@@ -66,7 +67,7 @@ spec:
                   - -c
                   - |
                     {{- tpl (.Files.Get "files/nodeinit/prestop.bash") . | nindent 20 }}
-          {{- end }}
+            {{- end }}
           env:
           {{- with .Values.nodeinit.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}
@@ -100,4 +101,7 @@ spec:
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
+      hostPID: true
+      hostNetwork: true
+      priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.nodeinit.priorityClassName "system-node-critical") }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -40,8 +40,6 @@ spec:
         - name: node-init
           image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
-          securityContext:
-            privileged: true
           volumeMounts:
             # To access iptables concurrently with other processes (e.g. kube-proxy)
             - mountPath: /run/xtables.lock
@@ -84,6 +82,10 @@ spec:
               {{- tpl (.Files.Get "files/nodeinit/startup.bash") . | nindent 14 }}
           {{- with .Values.nodeinit.resources }}
           resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeinit.securityContext }}
+          securityContext:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeinit.affinity }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -70,6 +70,9 @@ spec:
                     {{- tpl (.Files.Get "files/nodeinit/prestop.bash") . | nindent 20 }}
           {{- end }}
           env:
+          {{- with .Values.nodeinit.extraEnv }}
+          {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
           - name: CHECKPOINT_PATH
             value: /tmp/node-init.cilium.io
           # STARTUP_SCRIPT is the script run on node bootstrap. Node

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -140,10 +140,9 @@ spec:
               name: cilium-azure
               key: AZURE_CLIENT_SECRET
         {{- end }}
-        {{- range $key, $value := .Values.operator.extraEnv }}
-        - name: {{ $key }}
-          value: {{ $value }}
-        {{- end }}        
+        {{- with .Values.operator.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.operator.prometheus.enabled }}
         ports:
         - name: prometheus

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -41,12 +41,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      # In HA mode, cilium-operator pods must not be scheduled on the same
-      # node as they will clash with each other.
-      {{- with .Values.operator.affinity }}
-      affinity:
-        {{- toYaml . | trim | nindent 8 }}
-      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -212,6 +206,12 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.operator.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.operator.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.operator.name | quote }}
+      {{- with .Values.operator.affinity }}
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -191,6 +191,9 @@ spec:
           mountPath: /var/lib/cilium/bgp
           readOnly: true
         {{- end }}
+        {{- with .Values.operator.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.operator.resources }}
         resources:
           {{- toYaml . | trim | nindent 10 }}
@@ -266,5 +269,8 @@ spec:
       - name: bgp-config-path
         configMap:
           name: bgp-config
+      {{- end }}
+      {{- with .Values.operator.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -195,6 +195,10 @@ spec:
         resources:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
+        {{- with .Values.operator.securityContext }}
+        securityContext:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
       hostNetwork: true
       {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -72,6 +72,10 @@ spec:
             readOnly: true
           {{- end }}
           {{- end }}
+          {{- with .Values.preflight.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
           image: {{ include "cilium.image" .Values.preflight.image | quote }}
@@ -121,6 +125,10 @@ spec:
           {{- end }}
           {{- with .Values.preflight.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
+          {{- with .Values.preflight.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
           {{- end }}
         {{- end }}
       hostNetwork: true

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -55,6 +55,10 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+          {{- with .Values.preflight.extraEnv }}
+          env:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: cilium-run
             mountPath: /var/run/cilium
@@ -114,6 +118,9 @@ spec:
             mountPath: /var/lib/etcd-secrets
             readOnly: true
           {{- end }}
+          {{- end }}
+          {{- with .Values.preflight.extraEnv }}
+          {{- toYaml . | trim | nindent 10 }}
           {{- end }}
         {{- end }}
       hostNetwork: true

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -128,7 +128,7 @@ spec:
       serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       terminationGracePeriodSeconds: 1
-      {{- with .Values.tolerations }}
+      {{- with .Values.preflight.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -76,6 +76,10 @@ spec:
           resources:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
+          {{- with .Values.preflight.securityContext }}
+          securityContext:
+            {{- toYaml . | trim | nindent 14 }}
+          {{- end }}
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
           image: {{ include "cilium.image" .Values.preflight.image | quote }}
@@ -129,6 +133,10 @@ spec:
           {{- with .Values.preflight.resources }}
           resources:
             {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+          {{- with .Values.preflight.securityContext }}
+          securityContext:
+            {{- toYaml . | trim | nindent 14 }}
           {{- end }}
         {{- end }}
       hostNetwork: true

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -60,6 +60,9 @@ spec:
           - name: KUBERNETES_SERVICE_PORT
             value: {{ .Values.k8sServicePort | quote }}
           {{- end }}
+          {{- with .Values.preflight.extraEnv }}
+          {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-cluster-critical") }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -22,16 +22,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "k8s-app"
-                operator: In
-                values:
-                - cilium
-            topologyKey: "kubernetes.io/hostname"
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -76,11 +66,15 @@ spec:
       serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
       terminationGracePeriodSeconds: 1
+      {{- with .Values.preflight.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.preflight.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.preflight.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -63,6 +63,10 @@ spec:
           {{- with .Values.preflight.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
+          {{- with .Values.preflight.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-cluster-critical") }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
-        - >
+        - |
           rm -rf /var/run/etcd/*;
           /usr/local/bin/etcd --data-dir=/var/run/etcd --name=clustermesh-apiserver --listen-client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster-token=clustermesh-apiserver --initial-cluster-state=new --auto-compaction-retention=1 &
           export rootpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
@@ -151,6 +151,10 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
+      {{- with .Values.clustermesh.apiserver.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.clustermesh.apiserver.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -126,6 +126,9 @@ spec:
             configMapKeyRef:
               name: cilium-config
               key: identity-allocation-mode
+        {{- with .Values.clustermesh.apiserver.extraEnv }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         {{- with .Values.clustermesh.apiserver.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -35,16 +35,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: "k8s-app"
-                  operator: In
-                  values:
-                    - cilium
-            topologyKey: "kubernetes.io/hostname"
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -91,6 +81,10 @@ spec:
       serviceAccountName: {{ .Values.serviceAccounts.relay.name | quote }}
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 0
+      {{- with .Values.hubble.relay.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.hubble.relay.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -59,6 +59,10 @@ spec:
           livenessProbe:
             tcpSocket:
               port: grpc
+          {{- with .Values.hubble.relay.extraEnv }}
+          env:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
           {{- with .Values.hubble.relay.resources }}
           resources:
             {{- toYaml . | trim | nindent 12 }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -34,14 +34,6 @@ spec:
       priorityClassName: {{ .Values.hubble.ui.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.ui.name | quote }}
-      {{- with .Values.hubble.ui.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | trim | nindent 8 }}
-      {{- end }}
-      {{- with .Values.hubble.ui.tolerations }}
-      tolerations:
-        {{- toYaml . | trim | nindent 8 }}
-      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -113,6 +105,18 @@ spec:
         - name: hubble-ui-envoy-yaml
           mountPath: /etc/envoy.yaml
           subPath: envoy.yaml
+      {{- with .Values.hubble.ui.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hubble.ui.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hubble.ui.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       volumes:
       - name: hubble-ui-envoy-yaml
         configMap:

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -45,6 +45,10 @@ spec:
         ports:
         - name: http
           containerPort: 8080
+        {{- with .Values.hubble.ui.frontend.extraEnv }}
+        env:
+          {{- toYaml . | trim | nindent 12 }}
+        {{- end }}
         {{- with .Values.hubble.ui.frontend.resources }}
         resources:
           {{- toYaml . | trim | nindent 10 }}
@@ -72,6 +76,9 @@ spec:
         - name: FLOWS_API_ADDR
           value: "hubble-relay:80"
         {{- end }}
+        {{- with .Values.hubble.ui.backend.extraEnv }}
+        {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
         ports:
         - name: grpc
           containerPort: 8090
@@ -88,19 +95,23 @@ spec:
       - name: proxy
         image: {{ include "cilium.image" .Values.hubble.ui.proxy.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.proxy.image.pullPolicy }}
-        ports:
-        - name: http
-          containerPort: 8081
-        {{- with .Values.hubble.ui.proxy.resources }}
-        resources:
-          {{- toYaml . | trim | nindent 10 }}
-        {{- end }}
         command: [envoy]
         args:
         - -c
         - /etc/envoy.yaml
         - -l
         - info
+        ports:
+        - name: http
+          containerPort: 8081
+        {{- with .Values.hubble.ui.proxy.extraEnv }}
+        env:
+          {{- toYaml . | trim | nindent 12 }}
+        {{- end }}
+        {{- with .Values.hubble.ui.proxy.resources }}
+        resources:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: hubble-ui-envoy-yaml
           mountPath: /etc/envoy.yaml

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -123,9 +123,6 @@ extraArgs: []
 # -- Additional agent container environment variables.
 extraEnv: {}
 
-# -- Additional InitContainers to initialize the pod.
-extraInitContainers: []
-
 # -- Additional agent hostPath mounts.
 extraHostPathMounts: []
   # - name: host-mnt-data
@@ -1289,9 +1286,6 @@ etcd:
   # -- Additional cilium-etcd-operator container arguments.
   extraArgs: []
 
-  # -- Additional InitContainers to initialize the pod.
-  extraInitContainers: []
-
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1417,9 +1411,6 @@ operator:
   # -- Additional cilium-operator environment variables.
   extraEnv: {}
 
-  # -- Additional InitContainers to initialize the pod.
-  extraInitContainers: []
-
   # -- Additional cilium-operator hostPath mounts.
   extraHostPathMounts: []
     # - name: host-mnt-data
@@ -1520,9 +1511,6 @@ nodeinit:
   # -- Additional nodeinit environment variables.
   extraEnv: {}
 
-  # -- Additional nodeinit init containers.
-  extraInitContainers: []
-
   # -- Node tolerations for nodeinit scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1579,9 +1567,6 @@ preflight:
 
   # -- Additional preflight environment variables.
   extraEnv: {}
-
-  # -- Additional preflight init containers.
-  extraInitContainers: []
 
   # -- Node tolerations for preflight scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1292,14 +1292,6 @@ etcd:
   # -- Additional InitContainers to initialize the pod.
   extraInitContainers: []
 
-  # -- Additional cilium-etcd-operator hostPath mounts.
-  extraHostPathMounts: []
-    # - name: textfile-dir
-    #   mountPath: /srv/txt_collector
-    #   hostPath: /var/lib/cilium-etcd-operator
-    #   readOnly: true
-    #   mountPropagation: HostToContainer
-
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1531,14 +1523,6 @@ nodeinit:
   # -- Additional nodeinit init containers.
   extraInitContainers: []
 
-  # -- Additional nodeinit host path mounts.
-  extraHostPathMounts: []
-    # - name: textfile-dir
-    #   mountPath: /srv/txt_collector
-    #   hostPath: /var/lib/nodeinit
-    #   readOnly: true
-    #   mountPropagation: HostToContainer
-
   # -- Node tolerations for nodeinit scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1598,14 +1582,6 @@ preflight:
 
   # -- Additional preflight init containers.
   extraInitContainers: []
-
-  # -- Additional preflight host path mounts.
-  extraHostPathMounts: []
-    # - name: textfile-dir
-    #   mountPath: /srv/txt_collector
-    #   hostPath: /var/lib/preflight
-    #   readOnly: true
-    #   mountPropagation: HostToContainer
 
   # -- Node tolerations for preflight scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -135,13 +135,6 @@ extraHostPathMounts: []
   #   readOnly: true
   #   mountPropagation: HostToContainer
 
-# -- Additional agent ConfigMap mounts.
-extraConfigmapMounts: []
-  # - name: certs-configmap
-  #   mountPath: /certs
-  #   configMap: certs-configmap
-  #   readOnly: true
-
 # -- extraConfig allows you to specify additional configuration parameters to be
 # included in the cilium-config configmap.
 extraConfig: {}
@@ -1307,13 +1300,6 @@ etcd:
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
-  # -- Additional cilium-etcd-operator ConfigMap mounts.
-  extraConfigmapMounts: []
-    # - name: certs-configmap
-    #   mountPath: /certs
-    #   configMap: certs-configmap
-    #   readOnly: true
-
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1451,13 +1437,6 @@ operator:
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
-  # -- Additional cilium-operator ConfigMap mounts.
-  extraConfigmapMounts: []
-    # - name: certs-configmap
-    #   mountPath: /certs
-    #   configMap: certs-configmap
-    #   readOnly: true
-
   # -- Node tolerations for cilium-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1560,13 +1539,6 @@ nodeinit:
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
-  # -- Additional nodeinit ConfigMap mounts.
-  extraConfigmapMounts: []
-    # - name: certs-configmap
-    #   mountPath: /certs
-    #   configMap: certs-configmap
-    #   readOnly: true
-
   # -- Node tolerations for nodeinit scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1634,13 +1606,6 @@ preflight:
     #   hostPath: /var/lib/preflight
     #   readOnly: true
     #   mountPropagation: HostToContainer
-
-  # -- Additional preflight ConfigMap mounts.
-  extraConfigmapMounts: []
-    # - name: certs-configmap
-    #   mountPath: /certs
-    #   configMap: certs-configmap
-    #   readOnly: true
 
   # -- Node tolerations for preflight scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -134,6 +134,12 @@ extraHostPathMounts: []
   #   readOnly: true
   #   mountPropagation: HostToContainer
 
+# -- Additional agent volumes.
+extraVolumes: []
+
+# -- Additional agent volumeMounts.
+extraVolumeMounts: []
+
 # -- extraConfig allows you to specify additional configuration parameters to be
 # included in the cilium-config configmap.
 extraConfig: {}
@@ -1443,6 +1449,12 @@ operator:
     #   hostPathType: Directory
     #   readOnly: true
     #   mountPropagation: HostToContainer
+
+  # -- Additional cilium-operator volumes.
+  extraVolumes: []
+  
+  # -- Additional cilium-operator volumeMounts.
+  extraVolumeMounts: []
 
   # -- Annotations to be added to cilium-operator pods
   podAnnotations: {}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -110,6 +110,12 @@ tolerations:
   #   value: "value"
   #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+# -- Host aliases for cilium-agent.
+hostAliases: []
+# - ip: 10.10.xx.xx
+#   hostnames:
+#   - cluster1.mesh.cilium.io
+
 # -- The priority class to use for cilium-agent.
 priorityClassName: ""
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -829,16 +829,14 @@ hubble:
       # -- Additional hubble-ui backend environment variables.
       extraEnv: []
 
-      # [Example]
-      # resources:
+      # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
+      resources: {}
       #   limits:
       #     cpu: 1000m
       #     memory: 1024M
       #   requests:
       #     cpu: 100m
       #     memory: 64Mi
-      # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
-      resources: {}
 
     frontend:
       # -- Hubble-ui frontend image.
@@ -850,16 +848,14 @@ hubble:
       # -- Additional hubble-ui frontend environment variables.
       extraEnv: []
 
-      # [Example]
-      # resources:
+      # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
+      resources: {}
       #   limits:
       #     cpu: 1000m
       #     memory: 1024M
       #   requests:
       #     cpu: 100m
       #     memory: 64Mi
-      # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
-      resources: {}
 
     proxy:
       # -- Hubble-ui ingress proxy image.
@@ -871,16 +867,14 @@ hubble:
       # -- Additional hubble-ui proxy environment variables.
       extraEnv: []
 
-      # [Example]
-      # resources:
+      # -- Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment.
+      resources: {}
       #   limits:
       #     cpu: 1000m
       #     memory: 1024M
       #   requests:
       #     cpu: 100m
       #     memory: 64Mi
-      # -- Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment.
-      resources: {}
 
     # -- The number of replicas of Hubble UI to deploy.
     replicas: 1
@@ -1733,7 +1727,14 @@ clustermesh:
     #       requests:
     #         cpu: 100m
     #         memory: 64Mi
+    # -- Resource requests and limits for the clustermesh-apiserver
     resources: {}
+      # requests:
+      #   cpu: 100m
+      #   memory: 64Mi
+      # limits:
+      #   cpu: 1000m
+      #   memory: 1024M
 
     # -- Affinity for clustermesh.apiserver
     affinity:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -171,9 +171,9 @@ securityContext: {}
 
 # -- Cilium agent update strategy
 updateStrategy:
+  type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 2
-  type: RollingUpdate
 
 # Configuration Values for cilium-agent
 
@@ -731,9 +731,9 @@ hubble:
 
     # -- hubble-relay update strategy
     updateStrategy:
+      type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 1
-      type: RollingUpdate
 
     # -- hubble-relay security context
     securityContext: {}
@@ -919,9 +919,9 @@ hubble:
 
     # -- hubble-ui update strategy.
     updateStrategy:
+      type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 1
-      type: RollingUpdate
 
     securityContext:
       # -- Whether to set the security context on the Hubble UI pods.
@@ -1352,10 +1352,10 @@ etcd:
 
   # -- cilium-etcd-operator update strategy
   updateStrategy:
+    type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
-    type: RollingUpdate
 
   # -- If etcd is behind a k8s service set this option to true so that Cilium
   # does the service translation automatically without requiring a DNS to be
@@ -1399,18 +1399,15 @@ operator:
   # -- Number of replicas to run for the cilium-operator deployment
   replicas: 2
 
-  # -- For using with an existing serviceAccount.
-  serviceAccountName: cilium-operator
-
   # -- The priority class to use for cilium-operator
   priorityClassName: ""
 
   # -- cilium-operator update strategy
   updateStrategy:
+    type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
-    type: RollingUpdate
 
   # -- Affinity for cilium-operator
   affinity:
@@ -1767,9 +1764,9 @@ clustermesh:
 
     # -- clustermesh-apiserver update strategy
     updateStrategy:
+      type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 1
-      type: RollingUpdate
 
     # -- The priority class to use for clustermesh-apiserver
     priorityClassName: ""

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -88,31 +88,27 @@ image:
   digest: ""
   useDigest: false
 
-# -- Pod affinity for cilium-agent.
+# -- Affinity for cilium-agent.
 affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: kubernetes.io/os
-              operator: In
-              values:
-                - linux
-        # Compatible with Kubernetes 1.12.x and 1.13.x
-        - matchExpressions:
-            - key: beta.kubernetes.io/os
-              operator: In
-              values:
-                - linux
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
-    - labelSelector:
-        matchExpressions:
-        - key: k8s-app
-          operator: In
-          values:
-          - cilium
-      topologyKey: kubernetes.io/hostname
+    - topologyKey: kubernetes.io/hostname
+      labelSelector:
+        matchLabels:
+          k8s-app: cilium
+
+# -- Node selector for cilium-agent.
+nodeSelector:
+  kubernetes.io/os: linux
+
+# -- Node tolerations for agent scheduling to nodes with taints
+# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+tolerations:
+- operator: Exists
+  # - key: "key"
+  #   operator: "Equal|Exists"
+  #   value: "value"
+  #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
 # -- The priority class to use for cilium-agent.
 priorityClassName: ""
@@ -140,15 +136,6 @@ extraConfig: {}
 #    test 1
 #    test 2
 #    test 3
-
-# -- Node tolerations for agent scheduling to nodes with taints
-# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-tolerations:
-- operator: Exists
-  # - key: "key"
-  #   operator: "Equal|Exists"
-  #   value: "value"
-  #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
 # -- Annotations to be added to agent pods
 podAnnotations: {}
@@ -689,9 +676,23 @@ hubble:
     # -- Number of replicas run for the hubble-relay deployment.
     replicas: 1
 
+    # -- Affinity for hubble-replay
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              k8s-app: cilium
+
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
     nodeSelector: {}
+
+    # -- Node tolerations for pod assignment on nodes with taints
+    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    #
+    tolerations: []
 
     # -- Annotations to be added to hubble-relay pods
     podAnnotations: {}
@@ -709,10 +710,6 @@ hubble:
       minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
-
-    # -- Node tolerations for pod assignment on nodes with taints
-    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-    tolerations: []
 
     # -- The priority class to use for hubble-relay
     priorityClassName: ""
@@ -883,6 +880,9 @@ hubble:
       minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
+
+    # -- Affinity for hubble-ui
+    affinity: {}
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -1269,7 +1269,6 @@ wellKnownIdentities:
   # -- Enable the use of well-known identities.
   enabled: false
 
-
 etcd:
   # -- Enable etcd mode for the agent.
   enabled: false
@@ -1392,18 +1391,28 @@ operator:
       maxUnavailable: 1
     type: RollingUpdate
 
-  # -- cilium-operator affinity
+  # -- Affinity for cilium-operator
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: io.cilium/app
-            operator: In
-            values:
-            - operator
-        topologyKey: kubernetes.io/hostname
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            io.cilium/app: operator
 
+  # -- Node labels for cilium-operator pod assignment
+  # ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  # -- Node tolerations for cilium-operator scheduling to nodes with taints
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  tolerations:
+  - operator: Exists
+    # - key: "key"
+    #   operator: "Equal|Exists"
+    #   value: "value"
+    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
   # -- Additional cilium-operator container arguments.
   extraArgs: []
@@ -1419,19 +1428,6 @@ operator:
     #   hostPathType: Directory
     #   readOnly: true
     #   mountPropagation: HostToContainer
-
-  # -- Node tolerations for cilium-operator scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  tolerations:
-  - operator: Exists
-    # - key: "key"
-    #   operator: "Equal|Exists"
-    #   value: "value"
-    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
-
-  # -- Node labels for cilium-operator pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  nodeSelector: {}
 
   # -- Annotations to be added to cilium-operator pods
   podAnnotations: {}
@@ -1490,7 +1486,6 @@ operator:
   # -- Skip CRDs creation for cilium-operator
   skipCRDCreation: false
 
-
 nodeinit:
   # -- Enable the node initialization DaemonSet
   enabled: false
@@ -1511,6 +1506,14 @@ nodeinit:
   # -- Additional nodeinit environment variables.
   extraEnv: {}
 
+  # -- Affinity for cilium-nodeinit
+  affinity: {}
+
+  # -- Node labels for nodeinit pod assignment
+  # ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
   # -- Node tolerations for nodeinit scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -1519,10 +1522,6 @@ nodeinit:
     #   operator: "Equal|Exists"
     #   value: "value"
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
-
-  # -- Node labels for nodeinit pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  nodeSelector: {}
 
   # -- Annotations to be added to node-init pods.
   podAnnotations: {}
@@ -1568,15 +1567,29 @@ preflight:
   # -- Additional preflight environment variables.
   extraEnv: {}
 
+  # -- Affinity for cilium-preflight
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            k8s-app: cilium
+
+  # -- Node labels for preflight pod assignment
+  # ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
   # -- Node tolerations for preflight scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
-  - effect: NoSchedule
-    key: node.kubernetes.io/not-ready
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
-    key: node.cloudprovider.kubernetes.io/uninitialized
+  - key: node.kubernetes.io/not-ready
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+  - key: node.cloudprovider.kubernetes.io/uninitialized
+    effect: NoSchedule
     value: "true"
   - key: CriticalAddonsOnly
     operator: "Exists"
@@ -1584,10 +1597,6 @@ preflight:
     #   operator: "Equal|Exists"
     #   value: "value"
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
-
-  # -- Node labels for preflight pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  nodeSelector: {}
 
   # -- Annotations to be added to preflight pods
   podAnnotations: {}
@@ -1675,10 +1684,6 @@ clustermesh:
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 
-    # -- Node labels for pod assignment
-    # ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
-
     # -- Annotations to be added to clustermesh-apiserver pods
     podAnnotations: {}
 
@@ -1705,6 +1710,19 @@ clustermesh:
     #         cpu: 100m
     #         memory: 64Mi
     resources: {}
+
+    # -- Affinity for clustermesh.apiserver
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              k8s-app: clustermesh-apiserver
+
+    # -- Node labels for pod assignment
+    # ref: https://kubernetes.io/docs/user-guide/node-selection/
+    nodeSelector: {}
 
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1552,8 +1552,8 @@ nodeinit:
       memory: 100Mi
 
   # -- Security context to be added to nodeinit pods.
-  securityContext: {}
-    # runAsUser: 0
+  securityContext:
+    privileged: true
 
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -117,7 +117,7 @@ priorityClassName: ""
 extraArgs: []
 
 # -- Additional agent container environment variables.
-extraEnv: {}
+extraEnv: []
 
 # -- Additional agent hostPath mounts.
 extraHostPathMounts: []
@@ -694,6 +694,9 @@ hubble:
     #
     tolerations: []
 
+    # -- Additional hubble-relay environment variables.
+    extraEnv: []
+
     # -- Annotations to be added to hubble-relay pods
     podAnnotations: {}
 
@@ -816,6 +819,10 @@ hubble:
         repository: quay.io/cilium/hubble-ui-backend
         tag: latest
         pullPolicy: Always
+
+      # -- Additional hubble-ui backend environment variables.
+      extraEnv: []
+
       # [Example]
       # resources:
       #   limits:
@@ -833,6 +840,10 @@ hubble:
         repository: quay.io/cilium/hubble-ui
         tag: latest
         pullPolicy: Always
+
+      # -- Additional hubble-ui frontend environment variables.
+      extraEnv: []
+
       # [Example]
       # resources:
       #   limits:
@@ -850,6 +861,10 @@ hubble:
         repository: docker.io/envoyproxy/envoy
         tag: v1.18.4@sha256:e5c2bb2870d0e59ce917a5100311813b4ede96ce4eb0c6bfa879e3fbe3e83935
         pullPolicy: Always
+
+      # -- Additional hubble-ui proxy environment variables.
+      extraEnv: []
+
       # [Example]
       # resources:
       #   limits:
@@ -1418,7 +1433,7 @@ operator:
   extraArgs: []
 
   # -- Additional cilium-operator environment variables.
-  extraEnv: {}
+  extraEnv: []
 
   # -- Additional cilium-operator hostPath mounts.
   extraHostPathMounts: []
@@ -1504,7 +1519,7 @@ nodeinit:
     type: RollingUpdate
 
   # -- Additional nodeinit environment variables.
-  extraEnv: {}
+  extraEnv: []
 
   # -- Affinity for cilium-nodeinit
   affinity: {}
@@ -1565,7 +1580,7 @@ preflight:
     type: RollingUpdate
 
   # -- Additional preflight environment variables.
-  extraEnv: {}
+  extraEnv: []
 
   # -- Affinity for cilium-preflight
   affinity:
@@ -1683,6 +1698,9 @@ clustermesh:
 
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
+
+    # -- Additional clustermesh-apiserver environment variables.
+    extraEnv: []
 
     # -- Annotations to be added to clustermesh-apiserver pods
     podAnnotations: {}


### PR DESCRIPTION
This is fifth part of #16792 that aim to align configs in `values.yaml` with `templates` and between components.  
Some notable changes are:
* ~~Remove unused configs like `podDisruptionBudget`, `extraConfigmapMounts`, some `extraHostPathMounts`, `extraInitContainers`~~ [edit: `podDisruptionBudget` removal dropped, addressed by a different PR]
* unify placement configs (`affinity`, `affinity`, `tolerations`) between components
* Remove `terminationGracePeriodSeconds: 0 | 1` which unsafe and strongly discouraged
* Update `resources` & `securityContext` config
* support `hostAliases` in cilium-agent which will used in cluster-mesh
* support generic `extraVolumes` & `extraVolumeMounts` in cilium agent and operator which can be used to mount any volume types.