### PR TITLE
docs: Fix version sorting for CRD schema docs

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -29,7 +29,7 @@ get_schema_of_branch(){
 }
 
 get_stable_branches(){
-   git grep -o -E 'tree\/v[^>]+' -- README.rst | sed 's+.*tree/++' | sort -n
+   git grep -o -E 'tree\/v[^>]+' -- README.rst | sed 's+.*tree/++' | sort -V
 }
 
 get_stable_tags_for_minor(){


### PR DESCRIPTION
Use "sort -V" (versions) rather than "sort -n" (numeric) so that the
docs list the minor versions in chronological order.
