### PR TITLE
docs: Clarify exact requirements for the egress gateway

### DIFF
--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -29,7 +29,9 @@ workload.
 Enable Egress Gateway
 =====================
 
-The feature is disabled by default. Enable the feature:
+The feature is disabled by default. The egress gateway requires BPF
+masquerading, which itself requires BPF NodePort to be enabled. An easy way to
+enable all requirements is as follows.
 
 .. tabs::
 


### PR DESCRIPTION
The egress gateway doesn't exactly require our kube-proxy replacement to be enabled. It only requires BPF masquerading which itself requires BPF NodePort. Enabling KPR is just an easy way to enable BPF NodePort.