### PR TITLE
workflows: Disable unreliable ci-gke workflow

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -50,18 +50,23 @@ concurrency:
   #
   # Note: for `issue_comment` triggers, we additionally need to filter out based
   # on comment content, otherwise any comment will interrupt workflow runs.
+  #
+  # FIXME this workflow is disabled by adding false && ( ) to the conditional
+  # FIXME re-enable this workflow once https://github.com/cilium/cilium-cli/issues/342 is fixed
   group: |
     ${{ github.workflow }}
     ${{ github.event_name }}
     ${{
-      (github.event_name == 'schedule' && github.sha) ||
-      (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke') && !startsWith(github.event.comment.body, 'ci-gke-') ||
-        startsWith(github.event.comment.body, '/ci-gke') && !startsWith(github.event.comment.body, '/ci-gke-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
-      ) && github.event.issue.number) ||
-      (github.event_name == 'pull_request' && github.event.pull_request.number)
+      false && (
+        (github.event_name == 'schedule' && github.sha) ||
+        (github.event_name == 'issue_comment' && (
+          startsWith(github.event.comment.body, 'ci-gke') && !startsWith(github.event.comment.body, 'ci-gke-') ||
+          startsWith(github.event.comment.body, '/ci-gke') && !startsWith(github.event.comment.body, '/ci-gke-') ||
+          startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
+          startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        ) && github.event.issue.number) ||
+        (github.event_name == 'pull_request' && github.event.pull_request.number)
+      )
     }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Currently unreliable, see https://github.com/cilium/cilium-cli/issues/342
for details.

Signed-off-by: Tom Payne <tom@isovalent.com>
