### PR TITLE
[v1.9] Remove CiliumNode deletion logic from CiliumNode watcher and guarantee CiliumNode's OwnerReference is always set

### DIFF
--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -89,9 +89,6 @@ func startSynchronizingCiliumNodes(nodeManager allocator.NodeEventHandler) {
 }
 
 func deleteCiliumNode(nodeManager *allocator.NodeEventHandler, name string) {
-	if err := ciliumK8sClient.CiliumV2().CiliumNodes().Delete(context.TODO(), name, metav1.DeleteOptions{}); err == nil {
-		log.WithField("name", name).Info("Removed CiliumNode after receiving node deletion event")
-	}
 	if nodeManager != nil {
 		(*nodeManager).Delete(name)
 	}

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -302,9 +302,16 @@ func syncToK8s(nodeGetterUpdater ipam.CiliumNodeGetterUpdater, ciliumNodesToK8s 
 				err = nil
 			}
 		case k8sOpDelete:
-			err = nodeGetterUpdater.Delete(nodeName)
-			if k8sErrors.IsNotFound(err) || k8sErrors.IsGone(err) {
+			// There's no reason to handle a delete operation when we've
+			// already received the delete event for the resource anyway. We'll
+			// fetch it in case it still exists in k8s and warn if we find it.
+			_, err = nodeGetterUpdater.Get(nodeName)
+			if err != nil && k8sErrors.IsNotFound(err) {
+				// This is not an error because we expect the resource to
+				// already be deleted from k8s.
 				err = nil
+			} else {
+				log.WithError(err).Warn("Received a CiliumNode delete event, but the resource may not have been deleted (see error).")
 			}
 		}
 		switch {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -17,6 +17,7 @@ package nodediscovery
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -353,35 +354,56 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 
 	nodeResource.Spec.Addresses = []ciliumv2.NodeAddress{}
 
-	// Tie the CiliumNode custom resource lifecycle to the lifecycle of the
-	// Kubernetes node
-	if k8sNode, err := k8s.GetNode(k8s.Client(), nodeTypes.GetName()); err != nil {
-		log.WithError(err).Warning("Kubernetes node resource representing own node is not available, cannot set OwnerReference")
-	} else {
-		nodeResource.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: "v1",
-			Kind:       "Node",
-			Name:       nodeTypes.GetName(),
-			UID:        k8sNode.UID,
-		}}
-		providerID = k8sNode.Spec.ProviderID
+	// If we are unable to fetch the K8s Node resource and the CiliumNode does
+	// not have an OwnerReference set, then somehow we are running in an
+	// environment where only the CiliumNode exists. Do not proceed as this is
+	// unexpected.
+	//
+	// Note that we can rely on the OwnerReference to be set on the CiliumNode
+	// as this was added in sufficiently earlier versions of Cilium (v1.6).
+	// Source:
+	// https://github.com/cilium/cilium/commit/5c365f2c6d7930dcda0b8f0d5e6b826a64022a4f
+	k8sNode, err := k8s.GetNode(
+		k8s.Client(),
+		nodeTypes.GetName(),
+	)
+	switch {
+	case err != nil && k8serrors.IsNotFound(err) && len(nodeResource.ObjectMeta.OwnerReferences) == 0:
+		log.WithError(err).WithField(
+			logfields.NodeName, nodeTypes.GetName(),
+		).Fatal(
+			"Kubernetes Node resource does not exist, setting OwnerReference on " +
+				"CiliumNode is impossible. This is unexpected. Please investigate " +
+				"why Cilium is running on a Node that supposedly does not exist " +
+				"according to Kubernetes.",
+		)
+	case err != nil && !k8serrors.IsNotFound(err):
+		return fmt.Errorf("failed to fetch Kubernetes Node resource: %w", err)
+	}
 
-		// Get the addresses from k8s node and add them as part of Cilium Node.
-		// Cilium Node should contain all addresses from k8s.
-		nodeInterface := k8s.ConvertToNode(k8sNode)
-		typesNode := nodeInterface.(*k8sTypes.Node)
-		k8sNodeParsed := k8s.ParseNode(typesNode, source.Unspec)
-		k8sNodeAddresses = k8sNodeParsed.IPAddresses
+	nodeResource.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       nodeTypes.GetName(),
+		UID:        k8sNode.UID,
+	}}
+	providerID = k8sNode.Spec.ProviderID
 
-		nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels
+	// Get the addresses from k8s node and add them as part of Cilium Node.
+	// Cilium Node should contain all addresses from k8s.
+	nodeInterface := k8s.ConvertToNode(k8sNode)
+	typesNode := nodeInterface.(*k8sTypes.Node)
+	k8sNodeParsed := k8s.ParseNode(typesNode, source.Unspec)
+	k8sNodeAddresses = k8sNodeParsed.IPAddresses
 
-		for _, k8sAddress := range k8sNodeAddresses {
-			k8sAddressStr := k8sAddress.IP.String()
-			nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
-				Type: k8sAddress.Type,
-				IP:   k8sAddressStr,
-			})
-		}
+	nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels
+
+	for _, k8sAddress := range k8sNodeAddresses {
+		k8sAddressStr := k8sAddress.IP.String()
+		nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
+			Type: k8sAddress.Type,
+			IP:   k8sAddressStr,
+		})
 	}
 
 	for _, address := range n.LocalNode.IPAddresses {


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/17329.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17329; do contrib/backporting/set-labels.py $pr done 1.9; done
```
