### PR TITLE
v1.9 backports 2021-10-04

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1257,9 +1257,9 @@ Limitations
 
     * Cilium's eBPF kube-proxy replacement currently cannot be used with :ref:`encryption`.
     * Cilium's eBPF kube-proxy replacement relies upon the :ref:`host-services` feature
-      which uses eBPF cgroup hooks to implement the service translation. The getpeername(2)
-      hook address translation in eBPF is only available for v5.8 kernels. It is known to
-      currently not work with libceph deployments.
+      which uses eBPF cgroup hooks to implement the service translation. Using it with libceph
+      deployments currently requires support for the getpeername(2) hook address translation in
+      eBPF, which is only available for kernels v5.8 and higher.
     * Cilium's eBPF kube-proxy acceleration in XDP can only be used in a single device setup
       as a "one-legged" / hairpin load balancer scenario. In case of a multi-device environment,
       where auto-detection selects more than a single device to expose NodePort, the option

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -87,11 +87,11 @@ Cilium replacement has been installed:
 
 .. code:: bash
 
-      kubectl -n kube-system delete ds kube-proxy
-      # Delete the configmap as well to avoid kube-proxy being reinstalled during a kubeadm upgrade (works only for K8s 1.19 and newer)
-      kubectl -n kube-system delete cm kube-proxy
-      # Run on each node:
-      iptables-restore <(iptables-save | grep -v KUBE)
+    $ kubectl -n kube-system delete ds kube-proxy
+    $ # Delete the configmap as well to avoid kube-proxy being reinstalled during a kubeadm upgrade (works only for K8s 1.19 and newer)
+    $ kubectl -n kube-system delete cm kube-proxy
+    $ # Run on each node with root permissions:
+    $ iptables-save | grep -v KUBE | iptables-restore
 
 .. include:: k8s-install-download-release.rst
 

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -5,6 +5,9 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
 require_linux
 
+ORG=${ORG:-"cilium"}
+REPO=${REPO:-"cilium"}
+
 cleanup () {
   if [ -n "$TMPF" ]; then
     rm $TMPF
@@ -15,7 +18,7 @@ trap cleanup EXIT
 
 cherry_pick () {
   CID=$1
-  if ! commit_in_upstream "$CID" "master"; then
+  if ! commit_in_upstream "$CID" "master" "${ORG}" "${REPO}"; then
     echo "Commit $CID not in $REM/master!"
     exit 1
   fi
@@ -31,7 +34,7 @@ cherry_pick () {
 }
 
 main () {
-  REM="$(get_remote)"
+  REM="$(get_remote "${ORG}" "${REPO}")"
   for CID in "$@"; do
     cherry_pick "$CID"
   done

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -555,7 +555,7 @@ func (e *Endpoint) setRegenerateStateLocked(regenMetadata *regeneration.External
 func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
 	regen, err := e.SetRegenerateStateIfAlive(regenMetadata)
 	if err != nil {
-		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
+		log.WithError(err).Debugf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
 	}
 	if regen {
 		// Regenerate logs status according to the build success/failure

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -210,7 +212,11 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		config *rest.Config
 		err    error
 	)
-	userAgent := fmt.Sprintf("Cilium %s", version.Version)
+	cmdName := "cilium"
+	if len(os.Args[0]) != 0 {
+		cmdName = filepath.Base(os.Args[0])
+	}
+	userAgent := fmt.Sprintf("%s/%s", cmdName, version.Version)
 
 	switch {
 	// If the apiServerURL and the kubeCfgPath are empty then we can try getting
@@ -237,7 +243,7 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 }
 
 func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
-	if config.UserAgent != "" {
+	if userAgent != "" {
 		config.UserAgent = userAgent
 	}
 	if qps != 0.0 {

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -60,7 +60,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 	)
 
 	if option.Config.DisableCiliumEndpointCRD {
-		scopedLog.Warn("Not running controller. CEP CRD synchronization is disabled")
+		scopedLog.Debug("Not running controller. CEP CRD synchronization is disabled")
 		return
 	}
 

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -76,7 +76,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -124,7 +123,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -71,7 +71,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward cilium.test 10.100.0.100:53 {
@@ -119,7 +118,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/eks/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/eks/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
 * #15450 -- agent: Silence some useless warnings (@tgraf)
 * #16969 -- docs: clarify language on libceph and kernel 5.8 in kubeproxy-free GSG (@bluikko)
 * #16264 -- docs: Fix command for overwriting iptables on kube-proxy replacement install (@Stijn98s)
 * #17424 -- contrib/backporting: add environment variables to set ORG and REPO (@aanm)
 * #17417 -- pkg/k8s: fix User-Agent for kubernetes client (@aanm)
 * #17489 -- test: bump coredns version to 1.7.0 (@aanm)

PRs skipped due conflicts:

 * #17477 -- helm: set correct versions of docker images in Makefile (@aanm)
   REASON: Workflow file doesn't exist.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 15450 16969 16264 17424 17417 17489; do contrib/backporting/set-labels.py $pr done 1.9; done
```