### PR TITLE
workflows: Use new `cilium sysdump`

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -301,10 +301,9 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -304,10 +304,9 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -266,10 +266,17 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          cilium status
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
+
+          echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -269,10 +269,17 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          cilium status
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
+
+          echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -278,10 +278,9 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -281,10 +281,9 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -280,16 +280,15 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          kubectl get pods --all-namespaces -o wide
+          kubectl get cew --all-namespaces -o wide
+          kubectl get cep --all-namespaces -o wide
           cilium status
           cilium clustermesh status
           cilium clustermesh vm status
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
-          kubectl get pods --all-namespaces -o wide
-          kubectl get cew --all-namespaces -o wide
-          kubectl get cep --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE cluster and VM

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -283,16 +283,15 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          kubectl get pods --all-namespaces -o wide
+          kubectl get cew --all-namespaces -o wide
+          kubectl get cep --all-namespaces -o wide
           cilium status
           cilium clustermesh status
           cilium clustermesh vm status
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "cilium status"
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} --command "sudo docker logs cilium --timestamps"
-          kubectl get pods --all-namespaces -o wide
-          kubectl get cew --all-namespaces -o wide
-          kubectl get cep --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE cluster and VM

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -326,10 +326,9 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          kubectl get pods --all-namespaces -o wide
           cilium status
-          kubectl get pods --all-namespaces -o wide -v=6
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -329,10 +329,9 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          kubectl get pods --all-namespaces -o wide
           cilium status
-          kubectl get pods --all-namespaces -o wide -v=6
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -107,8 +107,17 @@ jobs:
       - name: Capture cilium-sysdump
         if: ${{ failure() }}
         run: |
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
+
+          echo "=== Retrieve cluster state ==="
+          kubectl get pods --all-namespaces -o wide
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
 
       - name: Upload cilium-sysdump
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -129,10 +129,9 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          cilium status
           kubectl get pods --all-namespaces -o wide
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -300,19 +300,19 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          kubectl get pods --all-namespaces -o wide
           cilium status --context ${{ steps.contexts.outputs.context1 }}
           cilium clustermesh status --context ${{ steps.contexts.outputs.context1 }}
           cilium status --context ${{ steps.contexts.outputs.context2 }}
           cilium clustermesh status --context ${{ steps.contexts.outputs.context2 }}
 
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           kubectl config use-context ${{ steps.contexts.outputs.context1 }}
           kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-context1
+          cilium sysdump --output-filename cilium-sysdump-context1
 
           kubectl config use-context ${{ steps.contexts.outputs.context2 }}
           kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-context2
+          cilium sysdump --output-filename cilium-sysdump-context2
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -303,19 +303,19 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          kubectl get pods --all-namespaces -o wide
           cilium status --context ${{ steps.contexts.outputs.context1 }}
           cilium clustermesh status --context ${{ steps.contexts.outputs.context1 }}
           cilium status --context ${{ steps.contexts.outputs.context2 }}
           cilium clustermesh status --context ${{ steps.contexts.outputs.context2 }}
 
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
           kubectl config use-context ${{ steps.contexts.outputs.context1 }}
           kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-context1
+          cilium sysdump --output-filename cilium-sysdump-context1
 
           kubectl config use-context ${{ steps.contexts.outputs.context2 }}
           kubectl get pods --all-namespaces -o wide
-          python cilium-sysdump.zip --output cilium-sysdump-context2
+          cilium sysdump --output-filename cilium-sysdump-context2
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -133,17 +133,17 @@ jobs:
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          version=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
-          curl -sLO "https://github.com/cilium/hubble/releases/download/${version}/hubble-linux-amd64.tar.gz"
-          tar zxf hubble-linux-amd64.tar.gz
-          chmod +x ./hubble
-          touch hubble-flows.json
-          ./hubble observe --all --output json > hubble-flows.json || true
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
-
-          tar zcf cilium-sysdump-out.tar.gz cilium-sysdump-out.zip hubble-flows.json
+          echo "=== Retrieve cluster state ==="
+          kubectl get pods --all-namespaces -o wide
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
 
       - name: Upload cilium-sysdump
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -182,17 +182,17 @@ jobs:
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          version=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
-          curl -sLO "https://github.com/cilium/hubble/releases/download/${version}/hubble-linux-amd64.tar.gz"
-          tar zxf hubble-linux-amd64.tar.gz
-          chmod +x ./hubble
-          touch hubble-flows.json
-          ./hubble observe --all --output json > hubble-flows.json || true
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-          curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-          python cilium-sysdump.zip --output cilium-sysdump-out
-
-          tar zcf cilium-sysdump-out.tar.gz cilium-sysdump-out.zip hubble-flows.json
+          echo "=== Retrieve cluster state ==="
+          kubectl get pods --all-namespaces -o wide
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out
 
       - name: Upload cilium-sysdump
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074


### PR DESCRIPTION
We've already been using the new `cilium sysdump` command in cilium-cli for a while, we can start using it in cilium/cilium as well. One advantage of using this new command is that we'll now have the Hubble flows in the sysdump.

Tested with https://github.com/cilium/cilium/commit/89aaaea53f0a9cf38ed9855b5ccc70685eb2f823 where some tests failed and sysdumps were correctly collected.