### PR TITLE
k8sT/Egress: fixes

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4297,7 +4297,6 @@ func GenerateNamespaceForTest(seed string) string {
 	replaced := strings.Replace(lowered, " ", "", -1)
 	replaced = strings.Replace(replaced, "_", "", -1)
 	replaced = strings.Replace(replaced, "/", "", -1)
-	replaced = strings.Replace(replaced, "-", "", -1)
 
 	timestamped := time.Now().Format("200601021504") + seed + replaced
 

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -25,7 +25,7 @@ import (
 )
 
 var _ = SkipDescribeIf(func() bool {
-	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || !helpers.RunsOn419OrLaterKernel() || helpers.DoesNotExistNodeWithoutCilium()
+	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || helpers.DoesNotRunWithKubeProxyReplacement() || helpers.DoesNotExistNodeWithoutCilium()
 }, "K8sEgressGatewayTest", func() {
 	var (
 		kubectl         *helpers.Kubectl
@@ -77,9 +77,6 @@ var _ = SkipDescribeIf(func() bool {
 	}
 
 	BeforeAll(func() {
-		if helpers.DoesNotRunWithKubeProxyReplacement() {
-			Skip("EgressGatewayTest requires KubeProxyReplacement")
-		}
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -88,6 +88,8 @@ var _ = SkipDescribeIf(func() bool {
 
 		deploymentManager.SetKubectl(kubectl)
 
+		// We deploy cilium, to run the echo server and assign egress IP, and redeploy with
+		// different configurations for the tests.
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 		DeployCiliumAndDNS(kubectl, ciliumFilename)
 

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -106,7 +106,7 @@ var _ = SkipDescribeIf(func() bool {
 
 	AfterFailed(func() {
 		// Especially check if there are duplicated address allocated on cilium_host
-		kubectl.CiliumReport("ip addr")
+		kubectl.CiliumReport("ip addr", "cilium bpf egress list", "cilium bpf nat list")
 	})
 
 	testEgressGateway := func(fromGateway bool) {

--- a/test/k8sT/manifests/egress-ip-deployment.yaml
+++ b/test/k8sT/manifests/egress-ip-deployment.yaml
@@ -25,14 +25,14 @@ spec:
         securityContext:
           privileged: true
         env:
-        - name: EGRESS_IPS
+        - name: EGRESS_IP
           value: "INPUT_EGRESS_IP/24"
         args:
-        - "for i in $EGRESS_IPS; do ip address add $i dev enp0s8; done; sleep 10000000"
+        - "ip address add $EGRESS_IP dev enp0s8; sleep inf"
         lifecycle:
           preStop:
             exec:
               command:
               - "/bin/sh"
               - "-c"
-              - "for i in $EGRESS_IPS; do ip address del $i dev enp0s8; done"
+              - "ip address del $EGRESS_IP dev enp0s8"


### PR DESCRIPTION
This PR includes fixes for the k8sT/egress test. It is a followup PR for https://github.com/cilium/cilium/pull/17517#pullrequestreview-776287048.

Updates:

1. @pchaigno noticed that the context helper was wrong, which lead to some kubectl commands being called with an empty namespace. In addition to that, I've added another commit to print the egress and nat tables in case of  a failure. This is meant to help identify potential issues as reported in https://github.com/cilium/cilium/issues/17604.
1. turns out that starting cilium at the begging was actually needed. fix the patch to just add a comment.
1. removed `=` from tests names, to avoid:
    >  	 The Namespace "202110141537k8segressgatewaytesttunnel=disabledwithendpointrout" is invalid: metadata.name: Invalid value: "202110141537k8segressgatewaytesttunnel=disabledwithendpointrout": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
1. agent bailed out with:
     >   2021-10-14T20:49:33.226452400Z level=fatal msg="auto-direct-node-routes cannot be used with tunneling. Packets must be routed through the tunnel device."     subsys=daemon
     
   adjusted configuration accordingly