### PR TITLE
checkpatch: update to latest image to ignore empty commit messages

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://quay.io/cilium/cilium-checkpatch:cd6f81901656157a3c06306832dd42e93998f660@sha256:3d70a22d55257342e5c50b1561ce45ccf67117c25f133d8d9e09209966b3f75c
+        uses: docker://quay.io/cilium/cilium-checkpatch:51c4dc61117528afe974dc3e30150a730c8fe6d1@sha256:a124116766e78169977e4c36da7e9c18e0edee01a062f4887ee788cbc5efdab3
       - name: Send slack notification
         if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}
         uses: 8398a7/action-slack@c84a35cfa82a01f3733a3cbf5d5260123e55c2f9


### PR DESCRIPTION
This image includes https://github.com/cilium/image-tools/pull/140.

Signed-off-by: Tom Payne <tom@isovalent.com>
