### PR TITLE
node: Skip ipcache for remote node IPs if IPsec is enabled

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -358,7 +358,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	mtuConfig = mtu.NewConfiguration(
 		authKeySize,
 		option.Config.EnableIPSec,
-		option.Config.Tunnel != option.TunnelDisabled,
+		option.Config.TunnelingEnabled(),
 		option.Config.EnableWireguard,
 		configuredMTU,
 		externalIP,
@@ -633,7 +633,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// happen after invoking initKubeProxyReplacementOptions().
 	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade &&
 		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "" || !option.Config.EnableRemoteNodeIdentity ||
-			(option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices())) {
+			(option.Config.TunnelingEnabled() && !hasFullHostReachableServices())) {
 
 		var msg string
 		switch {
@@ -644,7 +644,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 			msg = fmt.Sprintf("BPF masquerade requires remote node identities (--%s=\"true\").",
 				option.EnableRemoteNodeIdentity)
 		// Remove the check after https://github.com/cilium/cilium/issues/12544 is fixed
-		case option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices():
+		case option.Config.TunnelingEnabled() && !hasFullHostReachableServices():
 			msg = fmt.Sprintf("BPF masquerade requires --%s to be fully enabled (TCP and UDP).",
 				option.EnableHostReachableServices)
 		case option.Config.EgressMasqueradeInterfaces != "":

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1263,7 +1263,7 @@ func initEnv(cmd *cobra.Command) {
 			option.Config.Tunnel = option.TunnelVXLAN
 		}
 	case datapathOption.DatapathModeIpvlan:
-		if option.Config.Tunnel != "" && option.Config.Tunnel != option.TunnelDisabled {
+		if option.Config.Tunnel != "" && option.Config.TunnelingEnabled() {
 			log.WithField(logfields.Tunnel, option.Config.Tunnel).
 				Fatal("tunnel cannot be set in the 'ipvlan' datapath mode")
 		}
@@ -1327,7 +1327,7 @@ func initEnv(cmd *cobra.Command) {
 		log.Fatal("L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
 	}
 
-	if option.Config.EnableIPSec && option.Config.Tunnel != option.TunnelDisabled {
+	if option.Config.EnableIPSec && option.Config.TunnelingEnabled() {
 		if err := ipsec.ProbeXfrmStateOutputMask(); err != nil {
 			log.WithError(err).Fatal("IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later).")
 		}
@@ -1336,7 +1336,7 @@ func initEnv(cmd *cobra.Command) {
 	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
 	// that may be added or removed at runtime.
 	if option.Config.EnableIPSec &&
-		option.Config.Tunnel == option.TunnelDisabled &&
+		!option.Config.TunnelingEnabled() &&
 		len(option.Config.EncryptInterface) == 0 &&
 		option.Config.IPAM != ipamOption.IPAMENI {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
@@ -1346,7 +1346,7 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
 
-	if option.Config.Tunnel != option.TunnelDisabled && option.Config.EnableAutoDirectRouting {
+	if option.Config.TunnelingEnabled() && option.Config.EnableAutoDirectRouting {
 		log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
 	}
 
@@ -1421,7 +1421,7 @@ func initEnv(cmd *cobra.Command) {
 
 	if option.Config.LocalRouterIPv4 != "" || option.Config.LocalRouterIPv6 != "" {
 		// TODO(weil0ng): add a proper check for ipam in PR# 15429.
-		if option.Config.Tunnel != option.TunnelDisabled {
+		if option.Config.TunnelingEnabled() {
 			log.Fatalf("Cannot specify %s or %s in tunnel mode.", option.LocalRouterIPv4, option.LocalRouterIPv6)
 		}
 		if !option.Config.EnableEndpointRoutes {
@@ -1448,7 +1448,7 @@ func initEnv(cmd *cobra.Command) {
 		// InstallNoConntrackIptRules can only be enabled in direct
 		// routing mode as in tunneling mode the encapsulated traffic is
 		// already skipping netfilter conntrack.
-		if option.Config.Tunnel != option.TunnelDisabled {
+		if option.Config.TunnelingEnabled() {
 			log.Fatalf("%s requires the agent to run in direct routing mode.", option.InstallNoConntrackIptRules)
 		}
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -328,7 +328,7 @@ func initKubeProxyReplacementOptions() (bool, error) {
 	}
 
 	if option.Config.EnableNodePort {
-		if option.Config.Tunnel != option.TunnelDisabled &&
+		if option.Config.TunnelingEnabled() &&
 			option.Config.NodePortMode != option.NodePortModeSNAT {
 
 			log.Warnf("Disabling NodePort's %q mode feature due to tunneling mode being enabled",
@@ -337,7 +337,7 @@ func initKubeProxyReplacementOptions() (bool, error) {
 		}
 
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
-			if option.Config.Tunnel != option.TunnelDisabled {
+			if option.Config.TunnelingEnabled() {
 				return false, fmt.Errorf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
 					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
 			}
@@ -588,7 +588,7 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) error {
 	}
 
 	if option.Config.EnableIPv4 &&
-		option.Config.Tunnel == option.TunnelDisabled &&
+		!option.Config.TunnelingEnabled() &&
 		option.Config.NodePortMode != option.NodePortModeSNAT &&
 		len(option.Config.Devices) > 1 {
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -319,7 +319,19 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	// ipcache. This resulted in a behavioral change. New deployments will
 	// provide this behavior out of the gate, existing deployments will
 	// have to opt into this by enabling remote-node identities.
-	return !m.conf.EncryptionEnabled() && !m.conf.RemoteNodeIdentitiesEnabled()
+	if m.conf.RemoteNodeIdentitiesEnabled() {
+		return false
+	}
+	// Needed to store the SPI for nodes in the ipcache.
+	if m.conf.NodeEncryptionEnabled() {
+		return false
+	}
+	// Needed to store the SPI for pod->remote node in the ipcache since
+	// that path goes through the tunnel.
+	if m.conf.EncryptionEnabled() && m.conf.TunnelingEnabled() {
+		return false
+	}
+	return true
 }
 
 // NodeUpdated is called after the information of a node has been updated. The

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -53,6 +53,7 @@ type IPCache interface {
 // Configuration is the set of configuration options the node manager depends
 // on
 type Configuration interface {
+	TunnelingEnabled() bool
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
 	EncryptionEnabled() bool

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -35,9 +35,14 @@ type managerTestSuite struct{}
 var _ = check.Suite(&managerTestSuite{})
 
 type configMock struct {
+	Tunneling          bool
 	RemoteNodeIdentity bool
 	NodeEncryption     bool
 	Encryption         bool
+}
+
+func (c *configMock) TunnelingEnabled() bool {
+	return c.Tunneling
 }
 
 func (c *configMock) RemoteNodeIdentitiesEnabled() bool {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2112,6 +2112,12 @@ func (c *DaemonConfig) AlwaysAllowLocalhost() bool {
 	}
 }
 
+// TunnelingEnabled returns true if the remote-node identity feature
+// is enabled
+func (c *DaemonConfig) TunnelingEnabled() bool {
+	return c.Tunnel != TunnelDisabled
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -16,6 +16,11 @@ func (f *Config) CiliumNamespaceName() string {
 	return "kube-system"
 }
 
+// TunnelingEnabled returns true if the tunneling is used.
+func (f *Config) TunnelingEnabled() bool {
+	return true
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (f *Config) RemoteNodeIdentitiesEnabled() bool {


### PR DESCRIPTION
Before this pull request, if IPsec is enabled, we add all remote node IP addresses to the ipcache of all nodes, regardless of whether `enable-remote-node-identity` is true or false.

This pull request reverts that behavior to only add those IP addresses if remote-node identities, node encryption, or encryption+tunneling are enabled. If encryption+native routing is enabled, we don't need to expose the remote node IP addresses via the ipcache.