### PR TITLE
test: bump coredns version to 1.7.0

### DIFF
--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -76,7 +76,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -124,7 +123,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -71,7 +71,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward cilium.test 10.100.0.100:53 {
@@ -119,7 +118,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/eks/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/eks/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
coredns < 1.7.0 has a bug that makes the services resolution to become
out-of-sync with the last state from Kubernetes in case coredns
suffers from a disconnection with kube-apiserver [1]. This bug is fixed on
all versions equal and above 1.7.0. [2]

In our CI this affects all Kubernetes jobs 1.18 and below and can result
in flaky tests that have the result in the following similar logs:

```
service IP retrieved from DNS (10.101.253.144) does not match the IP for the service stored in Kubernetes (10.108.15.225)
```

[1] https://github.com/coredns/coredns/issues/3587
[2] https://github.com/coredns/coredns/pull/3924

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/17401
Fixes https://github.com/cilium/cilium/issues/14598