### PR TITLE
pkg/rate,proxylib: Use math.MaxInt constants

### DIFF
--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -885,7 +885,7 @@ func parsePositiveInt(value string) (int, error) {
 		return 0, fmt.Errorf("unable to parse positive integer %q: %v", value, err)
 	case i64 < 0:
 		return 0, fmt.Errorf("unable to parse positive integer %q: negative value", value)
-	case i64 > 9223372036854775807: // FIXME replace with math.MaxInt when https://github.com/cilium/cilium/pull/17394 is deployed
+	case i64 > math.MaxInt:
 		return 0, fmt.Errorf("unable to parse positive integer %q: overflow", value)
 	default:
 		return int(i64), nil

--- a/proxylib/testparsers/blockparser.go
+++ b/proxylib/testparsers/blockparser.go
@@ -6,6 +6,7 @@ package testparsers
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"strconv"
 
 	. "github.com/cilium/cilium/proxylib/proxylib"
@@ -65,7 +66,7 @@ func getBlock(data [][]byte) ([]byte, int, int, error) {
 				// indicating the length of the frame AFTER the ':'
 				if lenUint64, err := strconv.ParseUint(block.String(), 10, 64); err != nil {
 					return block.Bytes(), 0, 0, err
-				} else if lenUint64 > 9223372036854775807 { // FIXME replace with math.MaxInt when https://github.com/cilium/cilium/pull/17394 is deployed
+				} else if lenUint64 > math.MaxInt {
 					return block.Bytes(), 0, 0, fmt.Errorf("block length overflow")
 				} else {
 					blockLen = int(lenUint64)


### PR DESCRIPTION
Now that the CI infrastructure runs Go 1.17 everywhere (#17394), we can
use Go 1.17 features like math.MaxInt.

Signed-off-by: Tom Payne <tom@isovalent.com>
