### PR TITLE
workflows/L4LB: Reprovision if vagrant up fails

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -157,7 +157,7 @@ jobs:
           # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
           # Spend up to 10 seconds on this
           for i in {1..4}; do
-            if vagrant up; then
+            if vagrant up --provision; then
               break
             fi
             sleep $i

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -160,7 +160,7 @@ jobs:
           # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
           # Spend up to 10 seconds on this
           for i in {1..4}; do
-            if vagrant up; then
+            if vagrant up --provision; then
               break
             fi
             sleep $i


### PR DESCRIPTION
Make sure that a subsequent call to "vagrant up" does the provisioning
if a previous call has failed. Otherwise, we will risk running the L4LB
suite on the VM with missing dependencies.

Suggested-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Martynas Pumputis <m@lambda.lt>

Fix #17336 