### PR TITLE
fqdn: add fqdn proxy interface

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -8,6 +8,8 @@ package cmd
 
 import (
 	"context"
+	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
+	"github.com/cilium/cilium/pkg/proxy"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -73,6 +75,8 @@ func setupTestDirectories() {
 }
 
 func TestMain(m *testing.M) {
+	proxy.DefaultDNSProxy = fqdnproxy.MockFQDNProxy{}
+
 	// Set up all configuration options which are global to the entire test
 	// run.
 	option.Config.Populate()

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -1070,7 +1070,6 @@ func (d *Daemon) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), e
 }
 
 func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
-	// Many unit tests do not initialize the DNS proxy
 	if proxy.DefaultDNSProxy == nil {
 		return nil
 	}
@@ -1084,9 +1083,9 @@ func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
 }
 
 func (d *Daemon) RemoveRestoredDNSRules(epID uint16) {
-	// Many unit tests do not initialize the DNS proxy
 	if proxy.DefaultDNSProxy == nil {
 		return
 	}
+
 	proxy.DefaultDNSProxy.RemoveRestoredRules(epID)
 }

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -1074,7 +1074,13 @@ func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
 	if proxy.DefaultDNSProxy == nil {
 		return nil
 	}
-	return proxy.DefaultDNSProxy.GetRules(epID)
+
+	rules, err := proxy.DefaultDNSProxy.GetRules(epID)
+	if err != nil {
+		log.WithField(logfields.EndpointID, epID).WithError(err).Error("Could not get DNS rules")
+		return nil
+	}
+	return rules
 }
 
 func (d *Daemon) RemoveRestoredDNSRules(epID uint16) {

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -305,8 +305,8 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
-		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)
-		if err == nil && port == proxy.DefaultDNSProxy.BindPort {
+		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.GetBindPort())
+		if err == nil && port == proxy.DefaultDNSProxy.GetBindPort() {
 			log.Infof("Reusing previous DNS proxy port: %d", port)
 		}
 		proxy.DefaultDNSProxy.SetRejectReply(option.Config.FQDNRejectResponse)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -179,7 +179,7 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP stri
 
 // GetRules creates a fresh copy of EP's DNS rules to be stored
 // for later restoration.
-func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
+func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -221,7 +221,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 		}
 		restored[port] = ipRules
 	}
-	return restored
+	return restored, nil
 }
 
 // RestoreRules is used in the beginning of endpoint restoration to
@@ -682,6 +682,10 @@ func (p *DNSProxy) SetRejectReply(opt string) {
 			opt, option.FQDNRejectOptions)
 		return
 	}
+}
+
+func (p *DNSProxy) GetBindPort() uint16 {
+	return p.BindPort
 }
 
 // ExtractMsgDetails extracts a canonical query name, any IPs in a response,

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -633,11 +633,13 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
 		}},
 	}
-	restored1 := s.proxy.GetRules(uint16(epID1)).Sort()
+	restored1, _ := s.proxy.GetRules(uint16(epID1))
+	restored1.Sort()
 	c.Assert(restored1, checker.DeepEquals, expected1)
 
 	expected2 := restore.DNSRules{}
-	restored2 := s.proxy.GetRules(uint16(epID2)).Sort()
+	restored2, _ := s.proxy.GetRules(uint16(epID2))
+	restored2.Sort()
 	c.Assert(restored2, checker.DeepEquals, expected2)
 
 	expected3 := restore.DNSRules{
@@ -652,7 +654,8 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID4Selector]},
 		}}.Sort(),
 	}
-	restored3 := s.proxy.GetRules(uint16(epID3)).Sort()
+	restored3, _ := s.proxy.GetRules(uint16(epID3))
+	restored3.Sort()
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
 	// Test with limited set of allowed IPs
@@ -671,7 +674,8 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
 		}},
 	}
-	restored1b := s.proxy.GetRules(uint16(epID1)).Sort()
+	restored1b, _ := s.proxy.GetRules(uint16(epID1))
+	restored1b.Sort()
 	c.Assert(restored1b, checker.DeepEquals, expected1b)
 
 	// unlimited again
@@ -934,7 +938,8 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	c.Assert(response.Answer[0].String(), Equals, "cilium.io.\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
 
 	// Get restored rules
-	restored := s.proxy.GetRules(uint16(epID1)).Sort()
+	restored, _ := s.proxy.GetRules(uint16(epID1))
+	restored.Sort()
 
 	// remove rules
 	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2016-2020 Authors of Cilium
+
+package proxy
+
+import (
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+type DNSProxier interface {
+	GetRules(uint16) (restore.DNSRules, error)
+	RemoveRestoredRules(uint16)
+	UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error
+	GetBindPort() uint16
+	SetRejectReply(string)
+	RestoreRules(op *endpoint.Endpoint)
+}

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -17,3 +17,29 @@ type DNSProxier interface {
 	SetRejectReply(string)
 	RestoreRules(op *endpoint.Endpoint)
 }
+
+type MockFQDNProxy struct{}
+
+func (m MockFQDNProxy) GetRules(u uint16) (restore.DNSRules, error) {
+	return nil, nil
+}
+
+func (m MockFQDNProxy) RemoveRestoredRules(u uint16) {
+	return
+}
+
+func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+	return nil
+}
+
+func (m MockFQDNProxy) GetBindPort() uint16 {
+	return 0
+}
+
+func (m MockFQDNProxy) SetRejectReply(s string) {
+	return
+}
+
+func (m MockFQDNProxy) RestoreRules(op *endpoint.Endpoint) {
+	return
+}

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -5,7 +5,7 @@ package proxy
 
 import (
 	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -15,7 +15,7 @@ import (
 
 var (
 	// DefaultDNSProxy is the global, shared, DNS Proxy singleton.
-	DefaultDNSProxy *dnsproxy.DNSProxy
+	DefaultDNSProxy proxy.DNSProxier
 )
 
 // dnsRedirect implements the Redirect interface for an l7 proxy
@@ -39,7 +39,11 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 	if err := DefaultDNSProxy.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, newRules); err != nil {
 		return err
 	}
-	dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(DefaultDNSProxy.GetRules(uint16(dr.redirect.endpointID)))
+	rules, err := DefaultDNSProxy.GetRules(uint16(dr.redirect.endpointID))
+	if err != nil {
+		return err
+	}
+	dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(rules)
 	dr.currentRules = copyRules(dr.redirect.rules)
 
 	return nil


### PR DESCRIPTION
This change allows us to delete some of the test-specific code in agent and adds an interface for FQDN proxy.