### PR TITLE
helm: Expose l2 neigh discovery related agent flags

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -269,6 +269,8 @@ contributors across the globe, there is almost always someone available to help.
 | keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
+| l2NeighDiscovery.arping-refresh-period | string | `"5m"` | Set period for arping |
+| l2NeighDiscovery.enabled | bool | `true` | Enable L2 neighbour discovery in the agent |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -580,6 +580,15 @@ data:
   enable-svc-source-range-check: {{ .Values.svcSourceRangeCheck | quote }}
 {{- end }}
 
+{{- if hasKey .Values "l2NeighDiscovery" }}
+{{- if hasKey .Values.l2NeighDiscovery "enabled" }}
+  enable-l2-neigh-discovery: {{ .Values.l2NeighDiscovery.enabled | quote }}
+{{- end }}
+{{- if hasKey .Values.l2NeighDiscovery "refreshPeriod" }}
+  arping-refresh-period: {{ .Values.l2NeighDiscovery.refreshPeriod | quote }}
+{{- end }}
+{{- end }}
+
 {{- if and .Values.pprof .Values.pprof.enabled }}
   pprof: {{ .Values.pprof.enabled | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -968,6 +968,12 @@ readinessProbe:
 # By default it is disabled.
 kubeProxyReplacementHealthzBindAddr: ""
 
+l2NeighDiscovery:
+  # -- Enable L2 neighbour discovery in the agent
+  enabled: true
+  # -- Set period for arping
+  arping-refresh-period: "5m"
+
 # -- Enable Layer 7 network policy.
 l7Proxy: true
 


### PR DESCRIPTION
This commit exposes the following flags:

- `--enable-l2-neigh-discovery` via `l2NeighDiscovery.enabled`.
- `--arping-refresh-period` via `l2NeighDiscovery.refreshPeriod`.