### PR TITLE
docs: Add initial support for translations

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -33,6 +33,7 @@ DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
 		--env SKIP_LINT=$(SKIP_LINT) \
 		--user "$(shell id -u):$(shell id -g)"
 DOCKER_RUN := $(DOCKER_CTR) cilium/docs-builder
+LANGUAGES := es_ES
 
 update-cmdref: builder-image cilium-build
 	@$(ECHO_GEN)cmdref
@@ -91,6 +92,14 @@ $(HELM_VALUES): FORCE
 epub latex html: builder-image copy-api update-helm-values
 	@$(ECHO_GEN)_build/$@
 	$(QUIET)$(DOCKER_RUN) ./check-build.sh $(@) $(SPHINX_OPTS)
+
+gettext: builder-image copy-api
+	@$(ECHO_GEN)_build/$@
+	$(QUIET) SKIP_LINT=1 $(DOCKER_RUN) ./check-build.sh gettext $(SPHINX_OPTS)
+
+translation: gettext
+	@$(ECHO_GEN)_build/$@
+	$(QUIET) SKIP_LINT=1 $(DOCKER_RUN) sphinx-intl update -p _build/gettext $(foreach lang,$(LANGUAGES),-l $(lang))
 
 html-netlify: copy-api
 	@$(ECHO_GEN)_build/$@

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -100,7 +100,8 @@ sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@ -q 2> >(tee "${war
 
 # We can have warnings but no errors here, or sphinx-build would return non-0
 # and we would have exited because of "set -o errexit".
-if [ -s "${warnings}" ] ; then
-    echo "Please fix the above documentation warnings"
+if filter_warnings > /dev/null ;  then
+    echo "Please fix the following documentation warnings:"
+    filter_warnings
     exit 1
 fi

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -48,6 +48,10 @@ extensions = ['myst_parser',
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+locale_dirs = ['locale/']
+gettext_uuid = True
+gettext_compact = False
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -28,6 +28,7 @@ sphinxcontrib-openapi==0.7.0
 sphinxcontrib-spelling==7.3.2
 sphinxcontrib-websupport==1.2.4
 sphinx-tabs==3.3.1
+sphinx-intl==2.0.1
 sphinx-version-warning==1.1.2
 typing==3.7.4.3
 urllib3==1.26.8


### PR DESCRIPTION
usage:

```
  $ # Set LANGUAGES := es_ES to your locale in the Makefile
  $ make -C Documentation/ translation
  $ # ... translate the locale/.../LC_MESSAGES/... files
  $ SPHINX_OPTS="-D language='es_ES'" make -C Documentation/ html
```

Translators need to update the `"msgstr"` fields in each `locale/.../*.po` file to
provide the translation for the corresponding text from the `"msgid"`.

The 'html' make command will just overwrite the _build/ html output with
the translated copy of the messages. Once we get some initial locale
translations imported into the tree, it will likely make sense for us to
update the make targets to generate each supported language via
independent `sphinx-build -b ...` commands, outputting to separate
`_build/html/la_LA` translation directories so that readthedocs can pick
up on each of the translations & serve them.
