### PR TITLE
Fix label shown as Unknown App in hubble ui for http-sw-app example

### DIFF
--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: deathstar
+  labels:
+    app.kubernetes.io/name: deathstar
 spec:
   type: ClusterIP
   ports:
@@ -15,6 +17,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deathstar
+  labels:
+    app.kubernetes.io/name: deathstar
 spec:
   replicas: 2
   selector:
@@ -26,6 +30,7 @@ spec:
       labels:
         org: empire
         class: deathstar
+        app.kubernetes.io/name: deathstar
     spec:
       containers:
       - name: deathstar
@@ -38,6 +43,7 @@ metadata:
   labels:
     org: empire
     class: tiefighter
+    app.kubernetes.io/name: tiefighter
 spec:
   containers:
   - name: spaceship
@@ -48,6 +54,7 @@ kind: Pod
 metadata:
   name: xwing
   labels:
+    app.kubernetes.io/name: xwing
     org: alliance
     class: xwing
 spec:


### PR DESCRIPTION
Fix label shown as `Unknown App` due to missing labels following instructions at https://docs.cilium.io/en/stable/gettingstarted/hubble/