### PR TITLE
Revert "travis: login to Docker Hub"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ before_install: ./.travis/prepare.sh
 
 before_script:
   - export PATH=/usr/local/clang/bin:$PATH
-  # Login to Docker Hub using credentials stored in Travis configuration
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 script: ./.travis/build.sh
 


### PR DESCRIPTION
This reverts commit 03949cf60cb2e8dbfd3082a208c1b589b8f7c2d0.

Original PR: #17537
Rationale: it's not working and breaks Travis CI.