### PR TITLE
helm: support lookup remote CA

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/_helpers.tpl
@@ -17,7 +17,13 @@ certificate would be signed by a different CA.
       {{- $key := .Values.clustermesh.apiserver.tls.ca.key  | required "missing clustermesh.apiserver.tls.ca.key" }}
       {{- $ca = buildCustomCert $crt $key -}}
     {{- else }}
-      {{- $ca = genCA "clustermesh-apiserver-ca.cilium.io" (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) -}}
+      {{- with lookup "v1" "Secret" .Release.Namespace "clustermesh-apiserver-ca-cert" }}
+        {{- $crt := index .data "ca.crt" }}
+        {{- $key := index .data "ca.key" }}
+        {{- $ca = buildCustomCert $crt $key -}}
+      {{- else }}
+        {{- $ca = genCA "clustermesh-apiserver-ca.cilium.io" (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) -}}
+      {{- end }}
     {{- end }}
     {{- $_ := set . "cmca" $ca -}}
   {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/_helpers.tpl
@@ -17,7 +17,13 @@ certificate would be signed by a different CA.
       {{- $key := .Values.hubble.tls.ca.key  | required "missing hubble.tls.ca.key" }}
       {{- $ca = buildCustomCert $crt $key -}}
     {{- else }}
-      {{- $ca = genCA "hubble-ca.cilium.io" (.Values.hubble.tls.auto.certValidityDuration | int) -}}
+      {{- with lookup "v1" "Secret" .Release.Namespace "hubble-ca-secret" }}
+        {{- $crt := index .data "ca.crt" }}
+        {{- $key := index .data "ca.key" }}
+        {{- $ca = buildCustomCert $crt $key -}}
+      {{- else }}
+        {{- $ca = genCA "hubble-ca.cilium.io" (.Values.hubble.tls.auto.certValidityDuration | int) -}}
+      {{- end }}
     {{- end }}
     {{- $_ := set . "ca" $ca -}}
   {{- end }}


### PR DESCRIPTION
Currently, when TLS auto method is `helm` but user doesn't provide CA. CA and certificates are auto (re-)generated everytime you install/upgrade. And note that **new certificates are not compatible with old CA**.  So that can lead to downtime during rolling update or end-users need to re-import CA if they has 3rd party services/tools interact with cilium.

This PR aim to resolve above issue by re-use existing CA in k8s cluster (Certificates are still re-generated when `helm upgrade` as a part of renew mechanism).

[Note form `lookup` function](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function):
> Keep in mind that Helm is not supposed to contact the Kubernetes API Server during a `helm template` or a `helm install|update|delete|rollback --dry-run`, so the lookup function will return an empty list (i.e. dict) in such a case.

#16792