### PR TITLE
ipam/allocator/podcidr: fix old pod cidr logging error

### DIFF
--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -594,7 +594,7 @@ func releaseCIDRs(cidrAllocators []CIDRAllocator, cidrsToRelease []*net.IPNet) {
 				log.WithError(err).Error("failed to release cidr")
 				continue
 			}
-			log.Debug("node released cidrs")
+			log.Info("node released cidrs")
 			break
 		}
 	}


### PR DESCRIPTION
When releasing a pod cidr of a node, this pod cidr field is appended to
the log cache. But log cache could not be flushed because log is not in
debug mode. So old pod cidr is always in the log cache and shows up in
the log output even after a new pod cidr is allocated.
Fix this error by flushing the log cache.