### PR TITLE
add scruffy to garbage collect CI images from quay.io

### DIFF
--- a/.github/workflows/ci-images-garbage-collect.yaml
+++ b/.github/workflows/ci-images-garbage-collect.yaml
@@ -1,0 +1,22 @@
+name: Scruffy
+on:
+  workflow_dispatch:
+  schedule:
+    # Run the GC every Monday at 9am
+    - cron: "0 9 * * 1"
+
+permissions: read-all
+
+jobs:
+  scruffy:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    name: scruffy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: docker://quay.io/cilium/scruffy:v0.0.1@sha256:15e3926d8e74aa6a278cc07fb61d5888322fabdae49637384dc6a3fb32452969
+        with:
+          entrypoint: scruffy
+          args: --git-repository=./
+        env:
+          QUAY_TOKEN: ${{ secrets.SCRUFFY_QUAY_TOKEN }}

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -254,3 +254,14 @@ Nightly images are stored on dockerhub tagged with following format: ``YYYYMMDD-
 Job number is added to tag for the unlikely event of two consecutive nightly builds being built on the same date.
 
 .. _cilium/nightly: https://hub.docker.com/r/cilium/nightly/
+
+Image Building Process
+~~~~~~~~~~~~~~~~~~~~~~
+
+Images are automatically created by a GitHub action: ``build-images``. This
+action will automatically run for any Pull Request, including Pull Requests
+submitted from forked repositories, and push the images into
+``quay.io/cilium/*-ci``. They will be available there for 1 week before they are
+removed by the ``ci-images-garbage-collect`` workflow. Once they are removed, the
+developer must re-push the Pull Request into GitHub so that new images are
+created.


### PR DESCRIPTION
To avoid having too many docker image tags caused by the builds of PRs,
we should clean those tags every week.

Related to https://github.com/cilium/cilium/issues/14928

Signed-off-by: André Martins <andre@cilium.io>