### PR TITLE
CODEOWNERS: No review from @cilium/build on `bpf/Makefile`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,7 +45,7 @@
 /api/v1/relay/ @cilium/api @cilium/hubble
 /bpf/ @cilium/bpf
 Makefile* @cilium/build
-/bpf/Makefile* @cilium/build @cilium/loader
+/bpf/Makefile* @cilium/loader
 /bpf/init.sh @cilium/loader
 /bpf/custom/Makefile* @cilium/build @cilium/loader
 /bpf/sockops/Makefile* @cilium/build @cilium/loader


### PR DESCRIPTION
The Makefiles in `bpf/` are not actually used for builds but only for datapath tests (complexity tests and compile tests). To compile the datapath at runtime we rely on ad-hoc calls to clang and llc from function `compile` in `pkg/datapath/loader`.