### PR TITLE
hubble-ca-cert ConfigMap cleanup

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrole.yaml
@@ -8,7 +8,6 @@ rules:
       - ""
     resources:
       - secrets
-      - configmaps
     verbs:
       - create
   - apiGroups:
@@ -19,14 +18,6 @@ rules:
       - hubble-server-certs
       - hubble-relay-client-certs
       - hubble-relay-server-certs
-    verbs:
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    resourceNames:
-      - hubble-ca-cert
     verbs:
       - update
   - apiGroups:

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4383,7 +4383,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 		wg sync.WaitGroup
 
 		resourcesToDelete = map[string]string{
-			"configmap":          "cilium-config hubble-ca-cert hubble-relay-config",
+			"configmap":          "cilium-config hubble-relay-config",
 			"daemonset":          "cilium cilium-node-init",
 			"deployment":         "cilium-operator hubble-relay",
 			"clusterrolebinding": "cilium cilium-operator hubble-relay",


### PR DESCRIPTION
This PR deletes the last references to the `hubble-ca-cert` ConfigMap that has been removed by https://github.com/cilium/cilium/pull/16900.