### PR TITLE
config: Fix incorrect packet path with IPsec and endpoint routes

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -231,6 +231,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_EGRESS_GATEWAY"] = "1"
 	}
 
+	if option.Config.EnableEndpointRoutes {
+		cDefinesMap["ENABLE_ENDPOINT_ROUTES"] = "1"
+	}
+
 	if option.Config.EnableHostReachableServices {
 		if option.Config.EnableHostServicesTCP {
 			cDefinesMap["ENABLE_HOST_SERVICES_TCP"] = "1"
@@ -816,10 +820,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 
 	if e.RequireRouting() {
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
-	}
-
-	if e.RequireEndpointRoute() {
-		fmt.Fprintf(fw, "#define ENABLE_ENDPOINT_ROUTES 1\n")
 	}
 
 	if e.DisableSIPVerification() {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -160,12 +161,17 @@ func _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst *net.IPNet, tunnel bool
 		policy.Mark = &netlink.XfrmMark{
 			Mask: linux_defaults.IPsecMarkMaskIn,
 		}
-		if tunnel {
-			// Required as this policy with the following mark does not have a
-			// corresponding XFRM state matching it. The XFRM state for Dir=In
-			// has mark for decryption only. If we don't mark this optional,
-			// then we'll get a packet drop with the reason as
-			// XfrmInTmplMismatch.
+		if tunnel || option.Config.EnableEndpointRoutes {
+			// Required for tunneling mode as this policy with the following
+			// mark does not have a corresponding XFRM state matching it. The
+			// XFRM state for Dir=In has mark for decryption only. If we don't
+			// mark this optional, then we'll get a packet drop with the
+			// reason as XfrmInTmplMismatch.
+			// Required for endpoint routes because packets may have either the
+			// decrypt or the proxy mark when attempting to match them against
+			// XFRM policies, depending on whether the connection goes through
+			// the proxy. If not marked optional, packets are dropped with
+			// XfrmInNoPols.
 			optional = 1
 			policy.Mark.Value = linux_defaults.RouteMarkToProxy
 		} else {


### PR DESCRIPTION
First commit fixes the path bpf_network -> bpf_lxc for when endpoint routes and IPsec are enabled. Second commit implements an additional fix for that path when L7 proxy is used. See commit descriptions for details.