### PR TITLE
Remove unrelated labels from example node-local-dns yaml

### DIFF
--- a/examples/kubernetes-local-redirect/node-local-dns.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   name: node-local-dns
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: v1
 kind: Service
@@ -14,8 +11,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeDNSUpstream"
 spec:
   ports:
@@ -35,8 +30,6 @@ kind: ConfigMap
 metadata:
   name: node-local-dns
   namespace: kube-system
-  labels:
-    addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
     cluster.local:53 {
@@ -93,8 +86,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: node-local-dns
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   updateStrategy:
     rollingUpdate:


### PR DESCRIPTION
Just realized there were some accidental GKE-specific labels present in the example node-local-dns yaml. Removing them.

The two removed labels are only used by GKE's addon manager, hence it won't impact other use cases like one in the gsg. They were left there by mistake in the first place.

Signed-off-by: Weilong Cui <cuiwl@google.com>


