### PR TITLE
ci: Increase the CI image wait timeout to 30 minutes

### DIFF
--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -69,7 +69,7 @@ jobs:
           config: ${{ env.kind_config }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -83,7 +83,7 @@ jobs:
           config: ${{ env.KIND_CONFIG }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -115,7 +115,7 @@ jobs:
           config: ${{ env.KIND_CONFIG }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do


### PR DESCRIPTION
There are many CI image build runs that take more than 10 minutes to
complete because of the GitHub Actions concurrency limit. It would be
ideal if we can serialize workflow runs so that tests start after the
CI image build finishes, but in the meantime increase the wait time to
30 minutes as a short term workaround to prevent unnecessary failures.

Ref: https://github.com/cilium/cilium/actions/workflows/build-images-ci.yaml

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>