### PR TITLE
codeql: Fix GitHub Action permissions

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -37,6 +37,8 @@ jobs:
     needs: check_changes
     if: github.repository == 'cilium/cilium' && needs.check_changes.outputs.go-changes == 'true'
     runs-on: ubuntu-18.04
+    permissions:
+      security-events: write
     steps:
     - name: Checkout repo
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
CodeQL needs permission to write security events.

See https://github.com/github/codeql-action#usage, for example.