### PR TITLE
v1.10 backports 2021-10-12

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"context"
+	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
+	"github.com/cilium/cilium/pkg/proxy"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,6 +85,8 @@ func setupTestDirectories() {
 }
 
 func TestMain(m *testing.M) {
+	proxy.DefaultDNSProxy = fqdnproxy.MockFQDNProxy{}
+
 	// Set up all configuration options which are global to the entire test
 	// run.
 	option.Config.Populate()

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -1081,7 +1081,6 @@ func (d *Daemon) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), e
 }
 
 func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
-	// Many unit tests do not initialize the DNS proxy
 	if proxy.DefaultDNSProxy == nil {
 		return nil
 	}
@@ -1095,9 +1094,9 @@ func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
 }
 
 func (d *Daemon) RemoveRestoredDNSRules(epID uint16) {
-	// Many unit tests do not initialize the DNS proxy
 	if proxy.DefaultDNSProxy == nil {
 		return
 	}
+
 	proxy.DefaultDNSProxy.RemoveRestoredRules(epID)
 }

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -1085,7 +1085,13 @@ func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
 	if proxy.DefaultDNSProxy == nil {
 		return nil
 	}
-	return proxy.DefaultDNSProxy.GetRules(epID)
+
+	rules, err := proxy.DefaultDNSProxy.GetRules(epID)
+	if err != nil {
+		log.WithField(logfields.EndpointID, epID).WithError(err).Error("Could not get DNS rules")
+		return nil
+	}
+	return rules
 }
 
 func (d *Daemon) RemoveRestoredDNSRules(epID uint16) {

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -316,8 +316,8 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
-		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)
-		if err == nil && port == proxy.DefaultDNSProxy.BindPort {
+		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.GetBindPort())
+		if err == nil && port == proxy.DefaultDNSProxy.GetBindPort() {
 			log.Infof("Reusing previous DNS proxy port: %d", port)
 		}
 		proxy.DefaultDNSProxy.SetRejectReply(option.Config.FQDNRejectResponse)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -190,7 +190,7 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP stri
 
 // GetRules creates a fresh copy of EP's DNS rules to be stored
 // for later restoration.
-func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
+func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -232,7 +232,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) restore.DNSRules {
 		}
 		restored[port] = ipRules
 	}
-	return restored
+	return restored, nil
 }
 
 // RestoreRules is used in the beginning of endpoint restoration to
@@ -693,6 +693,10 @@ func (p *DNSProxy) SetRejectReply(opt string) {
 			opt, option.FQDNRejectOptions)
 		return
 	}
+}
+
+func (p *DNSProxy) GetBindPort() uint16 {
+	return p.BindPort
 }
 
 // ExtractMsgDetails extracts a canonical query name, any IPs in a response,

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -643,11 +643,13 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
 		}},
 	}
-	restored1 := s.proxy.GetRules(uint16(epID1)).Sort()
+	restored1, _ := s.proxy.GetRules(uint16(epID1))
+	restored1.Sort()
 	c.Assert(restored1, checker.DeepEquals, expected1)
 
 	expected2 := restore.DNSRules{}
-	restored2 := s.proxy.GetRules(uint16(epID2)).Sort()
+	restored2, _ := s.proxy.GetRules(uint16(epID2))
+	restored2.Sort()
 	c.Assert(restored2, checker.DeepEquals, expected2)
 
 	expected3 := restore.DNSRules{
@@ -662,7 +664,8 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID4Selector]},
 		}}.Sort(),
 	}
-	restored3 := s.proxy.GetRules(uint16(epID3)).Sort()
+	restored3, _ := s.proxy.GetRules(uint16(epID3))
+	restored3.Sort()
 	c.Assert(restored3, checker.DeepEquals, expected3)
 
 	// Test with limited set of allowed IPs
@@ -681,7 +684,8 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
 		}},
 	}
-	restored1b := s.proxy.GetRules(uint16(epID1)).Sort()
+	restored1b, _ := s.proxy.GetRules(uint16(epID1))
+	restored1b.Sort()
 	c.Assert(restored1b, checker.DeepEquals, expected1b)
 
 	// unlimited again
@@ -944,7 +948,8 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	c.Assert(response.Answer[0].String(), Equals, "cilium.io.\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
 
 	// Get restored rules
-	restored := s.proxy.GetRules(uint16(epID1)).Sort()
+	restored, _ := s.proxy.GetRules(uint16(epID1))
+	restored.Sort()
 
 	// remove rules
 	err = s.proxy.UpdateAllowed(epID1, dstPort, nil)

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2016-2020 Authors of Cilium
+
+package proxy
+
+import (
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+type DNSProxier interface {
+	GetRules(uint16) (restore.DNSRules, error)
+	RemoveRestoredRules(uint16)
+	UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error
+	GetBindPort() uint16
+	SetRejectReply(string)
+	RestoreRules(op *endpoint.Endpoint)
+}

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -17,3 +17,29 @@ type DNSProxier interface {
 	SetRejectReply(string)
 	RestoreRules(op *endpoint.Endpoint)
 }
+
+type MockFQDNProxy struct{}
+
+func (m MockFQDNProxy) GetRules(u uint16) (restore.DNSRules, error) {
+	return nil, nil
+}
+
+func (m MockFQDNProxy) RemoveRestoredRules(u uint16) {
+	return
+}
+
+func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+	return nil
+}
+
+func (m MockFQDNProxy) GetBindPort() uint16 {
+	return 0
+}
+
+func (m MockFQDNProxy) SetRejectReply(s string) {
+	return
+}
+
+func (m MockFQDNProxy) RestoreRules(op *endpoint.Endpoint) {
+	return
+}

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -1,0 +1,297 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+	. "github.com/onsi/gomega"
+)
+
+var _ = SkipDescribeIf(func() bool {
+	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || !helpers.RunsOn419OrLaterKernel() || helpers.DoesNotExistNodeWithoutCilium()
+}, "K8sEgressGatewayTest", func() {
+	var (
+		kubectl         *helpers.Kubectl
+		ciliumFilename  string
+		randomNamespace string
+
+		egressIP  string
+		k8s1IP    string
+		k8s2IP    string
+		outsideIP string
+
+		assignIPYAML string
+		echoPodYAML  string
+		policyYAML   string
+
+		namespaceSelector string = "ns=cilium-test"
+	)
+
+	runEchoServer := func() {
+		// Run echo server on outside node
+		originalEchoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-hostnetns.yaml")
+		res := kubectl.ExecMiddle("mktemp")
+		res.ExpectSuccess()
+		echoPodYAML = strings.Trim(res.Stdout(), "\n")
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/NODE_WITHOUT_CILIUM/%s/' %s > %s",
+			helpers.GetNodeWithoutCilium(), originalEchoPodPath, echoPodYAML)).ExpectSuccess()
+		kubectl.ApplyDefault(echoPodYAML).ExpectSuccess("Cannot install echoserver application")
+		Expect(kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=echoserver-hostnetns",
+			helpers.HelperTimeout)).Should(BeNil())
+	}
+
+	assignEgressIP := func() {
+		// Assign egress IP address to k8s2
+		originalAssignIPYAML := helpers.ManifestGet(kubectl.BasePath(), "egress-ip-deployment.yaml")
+		res := kubectl.ExecMiddle("mktemp")
+		res.ExpectSuccess()
+		assignIPYAML = strings.Trim(res.Stdout(), "\n")
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_EGRESS_IP/%s/' %s > %s",
+			egressIP, originalAssignIPYAML, assignIPYAML)).ExpectSuccess()
+		res = kubectl.ApplyDefault(assignIPYAML)
+		Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", assignIPYAML)
+		Expect(kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=egress-ip-assign",
+			helpers.HelperTimeout)).Should(BeNil())
+
+		// Wait egressIP online
+		srcPod, _ := fetchPodsWithOffset(kubectl, helpers.DefaultNamespace, "", "name=egress-ip-assign", "", false, 0)
+		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, srcPod, helpers.PingWithCount(egressIP, 5))
+		res.ExpectSuccess()
+	}
+
+	BeforeAll(func() {
+		if helpers.DoesNotRunWithKubeProxyReplacement() {
+			Skip("EgressGatewayTest requires KubeProxyReplacement")
+		}
+
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		_, k8s1IP = kubectl.GetNodeInfo(helpers.K8s1)
+		_, k8s2IP = kubectl.GetNodeInfo(helpers.K8s2)
+		_, outsideIP = kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+
+		egressIP = getEgressIP(k8s1IP)
+
+		deploymentManager.SetKubectl(kubectl)
+
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
+
+		runEchoServer()
+		assignEgressIP()
+	})
+
+	AfterAll(func() {
+		_ = kubectl.Delete(echoPodYAML)
+		_ = kubectl.Delete(assignIPYAML)
+
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
+	})
+
+	AfterFailed(func() {
+		// Especially check if there are duplicated address allocated on cilium_host
+		kubectl.CiliumReport("ip addr")
+	})
+
+	testEgressGateway := func(fromGateway bool) {
+		if fromGateway {
+			By("Check egress policy from gateway node")
+		} else {
+			By("Check egress policy from non-gateway node")
+		}
+
+		hostIP := k8s1IP
+		if fromGateway {
+			hostIP = k8s2IP
+		}
+		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", "zgroup=testDSClient", hostIP, false, 1)
+
+		res := kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.CurlFail("http://%s:80", outsideIP))
+		res.ExpectSuccess()
+		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", egressIP))
+	}
+
+	testConnectivity := func(fromGateway bool) {
+		if fromGateway {
+			By("Check connectivity from gateway node")
+		} else {
+			By("Check connectivity from non-gateway node")
+		}
+		hostIP := k8s1IP
+		if fromGateway {
+			hostIP = k8s2IP
+		}
+		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", "zgroup=testDSClient", hostIP, false, 1)
+
+		// Pod-to-node connectivity should work
+		res := kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.PingWithCount(k8s1IP, 1))
+		res.ExpectSuccess()
+
+		res = kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.PingWithCount(k8s2IP, 1))
+		res.ExpectSuccess()
+
+		// DNS query should work (pod-to-pod connectivity)
+		res = kubectl.ExecPodCmd(randomNamespace, srcPod, "dig kubernetes +time=2")
+		res.ExpectSuccess()
+	}
+
+	applyEgressPolicy := func() {
+		// Apply egress policy yaml
+		originalPolicyYAML := helpers.ManifestGet(kubectl.BasePath(), "egress-nat-policy.yaml")
+		res := kubectl.ExecMiddle("mktemp")
+		res.ExpectSuccess()
+		policyYAML = strings.Trim(res.Stdout(), "\n")
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_EGRESS_IP/%s/' %s > %s",
+			egressIP, originalPolicyYAML, policyYAML)).ExpectSuccess()
+		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_OUTSIDE_NODE_IP/%s/' -i %s",
+			outsideIP, policyYAML)).ExpectSuccess()
+		res = kubectl.ApplyDefault(policyYAML)
+		Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", policyYAML)
+	}
+
+	Context("tunnel disabled with endpoint routes enabled", func() {
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"egressGateway.enabled":  "true",
+				"tunnel":                 "disabled",
+				"autoDirectNodeRoutes":   "true",
+				"bpf.masquerade":         "true",
+				"endpointRoutes.enabled": "true",
+			})
+
+			randomNamespace = deploymentManager.DeployRandomNamespaceShared(DemoDaemonSet)
+			kubectl.NamespaceLabel(randomNamespace, namespaceSelector)
+			deploymentManager.WaitUntilReady()
+
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteAll()
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+		})
+
+		It("Checks connectivity works without policy", func() {
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+		It("Checks egress policy and basic connectivity both work", func() {
+			applyEgressPolicy()
+			kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
+			kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+			defer kubectl.Delete(policyYAML)
+
+			testEgressGateway(true)
+			testEgressGateway(false)
+			testConnectivity(true)
+			testConnectivity(false)
+		})
+
+	})
+
+	Context("tunnel disabled with endpoint routes disabled", func() {
+
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"egressGateway.enabled":  "true",
+				"tunnel":                 "disabled",
+				"autoDirectNodeRoutes":   "true",
+				"bpf.masquerade":         "true",
+				"endpointRoutes.enabled": "false",
+			})
+
+			randomNamespace = deploymentManager.DeployRandomNamespaceShared(DemoDaemonSet)
+			kubectl.NamespaceLabel(randomNamespace, namespaceSelector)
+			deploymentManager.WaitUntilReady()
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteAll()
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+		})
+
+		It("Checks connectivity works without policy", func() {
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+		It("Checks egress policy and basic connectivity both work", func() {
+			applyEgressPolicy()
+			kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
+			kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+			defer kubectl.Delete(policyYAML)
+
+			testEgressGateway(false)
+			testEgressGateway(true)
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+	})
+
+	Context("tunnel vxlan", func() {
+
+		BeforeAll(func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"egressGateway.enabled": "true",
+				"bpf.masquerade":        "true",
+				"tunnel":                "vxlan",
+			})
+
+			randomNamespace = deploymentManager.DeployRandomNamespaceShared(DemoDaemonSet)
+			kubectl.NamespaceLabel(randomNamespace, namespaceSelector)
+			deploymentManager.WaitUntilReady()
+		})
+
+		AfterAll(func() {
+			deploymentManager.DeleteAll()
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+		})
+
+		It("Checks connectivity works without policy", func() {
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+		It("Checks egress policy and basic connectivity both work", func() {
+			applyEgressPolicy()
+			kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
+			kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+			defer kubectl.Delete(policyYAML)
+
+			testEgressGateway(false)
+			testEgressGateway(true)
+			testConnectivity(false)
+			testConnectivity(true)
+		})
+
+	})
+
+})
+
+// Use x.x.x.100 as the egress IP
+func getEgressIP(nodeIP string) string {
+	ip := net.ParseIP(nodeIP).To4()
+	ip[3] = 100
+	return ip.String()
+}

--- a/test/k8sT/manifests/egress-ip-deployment.yaml
+++ b/test/k8sT/manifests/egress-ip-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "egress-ip-assign"
+  labels:
+    name: "egress-ip-assign"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: "egress-ip-assign"
+  template:
+    metadata:
+      labels:
+        name: "egress-ip-assign"
+    spec:
+      # Pin it on k8s2 so it becomes the gateway node
+      nodeSelector:
+        cilium.io/ci-node: k8s2
+      hostNetwork: true
+      containers:
+      - name: egress-ip
+        image: docker.io/library/busybox:1.31.1
+        command: ["/bin/sh","-c"]
+        securityContext:
+          privileged: true
+        env:
+        - name: EGRESS_IPS
+          value: "INPUT_EGRESS_IP/24"
+        args:
+        - "for i in $EGRESS_IPS; do ip address add $i dev enp0s8; done; sleep 10000000"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - "for i in $EGRESS_IPS; do ip address del $i dev enp0s8; done"

--- a/test/k8sT/manifests/egress-nat-policy.yaml
+++ b/test/k8sT/manifests/egress-nat-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEgressNATPolicy
+metadata:
+  name: egress-sample
+spec:
+  egress:
+  - podSelector:
+      matchLabels:
+        zgroup: testDSClient
+    namespaceSelector:
+      matchLabels:
+        ns: cilium-test
+  destinationCIDRs:
+  - INPUT_OUTSIDE_NODE_IP/32
+  egressSourceIP: INPUT_EGRESS_IP


### PR DESCRIPTION
 * #17318 -- fqdn: add fqdn proxy interface (@nebril)
 * #17517 -- egress gateway: fix non-tunnel mode (@kkourt)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17318 17517; do contrib/backporting/set-labels.py $pr done 1.10; done
```