### PR TITLE
pkg/k8s: fix User-Agent for kubernetes client

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -202,7 +204,11 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		config *rest.Config
 		err    error
 	)
-	userAgent := fmt.Sprintf("Cilium %s", version.Version)
+	cmdName := "cilium"
+	if len(os.Args[0]) != 0 {
+		cmdName = filepath.Base(os.Args[0])
+	}
+	userAgent := fmt.Sprintf("%s/%s", cmdName, version.Version)
 
 	switch {
 	// If the apiServerURL and the kubeCfgPath are empty then we can try getting
@@ -229,7 +235,7 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 }
 
 func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
-	if config.UserAgent != "" {
+	if userAgent != "" {
 		config.UserAgent = userAgent
 	}
 	if qps != 0.0 {


### PR DESCRIPTION
The Kubernetes' client User-Agent was never set and it would always
fallback to the default value. This commit fixes this issue and now all
Cilium components will correctly present their User-Agent.

Fixes: b31ed337090a ("Add k8s client qps and burst as cli flags for the operator")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Set right User Agent in Kubernetes client for all Cilium components.
```
