### PR TITLE
v1.10 backport 2021-10-08

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -79,6 +79,16 @@ void ctx_set_port(struct bpf_sock_addr *ctx, __be16 dport)
 	ctx->user_port = (__u32)dport;
 }
 
+static __always_inline __maybe_unused bool task_in_extended_hostns(void)
+{
+#ifdef ENABLE_MKE
+	/* Extension for non-Cilium managed containers on MKE. */
+	return get_cgroup_classid() == MKE_HOST;
+#else
+	return false;
+#endif
+}
+
 static __always_inline __maybe_unused bool
 ctx_in_hostns(void *ctx __maybe_unused, __net_cookie *cookie)
 {
@@ -87,7 +97,8 @@ ctx_in_hostns(void *ctx __maybe_unused, __net_cookie *cookie)
 
 	if (cookie)
 		*cookie = own_cookie;
-	return own_cookie == get_netns_cookie(NULL);
+	return own_cookie == get_netns_cookie(NULL) ||
+	       task_in_extended_hostns();
 #else
 	if (cookie)
 		*cookie = 0;

--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -46,6 +46,9 @@ static __u64 BPF_FUNC(jiffies64);
 static __sock_cookie BPF_FUNC(get_socket_cookie, void *ctx);
 static __net_cookie BPF_FUNC(get_netns_cookie, void *ctx);
 
+/* Legacy cgroups */
+static __u32 BPF_FUNC(get_cgroup_classid);
+
 /* Debugging */
 static __printf(1, 3) void
 BPF_FUNC(trace_printk, const char *fmt, int fmt_size, ...);

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -578,6 +578,14 @@ func init() {
 	flags.Bool(option.EnableLocalRedirectPolicy, false, "Enable Local Redirect Policy")
 	option.BindEnv(option.EnableLocalRedirectPolicy)
 
+	flags.Bool(option.EnableMKE, false, "Enable BPF kube-proxy replacement for MKE environments")
+	flags.MarkHidden(option.EnableMKE)
+	option.BindEnv(option.EnableMKE)
+
+	flags.String(option.CgroupPathMKE, "", "Cgroup v1 net_cls mount path for MKE environments")
+	flags.MarkHidden(option.CgroupPathMKE)
+	option.BindEnv(option.CgroupPathMKE)
+
 	flags.String(option.NodePortMode, option.NodePortModeSNAT, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
 	flags.MarkHidden(option.NodePortMode)
 	option.BindEnv(option.NodePortMode)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -19,8 +19,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
+	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/mountinfo"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/probe"
@@ -234,6 +238,28 @@ func initKubeProxyReplacementOptions() (strict bool) {
 		// Try to auto-load IPv6 module if it hasn't been done yet as there can
 		// be v4-in-v6 connections even if the agent has v6 support disabled.
 		probe.HaveIPv6Support()
+
+		if option.Config.EnableMKE {
+			foundClassid := false
+			foundCookie := false
+			if h := probesManager.GetHelpers("cgroup_sock_addr"); h != nil {
+				if _, ok := h["bpf_get_cgroup_classid"]; ok {
+					foundClassid = true
+				}
+				if _, ok := h["bpf_get_netns_cookie"]; ok {
+					foundCookie = true
+				}
+			}
+			if !foundClassid || !foundCookie {
+				if strict {
+					log.Fatalf("BPF kube-proxy replacement under MKE with --%s needs kernel 5.7 or newer", option.EnableMKE)
+				} else {
+					option.Config.EnableHostServicesTCP = false
+					option.Config.EnableHostServicesUDP = false
+					log.Warnf("Disabling host reachable services under MKE with --%s. Needs kernel 5.7 or newer.", option.EnableMKE)
+				}
+			}
+		}
 
 		option.Config.EnableHostServicesPeer = true
 		if option.Config.EnableIPv4 {
@@ -526,6 +552,12 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) {
 	// | After this point, BPF NodePort should not be disabled |
 	// +-------------------------------------------------------+
 
+	// For MKE, we only need to change/extend the socket LB behavior in case
+	// of kube-proxy replacement. Otherwise, nothing else is needed.
+	if option.Config.EnableMKE && option.Config.EnableHostReachableServices {
+		markHostExtension()
+	}
+
 	if !option.Config.EnableHostLegacyRouting {
 		msg := ""
 		switch {
@@ -779,6 +811,66 @@ func expandDevices() {
 		option.Config.Devices = append(option.Config.Devices, dev)
 	}
 	sort.Strings(option.Config.Devices)
+}
+
+// markHostExtension tells the socket LB that MKE managed containers belong
+// to the "hostns" as well despite them residing in their own netns. We use
+// net_cls as a marker.
+func markHostExtension() {
+	prefix := option.Config.CgroupPathMKE
+	if prefix == "" {
+		mountInfos, err := mountinfo.GetMountInfo()
+		if err != nil {
+			log.WithError(err).Fatal("Cannot retrieve mount infos for MKE")
+		}
+		for _, mountInfo := range mountInfos {
+			if mountInfo.FilesystemType == "cgroup" &&
+				strings.Contains(mountInfo.SuperOptions, "net_cls") {
+				// There can be multiple entries with the same mountpoint.
+				// Assert that there is no conflict.
+				if prefix != "" && prefix != mountInfo.MountPoint {
+					log.Fatalf("Multiple cgroup v1 net_cls mounts: %s, %s",
+						prefix, mountInfo.MountPoint)
+				}
+				prefix = mountInfo.MountPoint
+			}
+		}
+	}
+	if prefix == "" {
+		log.Fatal("Cannot retrieve cgroup v1 net_cls mount info for MKE")
+	}
+	log.WithField(logfields.Path, prefix).Info("Found cgroup v1 net_cls mount on MKE")
+	err := filepath.Walk(prefix,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() || strings.Contains(path, "kubepods") || path == prefix {
+				return nil
+			}
+			log.WithField(logfields.Path, path).Info("Marking as MKE host extension")
+			f, err := os.OpenFile(path+"/net_cls.classid", os.O_RDWR, 0644)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			valBytes, err := io.ReadAll(f)
+			if err != nil {
+				return err
+			}
+			class, err := strconv.Atoi(string(valBytes[:len(valBytes)-1]))
+			if err != nil {
+				return err
+			}
+			if class != 0 && class != option.HostExtensionMKE {
+				return errors.New("net_cls.classid already in use")
+			}
+			_, err = io.WriteString(f, fmt.Sprintf("%d", option.HostExtensionMKE))
+			return err
+		})
+	if err != nil {
+		log.WithError(err).Fatal("Cannot mark MKE-related container")
+	}
 }
 
 // checkNodePortAndEphemeralPortRanges checks whether the ephemeral port range

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -265,6 +265,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.EnableHealthDatapath {
 			cDefinesMap["ENABLE_HEALTH_CHECK"] = "1"
 		}
+		if option.Config.EnableMKE && option.Config.EnableHostReachableServices {
+			cDefinesMap["ENABLE_MKE"] = "1"
+			cDefinesMap["MKE_HOST"] = fmt.Sprintf("%d", option.HostExtensionMKE)
+		}
 		if option.Config.EnableRecorder {
 			cDefinesMap["ENABLE_CAPTURE"] = "1"
 			if option.Config.EnableIPv4 {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -320,6 +320,12 @@ const (
 	// EnableLocalRedirectPolicy enables support for local redirect policy
 	EnableLocalRedirectPolicy = "enable-local-redirect-policy"
 
+	// EnableMKE enables MKE specific 'chaining' for kube-proxy replacement
+	EnableMKE = "enable-mke"
+
+	// CgroupPathMKE points to the cgroupv1 net_cls mount instance
+	CgroupPathMKE = "mke-cgroup-mount"
+
 	// LibDir enables the directory path to store runtime build environment
 	LibDir = "lib-dir"
 
@@ -1738,6 +1744,12 @@ type DaemonConfig struct {
 	// EnableRecorder enables the datapath pcap recorder
 	EnableRecorder bool
 
+	// EnableMKE enables MKE specific 'chaining' for kube-proxy replacement
+	EnableMKE bool
+
+	// CgroupPathMKE points to the cgroupv1 net_cls mount instance
+	CgroupPathMKE string
+
 	// KubeProxyReplacementHealthzBindAddr is the KubeProxyReplacement healthz server bind addr
 	KubeProxyReplacementHealthzBindAddr string
 
@@ -2449,6 +2461,8 @@ func (c *DaemonConfig) Populate() {
 	c.EnableSessionAffinity = viper.GetBool(EnableSessionAffinity)
 	c.EnableBandwidthManager = viper.GetBool(EnableBandwidthManager)
 	c.EnableRecorder = viper.GetBool(EnableRecorder)
+	c.EnableMKE = viper.GetBool(EnableMKE)
+	c.CgroupPathMKE = viper.GetString(CgroupPathMKE)
 	c.EnableHostFirewall = viper.GetBool(EnableHostFirewall)
 	c.EnableLocalRedirectPolicy = viper.GetBool(EnableLocalRedirectPolicy)
 	c.EncryptInterface = viper.GetStringSlice(EncryptInterface)

--- a/pkg/option/constants.go
+++ b/pkg/option/constants.go
@@ -47,3 +47,5 @@ const (
 	ClockSourceKtime BPFClockSource = iota
 	ClockSourceJiffies
 )
+
+const HostExtensionMKE = 0x1bda7a


### PR DESCRIPTION
 * #17513 -- bpf: Add extension for running sock LB on MKE-related containers (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17513; do contrib/backporting/set-labels.py $pr done 1.10; done
```