### PR TITLE
treewide: Ensure that binaries are built with at least Go 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ postcheck: build ## Run Cilium build postcheck (update-cmdref, build documentati
 licenses-all: ## Generate file with all the License from dependencies.
 	@$(GO) run ./tools/licensegen > LICENSE.all || ( rm -f LICENSE.all ; false )
 
-update-go-version: update-dev-doctor-go-version update-gh-actions-go-version update-travis-go-version update-test-go-version update-images-go-version ## Update Go version for all the components (travis, dev-doctor, gh-actions etc.).
+update-go-version: update-dev-doctor-go-version update-gh-actions-go-version update-main-go-version update-travis-go-version update-test-go-version update-images-go-version ## Update Go version for all the components (travis, dev-doctor, gh-actions etc.).
 
 update-dev-doctor-go-version: ## Update dev-doctor Go version.
 	$(QUIET) sed -i 's/^const minGoVersionStr = ".*"/const minGoVersionStr = "$(GO_MAJOR_AND_MINOR_VERSION)"/' tools/dev-doctor/config.go
@@ -576,6 +576,14 @@ update-dev-doctor-go-version: ## Update dev-doctor Go version.
 update-gh-actions-go-version: ## Update Go version in GitHub action config.
 	$(QUIET) for fl in $(shell find .github/workflows -name "*.yaml" -print) ; do sed -i 's/go-version: .*/go-version: $(GO_IMAGE_VERSION)/g' $$fl ; done
 	@echo "Updated go version in GitHub Actions to $(GO_IMAGE_VERSION)"
+
+update-main-go-version: ## Update Go version in main.go.
+	$(QUIET) for fl in $(shell find .  -name main.go -not -path "./vendor/*" -print); do \
+		sed -i \
+			-e 's|^//go:build go.*|//go:build go$(GO_MAJOR_AND_MINOR_VERSION)|g' \
+			-e 's|^// +build go.*|// +build go$(GO_MAJOR_AND_MINOR_VERSION)|g' \
+			$$fl ; \
+	done
 
 update-travis-go-version: ## Update Go version in TravisCI config.
 	$(QUIET) sed -i 's/go: ".*/go: "$(GO_VERSION)"/g' .travis.yml

--- a/bugtool/main.go
+++ b/bugtool/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2017-2018 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/cilium-health/main.go
+++ b/cilium-health/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2017 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import "github.com/cilium/cilium/cilium-health/cmd"

--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2019 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/cilium/main.go
+++ b/cilium/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2016-2018 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2018-2021 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2016-2020 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/hubble-relay/main.go
+++ b/hubble-relay/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/operator/main.go
+++ b/operator/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2018-2020 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2016-2020 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2016-2017 Authors of Cilium
 
+// Ensure build fails on versions of Go that are not supported by Cilium.
+// This build tag should be kept in sync with the version specified in go.mod.
+//go:build go1.17
+// +build go1.17
+
 package main
 
 import (


### PR DESCRIPTION
Cilium relies on a number of Go features that are not covered by Go's
backward compatibility guarantee, for example:

* //go:embed (available since Go 1.16)
* //go:build (available since Go 1.17)

There may be other cases where, for example, we rely on bug fixes in the
standard library.

Building Cilium with an earlier version of Go may complete without
error, but there is no guarantee that the binary will behave correctly.

This PR adds //go:build tags to the main source file of each of the
principle binaries that will cause compilation to fail early and loudly
so the use of old toolchains can be detected quickly.

Signed-off-by: Tom Payne <tom@isovalent.com>
