### PR TITLE
ebpf unit testing -- lxc tests

### DIFF
--- a/bpf/ep_config.h
+++ b/bpf/ep_config.h
@@ -5,6 +5,8 @@
  * This is just a dummy header with dummy values to allow for test
  * compilation without the full code generation engine backend.
  */
+#ifndef __EP_CONFIG__
+#define __EP_CONFIG__
 #include "lib/utils.h"
 
 DEFINE_IPV6(LXC_IP, 0xbe, 0xef, 0, 0, 0, 0, 0, 0x1, 0, 0, 0, 0x1, 0x01, 0x65, 0x82, 0xbc);
@@ -45,3 +47,4 @@ DEFINE_U32(POLICY_VERDICT_LOG_FILTER, 0xffff);
 #define CONNTRACK
 #define CONNTRACK_ACCOUNTING
 #define DIRECT_ROUTING_DEV_IFINDEX 0
+#endif /* __EP_CONFIG__ */

--- a/bpf/mock/common_stub.h
+++ b/bpf/mock/common_stub.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// Header of functions to be mocked in common.h.
+// It is used to generate corresponding mock functions in common.h.
+// If other functions in common.h are needed, please add the function
+// declarations at the bottom. To avoid conflict between functions in
+// bpf/builtins.h and string.h, define __BPF_BUILTINS__ in conntrack_stub.h to
+// make sure the mock library can be compiled without functions in
+// bpf/builtins.h. To avoid conflict, we do not name the mock customized
+// functions as the original name like mock helper functions because customized
+// functions are actually implemented. Instead, we use "mock_" as the prefix of
+// each mock customized function.
+#define __BPF_BUILTINS__
+#include <bpf/ctx/skb.h>
+#include "lib/common.h"
+
+bool mock_revalidate_data(struct __ctx_buff *ctx, void **data, void **data_end, void **ip);

--- a/bpf/mock/l3_stub.h
+++ b/bpf/mock/l3_stub.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// Header of functions to be mocked in l3.h.
+
+#define __BPF_BUILTINS__
+#include <bpf/ctx/skb.h>
+#include "lib/common.h"
+#include <linux/ip.h>
+
+int mock_ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off, __u32 seclabel, struct iphdr *ip4, const struct endpoint_info *ep, __u8 direction, bool from_host);
+
+int mock_ipv4_l3(struct __ctx_buff *ctx, int l3_off, const __u8 *smac, const __u8 *dmac, struct iphdr *ip4);

--- a/bpf/mock/lb_stub.h
+++ b/bpf/mock/lb_stub.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// Header of functions to be mocked in lb.h.
+
+#define __BPF_BUILTINS__
+#include <bpf/ctx/skb.h>
+#include "lib/common.h"
+#include <linux/ip.h>
+#include "lib/csum.h"
+
+int mock_lb4_extract_key(struct __ctx_buff *ctx, struct iphdr *ip4, int l4_off, struct lb4_key *key, struct csum_offset *csum_off, int dir);
+
+struct lb4_service *mock_lb4_lookup_service(struct lb4_key *key, const bool scope_switch);
+
+int mock_lb4_local(const void *map, struct __ctx_buff *ctx, int l3_off, int l4_off, struct csum_offset *csum_off, struct lb4_key *key, struct ipv4_ct_tuple *tuple, const struct lb4_service *svc, struct ct_state *state, __be32 saddr, bool has_l4_header, const bool skip_l3_xlate);
+
+int mock_lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off, struct csum_offset *csum_off, struct ct_state *ct_state, struct ipv4_ct_tuple *tuple, int flags, bool has_l4_header);

--- a/bpf/mock/nodeport_stub.h
+++ b/bpf/mock/nodeport_stub.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// Header of functions to be mocked in nodeport.h.
+
+#define __BPF_BUILTINS__
+#include <bpf/ctx/skb.h>
+#include "lib/common.h"
+
+int mock_xlate_dsr_v4(struct __ctx_buff *ctx, const struct ipv4_ct_tuple *tuple, int l4_off, bool has_l4_header);

--- a/bpf/mock/policy_stub.h
+++ b/bpf/mock/policy_stub.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// Header of functions to be mocked in policy.h.
+
+#define __BPF_BUILTINS__
+#include <bpf/ctx/skb.h>
+#include "lib/common.h"
+
+int mock_policy_can_egress4(struct __ctx_buff *ctx, const struct ipv4_ct_tuple *tuple, __u32 src_id, __u32 dst_id, __u8 *match_type, __u8 *audited);

--- a/bpf/mock/trace_stub.h
+++ b/bpf/mock/trace_stub.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// Header of functions to be mocked in trace.h.
+
+#define __BPF_BUILTINS__
+#include <bpf/ctx/skb.h>
+#include "lib/common.h"
+
+void mock_send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex, __u8 reason, __u32 monitor);

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -11,6 +11,8 @@
  *
  *
  */
+#ifndef __NODE_CONFIG__
+#define __NODE_CONFIG__
 #include "lib/utils.h"
 
 DEFINE_MAC(NODE_MAC, 0xde, 0xad, 0xbe, 0xef, 0xc0, 0xde);
@@ -208,3 +210,4 @@ return true; \
 break; \
 } \
 return false;
+#endif /* __NODE_CONFIG__ */

--- a/bpf/tests/lxcv4_test.h
+++ b/bpf/tests/lxcv4_test.h
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// It contains function definitions for testing "handle_ipv4_from_lxc". If other
+// functions in bpf_lxc.c need to be tested, please add the function definitions
+// at the bottom.
+
+#define __BPF_HELPERS_SKB__
+#define __BPF_HELPERS__
+
+#define ENABLE_IPV4
+#define ENABLE_ROUTING 1
+#define ENABLE_WIREGUARD
+#define ENABLE_NODEPORT
+#define ENABLE_DSR
+
+
+#include <stdio.h>
+#include <assert.h>
+
+#include "unity.h"
+#include "mocks/mock_helpers.h"
+#include "mocks/mock_helpers_skb.h"
+#include "mocks/mock_conntrack_stub.h"
+#include "mocks/mock_policy_stub.h"
+#include "mocks/mock_lb_stub.h"
+#include "mocks/mock_l3_stub.h"
+#include "mocks/mock_nodeport_stub.h"
+#include "mocks/mock_common_stub.h"
+#include "mocks/mock_trace_stub.h"
+
+#undef __BPF_BUILTINS__
+#include "bpf/builtins.h"
+
+#include "bpf/ctx/skb.h"
+#include <ep_config.h>
+#include <node_config.h>
+#include "lib/conntrack.h"
+#include "lib/policy.h"
+#include "lib/lb.h"
+#include "lib/l3.h"
+#include "lib/nodeport.h"
+#include "lib/trace.h"
+
+
+#define ct_lookup4 mock_ct_lookup4
+#define ct_create4 mock_ct_create4
+#define revalidate_data mock_revalidate_data
+#define lb4_extract_key mock_lb4_extract_key
+#define lb4_lookup_service mock_lb4_lookup_service
+#define lb4_local mock_lb4_local
+#define lb4_rev_nat mock_lb4_rev_nat
+#define policy_can_egress4 mock_policy_can_egress4
+#define ipv4_local_delivery mock_ipv4_local_delivery
+#define ipv4_l3 mock_ipv4_l3
+#define ep_tail_call(a, b) tail_call(a, b, 0)
+#define xlate_dsr_v4 mock_xlate_dsr_v4
+#define send_trace_notify mock_send_trace_notify
+#include "bpf_lxc.c"
+
+
+struct __ctx_buff ctx;
+__u32 dst_id;
+struct iphdr ip4;
+struct lb4_service svc;
+struct remote_endpoint_info info;
+struct endpoint_info ep;
+struct ct_state state;
+
+bool revalidate_data_callback(struct __ctx_buff *ctx, void **data, void **data_end,
+                          void **ip, int cmock_num_calls) {
+  *ip = &ip4;
+  return true;
+}
+
+int ct_lookup4_callback(const void* map, struct ipv4_ct_tuple* tuple, struct __ctx_buff* ctx, int off, int dir, struct ct_state* ct_state, __u32* monitor, int cmock_num_calls) {
+  *ct_state = state;
+  return CT_REPLY;
+}
+
+void test_handle_ipv4_from_lxc() {
+
+    // revalidate_data returns 0.
+    mock_revalidate_data_ExpectAnyArgsAndReturn(0);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == DROP_INVALID);
+
+    // If IPv4 fragmentation is disabled AND a IPv4 fragmented packet is
+    // received, then drop the packet.
+    mock_revalidate_data_Stub(revalidate_data_callback);
+    ip4.frag_off = 1;
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == DROP_FRAG_NOSUPPORT);
+
+    // is_valid_lxc_src_ipv4 returns 0.
+    ip4.frag_off = 0;
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == DROP_INVALID_SIP);
+
+    // lb4_extract_key returns -1.
+    ip4.saddr = LXC_IPV4;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(-1);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == -1);
+
+    // lb4_local returns -1.
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(-1);
+    mock_lb4_lookup_service_ExpectAnyArgsAndReturn(&svc);
+    mock_lb4_local_ExpectAnyArgsAndReturn(-1);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == -1);
+
+    // ct_lookup4 returns -1.
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(-1);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == -1);
+
+    // policy_can_egress4 returns -1.
+    info.sec_label = 1;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(CT_NEW);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    skb_event_output_IgnoreAndReturn(0);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(-1);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == -1);
+
+    // ct_create4 returns -1.
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(CT_NEW);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(0);
+    mock_ct_create4_ExpectAnyArgsAndReturn(-1);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == -1);
+
+    // ipv4_l3 returns DROP_INVALID.
+    ep.flags = 1;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(CT_REOPENED);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(0);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&ep);
+    mock_ipv4_l3_ExpectAnyArgsAndReturn(DROP_INVALID);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == DROP_INVALID);
+
+    // ipv4_local_delivery returns 0.
+    ep.flags = 0;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    mock_ct_lookup4_ExpectAnyArgsAndReturn(CT_REOPENED);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(0);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&ep);
+    mock_ipv4_local_delivery_ExpectAnyArgsAndReturn(0);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == 0);
+
+    // CT_REPLY
+    // ct_state.node_port != 0
+    state.node_port = 1;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    mock_ct_lookup4_Stub(ct_lookup4_callback);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(0);
+    tail_call_Ignore();
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == DROP_MISSED_TAIL_CALL);
+
+    // xlate_dsr_v4 returns -1.
+    state.node_port = 0;
+    state.dsr = 1;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(0);
+    mock_xlate_dsr_v4_ExpectAnyArgsAndReturn(-1);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == -1);
+
+    // lb4_rev_nat returns -1.
+    state.dsr = 0;
+    state.rev_nat_index = 1;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(0);
+    mock_lb4_rev_nat_ExpectAnyArgsAndReturn(-1);
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == -1);
+
+    // The function returns CTX_ACT_OK at the end.
+    state.rev_nat_index = 0;
+    mock_lb4_extract_key_ExpectAnyArgsAndReturn(DROP_UNKNOWN_L4);
+    map_lookup_elem_ExpectAnyArgsAndReturn(&info);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_policy_can_egress4_ExpectAnyArgsAndReturn(0);
+    map_lookup_elem_ExpectAnyArgsAndReturn(NULL);
+    mock_ipv4_l3_ExpectAnyArgsAndReturn(CTX_ACT_OK);
+    mock_send_trace_notify_Ignore();
+    assert(handle_ipv4_from_lxc(&ctx, &dst_id) == CTX_ACT_OK);
+}

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -27,7 +27,7 @@ CLANG ?= $(QUIET) clang
 LLC ?= llc
 
 BPF_TARGETS := elf-demo.o
-ALL_TESTS := unit-test nat-test drop-notify-test
+ALL_TESTS := unit-test nat-test drop-notify-test lxcv4-test
 TARGETS := $(BPF_TARGETS) $(ALL_TESTS)
 
 all: $(TARGETS) unit-tests
@@ -45,13 +45,26 @@ nat-test: nat-test.c $(LIB)
 	make -C $(ROOT_DIR)/bpf/mock generate_helper_headers
 	make -C $(ROOT_DIR)/bpf/mock mock_helpers
 	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=conntrack_stub.h
-	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src -I../../../hashmap/include  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../../hashmap/src/hashmap.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c ../../bpf/mock/mocks/mock_conntrack_stub.c -o $@
+	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src -I../../../hashmap/include $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../../hashmap/src/hashmap.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c ../../bpf/mock/mocks/mock_conntrack_stub.c -o $@
 
 drop-notify-test: drop-notify-test.c $(LIB)
 	@$(ECHO_CC)
 	make -C $(ROOT_DIR)/bpf/mock generate_helper_headers
 	make -C $(ROOT_DIR)/bpf/mock mock_helpers
 	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c -o $@
+
+lxcv4-test: lxcv4-test.c $(LIB)
+	@$(ECHO_CC)
+	make -C $(ROOT_DIR)/bpf/mock generate_helper_headers
+	make -C $(ROOT_DIR)/bpf/mock mock_helpers
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=conntrack_stub.h
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=policy_stub.h
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=lb_stub.h
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=l3_stub.h
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=nodeport_stub.h
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=common_stub.h
+	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=trace_stub.h
+	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c ../../bpf/mock/mocks/mock_conntrack_stub.c ../../bpf/mock/mocks/mock_policy_stub.c ../../bpf/mock/mocks/mock_lb_stub.c ../../bpf/mock/mocks/mock_l3_stub.c ../../bpf/mock/mocks/mock_nodeport_stub.c ../../bpf/mock/mocks/mock_common_stub.c ../../bpf/mock/mocks/mock_trace_stub.c -o $@
 
 unit-tests: $(ALL_TESTS)
 	@$(ECHO_CHECK)

--- a/test/bpf/lxcv4-test.c
+++ b/test/bpf/lxcv4-test.c
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+// source file for lxcv4_test.h.
+// It contains contains main functions to run test functions lxcv4_test.h.
+// It is used to perform unit test on functions in bpf_lxc.c.
+
+#include "tests/lxcv4_test.h"
+
+void setUp(void) {
+    // set stuff up here
+}
+
+void tearDown(void) {
+    // clean stuff up here
+}
+
+
+int main(int argc, char *argv[])
+{
+    test_handle_ipv4_from_lxc();
+    return 0;
+}


### PR DESCRIPTION
This PR adds tests for bpf_lxc.c. The first commit contains a test on handle_ipv4_from_lxc, and I am going to wrtite tests for the other functions in the next commits. The test covers nearly every line of the function.

Signed-off-by: Xinyuan Zhang <zhangxinyuan@google.com>
