### PR TITLE
Refactor CEBtoCEPs and CEPtoCEB maps

### DIFF
--- a/operator/pkg/ciliumendpointbatch/ceptocebmap_test.go
+++ b/operator/pkg/ciliumendpointbatch/ceptocebmap_test.go
@@ -61,27 +61,27 @@ func TestCepToCebCounts(t *testing.T) {
 			count:   4,
 		},
 	}
-	cmap := newCepToCebMapping()
+	cmap := newDesiredCebMap()
 
 	// Insert new CEPs in cepCache map and check its total count
 	for _, tc := range testCases {
 		t.Run(tc.name, func(*testing.T) {
-			cmap.insert(tc.cepName, tc.cebName)
-			assert.Equal(t, cmap.count(), tc.count, "Number of CEP entries in cmap should match with Count")
-			assert.Equal(t, cmap.has(tc.cepName), true, "CEP name should present in cmap")
-			assert.Equal(t, cmap.has(tc.cebName), false, "CEB name should NOT present in cmap as Key")
+			cmap.insertCEP(tc.cepName, tc.cebName)
+			assert.Equal(t, cmap.countCEPs(), tc.count, "Number of CEP entries in cmap should match with Count")
+			assert.Equal(t, cmap.hasCEP(tc.cepName), true, "CEP name should present in cmap")
+			assert.Equal(t, cmap.hasCEP(tc.cebName), false, "CEB name should NOT present in cmap as Key")
 		})
 	}
 
 	// Insert and remove CEPs in cepCache and check for any stale entries present in cepCache.
 	for _, tc := range testCases {
 		t.Run(tc.name, func(*testing.T) {
-			cmap.insert(tc.cepName, tc.cebName)
-			cebName, ok := cmap.get(tc.cepName)
+			cmap.insertCEP(tc.cepName, tc.cebName)
+			cebName, ok := cmap.getCEBName(tc.cepName)
 			assert.Equal(t, ok, true, "CEP name should be there in map")
 			assert.Equal(t, cebName, tc.cebName, "CEP name should match with cebName")
-			cmap.deleteCep(tc.cepName)
-			assert.Equal(t, cmap.has(tc.cepName), false, "CEP name is removed from cache, so it shouldn't be in cache")
+			cmap.deleteCEP(tc.cepName)
+			assert.Equal(t, cmap.hasCEP(tc.cepName), false, "CEP name is removed from cache, so it shouldn't be in cache")
 		})
 	}
 

--- a/operator/pkg/ciliumendpointbatch/manager_test.go
+++ b/operator/pkg/ciliumendpointbatch/manager_test.go
@@ -97,17 +97,17 @@ func TestInsertAndRemoveCepsInCache(t *testing.T) {
 	// Remove CEPs from Cache and check total number of CEB and CEP
 	t.Run("Test Removing CEPs from cache and check number of CEPs and CEBs", func(*testing.T) {
 		m := newCebManagerFcfs(newQueue(), 2)
-		u := newCepToCebMapping()
+		u := newDesiredCebMap()
 		cn := m.InsertCepInCache(cep1, "kube-system")
-		u.insert(cep1.Name, cn)
+		u.insertCEP(cep1.Name, cn)
 		cn = m.InsertCepInCache(cep2, "kube-system")
-		u.insert(cep2.Name, cn)
+		u.insertCEP(cep2.Name, cn)
 		cn = m.InsertCepInCache(cep3, "kube-system")
-		u.insert(cep3.Name, cn)
+		u.insertCEP(cep3.Name, cn)
 		cn = m.InsertCepInCache(cep4, "kube-system")
-		u.insert(cep4.Name, cn)
+		u.insertCEP(cep4.Name, cn)
 		cn = m.InsertCepInCache(cep5, "kube-system")
-		u.insert(cep5.Name, cn)
+		u.insertCEP(cep5.Name, cn)
 		// Check all 5 CEP are inserted
 		assert.Equal(t, m.getCebCount(), 3, "Total number of CEBs allocated is 3")
 		assert.Equal(t, m.getTotalCepCount(), 5, "Total number of CEPs inserted is 5")
@@ -115,7 +115,7 @@ func TestInsertAndRemoveCepsInCache(t *testing.T) {
 		// Remove a CEP from Cache
 		// This should remove one CEP from cache and remove a CEB
 		m.RemoveCepFromCache(GetCepNameFromCCEP(cep5, "kube-system"))
-		if cn, ok := u.get(cep5.Name); ok {
+		if cn, ok := u.getCEBName(cep5.Name); ok {
 			// complete CEB delete from local datastore, after successful removal in k8s-apiserver.
 			m.deleteCebFromCache(cn)
 		}
@@ -131,7 +131,7 @@ func TestInsertAndRemoveCepsInCache(t *testing.T) {
 		// Remove a CEP from Cache
 		// This should remove one CEP in a CEB.
 		m.RemoveCepFromCache(GetCepNameFromCCEP(cep4, "kube-system"))
-		if cn, ok := u.get(cep4.Name); ok {
+		if cn, ok := u.getCEBName(cep4.Name); ok {
 			// complete CEB delete from local datastore, after successful removal in k8s-apiserver.
 			m.deleteCebFromCache(cn)
 		}
@@ -147,7 +147,7 @@ func TestInsertAndRemoveCepsInCache(t *testing.T) {
 		// Remove a CEP from Cache
 		// This should remove one CEP in a CEB.
 		m.RemoveCepFromCache(GetCepNameFromCCEP(cep2, "kube-system"))
-		if cn, ok := u.get(cep2.Name); ok {
+		if cn, ok := u.getCEBName(cep2.Name); ok {
 			// complete CEB delete from local datastore, after successful removal in k8s-apiserver.
 			m.deleteCebFromCache(cn)
 		}


### PR DESCRIPTION
1) Use single lock to protect both the CEBtoCEPs and CEPtoCEB
maps.

Currently we have 2 maps, 

1. `desiredCebMapping`  which is used to store desiredCEB state in local cache and maintains a map of `CEB name` to list of `CiliumEndpoints`, this map is protected by a separate mutex for thread safe access.
2. `cacheCEP` is inverse of `desiredCebMapping`, which maps `CEP name` to `CEB name`, and this map is protected by a separate mutex for thread safe access.

These 2 maps stores same information, this need to be protected by single mutex to avoid potential race condition issues.

This PR refactors these map implementation, uses single map to protect data for safe access.


Signed-off-by: Gobinath Krishnamoorthy <gobinathk@google.com>