### PR TITLE
Process source node CiliumEndpoints in CEB watch events

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint_batch_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_batch_subscriber.go
@@ -44,12 +44,9 @@ func (cs *cebSubscriber) OnAdd(ceb *cilium_v2a1.CiliumEndpointBatch) {
 			"CEPName": ep.Name,
 		}).Debug("CEB added, calling CoreEndpointUpdate")
 		c := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(&ceb.Endpoints[i], ceb.Namespace)
-		// LocalNode already has the latest CEP.
-		// Hence, skip processing endpointupdate for localNode CEPs.
 		if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
 			timeSinceCepCreated := time.Since(p.GetCreatedAt())
 			metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
-			continue
 		}
 		cs.kWatcher.endpointUpdated(nil, c)
 	}
@@ -98,12 +95,9 @@ func (cs *cebSubscriber) OnUpdate(oldCEB, newCEB *cilium_v2a1.CiliumEndpointBatc
 				"CEPName": CEPName,
 			}).Debug("CEP inserted, calling endpointUpdated")
 			c := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(newCEP, newCEB.Namespace)
-			// LocalNode already has the latest CEP.
-			// Hence, skip processing endpointupdate for localNode CEPs.
 			if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
 				timeSinceCepCreated := time.Since(p.GetCreatedAt())
 				metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
-				continue
 			}
 			cs.kWatcher.endpointUpdated(nil, c)
 		}
@@ -121,11 +115,6 @@ func (cs *cebSubscriber) OnUpdate(oldCEB, newCEB *cilium_v2a1.CiliumEndpointBatc
 			}).Debug("CEB updated, calling endpointUpdated")
 			newC := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(newCEP, newCEB.Namespace)
 			oldC := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(oldCEP, oldCEB.Namespace)
-			// LocalNode already has the latest CEP.
-			// Hence, skip processing endpointUpdated for localNode CEPs.
-			if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(newC)); p != nil {
-				continue
-			}
 			cs.kWatcher.endpointUpdated(oldC, newC)
 		}
 	}


### PR DESCRIPTION
Update CEPs in all cilium nodes including source node CEPs.

Found couple of issues while running CI tests against CEB feature enabled default.

1) If CEP's are updated through CEB watch events, process CEPs in all nodes. Currently, we are
skipping CEP updates in source nodes. 
Here is why we need to update on all nodes...
a) If a pod is deleted, and the corresponding CEP is removed from source node. If CEPs are updated through CEB watcher, in `OnDelete` [function](https://github.com/cilium/cilium/blob/feature/cep-scalability/pkg/k8s/watchers/cilium_endpoint_batch_subscriber.go#L136-L150) we are unable to identify the CEP is local to the node or not, in the below case `LookupPodName` returns `nil` for source node CEP, hence we are calling `cs.kWatcher.endpointDeleted`

```
    if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
			continue
   }
```
However, in `endpointDeleted`, we were trying to [delete ipCache](https://github.com/cilium/cilium/blob/feature/cep-scalability/pkg/k8s/watchers/cilium_endpoint.go#L230-L235) but that ends up in cilium-agent crash because for source node CEP's we never upserted `ipcache` as mentioned [here](https://github.com/cilium/cilium/blob/feature/cep-scalability/pkg/k8s/watchers/cilium_endpoint.go#L178-L212) because we always skip CEP updating for source node CEPs.

2) Program QPS limit and Burst limit to default values

In our code default qps and burst limit values are zero `option.Config.K8sClientQPSLimit` and `option.Config.K8sClientBurst`, unless they are configured in cilium configmap.

If the given `qps, burst` values are zero k8s client will override with defaults values, as mentioned [here](https://github.com/cilium/cilium/blob/master/pkg/defaults/defaults.go#L359-L365). 

For workqueues, if `qps limit` is zero, then 'queue.AddRateLimited` API isn't working, it's not adding the `work item` back into queue. Hence we need to program default qps, burst  values for workqueues.

Signed-off-by: Gobinath Krishnamoorthy gobinathk@google.com
