### PR TITLE
v1.10 backports 2021-10-07

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -254,6 +254,8 @@ contributors across the globe, there is almost always someone available to help.
 | keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
+| l2NeighDiscovery.arping-refresh-period | string | `"5m"` | Set period for arping |
+| l2NeighDiscovery.enabled | bool | `true` | Enable L2 neighbour discovery in the agent |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -567,6 +567,15 @@ data:
   enable-svc-source-range-check: {{ .Values.svcSourceRangeCheck | quote }}
 {{- end }}
 
+{{- if hasKey .Values "l2NeighDiscovery" }}
+{{- if hasKey .Values.l2NeighDiscovery "enabled" }}
+  enable-l2-neigh-discovery: {{ .Values.l2NeighDiscovery.enabled | quote }}
+{{- end }}
+{{- if hasKey .Values.l2NeighDiscovery "refreshPeriod" }}
+  arping-refresh-period: {{ .Values.l2NeighDiscovery.refreshPeriod | quote }}
+{{- end }}
+{{- end }}
+
 {{- if and .Values.pprof .Values.pprof.enabled }}
   pprof: {{ .Values.pprof.enabled | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -927,6 +927,12 @@ readinessProbe:
 # By default it is disabled.
 kubeProxyReplacementHealthzBindAddr: ""
 
+l2NeighDiscovery:
+  # -- Enable L2 neighbour discovery in the agent
+  enabled: true
+  # -- Set period for arping
+  arping-refresh-period: "5m"
+
 # -- Enable Layer 7 network policy.
 l7Proxy: true
 

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -957,6 +957,11 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
+	prevEnableL2NeighDiscovery := option.Config.EnableL2NeighDiscovery
+	defer func() { option.Config.EnableL2NeighDiscovery = prevEnableL2NeighDiscovery }()
+
+	option.Config.EnableL2NeighDiscovery = true
+
 	prevStateDir := option.Config.StateDir
 	defer func() { option.Config.StateDir = prevStateDir }()
 


### PR DESCRIPTION
* #17044 -- datapath/linux: enable neighbor discovery in unit tests (@aanm)
 * #17526 -- helm: Expose l2 neigh discovery related agent flags (@brb)

Skipped due to non-trivial backports

 * #17513 -- bpf: Add extension for running sock LB on MKE-related containers (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17044 17526; do contrib/backporting/set-labels.py $pr done 1.10; done
```