### PR TITLE
datapath: allow specifying cilium_host routes metric

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -223,6 +223,7 @@ cilium-agent [flags]
       --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
       --restore                                              Restores state, if possible, from previous daemon (default true)
+      --route-metric int                                     Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
       --sidecar-istio-proxy-image string                     Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
       --single-cluster-route                                 Use a single cluster route instead of per node routes
       --socket-path string                                   Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -723,6 +723,9 @@ func initializeFlags() {
 	flags.Int(option.MTUName, 0, "Overwrite auto-detected MTU of underlying network")
 	option.BindEnv(option.MTUName)
 
+	flags.Int(option.RouteMetric, 0, "Overwrite the metric used by cilium when adding routes to its 'cilium_host' device")
+	option.BindEnv(option.RouteMetric)
+
 	flags.Bool(option.PrependIptablesChainsName, true, "Prepend custom iptables chains instead of appending")
 	option.BindEnvWithLegacyEnvFallback(option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -351,11 +351,12 @@ func (n *linuxNodeHandler) createNodeRouteSpec(prefix *cidr.CIDR, isLocalNode bo
 
 	// The default routing table accounts for encryption overhead for encrypt-node traffic
 	return route.Route{
-		Nexthop: &nexthop,
-		Local:   local,
-		Device:  n.datapathConfig.HostDevice,
-		Prefix:  *prefix.IPNet,
-		MTU:     mtu,
+		Nexthop:  &nexthop,
+		Local:    local,
+		Device:   n.datapathConfig.HostDevice,
+		Prefix:   *prefix.IPNet,
+		MTU:      mtu,
+		Priority: option.Config.RouteMetric,
 	}, nil
 }
 

--- a/pkg/datapath/linux/route/route.go
+++ b/pkg/datapath/linux/route/route.go
@@ -14,15 +14,16 @@ import (
 )
 
 type Route struct {
-	Prefix  net.IPNet
-	Nexthop *net.IP
-	Local   net.IP
-	Device  string
-	MTU     int
-	Proto   int
-	Scope   netlink.Scope
-	Table   int
-	Type    int
+	Prefix   net.IPNet
+	Nexthop  *net.IP
+	Local    net.IP
+	Device   string
+	MTU      int
+	Priority int
+	Proto    int
+	Scope    netlink.Scope
+	Table    int
+	Type     int
 }
 
 // LogFields returns the route attributes as logrus.Fields map
@@ -59,6 +60,9 @@ func (r *Route) ToIPCommand(dev string) []string {
 		res = append(res, "-6")
 	}
 	res = append(res, "route", "add", r.Prefix.String())
+	if r.Priority != 0 {
+		res = append(res, "metric", fmt.Sprintf("%d", r.Priority))
+	}
 	if r.Nexthop != nil {
 		res = append(res, "via", r.Nexthop.String())
 	}

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -42,6 +42,7 @@ func (r *Route) getNetlinkRoute() netlink.Route {
 		Dst:      &r.Prefix,
 		Src:      r.Local,
 		MTU:      r.MTU,
+		Priority: r.Priority,
 		Protocol: netlink.RouteProtocol(r.Proto),
 		Table:    r.Table,
 		Type:     r.Type,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -445,6 +445,9 @@ const (
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
 
+	// RouteMetric is the name of the route-metric option
+	RouteMetric = "route-metric"
+
 	// DatapathMode is the name of the DatapathMode option
 	DatapathMode = "datapath-mode"
 
@@ -1274,6 +1277,9 @@ type DaemonConfig struct {
 
 	// MTU is the maximum transmission unit of the underlying network
 	MTU int
+
+	// RouteMetric is the metric used for the routes added to the cilium_host device
+	RouteMetric int
 
 	// ClusterName is the name of the cluster
 	ClusterName string
@@ -2255,6 +2261,10 @@ func (c *DaemonConfig) Validate() error {
 		return fmt.Errorf("MTU '%d' cannot be negative", c.MTU)
 	}
 
+	if c.RouteMetric < 0 {
+		return fmt.Errorf("RouteMetric '%d' cannot be negative", c.RouteMetric)
+	}
+
 	if c.IPAM == ipamOption.IPAMENI && c.EnableIPv6 {
 		return fmt.Errorf("IPv6 cannot be enabled in ENI IPAM mode")
 	}
@@ -2559,6 +2569,7 @@ func (c *DaemonConfig) Populate() {
 	c.ProxyPrometheusPort = viper.GetInt(ProxyPrometheusPort)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
 	c.RestoreState = viper.GetBool(Restore)
+	c.RouteMetric = viper.GetInt(RouteMetric)
 	c.RunDir = viper.GetString(StateDir)
 	c.SidecarIstioProxyImage = viper.GetString(SidecarIstioProxyImage)
 	c.UseSingleClusterRoute = viper.GetBool(SingleClusterRouteName)


### PR DESCRIPTION
The networks used by cilium (pod range, etc.) must be routed to the
nodes. One possibility of announcing the ranges is to add them to the
`lo` interface. Then, a specific route-map on the local router will announce
all the networks belonging to an interface.

However, when adding an IP or a range to an interface, the kernel
automatically adds a route to it like so:
```
  2001:my:range::/112 dev lo proto kernel metric 256 pref medium
```
this metric corresponds to `IP6_RT_PRIO_ADDRCONF = 256`.

The problem arises the moment cilium adds these routes to the cilium host
device. If a metric is not specified (by default 0), then the kernel will use
`IP6_RT_PRIO_USER = 1024`, which won't take precedence over the above
route.

We thus introduce the `--route-metric` param which allows overriding
this metric. If the param is not used, the default metrics won't change.

Fixes: #16539
Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>
