### PR TITLE
datapath: Always use of wait argument on iptables commands.

### DIFF
--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -73,6 +73,14 @@ func (m *fakeDatapath) GetProxyPort(name string) uint16 {
 	return 0
 }
 
+func (m *fakeDatapath) InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	return nil
+}
+
+func (m *fakeDatapath) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	return nil
+}
+
 func (f *fakeDatapath) Loader() datapath.Loader {
 	return f.loader
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -91,8 +91,21 @@ type iptablesInterface interface {
 }
 
 type ipt struct {
-	prog  string
-	ipset string
+	prog     string
+	ipset    string
+	waitArgs []string
+}
+
+func (ipt *ipt) initArgs(waitSeconds int) {
+	v, err := ipt.getVersion()
+	if err == nil {
+		switch {
+		case isWaitSecondsMinVersion(v):
+			ipt.waitArgs = []string{waitString, fmt.Sprintf("%d", waitSeconds)}
+		case isWaitMinVersion(v):
+			ipt.waitArgs = []string{waitString}
+		}
+	}
 }
 
 // package name is iptables so we use ip4tables internally for "iptables"
@@ -124,7 +137,11 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 }
 
 func (ipt *ipt) runProgCombinedOutput(args []string, quiet bool) ([]byte, error) {
-	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, args...).CombinedOutput(log, !quiet)
+	// Add wait argument to deal with concurrent calls that would fail otherwise
+	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
+	iptArgs = append(iptArgs, ipt.waitArgs...)
+	iptArgs = append(iptArgs, args...)
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).CombinedOutput(log, !quiet)
 	return out, err
 }
 
@@ -169,13 +186,13 @@ func KernelHasNetfilter() bool {
 	return false
 }
 
-func (c *customChain) add(waitArgs []string) error {
+func (c *customChain) add() error {
 	var err error
 	if option.Config.EnableIPv4 {
-		err = ip4tables.runProg(append(waitArgs, "-t", c.table, "-N", c.name), false)
+		err = ip4tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
 	}
 	if err == nil && option.Config.EnableIPv6 && c.ipv6 == true {
-		err = ip6tables.runProg(append(waitArgs, "-t", c.table, "-N", c.name), false)
+		err = ip6tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
 	}
 	return err
 }
@@ -197,7 +214,7 @@ func reverseRule(rule string) ([]string, error) {
 }
 
 func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) {
-	args := append(m.waitArgs, "-t", table, "-S")
+	args := []string{"-t", table, "-S"}
 
 	out, err := prog.runProgCombinedOutput(args, false)
 	if err != nil {
@@ -236,7 +253,7 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 			}
 
 			if len(reversedRule) > 0 {
-				deleteRule := append(append(m.waitArgs, "-t", table), reversedRule...)
+				deleteRule := append([]string{"-t", table}, reversedRule...)
 				log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Removing %s rule", prog)
 				err = prog.runProg(deleteRule, true)
 				if err != nil {
@@ -247,8 +264,8 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 	}
 }
 
-func (c *customChain) doRename(prog iptablesInterface, waitArgs []string, name string, quiet bool) {
-	args := append(waitArgs, "-t", c.table, "-E", c.name, name)
+func (c *customChain) doRename(prog iptablesInterface, name string, quiet bool) {
+	args := []string{"-t", c.table, "-E", c.name, name}
 	operation := "rename"
 	combinedOutput, err := prog.runProgCombinedOutput(args, true)
 	if err != nil && !quiet {
@@ -256,37 +273,37 @@ func (c *customChain) doRename(prog iptablesInterface, waitArgs []string, name s
 	}
 }
 
-func (c *customChain) rename(waitArgs []string, name string, quiet bool) {
+func (c *customChain) rename(name string, quiet bool) {
 	if option.Config.EnableIPv4 {
-		c.doRename(ip4tables, waitArgs, name, quiet)
+		c.doRename(ip4tables, name, quiet)
 	}
 	if option.Config.EnableIPv6 && c.ipv6 {
-		c.doRename(ip6tables, waitArgs, name, quiet)
+		c.doRename(ip6tables, name, quiet)
 	}
 }
 
-func (c *customChain) remove(waitArgs []string, quiet bool) {
+func (c *customChain) remove(quiet bool) {
 	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
 		combinedOutput, err := prog.runProgCombinedOutput(args, true)
 		if err != nil && !quiet {
 			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog.getProg(), c.name, string(combinedOutput))
 		}
 	}
-	doRemove := func(c *customChain, prog iptablesInterface, waitArgs []string, quiet bool) {
-		args := append(waitArgs, "-t", c.table, "-F", c.name)
+	doRemove := func(c *customChain, prog iptablesInterface, quiet bool) {
+		args := []string{"-t", c.table, "-F", c.name}
 		doProcess(c, prog, args, "flush", quiet)
-		args = append(waitArgs, "-t", c.table, "-X", c.name)
+		args = []string{"-t", c.table, "-X", c.name}
 		doProcess(c, prog, args, "delete", quiet)
 	}
 	if option.Config.EnableIPv4 {
-		doRemove(c, ip4tables, waitArgs, quiet)
+		doRemove(c, ip4tables, quiet)
 	}
 	if option.Config.EnableIPv6 && c.ipv6 {
-		doRemove(c, ip6tables, waitArgs, quiet)
+		doRemove(c, ip6tables, quiet)
 	}
 }
 
-func (c *customChain) installFeeder(waitArgs []string) error {
+func (c *customChain) installFeeder() error {
 	installMode := "-A"
 	if option.Config.PrependIptablesChains {
 		installMode = "-I"
@@ -294,13 +311,13 @@ func (c *customChain) installFeeder(waitArgs []string) error {
 
 	for _, feedArgs := range c.feederArgs {
 		if option.Config.EnableIPv4 {
-			err := ip4tables.runProg(append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
+			err := ip4tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
 			if err != nil {
 				return err
 			}
 		}
 		if option.Config.EnableIPv6 && c.ipv6 == true {
-			err := ip6tables.runProg(append(append(waitArgs, "-t", c.table, installMode, c.hook), getFeedRule(c.name, feedArgs)...), true)
+			err := ip6tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
 			if err != nil {
 				return err
 			}
@@ -391,7 +408,6 @@ type IptablesManager struct {
 	haveSocketMatch      bool
 	haveBPFSocketAssign  bool
 	ipEarlyDemuxDisabled bool
-	waitArgs             []string
 }
 
 // Init initializes the iptables manager and checks for iptables kernel modules
@@ -462,15 +478,8 @@ func (m *IptablesManager) Init() {
 	}
 	m.haveBPFSocketAssign = option.Config.EnableBPFTProxy
 
-	v, err := ip4tables.getVersion()
-	if err == nil {
-		switch {
-		case isWaitSecondsMinVersion(v):
-			m.waitArgs = []string{waitString, fmt.Sprintf("%d", option.Config.IPTablesLockTimeout/time.Second)}
-		case isWaitMinVersion(v):
-			m.waitArgs = []string{waitString}
-		}
-	}
+	ip4tables.initArgs(int(option.Config.IPTablesLockTimeout / time.Second))
+	ip6tables.initArgs(int(option.Config.IPTablesLockTimeout / time.Second))
 }
 
 // SupportsOriginalSourceAddr tells if an L7 proxy can use POD's original source address and port in
@@ -501,20 +510,20 @@ func (m *IptablesManager) removeOldRules(quiet bool) {
 
 	for _, c := range ciliumChains {
 		c.name = "OLD_" + c.name
-		c.remove(m.waitArgs, quiet)
+		c.remove(quiet)
 	}
 }
 
 func (m *IptablesManager) ingressProxyRule(l4Match, markMatch, mark, port, name string) []string {
-	return append(m.waitArgs,
+	return []string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
 		"-p", l4Match,
 		"-m", "mark", "--mark", markMatch,
-		"-m", "comment", "--comment", "cilium: TPROXY to host "+name+" proxy",
+		"-m", "comment", "--comment", "cilium: TPROXY to host " + name + " proxy",
 		"-j", "TPROXY",
 		"--tproxy-mark", mark,
-		"--on-port", port)
+		"--on-port", port}
 }
 
 func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
@@ -528,13 +537,13 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 	// 2. route original direction traffic that would otherwise be intercepted
 	//    by ip_early_demux
 	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
-	return append(m.waitArgs,
+	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
 		"-m", "socket", "--transparent",
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
-		"--set-mark", toProxyMark)
+		"--set-mark", toProxyMark}
 }
 
 func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
@@ -553,15 +562,15 @@ func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterfa
 }
 
 func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name string) []string {
-	return append(m.waitArgs,
+	return []string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
 		"-p", l4Match,
 		"-m", "mark", "--mark", markMatch,
-		"-m", "comment", "--comment", "cilium: TPROXY to host "+name+" proxy",
+		"-m", "comment", "--comment", "cilium: TPROXY to host " + name + " proxy",
 		"-j", "TPROXY",
 		"--tproxy-mark", mark,
-		"--on-port", port)
+		"--on-port", port}
 }
 
 func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
@@ -588,56 +597,51 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	var err error
 	if option.Config.EnableIPv4 {
 		// No conntrack for traffic to proxy
-		err = ip4tables.runProg(append(
-			m.waitArgs,
+		err = ip4tables.runProg([]string{
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
 			"-m", "mark", "--mark", matchToProxy,
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy traffic",
-			"-j", "NOTRACK"), false)
+			"-j", "NOTRACK"}, false)
 		if err == nil {
 			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip4tables.runProg(append(
-				m.waitArgs,
+			err = ip4tables.runProg([]string{
 				"-t", "filter",
 				"-A", ciliumInputChain,
 				"-m", "mark", "--mark", matchToProxy,
 				"-m", "comment", "--comment", "cilium: ACCEPT for proxy traffic",
-				"-j", "ACCEPT"), false)
+				"-j", "ACCEPT"}, false)
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic that is heading to lxc+
-			err = ip4tables.runProg(append(
-				m.waitArgs,
+			err = ip4tables.runProg([]string{
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
 				"-o", "lxc+",
 				"-m", "mark", "--mark", matchProxyReply,
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
-				"-j", "NOTRACK"), false)
+				"-j", "NOTRACK"}, false)
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic that is heading to cilium_host
-			err = ip4tables.runProg(append(
-				m.waitArgs,
+			err = ip4tables.runProg([]string{
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
 				"-o", "cilium_host",
 				"-m", "mark", "--mark", matchProxyReply,
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
-				"-j", "NOTRACK"), false)
+				"-j", "NOTRACK"}, false)
 		}
 		if err == nil {
 			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip4tables.runProg(append(
-				m.waitArgs,
+			err = ip4tables.runProg([]string{
 				"-t", "filter",
 				"-A", ciliumOutputChain,
 				"-m", "mark", "--mark", matchProxyReply,
 				"-m", "comment", "--comment", "cilium: ACCEPT for proxy return traffic",
-				"-j", "ACCEPT"), false)
+				"-j", "ACCEPT"}, false)
 		}
 		if err == nil && m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
@@ -646,44 +650,40 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	}
 	if err == nil && option.Config.EnableIPv6 {
 		// No conntrack for traffic to ingress proxy
-		err = ip6tables.runProg(append(
-			m.waitArgs,
+		err = ip6tables.runProg([]string{
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
 			"-m", "mark", "--mark", matchToProxy,
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy traffic",
-			"-j", "NOTRACK"), false)
+			"-j", "NOTRACK"}, false)
 		if err == nil {
 			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip6tables.runProg(append(
-				m.waitArgs,
+			err = ip6tables.runProg([]string{
 				"-t", "filter",
 				"-A", ciliumInputChain,
 				"-m", "mark", "--mark", matchToProxy,
 				"-m", "comment", "--comment", "cilium: ACCEPT for proxy traffic",
-				"-j", "ACCEPT"), false)
+				"-j", "ACCEPT"}, false)
 		}
 		if err == nil {
 			// No conntrack for proxy return traffic
-			err = ip6tables.runProg(append(
-				m.waitArgs,
+			err = ip6tables.runProg([]string{
 				"-t", "raw",
 				"-A", ciliumOutputRawChain,
 				"-m", "mark", "--mark", matchProxyReply,
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
-				"-j", "NOTRACK"), false)
+				"-j", "NOTRACK"}, false)
 		}
 		if err == nil {
 			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
 			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip6tables.runProg(append(
-				m.waitArgs,
+			err = ip6tables.runProg([]string{
 				"-t", "filter",
 				"-A", ciliumOutputChain,
 				"-m", "mark", "--mark", matchProxyReply,
 				"-m", "comment", "--comment", "cilium: ACCEPT for proxy return traffic",
-				"-j", "ACCEPT"), false)
+				"-j", "ACCEPT"}, false)
 		}
 		if err == nil && m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
@@ -694,7 +694,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 }
 
 func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) {
-	output, err := prog.runProgCombinedOutput(append(m.waitArgs, "-t", table, "-S"), true)
+	output, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"}, true)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"table": table,
@@ -716,7 +716,7 @@ func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string,
 				}).WithError(err).Warn("Unable to parse TPROXY rule, disruption to traffic selected by L7 policy possible")
 				continue
 			}
-			copyRule := append(append(m.waitArgs, "-t", table), args...)
+			copyRule := append([]string{"-t", table}, args...)
 			log.WithField(logfields.Object, logfields.Repr(copyRule)).Debugf("Copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
 			err = prog.runProg(copyRule, true)
 			if err != nil {
@@ -777,7 +777,7 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s TPROXY rule", prog)
 				continue
 			}
-			deleteRule := append(append(m.waitArgs, "-t", "mangle"), args...)
+			deleteRule := append([]string{"-t", "mangle"}, args...)
 			log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Deleting stale %s TPROXY rule from mangle table", prog)
 			err = prog.runProg(deleteRule, true)
 			if err != nil {
@@ -800,7 +800,7 @@ func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress bool, name str
 	return err
 }
 
-func endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr, ingress bool) error {
+func (m *IptablesManager) endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr, ingress bool) error {
 	protocol := strings.ToLower(port.Protocol)
 	p := strconv.FormatUint(uint64(port.Port), 10)
 	if ingress {
@@ -829,7 +829,7 @@ func endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *l
 // installed upon agent bootstrap (via function addNoTrackPodTrafficRules) and this function will be skipped.
 // When InstallNoConntrackIptRules is not set, this function will be executed to install NOTRACK rules.
 // The rules installed by this function is very specific, for now, the only user is node-local-dns pods.
-func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
+func (m *IptablesManager) InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	// Do not install per endpoint NOTRACK rules if we are already skipping
 	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
@@ -844,7 +844,7 @@ func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	}
 	ports := noTrackPorts(port)
 	for _, p := range ports {
-		if err := endpointNoTrackRules(prog, "-A", IP, p, true); err != nil {
+		if err := m.endpointNoTrackRules(prog, "-A", IP, p, true); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -852,7 +852,7 @@ func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 			}).WithError(err).Warn("Unable to install ingress NOTRACK rules")
 			return err
 		}
-		if err := endpointNoTrackRules(prog, "-A", IP, p, false); err != nil {
+		if err := m.endpointNoTrackRules(prog, "-A", IP, p, false); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -865,7 +865,7 @@ func InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
 }
 
 // See comments for InstallNoTrackRules.
-func RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
+func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	// Do not install per endpoint NOTRACK rules if we are already skipping
 	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
@@ -880,7 +880,7 @@ func RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
 	}
 	ports := noTrackPorts(port)
 	for _, p := range ports {
-		if err := endpointNoTrackRules(prog, "-D", IP, p, true); err != nil {
+		if err := m.endpointNoTrackRules(prog, "-D", IP, p, true); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -888,7 +888,7 @@ func RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
 			}).WithError(err).Warn("Unable to remove ingress NOTRACK rules")
 			return err
 		}
-		if err := endpointNoTrackRules(prog, "-D", IP, p, false); err != nil {
+		if err := m.endpointNoTrackRules(prog, "-D", IP, p, false); err != nil {
 			log.WithFields(logrus.Fields{
 				ipField:            IP,
 				logfields.Port:     p.Port,
@@ -985,40 +985,36 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 	//  - Node running backend:
 	//       IN=eno1 OUT=cilium_host
 	//       IN=lxc... OUT=eno1
-	if err := prog.runProg(append(
-		m.waitArgs,
+	if err := prog.runProg([]string{
 		"-A", forwardChain,
 		"-o", ifName,
-		"-m", "comment", "--comment", "cilium: any->cluster on "+ifName+" forward accept",
-		"-j", "ACCEPT"), false); err != nil {
+		"-m", "comment", "--comment", "cilium: any->cluster on " + ifName + " forward accept",
+		"-j", "ACCEPT"}, false); err != nil {
 		return err
 	}
-	if err := prog.runProg(append(
-		m.waitArgs,
+	if err := prog.runProg([]string{
 		"-A", forwardChain,
 		"-i", ifName,
-		"-m", "comment", "--comment", "cilium: cluster->any on "+ifName+" forward accept (nodeport)",
-		"-j", "ACCEPT"), false); err != nil {
+		"-m", "comment", "--comment", "cilium: cluster->any on " + ifName + " forward accept (nodeport)",
+		"-j", "ACCEPT"}, false); err != nil {
 		return err
 	}
-	if err := prog.runProg(append(
-		m.waitArgs,
+	if err := prog.runProg([]string{
 		"-A", forwardChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: cluster->any on lxc+ forward accept",
-		"-j", "ACCEPT"), false); err != nil {
+		"-j", "ACCEPT"}, false); err != nil {
 		return err
 	}
 	// Proxy return traffic to a remote source needs '-i cilium_net'.
 	// TODO: Make 'cilium_net' configurable if we ever support other than "cilium_host" as the Cilium host device.
 	if ifName == "cilium_host" {
 		ifPeerName := "cilium_net"
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-A", forwardChain,
 			"-i", ifPeerName,
-			"-m", "comment", "--comment", "cilium: cluster->any on "+ifPeerName+" forward accept (nodeport)",
-			"-j", "ACCEPT"), false); err != nil {
+			"-m", "comment", "--comment", "cilium: cluster->any on " + ifPeerName + " forward accept (nodeport)",
+			"-j", "ACCEPT"}, false); err != nil {
 			return err
 		}
 	}
@@ -1026,20 +1022,18 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 	// same (enable-endpoint-routes), a separate set of rules to allow
 	// from/to delivery interface is required.
 	if localDeliveryInterface != ifName {
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium: any->cluster on "+localDeliveryInterface+" forward accept",
-			"-j", "ACCEPT"), false); err != nil {
+			"-m", "comment", "--comment", "cilium: any->cluster on " + localDeliveryInterface + " forward accept",
+			"-j", "ACCEPT"}, false); err != nil {
 			return err
 		}
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium: cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
-			"-j", "ACCEPT"), false); err != nil {
+			"-m", "comment", "--comment", "cilium: cluster->any on " + localDeliveryInterface + " forward accept (nodeport)",
+			"-j", "ACCEPT"}, false); err != nil {
 			return err
 		}
 	}
@@ -1084,15 +1078,14 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 		if err := createIpset(prog.getIpset(), prog.getProg() == "ip6tables"); err != nil {
 			return err
 		}
-		progArgs := append(
-			m.waitArgs,
+		progArgs := []string{
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
 			"-s", allocRange,
 			"-m", "set", "--match-set", prog.getIpset(), "dst",
 			"-m", "comment", "--comment", "exclude traffic to cluster nodes from masquerade",
 			"-j", "ACCEPT",
-		)
+		}
 		if err := prog.runProg(progArgs, false); err != nil {
 			return err
 		}
@@ -1113,12 +1106,11 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 	//     range
 	// * Non-tunnel mode:
 	//   * May not be targeted to an IP in the cluster range
-	progArgs := append(
-		m.waitArgs,
+	progArgs := []string{
 		"-t", "nat",
 		"-A", ciliumPostNatChain,
 		"!", "-d", snatDstExclusionCIDR,
-	)
+	}
 
 	if option.Config.EgressMasqueradeInterfaces != "" {
 		progArgs = append(
@@ -1146,14 +1138,13 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 	// are considered.
 
 	// Exclude proxy return traffic from the masquarade rules.
-	if err := prog.runProg(append(
-		m.waitArgs,
+	if err := prog.runProg([]string{
 		"-t", "nat",
 		"-A", ciliumPostNatChain,
 		// Don't match proxy (return) traffic
 		"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyMask),
 		"-m", "comment", "--comment", "exclude proxy return traffic from masquerade",
-		"-j", "ACCEPT"), false); err != nil {
+		"-j", "ACCEPT"}, false); err != nil {
 		return err
 	}
 
@@ -1165,15 +1156,14 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 		// * Must be targeted for the ifName interface
 		// * Must be targeted to an IP that is not local
 		// * May not already be originating from the node's pod CIDR.
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
 			"!", "-s", allocRange,
 			"!", "-d", allocRange,
 			"-o", "cilium_host",
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",
-			"-j", "SNAT", "--to-source", hostMasqueradeIP), false); err != nil {
+			"-j", "SNAT", "--to-source", hostMasqueradeIP}, false); err != nil {
 			return err
 		}
 	}
@@ -1191,14 +1181,13 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 	// The following conditions must be met:
 	// * Must be targeted for local endpoint
 	// * Must be from 127.0.0.1
-	if err := prog.runProg(append(
-		m.waitArgs,
+	if err := prog.runProg([]string{
 		"-t", "nat",
 		"-A", ciliumPostNatChain,
 		"-s", loopbackAddr,
 		"-o", localDeliveryInterface,
-		"-m", "comment", "--comment", "cilium host->cluster from "+loopbackAddr+" masquerade",
-		"-j", "SNAT", "--to-source", hostMasqueradeIP), false); err != nil {
+		"-m", "comment", "--comment", "cilium host->cluster from " + loopbackAddr + " masquerade",
+		"-j", "SNAT", "--to-source", hostMasqueradeIP}, false); err != nil {
 		return err
 	}
 
@@ -1218,15 +1207,14 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 	//    on the same node
 	//  - kiam if source and server are on the same node
 	if !option.Config.EnableEndpointRoutes {
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
 			"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask),
 			"-o", localDeliveryInterface,
 			"-m", "conntrack", "--ctstate", "DNAT",
 			"-m", "comment", "--comment", "hairpin traffic that originated from a local pod",
-			"-j", "SNAT", "--to-source", hostMasqueradeIP), false); err != nil {
+			"-j", "SNAT", "--to-source", hostMasqueradeIP}, false); err != nil {
 			return err
 		}
 	}
@@ -1265,15 +1253,14 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 	matchFromProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyMask)
 	markAsFromHost := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkHost, linux_defaults.MagicMarkHostMask)
 
-	return prog.runProg(append(
-		m.waitArgs,
+	return prog.runProg([]string{
 		"-t", "filter",
 		"-A", ciliumOutputChain,
 		"-m", "mark", "!", "--mark", matchFromIPSecDecrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromProxy, // Don't match proxy traffic
 		"-m", "comment", "--comment", "cilium: host->any mark as from host",
-		"-j", "MARK", "--set-xmark", markAsFromHost), false)
+		"-j", "MARK", "--set-xmark", markAsFromHost}, false)
 }
 
 // InstallRules installs iptables rules for Cilium in specific use-cases
@@ -1286,7 +1273,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 
 	// Rename any old chains we may have
 	for _, c := range ciliumChains {
-		c.rename(m.waitArgs, "OLD_"+c.name, quiet)
+		c.rename("OLD_"+c.name, quiet)
 	}
 
 	// install rules if needed
@@ -1312,7 +1299,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 func (m *IptablesManager) installRules(ifName string) error {
 	// Install new rules
 	for _, c := range ciliumChains {
-		if err := c.add(m.waitArgs); err != nil {
+		if err := c.add(); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
 			skipFeeder := false
 			for _, disabledChain := range option.Config.DisableIptablesFeederRules {
@@ -1414,7 +1401,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 			continue
 		}
 
-		if err := c.installFeeder(m.waitArgs); err != nil {
+		if err := c.installFeeder(); err != nil {
 			return fmt.Errorf("cannot install feeder rule %s: %s", c.feederArgs, err)
 		}
 	}
@@ -1427,12 +1414,11 @@ func (m *IptablesManager) ciliumNoTrackXfrmRules(prog iptablesInterface, input s
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
 	for _, match := range []string{matchFromIPSecDecrypt, matchFromIPSecEncrypt} {
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-t", "raw", input, ciliumPreRawChain,
 			"-m", "mark", "--mark", match,
 			"-m", "comment", "--comment", xfrmDescription,
-			"-j", "NOTRACK"), false); err != nil {
+			"-j", "NOTRACK"}, false); err != nil {
 			return err
 		}
 	}
@@ -1453,23 +1439,21 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 
 		comment := "exclude xfrm marks from " + table + " " + chain + " chain"
 
-		if err := ip4tables.runProg(append(
-			m.waitArgs,
+		if err := ip4tables.runProg([]string{
 			"-t", table,
 			"-A", chain,
 			"-m", "mark", "--mark", matchFromIPSecEncrypt,
 			"-m", "comment", "--comment", comment,
-			"-j", "ACCEPT"), false); err != nil {
+			"-j", "ACCEPT"}, false); err != nil {
 			return err
 		}
 
-		return ip4tables.runProg(append(
-			m.waitArgs,
+		return ip4tables.runProg([]string{
 			"-t", table,
 			"-A", chain,
 			"-m", "mark", "--mark", matchFromIPSecDecrypt,
 			"-m", "comment", "--comment", comment,
-			"-j", "ACCEPT"), false)
+			"-j", "ACCEPT"}, false)
 	}
 	if err := insertAcceptXfrm("filter", ciliumInputChain); err != nil {
 		return err
@@ -1501,24 +1485,22 @@ func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
 
 func (m *IptablesManager) addNoTrackPodTrafficRules(prog iptablesInterface, podsCIDR string) error {
 	for _, chain := range []string{ciliumPreRawChain, ciliumOutputRawChain} {
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-t", "raw",
 			"-I", chain,
 			"-s", podsCIDR,
 			"-m", "comment", "--comment", "cilium: NOTRACK for pod traffic",
-			"-j", "NOTRACK"),
+			"-j", "NOTRACK"},
 			false); err != nil {
 			return err
 		}
 
-		if err := prog.runProg(append(
-			m.waitArgs,
+		if err := prog.runProg([]string{
 			"-t", "raw",
 			"-I", chain,
 			"-d", podsCIDR,
 			"-m", "comment", "--comment", "cilium: NOTRACK for pod traffic",
-			"-j", "NOTRACK"),
+			"-j", "NOTRACK"},
 			false); err != nil {
 			return err
 		}
@@ -1543,23 +1525,21 @@ func (m *IptablesManager) addCiliumENIRules() error {
 	// Note: these rules need the xt_connmark module (iptables usually
 	// loads it when required, unless loading modules after boot has been
 	// disabled).
-	if err := ip4tables.runProg(append(
-		m.waitArgs,
+	if err := ip4tables.runProg([]string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
 		"-i", iface.Attrs().Name,
 		"-m", "comment", "--comment", "cilium: primary ENI",
 		"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
-		"-j", "CONNMARK", "--set-xmark", nfmask+"/"+ctmask),
+		"-j", "CONNMARK", "--set-xmark", nfmask + "/" + ctmask},
 		false); err != nil {
 		return err
 	}
-	return ip4tables.runProg(append(
-		m.waitArgs,
+	return ip4tables.runProg([]string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: primary ENI",
-		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask),
+		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask},
 		false)
 }

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -98,7 +98,6 @@ var mockManager = &IptablesManager{
 	haveSocketMatch:      true,
 	haveBPFSocketAssign:  false,
 	ipEarlyDemuxDisabled: false,
-	waitArgs:             nil,
 }
 
 func init() {
@@ -117,13 +116,13 @@ func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
 		table: "mangle",
 		name:  "CILIUM_PRE_mangle",
 	}
-	chain.doRename(mockIp4tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	chain.doRename(mockIp4tables, "OLD_CILIUM_PRE_mangle", false)
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
 	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
 	mockIp6tables.expectations = mockIp4tables.expectations
-	chain.doRename(mockIp6tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	chain.doRename(mockIp6tables, "OLD_CILIUM_PRE_mangle", false)
 	err = mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -62,4 +62,18 @@ type IptablesManager interface {
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.
 	GetProxyPort(listener string) uint16
+
+	// InstallNoTrackRules is explicitly called when a pod has valid
+	// "io.cilium.no-track-port" annotation.  When
+	// InstallNoConntrackIptRules flag is set, a super set of v4 NOTRACK
+	// rules will be automatically installed upon agent bootstrap (via
+	// function addNoTrackPodTrafficRules) and this function will be
+	// skipped.  When InstallNoConntrackIptRules is not set, this function
+	// will be executed to install NOTRACK rules.  The rules installed by
+	// this function is very specific, for now, the only user is
+	// node-local-dns pods.
+	InstallNoTrackRules(IP string, port uint16, ipv6 bool) error
+
+	// See comments for InstallNoTrackRules.
+	RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -2207,12 +2206,12 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		}).Debug("Deleting endpoint NOTRACK rules")
 
 		if e.IPv4.IsSet() {
-			if err := iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
+			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv4 rules: %s", err))
 			}
 		}
 		if e.IPv6.IsSet() {
-			if err := iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
+			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv6 rules: %s", err))
 			}
 		}

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium/pkg/bandwidth"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
@@ -159,21 +158,21 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 		log.Debug("Updating NOTRACK rules")
 		if e.IPv4.IsSet() {
 			if port > 0 {
-				err = iptables.InstallNoTrackRules(e.IPv4.String(), port, false)
+				err = e.owner.Datapath().InstallNoTrackRules(e.IPv4.String(), port, false)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
+				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}
 		if e.IPv6.IsSet() {
 			if port > 0 {
-				iptables.InstallNoTrackRules(e.IPv6.String(), port, true)
+				e.owner.Datapath().InstallNoTrackRules(e.IPv6.String(), port, true)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
+				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -229,6 +229,8 @@ const (
 	uninitializedRegen  = "Uninitialized regeneration level"                         // from https://github.com/cilium/cilium/pull/10949
 	unstableStat        = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
+	missingIptablesWait = "Missing iptables wait arg (-w):"
+
 	// ...and their exceptions.
 	lrpExists          = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
 	opCantBeFulfilled  = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
@@ -296,6 +298,7 @@ var badLogMessages = map[string][]string{
 	uninitializedRegen:  nil,
 	unstableStat:        nil,
 	removeTransientRule: nil,
+	missingIptablesWait: nil,
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.


### PR DESCRIPTION
A missing wait arg can lead to spurious iptables command failure if
two of them are executed in parallel due to an internal lock being
held. This may cause test flakes due to missing iptables rules.

Solve this by always injecting the wait args at
runProgCombinedOutput() that ultimately does all iptables calls and
remove the wait args from all the callers.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
