### PR TITLE
[v1.9] Backport of #17492

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
@@ -345,7 +347,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	if option.Config.EnableIPv6 && ep.IPv6 != nil {
 		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
 		if err != nil {
-			return fmt.Errorf("unable to reallocate %s IPv6 address: %s", ep.IPv6.IP(), err)
+			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6.IP(), err)
 		}
 
 		defer func() {
@@ -356,8 +358,30 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4 != nil {
-		if _, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
-			return fmt.Errorf("unable to reallocate %s IPv4 address: %s", ep.IPv4.IP(), err)
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.IP(), ep.HumanStringLocked()+"[restored]")
+		switch {
+		// We only check for BypassIPAllocUponRestore for IPv4 because we
+		// assume that this flag is only turned on for IPv4-only IPAM modes
+		// such as ENI.
+		//
+		// Additionally, only check for a specific error which can be caused by
+		// https://github.com/cilium/cilium/pull/15453. Other errors are not
+		// bypassed.
+		case err != nil &&
+			errors.Is(err, ipam.NewIPNotAvailableInPoolError(ep.IPv4.IP())) &&
+			option.Config.BypassIPAvailabilityUponRestore:
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.IPAddr:     ep.IPv4.IP(),
+				logfields.EndpointID: ep.ID,
+				logfields.K8sPodName: ep.GetK8sNamespaceAndPodName(),
+			}).Warn(
+				"Bypassing IP not available error on endpoint restore. This is " +
+					"to prevent errors upon Cilium upgrade and should not be " +
+					"relied upon. Consider restarting this pod in order to get " +
+					"a fresh IP from the pool.",
+			)
+		case err != nil:
+			return fmt.Errorf("unable to reallocate %s IPv4 address: %w", ep.IPv4.IP(), err)
 		}
 	}
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -394,7 +394,7 @@ func (n *nodeStore) allocate(ip net.IP) (*ipamTypes.AllocationIP, error) {
 
 	ipInfo, ok := n.ownNode.Spec.IPAM.Pool[ip.String()]
 	if !ok {
-		return nil, fmt.Errorf("IP %s is not available", ip.String())
+		return nil, NewIPNotAvailableInPoolError(ip)
 	}
 
 	return &ipInfo, nil
@@ -684,4 +684,35 @@ func (a *crdAllocator) RestoreFinished() {
 	a.store.restoreCloseOnce.Do(func() {
 		close(a.store.restoreFinished)
 	})
+}
+
+// NewIPNotAvailableInPoolError returns an error resprenting the given IP not
+// being available in the IPAM pool.
+func NewIPNotAvailableInPoolError(ip net.IP) error {
+	return &ErrIPNotAvailableInPool{ip: ip}
+}
+
+// ErrIPNotAvailableInPool represents an error when an IP is not available in
+// the pool.
+type ErrIPNotAvailableInPool struct {
+	ip net.IP
+}
+
+func (e *ErrIPNotAvailableInPool) Error() string {
+	return fmt.Sprintf("IP %s is not available", e.ip.String())
+}
+
+// Is provides this error type with the logic for use with errors.Is.
+func (e *ErrIPNotAvailableInPool) Is(target error) bool {
+	if e == nil || target == nil {
+		return false
+	}
+	t, ok := target.(*ErrIPNotAvailableInPool)
+	if !ok {
+		return ok
+	}
+	if t == nil {
+		return false
+	}
+	return t.ip.Equal(e.ip)
 }

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package ipam
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPNotAvailableInPoolError(t *testing.T) {
+	err := NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err2 := NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	assert.Equal(t, err, err2)
+	assert.True(t, errors.Is(err, err2))
+
+	err = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+
+	err = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	err2 = errors.New("another error")
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+
+	err = errors.New("another error")
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+
+	err = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err2 = nil
+	assert.False(t, errors.Is(err, err2))
+
+	err = nil
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	assert.False(t, errors.Is(err, err2))
+
+	// We don't match against strings. It must be the sentinel value.
+	err = errors.New("IP 2.1.1.1 is not available")
+	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	assert.NotEqual(t, err, err2)
+	assert.False(t, errors.Is(err, err2))
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -887,6 +887,11 @@ const (
 	// store rules and routes under ENI and Azure IPAM modes, if false.
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat = "egress-multi-home-ip-rule-compat"
+
+	// BypassIPAvailabilityUponRestore bypasses the IP availability error
+	// within IPAM upon endpoint restore and allows the use of the restored IP
+	// regardless of whether it's available in the pool.
+	BypassIPAvailabilityUponRestore = "bypass-ip-availability-upon-restore"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -2083,6 +2088,11 @@ type DaemonConfig struct {
 
 	// ARPPingRefreshPeriod is the ARP entries refresher period.
 	ARPPingRefreshPeriod time.Duration
+
+	// BypassIPAvailabilityUponRestore bypasses the IP availability error
+	// within IPAM upon endpoint restore and allows the use of the restored IP
+	// regardless of whether it's available in the pool.
+	BypassIPAvailabilityUponRestore bool
 }
 
 var (
@@ -2822,6 +2832,7 @@ func (c *DaemonConfig) Populate() {
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
+	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
 }
 
 func (c *DaemonConfig) populateDevices() {


### PR DESCRIPTION
* #17492 -- daemon, ipam, option: Introduce ability to bypass IP availability error (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17492; do contrib/backporting/set-labels.py $pr done 1.9; done
```
