### PR TITLE
.github: Rename `project/ci-force` to `ci/flake`

### DIFF
--- a/.github/ISSUE_TEMPLATE/failing_test_template.md
+++ b/.github/ISSUE_TEMPLATE/failing_test_template.md
@@ -2,7 +2,7 @@
 name: Failing Test
 about: Report test failures in Cilium CI jobs
 title: 'CI: '
-labels: area/CI, project/ci-force
+labels: area/CI, ci/flake
 assignees: ''
 
 ---

--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -47,7 +47,7 @@ block-pr-with:
 flake-tracker:
   issue-tracker-config:
     issue-labels:
-    - project/ci-force
+    - ci/flake
   jenkins-config:
     jenkins-url: https://jenkins.cilium.io
     regex-trigger: (^test-me-please)


### PR DESCRIPTION
Following discussion in the community meeting, we decided to rename the `project/ci-force` label to `ci/flake`. We need to rename it in MLH and the issue template.