### PR TITLE
ci/multicluster: Test WireGuard in clustermesh

### DIFF
--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -306,6 +306,26 @@ jobs:
             --test '!/pod-to-.*-nodeport' \
              --flow-validation=disabled
 
+      - name: Enable WireGuard
+        run: |
+          for ctx in ${{ steps.contexts.outputs.context1 }} ${{ steps.contexts.outputs.context2 }} ; do
+            kubectl config use-context "$ctx"
+            cilium config set --restart=false enable-wireguard true
+            cilium config set --restart=false enable-wireguard-userspace-fallback true
+            cilium config set --restart=true  enable-l7-proxy  false
+            cilium status --wait
+          done
+
+      - name: Run connectivity test with WireGuard
+        run: |
+          # TODO: Once WireGuard supports the L7 proxy, the L7 tests can be
+          # included here. See cilium/cilium#15462
+          cilium connectivity test \
+            --context ${{ steps.contexts.outputs.context1 }} \
+            --multi-cluster ${{ steps.contexts.outputs.context2 }} \
+            --test '!/pod-to-.*-nodeport,!client-egress-l7,!echo-ingress-l7,!to-fqdns,!dns-only' \
+             --flow-validation=disabled
+
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |

--- a/Documentation/gettingstarted/encryption-wireguard.rst
+++ b/Documentation/gettingstarted/encryption-wireguard.rst
@@ -199,6 +199,17 @@ must hold:
  - ``peers[*].allowed-ips`` should contain a list of pod IP addresses running
    on the remote.
 
+Cluster Mesh
+============
+
+WireGuard enabled Cilium clusters can be connected via :ref:`Cluster Mesh`. The
+``clustermesh-apiserver`` will forward the necessary WireGuard public keys
+automatically to remote clusters.
+In such a setup, it is important to note that all participating clusters must
+have WireGuard encryption enabled, i.e. mixed mode is currently not supported.
+In addition, UDP traffic between nodes of different clusters on port ``51871``
+must be allowed.
+
 Limitations
 ===========
 


### PR DESCRIPTION
This adds an additional WireGuard test to the **Multicluster / Cluster mesh (ci-multicluster)** CI 3.0 workflow.

The new test enables WireGuard after the regular clustermesh test suite, restarts the Cilium pods in both clusters and then runs the regular intra-cluster connectivity check (with any tests disabled that rely on the L7 proxy).

- L7 tests are disabled because the L7 proxy is not supported by WireGuard yet.
- We also fall back on WireGuard user-mode, due to the fact that GKE COS VM images do not ship with WireGuard kernel support. The mode doesn't matter much for this test suite, as this is about ensuring that the control plane (i.e. cilium-agent and clustermesh-apiserver) propagates the WireGuard public keys correctly.

Now that we a regression test for WireGuard+clustermesh, the documentation is also updated to mention that WireGuard may be used together with clustermesh.