### PR TITLE
contrib: Fix bump-readme.sh script

### DIFF
--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -34,7 +34,7 @@ for release in $(grep "General Announcement" README.rst \
     elease=$(echo $release | sed 's/v//')
     old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
                | sed "$PROJECTS_REGEX")
-    new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep project \
+    new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep projects \
                | sed "$PROJECTS_REGEX")
 
     echo "Updating $release:"


### PR DESCRIPTION
This script is matching on more lines than we intended from the
maintainer's little helper .github configuration. Change it to match on
"projects" and it will only match the correct lines in the file.
