### PR TITLE
docs: Update community page

### DIFF
--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -8,13 +8,12 @@ Weekly Community Meeting
 ========================
 
 The Cilium contributors gather every Wednesday at 8am PDT, 17:00 CEST, for a
-one-hour Zoom call open to everyone. During that time, we discuss:
+Zoom call open to everyone. During that time, we discuss:
 
-- the statuses of the next releases for each supported Cilium release
-- the current state of our CI: flakes being investigated and upcoming
-  changes
-- the development items for the next release
-- miscellaneous topics during the open session
+- Status of the next releases for each supported Cilium release
+- Current state of our CI: flakes being investigated and upcoming changes
+- Development items for the next release
+- Any other community-relevant topics during the open session
 
 If you want to discuss something during the next meeting's open session,
 you can add it to `the meeting's Google doc
@@ -27,43 +26,47 @@ Slack
 =====
 
 Our Cilium & eBPF Slack is the main discussion space for the Cilium community.
-Click `here <https://cilium.herokuapp.com>`_ to request an invite. 
+Click `here <https://cilium.herokuapp.com>`_ to request an invite.
 
 Slack channels
 --------------
 
-==================== ====================================
+==================== ==========================================================
 Name                 Purpose
-==================== ====================================
+==================== ==========================================================
 #general             General user discussions & questions
 #hubble              Questions on Hubble
 #kubernetes          Kubernetes-specific questions
 #networkpolicy       Questions on network policies
 #release             Release announcements only
-==================== ====================================
+==================== ==========================================================
 
 You can join the following channels if you are looking to contribute to
 Cilium:
 
-==================== ====================================
+==================== ==========================================================
 Name                 Purpose
-==================== ====================================
-#development         Development discussions
+==================== ==========================================================
+#development         Development discussions around Cilium
+#ebpf-go-dev         Development discussion for the `eBPF Go library`_
 #git                 GitHub notifications
 #sig-*               SIG-specific discussions (see below)
 #testing             Testing and CI discussions
-==================== ====================================
+==================== ==========================================================
 
 If you are interested in eBPF, then the following channels are for you:
 
-==================== ====================================================================
+==================== ==========================================================
 Name                 Purpose
-==================== ====================================================================
-#ebpf                eBPF-specific questions
-#ebpf-lsm            Questions on BPF LSM
-#ebpf-news           Contributions to the `eBPF Updates <https://ebpf.io/blog>`_
-#libbpf-go           Questions on the `eBPF Go library <https://github.com/cilium/ebpf>`_
-==================== ====================================================================
+==================== ==========================================================
+#ebpf                General eBPF questions
+#ebpf-go             Questions on the `eBPF Go library`_
+#ebpf-lsm            Questions on BPF Linux Security Modules (LSM)
+#ebpf-news           Contributions to the `eBPF Updates`_
+==================== ==========================================================
+
+.. _eBPF Go library: https://github.com/cilium/ebpf
+.. _eBPF Updates: https://ebpf.io/blog
 
 
 Special Interest Groups
@@ -79,12 +82,12 @@ and meeting links.
 ====================== ===================================== ============= ================================================================================
 SIG                    Meeting                               Slack         Description
 ====================== ===================================== ============= ================================================================================
-Datapath               Thursdays, 08:00 PT                   #sig-datapath Owner of all eBPF- and Linux-kernel-related datapath code.
-Documentation          None                                  #sig-docs     All documentation related discussions
+Datapath               Thursdays, 08:00 PT                   #sig-datapath Development discussions for Linux and eBPF code used in Cilium.
+Documentation          None                                  #sig-docs     Documentation, Helm references, and translations.
 Envoy                  On demand                             #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
-Hubble                 During community meeting              #sig-hubble   Owner of all Hubble-related code: Server, UI, CLI and Relay.
-Policy                 None                                  #sig-policy   All topics related to policy. The SIG is responsible for all security relevant APIs and the enforcement logic.
-Release Management     None                                  #launchpad    Responsible for the release management and backport process.
+Hubble                 During community meeting              #sig-hubble   All Hubble-related code: Server, UI, CLI and Relay.
+Policy                 None                                  #sig-policy   Network policy and enforcement.
+Release Management     None                                  #launchpad    Release management and backport coordination.
 ====================== ===================================== ============= ================================================================================
 
 How to create a SIG


### PR DESCRIPTION
There's been a few changes lately, for instance we are trying a shorter
format for the weekly meeting, and the eBPF library channels have shifted
around. While we're at it, fix up some formatting / grammar /
consistency for the page overall.
