### PR TITLE
bpf: Add a new option to skip socket lb when in pod ns

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -45,6 +45,7 @@ cilium-agent [flags]
       --bpf-lb-mode string                                   BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
       --bpf-lb-rss-ipv4-src-cidr string                      BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
       --bpf-lb-rss-ipv6-src-cidr string                      BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
+      --bpf-lb-sock-hostns-only                              Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
       --bpf-map-dynamic-size-ratio float                     Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
       --bpf-nat-global-max int                               Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-neigh-global-max int                             Maximum number of entries for the global BPF neighbor table (default 524288)

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -31,6 +31,15 @@ proxy, but that will only work if mTLS is not used.
    other GSGs. 5 GB and 4 CPUs should be enough for this GSG
    (``--vm=true --memory=5120 --cpus=4``).
 
+.. note::
+
+   If Cilium is deployed in kube-proxy-free mode, you need to set
+   ``--bpf-lb-sock-hostns-only: true`` in the deployment yaml
+   directly or via ``hostServices.hostNamespaceOnly`` option with Helm.
+   Without this option, when Cilium does service resolution via
+   socket load balancing, Istio sidecar will be bypassed, resulting
+   in loss of Istio features including encryption and telemetry.
+
 Step 2: Install cilium-istioctl
 ===============================
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -495,6 +495,30 @@ mode would look as follows:
 
 .. _XDP acceleration:
 
+Socket LoadBalancer Bypass in Pod Namespace
+*******************************************
+
+Cilium has built-in support for bypassing the socket-level loadbalancer and falling back
+to the tc loadbalancer at the veth interface when a custom redirection/operation relies
+on the original ClusterIP within pod namespace (e.g., Istio side-car).
+
+Setting ``hostServices.hostNamespaceOnly=true`` enables this bypassing mode. When enabled,
+this circumvents socket rewrite in the ``connect()`` and ``sendmsg()`` syscall bpf hook and
+will pass the original packet to next stage of operation (e.g., stack in
+``per-endpoint-routing`` mode) and re-enables service lookup in the tc bpf program.
+
+A Helm example configuration in a kube-proxy-free environment with socket LB bypass
+looks as follows:
+
+.. parsed-literal::
+
+    helm install cilium |CHART_RELEASE| \\
+        --namespace kube-system \\
+        --set tunnel=disabled \\
+        --set autoDirectNodeRoutes=true \\
+        --set kubeProxyReplacement=strict \\
+        --set hostServices.hostNamespaceOnly=true
+
 LoadBalancer & NodePort XDP Acceleration
 ****************************************
 

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -185,6 +185,7 @@ Cilium Feature                              Minimum Kernel Version
 Full support for :ref:`session-affinity`    >= 5.7
 BPF-based proxy redirection                 >= 5.7
 BPF-based host routing                      >= 5.10
+Socket-level LB bypass in pod netns         >= 5.7
 =========================================== ===============================
 
 .. _req_kvstore:

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -415,12 +415,12 @@ healthz
 herokuapp
 hexData
 hoc
-hostRoot
 hostConfDirMountPath
 hostFirewall
 hostNetwork
 hostPath
 hostPort
+hostRoot
 hostServices
 hostname
 hostonlyif
@@ -617,6 +617,7 @@ netdevice
 netdevices
 netdevsim
 netfilter
+netns
 netperf
 netsec
 netvsc
@@ -704,6 +705,7 @@ queueing
 rbac
 rc
 rcW
+reStructuredText
 readCniConf
 readinessProbe
 readthedocs

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -116,7 +116,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 
 	l4_off = l3_off + hdrlen;
 
-#ifndef ENABLE_HOST_SERVICES_FULL
+#if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_SOCKET_LB_HOST_ONLY)
 	{
 		struct lb6_service *svc;
 		struct lb6_key key = {};
@@ -149,7 +149,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 	}
 
 skip_service_lookup:
-#endif /* !ENABLE_HOST_SERVICES_FULL */
+#endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_SOCKET_LB_HOST_ONLY */
 
 	/* The verifier wants to see this assignment here in case the above goto
 	 * skip_service_lookup is hit. However, in the case the packet
@@ -552,7 +552,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 
-#ifndef ENABLE_HOST_SERVICES_FULL
+#if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_SOCKET_LB_HOST_ONLY)
 	{
 		struct lb4_service *svc;
 		struct lb4_key key = {};
@@ -578,7 +578,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	}
 
 skip_service_lookup:
-#endif /* !ENABLE_HOST_SERVICES_FULL */
+#endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_SOCKET_LB_HOST_ONLY */
 
 	/* The verifier wants to see this assignment here in case the above goto
 	 * skip_service_lookup is hit. However, in the case the packet

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -341,6 +341,9 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	bool backend_from_affinity = false;
 	__u32 backend_id = 0;
 
+	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
+		return -ENXIO;
+
 	if (!udp_only && !sock_proto_enabled(ctx->protocol))
 		return -ENOTSUP;
 
@@ -938,6 +941,9 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
 	__u32 backend_id = 0;
+
+	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
+		return -ENXIO;
 
 	if (!udp_only && !sock_proto_enabled(ctx->protocol))
 		return -ENOTSUP;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -357,6 +357,9 @@ func init() {
 	flags.String(option.EgressMasqueradeInterfaces, "", "Limit egress masquerading to interface selector")
 	option.BindEnv(option.EgressMasqueradeInterfaces)
 
+	flags.Bool(option.BPFSocketLBHostnsOnly, false, "Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).")
+	option.BindEnv(option.BPFSocketLBHostnsOnly)
+
 	flags.Bool(option.EnableHostReachableServices, false, "Enable reachability of services for host applications")
 	option.BindEnv(option.EnableHostReachableServices)
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -372,6 +372,27 @@ func initKubeProxyReplacementOptions() (strict bool) {
 		}
 	}
 
+	if option.Config.BPFSocketLBHostnsOnly {
+		if !option.Config.EnableHostReachableServices {
+			option.Config.BPFSocketLBHostnsOnly = false
+			log.Warnf("%s only takes effect when %s is true", option.BPFSocketLBHostnsOnly, option.EnableHostReachableServices)
+		} else {
+			found := false
+			if helpers := probesManager.GetHelpers("cgroup_sock_addr"); helpers != nil {
+				if _, ok := helpers["bpf_get_netns_cookie"]; ok {
+					found = true
+				}
+			}
+			if !found {
+				option.Config.BPFSocketLBHostnsOnly = false
+				log.Warn("Without network namespace cookie lookup functionality, BPF datapath " +
+					"cannot distinguish root and non-root namespace, skipping socket-level " +
+					"loadbalancing will not work. Istio routing chains will be missed. " +
+					"Needs kernel version >= 5.7")
+			}
+		}
+	}
+
 	return
 }
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -504,6 +504,9 @@ data:
 {{- if ne .Values.hostServices.protocols "tcp,udp" }}
   host-reachable-services-protos: {{ .Values.hostServices.protocols }}
 {{- end }}
+{{- if hasKey .Values.hostServices "hostNamespaceOnly" }}
+  bpf-lb-sock-hostns-only: {{ .Values.hostServices.hostNamespaceOnly | quote }}
+{{- end }}
 {{- end }}
 {{- if hasKey .Values "hostPort" }}
 {{- if eq $kubeProxyReplacement "partial" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -526,6 +526,8 @@ hostServices:
   # -- Supported list of protocols to apply ClusterIP translation to.
   protocols: tcp,udp
 
+  # -- Disable socket lb for non-root ns. This is used to enable Istio routing rules.
+  # hostNamespaceOnly: false
 
 # -- Configure certificate generation for Hubble integration.
 # If hubble.tls.auto.method=cronJob, these values are used

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -249,11 +249,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.EnableHostServicesUDP {
 			cDefinesMap["ENABLE_HOST_SERVICES_UDP"] = "1"
 		}
-		if option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP {
+		if option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP && !option.Config.BPFSocketLBHostnsOnly {
 			cDefinesMap["ENABLE_HOST_SERVICES_FULL"] = "1"
 		}
 		if option.Config.EnableHostServicesPeer {
 			cDefinesMap["ENABLE_HOST_SERVICES_PEER"] = "1"
+		}
+		if option.Config.BPFSocketLBHostnsOnly {
+			cDefinesMap["ENABLE_SOCKET_LB_HOST_ONLY"] = "1"
 		}
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -452,6 +452,9 @@ const (
 	// EnableHostReachableServices is the name of the EnableHostReachableServices option
 	EnableHostReachableServices = "enable-host-reachable-services"
 
+	// BPFSocketLBHostnsOnly is the name of the BPFSocketLBHostnsOnly option
+	BPFSocketLBHostnsOnly = "bpf-lb-sock-hostns-only"
+
 	// HostReachableServicesProtos is the name of the HostReachableServicesProtos option
 	HostReachableServicesProtos = "host-reachable-services-protos"
 
@@ -1414,6 +1417,7 @@ type DaemonConfig struct {
 	// CLI options
 
 	BPFRoot                       string
+	BPFSocketLBHostnsOnly         bool
 	CGroupRoot                    string
 	BPFCompileDebug               string
 	CompilerFlags                 []string
@@ -2394,6 +2398,7 @@ func (c *DaemonConfig) Populate() {
 	c.DevicePreFilter = viper.GetString(PrefilterDevice)
 	c.DisableCiliumEndpointCRD = viper.GetBool(DisableCiliumEndpointCRDName)
 	c.EgressMasqueradeInterfaces = viper.GetString(EgressMasqueradeInterfaces)
+	c.BPFSocketLBHostnsOnly = viper.GetBool(BPFSocketLBHostnsOnly)
 	c.EnableHostReachableServices = viper.GetBool(EnableHostReachableServices)
 	c.EnableRemoteNodeIdentity = viper.GetBool(EnableRemoteNodeIdentity)
 	c.K8sHeartbeatTimeout = viper.GetDuration(K8sHeartbeatTimeout)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -502,6 +502,94 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		})
 	})
 
+	SkipContextIf(func() bool {
+		return helpers.RunsWithKubeProxy() || helpers.DoesNotRunOnNetNextKernel()
+	}, "Checks connectivity when skipping socket lb in pod ns", func() {
+		var (
+			demoDSYAML  string
+			demoYAML    string
+			serviceName = testDSServiceIPv4
+		)
+
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"hostServices.hostNamespaceOnly": "true",
+			})
+			demoDSYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
+			res := kubectl.ApplyDefault(demoDSYAML)
+			res.ExpectSuccess("Unable to apply %s", demoDSYAML)
+			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+			res = kubectl.ApplyDefault(demoYAML)
+			res.ExpectSuccess("unable to apply %s", demoYAML)
+			waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
+		})
+
+		AfterAll(func() {
+			_ = kubectl.Delete(demoDSYAML)
+			_ = kubectl.Delete(demoYAML)
+			ExpectAllPodsTerminated(kubectl)
+		})
+
+		It("Checks ClusterIP connectivity on the same node", func() {
+			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, serviceName)
+			Expect(err).Should(BeNil(), "Cannot get service %s", serviceName)
+			Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+
+			// Test that socket lb doesn't kick in, aka we see service VIP in monitor trace.
+			// Note that cilium monitor won't capture service VIP if run with Istio.
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
+			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
+			monitorRes, monitorCancel := kubectl.MonitorStart(ciliumPodK8s1)
+			defer func() {
+				monitorCancel()
+				helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), "skip-socket-lb-connectivity-same-node.log")
+			}()
+
+			httpSVCURL := fmt.Sprintf("http://%s/", clusterIP)
+			tftpSVCURL := fmt.Sprintf("tftp://%s/hello", clusterIP)
+
+			// Test connectivbity from root ns
+			status := kubectl.ExecInHostNetNS(context.TODO(), ni.k8s1NodeName,
+				helpers.CurlFail(httpSVCURL))
+			status.ExpectSuccess("cannot curl to service IP from host")
+			status = kubectl.ExecInHostNetNS(context.TODO(), ni.k8s1NodeName,
+				helpers.CurlFail(tftpSVCURL))
+			status.ExpectSuccess("cannot curl to service IP from host")
+
+			// Test connectivity from pod ns
+			testCurlFromPods(kubectl, "id=app2", httpSVCURL, 10, 0)
+			testCurlFromPods(kubectl, "id=app2", tftpSVCURL, 10, 0)
+
+			monitorRes.ExpectContains(clusterIP, "Service VIP not seen in monitor trace, indicating socket lb still in effect")
+		})
+
+		It("Checks ClusterIP connectivity across nodes", func() {
+			service := "testds-service"
+
+			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, service)
+			Expect(err).Should(BeNil(), "Cannot get services %s", service)
+			Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+
+			// Test that socket lb doesn't kick in, aka we see service VIP in monitor output.
+			// Note that cilium monitor won't capture service VIP if run with Istio.
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
+			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
+			monitorRes, monitorCancel := kubectl.MonitorStart(ciliumPodK8s1)
+			defer func() {
+				monitorCancel()
+				helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), "skip-socket-lb-connectivity-across-nodes.log")
+			}()
+
+			url := fmt.Sprintf("http://%s/", clusterIP)
+			testCurlFromPods(kubectl, testDSClient, url, 10, 0)
+
+			url = fmt.Sprintf("tftp://%s/hello", clusterIP)
+			testCurlFromPods(kubectl, testDSClient, url, 10, 0)
+
+			monitorRes.ExpectContains(clusterIP, "Service VIP not seen in monitor trace, indicating socket lb still in effect")
+		})
+	})
+
 	Context("Checks service across nodes", func() {
 
 		var (


### PR DESCRIPTION
[ non-upstream commit: ee5736d17f6dd9a4c2ae9388eb7dfc39e8b210dd
  https://github.com/cilium/cilium/pull/17154 ]

This is for compatibility with Isio in kube-proxy free mode.
Currently, even though Isiot would still get all traffic within pod
namespace, but the original service VIP is lost during socket lb,
causing it to miss all Istio routing chains and therefore bypassing
all Istio functionalities.

This adds a new option to bypass socket lb in pod namespace. When
enabled, service resolution for connection from pod namespaces will be
handled in bpf_lxc at veth. For host-namespaced pods, socket lb kept as
is.

Signed-off-by: Weilong Cui <cuiwl@google.com>
Signed-off-by: Martynas Pumputis <m@lambda.lt>