### PR TITLE
ci: fix sysdump path

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -149,8 +149,8 @@ jobs:
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
         if: ${{ failure() }}
         with:
-          name: cilium-sysdump-out.tar.gz
-          path: cilium-sysdump-out.tar.gz
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip
 
       - name: Send slack notification
         if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -198,8 +198,8 @@ jobs:
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
         if: ${{ failure() }}
         with:
-          name: cilium-sysdump-out.tar.gz
-          path: cilium-sysdump-out.tar.gz
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip
 
       - name: Send slack notification
         if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}


### PR DESCRIPTION
Seems like we switched from tar.gz to zip at some point and this was not
reflected in these workflows.

![image](https://user-images.githubusercontent.com/1417888/134358422-ce2de972-a5bd-4993-b0ad-9413840d211f.png)
