### PR TITLE
daemon, ipam, option: Introduce ability to bypass IP availability error

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -986,6 +986,10 @@ func init() {
 	flags.MarkHidden(option.EnableICMPRules)
 	option.BindEnv(option.EnableICMPRules)
 
+	flags.Bool(option.BypassIPAvailabilityUponRestore, false, "Bypasses the IP availability error within IPAM upon endpoint restore")
+	flags.MarkHidden(option.BypassIPAvailabilityUponRestore)
+	option.BindEnv(option.BypassIPAvailabilityUponRestore)
+
 	viper.BindPFlags(flags)
 }
 
@@ -1448,6 +1452,29 @@ func initEnv(cmd *cobra.Command) {
 	if option.Config.BGPAnnounceLBIP {
 		option.Config.EnableNodePort = true
 		log.Infof("Auto-set BPF NodePort (%q) because LB IP announcements via BGP depend on it.", option.EnableNodePort)
+	}
+
+	// Ensure that the user does not turn on this mode unless it's for an IPAM
+	// mode which support the bypass.
+	if option.Config.BypassIPAvailabilityUponRestore {
+		switch option.Config.IPAMMode() {
+		case ipamOption.IPAMENI:
+			log.Info(
+				"Running with bypass of IP not available errors upon endpoint " +
+					"restore. Be advised that this mode is intended to be " +
+					"temporary to ease upgrades. Consider restarting the pods " +
+					"which have IPs not from the pool.",
+			)
+		default:
+			option.Config.BypassIPAvailabilityUponRestore = false
+			log.Warnf(
+				"Bypassing IP allocation upon endpoint restore (%q) is enabled with"+
+					"unintended IPAM modes. This bypass is only intended "+
+					"to work for CRD-based IPAM modes such as ENI. Disabling "+
+					"bypass.",
+				option.BypassIPAvailabilityUponRestore,
+			)
+		}
 	}
 }
 

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
@@ -333,7 +335,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	if option.Config.EnableIPv6 && ep.IPv6 != nil {
 		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
 		if err != nil {
-			return fmt.Errorf("unable to reallocate %s IPv6 address: %s", ep.IPv6.IP(), err)
+			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6.IP(), err)
 		}
 
 		defer func() {
@@ -344,8 +346,30 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4 != nil {
-		if _, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
-			return fmt.Errorf("unable to reallocate %s IPv4 address: %s", ep.IPv4.IP(), err)
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+"[restored]")
+		switch {
+		// We only check for BypassIPAllocUponRestore for IPv4 because we
+		// assume that this flag is only turned on for IPv4-only IPAM modes
+		// such as ENI.
+		//
+		// Additionally, only check for a specific error which can be caused by
+		// https://github.com/cilium/cilium/pull/15453. Other errors are not
+		// bypassed.
+		case err != nil &&
+			errors.Is(err, ipam.NewIPNotAvailableInPoolError(ep.IPv4.IP())) &&
+			option.Config.BypassIPAvailabilityUponRestore:
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.IPAddr:     ep.IPv4.IP(),
+				logfields.EndpointID: ep.ID,
+				logfields.K8sPodName: ep.GetK8sNamespaceAndPodName(),
+			}).Warn(
+				"Bypassing IP not available error on endpoint restore. This is " +
+					"to prevent errors upon Cilium upgrade and should not be " +
+					"relied upon. Consider restarting this pod in order to get " +
+					"a fresh IP from the pool.",
+			)
+		case err != nil:
+			return fmt.Errorf("unable to reallocate %s IPv4 address: %w", ep.IPv4.IP(), err)
 		}
 	}
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -391,7 +391,7 @@ func (n *nodeStore) allocate(ip net.IP) (*ipamTypes.AllocationIP, error) {
 
 	ipInfo, ok := n.ownNode.Spec.IPAM.Pool[ip.String()]
 	if !ok {
-		return nil, fmt.Errorf("IP %s is not available", ip.String())
+		return nil, NewIPNotAvailableInPoolError(ip)
 	}
 
 	return &ipInfo, nil
@@ -696,4 +696,35 @@ func (a *crdAllocator) RestoreFinished() {
 	a.store.restoreCloseOnce.Do(func() {
 		close(a.store.restoreFinished)
 	})
+}
+
+// NewIPNotAvailableInPoolError returns an error resprenting the given IP not
+// being available in the IPAM pool.
+func NewIPNotAvailableInPoolError(ip net.IP) error {
+	return &ErrIPNotAvailableInPool{ip: ip}
+}
+
+// ErrIPNotAvailableInPool represents an error when an IP is not available in
+// the pool.
+type ErrIPNotAvailableInPool struct {
+	ip net.IP
+}
+
+func (e *ErrIPNotAvailableInPool) Error() string {
+	return fmt.Sprintf("IP %s is not available", e.ip.String())
+}
+
+// Is provides this error type with the logic for use with errors.Is.
+func (e *ErrIPNotAvailableInPool) Is(target error) bool {
+	if e == nil || target == nil {
+		return false
+	}
+	t, ok := target.(*ErrIPNotAvailableInPool)
+	if !ok {
+		return ok
+	}
+	if t == nil {
+		return false
+	}
+	return t.ip.Equal(e.ip)
 }

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package ipam
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPNotAvailableInPoolError(t *testing.T) {
+	err := NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err2 := NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	assert.Equal(t, err, err2)
+	assert.True(t, errors.Is(err, err2))
+
+	err = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+
+	err = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	err2 = errors.New("another error")
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+
+	err = errors.New("another error")
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+
+	err = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err2 = nil
+	assert.False(t, errors.Is(err, err2))
+
+	err = nil
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	assert.False(t, errors.Is(err, err2))
+
+	// We don't match against strings. It must be the sentinel value.
+	err = errors.New("IP 2.1.1.1 is not available")
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -956,6 +956,11 @@ const (
 
 	// EnableICMPRules enables ICMP-based rule support for Cilium Network Policies.
 	EnableICMPRules = "enable-icmp-rules"
+
+	// BypassIPAvailabilityUponRestore bypasses the IP availability error
+	// within IPAM upon endpoint restore and allows the use of the restored IP
+	// regardless of whether it's available in the pool.
+	BypassIPAvailabilityUponRestore = "bypass-ip-availability-upon-restore"
 )
 
 // Default string arguments
@@ -1970,6 +1975,11 @@ type DaemonConfig struct {
 
 	// EnableICMPRules enables ICMP-based rule support for Cilium Network Policies.
 	EnableICMPRules bool
+
+	// BypassIPAvailabilityUponRestore bypasses the IP availability error
+	// within IPAM upon endpoint restore and allows the use of the restored IP
+	// regardless of whether it's available in the pool.
+	BypassIPAvailabilityUponRestore bool
 }
 
 var (
@@ -2757,6 +2767,7 @@ func (c *DaemonConfig) Populate() {
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
 	c.EnableICMPRules = viper.GetBool(EnableICMPRules)
+	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
 }
 
 func (c *DaemonConfig) populateDevices() {


### PR DESCRIPTION
In CRD-backed IPAM modes such as ENI mode, some IPs were recently
removed from the IPAM pool [1]. In user environments where Cilium was
running a version prior to [1], it is possible for endpoints to be
assigned "unavailable" IPs. Upon upgrade (to a version which includes
[1]), endpoint restoration will fail with [2].

In order to workaround this failure and not disrupt the upgrade, this
change introduces a hidden flag
(`--bypass-ip-availability-upon-restore`) which will inform Cilium to
continue on if the restored endpoint's IP is not available for
reallocation, bypassing the specific error "IP is not available". Other
errors will not be bypassed, in order to reduce the scope of this
stop-gap solution.

With the flag set, restored endpoints which had "unavailable" IPs will
keep them. Any new endpoints / pods will be assigned fresh, valid IPs
from the pool.

This flag is only meant to be enabled with CRD-backed IPAM modes such as
ENI mode. The reason is because of the change described in [1], where
the primary ENI IP was removed from the IPAM pool. In any other mode
that this flag is enabled in, the user is warned that the flag is not
intended for other modes and will have no effect.

This patch is intended to be reverted in the future, as this stop-gap
solution will no longer be required, as users of Cilium don't upgrade
from versions prior to [1]. I propose that we revert this in the
following release that this patch makes it in (N+1).

How was this tested?

1) Deployed a Cilium version that doesn't include [1] on EKS cluster
2) Created a Deployment object which I scaled to max out the ENI IPs,
   such that at least one pod is assigned an "unavailable" IP
3) Upgraded Cilium to a version which does include [1] and observe [2]
   failures
4) Reset cluster back to state from (2)
5) Upgrade Cilium to the version that contains this commit
6) Observe log msgs from this commit and endpoint restoration succeeding
7) Scale Deployment to 0 and back up, to restart all pods
8) Observe that they all get fresh IPs and none of the "unavailable"
   IPs


[1]: https://github.com/cilium/cilium/pull/15453
[2]:

```
{
"time":"2021-09-20T16:57:00.400086481Z",
"level":"WARN",
"origin":"cilium.io/agent",
"message":"Unable to restore endpoint, ignoring",
"params":{
    "endpointID":"992",
    "error":"Failed to re-allocate IP of endpoint: unable to reallocate 10.0.133.193 IPv4 address: IP 10.0.133.193 is not available",
    "k8sPodName":"default/pod-1",
    "subsys":"daemon"
  }
}
```

Signed-off-by: Chris Tarazi <chris@isovalent.com>
