### PR TITLE
Remove CiliumNode deletion logic from CiliumNode watcher and guarantee CiliumNode's OwnerReference is always set

### DIFF
--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -11,7 +11,6 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -79,9 +78,6 @@ func startSynchronizingCiliumNodes(nodeManager allocator.NodeEventHandler) {
 }
 
 func deleteCiliumNode(nodeManager *allocator.NodeEventHandler, name string) {
-	if err := ciliumK8sClient.CiliumV2().CiliumNodes().Delete(context.TODO(), name, metav1.DeleteOptions{}); err == nil {
-		log.WithField(logfields.NodeName, name).Info("Removed CiliumNode after receiving node deletion event")
-	}
 	if nodeManager != nil {
 		(*nodeManager).Delete(name)
 	}

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -290,9 +290,16 @@ func syncToK8s(nodeGetterUpdater ipam.CiliumNodeGetterUpdater, ciliumNodesToK8s 
 				err = nil
 			}
 		case k8sOpDelete:
-			err = nodeGetterUpdater.Delete(nodeName)
-			if k8sErrors.IsNotFound(err) || k8sErrors.IsGone(err) {
+			// There's no reason to handle a delete operation when we've
+			// already received the delete event for the resource anyway. We'll
+			// fetch it in case it still exists in k8s and warn if we find it.
+			_, err = nodeGetterUpdater.Get(nodeName)
+			if err != nil && k8sErrors.IsNotFound(err) {
+				// This is not an error because we expect the resource to
+				// already be deleted from k8s.
 				err = nil
+			} else {
+				log.WithError(err).Warn("Received a CiliumNode delete event, but the resource may not have been deleted (see error).")
 			}
 		}
 		switch {

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func Test(t *testing.T) {
@@ -1972,13 +1973,11 @@ func (s *PodCIDRSuite) Test_syncToK8s(c *C) {
 			},
 			args: &args{
 				nodeGetter: &k8sNodeMock{
-					OnDelete: func(nodeName string) error {
+					// k8sOpDelete calls Get(), instead of Delete()
+					OnGet: func(nodeName string) (*v2.CiliumNode, error) {
 						calls[k8sOpDelete]++
 						c.Assert(nodeName, checker.DeepEquals, "node-1")
-						return &k8sErrors.StatusError{
-							ErrStatus: v1.Status{
-								Reason: v1.StatusReasonNotFound,
-							}}
+						return nil, k8sErrors.NewNotFound(schema.GroupResource{}, nodeName)
 					},
 				},
 				ciliumNodesToK8s: map[string]*ciliumNodeK8sOp{
@@ -1996,19 +1995,17 @@ func (s *PodCIDRSuite) Test_syncToK8s(c *C) {
 			wantErr: false,
 		},
 		{
-			name: "test-7 - delete node and do not ignore error if node was not found",
+			name: "test-7 - delete node and do not ignore any other error besides node was not found",
 			testSetup: func() {
 				calls = map[k8sOp]int{}
 			},
 			args: &args{
 				nodeGetter: &k8sNodeMock{
-					OnDelete: func(nodeName string) error {
+					// k8sOpDelete calls Get(), instead of Delete()
+					OnGet: func(nodeName string) (*v2.CiliumNode, error) {
 						calls[k8sOpDelete]++
 						c.Assert(nodeName, checker.DeepEquals, "node-1")
-						return &k8sErrors.StatusError{
-							ErrStatus: v1.Status{
-								Reason: v1.StatusReasonBadRequest,
-							}}
+						return nil, k8sErrors.NewTimeoutError("", 0)
 					},
 				},
 				ciliumNodesToK8s: map[string]*ciliumNodeK8sOp{
@@ -2041,50 +2038,52 @@ func (s *PodCIDRSuite) Test_syncToK8s(c *C) {
 }
 
 func (s *PodCIDRSuite) TestNewNodesPodCIDRManager(c *C) {
-	onDeleteCalls := 0
-	deleted2Times := make(chan struct{})
+	name := "node-1"
+	ciliumNode := &v2.CiliumNode{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+	}
+	// `nm` will call Get() on a delete op, because we don't actually delete.
+	onGetCalls := 0
+	wasDeletedOnce := make(chan struct{})
 	nodeGetter := &k8sNodeMock{
-		OnDelete: func(nodeName string) error {
-			onDeleteCalls++
-			switch {
-			case onDeleteCalls < 2:
-				return &k8sErrors.StatusError{
-					ErrStatus: v1.Status{
-						Reason: v1.StatusReasonBadRequest,
-					}}
-			case onDeleteCalls == 2:
-				close(deleted2Times)
-				fallthrough
-			default:
-				return nil
+		OnGet: func(nodeName string) (*v2.CiliumNode, error) {
+			onGetCalls++
+			if onGetCalls == 1 {
+				close(wasDeletedOnce)
+			} else if onGetCalls > 1 {
+				return ciliumNode, nil
 			}
+			return nil, k8sErrors.NewNotFound(schema.GroupResource{}, nodeName)
 		},
 	}
 	updateK8sInterval = time.Second
-	nm := NewNodesPodCIDRManager(nil, nil, nodeGetter, nil)
 
+	nm := NewNodesPodCIDRManager(nil, nil, nodeGetter, nil)
 	nm.k8sReSync.Trigger()
 	// Waiting 2 times the amount of time set in the trigger
 	time.Sleep(2 * time.Second)
-	c.Assert(onDeleteCalls, Equals, 0)
+	c.Assert(onGetCalls, Equals, 0)
 
 	nm.Mutex.Lock()
 	nm.ciliumNodesToK8s = map[string]*ciliumNodeK8sOp{
-		"node-1": {
+		name: {
 			op: k8sOpDelete,
 		},
 	}
 	nm.Mutex.Unlock()
 	select {
-	case <-deleted2Times:
+	case <-wasDeletedOnce:
 	case <-time.Tick(5 * time.Second):
-		c.Error("The controller should have tried to delete the node by now")
+		c.Error("The controller should have received the delete operation by now")
 	}
 	nm.Mutex.Lock()
 	c.Assert(nm.ciliumNodesToK8s, checker.DeepEquals, map[string]*ciliumNodeK8sOp{})
 	nm.Mutex.Unlock()
 	// Wait for the controller to try more times, the number of deletedCalls
-	// should not be different because we have successfully deleted the node.
+	// should not be different because we have successfully processed the
+	// deletion operation of the node.
 	time.Sleep(2 * time.Second)
-	c.Assert(onDeleteCalls, Equals, 2)
+	c.Assert(onGetCalls, Equals, 1)
 }

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -6,6 +6,7 @@ package nodediscovery
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -347,35 +348,56 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 
 	nodeResource.Spec.Addresses = []ciliumv2.NodeAddress{}
 
-	// Tie the CiliumNode custom resource lifecycle to the lifecycle of the
-	// Kubernetes node
-	if k8sNode, err := n.k8sNodeGetter.GetK8sNode(context.TODO(), nodeTypes.GetName()); err != nil {
-		log.WithError(err).Warning("Kubernetes node resource representing own node is not available, cannot set OwnerReference")
-	} else {
-		nodeResource.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: "v1",
-			Kind:       "Node",
-			Name:       nodeTypes.GetName(),
-			UID:        k8sNode.UID,
-		}}
-		providerID = k8sNode.Spec.ProviderID
+	// If we are unable to fetch the K8s Node resource and the CiliumNode does
+	// not have an OwnerReference set, then somehow we are running in an
+	// environment where only the CiliumNode exists. Do not proceed as this is
+	// unexpected.
+	//
+	// Note that we can rely on the OwnerReference to be set on the CiliumNode
+	// as this was added in sufficiently earlier versions of Cilium (v1.6).
+	// Source:
+	// https://github.com/cilium/cilium/commit/5c365f2c6d7930dcda0b8f0d5e6b826a64022a4f
+	k8sNode, err := n.k8sNodeGetter.GetK8sNode(
+		context.TODO(),
+		nodeTypes.GetName(),
+	)
+	switch {
+	case err != nil && k8serrors.IsNotFound(err) && len(nodeResource.ObjectMeta.OwnerReferences) == 0:
+		log.WithError(err).WithField(
+			logfields.NodeName, nodeTypes.GetName(),
+		).Fatal(
+			"Kubernetes Node resource does not exist, setting OwnerReference on " +
+				"CiliumNode is impossible. This is unexpected. Please investigate " +
+				"why Cilium is running on a Node that supposedly does not exist " +
+				"according to Kubernetes.",
+		)
+	case err != nil && !k8serrors.IsNotFound(err):
+		return fmt.Errorf("failed to fetch Kubernetes Node resource: %w", err)
+	}
 
-		// Get the addresses from k8s node and add them as part of Cilium Node.
-		// Cilium Node should contain all addresses from k8s.
-		nodeInterface := k8s.ConvertToNode(k8sNode)
-		typesNode := nodeInterface.(*k8sTypes.Node)
-		k8sNodeParsed := k8s.ParseNode(typesNode, source.Unspec)
-		k8sNodeAddresses = k8sNodeParsed.IPAddresses
+	nodeResource.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       nodeTypes.GetName(),
+		UID:        k8sNode.UID,
+	}}
+	providerID = k8sNode.Spec.ProviderID
 
-		nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels
+	// Get the addresses from k8s node and add them as part of Cilium Node.
+	// Cilium Node should contain all addresses from k8s.
+	nodeInterface := k8s.ConvertToNode(k8sNode)
+	typesNode := nodeInterface.(*k8sTypes.Node)
+	k8sNodeParsed := k8s.ParseNode(typesNode, source.Unspec)
+	k8sNodeAddresses = k8sNodeParsed.IPAddresses
 
-		for _, k8sAddress := range k8sNodeAddresses {
-			k8sAddressStr := k8sAddress.IP.String()
-			nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
-				Type: k8sAddress.Type,
-				IP:   k8sAddressStr,
-			})
-		}
+	nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels
+
+	for _, k8sAddress := range k8sNodeAddresses {
+		k8sAddressStr := k8sAddress.IP.String()
+		nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
+			Type: k8sAddress.Type,
+			IP:   k8sAddressStr,
+		})
 	}
 
 	for _, address := range n.LocalNode.IPAddresses {


### PR DESCRIPTION
First commit:

> We don't need to implement this logic for two reasons:
> 
> 1) We rely on CiliumNode resources to be deleted / cleaned up by
>    attaching the corresponding K8s Node as an `ownerReference` in the
>    CiliumNode.
> 2) It is redundant to delete the CiliumNode in response to an
>    event...of the CiliumNode deletion itself.
> 
> In very rare cases, this logic can actually delete a newly created
> CiliumNode by accident (see example below). Instead, keep all deletion
> logic besides the actual K8s API calls (DELETE) and perform a Get() to
> ensure that it's been deleted. Otherwise, log to the user that the
> resource may still exist.
> 
> Example:
> Say an existing node was deleted and then recreated in
> quick succession with the same name. When the node is recreated, the
> agent will be scheduled on it. During bootstrap it'll create a
> corresponding CiliumNode resource. Given that only one Operator is
> operational at any time in a cluster, it is already running on another
> node in the cluster. The node-delete event will first delete the K8s
> node and then trigger a CN-delete via reason 1 from above. It is
> possible for the CN-delete event to be delayed such that it is received
> after the node-create event (the recreate). When the CN-delete event is
> received by the already-running Operator, the CiliumNode watcher logic
> will then trigger (erroneously) another CN-delete, thereby deleting the
> CiliumNode resource while the K8s node is still alive.

Second commit:

> It is impossible to set the OwnerReference if we fail to fetch the
> corresponding Kubernetes Node and the existing CiliumNode resource
> doesn't already have it set. We can rely the OwnerReference to be set
> because this logic was added in v1.6, which is sufficiently earlier
> version of Cilium. [1]
> 
> The reason for doing this is to ensure that the OwnerReference can
> always be set. If we cannot, this should be treated as an error and we
> shouldn't proceed. Cilium should not run in an environment where the
> Kubernetes Node resource is missing.
> 
> [1]: 5c365f2 ("ipam: Automatically
> create CiliumNode resource on startup")