### PR TITLE
bpf/Makefile: Default to `KERNEL=netnext`

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -14,7 +14,7 @@ BPF_TEST=tests/bpf_ct_tests.o
 BPF = bpf_lxc.o bpf_overlay.o bpf_sock.o bpf_host.o bpf_xdp.o $(BPF_SIMPLE)
 
 TARGET=cilium-probe-kernel-hz
-KERNEL ?= "49"
+KERNEL ?= "netnext"
 
 include ./Makefile.bpf
 


### PR DESCRIPTION
The Makefile in `bpf/` is used to compile-test our BPF programs but also to compile the kernel-specific object files we use for complexity tests. It takes a KERNEL environment variable to generate BPF programs with the appropriate features enabled. That is, it tries to maximize the program size for each kernel. KERNEL currently defaults to v4.9.

On bpf-next, Cilium's BPF programs are sometimes used to validate verifier patches, to measure the performance impact or verify
correctness. Since Cilium has some of the largest open source BPF programs, this is a quick way to avoid regressions.

Folks using our Makefile for that purpose are unlikely to know about the KERNEL environment variable and will use its default value. To reduce the likelihood of regressions, we can switch the default KERNEL value to netnext. That will generate BPF programs with all possible options on the latest kernels, which more closely match what bpf-next folks are looking for when testing their patches.