### PR TITLE
v1.8 backports 2021-10-04

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1027,10 +1027,10 @@ Limitations
 ###########
 
     * Cilium's BPF kube-proxy replacement currently cannot be used with :ref:`encryption`.
-    * Cilium's BPF kube-proxy replacement relies upon the :ref:`host-services` feature
-      which uses BPF cgroup hooks to implement the service translation. The getpeername(2)
-      hook address translation in BPF is only available for v5.8 kernels. It is known to
-      currently not work with libceph deployments.
+    * Cilium's eBPF kube-proxy replacement relies upon the :ref:`host-services` feature
+      which uses eBPF cgroup hooks to implement the service translation. Using it with libceph
+      deployments currently requires support for the getpeername(2) hook address translation in
+      eBPF, which is only available for kernels v5.8 and higher.
     * Cilium's BPF kube-proxy acceleration in XDP can only be used in a single device setup
       as a "one-legged" / hairpin load balancer scenario. In case of a multi-device environment,
       where auto-detection selects more than a single device to expose NodePort, the option

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -91,6 +91,19 @@ the token returned by ``kubeadm init``:
     each node has an ``InternalIP`` which is assigned to a device with the same
     name on each node.
 
+For existing installations with ``kube-proxy`` running as a DaemonSet, remove it
+by using the following commands below. **Careful:** Be aware that this will break
+existing service connections. It will also stop service related traffic until the
+Cilium replacement has been installed:
+
+.. code-block:: shell-session
+
+    kubectl -n kube-system delete ds kube-proxy
+    # Delete the configmap as well to avoid kube-proxy being reinstalled during a kubeadm upgrade (works only for K8s 1.19 and newer)
+    kubectl -n kube-system delete cm kube-proxy
+    # Run on each node with root permissions:
+    iptables-save | grep -v KUBE | iptables-restore
+
 .. include:: k8s-install-download-release.rst
 
 Next, generate the required YAML files and deploy them. **Important:** Replace

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -5,6 +5,9 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
 require_linux
 
+ORG=${ORG:-"cilium"}
+REPO=${REPO:-"cilium"}
+
 cleanup () {
   if [ -n "$TMPF" ]; then
     rm $TMPF
@@ -15,7 +18,7 @@ trap cleanup EXIT
 
 cherry_pick () {
   CID=$1
-  if ! commit_in_upstream "$CID" "master"; then
+  if ! commit_in_upstream "$CID" "master" "${ORG}" "${REPO}"; then
     echo "Commit $CID not in $REM/master!"
     exit 1
   fi
@@ -31,7 +34,7 @@ cherry_pick () {
 }
 
 main () {
-  REM="$(get_remote)"
+  REM="$(get_remote "${ORG}" "${REPO}")"
   for CID in "$@"; do
     cherry_pick "$CID"
   done

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -62,7 +64,11 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		config *rest.Config
 		err    error
 	)
-	userAgent := fmt.Sprintf("Cilium %s", version.Version)
+	cmdName := "cilium"
+	if len(os.Args[0]) != 0 {
+		cmdName = filepath.Base(os.Args[0])
+	}
+	userAgent := fmt.Sprintf("%s/%s", cmdName, version.Version)
 
 	switch {
 	// If the apiServerURL and the kubeCfgPath are empty then we can try getting
@@ -89,7 +95,7 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 }
 
 func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
-	if config.UserAgent != "" {
+	if userAgent != "" {
 		config.UserAgent = userAgent
 	}
 	if qps != 0.0 {

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -76,7 +76,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -124,7 +123,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -71,7 +71,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward cilium.test 10.100.0.100:53 {
@@ -119,7 +118,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/eks/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/eks/coredns_deployment.yaml
@@ -78,7 +78,6 @@ data:
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             ttl 0
-            upstream
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf {
@@ -126,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.5
+        image: k8s.gcr.io/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
 * #16969 -- docs: clarify language on libceph and kernel 5.8 in kubeproxy-free GSG (@bluikko)
 * #16264 -- docs: Fix command for overwriting iptables on kube-proxy replacement install (@Stijn98s)
 * #17424 -- contrib/backporting: add environment variables to set ORG and REPO (@aanm)
 * #17417 -- pkg/k8s: fix User-Agent for kubernetes client (@aanm)
 * #17489 -- test: bump coredns version to 1.7.0 (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16969 16264 17424 17417 17489; do contrib/backporting/set-labels.py $pr done 1.8; done
```
or with
```
$ make add-label branch=v1.8 issues=16969,16264,17424,17417,17489
```