### PR TITLE
options: Disable force-local-policy-eval-at-source by default

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -125,7 +125,7 @@ cilium-agent [flags]
       --envoy-log string                                     Path to a separate Envoy log file, if any
       --exclude-local-address strings                        Exclude CIDR from being recognized as local address
       --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
+      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint
       --gops-port int                                        Port for gops server to listen on (default 9890)
   -h, --help                                                 help for cilium-agent
       --host-reachable-services-protos strings               Only enable reachability of services for host applications for specific protocols (default [tcp,udp])

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -288,9 +288,9 @@ const (
 	EndpointInterfaceNamePrefix = "lxc+"
 
 	// ForceLocalPolicyEvalAtSource is the default value for
-	// option.ForceLocalPolicyEvalAtSource. It is enabled by default to
-	// provide backwards compatibility, it can be disabled via an option
-	ForceLocalPolicyEvalAtSource = true
+	// option.ForceLocalPolicyEvalAtSource. It can be enabled to provide
+	// backwards compatibility.
+	ForceLocalPolicyEvalAtSource = false
 
 	// EnableEndpointRoutes is the value for option.EnableEndpointRoutes.
 	// It is disabled by default for backwards compatibility.


### PR DESCRIPTION
The `force-local-policy-eval-at-source` flag was introduced in commit c525c755 ("bpf: Continue to enforce policy at source endpoint unless disabled"). It is enabled by default and causes Cilium to always enforce policies at the source when the destination is a local pod.

Unfortunately, this flag is also causing [issues when both endpoint routes and tunneling are enabled](https://github.com/cilium/cilium/issues/14657) (a configuration that was not possible at the time the flag was introduced).

We have enough test coverage (L7 on multiple cloud providers) now to be able to safely disable this flag by default. We can remove it after a couple releases.

Related: https://github.com/cilium/cilium/issues/15452.