### PR TITLE
bpf: Define `EGRESS_MAP` in dummy `node_config.h`

### DIFF
--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -76,6 +76,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define CAPTURE6_SIZE 16384
 #endif /* ENABLE_IPV6 */
 
+#define EGRESS_MAP test_cilium_egress_v4
 #define ENDPOINTS_MAP test_cilium_lxc
 #define EVENTS_MAP test_cilium_events
 #define SIGNAL_MAP test_cilium_signals


### PR DESCRIPTION
Values in `node_config.h` are used while compile-testing and during verifier tests (verifier-test.sh and K8sVerifier). Because `EGRESS_MAP` is currently undefined in that file, the `EGRESS_MAP` is literally created in the bpffs instead of `test_cilium_xxx`. This pull request fixes it.