### PR TITLE
daemon: add support for IPv6 native routing CIDR

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -114,7 +114,8 @@ jobs:
             --set ipv6.enabled=true \
             --set ipv4.enabled=false \
             --set tunnel=disabled \
-            --set autoDirectNodeRoutes=true
+            --set autoDirectNodeRoutes=true \
+            --set ipv6NativeRoutingCIDR=2001:db8:1::/64
 
           kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=${{ env.TIMEOUT }}
           # To make sure that cilium CRD is available (default timeout is 5m)

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -176,6 +176,7 @@ cilium-agent [flags]
       --ipv4-service-range string                            Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
       --ipv6-cluster-alloc-cidr string                       IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
       --ipv6-mcast-device string                             Device that joins a Solicited-Node multicast group for IPv6
+      --ipv6-native-routing-cidr string                      Allows to explicitly specify the IPv6 CIDR for native routing. This value corresponds to the configured cluster-cidr.
       --ipv6-node string                                     IPv6 address of node (default "auto")
       --ipv6-pod-subnets strings                             List of IPv6 pod subnets to preconfigure for encryption
       --ipv6-range string                                    Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -31,8 +31,8 @@ Setting the routable CIDR
   The default behavior is to exclude any destination within the IP allocation
   CIDR of the local node. If the pod IPs are routable across a wider network,
   that network can be specified with the option: ``ipv4-native-routing-cidr:
-  10.0.0.0/8`` in which case all destinations within that CIDR will **not** be
-  masqueraded.
+  10.0.0.0/8`` (or ``ipv6-native-routing-cidr: fd00::/100`` for IPv6 addresses)
+  in which case all destinations within that CIDR will **not** be masqueraded.
 
 Setting the masquerading interface
   See :ref:`masq_modes` for configuring the masquerading interfaces.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -946,7 +946,7 @@
      - object
      - ``{}``
    * - monitor
-     - Specify the IPv4 CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. ipv4NativeRoutingCIDR:
+     - cilium-monitor sidecar.
      - object
      - ``{"enabled":false}``
    * - monitor.enabled

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -289,6 +289,18 @@ Annotations:
 
 .. _current_release_required_changes:
 
+.. _1.12_upgrade_notes:
+
+1.12 Upgrade Notes
+------------------
+
+New Options
+~~~~~~~~~~~
+
+* ``ipv6-native-routing-cidr``: This option specifies the IPv6 CIDR for native
+  routing. It must be set whenever running in direct routing mode with IPv6
+  masquerading enabled.
+
 .. _1.11_upgrade_notes:
 
 1.11 Upgrade Notes

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -262,7 +262,13 @@ func restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 	)
 
 	if ipv6 {
-		cidr = node.GetIPv6AllocRange()
+		switch option.Config.IPAMMode() {
+		case ipamOption.IPAMCRD:
+			// The native routing CIDR is the pod CIDR in these IPAM modes.
+			cidr = option.Config.GetIPv6NativeRoutingCIDR()
+		default:
+			cidr = node.GetIPv6AllocRange()
+		}
 		fromFS = node.GetIPv6Router()
 	} else {
 		switch option.Config.IPAMMode() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -656,6 +656,9 @@ func initializeFlags() {
 	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the IPv4 CIDR for native routing. This value corresponds to the configured cluster-cidr.")
 	option.BindEnv(option.IPv4NativeRoutingCIDR)
 
+	flags.String(option.IPv6NativeRoutingCIDR, "", "Allows to explicitly specify the IPv6 CIDR for native routing. This value corresponds to the configured cluster-cidr.")
+	option.BindEnv(option.IPv6NativeRoutingCIDR)
+
 	flags.String(option.LibDir, defaults.LibraryPath, "Directory path to store runtime build environment")
 	option.BindEnv(option.LibDir)
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -309,6 +309,11 @@ func (d *Daemon) allocateIPs() error {
 
 	if option.Config.EnableIPv6 {
 		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
+
+		if c := option.Config.GetIPv6NativeRoutingCIDR(); c != nil {
+			log.Infof("  IPv6 native routing prefix: %s", c.String())
+		}
+
 		log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
 
 		if addrs, err := d.datapath.LocalNodeAddressing().IPv6().LocalAddresses(); err != nil {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -287,7 +287,7 @@ contributors across the globe, there is almost always someone available to help.
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
-| monitor | object | `{"enabled":false}` | Specify the IPv4 CIDR for native routing (ie to avoid IP masquerade for). This value corresponds to the configured cluster-cidr. ipv4NativeRoutingCIDR: |
+| monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent container name. |
 | nodePort | object | `{"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enabled":false}` | Configure N-S k8s service loadbalancing |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -498,6 +498,10 @@ data:
   ipv4-native-routing-cidr: {{ .Values.ipv4NativeRoutingCIDR }}
 {{- end }}
 
+{{- if hasKey .Values "ipv6NativeRoutingCIDR" }}
+  ipv6-native-routing-cidr: {{ .Values.ipv6NativeRoutingCIDR }}
+{{- end }}
+
 {{- if hasKey .Values "fragmentTracking" }}
   enable-ipv4-fragment-tracking: {{ .Values.fragmentTracking | quote }}
 {{- else if (ne $fragmentTracking "true") }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1065,6 +1065,11 @@ egressGateway:
 # This value corresponds to the configured cluster-cidr.
 # ipv4NativeRoutingCIDR:
 
+# -- Specify the IPv6 CIDR for native routing (ie to avoid IP masquerade for).
+# This value corresponds to the configured cluster-cidr.
+# ipv6NativeRoutingCIDR:
+
+# -- cilium-monitor sidecar.
 monitor:
   # -- Enable the cilium-monitor sidecar.
   enabled: false

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -132,5 +132,10 @@ func RemoteSNATDstAddrExclusionCIDRv4() *cidr.CIDR {
 // packet sent from a local endpoint to an IP address belonging to the CIDR
 // should not be SNAT'd.
 func RemoteSNATDstAddrExclusionCIDRv6() *cidr.CIDR {
+	if c := option.Config.GetIPv6NativeRoutingCIDR(); c != nil {
+		// ipv6-native-routing-cidr is set, so use it
+		return c
+	}
+
 	return node.GetIPv6AllocRange()
 }

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -549,6 +549,66 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 
 }
 
+func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		d       *DaemonConfig
+		wantErr bool
+	}{
+		{
+			name: "with native routing cidr",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade:  true,
+				EnableIPv6Masquerade:  true,
+				Tunnel:                TunnelDisabled,
+				IPv6NativeRoutingCIDR: cidr.MustParseCIDR("fd00::/120"),
+				EnableIPv6:            true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "without native routing cidr and no masquerade",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: false,
+				EnableIPv6Masquerade: false,
+				Tunnel:               TunnelDisabled,
+				EnableIPv6:           true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "without native routing cidr and tunnel enabled",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				Tunnel:               TunnelVXLAN,
+				EnableIPv6:           true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "without native routing cidr and tunnel disabled",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				Tunnel:               TunnelDisabled,
+				EnableIPv6:           true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.d.checkIPv6NativeRoutingCIDR()
+			if tt.wantErr && err == nil {
+				t.Error("expected error, but got nil")
+			}
+		})
+	}
+
+}
+
 func Test_populateNodePortRange(t *testing.T) {
 	type want struct {
 		wantMin int

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -69,7 +69,8 @@ const (
 	LogGathererSelector = "k8s-app=cilium-test-logs"
 	CiliumSelector      = "k8s-app=cilium"
 
-	NativeRoutingCIDR = "10.0.0.0/8"
+	NativeRoutingCIDR     = "10.0.0.0/8"
+	IPv6NativeRoutingCIDR = "fd02::/112"
 )
 
 var (
@@ -112,6 +113,7 @@ var (
 		// We need CNP node status to know when a policy is being enforced
 		"enableCnpStatusUpdates": "true",
 		"nativeRoutingCIDR":      NativeRoutingCIDR,
+		"ipv6NativeRoutingCIDR":  IPv6NativeRoutingCIDR,
 
 		"ipam.operator.clusterPoolIPv6PodCIDR": "fd02::/112",
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -69,7 +69,7 @@ const (
 	LogGathererSelector = "k8s-app=cilium-test-logs"
 	CiliumSelector      = "k8s-app=cilium"
 
-	NativeRoutingCIDR     = "10.0.0.0/8"
+	IPv4NativeRoutingCIDR = "10.0.0.0/8"
 	IPv6NativeRoutingCIDR = "fd02::/112"
 )
 
@@ -112,7 +112,7 @@ var (
 
 		// We need CNP node status to know when a policy is being enforced
 		"enableCnpStatusUpdates": "true",
-		"nativeRoutingCIDR":      NativeRoutingCIDR,
+		"ipv4NativeRoutingCIDR":  IPv4NativeRoutingCIDR,
 		"ipv6NativeRoutingCIDR":  IPv6NativeRoutingCIDR,
 
 		"ipam.operator.clusterPoolIPv6PodCIDR": "fd02::/112",

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -859,23 +859,23 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 
-			cmd := fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -s %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.NativeRoutingCIDR)
+			cmd := fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -s %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.IPv4NativeRoutingCIDR)
 			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
 			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing '-j CT --notrack' iptables rule")
 
-			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -d %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.NativeRoutingCIDR)
+			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_PRE_raw -d %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.IPv4NativeRoutingCIDR)
 			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
 			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing '-j CT --notrack' iptables rule")
 
-			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -s %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.NativeRoutingCIDR)
+			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -s %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.IPv4NativeRoutingCIDR)
 			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
 			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing '-j CT --notrack' iptables rule")
 
-			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -d %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.NativeRoutingCIDR)
+			cmd = fmt.Sprintf("iptables -t raw -C CILIUM_OUTPUT_raw -d %s -m comment --comment 'cilium: NOTRACK for pod traffic' -j CT --notrack", helpers.IPv4NativeRoutingCIDR)
 			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
 			Expect(res.WasSuccessful()).Should(BeTrue(), "Missing '-j CT --notrack' iptables rule")
 
-			cmd = fmt.Sprintf("conntrack -L -s %s -d %s | wc -l", helpers.NativeRoutingCIDR, helpers.NativeRoutingCIDR)
+			cmd = fmt.Sprintf("conntrack -L -s %s -d %s | wc -l", helpers.IPv4NativeRoutingCIDR, helpers.IPv4NativeRoutingCIDR)
 			res = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
 			Expect(res.WasSuccessful()).Should(BeTrue(), "Cannot list conntrack entries")
 			Expect(strings.TrimSpace(res.Stdout())).To(Equal("0"), "Unexpected conntrack entries")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -668,8 +668,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 			BeforeAll(func() {
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-					"tunnel":               "disabled",
-					"autoDirectNodeRoutes": "true",
+					"tunnel":                "disabled",
+					"autoDirectNodeRoutes":  "true",
+					"ipv6NativeRoutingCIDR": helpers.IPv6NativeRoutingCIDR,
 				})
 
 				pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
@@ -684,8 +685,42 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 				ciliumAddService(kubectl, 31080, net.JoinHostPort(testDSK8s1IPv6, "80"), k8s1Backends, "ClusterIP", "Cluster")
 			})
 
-			It("across K8s nodes", func() {
+			It("across K8s nodes, skipped due to native routing CIDR", func() {
+				// Because a native routing CIDR is set, the
+				// IPv6 for packets routed to another node are
+				// _not_ masqueraded. Retrieve the address for
+				// the client, and make sure the echo server
+				// receives it unchanged.
+				pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
+				Expect(err).Should(BeNil(), "Cannot get cilium pod on node %s", helpers.K8s2)
+				k8s2EndpointIPs := kubectl.CiliumEndpointIPv6(pod, fmt.Sprintf("-l k8s:%s,k8s:io.kubernetes.pod.namespace=default", testDSK8s2))
+				k8s2ClientIPv6 := ""
+				for _, epIP := range k8s2EndpointIPs {
+					k8s2ClientIPv6 = epIP
+					break
+				}
+				Expect(k8s2ClientIPv6).ShouldNot(BeEmpty(), "Cannot get client IPv6")
+
 				url := fmt.Sprintf(`"http://[%s]:80/"`, testDSK8s1IPv6)
+				testCurlFromPodWithSourceIPCheck(kubectl, testDSK8s2, url, 5, k8s2ClientIPv6)
+
+				for _, epIP := range k8s1EndpointIPs {
+					url = fmt.Sprintf(`"http://[%s]:80/"`, epIP)
+					testCurlFromPodWithSourceIPCheck(kubectl, testDSK8s2, url, 5, k8s2ClientIPv6)
+				}
+			})
+
+			// Note: At the time we add the test below, it does not
+			// run on the CI because the only job which is running
+			// with a 3rd, non-K8s node (net-next) also has KPR,
+			// and skips the context we're in. Run locally.
+			SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "for external traffic", func() {
+				// A native routing CIDR is set, but it does
+				// not prevent masquerading for packets going
+				// outside of the K8s cluster. Check that the
+				// echo server sees the IPv6 address of the
+				// client's node.
+				url := fmt.Sprintf(`"http://[%s]:80/"`, ni.outsideIPv6)
 				testCurlFromPodWithSourceIPCheck(kubectl, testDSK8s2, url, 5, ni.primaryK8s2IPv6)
 
 				for _, epIP := range k8s1EndpointIPs {


### PR DESCRIPTION
This commit introduces a new option, --ipv6-native-routing-cidr, which
mimics the behaviour of the IPv4 one, allowing to specify the CIDR
within which traffic should not be masqueraded.