### PR TITLE
bpf: Fix reset of CB_PROXY_MAGIC

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1124,7 +1124,7 @@ int to_host(struct __ctx_buff *ctx)
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
 
-		ctx_store_meta(ctx, 0, CB_PROXY_MAGIC);
+		ctx_store_meta(ctx, CB_PROXY_MAGIC, 0);
 		ret = ctx_redirect_to_proxy_first(ctx, port);
 		if (IS_ERR(ret))
 			goto out;


### PR DESCRIPTION
ctx_store_meta() takes the value as the last parameter. So instead of

		ctx_store_meta(ctx, 0, CB_PROXY_MAGIC);

it should be:

		ctx_store_meta(ctx, CB_PROXY_MAGIC, 0);

In this instance this does not make functional difference as
CB_PROXY_MAGIC is also 0.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
