### PR TITLE
v1.10 backports 2021-08-30

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -293,6 +293,7 @@ func (c *Controller) runController() {
 
 		case <-runTimer.After(interval):
 		case <-c.trigger:
+			runFunc = true
 		}
 
 	}

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -40,6 +40,9 @@ type K8sClient struct {
 	// kubernetes.Interface is the object through which interactions with
 	// Kubernetes are performed.
 	kubernetes.Interface
+
+	// ctrlMgr is the manager of controllers for this K8sClient.
+	ctrlMgr *controller.Manager
 }
 
 // K8sCiliumClient is a wrapper around clientset.Interface.

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/controller"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	slim_apiextclientsetscheme "github.com/cilium/cilium/pkg/k8s/slim/k8s/apiextensions-client/clientset/versioned/scheme"
@@ -48,7 +49,9 @@ import (
 
 var (
 	// k8sCLI is the default client.
-	k8sCLI = &K8sClient{}
+	k8sCLI = &K8sClient{
+		ctrlMgr: controller.NewManager(),
+	}
 
 	// k8sWatcherCLI is the client dedicated k8s structure watchers.
 	k8sWatcherCLI = &K8sClient{}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -307,7 +307,7 @@ const (
 func (k8sCli K8sClient) MarkNodeReady(nodeGetter nodeGetter, nodeName string) {
 	log.WithField(logfields.NodeName, nodeName).Debug("Setting NetworkUnavailable=false")
 
-	controller.NewManager().UpdateController(markK8sNodeReadyControllerName,
+	k8sCli.ctrlMgr.UpdateController(markK8sNodeReadyControllerName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				err := removeNodeTaint(ctx, k8sCli, nodeGetter, nodeName)
@@ -322,5 +322,5 @@ func (k8sCli K8sClient) MarkNodeReady(nodeGetter nodeGetter, nodeName string) {
 // ReMarkNodeReady re-triggers the controller set by 'MarkNodeReady'. If
 // 'MarkNodeReady' has not been executed yet, calling this function be a no-op.
 func (k8sCli K8sClient) ReMarkNodeReady() {
-	controller.NewManager().TriggerController(markK8sNodeReadyControllerName)
+	k8sCli.ctrlMgr.TriggerController(markK8sNodeReadyControllerName)
 }


### PR DESCRIPTION
* #17112 -- pkg/k8s: use a controller manager in K8sClient (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17112; do contrib/backporting/set-labels.py $pr done 1.10; done
```