### PR TITLE
test/runtime: Look into log errors after test start

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1745,7 +1745,8 @@ var _ = Describe("RuntimePolicies", func() {
 
 var _ = Describe("RuntimePolicyImportTests", func() {
 	var (
-		vm *helpers.SSHMeta
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
 	)
 
 	BeforeAll(func() {
@@ -1765,8 +1766,12 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		_ = vm.PolicyDelAll()
 	})
 
+	JustBeforeEach(func() {
+		testStartTime = time.Now()
+	})
+
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 	})
 
 	AfterFailed(func() {

--- a/test/runtime/benchmark.go
+++ b/test/runtime/benchmark.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/pkg/logging"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -57,8 +58,9 @@ func superNetperfStream(s *helpers.SSHMeta, client string, server string, num in
 
 var _ = Describe("BenchmarkNetperfPerformance", func() {
 	var (
-		vm          *helpers.SSHMeta
-		monitorStop = func() error { return nil }
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+		monitorStop   = func() error { return nil }
 
 		log    = logging.DefaultLogger
 		logger = logrus.NewEntry(log)
@@ -74,10 +76,11 @@ var _ = Describe("BenchmarkNetperfPerformance", func() {
 
 	JustBeforeEach(func() {
 		_, monitorStop = vm.MonitorStart()
+		testStartTime = time.Now()
 	})
 
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 

--- a/test/runtime/cassandra.go
+++ b/test/runtime/cassandra.go
@@ -5,6 +5,7 @@ package RuntimeTest
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -16,8 +17,9 @@ import (
 var _ = Describe("RuntimeCassandra", func() {
 
 	var (
-		vm          *helpers.SSHMeta
-		cassandraIP string
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+		cassandraIP   string
 	)
 
 	containers := func(mode string) {
@@ -107,8 +109,12 @@ var _ = Describe("RuntimeCassandra", func() {
 		vm.CloseSSHClient()
 	})
 
+	JustBeforeEach(func() {
+		testStartTime = time.Now()
+	})
+
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 	})
 
 	AfterFailed(func() {

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -4,6 +4,8 @@
 package RuntimeTest
 
 import (
+	"time"
+
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	"github.com/cilium/cilium/test/helpers/constants"
@@ -12,7 +14,10 @@ import (
 )
 
 var _ = Describe("RuntimeChaos", func() {
-	var vm *helpers.SSHMeta
+	var (
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+	)
 
 	BeforeAll(func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
@@ -37,8 +42,12 @@ var _ = Describe("RuntimeChaos", func() {
 		vm.PolicyDelAll()
 	})
 
+	JustBeforeEach(func() {
+		testStartTime = time.Now()
+	})
+
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 		ExpectDockerContainersMatchCiliumEndpoints(vm)
 	})
 

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -21,8 +21,9 @@ var _ = Describe("RuntimeConntrackInVethModeTest", runtimeConntrackTest("veth"))
 var runtimeConntrackTest = func(datapathMode string) func() {
 	return func() {
 		var (
-			vm          *helpers.SSHMeta
-			monitorStop = func() error { return nil }
+			vm            *helpers.SSHMeta
+			testStartTime time.Time
+			monitorStop   = func() error { return nil }
 
 			curl1ContainerName             = "curl"
 			curl2ContainerName             = "curl2"
@@ -362,6 +363,7 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 
 		JustBeforeEach(func() {
 			_, monitorStop = vm.MonitorStart()
+			testStartTime = time.Now()
 		})
 
 		AfterEach(func() {
@@ -375,7 +377,7 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 		})
 
 		JustAfterEach(func() {
-			vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+			vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 			Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 		})
 

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -138,8 +139,9 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 	)
 
 	var (
-		vm          *helpers.SSHMeta
-		monitorStop = func() error { return nil }
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+		monitorStop   = func() error { return nil }
 
 		ciliumTestImages = map[string]string{
 			WorldHttpd1: constants.HttpdImage,
@@ -253,10 +255,11 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 
 	JustBeforeEach(func() {
 		_, monitorStop = vm.MonitorStart()
+		testStartTime = time.Now()
 	})
 
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 		ExpectDockerContainersMatchCiliumEndpoints(vm)
 		monitorStop()
 	})

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -6,6 +6,7 @@ package RuntimeTest
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -17,9 +18,10 @@ import (
 var _ = Describe("RuntimeKafka", func() {
 
 	var (
-		vm          *helpers.SSHMeta
-		monitorRes  *helpers.CmdRes
-		monitorStop = func() error { return nil }
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+		monitorRes    *helpers.CmdRes
+		monitorStop   = func() error { return nil }
 
 		allowedTopic  = "allowedTopic"
 		disallowTopic = "disallowTopic"
@@ -134,11 +136,12 @@ var _ = Describe("RuntimeKafka", func() {
 	})
 
 	JustBeforeEach(func() {
+		testStartTime = time.Now()
 		monitorRes, monitorStop = vm.MonitorStart("--type l7")
 	})
 
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -6,6 +6,7 @@ package RuntimeTest
 import (
 	"fmt"
 	"net"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -16,8 +17,9 @@ import (
 
 var _ = Describe("RuntimeLB", func() {
 	var (
-		vm          *helpers.SSHMeta
-		monitorStop = func() error { return nil }
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+		monitorStop   = func() error { return nil }
 	)
 
 	BeforeAll(func() {
@@ -32,10 +34,11 @@ var _ = Describe("RuntimeLB", func() {
 
 	JustBeforeEach(func() {
 		_, monitorStop = vm.MonitorStart()
+		testStartTime = time.Now()
 	})
 
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 

--- a/test/runtime/memcache.go
+++ b/test/runtime/memcache.go
@@ -5,6 +5,8 @@ package RuntimeTest
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	"github.com/cilium/cilium/test/helpers/constants"
@@ -15,8 +17,9 @@ import (
 var _ = XDescribe("RuntimeMemcache", func() {
 
 	var (
-		vm         *helpers.SSHMeta
-		memcacheIP string
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+		memcacheIP    string
 	)
 
 	containers := func(mode string) {
@@ -103,8 +106,12 @@ var _ = XDescribe("RuntimeMemcache", func() {
 		vm.CloseSSHClient()
 	})
 
+	JustBeforeEach(func() {
+		testStartTime = time.Now()
+	})
+
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 	})
 
 	AfterFailed(func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -26,7 +27,10 @@ const (
 
 var _ = Describe("RuntimeMonitorTest", func() {
 
-	var vm *helpers.SSHMeta
+	var (
+		vm            *helpers.SSHMeta
+		testStartTime time.Time
+	)
 
 	BeforeAll(func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
@@ -46,8 +50,12 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		}
 	})
 
+	JustBeforeEach(func() {
+		testStartTime = time.Now()
+	})
+
 	JustAfterEach(func() {
-		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		vm.ValidateNoErrorsInLogs(time.Since(testStartTime))
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
When running runtime tests locally sometimes the test fail as level=error
log entries are found that are the result of cilium-agent restarts during
provisioning.

This is similar to the fix done in https://github.com/cilium/cilium/pull/14529.