### PR TITLE
all: remove unnecessary string(byteslice) when passed into fmt.*rintf("%s", string(b))

### DIFF
--- a/cilium/cmd/kvstore_get.go
+++ b/cilium/cmd/kvstore_get.go
@@ -43,7 +43,7 @@ var kvstoreGetCmd = &cobra.Command{
 				return
 			}
 			for k, v := range pairs {
-				fmt.Printf("%s => %s\n", k, string(v.Data))
+				fmt.Printf("%s => %s\n", k, v.Data)
 			}
 		} else {
 			val, err := kvstore.Client().Get(ctx, key)
@@ -59,7 +59,7 @@ var kvstoreGetCmd = &cobra.Command{
 				}
 				return
 			}
-			fmt.Printf("%s => %s\n", key, string(val))
+			fmt.Printf("%s => %s\n", key, val)
 		}
 	},
 }

--- a/cilium/cmd/policy_validate.go
+++ b/cilium/cmd/policy_validate.go
@@ -36,7 +36,7 @@ var policyValidateCmd = &cobra.Command{
 				if err != nil {
 					Fatalf("Cannot marshal policy %s: %s\n", path, err)
 				}
-				fmt.Printf("%s", string(jsonPolicy))
+				fmt.Printf("%s", jsonPolicy)
 			}
 		}
 	},


### PR DESCRIPTION
fmt.*printf's "%s" verb converts values to strings in a performant
way so no need to cast and unnecessarily allocate byteslice->string
conversions.

Noticed from own benchmarking per

https://dashboard.github.orijtech.com/benchmark/3245b8e4bbbd44a597480319aaa4b9fe

that avoiding this unnecessary pattern can reduce time spent and
allocations by quite a big value and that showed the following
improvements:
```shell
* time/op (ns/op)
FormatIt-8	1.2µs ± 2%	1.1µs ± 10%	-11.77%	(p=0.000 n=10+9)

* allocs/op (MBs/op)
FormatIt-8	0.71GB/s ± 2%	0.80GB/s ± 9%	+13.59%	(p=0.000 n=10+9)

* allocs/op (B/op)
FormatIt-8	2.0kB ± 0%	1.1kB ± 0%	-45.62%	(p=0.000 n=10+10)

* allocs/op (count/op)
FormatIt-8	11 ± 0%	9.0 ± 0%	-18.18%	(p=0.000 n=10+10)
```

Signed-off-by: Emmanuel T Odeke <emmanuel@orijtech.com>