### PR TITLE
operator: Improve identity GC efficiency

### DIFF
--- a/operator/identity_gc.go
+++ b/operator/identity_gc.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/allocator"
@@ -31,7 +33,9 @@ func startKvstoreIdentityGC() {
 		gcTimer, gcTimerDone := inctimer.New()
 		defer gcTimerDone()
 		for {
+			now := time.Now()
 			keysToDelete2, gcStats, err := a.RunGC(identityRateLimiter, keysToDelete)
+			gcDuration := time.Since(now)
 			if err != nil {
 				log.WithError(err).Warning("Unable to run security identity garbage collector")
 
@@ -50,7 +54,20 @@ func startKvstoreIdentityGC() {
 					metrics.IdentityGCSize.WithLabelValues("deleted").Set(float64(gcStats.Deleted))
 				}
 			}
-			<-gcTimer.After(operatorOption.Config.IdentityGCInterval)
+
+			sleep := operatorOption.Config.IdentityGCInterval
+			if operatorOption.Config.IdentityGCInterval <= gcDuration {
+				log.WithFields(logrus.Fields{
+					logfields.Interval: operatorOption.Config.IdentityGCInterval,
+					logfields.Duration: gcDuration,
+					logfields.Hint:     "Is there a ratelimit configured on the kvstore client or server?",
+				}).Warning("Identity garbage collection took longer than the GC interval")
+				// Don't sleep because we have a lot of work to do.
+			} else {
+				sleep -= gcDuration
+				<-gcTimer.After(sleep)
+			}
+
 			log.WithFields(logrus.Fields{
 				"identities-to-delete": keysToDelete,
 			}).Debug("Will delete identities if they are still unused")

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -535,4 +535,7 @@ const (
 
 	// ExpectedENIs are the ENIs which are expected to be available
 	ExpectedENIs = "expectedENIs"
+
+	// Hint helps nudge the user in the right direction when troubleshooting.
+	Hint = "hint"
 )


### PR DESCRIPTION
With this commit, the identity GC rate limit
(--identity-gc-rate-interval) becomes the effective rate at which
identities are garbage collected. Previously, the identity GC interval
(--identity-gc-interval) would cause the Operator to GC for that much
time, then the sleep for that much time, rinse and repeat, effectively
halving the rate.

To use concrete numbers for an example, let's say our interval is 5m and
our GC rate interval is 1000 per minute. It would mean that previously,
we would GC 5000 identities at a maximum for 10m (assuming that deletion
takes 0s). How was that calculated? Each minute, we GC 1000 identities.
After 5m, we have GC'd 5000 identities. But now we have to sleep for 5m
because that's our GC interval. Hence making our effective GC rate 500
per minute (instead of being 1000/m).

Now, we compute the time taken to perform the actual GC and subtract
that from the interval. So in our above example, we eliminate the dead
time of 5m and avoid slashing our effective GC rate in half. This change
allows the Operator to keep up with the demand more efficiently. The
Operator will warn if the GC duration took longer than the interval and
set the sleep duration to 0.

Suggested-by: Joe Stringer <joe@cilium.io>
Suggested-by: Dan Wendlandt <dan@isovalent.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
