### PR TITLE
v1.8: .github: Remove conformance test from lint workflow

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -70,15 +70,3 @@ jobs:
         with:
           command: install
           config: install/kubernetes/chart-testing.yaml
-
-      - name: Install ginkgo
-        run: |
-          cd $HOME
-          go get -u github.com/onsi/ginkgo/ginkgo
-          go get -u github.com/onsi/gomega/...
-
-      - name: Run test suite
-        run: |
-          cd test
-          export PATH=$PATH:$HOME/go/bin
-          ginkgo -v --focus="K8sConformance Portmap Chaining Check one node" -- -cilium.provision=false -test.v --cilium.kubeconfig=${HOME}/.kube/config -cilium.image=cilium/cilium:latest -cilium.operator-image=cilium/operator-generic:latest


### PR DESCRIPTION
Recently, upstream gomega moved to Go 1.16 which is apparently not                                                                                                                                                                                             
available in the workflow environment here. This causes problems like:          
                                                                                
    # github.com/onsi/gomega/matchers                                           
    go/src/github.com/onsi/gomega/matchers/have_http_body_matcher.go:84:30: undefined: io.ReadAll
    go/src/github.com/onsi/gomega/matchers/have_http_status_matcher.go:81:16: undefined: io.ReadAll
    # github.com/onsi/gomega/gmeasure                                           
    go/src/github.com/onsi/gomega/gmeasure/cache.go:69:18: undefined: os.ReadDir
    go/src/github.com/onsi/gomega/gmeasure/cache.go:90:18: undefined: os.ReadDir
                                                                                
We already run the K8sConformance one-node test as part of the regular          
jenkins runs, so this run in the GitHub workflow is duplicate. Newer            
releases don't run this test as part of the linting since it's not              
linting anyway, so we can just drop these steps to resolve the issue and        
rely on Jenkins to provide feedback on this particular test.                    
                                                                                
For what it's worth, I did briefly try pinning to ginkgo@v1.15.2 and            
gomega@v1.15.0 to resolve this but Go would complain about not wanting          
to pull a specific version into the $GOPATH, or otherwise complain about        
the vendor dependencies conflicting if I tried to use GO111MODULE.              
Seemed simpler in the end to just drop this logic from the GitHub action.

Fixes: #17263
