### PR TITLE
Fix bug where IP addresses of devices in unknown state are resolved as remote-node

### DIFF
--- a/pkg/node/ip_linux.go
+++ b/pkg/node/ip_linux.go
@@ -24,7 +24,12 @@ func initExcludedIPs() {
 	}
 	for _, l := range links {
 		// ... also all down devices since they won't be reachable.
-		if l.Attrs().OperState == netlink.OperUp {
+		//
+		// We need to check for both "up" and "unknown" state, as some
+		// drivers may not implement operstate handling, and just report
+		// their state as unknown even though they are operational.
+		if l.Attrs().OperState == netlink.OperUp ||
+			l.Attrs().OperState == netlink.OperUnknown {
 			skip := true
 			for _, p := range prefixes {
 				if strings.HasPrefix(l.Attrs().Name, p) {


### PR DESCRIPTION
In initExcludedIPs() we build a list of IPs that Cilium needs to exclude
to operate. One check to determine if an IP should be excluded is based
on the state of the net device: if the device is not up, then its IPs
are excluded.

Unfortunately, this check is not enough, as it's possible to have a
device reporting an unknown state (because its driver is missing the
operstate handling, e.g. a dummy device) while still being operational.

This commit changes the logic in initExcludedIPs() to not exclude IPs of
devices reporting an unknown state.