### PR TITLE
monitor: Initialize agent in deamon early

### DIFF
--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -69,34 +69,55 @@ type Agent struct {
 }
 
 // NewAgent starts a new monitor agent instance which distributes monitor events
-// to registered listeners. It spawns a singleton goroutine reading events from
+// to registered listeners. Once the datapath is set up, AttachToEventsMap needs
+// to be called to receive events from the perf ring buffer. Otherwise, only
+// user space events received via SendEvent are distributed registered listeners.
+// Internally, the agent spawns a singleton goroutine reading events from
 // the BPF perf ring buffer and provides an interface to pass in non-BPF events.
 // The instance can be stopped by cancelling ctx, which will stop the perf reader
 // go routine and close all registered listeners.
 // Note that the perf buffer reader is started only when listeners are
 // connected.
-func NewAgent(ctx context.Context, nPages int) (a *Agent, err error) {
-	// assert that we can actually connect the monitor
-	path := oldBPF.MapPath(eventsMapName)
-	eventsMap, err := ebpf.LoadPinnedMap(path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	a = &Agent{
+func NewAgent(ctx context.Context) *Agent {
+	return &Agent{
 		ctx:              ctx,
 		listeners:        make(map[listener.MonitorListener]struct{}),
 		consumers:        make(map[consumer.MonitorConsumer]struct{}),
 		perfReaderCancel: func() {}, // no-op to avoid doing null checks everywhere
-		events:           eventsMap,
-		MonitorStatus: models.MonitorStatus{
-			Cpus:     int64(eventsMap.MaxEntries()),
-			Npages:   int64(nPages),
-			Pagesize: int64(os.Getpagesize()),
-		},
+	}
+}
+
+// AttachToEventsMap opens the events perf ring buffer and makes it ready for
+// consumption, such that any subscribed consumers may receive events
+// from it. This function is to be called once the events map has been set up.
+func (a *Agent) AttachToEventsMap(nPages int) error {
+	a.Lock()
+	defer a.Unlock()
+
+	if a.events != nil {
+		return errors.New("events map already attached")
 	}
 
-	return a, nil
+	// assert that we can actually connect the monitor
+	path := oldBPF.MapPath(eventsMapName)
+	eventsMap, err := ebpf.LoadPinnedMap(path, nil)
+	if err != nil {
+		return err
+	}
+
+	a.events = eventsMap
+	a.MonitorStatus = models.MonitorStatus{
+		Cpus:     int64(eventsMap.MaxEntries()),
+		Npages:   int64(nPages),
+		Pagesize: int64(os.Getpagesize()),
+	}
+
+	// start the perf reader if we already have subscribers
+	if a.hasSubscribersLocked() {
+		a.startPerfReaderLocked()
+	}
+
+	return nil
 }
 
 // SendEvent distributes an event to all monitor listeners
@@ -154,6 +175,10 @@ func (a *Agent) hasSubscribersLocked() bool {
 // (e.g. on program shutdown) will also cancel the derived context.
 // Note: it is critical to hold the lock for this operation.
 func (a *Agent) startPerfReaderLocked() {
+	if a.events == nil {
+		return // not attached to events map yet
+	}
+
 	a.perfReaderCancel() // don't leak any old readers, just in case.
 	perfEventReaderCtx, cancel := context.WithCancel(a.ctx)
 	a.perfReaderCancel = cancel


### PR DESCRIPTION
The `pkg/monitor/agent` package mainly performs three tasks:

 - Managing subscribers of monitor events (such as `cilium monitor`
   clients or the Hubble observer)
 - Receiving and broadcasting user-space notifications ("agent events")
   to the above subscribers.
 - Polling the perf event ring buffer for datapath notifications and
   broadcasting them to subscribers.

The third task can only be performed once the perf event ring buffer map
has been set up by the daemon. However, some subsystems will try to send
user-space notifications before the events map has been set up. This
often causes an unnecessary log warning to be emitted, which regularly
confuses users (see #14146). Fundamentally however, there is no reason
to drop user-space events if the datapath is not set up yet.

Therefore, this commit splits the monitor agent constructor into two
functions: The first one, `NewAgent` initializes the subscriber
management and allows user-space notifications to be received early, the
second function `AttachToEventsMap` opens the perf event ring buffer to
poll datapath events.

By splitting up the initialization phase and invoking the constructor
earlier, we can avoid the data race in #17167 and we also avoid emitting
a unhelpful warning if user-space events are created early.

Note: Because subscribers (i.e. Hubble or `cilium monitor` clients) are
still attached relatively late, we will still drop early events if there
is no one listening for them. This commit does not address that - but
instead of emitting a confusing warning that the user cannot do anything
about, it will drop the event the same way Cilium up to version 1.8 did.

Fixes: #17167
