### PR TITLE
aks: fix AKS cluster creation following new taint limitations

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -65,6 +65,7 @@ concurrency:
 env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
+  cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_version: v0.9.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -185,7 +186,6 @@ jobs:
             az account show
 
       - name: Create AKS cluster
-        id: cluster-creation
         run: |
           # Create group
           az group create \
@@ -193,37 +193,47 @@ jobs:
             --location ${{ env.location }} \
             --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
 
-          # Create cluster with a 1 node-count (we will remove this node pool
-          # afterwards)
-          # Details: Basic load balancers are not supported with multiple node
-          # pools. Create a cluster with standard load balancer selected to use
-          # multiple node pools, learn more at https://aka.ms/aks/nodepools.
+          # Create AKS cluster
           az aks create \
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
             --network-plugin azure \
             --node-count 1 \
-            --load-balancer-sku standard \
-            --node-vm-size Standard_B2s \
-            --node-osdisk-size 30 \
+            ${{ env.cost_reduction }} \
             --generate-ssh-keys
 
-          # Get the name of the node pool that we will delete afterwards
-          echo ::set-output name=nodepool_to_delete::$(az aks nodepool list --cluster-name ${{ env.name }} -g ${{ env.name }} -o json | jq -r '.[0].name')
+          # Get name of initial system node pool
+          nodepool_to_delete=$(az aks nodepool list --resource-group ${{ env.name }} --cluster-name ${{ env.name }} --output tsv --query "[0].name")
 
-          # Create a node pool with the taint 'node.cilium.io/agent-not-ready=true:NoSchedule'
-          # and with 'mode=system' as it it the same mode used for the nodepool
-          # created with the cluster.
+          # Create system node pool tainted with `CriticalAddonsOnly=true:NoSchedule`
           az aks nodepool add \
-            --name nodepool2 \
-            --cluster-name ${{ env.name }} \
             --resource-group ${{ env.name }} \
-            --node-count 2 \
-            --node-vm-size Standard_B2s \
-            --node-osdisk-size 30 \
+            --cluster-name ${{ env.name }} \
+            --name systempool \
             --mode system \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule
+            --node-count 1 \
+            --node-taints "CriticalAddonsOnly=true:NoSchedule" \
+            ${{ env.cost_reduction }} \
+            --no-wait
+
+          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule`
+          az aks nodepool add \
+            --resource-group ${{ env.name }} \
+            --cluster-name ${{ env.name }} \
+            --name userpool \
+            --mode user \
+            --node-count 2 \
+            --node-taints "node.cilium.io/agent-not-ready=true:NoSchedule" \
+            ${{ env.cost_reduction }} \
+            --no-wait
+
+          # Delete the initial system node pool
+          az aks nodepool delete \
+            --resource-group ${{ env.name }} \
+            --cluster-name ${{ env.name }} \
+            --name "${nodepool_to_delete}" \
+            --no-wait
 
       - name: Get cluster credentials
         run: |
@@ -242,17 +252,6 @@ jobs:
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
-
-      - name: Delete the first node pool
-        run: |
-          # We can only delete the first node pool after Cilium is installed
-          # because some pods have Pod Disruption Budgets set. If we try to
-          # delete the first node pool without the second node pool being ready,
-          # AKS will not succeed with the pool deletion because some Deployments
-          # can't cease to exist in the cluster.
-          az aks nodepool delete --name ${{ steps.cluster-creation.outputs.nodepool_to_delete }} \
-            --cluster-name ${{ env.name }} \
-            --resource-group ${{ env.name }}
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -68,6 +68,7 @@ concurrency:
 env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
+  cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
   cilium_cli_version: v0.9.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -188,7 +189,6 @@ jobs:
             az account show
 
       - name: Create AKS cluster
-        id: cluster-creation
         run: |
           # Create group
           az group create \
@@ -196,37 +196,47 @@ jobs:
             --location ${{ env.location }} \
             --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
 
-          # Create cluster with a 1 node-count (we will remove this node pool
-          # afterwards)
-          # Details: Basic load balancers are not supported with multiple node
-          # pools. Create a cluster with standard load balancer selected to use
-          # multiple node pools, learn more at https://aka.ms/aks/nodepools.
+          # Create AKS cluster
           az aks create \
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
             --network-plugin azure \
             --node-count 1 \
-            --load-balancer-sku standard \
-            --node-vm-size Standard_B2s \
-            --node-osdisk-size 30 \
+            ${{ env.cost_reduction }} \
             --generate-ssh-keys
 
-          # Get the name of the node pool that we will delete afterwards
-          echo ::set-output name=nodepool_to_delete::$(az aks nodepool list --cluster-name ${{ env.name }} -g ${{ env.name }} -o json | jq -r '.[0].name')
+          # Get name of initial system node pool
+          nodepool_to_delete=$(az aks nodepool list --resource-group ${{ env.name }} --cluster-name ${{ env.name }} --output tsv --query "[0].name")
 
-          # Create a node pool with the taint 'node.cilium.io/agent-not-ready=true:NoSchedule'
-          # and with 'mode=system' as it it the same mode used for the nodepool
-          # created with the cluster.
+          # Create system node pool tainted with `CriticalAddonsOnly=true:NoSchedule`
           az aks nodepool add \
-            --name nodepool2 \
-            --cluster-name ${{ env.name }} \
             --resource-group ${{ env.name }} \
-            --node-count 2 \
-            --node-vm-size Standard_B2s \
-            --node-osdisk-size 30 \
+            --cluster-name ${{ env.name }} \
+            --name systempool \
             --mode system \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule
+            --node-count 1 \
+            --node-taints "CriticalAddonsOnly=true:NoSchedule" \
+            ${{ env.cost_reduction }} \
+            --no-wait
+
+          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule`
+          az aks nodepool add \
+            --resource-group ${{ env.name }} \
+            --cluster-name ${{ env.name }} \
+            --name userpool \
+            --mode user \
+            --node-count 2 \
+            --node-taints "node.cilium.io/agent-not-ready=true:NoSchedule" \
+            ${{ env.cost_reduction }} \
+            --no-wait
+
+          # Delete the initial system node pool
+          az aks nodepool delete \
+            --resource-group ${{ env.name }} \
+            --cluster-name ${{ env.name }} \
+            --name "${nodepool_to_delete}" \
+            --no-wait
 
       - name: Get cluster credentials
         run: |
@@ -245,17 +255,6 @@ jobs:
       - name: Install Cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
-
-      - name: Delete the first node pool
-        run: |
-          # We can only delete the first node pool after Cilium is installed
-          # because some pods have Pod Disruption Budgets set. If we try to
-          # delete the first node pool without the second node pool being ready,
-          # AKS will not succeed with the pool deletion because some Deployments
-          # can't cease to exist in the cluster.
-          az aks nodepool delete --name ${{ steps.cluster-creation.outputs.nodepool_to_delete }} \
-            --cluster-name ${{ env.name }} \
-            --resource-group ${{ env.name }}
 
       - name: Enable Relay
         run: |

--- a/Documentation/gettingstarted/requirements-aks.rst
+++ b/Documentation/gettingstarted/requirements-aks.rst
@@ -20,8 +20,21 @@ Direct Routing  Azure IPAM          Kubernetes CRD
   compatibility with Cilium. The Azure network plugin will be replaced with
   Cilium by the installer.
 
-* Node pools must also be created with the taint ``node.cilium.io/agent-not-ready=true:NoSchedule``
-  using ``--node-taints`` option.
+* Node pools must be properly tainted to ensure applications pods are properly
+  managed by Cilium:
+
+  * User node pools must be tainted with ``node.cilium.io/agent-not-ready=true:NoSchedule``
+    to ensure application pods will only be scheduled once Cilium is ready to
+    manage them.
+
+  * System node pools must be tainted with ``CriticalAddonsOnly=true:NoSchedule``,
+    preventing application pods from being scheduled on them. This is necessary
+    because it is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoSchedule``
+    to system node pools, cf. `Azure/AKS#2578 <https://github.com/Azure/AKS/issues/2578>`_.
+    
+    * The initial node pool must be replaced with a new system node pool since
+      it is not possible to assign taints to the initial node pool at this time,
+      cf. `Azure/AKS#1402 <https://github.com/Azure/AKS/issues/1402>`_.
 
 **Limitations:**
 


### PR DESCRIPTION
Context: we recommend users taint all nodepools with `node.cilium.io/agent-not-ready=true:NoSchedule` to prevent application pods from being managed by the default AKS CNI plugin.

To this end, the proposed workflow users should follow when installing Cilium into AKS was to replace the initial AKS node pool with a new tainted system node pool, as it is not possible to taint the initial AKS node pool, cf. https://github.com/Azure/AKS/issues/1402.

AKS recently pushed a change on the API side that forbids setting up custom taints on system node pools, cf. https://github.com/Azure/AKS/issues/2578.

It is not possible anymore for us to recommend users taint all nodepools with `node.cilium.io/agent-not-ready=true:NoSchedule` to prevent application pods from being managed by the default AKS CNI plugin.

To work around this new limitation, we propose the following workflow instead:

- Replace the initial node pool with a system node pool tainted with `CriticalAddonsOnly=true:NoSchedule`, preventing application pods from being scheduled on it.
- Create a secondary user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule` to prevent application pods from being scheduled on the user node pool until Cilium is ready to manage them.