### PR TITLE
v1.8: Update cilium base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGI
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2021-08-21-v1.8@sha256:389a9a11d7d56fcefc222309f11541b0f6cf71e646b0f7741da25e28ecf7bea0
+FROM quay.io/cilium/cilium-runtime:2021-08-30-v1.8@sha256:459c938edea6a4065e27948caa2cc18ecd1a04109295022ac83aeb71ae030ea6
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@
 # Cilium build-time base image (image created from this file is used to build Cilium)
 FROM docker.io/cilium/cilium-llvm:33c302266cecc264febfca95129ce8dad9397c81 as cilium-llvm
 
-FROM quay.io/cilium/cilium-runtime:2021-08-21-v1.8@sha256:389a9a11d7d56fcefc222309f11541b0f6cf71e646b0f7741da25e28ecf7bea0
+FROM quay.io/cilium/cilium-runtime:2021-08-30-v1.8@sha256:459c938edea6a4065e27948caa2cc18ecd1a04109295022ac83aeb71ae030ea6
 LABEL maintainer="maintainer@cilium.io"
 ARG ARCH=amd64
 WORKDIR /go/src/github.com/cilium/cilium

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -3,7 +3,7 @@
 # development environmennt
 FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
-FROM quay.io/cilium/cilium-runtime:2021-08-21-v1.8@sha256:389a9a11d7d56fcefc222309f11541b0f6cf71e646b0f7741da25e28ecf7bea0
+FROM quay.io/cilium/cilium-runtime:2021-08-30-v1.8@sha256:459c938edea6a4065e27948caa2cc18ecd1a04109295022ac83aeb71ae030ea6
 LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium


### PR DESCRIPTION
Bump the cilium-runtime base images to pick up the latest set of underlying packages.

Related: #17264
