### PR TITLE
proxy: Expose cachedSelectorREEntry type

### DIFF
--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -7,9 +7,68 @@
 package dnsproxy
 
 import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/golang/groupcache/lru"
 	. "gopkg.in/check.v1"
+	"testing"
 )
 
 type DNSProxyHelperTestSuite struct{}
 
 var _ = Suite(&DNSProxyHelperTestSuite{})
+
+// Hook up gocheck into the "go test" runner.
+func TestNonPrivileged(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *DNSProxyHelperTestSuite) TestGetSelectorRegexMap(c *C) {
+	selector := MockCachedSelector{}
+
+	dnsName := "example.name."
+
+	l7 := policy.L7DataMap{
+		selector: &policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{
+				{
+					MatchName: dnsName,
+				},
+			}},
+		},
+	}
+	cache := &lru.Cache{}
+	m, err := GetSelectorRegexMap(l7, cache)
+
+	c.Assert(err, Equals, nil)
+
+	regex, ok := m[selector]
+
+	c.Assert(ok, Equals, true)
+
+	c.Assert(regex.MatchString(dnsName), Equals, true)
+	c.Assert(regex.MatchString(dnsName+"trolo"), Equals, false)
+}
+
+type MockCachedSelector struct{}
+
+func (m MockCachedSelector) GetSelections() []identity.NumericIdentity {
+	return nil
+}
+
+func (m MockCachedSelector) Selects(_ identity.NumericIdentity) bool {
+	return false
+}
+
+func (m MockCachedSelector) IsWildcard() bool {
+	return false
+}
+
+func (m MockCachedSelector) IsNone() bool {
+	return false
+}
+
+func (m MockCachedSelector) String() string {
+	return "string"
+}


### PR DESCRIPTION
This type will be useful for serializing cache entries for communication
between agent and external components

Also factored out retrieval of cached selector -> regex map for future use