### PR TITLE
.github: Fix codeQL workflow skip logic

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           filters: |
             src:
-              - '*.go'
+              - '**/*.go'
               - 'go.mod'
               - 'go.sum'
 


### PR DESCRIPTION
Between commits 3ceb7425a60a (".github: Skip unnecessary docs test") and
b08f700aff5a ("workflows: Skip jobs instead of workflows"), we attempted
to add (and fix) logic to skip workflows when the workflow only checks
certain types of code. However, this inadvertently disabled the CodeQL
workflows. Fix it by adjusting the wildcard logic.

Suggested-by: Nicolas Busseneau <nicolas@isovalent.com>
