### PR TITLE
examples: Fix up standalone-etcd.yaml

### DIFF
--- a/examples/kubernetes/addons/etcd/standalone-etcd.yaml
+++ b/examples/kubernetes/addons/etcd/standalone-etcd.yaml
@@ -31,13 +31,16 @@ spec:
   selector:
     component: "cilium-etcd"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "etcd-cilium"
   labels:
     component: "cilium-etcd"
 spec:
+  selector:
+    matchLabels:
+      component: "cilium-etcd"
   serviceName: "cilium-etcd"
   template:
     metadata:
@@ -45,6 +48,9 @@ spec:
       labels:
         component: "cilium-etcd"
     spec:
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
       hostNetwork: true
       affinity:
         podAntiAffinity:
@@ -58,7 +64,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: "etcd"
-        image: "quay.io/coreos/etcd:v3.3.2"
+        image: "quay.io/coreos/etcd:v3.3.25"
         env:
         - name: HOSTNAME_IP
           valueFrom:


### PR DESCRIPTION
This YAML was a bit out-of-date, using older etcd and v1beta1 StatefulSet.
Give it a refresh.

Used by:

```
./contrib/scripts/kind.sh
kubectl apply -f examples/kubernetes/addons/etcd/standalone-etcd.yaml
kubectl get pods
# Wait for the ETCD pod to become ready
cat <<EOF > cilium-etcd.yaml
identityAllocationMode: kvstore
nativeRoutingCIDR: "172.16.0.0/12"
etcd:
  enabled: true
  endpoints:
  - http://$(k get pod etcd-cilium-0 -o json | jq -r '.status.podIP'):32379
EOF
cd /tmp/
helm install cilium cilium/cilium --version 1.9.10 \
  --namespace kube-system -f cilium-etcd.yaml
```