### PR TITLE
Adds an `ACCEPT` rule for untracked pkts in `filter:CILIUM_OUTPUT`

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -813,6 +813,9 @@ func (m *IptablesManager) endpointNoTrackRules(prog iptablesInterface, cmd strin
 		if _, err := prog.runProgCombinedOutput([]string{"-t", "raw", cmd, ciliumOutputRawChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "CT", "--notrack"}, false); err != nil {
 			return err
 		}
+		if _, err := prog.runProgCombinedOutput([]string{"-t", "filter", cmd, ciliumOutputChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "ACCEPT"}, false); err != nil {
+			return err
+		}
 	} else {
 		if _, err := prog.runProgCombinedOutput([]string{"-t", "raw", cmd, ciliumOutputRawChain, "-p", protocol, "-s", IP, "--sport", p, "-j", "CT", "--notrack"}, false); err != nil {
 			return err


### PR DESCRIPTION
Currently, when `no-track-port` is specified for a pod (the only use
case for now is nodelocaldns), we insert several iptable rules to skip
conntrack for packet to and from the pod to achieve pararity with OSS
node-local-dns.

However, we need to add a specific accept rule int the CILIUM_OUTPUT
chain to accept such packets. Otherwise, a dns query pkt originated from
the hostns will skip conntrack and gets dropped in the filter OUTPUT
chain. This rule is however NOT needed for standard OSS node-local-dns
because it relies on the loopback rule installed by the OS to allowlist
this traffic pattern. With Cilium, we DNAT such packet in a way that its
dst is the pod IP of the local node-cache pod, so it will NOT hit the
loopback dev, hence we need to punch a specific hole to allowlist it.

Fixes: #16694 

Signed-off-by: Weilong Cui <cuiwl@google.com>