### PR TITLE
Fix bugs in CiliumEndpointBatch metrics

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -99,18 +99,18 @@ var (
 	// number of CEBs in the CEP range <0, 10>
 	// number of CEBs in the CEP range <11, 20>
 	// number of CEBs in the CEP range <21, 30> and so on
-	CiliumEndpointBatchDensity *prometheus.HistogramVec
+	CiliumEndpointBatchDensity prometheus.Histogram
 
 	// CiliumEndpointsChangeCount indicates the total number of CEPs changed for every CEB request sent to k8s-apiserver.
 	// This metric is used to collect number of CEP changes happening at various buckets.
 	CiliumEndpointsChangeCount *prometheus.HistogramVec
 
 	// CiliumEndpointBatchSyncErrors used to track the total number of errors occurred during syncing CEB with k8s-apiserver.
-	CiliumEndpointBatchSyncErrors *prometheus.CounterVec
+	CiliumEndpointBatchSyncErrors prometheus.Counter
 
 	// CiliumEndpointBatchQueueDelay measures the time spent by CEB's in the workqueue. This measures time difference between
 	// CEB insert in the workqueue and removal from workqueue.
-	CiliumEndpointBatchQueueDelay *prometheus.HistogramVec
+	CiliumEndpointBatchQueueDelay prometheus.Histogram
 )
 
 const (
@@ -165,11 +165,11 @@ func registerMetrics() []prometheus.Collector {
 	}, []string{LabelOutcome})
 	collectors = append(collectors, IdentityGCRuns)
 
-	CiliumEndpointBatchDensity = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	CiliumEndpointBatchDensity = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "number_of_ceps_per_ceb",
 		Help:      "The number of CEPs batched in a CEB",
-	}, []string{})
+	})
 	collectors = append(collectors, CiliumEndpointBatchDensity)
 
 	CiliumEndpointsChangeCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -179,18 +179,18 @@ func registerMetrics() []prometheus.Collector {
 	}, []string{LabelOpcode})
 	collectors = append(collectors, CiliumEndpointsChangeCount)
 
-	CiliumEndpointBatchSyncErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+	CiliumEndpointBatchSyncErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "ceb_sync_errors_total",
 		Help:      "Number of CEB sync errors",
-	}, []string{})
+	})
 	collectors = append(collectors, CiliumEndpointBatchSyncErrors)
 
-	CiliumEndpointBatchQueueDelay = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	CiliumEndpointBatchQueueDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "ceb_queueing_delay_seconds",
 		Help:      "CiliumEndpointBatch queueing delay in seconds",
-	}, []string{})
+	})
 	collectors = append(collectors, CiliumEndpointBatchQueueDelay)
 
 	Registry.MustRegister(collectors...)

--- a/pkg/k8s/watchers/cilium_endpoint_batch_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_batch_subscriber.go
@@ -48,7 +48,7 @@ func (cs *cebSubscriber) OnAdd(ceb *cilium_v2a1.CiliumEndpointBatch) {
 		// Hence, skip processing endpointupdate for localNode CEPs.
 		if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
 			timeSinceCepCreated := time.Since(p.GetCreatedAt())
-			metrics.EndpointPropagationDelay.WithLabelValues("").Observe(timeSinceCepCreated.Seconds())
+			metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
 			continue
 		}
 		cs.kWatcher.endpointUpdated(nil, c)
@@ -102,7 +102,7 @@ func (cs *cebSubscriber) OnUpdate(oldCEB, newCEB *cilium_v2a1.CiliumEndpointBatc
 			// Hence, skip processing endpointupdate for localNode CEPs.
 			if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
 				timeSinceCepCreated := time.Since(p.GetCreatedAt())
-				metrics.EndpointPropagationDelay.WithLabelValues("").Observe(timeSinceCepCreated.Seconds())
+				metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
 				continue
 			}
 			cs.kWatcher.endpointUpdated(nil, c)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -546,6 +546,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_drop_bytes_total":                                              {},
 		Namespace + "_forward_count_total":                                           {},
 		Namespace + "_forward_bytes_total":                                           {},
+		Namespace + "_endpoint_propagation_delay_seconds":                            {},
 		Namespace + "_" + SubsystemDatapath + "_conntrack_dump_resets_total":         {},
 		Namespace + "_" + SubsystemDatapath + "_conntrack_gc_runs_total":             {},
 		Namespace + "_" + SubsystemDatapath + "_conntrack_gc_key_fallbacks_total":    {},


### PR DESCRIPTION
a) Update CiliumEndpointBatch metrics in operator only if metrics is
enabled in cilium-config. 2) Add _endpoint_propagation_delay_seconds in
default metrics 3) Use NewHistogram type in Operator for CEB related
metrics.

Signed-off-by: Gobinath Krishnamoorthy gobinathk@google.com

