### PR TITLE
Perform reverse NAT at Host Interface

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1013,6 +1013,10 @@
      - Agent container name.
      - string
      - ``"cilium"``
+   * - netfilterCompatMode
+     - Enable the netfilter compatible mode, guarantees only nodeport traffic will pass through netfilter.
+     - bool
+     - ``false``
    * - nodePort
      - Configure N-S k8s service loadbalancing
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -657,6 +657,7 @@ nodeSelector
 nodeX
 nodegroup
 nodeinit
+nodeport
 nonMasqueradeCIDRs
 numReplicas
 observability

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -638,6 +638,7 @@ netdevice
 netdevices
 netdevsim
 netfilter
+netfilterCompatMode
 netns
 netperf
 netsec

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -174,6 +174,11 @@ MAX_HOST_OPTIONS = $(MAX_BASE_OPTIONS) -DENCAP_IFINDEX=1 -DTUNNEL_MODE=1
 ifneq (,$(filter $(KERNEL),"54" "netnext"))
 MAX_HOST_OPTIONS += -DENABLE_EGRESS_GATEWAY=1
 endif
+ifeq ("$(KERNEL)","54")
+MAX_HOST_OPTIONS += -DNETFILTER_COMPAT_MODE=1
+else ifeq ("$(KERNEL)","netnext")
+MAX_HOST_OPTIONS += -DNETFILTER_COMPAT_MODE=1
+endif
 endif
 
 bpf_host.ll: bpf_host.c $(LIB)

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1081,6 +1081,19 @@ out:
 	 (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) || \
 	 defined(ENABLE_MASQUERADE) || \
 	 defined(ENABLE_EGRESS_GATEWAY))
+
+#ifdef NETFILTER_COMPAT_MODE
+
+	/* For a packet which is a reply from a local endpoint to a NodePort request,
+	 * do rev-DNAT. To determine if it is Nodeport traffic, do conntrack lookup for
+	 * all reply packets.
+	 */
+	ret = rev_nodeport_lb(ctx);
+	if (IS_ERR(ret))
+		return send_drop_notify_error(ctx, 0, ret,
+						CTX_ACT_DROP,
+						METRIC_EGRESS);
+#endif /* NETFILTER_COMPAT_MODE */
 	if ((ctx->mark & MARK_MAGIC_SNAT_DONE) != MARK_MAGIC_SNAT_DONE) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -277,6 +277,12 @@ ct_recreate6:
 		policy_mark_skip(ctx);
 
 #ifdef ENABLE_NODEPORT
+#ifdef NETFILTER_COMPAT_MODE
+		if (ct_state.node_port) {
+			return CTX_ACT_OK;
+		}
+#endif /* NETFILTER_COMPAT_MODE */
+
 # ifdef ENABLE_DSR
 		if (ct_state.dsr) {
 			ret = xlate_dsr_v6(ctx, tuple, l4_off);
@@ -718,6 +724,14 @@ ct_recreate4:
 		policy_mark_skip(ctx);
 
 #ifdef ENABLE_NODEPORT
+#ifdef NETFILTER_COMPAT_MODE
+		if (ct_state.node_port) {
+			/* Pass the packet to the stack and let bpf_host perform
+			 * rev-DNAT at egress of the native device.
+			 */
+			return CTX_ACT_OK;
+#endif /* NETFILTER_COMPAT_MODE */
+
 # ifdef ENABLE_DSR
 		if (ct_state.dsr) {
 			ret = xlate_dsr_v4(ctx, &tuple, l4_off, has_l4_header);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -847,7 +847,8 @@ redo:
 }
 
 /* See comment in tail_rev_nodeport_lb4(). */
-static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex)
+static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex,
+					    const bool rev_dnat_at_netdev)
 {
 	int ret, fib_ret, ret2, l3_off = ETH_HLEN, l4_off, hdrlen;
 	struct ipv6_ct_tuple tuple = {};
@@ -875,6 +876,10 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 
 	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
 			 &monitor);
+
+	/* See ipv4 equivalent for details */
+	if (rev_dnat_at_netdev && !ct_state.node_port)
+		return CTX_ACT_OK;
 
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret2 = lb6_rev_nat(ctx, l4_off, &csum_off, ct_state.rev_nat_index,
@@ -983,7 +988,7 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	 */
 	ctx_skip_host_fw_set(ctx);
 #endif
-	ret = rev_nodeport_lb6(ctx, &ifindex);
+	ret = rev_nodeport_lb6(ctx, &ifindex, false);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 
@@ -1840,7 +1845,8 @@ redo:
  * CILIUM_CALL_IPV{4,6}_NODEPORT_REVNAT is plugged into CILIUM_MAP_CALLS
  * of the bpf_host, bpf_overlay and of the bpf_lxc.
  */
-static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex)
+static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex,
+					    const bool rev_dnat_at_netdev)
 {
 	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
@@ -1890,6 +1896,14 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 #endif /* ENABLE_EGRESS_GATEWAY */
 	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
 			 &monitor);
+
+	/* When we do the rev-DNAT for a NodePort reply from a local service endpoint
+	 * on the bpf_host's "to-netdev" instead of bpf_lxc, then this function is
+	 * executed on all packets. Return early if we detect that a packet is not
+	 * the reply to avoid unnecessary waste of resources.
+	 */
+	if (rev_dnat_at_netdev && !ct_state.node_port)
+		return CTX_ACT_OK;
 
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret2 = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
@@ -2019,7 +2033,7 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 	 */
 	ctx_skip_host_fw_set(ctx);
 #endif
-	ret = rev_nodeport_lb4(ctx, &ifindex);
+	ret = rev_nodeport_lb4(ctx, &ifindex, false);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 
@@ -2171,5 +2185,36 @@ static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx)
 	return ret;
 }
 
+/* Wrapper function to call rev_nodeport_lb4/6.
+ * This function calls rev_nodeport_lb4/6, to perform conntrack lookup
+ * and reverse DNAT only if it is NodePort traffic.
+ * arguments
+ * ctx    : Pointer to packet context buffer.
+ * return : Returns the output of rev_nodeport_lb4/6 for valid packets.
+ */
+static __always_inline int rev_nodeport_lb(struct __ctx_buff *ctx)
+{
+	int ret = CTX_ACT_OK;
+	int ifindex = 0;
+	__u16 proto;
+
+	if (!validate_ethertype(ctx, &proto))
+		return CTX_ACT_OK;
+	switch (proto) {
+#ifdef ENABLE_IPV4
+	case bpf_htons(ETH_P_IP):
+		ret = rev_nodeport_lb4(ctx, &ifindex, true);
+	break;
+#endif /* ENABLE_IPV4 */
+#ifdef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6):
+		ret = rev_nodeport_lb6(ctx, &ifindex, true);
+	break;
+#endif /* ENABLE_IPV6 */
+	default:
+	break;
+	}
+	return ret;
+}
 #endif /* ENABLE_NODEPORT */
 #endif /* __NODEPORT_H_ */

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -551,6 +551,8 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) error {
 		// Non-BPF masquerade requires netfilter and hence CT.
 		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
+		case option.Config.NetfilterCompatibleMode:
+			msg = fmt.Sprintf("BPF host routing is not supported with %s.", option.NetfilterCompatibleMode)
 		// All cases below still need to be implemented ...
 		case option.Config.EnableEndpointRoutes:
 			msg = fmt.Sprintf("BPF host routing is currently not supported with %s.", option.EnableEndpointRoutes)

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -304,6 +304,7 @@ contributors across the globe, there is almost always someone available to help.
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent container name. |
+| netfilterCompatMode | bool | `false` | Enable the netfilter compatible mode, guarantees only nodeport traffic will pass through netfilter. |
 | nodePort | object | `{"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enabled":false}` | Configure N-S k8s service loadbalancing |
 | nodePort.autoProtectPortRange | bool | `true` | Append NodePort range to ip_local_reserved_ports if clash with ephemeral ports is detected. |
 | nodePort.bindProtection | bool | `true` | Set to true to prevent applications binding to service ports. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -801,6 +801,10 @@ data:
   enable-k8s-terminating-endpoint: {{ .Values.enableK8sTerminatingEndpoint | quote }}
 {{- end }}
 
+{{- if hasKey .Values "netfilterCompatMode" }}
+  netfilter-compatible-mode: {{ .Values.netfilterCompatMode | quote }}
+{{- end }}
+
 {{- if .Values.extraConfig }}
   {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1083,6 +1083,10 @@ enableIPv6Masquerade: true
 egressGateway:
   enabled: false
 
+# -- Enable the netfilter compatible mode, guarantees only nodeport
+# traffic will pass through netfilter.
+netfilterCompatMode: false
+
 # -- Specify the IPv4 CIDR for native routing (ie to avoid IP masquerade for).
 # This value corresponds to the configured cluster-cidr.
 # Deprecated in favor of ipv4NativeRoutingCIDR, will be removed in 1.12.

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -397,6 +397,12 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["NATIVE_DEV_MAC_BY_IFINDEX(IFINDEX)"] = macByIfIndexMacro
 		cDefinesMap["IS_L3_DEV(ifindex)"] = isL3DevMacro
 	}
+
+	if option.Config.NetfilterCompatibleMode &&
+		(option.Config.InstallIptRules || iptables.KernelHasNetfilter()) {
+		cDefinesMap["NETFILTER_COMPAT_MODE"] = "1"
+	}
+
 	const (
 		selectionRandom = iota + 1
 		selectionMaglev

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -313,7 +313,7 @@ func (p *ProbeManager) GetMapTypes() *MapTypes {
 	return &p.features.MapTypes
 }
 
-// GetMisc returns information about kernel misc.
+// GetMisc returns information about miscellaneous eBPF features.
 func (p *ProbeManager) GetMisc() Misc {
 	return p.features.Misc
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -998,6 +998,10 @@ const (
 	// EnableK8sTerminatingEndpoint enables the option to auto detect terminating
 	// state for endpoints in order to support graceful termination.
 	EnableK8sTerminatingEndpoint = "enable-k8s-terminating-endpoint"
+
+	// NetfilterCompatibleMode guarantees the traffic will pass through kernel
+	// netfilter. This option only affects NodePort traffic.
+	NetfilterCompatibleMode = "netfilter-compatible-mode"
 )
 
 // Default string arguments
@@ -1701,6 +1705,10 @@ type DaemonConfig struct {
 
 	// EnableHostLegacyRouting enables the old routing path via stack.
 	EnableHostLegacyRouting bool
+
+	// NetfilterCompatibleMode guarantees the traffic will pass through kernel
+	// netfilter. Currently, it only affects NodePort traffic.
+	NetfilterCompatibleMode bool
 
 	// NodePortMode indicates in which mode NodePort implementation should run
 	// ("snat", "dsr" or "hybrid")
@@ -2657,6 +2665,7 @@ func (c *DaemonConfig) Populate() {
 	c.BGPAnnouncePodCIDR = viper.GetBool(BGPAnnouncePodCIDR)
 	c.BGPConfigPath = viper.GetString(BGPConfigPath)
 	c.ExternalClusterIP = viper.GetBool(ExternalClusterIPName)
+	c.NetfilterCompatibleMode = viper.GetBool(NetfilterCompatibleMode)
 
 	c.EnableIPv4Masquerade = viper.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
 	c.EnableIPv6Masquerade = viper.GetBool(EnableIPv6Masquerade) && c.EnableIPv6

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4632,3 +4632,36 @@ func (kub *Kubectl) WaitForServiceBackend(node, ipAddr string) error {
 		fmt.Sprintf("backend entry for %s was not found in time", ipAddr),
 		&TimeoutConfig{Timeout: HelperTimeout})
 }
+
+// WaitForCiliumPodToCompleteRegeneration waits for the cilium endpoint regneration to succeed, until timeout occurs.
+// Endpoint.status.log tracks the regeneration status, if log.Code equals OK and state equals ready
+// then it is considered as success.
+func (kub *Kubectl) WaitForCiliumPodToCompleteRegeneration(ciliumPod string, timeout time.Duration) error {
+	body := func() bool {
+		cmd := fmt.Sprintf("cilium endpoint list -o jsonpath='{[?(@.status.identity.id==%d)].status.log}'", ReservedIdentityHost)
+		res := kub.CiliumExecContext(context.Background(), ciliumPod, cmd)
+		if !res.WasSuccessful() {
+			kub.Logger().Errorf("unable to run command '%s' to retrieve status log of host endpoint from %s: %s",
+				cmd, ciliumPod, res.OutputPrettyPrint())
+			return false
+		}
+
+		var logs []models.EndpointStatusChange
+		if err := res.Unmarshal(&logs); err != nil {
+			kub.Logger().Errorf("unable to unmarshal EndpointStatusChange slice '%#v': %s", logs, err)
+			return false
+		}
+
+		// return true only if log Code and State return success
+		if logs[0].Code == "OK" && logs[0].State == "ready" {
+			return true
+		}
+
+		return false
+	}
+
+	return WithTimeout(
+		body,
+		fmt.Sprintf("timed out waiting for cilium pod %q to regenerate", ciliumPod),
+		&TimeoutConfig{Timeout: timeout})
+}

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -565,9 +565,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		})
 	})
 
-	SkipContextIf(func() bool {
-		return helpers.SkipQuarantined() && helpers.RunsOnNetNextKernel()
-	}, "Checks service across nodes", func() {
+	SkipContextIf(func() bool { return false }, "Checks service across nodes", func() {
 
 		var (
 			demoYAML   string


### PR DESCRIPTION
Description: if NETFILTER_COMPAT_MODE flag is set, guarantees that traffic will
pass-through kernel netfilter and that Iptables rules are enforced on traffic.

Problem: if Nodeport traffic ingress on the same node as a backend pod's node,
NAT and reverse NAT translations at 2 different interfaces.
On ingress path, NAT happens at Node's host interface, pass through kernel stack.
on egress path reverse NAT happen at Pod's Veth interface and bypasses kernel stack.
This asymmetric behavior, reflects in kernel conntrack entries and having a IPTABLE
rule to DROP any packets if conntrack state is INVALID which results in packet DROP.

Fixes: #11914

Signed-off-by: Gobinath Krishnamoorthy <gobinathk@google.com>

This PR was already reviewed and merged [here](https://github.com/cilium/cilium/pull/15354), we found some flakiness in CI tests, which was added by this [PR](https://github.com/cilium/cilium/pull/15354), hence this PR was reverted. Github Issue for flakiness tracked [here](https://github.com/cilium/cilium/issues/17060). 

Added fix In test/k8sT/Services.go and test/helpers/kubectl.go to resolve the flakiness issue.
@brb @pchaigno  