### PR TITLE
Fix FQDN memory leak

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -131,6 +131,10 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		Cache:           fqdn.NewDNSCache(option.Config.ToFQDNsMinTTL),
 		UpdateSelectors: d.updateSelectors,
 	}
+	// Disable cleanup tracking on the default DNS cache. This cache simply
+	// tracks which api.FQDNSelector are present in policy which apply to
+	// locally running endpoints.
+	cfg.Cache.DisableCleanupTrack()
 
 	rg := fqdn.NewNameManager(cfg)
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(rg)

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -160,6 +160,12 @@ func NewDNSCacheWithLimit(minTTL int, limit int) *DNSCache {
 	return c
 }
 
+func (c *DNSCache) DisableCleanupTrack() {
+	c.Lock()
+	defer c.Unlock()
+	c.cleanup = nil
+}
+
 // Update inserts a new entry into the cache.
 // After insertion cache entries for name are expired and redundant entries
 // evicted. This is O(number of new IPs) for eviction, and O(number of IPs for
@@ -213,6 +219,9 @@ func (c *DNSCache) updateWithEntry(entry *cacheEntry) bool {
 // delete the entry from the policy when it expires.
 // Need to be called with a write lock
 func (c *DNSCache) addNameToCleanup(entry *cacheEntry) {
+	if c.cleanup == nil {
+		return
+	}
 	if c.lastCleanup.IsZero() || entry.ExpirationTime.Before(c.lastCleanup) {
 		c.lastCleanup = entry.ExpirationTime
 	}

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -565,15 +565,6 @@ func (c *DNSCache) ForceExpire(expireLookupsBefore time.Time, nameMatch *regexp.
 	return KeepUniqueNames(namesAffected)
 }
 
-// ForceExpireByNames is the same function as ForceExpire but uses the exact
-// names to delete the entries.
-func (c *DNSCache) ForceExpireByNames(expireLookupsBefore time.Time, names []string) (namesAffected []string) {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.forceExpireByNames(expireLookupsBefore, names)
-}
-
 func (c *DNSCache) forceExpireByNames(expireLookupsBefore time.Time, names []string) (namesAffected []string) {
 	for _, name := range names {
 		entries, exists := c.forward[name]

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2021 Authors of Cilium
 
 //go:build !privileged_tests
 // +build !privileged_tests
@@ -131,7 +131,7 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 	c.Assert(len(dump), Equals, 0, Commentf("Returned cache entries from cache dump after the cache was fully cleared: %v", dump))
 }
 
-func (ds *DNSCacheTestSuite) TestForceExpiredByNames(c *C) {
+func (ds *DNSCacheTestSuite) Test_forceExpiredByNames(c *C) {
 	names := []string{"test1.com", "test2.com"}
 	cache := NewDNSCache(0)
 	for i := 1; i < 4; i++ {
@@ -143,12 +143,12 @@ func (ds *DNSCacheTestSuite) TestForceExpiredByNames(c *C) {
 	}
 
 	c.Assert(cache.forward, HasLen, 3)
-	result := cache.ForceExpireByNames(time.Now(), names)
+	result := cache.forceExpireByNames(time.Now(), names)
 	c.Assert(result, checker.DeepEquals, names)
 	c.Assert(result, HasLen, 2)
 	c.Assert(cache.forward["test3.com"], Not(IsNil))
 
-	invalidName := cache.ForceExpireByNames(now, []string{"invalid.name"})
+	invalidName := cache.forceExpireByNames(now, []string{"invalid.name"})
 	c.Assert(invalidName, HasLen, 0)
 }
 


### PR DESCRIPTION
In the FQDN architecture there's a DNS Cache per endpoint, used to track
which domain names each endpoint makes DNS requests, and a global DNS
Cache where its main functionality is to help tracking which
api.FQDNSelector present in the policy applies to locally running
endpoints. The latter, as opposed to the former, didn't have any
cleanup mechanism for the map that tracked which entries should be
garbage collected, making the global DNS Cache to grow.
This commit prevents those entries from being tracked for Garbage
Collection in the global DNS Cache.

Fixes https://github.com/cilium/cilium/issues/16300

```release-note
Fix memory leak that can occur with the presence of FQDN policies
```
