### PR TITLE
contrib: Support prereleases in release prep scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -24,12 +24,16 @@ assignees: ''
 - [ ] Push a PR including the changes necessary for the new release:
   - [ ] Pull latest changes from the branch being released
   - [ ] Run `contrib/release/start-release.sh`
-        **Note**: For `RCs` that are not in a stable branch, you need to follow
-                  the RC release guide manually.
   - [ ] Run `Documentation/check-crd-compat-table.sh vX.Y` and if needed, follow the
         instructions.
+        **Note**: For `RCs` that are not in a stable branch, you need to follow
+                  bump the CRD version manually and skip this step.
   - [ ] Commit all changes with title `Prepare for release vX.Y.Z`
+    - [ ] For RC versions, commit the `AUTHORS` file changes separately.
   - [ ] Submit PR (`contrib/release/submit-release.sh`)
+  - [ ] For a new RC version on the master branch:
+    - [ ] Allow the CI to sanity-check the PR and get review
+    - [ ] Revert the release commit and re-push
   - [ ] For a new minor version:
     - [ ] Add the 'stable' tag as part of the GitHub workflow and remove the
           'stable' tag from the last stable branch.
@@ -41,7 +45,9 @@ assignees: ''
           branch.
 - [ ] Merge PR
 - [ ] Create and push *both* tags to GitHub (`vX.Y.Z`, `X.Y.Z`)
-  - Pull latest branch locally and run `contrib/release/tag-release.sh`
+  - Pull latest branch locally and run `contrib/release/tag-release.sh`.
+  - For RCs, this means checking out the commit before the revert and running
+    `tag-release.sh` against that commit.
 - [ ] Ask a maintainer to approve the build in the following links (keep the URL
       of the GitHub run to be used later):
   - [Cilium Image Release builds](https://github.com/cilium/cilium/actions?query=workflow:%22Image+Release+Build%22)
@@ -49,6 +55,7 @@ assignees: ''
     `make -C install/kubernetes/ check-docker-images`
 - [ ] Get the image digests from the build process and make a commit and PR with
       these digests.
+  - For RCs on the master branch, skip this step.
   - [ ] Run `contrib/release/post-release.sh` to fetch the image
         digests and submit a PR to update these, use the URL of the GitHub run here.
   - [ ] Merge PR
@@ -70,8 +77,10 @@ assignees: ''
           [docsearch-scraper-webhook].
 - [ ] Check draft release from [releases] page
   - [ ] Update the text at the top with 2-3 highlights of the release
-  - [ ] Copy the text from `digest-vX.Y.Z.txt` (previously generated with
-        `contrib/release/post-release.sh`) to the end of the release.
+  - [ ] Copy the text from `digest-vX.Y.Z.txt` to the end of the release text.
+        This text was previously generated with
+        `contrib/release/post-release.sh`, or is otherwise available in the
+        GitHub workflow run that built the images.
   - [ ] Publish the release
 - [ ] Announce the release in #general on Slack (only [@]channel for vX.Y.0)
 - [ ] Update Grafana dashboards (only for vX.Y.0)

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -108,14 +108,6 @@ Reference steps for the template
    This will leave a file with the format ``digest-vX.Y.Z.txt`` in the local
    directory which can be used to prepare the release in the next step.
 
-#. `Publish a GitHub release <https://github.com/cilium/cilium/releases/>`_:
-
-   Following the steps above, the release draft will already be prepared.
-   Preview the description and then publish the release.
-
-   #. Copy the official docker manifests for the release from the previous step
-      into the end of the Github release announcement.
-
 #. Prepare Helm changes for the release using the `Cilium Helm Charts Repository <https://github.com/cilium/charts/>`__
    and push the changes into that repository (not the main cilium repository):
 
@@ -142,6 +134,17 @@ Reference steps for the template
 
    After pushing you can revert all the changes made in the local branch
    ``x.y-dev`` from ``cilium/cilium``.
+
+#. Wait for the `Cilium Helm Charts Workflow <https://github.com/cilium/charts/actions>`__
+   to successfully deploy a cluster using the new Helm charts.
+
+#. `Publish a GitHub release <https://github.com/cilium/cilium/releases/>`_:
+
+   Following the steps above, the release draft will already be prepared.
+   Preview the description and then publish the release.
+
+   #. Copy the official docker manifests for the release from the previous step
+      into the end of the Github release announcement.
 
 #. Announce the release in the ``#general`` channel on Slack. Sample text:
 

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -16,6 +16,8 @@
 
 set -e
 
+RELEASE_REGEX="[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(snapshot\)\)\(\.\)\?[0-9]\+\)\?$"
+
 get_remote () {
   local remote
   local org=${1:-cilium}
@@ -60,4 +62,13 @@ commit_in_upstream() {
     local remote="$(get_remote ${org} ${repo})"
     local branches="$(git branch -q -r --contains $commit $remote/$branch 2> /dev/null)"
     echo "$branches" | grep -q ".*$remote/$branch"
+}
+
+get_branch_from_version() {
+    local remote="$1"
+    local branch="$(echo $2 | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
+    if [ -z "$(git ls-remote --heads $remote $branch)" ]; then
+        branch="master"
+    fi
+    echo "$branch"
 }

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -29,12 +29,12 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+    if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z"
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
     fi
 
-    if ! echo "$2" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+[-rc0-9]*"; then
+    if ! echo "$2" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
         common::exit 1 "Invalid NEW-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
     fi

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -6,6 +6,7 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
+VERSION_GLOB='v[0-9]*\.[0-9]*\.[0-9]*'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
@@ -73,8 +74,11 @@ main() {
     git fetch -q $REMOTE
     if [ "$branch" = "master" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
-        local old_branch="$(get_branch_from_version $REMOTE v$(cat VERSION))"
-        old_version="$(git show $old_branch:VERSION)"
+        if echo "$version" | grep -q 'rc'; then
+            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'snapshot' | sort -V | tail -n 1)"
+        else
+            old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"
+        fi
     else
         git checkout -b pr/prepare-$version $REMOTE/$branch
         old_version="$(cat VERSION)"

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -7,6 +7,7 @@ source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+VERSION_TO_BRANCH_REGEX='s/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
@@ -16,6 +17,18 @@ usage() {
     logecho "GH-PROJECT Project Number for next (X.Y.Z+1) development release"
     logecho
     logecho "--help     Print this help message"
+}
+
+# $1 - VERSION
+version_is_prerelease() {
+    case "$1" in
+        *rc*|*snapshot*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 handle_args() {
@@ -29,12 +42,12 @@ handle_args() {
         common::exit 0
     fi
 
-    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+    if ! echo "$1" | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(snapshot\)\)\(\.\)\?[0-9]\+\)\?$"; then
         usage 2>&1
         common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
     fi
 
-    if ! echo "$2" | grep -q "^[0-9]\+"; then
+    if ! echo "$2" | grep -q "^[0-9]\+" && ! version_is_prerelease "$1"; then
         usage 2>&1
         common::exit 1 "Invalid GH-PROJECT ID argument. Expected [0-9]+"
     fi
@@ -54,25 +67,37 @@ main() {
 
     local ersion="$(echo $1 | sed 's/^v//')"
     local version="v$ersion"
-    local branch="v$(echo $ersion | sed 's/[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/')"
+    local branch="v$(echo $ersion | sed $VERSION_TO_BRANCH_REGEX)"
     local new_proj="$2"
+    local old_version=""
 
     git fetch $REMOTE
-    git checkout -b pr/prepare-$version $REMOTE/$branch
-    local old_version="$(cat VERSION)"
+    if [ -n "$(git ls-remote --heads $REMOTE $branch)" ]; then
+        git checkout -b pr/prepare-$version $REMOTE/$branch
+        old_version="$(cat VERSION)"
+    else
+        logecho "Cannot find $REMOTE/$branch. Basing release on master."
+        branch="master"
+        git checkout -b pr/prepare-$version $REMOTE/$branch
+        local old_branch="$(cat VERSION | sed $VERSION_TO_BRANCH_REGEX)"
+        old_version="$(git show v$old_branch:VERSION)"
+    fi
 
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
     logrun make update-authors
-    old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
-    sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+    if ! version_is_prerelease "$version"; then
+        old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
+        sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
+    fi
 
     $DIR/prep-changelog.sh "$old_version" "$version"
 
     logecho "Next steps:"
     logecho "* Check all changes and add to a new commit"
+    logecho "  * If this is a prerelease, create a revert commit"
     logecho "* Push the PR to Github for review ('submit-release.sh')"
     logecho "* Close https://github.com/cilium/cilium/projects/$old_proj"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -10,8 +10,10 @@ REMOTE="$(get_remote)"
 BRANCH="${1:-""}"
 if [ "$BRANCH" = "" ]; then
     BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')
+    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
+        BRANCH=master
+    fi
 fi
-BRANCH=$(echo "$BRANCH" | sed 's/^v//')
 
 RELEASE="v$(cat VERSION)"
 SUMMARY=${2:-}
@@ -23,10 +25,10 @@ fi
 
 USER_REMOTE=$(get_user_remote ${3:-})
 
-if ! git branch -a | grep -q "$REMOTE/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+if ! git branch -a | grep -q "$REMOTE/$BRANCH$" || [ ! -e $SUMMARY ]; then
     echo "usage: $0 [branch version] [release-summary] [your remote]" 1>&2
     echo 1>&2
-    echo "Ensure 'branch version' is available in '$REMOTE' and the summary file exists" 1>&2
+    echo "Ensure '$BRANCH' is available in '$REMOTE' and the summary file exists" 1>&2
     exit 1
 fi
 
@@ -51,12 +53,21 @@ if $GENERATE_SUMMARY; then
     CHANGELOG=$SUMMARY
     SUMMARY="$RELEASE-pr-$(date --rfc-3339=date).txt"
     echo "Prepare for release $RELEASE" > $SUMMARY
-    tail -n+4 $CHANGELOG >> $SUMMARY
+    if [ "$BRANCH" = "master" ]; then
+        echo "" >> $SUMMARY
+        echo "See the included CHANGELOG.md for a full list of changes." >> $SUMMARY
+    else
+        tail -n+4 $CHANGELOG >> $SUMMARY
+    fi
 fi
 
-echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+echo -e "Sending PR for branch $BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
 echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push $USER_REMOTE "$PR_BRANCH"
-hub pull-request -b "v$BRANCH" -l kind/release,backport/$BRANCH -F $SUMMARY
+LABELS="kind/release"
+if [ "$BRANCH" != "master" ]; then
+    labels = "$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
+fi
+hub pull-request -b "$BRANCH" -l "$LABELS" -F $SUMMARY

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -9,10 +9,7 @@ source $DIR/../backporting/common.sh
 REMOTE="$(get_remote)"
 BRANCH="${1:-""}"
 if [ "$BRANCH" = "" ]; then
-    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')
-    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
-        BRANCH=master
-    fi
+    BRANCH="$(get_branch_from_version $REMOTE $(git symbolic-ref -q --short HEAD))"
 fi
 
 RELEASE="v$(cat VERSION)"

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -60,10 +60,7 @@ main() {
     git fetch $REMOTE
 
     local commit="$(git rev-parse HEAD)"
-    BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
-    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
-        BRANCH="master"
-    fi
+    BRANCH="$(get_branch_from_version $REMOTE $(git symbolic-ref -q --short HEAD))"
     echo "Current HEAD is:"
     git log --oneline -1 "$commit"
     if ! commit_in_upstream "$commit" "$BRANCH"; then

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -61,6 +61,9 @@ main() {
 
     local commit="$(git rev-parse HEAD)"
     BRANCH="$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
+    if [ -z "$(git ls-remote --heads $REMOTE $BRANCH)" ]; then
+        BRANCH="master"
+    fi
     echo "Current HEAD is:"
     git log --oneline -1 "$commit"
     if ! commit_in_upstream "$commit" "$BRANCH"; then


### PR DESCRIPTION
Add support for vX.Y.0-rcN and vX.Y.0-snapshotN prereleases into the
start-release.sh and submit-release.sh scripts.
