### PR TITLE
install: validate cilium tag being set by user

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -19,6 +19,9 @@ will return `quay.io/cilium/cilium:v1.10.1@abcdefgh`
 */}}
 {{- define "cilium.image" -}}
 {{- $digest := (.useDigest | default false) | ternary (printf "@%s" .digest) "" -}}
+{{- if not .tag }}
+  {{ fail "image.tag needs to be set" }}
+{{- end }}
 {{- printf "%s:%s%s" .repository .tag $digest -}}
 {{- end -}}
 

--- a/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
@@ -16,5 +16,8 @@ Return cilium operator image
 {{- define "cilium.operator.image" -}}
 {{- $cloud := include "cilium.operator.cloud" . }}
 {{- $digest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.digest) "" -}}
+{{- if not .Values.operator.image.tag }}
+  {{ fail "operator.image.tag needs to be set" }}
+{{- end }}
 {{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $digest -}}
 {{- end -}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -82,7 +82,7 @@ rollOutCiliumPods: false
 # -- Agent container image.
 image:
   repository: quay.io/cilium/cilium
-  tag: latest
+  tag: ""
   pullPolicy: Always
   # cilium-digest
   digest: ""
@@ -1240,7 +1240,7 @@ operator:
   # -- cilium-operator image.
   image:
     repository: quay.io/cilium/operator
-    tag: latest
+    tag: ""
     # operator-generic-digest
     genericDigest: ""
     # operator-azure-digest
@@ -1464,7 +1464,7 @@ preflight:
   # -- Cilium pre-flight image.
   image:
     repository: quay.io/cilium/cilium
-    tag: latest
+    tag: ""
     # cilium-digest
     digest: ""
     useDigest: false


### PR DESCRIPTION
Since we retired `latest` tag in our image repositories, we need to
validate that user explicitly sets image tags they want to deploy Cilium
from.

This change couldn't have used helm builtin `required` because of magic
image string creating functions that we are using, so instead the
validation happens inside these functions.