### PR TITLE
Add Kernel Misc Probe

### DIFF
--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -126,11 +126,17 @@ type MapTypes struct {
 	HaveStackMapType               bool `json:"have_stack_map_type"`
 }
 
+// Kernel misc configurations kernel large 1M instructions support
+type Misc struct {
+	HaveLargeInsnLimit bool `json:"have_large_insn_limit"`
+}
+
 // Features contains BPF feature checks returned by bpftool.
 type Features struct {
 	SystemConfig `json:"system_config"`
 	MapTypes     `json:"map_types"`
 	Helpers      map[string][]string `json:"helpers"`
+	Misc         `json:"misc"`
 }
 
 // ProbeManager is a manager of BPF feature checks.
@@ -304,6 +310,11 @@ func (p *ProbeManager) GetOptionalConfig() map[KernelParam]kernelOption {
 // GetMapTypes returns information about supported BPF map types.
 func (p *ProbeManager) GetMapTypes() *MapTypes {
 	return &p.features.MapTypes
+}
+
+// GetMisc returns information about kernel misc.
+func (p *ProbeManager) GetMisc() Misc {
+	return p.features.Misc
 }
 
 // GetHelpers returns information about available BPF helpers for the given


### PR DESCRIPTION
Add Kernel Misc Probe
    
Add kernel misc feature probe which include kernel BPF large instruction
support information. It allows Cilium features to probe kernel large instruction
    
Signed-off-by: Vincent Li <vincent.mc.li@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->



```release-note
Add Kernel Misc Probe
```
