### PR TITLE
contrib/vagrant/start.sh: add a NO_BUILD export

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -48,6 +48,10 @@ export 'TUNNEL_MODE_STRING'=${TUNNEL_MODE_STRING:-"-t vxlan"}
 # Replies Yes to all prompts asked in this script
 export 'YES_TO_ALL'=${YES_TO_ALL:-"0"}
 
+# Don't build the tree inside the VMs (faster)
+# Example use as: make -j$(nproc) && NO_BUILD=1 ./contrib/vagrant/start.sh
+export 'NO_BUILD'=${NO_BUILD:-"0"}
+
 # Internal variables used in the Vagrantfile
 export 'CILIUM_SCRIPT'=true
 # Sets the directory where the temporary setup scripts are created


### PR DESCRIPTION
Add an export for NO_BUILD, to make it clear(er) that this option is
available.

Ideally, we would want argument options instead of environment variables for this
script, but that's a bigger change.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>
