### PR TITLE
hubble: Fix data races in `pkg/hubble.TestRingReader_NextFollow_WithEmptyRing`

### DIFF
--- a/pkg/hubble/container/ring_reader.go
+++ b/pkg/hubble/container/ring_reader.go
@@ -121,9 +121,10 @@ func (r *RingReader) NextFollow(ctx context.Context) *v1.Event {
 	}
 }
 
-// Close waits for any method to return and closes the RingReader. It is not
+// Close waits for any spawned go routines to finish. It is not
 // required to call Close on a RingReader but it may be useful for specific
-// situations such as testing.
+// situations such as testing. Must not be called concurrently with NextFollow,
+// as otherwise NextFollow spawns new go routines that are not waited on.
 func (r *RingReader) Close() error {
 	r.wg.Wait()
 	return nil

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -289,11 +289,13 @@ func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
 	reader := NewRingReader(ring, ring.LastWriteParallel())
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan *v1.Event)
+	done := make(chan struct{})
 	go func() {
 		select {
 		case <-ctx.Done():
 		case c <- reader.NextFollow(ctx):
 		}
+		close(done)
 	}()
 	select {
 	case <-c:
@@ -302,5 +304,6 @@ func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
 		// the call blocked, we're good
 	}
 	cancel()
+	<-done
 	assert.Nil(t, reader.Close())
 }


### PR DESCRIPTION
This fixes two unit test data races reported in #17255 - see commit messages for details. Both races were easy to reproduce locally via `go test -race -count 10 .` inside `pkg/hubble/container`. I have verified that the races are fixed by running `go test -race -count 1000 .`

Fixes: #17255