### PR TITLE
istio: Update to release 1.10.4

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -38,32 +38,32 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.10.3 <https://github.com/cilium/istio/releases/tag/1.10.3>`_:
+Download the `cilium enhanced istioctl version 1.10.4 <https://github.com/cilium/istio/releases/tag/1.10.4>`_:
 
 .. tabs::
   .. group-tab:: Linux (amd64)
 
     .. code-block:: shell-session
 
-        curl -L https://github.com/cilium/istio/releases/download/1.10.3/cilium-istioctl-1.10.3-linux-amd64.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.10.4/cilium-istioctl-1.10.4-linux-amd64.tar.gz | tar xz
 
   .. group-tab:: Linux (arm64)
 
     .. code-block:: shell-session
 
-        curl -L https://github.com/cilium/istio/releases/download/1.10.3/cilium-istioctl-1.10.3-linux-arm64.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.10.4/cilium-istioctl-1.10.4-linux-arm64.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. code-block:: shell-session
 
-        curl -L https://github.com/cilium/istio/releases/download/1.10.3/cilium-istioctl-1.10.3-osx.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.10.4/cilium-istioctl-1.10.4-osx.tar.gz | tar xz
 
   .. group-tab:: OSX (Apple Silicon)
 
     .. code-block:: shell-session
 
-        curl -L https://github.com/cilium/istio/releases/download/1.10.3/cilium-istioctl-1.10.3-osx-arm64.tar.gz | tar xz
+        curl -L https://github.com/cilium/istio/releases/download/1.10.4/cilium-istioctl-1.10.4-osx-arm64.tar.gz | tar xz
 
 .. note::
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -26,7 +26,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.10.3"
+		istioVersion = "1.10.4"
 
 		// Modifiers for pre-release testing, normally empty
 		prerelease     = "" // "-beta.1"
@@ -36,9 +36,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 		// - remind how to test with prerelease images in future
 		// - cause CI infra to prepull these images so that they do not
 		//   need to be pulled on demand during the test
-		// " --set values.pilot.image=quay.io/cilium/istio_pilot:1.10.3" + prerelease +
-		// " --set values.global.proxy.image=quay.io/cilium/istio_proxy:1.10.3" + prerelease +
-		// " --set values.global.proxy_init.image=quay.io/cilium/istio_proxy:1.10.3" + prerelease +
+		// " --set values.pilot.image=quay.io/cilium/istio_pilot:1.10.4" + prerelease +
+		// " --set values.global.proxy.image=quay.io/cilium/istio_proxy:1.10.4" + prerelease +
+		// " --set values.global.proxy_init.image=quay.io/cilium/istio_proxy:1.10.4" + prerelease +
 		// " --set values.global.proxy.logLevel=debug" +
 		// " --set values.global.logging.level=debug"
 		// " --set values.global.mtls.auto=false"


### PR DESCRIPTION
Update Cilium Istio integration to Istio release 1.10.4.

```release-note
Cilium Istio integration is updated to Istio release 1.10.4
```
