### PR TITLE
contrib: Fix submit-release.sh regression

### DIFF
--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -65,6 +65,6 @@ PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push $USER_REMOTE "$PR_BRANCH"
 LABELS="kind/release"
 if [ "$BRANCH" != "master" ]; then
-    labels = "$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
+    LABELS="$LABELS,backport/$(echo $BRANCH | sed 's/^v//')"
 fi
 hub pull-request -b "$BRANCH" -l "$LABELS" -F $SUMMARY


### PR DESCRIPTION
Commit aea0c1efd143 ("contrib: Support prereleases in release prep
scripts") accidentally broke this script because the variable wasn't
being set properly for regular releases. Fix up the variable assignment.

Fixes this error:

    Sending pull request...
    Enumerating objects: 37, done.
    Counting objects: 100% (37/37), done.
    Delta compression using up to 8 threads
    Compressing objects: 100% (17/17), done.
    Writing objects: 100% (19/19), 4.10 KiB | 839.00 KiB/s, done.
    Total 19 (delta 15), reused 0 (delta 0)
    remote: Resolving deltas: 100% (15/15), completed with 15 local objects.
    remote:
    remote: Create a pull request for 'pr/prepare-v1.10.5' on GitHub by
    visiting:
    remote:
    https://github.com/joestringer/cilium/pull/new/pr/prepare-v1.10.5
    remote:
    To github.com:joestringer/cilium
     * [new branch]                pr/prepare-v1.10.5 -> pr/prepare-v1.10.5
     /home/joe/git/cilium/contrib/release/submit-release.sh: line 68:
     labels: command not found

     Signal ERR caught!

     Traceback (line function script):
     68 main /home/joe/git/cilium/contrib/release/submit-release.sh
