### PR TITLE
test: Skip Istio test on k8s <1.17

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -68,7 +68,8 @@ Download the `cilium enhanced istioctl version 1.10.4 <https://github.com/cilium
 .. note::
 
    Cilium integration, as presented in this Getting Started Guide, has
-   been tested with Kubernetes releases 1.16, 1.17, 1.18, 1.19, 1.20 and 1.21.
+   been tested with Kubernetes releases 1.17, 1.18, 1.19, 1.20 and 1.21.
+   This Istio release does not work with Kubernetes 1.16 or older.
 
 Deploy the default Istio configuration profile onto Kubernetes:
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -74,6 +74,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 	)
 
 	BeforeAll(func() {
+		if helpers.SkipK8sVersions("<1.17.0") {
+			Skip(fmt.Sprintf("Istio %s requires at least K8s version 1.17", istioVersion))
+		}
+
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		By("Downloading cilium-istioctl")


### PR DESCRIPTION
Istio 1.10 requires at least k8s version 1.17.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
