### PR TITLE
docs: fix docs following #17526

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -873,6 +873,14 @@
      - healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled.
      - string
      - ``""``
+   * - l2NeighDiscovery.arping-refresh-period
+     - Set period for arping
+     - string
+     - ``"5m"``
+   * - l2NeighDiscovery.enabled
+     - Enable L2 neighbor discovery in the agent
+     - bool
+     - ``true``
    * - l7Proxy
      - Enable Layer 7 network policy.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -94,6 +94,7 @@ Minikube
 Monnet
 Mythbusters
 NativeRoutingCIDR
+NeighDiscovery
 Netronome
 NewProto
 Nic
@@ -154,6 +155,7 @@ app
 apps
 archs
 arithmetics
+arping
 artii
 asm
 assignees

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -270,7 +270,7 @@ contributors across the globe, there is almost always someone available to help.
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
 | l2NeighDiscovery.arping-refresh-period | string | `"5m"` | Set period for arping |
-| l2NeighDiscovery.enabled | bool | `true` | Enable L2 neighbour discovery in the agent |
+| l2NeighDiscovery.enabled | bool | `true` | Enable L2 neighbor discovery in the agent |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -969,7 +969,7 @@ readinessProbe:
 kubeProxyReplacementHealthzBindAddr: ""
 
 l2NeighDiscovery:
-  # -- Enable L2 neighbour discovery in the agent
+  # -- Enable L2 neighbor discovery in the agent
   enabled: true
   # -- Set period for arping
   arping-refresh-period: "5m"


### PR DESCRIPTION
It seems we forgot to update `helm-values.rst` in #17526, yielding issues when building documentation locally with `make render-docs`:

```
Please fix the following spelling mistakes:
* Documentation/helm-reference.rst:876: (NeighDiscovery)
* Documentation/helm-reference.rst:876: (arping)
* Documentation/helm-reference.rst:877: (arping)
* Documentation/helm-reference.rst:880: (NeighDiscovery)
* Documentation/helm-reference.rst:881: (neighbour)
* Documentation/helm-values.rst:876: (NeighDiscovery)
* Documentation/helm-values.rst:876: (arping)
* Documentation/helm-values.rst:877: (arping)
* Documentation/helm-values.rst:880: (NeighDiscovery)
* Documentation/helm-values.rst:881: (neighbour)

If the words are not misspelled, run:
Documentation/update-spelling_wordlist.sh NeighDiscovery arping neighbour
```

Since we already have more occurrences of `neighbor` (US spelling) in the repo, we replace `neighbour` with `neighbor` for consistency and then fix `helm-values.rst` + spelling wordlist.