### PR TITLE
datapath: Pass proxy port in to-proxy traces

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -308,7 +308,7 @@ ct_recreate6:
 	if (redirect_to_proxy(verdict, reason)) {
 		/* Trace the packet before it is forwarded to proxy */
 		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
-				  0, 0, reason, monitor);
+				  bpf_ntohs(verdict), 0, reason, monitor);
 		return ctx_redirect_to_proxy6(ctx, tuple, verdict, false);
 	}
 
@@ -739,7 +739,7 @@ ct_recreate4:
 	if (redirect_to_proxy(verdict, reason)) {
 		/* Trace the packet before it is forwarded to proxy */
 		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
-				  0, 0, reason, monitor);
+				  bpf_ntohs(verdict), 0, reason, monitor);
 		return ctx_redirect_to_proxy4(ctx, &tuple, verdict, false);
 	}
 
@@ -1073,7 +1073,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 		 * into ctx->mark and *proxy_port can be left unset.
 		 */
 		send_trace_notify6(ctx, TRACE_TO_PROXY, src_label, SECLABEL, &orig_sip,
-				  0, ifindex, 0, monitor);
+				   0, ifindex, 0, monitor);
 		if (tuple_out)
 			memcpy(tuple_out, &tuple, sizeof(tuple));
 		return POLICY_ACT_PROXY_REDIRECT;
@@ -1141,7 +1141,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 	if (redirect_to_proxy(verdict, *reason)) {
 		*proxy_port = verdict;
 		send_trace_notify6(ctx, TRACE_TO_PROXY, src_label, SECLABEL, &orig_sip,
-				  0, ifindex, *reason, monitor);
+				   bpf_ntohs(verdict), ifindex, *reason, monitor);
 		if (tuple_out)
 			memcpy(tuple_out, &tuple, sizeof(tuple));
 		return POLICY_ACT_PROXY_REDIRECT;
@@ -1351,7 +1351,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 		 * into ctx->mark and *proxy_port can be left unset.
 		 */
 		send_trace_notify4(ctx, TRACE_TO_PROXY, src_label, SECLABEL, orig_sip,
-				  0, ifindex, 0, monitor);
+				   0, ifindex, 0, monitor);
 		if (tuple_out)
 			*tuple_out = tuple;
 		return POLICY_ACT_PROXY_REDIRECT;
@@ -1443,7 +1443,7 @@ skip_policy_enforcement:
 	if (redirect_to_proxy(verdict, *reason)) {
 		*proxy_port = verdict;
 		send_trace_notify4(ctx, TRACE_TO_PROXY, src_label, SECLABEL, orig_sip,
-				  0, ifindex, *reason, monitor);
+				   bpf_ntohs(verdict), ifindex, *reason, monitor);
 		if (tuple_out)
 			*tuple_out = tuple;
 		return POLICY_ACT_PROXY_REDIRECT;

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -146,7 +146,11 @@ func (n *TraceNotify) traceSummary() string {
 	case api.TraceToLxc:
 		return fmt.Sprintf("-> endpoint %d", n.DstID)
 	case api.TraceToProxy:
-		return "-> proxy"
+		pp := ""
+		if n.DstID != 0 {
+			pp = fmt.Sprintf(" port %d", n.DstID)
+		}
+		return "-> proxy" + pp
 	case api.TraceToHost:
 		return "-> host from"
 	case api.TraceToStack:
@@ -216,13 +220,18 @@ func (n *TraceNotify) DumpVerbose(dissect bool, data []byte, prefix string, nume
 	}
 
 	if n.SrcLabel != 0 || n.DstLabel != 0 {
+		fmt.Fprintf(buf, ", ")
 		n.dumpIdentity(buf, numeric)
 	}
 
 	fmt.Fprintf(buf, ", orig-ip %s", n.OriginalIP().String())
 
 	if n.DstID != 0 {
-		fmt.Fprintf(buf, ", to endpoint %d\n", n.DstID)
+		dst := "endpoint"
+		if n.ObsPoint == api.TraceToProxy {
+			dst = "proxy-port"
+		}
+		fmt.Fprintf(buf, ", to %s %d\n", dst, n.DstID)
 	} else {
 		fmt.Fprintf(buf, "\n")
 	}


### PR DESCRIPTION
Include proxy port in the to-proxy trace messages.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
