### PR TITLE
helm: ensure defaultMode=0400 for projected volumes containing secrets

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -517,7 +517,8 @@ spec:
       - name: etcd-config-path
         configMap:
           name: cilium-config
-          defaultMode: 420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           items:
           - key: etcd-config
             path: etcd.config
@@ -526,7 +527,8 @@ spec:
       - name: etcd-secrets
         secret:
           secretName: cilium-etcd-secrets
-          defaultMode: 420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           optional: true
       {{- end }}
       {{- end }}
@@ -534,7 +536,8 @@ spec:
       - name: clustermesh-secrets
         secret:
           secretName: cilium-clustermesh
-          defaultMode: 420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           optional: true
         # To read the configuration from the config map
       - name: cilium-config-path
@@ -567,6 +570,8 @@ spec:
       {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
       - name: hubble-tls
         projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           sources:
           - secret:
               name: hubble-server-certs

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -228,7 +228,8 @@ spec:
       - name: etcd-config-path
         configMap:
           name: cilium-config
-          defaultMode: 420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           items:
           - key: etcd-config
             path: etcd.config
@@ -237,7 +238,8 @@ spec:
       - name: etcd-secrets
         secret:
           secretName: cilium-etcd-secrets
-          defaultMode: 420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           optional: true
       {{- end }}
       {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -147,7 +147,8 @@ spec:
       - name: etcd-config-path
         configMap:
           name: cilium-config
-          defaultMode: 420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           items:
           - key: etcd-config
             path: etcd.config
@@ -156,7 +157,8 @@ spec:
       - name: etcd-secrets
         secret:
           secretName: cilium-etcd-secrets
-          defaultMode: 420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           optional: true
       {{- end }}
       {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -138,11 +138,13 @@ spec:
       - name: etcd-server-secrets
         secret:
           secretName: clustermesh-apiserver-server-cert
-          defaultMode: 0420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
       - name: etcd-admin-client
         secret:
           secretName: clustermesh-apiserver-admin-cert
-          defaultMode: 0420
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
       - name: etcd-data-dir
         emptyDir: {}
       restartPolicy: Always

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -109,6 +109,8 @@ spec:
       {{- if .Values.hubble.tls.enabled }}
       - name: tls
         projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           sources:
           - secret:
               name: hubble-relay-client-certs

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -120,6 +120,8 @@ spec:
       {{- if .Values.hubble.relay.tls.server.enabled }}
       - name: hubble-ui-client-certs
         projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           sources:
           - secret:
               name: hubble-ui-client-certs


### PR DESCRIPTION
It seems that these volumes were wrongly given permission `420` (`420` decimal == `0644` octal) instead of `0400`, meaning that they were world readable and user writable. Secrets should only be readable by the actual user, thus with permission `0400`.