### PR TITLE
add note about selecting proper interface name for masquerading

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -188,6 +188,10 @@ Install Cilium
           ``tunnel=disabled`` from the helm command will configure Cilium to
           use overlay routing mode (which is the helm default).
 
+         Some Linux distributions use a different interface naming convention.
+         If you use masquerading with the option ``egressMasqueradeInterfaces=eth0``,
+         remember to replace ``eth0`` with the proper interface name.
+
        Cilium is now deployed and you are ready to scale-up the cluster:
 
     .. group-tab:: OpenShift


### PR DESCRIPTION
Added small note to documentation about `egressMasqueradeInterfaces` option. For linux distributions like Fedora CoreOS, network interfaces have different naming like `ens5` not `eth0`. 

Signed-off-by: Kamil Lach <kamil.lach.rs@gmail.com>

