### PR TITLE
test: Delete hubble-ca-secret when cleaning up

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2517,6 +2517,9 @@ func (kub *Kubectl) CiliumInstall(filename string, options map[string]string) er
 		return res.GetErr("Unable to delete existing cilium YAML")
 	}
 
+	// Remove any dangling resources not yet deleted
+	kub.CleanupCiliumComponents()
+
 	if err := kub.generateCiliumYaml(options, filename); err != nil {
 		return err
 	}
@@ -4385,7 +4388,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"clusterrole":        "cilium cilium-operator hubble-relay",
 			"serviceaccount":     "cilium cilium-operator hubble-relay",
 			"service":            "cilium-agent hubble-metrics hubble-relay",
-			"secret":             "hubble-relay-client-certs hubble-server-certs",
+			"secret":             "hubble-relay-client-certs hubble-server-certs hubble-ca-secret",
 			"resourcequota":      "cilium-resource-quota cilium-operator-resource-quota",
 		}
 


### PR DESCRIPTION
Remove hubble-ca-secret when cleaning up Cilium components. Otherwise
tests can fail installing Cilium with this error message:

  Error: rendered manifests contain a resource that already
  exists. Unable to continue with install: existing resource conflict:
  kind: Secret, namespace: kube-system, name: hubble-ca-secret

Add a clean up call to the Cilium install code to clean up any
resources that may be left behind after kubectl delete on the cilium
yaml.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
